### PR TITLE
test: raise coverage across pos-marketing, pos-order, and pos-customer (plan Phases 1-2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,11 @@ Each service owns its own database schema; there are no cross-service foreign ke
 # Cross-module ArchUnit architecture tests (run after touching package layout)
 ./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test
 
-# Format code (Palantir Java Format via Spotless) — run before committing
+# Format code (Palantir Java Format via Spotless) — run before committing.
+# `spotless:check` is bound to the `validate` phase, so an unformatted file
+# fails the build up front. Bypass with -Dspotless.check.skip=true while iterating.
+# Note: spotless:apply formats main *and* test sources in the modules you pass,
+# so check `git status` before staging if you only meant to touch tests.
 ./mvnw spotless:apply
 
 # Run a single service locally (random port, registers with Eureka)

--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -1,6 +1,7 @@
 # Test Coverage Improvement Plan
 
-Status: Phase 0 complete, Phase 1 complete. Phases 2–4 outstanding.
+Status: Phase 0 complete, Phase 1 complete. Phase 2 in progress (pos-event-receiver and
+pos-marketing done; pos-customer partial). Phases 3–4 outstanding.
 Date: 2026-08-11
 
 Method: `.agents/skills/test-coverage-improver` workflow, adapted from its pnpm/JS
@@ -285,10 +286,10 @@ exists now that every module is measured. The merged priority order is:
 
 | # | Module | Line% | Missed | Why here |
 | ---: | --- | ---: | ---: | --- |
-| 1 | pos-event-receiver | 3.0 | 424 | Every service registers against it; lowest coverage in the reactor |
-| 2 | pos-customer | 61.5 | 2,067 | Largest absolute gap |
+| 1 | ~~pos-event-receiver~~ | 3.0 | 424 | **Done** — every service registers against it; was lowest in the reactor |
+| 2 | pos-customer | 61.5 | 2,067 | Largest absolute gap; several waves landed, not yet re-measured |
 | 3 | pos-order | 53.4 | 1,510 | Second-lowest coverage among large modules |
-| 4 | pos-marketing | 28.1 | 889 | Second-lowest coverage overall, 0 ITs |
+| 4 | ~~pos-marketing~~ | 28.1 | 889 | **Done — now 87.9% line / 82.9% branch, 150 missed** (see §4.1) |
 | 5 | pos-people | 61.5 | 1,101 | Large gap, thin suite |
 | 6 | pos-invoice | 63.4 | 1,210 | Large gap, **0 ITs** |
 | 7 | pos-workorder | 73.0 | 2,012 | Large absolute gap despite decent ratio |
@@ -306,6 +307,28 @@ Deliberately **not** prioritized: `pos-accounting` (85.7%), `pos-inventory`
 The four small modules at 0% — `pos-vehicle-reference-nhtsa` (189),
 `pos-vehicle-reference-carapi` (69), `pos-image` (61), `pos-inquiry` (16) — total
 335 missed lines and are cheap; treat them as filler work rather than a priority.
+
+### 4.1 pos-marketing outcome (delivered 2026-08-11)
+
+**28.1% → 87.9% line, 29.8% → 82.9% branch** (889 → 150 missed lines), 183 unit
+tests, no ITs added. Every service-layer class is now covered:
+
+| Class | Was | Notes |
+| --- | ---: | --- |
+| `CampaignServiceImpl` | 0% | Lifecycle, readiness aggregation, audience-type immutability |
+| `CampaignSendServiceImpl` | 0% | Dispatch matrix, collision tolerance, page-size clamp |
+| `CampaignStatsServiceImpl` | 0% | Cumulative funnel arithmetic, null-SUM handling |
+| `MessageTemplateServiceImpl` | 0% | Channel/audience immutability, in-use delete guard |
+| `CustomerEventsListener` | 0% | Replay guard, redemption idempotency, mid-send audience protection |
+| `MarketingFactPublisher` | 0% | Kafka-disabled no-op, party-keyed send facts |
+| `OutboxEventWriter` | 4.5% | Aggregate-keyed row, fatal serialization failure |
+| `SegmentResolveRequester` | 5.0% | Correlated resolve command, segment-keyed ordering |
+| `MarketingExceptionHandler` | 0% | ADR-0017 status/code pairing, correlation-id passthrough |
+
+Remaining 150 missed lines are controllers (30), Spring config (`OpenApiConfig`,
+`RestClientConfig`, `FlywayConfig`, `KafkaErrorHandlingConfig`, 40), and
+`LoggingMessageChannel`. Controllers want `@WebMvcTest` slices, which is a
+different shape of work; the module's business logic is done.
 
 The per-module detail below predates the measurement and is kept for the specific
 class-level targets it names.

--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -1,9 +1,15 @@
 # Test Coverage Improvement Plan
 
-Status: Phase 0 complete, Phase 1 complete. Phase 2 in progress (pos-event-receiver
-and pos-marketing done; pos-order and pos-customer partial). Phases 3–4
-outstanding.
-Date: 2026-08-11
+Status: Phase 0 complete. Phase 1 complete except wave 1c (see §3.3). Phase 2 in
+progress — `pos-event-receiver` and `pos-marketing` done, `pos-order` and
+`pos-customer` substantially done (§4.1–§4.3); the remaining nine modules in the
+§4 table are untouched. Phases 3–4 outstanding.
+Date: 2026-08-11 (last updated 2026-08-11)
+
+**Before Phase 4, re-run the Phase 0 full-reactor command.** Every figure in
+§4.1–§4.3 is unit-only (`-DskipITs`) and therefore not comparable to the §1.5
+baseline, which included Failsafe ITs. No threshold should be set from the
+numbers in those sections.
 
 Method: `.agents/skills/test-coverage-improver` workflow, adapted from its pnpm/JS
 assumptions to this Maven reactor; test authoring follows `.agents/skills/java-testing`.
@@ -418,7 +424,9 @@ them is a separate decision):
 
 Both are pinned by tests carrying an explicit "documents current behaviour, not
 desired behaviour" comment, so a future fix will fail a test rather than pass
-silently.
+silently. Filed as louisburroughs/durion-positivity-backend#1245 (VIN loss) and
+louisburroughs/durion-positivity-backend#1246 (name transposition); both issues
+name the pinning tests that must be updated alongside the fix.
 
 Remaining in `pos-customer`, largest first: `SegmentResolutionService` (64 missed,
 73.1% — almost all of it in the `loadCommercialCandidates` projection lambda),

--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -290,7 +290,7 @@ exists now that every module is measured. The merged priority order is:
 | # | Module | Line% | Missed | Why here |
 | ---: | --- | ---: | ---: | --- |
 | 1 | ~~pos-event-receiver~~ | 3.0 | 424 | **Done** — every service registers against it; was lowest in the reactor |
-| 2 | pos-customer | 61.5 | 2,067 | Largest absolute gap; several waves landed, not yet re-measured |
+| 2 | pos-customer | 61.5 | 2,067 | **In progress — 85.9% line / 70.6% branch unit-only** (see §4.3) |
 | 3 | pos-order | 53.4 | 1,510 | **In progress — 83.6% line / 67.7% branch unit-only** (see §4.2) |
 | 4 | ~~pos-marketing~~ | 28.1 | 889 | **Done — now 87.9% line / 82.9% branch, 150 missed** (see §4.1) |
 | 5 | pos-people | 61.5 | 1,101 | Large gap, thin suite |
@@ -373,6 +373,61 @@ Remaining in `pos-order`, largest first: `SalesOrderServiceImpl` (133 missed,
 DTOs (60 combined at 0%, all static `from(...)` mappers), `PaymentEventsListener`
 (19, 83.9%), `PriceOverrideServiceImpl` (16, 93.2%). The two controllers want
 `@WebMvcTest` slices; the rest are ordinary unit work.
+
+### 4.3 pos-customer progress (2026-08-11)
+
+Measured **unit-only** (`-DskipITs`), so not comparable to the §1.5 61.5%, which
+included ITs. The earlier waves (segment/party-tag services, suppression register,
+replica listeners, consent resolution, account tier, permission registry, manifest
+publisher) had never been re-measured; they had already taken the module to 80.7%
+line / 65.9% branch before this pass began.
+
+| | Start of this pass | Now |
+|---|---:|---:|
+| Line | 80.7% | **85.9%** |
+| Branch | 65.9% | **70.6%** |
+| Missed lines | 1,034 | **757** |
+
+Delivered this pass:
+
+- **`PersonPartyServiceImpl`** (74 missed at 30.2%) — sort sanitization, directory
+  delegation for name/email search, the deliberate non-application of name edits.
+- **`CommercialPartyServiceImpl`** (70 at 24.7%) — organization CRUD and the
+  email-only search short-circuit.
+- **`CrmExceptionHandler`** (38 at 53.1%) — ADR-0017 status/code pairings, the
+  422-vs-400 distinction, correlation-id passthrough, null-request tolerance.
+- **`OutboxEventWriter`** (21 at 4.5%) — aggregate-keyed row, fatal serialization
+  failure.
+- **`PartyServiceImpl`** billing rules and duplicate check (~86 of its 99 missed).
+
+**Two defects found and documented, not fixed** (both API-visible, so changing
+them is a separate decision):
+
+1. **A partial update wipes a party's VIN list.** `CustomerDTO` declares
+   `vehicleVins` `@Builder.Default` with an empty `ArrayList` and initializes it in
+   the no-args constructor Jackson uses, so the `vehicleVins != null` guard in
+   `updateEntityFromDTO` can never be false. A PUT that simply omits `vehicleVins`
+   reaches the `clear()`/`addAll()` branch with an empty list and drops every VIN
+   association. Both `PersonPartyServiceImpl` and `CommercialPartyServiceImpl` are
+   affected.
+2. **`CommercialPartyServiceImpl` transposes its two name fields on a round
+   trip.** `toEntity` maps `firstName -> legalName` and `lastName -> displayName`;
+   `toDTO` maps `legalName -> lastName` and `displayName -> firstName`. A client
+   that POSTs a commercial party and reads it back gets the two names swapped.
+   `updateEntityFromDTO` follows the write direction, so updates transpose too.
+
+Both are pinned by tests carrying an explicit "documents current behaviour, not
+desired behaviour" comment, so a future fix will fail a test rather than pass
+silently.
+
+Remaining in `pos-customer`, largest first: `SegmentResolutionService` (64 missed,
+73.1% — almost all of it in the `loadCommercialCandidates` projection lambda),
+`CustomerFactPublisher` (42, 68.7% — six publish methods), `InquiryServiceImpl`
+(38, 65.8%), `CustomerCommandListener` (31, 64.8%), `SegmentPredicateEvaluator`
+(30, 61.5%), `CrmAccountsController` (29, 45.3%), `FollowUpTaskServiceImpl` (27,
+58.5%), `SegmentPredicateValidator` (26, 71.4%), and the CRM controllers
+(`CustomerController` 26, `CrmPartyRelationshipController` 24, `CrmPersonController`
+21 — all want `@WebMvcTest` slices).
 
 The per-module detail below predates the measurement and is kept for the specific
 class-level targets it names.

--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -1,7 +1,8 @@
 # Test Coverage Improvement Plan
 
-Status: Phase 0 complete, Phase 1 complete. Phase 2 in progress (pos-event-receiver and
-pos-marketing done; pos-customer partial). Phases 3–4 outstanding.
+Status: Phase 0 complete, Phase 1 complete. Phase 2 in progress (pos-event-receiver
+and pos-marketing done; pos-order and pos-customer partial). Phases 3–4
+outstanding.
 Date: 2026-08-11
 
 Method: `.agents/skills/test-coverage-improver` workflow, adapted from its pnpm/JS
@@ -270,7 +271,9 @@ startup registration delegates to them: `pos-events`
   define a registry class (`pos-inventory`, `pos-customer`, `pos-marketing`); the
   shared `PermissionRegistrationSupport` they extend is now covered, so the
   remaining value here is small.
-- **Wave 1e (Kafka `*EventsListener`)** — not started, and it is the largest
+- **Wave 1e (Kafka `*EventsListener`)** — closed for `pos-customer`,
+  `pos-marketing`, and `pos-order` (see §4.1 and §4.2); open elsewhere. It was
+  originally recorded as not started, and it is the largest
   remaining archetype: **78 listener classes** across the reactor, many at 0%
   (`CustomerEventsListener` 145 missed lines, `VehicleEventsListener` 119,
   `InventoryEventsListener` 72, `InventoryManifestListener` 49). Unlike the other
@@ -288,7 +291,7 @@ exists now that every module is measured. The merged priority order is:
 | ---: | --- | ---: | ---: | --- |
 | 1 | ~~pos-event-receiver~~ | 3.0 | 424 | **Done** — every service registers against it; was lowest in the reactor |
 | 2 | pos-customer | 61.5 | 2,067 | Largest absolute gap; several waves landed, not yet re-measured |
-| 3 | pos-order | 53.4 | 1,510 | Second-lowest coverage among large modules |
+| 3 | pos-order | 53.4 | 1,510 | **In progress — 77.9% line / 60.8% branch unit-only** (see §4.2) |
 | 4 | ~~pos-marketing~~ | 28.1 | 889 | **Done — now 87.9% line / 82.9% branch, 150 missed** (see §4.1) |
 | 5 | pos-people | 61.5 | 1,101 | Large gap, thin suite |
 | 6 | pos-invoice | 63.4 | 1,210 | Large gap, **0 ITs** |
@@ -329,6 +332,40 @@ Remaining 150 missed lines are controllers (30), Spring config (`OpenApiConfig`,
 `RestClientConfig`, `FlywayConfig`, `KafkaErrorHandlingConfig`, 40), and
 `LoggingMessageChannel`. Controllers want `@WebMvcTest` slices, which is a
 different shape of work; the module's business logic is done.
+
+### 4.2 pos-order progress (2026-08-11)
+
+Measured **unit-only** (`-DskipITs`), so these are not comparable to the §1.5
+figure, which included ITs. Unit-only baseline at the start of this pass was
+57.5% line / 44.0% branch, 1,377 missed.
+
+| | Unit-only baseline | Now |
+|---|---:|---:|
+| Line | 57.5% | **77.9%** |
+| Branch | 44.0% | **60.8%** |
+| Missed lines | 1,377 | **715** |
+
+Delivered:
+
+- **All five `ext_*` replica listeners** (customer, vehicle, product, location,
+  workorder — 339 missed lines at 0%). Their shared consumer contract is pinned
+  once, parameterized across all five, in `ReplicaListenerContractTest`; the
+  per-listener tests cover mapping, the aggregate-version guard, and the
+  snapshot-is-a-replacement rule for workorder lines. **This closes wave 1e for
+  `pos-order`.**
+- **`OrderDomainEventPublisher`** (148 missed at 2.6%) — the module's whole
+  outbound contract, including the R7.5 rule that a WORKORDER-sourced line is
+  not fulfillable.
+- **The four exception advices** (169 missed) — status/code pairings per endpoint
+  family, per-line over-cap field errors, correlation-id passthrough.
+
+Remaining in `pos-order`, largest first: `SalesOrderServiceImpl` (133 missed,
+72.4%), `ReturnOrderServiceImpl` (61, 77.4%), `RestInvoicingPortAdapter` (56,
+6.7%), `OrderTaxService` (53, 1.9%), `RegisterSessionServiceImpl` (39, 78.0%),
+`CatalogPricePricingAdapter` (34, 19.0%), `RegisterSessionController` (27),
+`ReturnOrderResponse`/`SessionReportResponse`/`RegisterSessionResponse` DTOs
+(60 combined at 0%), `OrderNumberService` (19), `ReplicaCustomerPortAdapter`
+(16).
 
 The per-module detail below predates the measurement and is kept for the specific
 class-level targets it names.

--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -1,9 +1,14 @@
 # Test Coverage Improvement Plan
 
-Status: proposed (no tests written yet — awaiting approval)
+Status: Phase 0 complete, Phase 1 complete. Phases 2–4 outstanding.
 Date: 2026-08-11
+
 Method: `.agents/skills/test-coverage-improver` workflow, adapted from its pnpm/JS
 assumptions to this Maven reactor; test authoring follows `.agents/skills/java-testing`.
+
+> **Sections 1.1–1.3 below describe the stale reports that motivated this plan.
+> They are kept for context but are superseded by the real measurement in
+> §1.5 — read that first.**
 
 ## 1. Baseline: what the existing reports actually say
 
@@ -84,6 +89,75 @@ cheap, high-count wins because one test template applies across ~30 modules:
    `CampaignSendServiceImpl` 68, `MessageTemplateServiceImpl` 61.
 6. **Config classes** — `FlywayConfig`, `GlobalExceptionHandler` partials.
 
+### 1.5 MEASURED BASELINE (2026-08-11, full reactor `verify`, BUILD SUCCESS in 44:21)
+
+This supersedes §1.1–1.3. Produced by the Phase 0 command below, including
+Failsafe ITs. The aggregate now reports 36 module groups instead of 29.
+
+| | Baseline |
+|---|---:|
+| Total lines | 73,833 |
+| **Line coverage** | **72.6%** |
+| **Branch coverage** | **59.5%** |
+| Missed lines | 20,265 |
+
+Per module, ordered by missed lines:
+
+| Module | Lines | Line% | Branch% | Missed |
+| --- | ---: | ---: | ---: | ---: |
+| pos-customer | 5,364 | 61.5 | 48.6 | 2,067 |
+| pos-workorder | 7,465 | 73.0 | 55.0 | 2,012 |
+| pos-inventory | 10,055 | 83.2 | 66.9 | 1,686 |
+| pos-order | 3,241 | 53.4 | 43.2 | 1,510 |
+| pos-accounting | 10,510 | 85.7 | 72.5 | 1,498 |
+| pos-mcp-server | 6,152 | 78.5 | 67.4 | 1,324 |
+| pos-invoice | 3,308 | 63.4 | 52.5 | 1,210 |
+| pos-people | 2,859 | 61.5 | 47.1 | 1,101 |
+| pos-catalog | 2,807 | 68.3 | 46.3 | 891 |
+| pos-marketing | 1,236 | 28.1 | 29.8 | 889 |
+| pos-people-contact | 1,477 | 45.6 | 26.9 | 803 |
+| pos-vehicle-inventory | 976 | 28.8 | 25.9 | 695 |
+| pos-security-service | 3,501 | 80.4 | 69.6 | 687 |
+| pos-shop-manager | 1,933 | 67.3 | 60.2 | 633 |
+| pos-location | 2,167 | 75.1 | 64.5 | 539 |
+| pos-bulk-loader | 1,770 | 73.9 | 64.9 | 462 |
+| pos-event-receiver | 437 | 3.0 | 0.0 | 424 |
+| pos-warranty | 2,561 | 85.7 | 79.5 | 367 |
+| pos-tax | 984 | 74.8 | 66.3 | 248 |
+| pos-document-helper | 374 | 44.4 | 25.9 | 208 |
+| pos-vehicle-reference-nhtsa | 189 | 0.0 | 0.0 | 189 |
+| pos-domain-events | 511 | 65.8 | 56.1 | 175 |
+| pos-vehicle-fitment | 542 | 77.9 | 62.9 | 120 |
+| pos-documents | 383 | 74.4 | 51.9 | 98 |
+| pos-security-common | 406 | 81.3 | 62.0 | 76 |
+| pos-vehicle-reference-carapi | 69 | 0.0 | 0.0 | 69 |
+| pos-api-gateway | 938 | 92.9 | 72.2 | 67 |
+| pos-image | 61 | 0.0 | 0.0 | 61 |
+| pos-price | 1,053 | 94.5 | 81.3 | 58 |
+| pos-events | 174 | 81.0 | 64.3 | 33 |
+| pos-tax-common | 100 | 79.0 | 46.4 | 21 |
+| pos-inquiry | 16 | 0.0 | — | 16 |
+| pos-shared-dtos | 34 | 61.8 | 8.8 | 13 |
+| pos-openapi-validation | 173 | 93.6 | 82.3 | 11 |
+| pos-service-discovery | 4 | 0.0 | — | 4 |
+| pos-bulk-ingest-lib | 3 | 100.0 | — | 0 |
+
+**Corrections to the assumptions in §1.2–1.3.** The three largest modules are
+not the worst covered — `pos-accounting` (85.7%), `pos-inventory` (83.2%), and
+`pos-warranty` (85.7%) are among the best. `pos-customer` is 61.5%, not the
+39.0% its stale per-module report showed. The genuinely thin modules are
+`pos-event-receiver` (3.0%), `pos-marketing` (28.1%), `pos-vehicle-inventory`
+(28.8%), `pos-document-helper` (44.4%), `pos-people-contact` (45.6%), and
+`pos-order` (53.4%).
+
+**Aggregate vs per-module numbers differ for shared libraries, and the
+difference matters for Phase 4.** `report-aggregate` merges exec data from every
+module, so a shared library gets credit for the coverage its consumers' tests
+produce: `pos-security-common` reads 81.3% in the aggregate but 29.7% in its own
+report; `pos-events` 81.0% vs 31.0%; `pos-shared-dtos` 61.8% vs 0%. A per-module
+JaCoCo `check` ratchet reads the **per-module** report, so its thresholds must be
+set from those lower numbers, not from this table.
+
 ## 2. Phase 0 — Restore a trustworthy baseline (blocking, no test code)
 
 Nothing downstream is worth doing until the numbers are real.
@@ -141,9 +215,100 @@ largest coverage delta available, and the tests are genuinely useful — they lo
 in the event/permission registration contract that `CLAUDE.md` marks
 non-negotiable.
 
+### 3.1 Phase 1 outcome (delivered 2026-08-11)
+
+**64 test files across 24 modules, all passing.** Waves 1a, 1b, and 1d are done;
+waves 1c and 1e were not attempted and remain open (see §3.3).
+
+Coverage delta measured on the first 11 modules verified: **395 missed lines
+recovered**. Largest movers:
+
+| Module | Before | After |
+| --- | ---: | ---: |
+| pos-event-receiver | 3.0% | 19.0% |
+| pos-security-common | 29.7% | 46.7% |
+| pos-events | 31.0% | 59.8% |
+| pos-tax | 74.8% | 78.5% |
+| pos-bulk-loader | 73.9% | 76.8% |
+| pos-catalog | 68.3% | 70.1% |
+| pos-invoice | 63.4% | 65.0% |
+
+The remaining 13 modules' contribution is **not measured** — the confirming
+full-reactor run was interrupted. Re-run the Phase 0 command to obtain the true
+post-Phase-1 repo-wide figure before setting any Phase 4 thresholds.
+
+The highest-value files are the two shared-library tests, since every module's
+startup registration delegates to them: `pos-events`
+`EventTypeInitializerSupportTest` (26 lines, previously 0%) and
+`pos-security-common` `PermissionRegistrationSupportTest` (77 lines, previously
+0%).
+
+### 3.2 Findings surfaced by the new tests
+
+1. **`WORKEXEC_DASHBOARD_TODAY_GET` uses hand-tuned thresholds** (1s/2s/3.5s)
+   rather than one of the four presets. Legitimate — it aggregates across every
+   open workorder for a location — so it is recorded as a documented exemption in
+   `pos-workorder` `EventTypesTest`, paired with a guard test that fails if the
+   exemption ever goes stale. Any *new* ad-hoc threshold in any module still
+   fails the build.
+2. **`pos-vehicle-inventory`'s `EventTypeInitializer` registers on a virtual
+   thread**, so `run()` returns before any PUT is issued. It is the only async
+   initializer in the reactor. Its tests await completion via Mockito
+   `timeout()`; a naive "did not throw" assertion is vacuous there and was
+   replaced with one that proves every type was still attempted.
+3. **`pos-order`'s `OutboxPublisher` diverges from its 12 siblings**: no
+   Micrometer counters, no `attempts` reset on success, and no class-name
+   fallback or length cap on `last_error`. The divergences are safe —
+   `last_error` is an unbounded `TEXT` column in both schemas — but they are easy
+   to erase by copying a sibling over it, so its bespoke test pins each one
+   explicitly.
+
+### 3.3 Phase 1 remainder
+
+- **Wave 1c (`{Module}PermissionRegistry`)** — not started. Only three modules
+  define a registry class (`pos-inventory`, `pos-customer`, `pos-marketing`); the
+  shared `PermissionRegistrationSupport` they extend is now covered, so the
+  remaining value here is small.
+- **Wave 1e (Kafka `*EventsListener`)** — not started, and it is the largest
+  remaining archetype: **78 listener classes** across the reactor, many at 0%
+  (`CustomerEventsListener` 145 missed lines, `VehicleEventsListener` 119,
+  `InventoryEventsListener` 72, `InventoryManifestListener` 49). Unlike the other
+  waves these are not uniform enough for one template, so expect per-module work.
+- **`ManifestPublisher`** (10 classes) was folded into wave 1d's scope in the
+  table above but not implemented; only `OutboxPublisher` was covered.
+
 ## 4. Phase 2 — Worst-covered domain services
 
-Ordered by missed lines in modules where we have data. Re-rank after Phase 0.
+**Re-ranked against the §1.5 measurement.** Phases 2 and 3 as originally written
+split "modules with data" from "modules without data"; that split no longer
+exists now that every module is measured. The merged priority order is:
+
+| # | Module | Line% | Missed | Why here |
+| ---: | --- | ---: | ---: | --- |
+| 1 | pos-event-receiver | 3.0 | 424 | Every service registers against it; lowest coverage in the reactor |
+| 2 | pos-customer | 61.5 | 2,067 | Largest absolute gap |
+| 3 | pos-order | 53.4 | 1,510 | Second-lowest coverage among large modules |
+| 4 | pos-marketing | 28.1 | 889 | Second-lowest coverage overall, 0 ITs |
+| 5 | pos-people | 61.5 | 1,101 | Large gap, thin suite |
+| 6 | pos-invoice | 63.4 | 1,210 | Large gap, **0 ITs** |
+| 7 | pos-workorder | 73.0 | 2,012 | Large absolute gap despite decent ratio |
+| 8 | pos-people-contact | 45.6 | 803 | Low ratio and low branch coverage (26.9%) |
+| 9 | pos-vehicle-inventory | 28.8 | 695 | Third-lowest coverage overall |
+| 10 | pos-catalog | 68.3 | 891 | Branch coverage (46.3%) is the real weakness |
+| 11 | pos-document-helper | 44.4 | 208 | Shared library; `DocumentServiceClient` 80 missed at 0% |
+| 12 | pos-shop-manager | 67.3 | 633 | |
+| 13 | pos-mcp-server | 78.5 | 1,324 | Large absolute gap despite good ratio |
+
+Deliberately **not** prioritized: `pos-accounting` (85.7%), `pos-inventory`
+(83.2%), `pos-warranty` (85.7%), `pos-security-service` (80.4%), `pos-price`
+(94.5%), `pos-api-gateway` (92.9%), `pos-openapi-validation` (93.6%).
+
+The four small modules at 0% — `pos-vehicle-reference-nhtsa` (189),
+`pos-vehicle-reference-carapi` (69), `pos-image` (61), `pos-inquiry` (16) — total
+335 missed lines and are cheap; treat them as filler work rather than a priority.
+
+The per-module detail below predates the measurement and is kept for the specific
+class-level targets it names.
 
 **pos-customer (39.0% → target 70%)** — largest measured gap, 3,270 missed lines.
 
@@ -179,10 +344,21 @@ the real weakness.
 **pos-price (94.3%)** — leave alone. Already the reference standard; use its test
 style as the template for other modules.
 
-## 5. Phase 3 — Modules with no coverage data and thin test suites
+## 5. Phase 3 — (merged into Phase 2)
 
-Sequenced after Phase 0 reveals actual numbers. Provisional order by
-main-class count × test-density deficit:
+Every module now has real coverage data, so the "no data" distinction that
+defined this phase is gone; its modules are folded into the §4 priority table.
+The list below is retained only for the two structural gaps it records, which the
+measurement does not show:
+
+- `pos-invoice` (178 main classes) and `pos-warranty` (144) have **zero
+  integration tests**. Both need a Failsafe IT layer, not just more unit tests —
+  `pos-warranty` reaching 85.7% on unit tests alone means its persistence and
+  transaction boundaries are untested.
+- `pos-tax-common` has **zero test classes** of its own (its 79.0% aggregate
+  reading comes entirely from consumers' tests).
+
+Original provisional ordering, superseded by §4:
 
 1. `pos-inventory` (584 main) — largest surface in the repo.
 2. `pos-accounting` (505 main) — financial posting semantics; highest blast
@@ -201,14 +377,22 @@ Only after real numbers exist and the first waves land:
 
 1. Add a JaCoCo `check` rule with per-module minimums set slightly **below**
    each module's measured baseline (ratchet, never a cliff). Do not set a single
-   repo-wide 80% bar — it would fail ~30 modules on day one.
+   repo-wide 80% bar — at the measured 72.6% it would fail roughly half the
+   reactor on day one. Two constraints from §1.5: set thresholds from each
+   module's **own** report, not the aggregate (shared libraries read far higher in
+   the aggregate), and re-measure after Phase 1 first — the numbers in §1.5 are
+   pre-Phase-1 for 13 of the 24 modules that received tests.
 2. Wire the aggregate XML into the existing SonarCloud step so the coverage
    number is visible per PR.
-3. Consider excluding genuinely untestable generated code (JPA metamodel,
-   OpenAPI-generated clients, `PosXApplication` mains) via
-   `jacoco.excludes`. Note: commit `8dd877415` added exclusion annotations, but
-   no `jacoco.excludes` / `<excludes>` configuration is present in the root
-   `pom.xml` today — verify whether that work is complete.
+3. ~~Consider excluding generated code via `jacoco.excludes`.~~ **Resolved — no
+   work needed.** Commit `8dd877415` added
+   `com.positivity.shared.annotation.@CoverageGenerated` (`@Retention(CLASS)`),
+   whose name ends in `Generated`, so JaCoCo's built-in generated-code filter
+   excludes annotated types automatically — no `jacoco.excludes` configuration
+   is required. It is currently applied to the 24 `Pos*Application` mains only,
+   which matches the annotation's own instruction not to apply it to handwritten
+   business behavior. Extend it case by case if genuinely mechanical code shows
+   up in a coverage gap; do not use it to hide untested logic.
 
 ## 7. Standing conventions for every test written under this plan
 

--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -291,7 +291,7 @@ exists now that every module is measured. The merged priority order is:
 | ---: | --- | ---: | ---: | --- |
 | 1 | ~~pos-event-receiver~~ | 3.0 | 424 | **Done** — every service registers against it; was lowest in the reactor |
 | 2 | pos-customer | 61.5 | 2,067 | Largest absolute gap; several waves landed, not yet re-measured |
-| 3 | pos-order | 53.4 | 1,510 | **In progress — 77.9% line / 60.8% branch unit-only** (see §4.2) |
+| 3 | pos-order | 53.4 | 1,510 | **In progress — 83.6% line / 67.7% branch unit-only** (see §4.2) |
 | 4 | ~~pos-marketing~~ | 28.1 | 889 | **Done — now 87.9% line / 82.9% branch, 150 missed** (see §4.1) |
 | 5 | pos-people | 61.5 | 1,101 | Large gap, thin suite |
 | 6 | pos-invoice | 63.4 | 1,210 | Large gap, **0 ITs** |
@@ -341,9 +341,9 @@ figure, which included ITs. Unit-only baseline at the start of this pass was
 
 | | Unit-only baseline | Now |
 |---|---:|---:|
-| Line | 57.5% | **77.9%** |
-| Branch | 44.0% | **60.8%** |
-| Missed lines | 1,377 | **715** |
+| Line | 57.5% | **83.6%** |
+| Branch | 44.0% | **67.7%** |
+| Missed lines | 1,377 | **530** |
 
 Delivered:
 
@@ -358,14 +358,21 @@ Delivered:
   not fulfillable.
 - **The four exception advices** (169 missed) — status/code pairings per endpoint
   family, per-line over-cap field errors, correlation-id passthrough.
+- **`OrderTaxService`** (53 at 1.9%) — every jurisdiction/tax failure raises
+  `TaxUnavailableException` instead of defaulting to zero.
+- **`RestInvoicingPortAdapter`** (56 at 6.7%) and **`CatalogPricePricingAdapter`**
+  (34 at 19.0%) — the module's two synchronous outbound calls, via
+  `MockRestServiceServer`.
+- **`ReplicaCustomerPortAdapter`** (16 at 5.9%) and **`OrderNumberService`**
+  (19 at 5.0%).
 
 Remaining in `pos-order`, largest first: `SalesOrderServiceImpl` (133 missed,
-72.4%), `ReturnOrderServiceImpl` (61, 77.4%), `RestInvoicingPortAdapter` (56,
-6.7%), `OrderTaxService` (53, 1.9%), `RegisterSessionServiceImpl` (39, 78.0%),
-`CatalogPricePricingAdapter` (34, 19.0%), `RegisterSessionController` (27),
-`ReturnOrderResponse`/`SessionReportResponse`/`RegisterSessionResponse` DTOs
-(60 combined at 0%), `OrderNumberService` (19), `ReplicaCustomerPortAdapter`
-(16).
+72.4%), `ReturnOrderServiceImpl` (61, 77.4%), `RegisterSessionServiceImpl` (39,
+78.0%), `RegisterSessionController` (27, 3.6%), `ReturnOrderController` (22,
+4.3%), the `ReturnOrderResponse`/`SessionReportResponse`/`RegisterSessionResponse`
+DTOs (60 combined at 0%, all static `from(...)` mappers), `PaymentEventsListener`
+(19, 83.9%), `PriceOverrideServiceImpl` (16, 93.2%). The two controllers want
+`@WebMvcTest` slices; the rest are ordinary unit work.
 
 The per-module detail below predates the measurement and is kept for the specific
 class-level targets it names.

--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,22 @@
 						</palantirJavaFormat>
 					</java>
 				</configuration>
+				<executions>
+					<!-- Gate formatting in the build rather than relying on contributors to
+					     remember `spotless:apply`. Without a lifecycle binding Spotless only
+					     ran when invoked by hand, and 24 files had drifted out of Palantir
+					     format on main before this binding was added.
+
+					     Bound to validate so it fails in seconds, before compilation, and
+					     skippable with -Dspotless.check.skip=true for a fast local loop. -->
+					<execution>
+						<id>spotless-check</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/AccountingPeriodController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/AccountingPeriodController.java
@@ -48,154 +48,248 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/v1/accounting/periods")
-@Tag(name = "Accounting Periods", description = "Accounting period lifecycle: list periods, close a period, reopen a closed period,"
+@Tag(
+        name = "Accounting Periods",
+        description = "Accounting period lifecycle: list periods, close a period, reopen a closed period,"
                 + " and manage the org-level hard-lock date.")
 @RequiredArgsConstructor
 @Validated
 public class AccountingPeriodController {
 
-        private static final Logger log = LoggerFactory.getLogger(AccountingPeriodController.class);
+    private static final Logger log = LoggerFactory.getLogger(AccountingPeriodController.class);
 
-        private final AccountingPeriodService accountingPeriodService;
-        private final AccountingConfigurationService accountingConfigurationService;
+    private final AccountingPeriodService accountingPeriodService;
+    private final AccountingConfigurationService accountingConfigurationService;
 
-        @GetMapping
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:period:view" })
-        @PreAuthorize("hasAuthority('accounting:period:view')")
-        @EmitEvent(id = "ACCOUNTING_PERIOD_LIST", apiVersion = "1")
-        @Operation(summary = "List accounting periods", operationId = "listAccountingPeriods", description = "Lists all known accounting periods, most recent first (descending period code)."
-                        + " Use this tool to review period statuses before closing or reopening a period."
-                        + " Periods are auto-provisioned on first posting, so months never posted into may be absent;"
-                        + " an absent month counts as OPEN for posting purposes."
-                        + " No preconditions and no side effects; nothing is created by this call.", tags = {
-                                        "Accounting Periods" })
-        @ApiResponse(responseCode = "200", description = "Accounting periods listed, most recent first", content = @Content(array = @ArraySchema(schema = @Schema(implementation = AccountingPeriodResponse.class))))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:period:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<List<AccountingPeriodResponse>> listAccountingPeriods() {
-                log.info("List accounting periods");
-                List<AccountingPeriodResponse> response = accountingPeriodService.listPeriods();
-                return ResponseEntity.ok(response);
+    @GetMapping
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:period:view"})
+    @PreAuthorize("hasAuthority('accounting:period:view')")
+    @EmitEvent(id = "ACCOUNTING_PERIOD_LIST", apiVersion = "1")
+    @Operation(
+            summary = "List accounting periods",
+            operationId = "listAccountingPeriods",
+            description = "Lists all known accounting periods, most recent first (descending period code)."
+                    + " Use this tool to review period statuses before closing or reopening a period."
+                    + " Periods are auto-provisioned on first posting, so months never posted into may be absent;"
+                    + " an absent month counts as OPEN for posting purposes."
+                    + " No preconditions and no side effects; nothing is created by this call.",
+            tags = {"Accounting Periods"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Accounting periods listed, most recent first",
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = AccountingPeriodResponse.class))))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:period:view permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<List<AccountingPeriodResponse>> listAccountingPeriods() {
+        log.info("List accounting periods");
+        List<AccountingPeriodResponse> response = accountingPeriodService.listPeriods();
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{periodCode}/close")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:period:close"})
+    @PreAuthorize("hasAuthority('accounting:period:close')")
+    @EmitEvent(id = "ACCOUNTING_PERIOD_CLOSE", apiVersion = "1")
+    @Operation(
+            summary = "Close an accounting period",
+            operationId = "closeAccountingPeriod",
+            description = "Closes an OPEN accounting period (OPEN → CLOSED), recording its lifecycle status as"
+                    + " CLOSED. Use this tool during month-end close after all journal entries for the month"
+                    + " are posted; use reopenAccountingPeriod to reverse the transition."
+                    + " Note: journal-entry posting paths do not yet reject postings dated into a CLOSED period;"
+                    + " that enforcement (error code PERIOD_CLOSED) arrives with the period-enforcement story"
+                    + " (parity-B2)."
+                    + " Preconditions: the period must not already be CLOSED, and no DRAFT journal entries may"
+                    + " be dated inside the period. A valid YYYY-MM period with no row whose month has already"
+                    + " started is auto-provisioned and then closed."
+                    + " The close is audit-logged with the acting user and emits ACCOUNTING_PERIOD_CLOSE."
+                    + " Returns 409 PERIOD_ALREADY_CLOSED if the period is already closed, and 422"
+                    + " PERIOD_HAS_DRAFT_ENTRIES listing the blocking draft journal entry IDs in fieldErrors —"
+                    + " post or delete those entries before retrying.",
+            tags = {"Accounting Periods"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Period closed; the updated period is returned",
+            content = @Content(schema = @Schema(implementation = AccountingPeriodResponse.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "periodCode is not a valid YYYY-MM period code",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:period:close permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Period not found and its month has not started (PERIOD_NOT_FOUND)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Period is already closed (PERIOD_ALREADY_CLOSED)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "DRAFT journal entries are dated inside the period (PERIOD_HAS_DRAFT_ENTRIES);"
+                    + " fieldErrors lists the blocking draftJournalEntryIds",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<AccountingPeriodResponse> closeAccountingPeriod(
+            @Parameter(description = "Period code in YYYY-MM format", required = true, example = "2026-06")
+                    @PathVariable
+                    @NonNull
+                    String periodCode) {
+        if (log.isInfoEnabled()) {
+            log.info("Close accounting period {}", sanitizeForLog(periodCode));
         }
+        AccountingPeriodResponse response = accountingPeriodService.closePeriod(periodCode);
+        return ResponseEntity.ok(response);
+    }
 
-        @PostMapping("/{periodCode}/close")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:period:close" })
-        @PreAuthorize("hasAuthority('accounting:period:close')")
-        @EmitEvent(id = "ACCOUNTING_PERIOD_CLOSE", apiVersion = "1")
-        @Operation(summary = "Close an accounting period", operationId = "closeAccountingPeriod", description = "Closes an OPEN accounting period (OPEN → CLOSED), recording its lifecycle status as"
-                        + " CLOSED. Use this tool during month-end close after all journal entries for the month"
-                        + " are posted; use reopenAccountingPeriod to reverse the transition."
-                        + " Note: journal-entry posting paths do not yet reject postings dated into a CLOSED period;"
-                        + " that enforcement (error code PERIOD_CLOSED) arrives with the period-enforcement story"
-                        + " (parity-B2)."
-                        + " Preconditions: the period must not already be CLOSED, and no DRAFT journal entries may"
-                        + " be dated inside the period. A valid YYYY-MM period with no row whose month has already"
-                        + " started is auto-provisioned and then closed."
-                        + " The close is audit-logged with the acting user and emits ACCOUNTING_PERIOD_CLOSE."
-                        + " Returns 409 PERIOD_ALREADY_CLOSED if the period is already closed, and 422"
-                        + " PERIOD_HAS_DRAFT_ENTRIES listing the blocking draft journal entry IDs in fieldErrors —"
-                        + " post or delete those entries before retrying.", tags = { "Accounting Periods" })
-        @ApiResponse(responseCode = "200", description = "Period closed; the updated period is returned", content = @Content(schema = @Schema(implementation = AccountingPeriodResponse.class)))
-        @ApiResponse(responseCode = "400", description = "periodCode is not a valid YYYY-MM period code", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:period:close permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "Period not found and its month has not started (PERIOD_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "409", description = "Period is already closed (PERIOD_ALREADY_CLOSED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "422", description = "DRAFT journal entries are dated inside the period (PERIOD_HAS_DRAFT_ENTRIES);"
-                        + " fieldErrors lists the blocking draftJournalEntryIds", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<AccountingPeriodResponse> closeAccountingPeriod(
-                        @Parameter(description = "Period code in YYYY-MM format", required = true, example = "2026-06") @PathVariable @NonNull String periodCode) {
-                if (log.isInfoEnabled()) {
-                        log.info("Close accounting period {}", sanitizeForLog(periodCode));
-                }
-                AccountingPeriodResponse response = accountingPeriodService.closePeriod(periodCode);
-                return ResponseEntity.ok(response);
+    @PostMapping("/{periodCode}/reopen")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:period:reopen"})
+    @PreAuthorize("hasAuthority('accounting:period:reopen')")
+    @EmitEvent(id = "ACCOUNTING_PERIOD_REOPEN", apiVersion = "1")
+    @Operation(
+            summary = "Reopen a closed accounting period",
+            operationId = "reopenAccountingPeriod",
+            description = "Reopens a CLOSED accounting period (CLOSED → OPEN), resetting its lifecycle status"
+                    + " to OPEN."
+                    + " Use this tool only when late adjustments must be posted into an already-closed month;"
+                    + " use closeAccountingPeriod to close it again afterwards."
+                    + " Preconditions: a period row must exist for the code and be CLOSED."
+                    + " Required input: a non-blank justification (max 500 characters) which is recorded on the"
+                    + " period and in the audit trail with the acting user."
+                    + " Emits ACCOUNTING_PERIOD_REOPEN. Returns 409 PERIOD_ALREADY_OPEN if the period is not"
+                    + " closed, and 400 if the justification is missing or blank.",
+            tags = {"Accounting Periods"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Period reopened; the updated period is returned",
+            content = @Content(schema = @Schema(implementation = AccountingPeriodResponse.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "periodCode is not a valid YYYY-MM period code, or justification is missing or blank",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:period:reopen permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "No period row exists for the code (PERIOD_NOT_FOUND)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Period is already open (PERIOD_ALREADY_OPEN)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<AccountingPeriodResponse> reopenAccountingPeriod(
+            @Parameter(description = "Period code in YYYY-MM format", required = true, example = "2026-06")
+                    @PathVariable
+                    @NonNull
+                    String periodCode,
+            @Valid @RequestBody @NonNull AccountingPeriodReopenRequest request) {
+        if (log.isInfoEnabled()) {
+            log.info("Reopen accounting period {}", sanitizeForLog(periodCode));
         }
+        AccountingPeriodResponse response =
+                accountingPeriodService.reopenPeriod(periodCode, request.getJustification());
+        return ResponseEntity.ok(response);
+    }
 
-        @PostMapping("/{periodCode}/reopen")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:period:reopen" })
-        @PreAuthorize("hasAuthority('accounting:period:reopen')")
-        @EmitEvent(id = "ACCOUNTING_PERIOD_REOPEN", apiVersion = "1")
-        @Operation(summary = "Reopen a closed accounting period", operationId = "reopenAccountingPeriod", description = "Reopens a CLOSED accounting period (CLOSED → OPEN), resetting its lifecycle status"
-                        + " to OPEN."
-                        + " Use this tool only when late adjustments must be posted into an already-closed month;"
-                        + " use closeAccountingPeriod to close it again afterwards."
-                        + " Preconditions: a period row must exist for the code and be CLOSED."
-                        + " Required input: a non-blank justification (max 500 characters) which is recorded on the"
-                        + " period and in the audit trail with the acting user."
-                        + " Emits ACCOUNTING_PERIOD_REOPEN. Returns 409 PERIOD_ALREADY_OPEN if the period is not"
-                        + " closed, and 400 if the justification is missing or blank.", tags = { "Accounting Periods" })
-        @ApiResponse(responseCode = "200", description = "Period reopened; the updated period is returned", content = @Content(schema = @Schema(implementation = AccountingPeriodResponse.class)))
-        @ApiResponse(responseCode = "400", description = "periodCode is not a valid YYYY-MM period code, or justification is missing or blank", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:period:reopen permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "No period row exists for the code (PERIOD_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "409", description = "Period is already open (PERIOD_ALREADY_OPEN)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<AccountingPeriodResponse> reopenAccountingPeriod(
-                        @Parameter(description = "Period code in YYYY-MM format", required = true, example = "2026-06") @PathVariable @NonNull String periodCode,
-                        @Valid @RequestBody @NonNull AccountingPeriodReopenRequest request) {
-                if (log.isInfoEnabled()) {
-                        log.info("Reopen accounting period {}", sanitizeForLog(periodCode));
-                }
-                AccountingPeriodResponse response = accountingPeriodService.reopenPeriod(periodCode,
-                                request.getJustification());
-                return ResponseEntity.ok(response);
-        }
+    @GetMapping("/hard-lock")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:period:view"})
+    @PreAuthorize("hasAuthority('accounting:period:view')")
+    @EmitEvent(id = "ACCOUNTING_PERIOD_HARD_LOCK_VIEW", apiVersion = "1")
+    @Operation(
+            summary = "Get the accounting hard-lock date",
+            operationId = "getAccountingHardLockDate",
+            description = "Returns the org-level hard-lock date: journal entries dated strictly before this"
+                    + " date are permanently rejected (422 PERIOD_HARD_LOCKED) with no override path — unlike"
+                    + " a CLOSED period, which accounting:period:override plus a justification can bypass."
+                    + " Use this tool to check the current lock boundary before posting backdated entries or"
+                    + " before moving the lock with setAccountingHardLockDate."
+                    + " Returns hardLockDate: null when no hard lock has been configured yet."
+                    + " No preconditions and no side effects.",
+            tags = {"Accounting Periods"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Current hard-lock date returned; hardLockDate is null when no hard lock is set",
+            content = @Content(schema = @Schema(implementation = HardLockDateResponse.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:period:view permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<HardLockDateResponse> getHardLockDate() {
+        log.debug("Get accounting hard-lock date");
+        LocalDate hardLockDate =
+                accountingConfigurationService.getHardLockDate().orElse(null);
+        return ResponseEntity.ok(new HardLockDateResponse(hardLockDate));
+    }
 
-        @GetMapping("/hard-lock")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:period:view" })
-        @PreAuthorize("hasAuthority('accounting:period:view')")
-        @EmitEvent(id = "ACCOUNTING_PERIOD_HARD_LOCK_VIEW", apiVersion = "1")
-        @Operation(summary = "Get the accounting hard-lock date", operationId = "getAccountingHardLockDate", description = "Returns the org-level hard-lock date: journal entries dated strictly before this"
-                        + " date are permanently rejected (422 PERIOD_HARD_LOCKED) with no override path — unlike"
-                        + " a CLOSED period, which accounting:period:override plus a justification can bypass."
-                        + " Use this tool to check the current lock boundary before posting backdated entries or"
-                        + " before moving the lock with setAccountingHardLockDate."
-                        + " Returns hardLockDate: null when no hard lock has been configured yet."
-                        + " No preconditions and no side effects.", tags = { "Accounting Periods" })
-        @ApiResponse(responseCode = "200", description = "Current hard-lock date returned; hardLockDate is null when no hard lock is set", content = @Content(schema = @Schema(implementation = HardLockDateResponse.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:period:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<HardLockDateResponse> getHardLockDate() {
-                log.debug("Get accounting hard-lock date");
-                LocalDate hardLockDate = accountingConfigurationService.getHardLockDate().orElse(null);
-                return ResponseEntity.ok(new HardLockDateResponse(hardLockDate));
+    @PutMapping("/hard-lock")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:period:hard_lock"})
+    @PreAuthorize("hasAuthority('accounting:period:hard_lock')")
+    @EmitEvent(id = "ACCOUNTING_PERIOD_HARD_LOCK_SET", apiVersion = "1")
+    @Operation(
+            summary = "Set the accounting hard-lock date",
+            operationId = "setAccountingHardLockDate",
+            description = "Sets the org-level hard-lock date: from then on, journal entries dated strictly"
+                    + " before this date are permanently rejected (422 PERIOD_HARD_LOCKED) with NO override"
+                    + " path — not even accounting:period:override can bypass it (that permission only covers"
+                    + " CLOSED periods, error PERIOD_CLOSED)."
+                    + " Use this tool after statutory filings or audits to make history immutable; use"
+                    + " closeAccountingPeriod for the reversible month-end close instead."
+                    + " The date is monotonic-forward-only: it must be on or after the currently stored"
+                    + " hard-lock date, and moving it backward is rejected with 422 HARD_LOCK_DATE_REGRESSION"
+                    + " — effectively irreversible, so set it deliberately."
+                    + " Required inputs: hardLockDate (ISO date) and a non-blank justification (max 500"
+                    + " characters), recorded in the audit trail with the acting user."
+                    + " Emits ACCOUNTING_PERIOD_HARD_LOCK_SET and returns the stored hard-lock date."
+                    + " Returns 400 if the date is missing or the justification is missing or blank.",
+            tags = {"Accounting Periods"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Hard-lock date updated; the stored value is returned",
+            content = @Content(schema = @Schema(implementation = HardLockDateResponse.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "hardLockDate is missing, or justification is missing, blank, or over 500 characters"
+                    + " (ARGUMENT_NOT_VALID)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:period:hard_lock permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "Requested date is before the currently stored hard-lock date"
+                    + " (HARD_LOCK_DATE_REGRESSION) — the hard lock only moves forward",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<HardLockDateResponse> setHardLockDate(
+            @Valid @RequestBody @NonNull HardLockDateUpdateRequest request) {
+        if (log.isInfoEnabled()) {
+            log.info("Set accounting hard-lock date to {}", sanitizeForLog(request.getHardLockDate()));
         }
+        LocalDate stored =
+                accountingConfigurationService.setHardLockDate(request.getHardLockDate(), request.getJustification());
+        return ResponseEntity.ok(new HardLockDateResponse(stored));
+    }
 
-        @PutMapping("/hard-lock")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:period:hard_lock" })
-        @PreAuthorize("hasAuthority('accounting:period:hard_lock')")
-        @EmitEvent(id = "ACCOUNTING_PERIOD_HARD_LOCK_SET", apiVersion = "1")
-        @Operation(summary = "Set the accounting hard-lock date", operationId = "setAccountingHardLockDate", description = "Sets the org-level hard-lock date: from then on, journal entries dated strictly"
-                        + " before this date are permanently rejected (422 PERIOD_HARD_LOCKED) with NO override"
-                        + " path — not even accounting:period:override can bypass it (that permission only covers"
-                        + " CLOSED periods, error PERIOD_CLOSED)."
-                        + " Use this tool after statutory filings or audits to make history immutable; use"
-                        + " closeAccountingPeriod for the reversible month-end close instead."
-                        + " The date is monotonic-forward-only: it must be on or after the currently stored"
-                        + " hard-lock date, and moving it backward is rejected with 422 HARD_LOCK_DATE_REGRESSION"
-                        + " — effectively irreversible, so set it deliberately."
-                        + " Required inputs: hardLockDate (ISO date) and a non-blank justification (max 500"
-                        + " characters), recorded in the audit trail with the acting user."
-                        + " Emits ACCOUNTING_PERIOD_HARD_LOCK_SET and returns the stored hard-lock date."
-                        + " Returns 400 if the date is missing or the justification is missing or blank.", tags = {
-                                        "Accounting Periods" })
-        @ApiResponse(responseCode = "200", description = "Hard-lock date updated; the stored value is returned", content = @Content(schema = @Schema(implementation = HardLockDateResponse.class)))
-        @ApiResponse(responseCode = "400", description = "hardLockDate is missing, or justification is missing, blank, or over 500 characters"
-                        + " (ARGUMENT_NOT_VALID)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:period:hard_lock permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "422", description = "Requested date is before the currently stored hard-lock date"
-                        + " (HARD_LOCK_DATE_REGRESSION) — the hard lock only moves forward", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<HardLockDateResponse> setHardLockDate(
-                        @Valid @RequestBody @NonNull HardLockDateUpdateRequest request) {
-                if (log.isInfoEnabled()) {
-                        log.info("Set accounting hard-lock date to {}", sanitizeForLog(request.getHardLockDate()));
-                }
-                LocalDate stored = accountingConfigurationService.setHardLockDate(request.getHardLockDate(),
-                                request.getJustification());
-                return ResponseEntity.ok(new HardLockDateResponse(stored));
+    private static String sanitizeForLog(@Nullable Object value) {
+        if (value == null) {
+            return "null";
         }
-
-        private static String sanitizeForLog(@Nullable Object value) {
-                if (value == null) {
-                        return "null";
-                }
-                return value.toString().replace('\n', '_').replace('\r', '_');
-        }
+        return value.toString().replace('\n', '_').replace('\r', '_');
+    }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/BankReconciliationController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/BankReconciliationController.java
@@ -61,222 +61,400 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/v1/accounting/reconciliations")
-@Tag(name = "Bank Reconciliation", description = "Manual CSV bank reconciliation: import a statement, match lines to posted GL entries,"
+@Tag(
+        name = "Bank Reconciliation",
+        description = "Manual CSV bank reconciliation: import a statement, match lines to posted GL entries,"
                 + " record adjustments, and finalize when balanced.")
 @RequiredArgsConstructor
 @Validated
 public class BankReconciliationController {
 
-        private static final Logger log = LoggerFactory.getLogger(BankReconciliationController.class);
+    private static final Logger log = LoggerFactory.getLogger(BankReconciliationController.class);
 
-        private final BankReconciliationService bankReconciliationService;
+    private final BankReconciliationService bankReconciliationService;
 
-        @PostMapping("/import")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
-        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_IMPORT", apiVersion = "1")
-        @Operation(summary = "Import a bank statement CSV and start a reconciliation", operationId = "importReconciliation", description = "Parses a bank statement CSV (columns: date, description, amount [signed], reference) for a"
-                        + " reconcilable GL cash account and creates an IN_PROGRESS reconciliation with its imported"
-                        + " statement lines (UNMATCHED). The GL ending balance is snapshotted from posted journal-entry"
-                        + " lines on the account as-of the statement date. Returns 422 ACCOUNT_NOT_RECONCILABLE if the"
-                        + " account's reconcilable flag (story H1) is false, and 400 if the CSV is malformed.", tags = {
-                                        "Bank Reconciliation" })
-        @ApiResponse(responseCode = "200", description = "Reconciliation created", content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
-        @ApiResponse(responseCode = "400", description = "Request body invalid or CSV malformed (ARGUMENT_NOT_VALID / VALIDATION_ERROR)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "422", description = "GL account is not reconcilable (ACCOUNT_NOT_RECONCILABLE)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<BankReconciliationResponse> importReconciliation(
-                        @Valid @RequestBody @NonNull BankReconciliationImportRequest request) {
-                if (log.isInfoEnabled()) {
-                        log.info("Import bank reconciliation for account {}", sanitizeForLog(request.getGlAccountId()));
-                }
-                return ResponseEntity.ok(bankReconciliationService.importStatement(request));
+    @PostMapping("/import")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:reconciliation:adjust"})
+    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_IMPORT", apiVersion = "1")
+    @Operation(
+            summary = "Import a bank statement CSV and start a reconciliation",
+            operationId = "importReconciliation",
+            description = "Parses a bank statement CSV (columns: date, description, amount [signed], reference) for a"
+                    + " reconcilable GL cash account and creates an IN_PROGRESS reconciliation with its imported"
+                    + " statement lines (UNMATCHED). The GL ending balance is snapshotted from posted journal-entry"
+                    + " lines on the account as-of the statement date. Returns 422 ACCOUNT_NOT_RECONCILABLE if the"
+                    + " account's reconcilable flag (story H1) is false, and 400 if the CSV is malformed.",
+            tags = {"Bank Reconciliation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Reconciliation created",
+            content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "Request body invalid or CSV malformed (ARGUMENT_NOT_VALID / VALIDATION_ERROR)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:reconciliation:adjust permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "GL account is not reconcilable (ACCOUNT_NOT_RECONCILABLE)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<BankReconciliationResponse> importReconciliation(
+            @Valid @RequestBody @NonNull BankReconciliationImportRequest request) {
+        if (log.isInfoEnabled()) {
+            log.info("Import bank reconciliation for account {}", sanitizeForLog(request.getGlAccountId()));
         }
+        return ResponseEntity.ok(bankReconciliationService.importStatement(request));
+    }
 
-        @GetMapping("/adjustment-types")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:view" })
-        @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
-        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_ADJUSTMENT_TYPES_LIST", apiVersion = "1")
-        @Operation(summary = "List reconciliation adjustment types", operationId = "listReconciliationAdjustmentTypes", description = "Returns the supported reconciliation adjustment types (decision D-6) so the frontend never"
-                        + " hardcodes the enum. No preconditions and no side effects.", tags = {
-                                        "Bank Reconciliation" })
-        @ApiResponse(responseCode = "200", description = "Adjustment types listed", content = @Content(array = @ArraySchema(schema = @Schema(implementation = AdjustmentTypeResponse.class))))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<List<AdjustmentTypeResponse>> listAdjustmentTypes() {
-                List<AdjustmentTypeResponse> types = Arrays.stream(BankAdjustmentType.values())
-                                .map(AdjustmentTypeResponse::from)
-                                .toList();
-                return ResponseEntity.ok(types);
-        }
+    @GetMapping("/adjustment-types")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:reconciliation:view"})
+    @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
+    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_ADJUSTMENT_TYPES_LIST", apiVersion = "1")
+    @Operation(
+            summary = "List reconciliation adjustment types",
+            operationId = "listReconciliationAdjustmentTypes",
+            description = "Returns the supported reconciliation adjustment types (decision D-6) so the frontend never"
+                    + " hardcodes the enum. No preconditions and no side effects.",
+            tags = {"Bank Reconciliation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Adjustment types listed",
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = AdjustmentTypeResponse.class))))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:reconciliation:view permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<List<AdjustmentTypeResponse>> listAdjustmentTypes() {
+        List<AdjustmentTypeResponse> types = Arrays.stream(BankAdjustmentType.values())
+                .map(AdjustmentTypeResponse::from)
+                .toList();
+        return ResponseEntity.ok(types);
+    }
 
-        @GetMapping
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:view" })
-        @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
-        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_LIST", apiVersion = "1")
-        @Operation(summary = "List reconciliations", operationId = "listReconciliations", description = "Lists reconciliations, optionally filtered by glAccountId and/or status, most recent first."
-                        + " Paginated. No side effects.", tags = { "Bank Reconciliation" })
-        @ApiResponse(responseCode = "200", description = "Reconciliations listed", content = @Content(schema = @Schema(implementation = BankReconciliationListResponse.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<BankReconciliationListResponse> listReconciliations(
-                        @Parameter(description = "Filter by reconciled GL account id") @RequestParam(required = false) UUID glAccountId,
-                        @Parameter(description = "Filter by reconciliation status") @RequestParam(required = false) ReconciliationStatus status,
-                        @Parameter(description = "Zero-based page index", example = "0") @RequestParam(defaultValue = "0") int page,
-                        @Parameter(description = "Page size", example = "20") @RequestParam(defaultValue = "20") int size) {
-                Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-                return ResponseEntity.ok(bankReconciliationService.list(glAccountId, status, pageable));
-        }
+    @GetMapping
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:reconciliation:view"})
+    @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
+    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_LIST", apiVersion = "1")
+    @Operation(
+            summary = "List reconciliations",
+            operationId = "listReconciliations",
+            description = "Lists reconciliations, optionally filtered by glAccountId and/or status, most recent first."
+                    + " Paginated. No side effects.",
+            tags = {"Bank Reconciliation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Reconciliations listed",
+            content = @Content(schema = @Schema(implementation = BankReconciliationListResponse.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:reconciliation:view permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<BankReconciliationListResponse> listReconciliations(
+            @Parameter(description = "Filter by reconciled GL account id") @RequestParam(required = false)
+                    UUID glAccountId,
+            @Parameter(description = "Filter by reconciliation status") @RequestParam(required = false)
+                    ReconciliationStatus status,
+            @Parameter(description = "Zero-based page index", example = "0") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size", example = "20") @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return ResponseEntity.ok(bankReconciliationService.list(glAccountId, status, pageable));
+    }
 
-        @GetMapping("/{reconciliationId}")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:view" })
-        @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
-        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_GET", apiVersion = "1")
-        @Operation(summary = "Get a reconciliation", operationId = "getReconciliation", description = "Returns one reconciliation with its imported statement lines and adjustments. Returns 404"
-                        + " RECONCILIATION_NOT_FOUND if the id is unknown.", tags = { "Bank Reconciliation" })
-        @ApiResponse(responseCode = "200", description = "Reconciliation found", content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<BankReconciliationResponse> getReconciliation(
-                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
-                return ResponseEntity.ok(bankReconciliationService.get(reconciliationId));
-        }
+    @GetMapping("/{reconciliationId}")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:reconciliation:view"})
+    @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
+    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_GET", apiVersion = "1")
+    @Operation(
+            summary = "Get a reconciliation",
+            operationId = "getReconciliation",
+            description = "Returns one reconciliation with its imported statement lines and adjustments. Returns 404"
+                    + " RECONCILIATION_NOT_FOUND if the id is unknown.",
+            tags = {"Bank Reconciliation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Reconciliation found",
+            content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:reconciliation:view permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<BankReconciliationResponse> getReconciliation(
+            @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
+        return ResponseEntity.ok(bankReconciliationService.get(reconciliationId));
+    }
 
-        @PostMapping("/{reconciliationId}/match")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
-        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_MATCH", apiVersion = "1")
-        @Operation(summary = "Match statement lines to GL lines", operationId = "matchReconciliation", description = "Matches a set of statement lines to a set of posted GL journal-entry lines on the reconciled"
-                        + " account (1-to-1 or N-to-1). The two sets must net to equal signed amounts within ±0.01."
-                        + " Marks the statement lines MATCHED and records the linkage. Returns 404"
-                        + " RECONCILIATION_NOT_FOUND if the reconciliation or a line is missing, 409"
-                        + " RECONCILIATION_ALREADY_FINALIZED if the reconciliation is finalized, and 422"
-                        + " MATCH_AMOUNT_MISMATCH if the sets do not net.", tags = { "Bank Reconciliation" })
-        @ApiResponse(responseCode = "200", description = "Lines matched", content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
-        @ApiResponse(responseCode = "400", description = "Request body invalid (ARGUMENT_NOT_VALID / VALIDATION_ERROR)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "Reconciliation or a referenced line not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "409", description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED), or a statement/GL"
-                        + " line is ineligible — not UNMATCHED, not POSTED, or already reconciled"
-                        + " (RECONCILIATION_LINE_INELIGIBLE)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "422", description = "Matched sets do not net to equal amounts (MATCH_AMOUNT_MISMATCH)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<BankReconciliationResponse> matchReconciliation(
-                        @Parameter(description = "Reconciliation id", required = true) @PathVariable @NonNull UUID reconciliationId,
-                        @Valid @RequestBody @NonNull ReconciliationMatchRequest request) {
-                if (log.isInfoEnabled()) {
-                        log.info("Match lines in reconciliation {}", sanitizeForLog(reconciliationId));
-                }
-                return ResponseEntity.ok(bankReconciliationService.match(reconciliationId, request));
+    @PostMapping("/{reconciliationId}/match")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:reconciliation:adjust"})
+    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_MATCH", apiVersion = "1")
+    @Operation(
+            summary = "Match statement lines to GL lines",
+            operationId = "matchReconciliation",
+            description = "Matches a set of statement lines to a set of posted GL journal-entry lines on the reconciled"
+                    + " account (1-to-1 or N-to-1). The two sets must net to equal signed amounts within ±0.01."
+                    + " Marks the statement lines MATCHED and records the linkage. Returns 404"
+                    + " RECONCILIATION_NOT_FOUND if the reconciliation or a line is missing, 409"
+                    + " RECONCILIATION_ALREADY_FINALIZED if the reconciliation is finalized, and 422"
+                    + " MATCH_AMOUNT_MISMATCH if the sets do not net.",
+            tags = {"Bank Reconciliation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Lines matched",
+            content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "Request body invalid (ARGUMENT_NOT_VALID / VALIDATION_ERROR)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:reconciliation:adjust permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Reconciliation or a referenced line not found (RECONCILIATION_NOT_FOUND)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED), or a statement/GL"
+                    + " line is ineligible — not UNMATCHED, not POSTED, or already reconciled"
+                    + " (RECONCILIATION_LINE_INELIGIBLE)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "Matched sets do not net to equal amounts (MATCH_AMOUNT_MISMATCH)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<BankReconciliationResponse> matchReconciliation(
+            @Parameter(description = "Reconciliation id", required = true) @PathVariable @NonNull UUID reconciliationId,
+            @Valid @RequestBody @NonNull ReconciliationMatchRequest request) {
+        if (log.isInfoEnabled()) {
+            log.info("Match lines in reconciliation {}", sanitizeForLog(reconciliationId));
         }
+        return ResponseEntity.ok(bankReconciliationService.match(reconciliationId, request));
+    }
 
-        @PostMapping("/{reconciliationId}/unmatch")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
-        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_UNMATCH", apiVersion = "1")
-        @Operation(summary = "Reverse a match", operationId = "unmatchReconciliation", description = "Reverses a match by matchId or by statement line ids, returning the affected statement lines"
-                        + " to UNMATCHED and releasing the linked GL lines. Returns 404 RECONCILIATION_NOT_FOUND if the"
-                        + " reconciliation or match group is missing, and 409 RECONCILIATION_ALREADY_FINALIZED if the"
-                        + " reconciliation is finalized.", tags = { "Bank Reconciliation" })
-        @ApiResponse(responseCode = "200", description = "Match reversed", content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
-        @ApiResponse(responseCode = "400", description = "Neither matchId nor statementLineIds resolved to a single match group (VALIDATION_ERROR)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "Reconciliation or match group not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "409", description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<BankReconciliationResponse> unmatchReconciliation(
-                        @Parameter(description = "Reconciliation id", required = true) @PathVariable @NonNull UUID reconciliationId,
-                        @Valid @RequestBody @NonNull ReconciliationUnmatchRequest request) {
-                if (log.isInfoEnabled()) {
-                        log.info("Unmatch in reconciliation {}", sanitizeForLog(reconciliationId));
-                }
-                return ResponseEntity.ok(bankReconciliationService.unmatch(reconciliationId, request));
+    @PostMapping("/{reconciliationId}/unmatch")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:reconciliation:adjust"})
+    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_UNMATCH", apiVersion = "1")
+    @Operation(
+            summary = "Reverse a match",
+            operationId = "unmatchReconciliation",
+            description = "Reverses a match by matchId or by statement line ids, returning the affected statement lines"
+                    + " to UNMATCHED and releasing the linked GL lines. Returns 404 RECONCILIATION_NOT_FOUND if the"
+                    + " reconciliation or match group is missing, and 409 RECONCILIATION_ALREADY_FINALIZED if the"
+                    + " reconciliation is finalized.",
+            tags = {"Bank Reconciliation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Match reversed",
+            content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "Neither matchId nor statementLineIds resolved to a single match group (VALIDATION_ERROR)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:reconciliation:adjust permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Reconciliation or match group not found (RECONCILIATION_NOT_FOUND)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<BankReconciliationResponse> unmatchReconciliation(
+            @Parameter(description = "Reconciliation id", required = true) @PathVariable @NonNull UUID reconciliationId,
+            @Valid @RequestBody @NonNull ReconciliationUnmatchRequest request) {
+        if (log.isInfoEnabled()) {
+            log.info("Unmatch in reconciliation {}", sanitizeForLog(reconciliationId));
         }
+        return ResponseEntity.ok(bankReconciliationService.unmatch(reconciliationId, request));
+    }
 
-        @PostMapping("/{reconciliationId}/adjustments")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
-        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_ADJUSTMENT", apiVersion = "1")
-        @Operation(summary = "Record a reconciliation adjustment", operationId = "addReconciliationAdjustment", description = "Records a signed adjustment and posts a real balanced journal entry (Dr/Cr the reconciled"
-                        + " cash account against the type's mapped counter account) through the accounting-period gate."
-                        + " Returns 404 RECONCILIATION_NOT_FOUND if the reconciliation is missing, 409"
-                        + " RECONCILIATION_ALREADY_FINALIZED if it is finalized, and 422 PERIOD_CLOSED / PERIOD_HARD_LOCKED"
-                        + " if the adjustment JE is dated into a locked accounting period.", tags = {
-                                        "Bank Reconciliation" })
-        @ApiResponse(responseCode = "200", description = "Adjustment recorded and JE posted", content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
-        @ApiResponse(responseCode = "400", description = "Request body invalid or amount is zero (ARGUMENT_NOT_VALID / VALIDATION_ERROR)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "409", description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "422", description = "Adjustment JE dated into a CLOSED or hard-locked period (PERIOD_CLOSED / PERIOD_HARD_LOCKED),"
-                        + " or the amount sign is not permitted for the type — BANK_FEE/NSF_FEE must be negative,"
-                        + " INTEREST_EARNED must be positive (RECONCILIATION_ADJUSTMENT_SIGN_INVALID)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<BankReconciliationResponse> addReconciliationAdjustment(
-                        @Parameter(description = "Reconciliation id", required = true) @PathVariable @NonNull UUID reconciliationId,
-                        @Valid @RequestBody @NonNull ReconciliationAdjustmentRequest request) {
-                if (log.isInfoEnabled()) {
-                        log.info(
-                                        "Record {} adjustment on reconciliation {}",
-                                        sanitizeForLog(request.getType()),
-                                        sanitizeForLog(reconciliationId));
-                }
-                return ResponseEntity.ok(bankReconciliationService.addAdjustment(reconciliationId, request));
+    @PostMapping("/{reconciliationId}/adjustments")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:reconciliation:adjust"})
+    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_ADJUSTMENT", apiVersion = "1")
+    @Operation(
+            summary = "Record a reconciliation adjustment",
+            operationId = "addReconciliationAdjustment",
+            description = "Records a signed adjustment and posts a real balanced journal entry (Dr/Cr the reconciled"
+                    + " cash account against the type's mapped counter account) through the accounting-period gate."
+                    + " Returns 404 RECONCILIATION_NOT_FOUND if the reconciliation is missing, 409"
+                    + " RECONCILIATION_ALREADY_FINALIZED if it is finalized, and 422 PERIOD_CLOSED / PERIOD_HARD_LOCKED"
+                    + " if the adjustment JE is dated into a locked accounting period.",
+            tags = {"Bank Reconciliation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Adjustment recorded and JE posted",
+            content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "Request body invalid or amount is zero (ARGUMENT_NOT_VALID / VALIDATION_ERROR)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:reconciliation:adjust permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description =
+                    "Adjustment JE dated into a CLOSED or hard-locked period (PERIOD_CLOSED / PERIOD_HARD_LOCKED),"
+                            + " or the amount sign is not permitted for the type — BANK_FEE/NSF_FEE must be negative,"
+                            + " INTEREST_EARNED must be positive (RECONCILIATION_ADJUSTMENT_SIGN_INVALID)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<BankReconciliationResponse> addReconciliationAdjustment(
+            @Parameter(description = "Reconciliation id", required = true) @PathVariable @NonNull UUID reconciliationId,
+            @Valid @RequestBody @NonNull ReconciliationAdjustmentRequest request) {
+        if (log.isInfoEnabled()) {
+            log.info(
+                    "Record {} adjustment on reconciliation {}",
+                    sanitizeForLog(request.getType()),
+                    sanitizeForLog(reconciliationId));
         }
+        return ResponseEntity.ok(bankReconciliationService.addAdjustment(reconciliationId, request));
+    }
 
-        @PostMapping("/{reconciliationId}/finalize")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
-        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_FINALIZE", apiVersion = "1")
-        @Operation(summary = "Finalize a reconciliation", operationId = "finalizeReconciliation", description = "Finalizes a reconciliation (IN_PROGRESS to FINALIZED) only when it balances: the statement"
-                        + " ending balance must equal the GL ending balance plus the sum of adjustments, within ±0.01"
-                        + " (matched GL lines are already reflected in the GL ending balance). Returns 404"
-                        + " RECONCILIATION_NOT_FOUND if missing, 409"
-                        + " RECONCILIATION_ALREADY_FINALIZED if already finalized, and 422 RECONCILIATION_NOT_BALANCED"
-                        + " (with the outstanding difference) if it does not balance.", tags = {
-                                        "Bank Reconciliation" })
-        @ApiResponse(responseCode = "200", description = "Reconciliation finalized", content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "409", description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "422", description = "Reconciliation does not balance (RECONCILIATION_NOT_BALANCED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<BankReconciliationResponse> finalizeReconciliation(
-                        @Parameter(description = "Reconciliation id", required = true) @PathVariable @NonNull UUID reconciliationId) {
-                if (log.isInfoEnabled()) {
-                        log.info("Finalize reconciliation {}", sanitizeForLog(reconciliationId));
-                }
-                return ResponseEntity.ok(bankReconciliationService.finalizeReconciliation(reconciliationId));
+    @PostMapping("/{reconciliationId}/finalize")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:reconciliation:adjust"})
+    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_FINALIZE", apiVersion = "1")
+    @Operation(
+            summary = "Finalize a reconciliation",
+            operationId = "finalizeReconciliation",
+            description = "Finalizes a reconciliation (IN_PROGRESS to FINALIZED) only when it balances: the statement"
+                    + " ending balance must equal the GL ending balance plus the sum of adjustments, within ±0.01"
+                    + " (matched GL lines are already reflected in the GL ending balance). Returns 404"
+                    + " RECONCILIATION_NOT_FOUND if missing, 409"
+                    + " RECONCILIATION_ALREADY_FINALIZED if already finalized, and 422 RECONCILIATION_NOT_BALANCED"
+                    + " (with the outstanding difference) if it does not balance.",
+            tags = {"Bank Reconciliation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Reconciliation finalized",
+            content = @Content(schema = @Schema(implementation = BankReconciliationResponse.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:reconciliation:adjust permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Reconciliation already finalized (RECONCILIATION_ALREADY_FINALIZED)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "Reconciliation does not balance (RECONCILIATION_NOT_BALANCED)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<BankReconciliationResponse> finalizeReconciliation(
+            @Parameter(description = "Reconciliation id", required = true) @PathVariable @NonNull
+                    UUID reconciliationId) {
+        if (log.isInfoEnabled()) {
+            log.info("Finalize reconciliation {}", sanitizeForLog(reconciliationId));
         }
+        return ResponseEntity.ok(bankReconciliationService.finalizeReconciliation(reconciliationId));
+    }
 
-        private static String sanitizeForLog(@Nullable Object value) {
-                if (value == null) {
-                        return "null";
-                }
-                return value.toString().replace('\n', '_').replace('\r', '_');
+    private static String sanitizeForLog(@Nullable Object value) {
+        if (value == null) {
+            return "null";
         }
+        return value.toString().replace('\n', '_').replace('\r', '_');
+    }
 
-        @GetMapping("/{reconciliationId}/report")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:view" })
-        @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
-        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_REPORT", apiVersion = "1")
-        @Operation(summary = "Reconciliation report", operationId = "getReconciliationReport", description = "Returns the reconciliation report: opening (GL) and closing (statement) balances, matched"
-                        + " vs outstanding lines, adjustments, and the outstanding difference. Returns 404"
-                        + " RECONCILIATION_NOT_FOUND if the id is unknown.", tags = { "Bank Reconciliation" })
-        @ApiResponse(responseCode = "200", description = "Report generated", content = @Content(schema = @Schema(implementation = ReconciliationReportResponse.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<ReconciliationReportResponse> getReconciliationReport(
-                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
-                return ResponseEntity.ok(bankReconciliationService.report(reconciliationId));
-        }
+    @GetMapping("/{reconciliationId}/report")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:reconciliation:view"})
+    @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
+    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_REPORT", apiVersion = "1")
+    @Operation(
+            summary = "Reconciliation report",
+            operationId = "getReconciliationReport",
+            description = "Returns the reconciliation report: opening (GL) and closing (statement) balances, matched"
+                    + " vs outstanding lines, adjustments, and the outstanding difference. Returns 404"
+                    + " RECONCILIATION_NOT_FOUND if the id is unknown.",
+            tags = {"Bank Reconciliation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Report generated",
+            content = @Content(schema = @Schema(implementation = ReconciliationReportResponse.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:reconciliation:view permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<ReconciliationReportResponse> getReconciliationReport(
+            @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
+        return ResponseEntity.ok(bankReconciliationService.report(reconciliationId));
+    }
 
-        @GetMapping("/{reconciliationId}/audit")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:view" })
-        @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
-        @EmitEvent(id = "ACCOUNTING_RECONCILIATION_AUDIT", apiVersion = "1")
-        @Operation(summary = "Reconciliation audit trail", operationId = "getReconciliationAudit", description = "Returns the audit trail of a reconciliation's actions (import, matches, adjustments,"
-                        + " finalize), ordered by time. Returns 404 RECONCILIATION_NOT_FOUND if the id is unknown.", tags = {
-                                        "Bank Reconciliation" })
-        @ApiResponse(responseCode = "200", description = "Audit trail generated", content = @Content(schema = @Schema(implementation = ReconciliationAuditResponse.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<ReconciliationAuditResponse> getReconciliationAudit(
-                        @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
-                return ResponseEntity.ok(bankReconciliationService.audit(reconciliationId));
-        }
+    @GetMapping("/{reconciliationId}/audit")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:reconciliation:view"})
+    @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
+    @EmitEvent(id = "ACCOUNTING_RECONCILIATION_AUDIT", apiVersion = "1")
+    @Operation(
+            summary = "Reconciliation audit trail",
+            operationId = "getReconciliationAudit",
+            description = "Returns the audit trail of a reconciliation's actions (import, matches, adjustments,"
+                    + " finalize), ordered by time. Returns 404 RECONCILIATION_NOT_FOUND if the id is unknown.",
+            tags = {"Bank Reconciliation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Audit trail generated",
+            content = @Content(schema = @Schema(implementation = ReconciliationAuditResponse.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:reconciliation:view permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Reconciliation not found (RECONCILIATION_NOT_FOUND)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<ReconciliationAuditResponse> getReconciliationAudit(
+            @Parameter(description = "Reconciliation id", required = true) @PathVariable UUID reconciliationId) {
+        return ResponseEntity.ok(bankReconciliationService.audit(reconciliationId));
+    }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/SettlementReconciliationController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/SettlementReconciliationController.java
@@ -48,124 +48,191 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/v1/accounting/settlements")
-@Tag(name = "Settlement Reconciliation", description = "Processor settlement reconciliation review: list settlement lines, manually match an"
+@Tag(
+        name = "Settlement Reconciliation",
+        description = "Processor settlement reconciliation review: list settlement lines, manually match an"
                 + " unmatched line to a receivable payment, and write off small unmatched lines.")
 @RequiredArgsConstructor
 @Validated
 public class SettlementReconciliationController {
 
-        private static final Logger log = LoggerFactory.getLogger(SettlementReconciliationController.class);
+    private static final Logger log = LoggerFactory.getLogger(SettlementReconciliationController.class);
 
-        private final SettlementReconciliationService settlementReconciliationService;
+    private final SettlementReconciliationService settlementReconciliationService;
 
-        @GetMapping("/{settlementId}/lines")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:view" })
-        @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
-        @EmitEvent(id = "ACCOUNTING_SETTLEMENT_LINES_LIST", apiVersion = "1")
-        @Operation(summary = "List settlement lines", operationId = "listSettlementLines", description = "Lists the lines of one processor settlement (payout), optionally filtered to only the"
-                        + " UNMATCHED lines awaiting review. Use this tool to triage a settlement before manually"
-                        + " matching or writing off its unmatched lines. Matched lines are already posted; unmatched"
-                        + " lines park their gross in the settlement suspense account until resolved (decision D-13)."
-                        + " No preconditions and no side effects; an unknown settlementId returns an empty list.", tags = {
-                                        "Settlement Reconciliation" })
-        @ApiResponse(responseCode = "200", description = "Settlement lines listed", content = @Content(array = @ArraySchema(schema = @Schema(implementation = SettlementLineResponse.class))))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:view permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<List<SettlementLineResponse>> listSettlementLines(
-                        @Parameter(description = "Provider settlement (payout) id", required = true, example = "stl_1Mx3k2eZvKYlo2C0") @PathVariable @NonNull String settlementId,
-                        @Parameter(description = "When true, return only UNMATCHED lines", example = "true") @RequestParam(name = "unmatchedOnly", defaultValue = "false") boolean unmatchedOnly) {
-                if (log.isInfoEnabled()) {
-                        log.info(
-                                        "List settlement lines for {} (unmatchedOnly={})",
-                                        sanitizeForLog(settlementId),
-                                        sanitizeForLog(unmatchedOnly));
-                }
-                List<SettlementLineResponse> response = settlementReconciliationService
-                                .listLines(settlementId, unmatchedOnly).stream()
-                                .map(SettlementLineResponse::from)
-                                .toList();
-                return ResponseEntity.ok(response);
+    @GetMapping("/{settlementId}/lines")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:reconciliation:view"})
+    @PreAuthorize("hasAuthority('accounting:reconciliation:view')")
+    @EmitEvent(id = "ACCOUNTING_SETTLEMENT_LINES_LIST", apiVersion = "1")
+    @Operation(
+            summary = "List settlement lines",
+            operationId = "listSettlementLines",
+            description = "Lists the lines of one processor settlement (payout), optionally filtered to only the"
+                    + " UNMATCHED lines awaiting review. Use this tool to triage a settlement before manually"
+                    + " matching or writing off its unmatched lines. Matched lines are already posted; unmatched"
+                    + " lines park their gross in the settlement suspense account until resolved (decision D-13)."
+                    + " No preconditions and no side effects; an unknown settlementId returns an empty list.",
+            tags = {"Settlement Reconciliation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Settlement lines listed",
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = SettlementLineResponse.class))))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:reconciliation:view permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<List<SettlementLineResponse>> listSettlementLines(
+            @Parameter(
+                            description = "Provider settlement (payout) id",
+                            required = true,
+                            example = "stl_1Mx3k2eZvKYlo2C0")
+                    @PathVariable
+                    @NonNull
+                    String settlementId,
+            @Parameter(description = "When true, return only UNMATCHED lines", example = "true")
+                    @RequestParam(name = "unmatchedOnly", defaultValue = "false")
+                    boolean unmatchedOnly) {
+        if (log.isInfoEnabled()) {
+            log.info(
+                    "List settlement lines for {} (unmatchedOnly={})",
+                    sanitizeForLog(settlementId),
+                    sanitizeForLog(unmatchedOnly));
         }
+        List<SettlementLineResponse> response =
+                settlementReconciliationService.listLines(settlementId, unmatchedOnly).stream()
+                        .map(SettlementLineResponse::from)
+                        .toList();
+        return ResponseEntity.ok(response);
+    }
 
-        @PostMapping("/lines/{lineId}/match")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
-        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-        @EmitEvent(id = "ACCOUNTING_SETTLEMENT_LINE_MATCH", apiVersion = "1")
-        @Operation(summary = "Manually match a settlement line", operationId = "matchSettlementLine", description = "Manually matches an UNMATCHED settlement line to an AR receivable payment, posting a"
-                        + " reclass entry (Dr Settlement Suspense / Cr Undeposited Funds) that clears the line's gross"
-                        + " out of suspense. Use this tool when the automatic gross match could not identify the"
-                        + " payment. AP (vendor) matching is not supported in v1."
-                        + " Preconditions: the line must exist and be UNMATCHED, its parent settlement must already"
-                        + " be POSTED, and the receivable payment must exist. Returns 404 if the line or payment is"
-                        + " not found (SETTLEMENT_LINE_NOT_FOUND / RECEIVABLE_PAYMENT_NOT_FOUND), 409 if the line is"
-                        + " no longer UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED) or the settlement has not yet posted"
-                        + " (SETTLEMENT_NOT_POSTED), and 422 if the reclass entry is dated into a locked accounting"
-                        + " period (PERIOD_CLOSED / PERIOD_HARD_LOCKED). Emits ACCOUNTING_SETTLEMENT_LINE_MATCH.", tags = {
-                                        "Settlement Reconciliation" })
-        @ApiResponse(responseCode = "200", description = "Line matched; the updated line is returned", content = @Content(schema = @Schema(implementation = SettlementLineResponse.class)))
-        @ApiResponse(responseCode = "400", description = "receivablePaymentId is missing (ARGUMENT_NOT_VALID)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "Settlement line or receivable payment not found"
-                        + " (SETTLEMENT_LINE_NOT_FOUND / RECEIVABLE_PAYMENT_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "409", description = "Settlement line is not UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED), or the settlement"
-                        + " has not yet posted (SETTLEMENT_NOT_POSTED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "422", description = "Reclass entry is dated into a CLOSED or hard-locked accounting period"
-                        + " (PERIOD_CLOSED / PERIOD_HARD_LOCKED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<SettlementLineResponse> matchSettlementLine(
-                        @Parameter(description = "Settlement line id", required = true) @PathVariable @NonNull UUID lineId,
-                        @Valid @RequestBody @NonNull SettlementManualMatchRequest request) {
-                if (log.isInfoEnabled()) {
-                        log.info(
-                                        "Manual match settlement line {} to receivable payment {}",
-                                        sanitizeForLog(lineId),
-                                        sanitizeForLog(request.getReceivablePaymentId()));
-                }
-                SettlementLineResponse response = SettlementLineResponse.from(
-                                settlementReconciliationService.manualMatchToReceivable(lineId,
-                                                request.getReceivablePaymentId()));
-                return ResponseEntity.ok(response);
+    @PostMapping("/lines/{lineId}/match")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:reconciliation:adjust"})
+    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+    @EmitEvent(id = "ACCOUNTING_SETTLEMENT_LINE_MATCH", apiVersion = "1")
+    @Operation(
+            summary = "Manually match a settlement line",
+            operationId = "matchSettlementLine",
+            description = "Manually matches an UNMATCHED settlement line to an AR receivable payment, posting a"
+                    + " reclass entry (Dr Settlement Suspense / Cr Undeposited Funds) that clears the line's gross"
+                    + " out of suspense. Use this tool when the automatic gross match could not identify the"
+                    + " payment. AP (vendor) matching is not supported in v1."
+                    + " Preconditions: the line must exist and be UNMATCHED, its parent settlement must already"
+                    + " be POSTED, and the receivable payment must exist. Returns 404 if the line or payment is"
+                    + " not found (SETTLEMENT_LINE_NOT_FOUND / RECEIVABLE_PAYMENT_NOT_FOUND), 409 if the line is"
+                    + " no longer UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED) or the settlement has not yet posted"
+                    + " (SETTLEMENT_NOT_POSTED), and 422 if the reclass entry is dated into a locked accounting"
+                    + " period (PERIOD_CLOSED / PERIOD_HARD_LOCKED). Emits ACCOUNTING_SETTLEMENT_LINE_MATCH.",
+            tags = {"Settlement Reconciliation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Line matched; the updated line is returned",
+            content = @Content(schema = @Schema(implementation = SettlementLineResponse.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "receivablePaymentId is missing (ARGUMENT_NOT_VALID)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:reconciliation:adjust permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Settlement line or receivable payment not found"
+                    + " (SETTLEMENT_LINE_NOT_FOUND / RECEIVABLE_PAYMENT_NOT_FOUND)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Settlement line is not UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED), or the settlement"
+                    + " has not yet posted (SETTLEMENT_NOT_POSTED)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "Reclass entry is dated into a CLOSED or hard-locked accounting period"
+                    + " (PERIOD_CLOSED / PERIOD_HARD_LOCKED)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<SettlementLineResponse> matchSettlementLine(
+            @Parameter(description = "Settlement line id", required = true) @PathVariable @NonNull UUID lineId,
+            @Valid @RequestBody @NonNull SettlementManualMatchRequest request) {
+        if (log.isInfoEnabled()) {
+            log.info(
+                    "Manual match settlement line {} to receivable payment {}",
+                    sanitizeForLog(lineId),
+                    sanitizeForLog(request.getReceivablePaymentId()));
         }
+        SettlementLineResponse response = SettlementLineResponse.from(
+                settlementReconciliationService.manualMatchToReceivable(lineId, request.getReceivablePaymentId()));
+        return ResponseEntity.ok(response);
+    }
 
-        @PostMapping("/lines/{lineId}/write-off")
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:reconciliation:adjust" })
-        @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
-        @EmitEvent(id = "ACCOUNTING_SETTLEMENT_LINE_WRITE_OFF", apiVersion = "1")
-        @Operation(summary = "Write off a small unmatched settlement line", operationId = "writeOffSettlementLine", description = "Writes off an UNMATCHED settlement line whose gross is at or below the configured"
-                        + " reconciliation write-off threshold (default $25.00, decision D-14), posting a reversible"
-                        + " adjustment entry (Dr Settlement Suspense / Cr Settlement Adjustment) — never a silent"
-                        + " status flip. Use this tool only for genuinely unidentifiable small residuals; above the"
-                        + " threshold there is no self-service write-off — manually match or escalate."
-                        + " Preconditions: the line must exist and be UNMATCHED, its gross must not exceed the"
-                        + " threshold (compared on absolute value), and a non-blank reason (max 500 chars) is required"
-                        + " and audited. Respects accounting period locks (Story B2). Emits"
-                        + " ACCOUNTING_SETTLEMENT_LINE_WRITE_OFF. Returns 422 when the absolute gross exceeds the"
-                        + " threshold (WRITE_OFF_THRESHOLD_EXCEEDED) or the adjustment entry is dated into a locked"
-                        + " accounting period (PERIOD_CLOSED / PERIOD_HARD_LOCKED), and 409 when the line is no longer"
-                        + " UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED) or the settlement has not yet posted"
-                        + " (SETTLEMENT_NOT_POSTED).", tags = { "Settlement Reconciliation" })
-        @ApiResponse(responseCode = "200", description = "Line written off; the updated line is returned", content = @Content(schema = @Schema(implementation = SettlementLineResponse.class)))
-        @ApiResponse(responseCode = "400", description = "reason is missing, blank, or over 500 characters (ARGUMENT_NOT_VALID)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "Caller lacks the accounting:reconciliation:adjust permission", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "Settlement line not found (SETTLEMENT_LINE_NOT_FOUND)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "409", description = "Settlement line is not UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED), or the settlement"
-                        + " has not yet posted (SETTLEMENT_NOT_POSTED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "422", description = "Line absolute gross exceeds the write-off threshold (WRITE_OFF_THRESHOLD_EXCEEDED);"
-                        + " manual match or escalate — or the adjustment entry is dated into a CLOSED or hard-locked"
-                        + " accounting period (PERIOD_CLOSED / PERIOD_HARD_LOCKED)", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<SettlementLineResponse> writeOffSettlementLine(
-                        @Parameter(description = "Settlement line id", required = true) @PathVariable @NonNull UUID lineId,
-                        @Valid @RequestBody @NonNull SettlementWriteOffRequest request) {
-                if (log.isInfoEnabled()) {
-                        log.info("Write off settlement line {}", sanitizeForLog(lineId));
-                }
-                SettlementLineResponse response = SettlementLineResponse
-                                .from(settlementReconciliationService.writeOffLine(lineId, request.getReason()));
-                return ResponseEntity.ok(response);
+    @PostMapping("/lines/{lineId}/write-off")
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:reconciliation:adjust"})
+    @PreAuthorize("hasAuthority('accounting:reconciliation:adjust')")
+    @EmitEvent(id = "ACCOUNTING_SETTLEMENT_LINE_WRITE_OFF", apiVersion = "1")
+    @Operation(
+            summary = "Write off a small unmatched settlement line",
+            operationId = "writeOffSettlementLine",
+            description = "Writes off an UNMATCHED settlement line whose gross is at or below the configured"
+                    + " reconciliation write-off threshold (default $25.00, decision D-14), posting a reversible"
+                    + " adjustment entry (Dr Settlement Suspense / Cr Settlement Adjustment) — never a silent"
+                    + " status flip. Use this tool only for genuinely unidentifiable small residuals; above the"
+                    + " threshold there is no self-service write-off — manually match or escalate."
+                    + " Preconditions: the line must exist and be UNMATCHED, its gross must not exceed the"
+                    + " threshold (compared on absolute value), and a non-blank reason (max 500 chars) is required"
+                    + " and audited. Respects accounting period locks (Story B2). Emits"
+                    + " ACCOUNTING_SETTLEMENT_LINE_WRITE_OFF. Returns 422 when the absolute gross exceeds the"
+                    + " threshold (WRITE_OFF_THRESHOLD_EXCEEDED) or the adjustment entry is dated into a locked"
+                    + " accounting period (PERIOD_CLOSED / PERIOD_HARD_LOCKED), and 409 when the line is no longer"
+                    + " UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED) or the settlement has not yet posted"
+                    + " (SETTLEMENT_NOT_POSTED).",
+            tags = {"Settlement Reconciliation"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Line written off; the updated line is returned",
+            content = @Content(schema = @Schema(implementation = SettlementLineResponse.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "reason is missing, blank, or over 500 characters (ARGUMENT_NOT_VALID)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Caller lacks the accounting:reconciliation:adjust permission",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Settlement line not found (SETTLEMENT_LINE_NOT_FOUND)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Settlement line is not UNMATCHED (SETTLEMENT_LINE_NOT_UNMATCHED), or the settlement"
+                    + " has not yet posted (SETTLEMENT_NOT_POSTED)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "Line absolute gross exceeds the write-off threshold (WRITE_OFF_THRESHOLD_EXCEEDED);"
+                    + " manual match or escalate — or the adjustment entry is dated into a CLOSED or hard-locked"
+                    + " accounting period (PERIOD_CLOSED / PERIOD_HARD_LOCKED)",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<SettlementLineResponse> writeOffSettlementLine(
+            @Parameter(description = "Settlement line id", required = true) @PathVariable @NonNull UUID lineId,
+            @Valid @RequestBody @NonNull SettlementWriteOffRequest request) {
+        if (log.isInfoEnabled()) {
+            log.info("Write off settlement line {}", sanitizeForLog(lineId));
         }
+        SettlementLineResponse response =
+                SettlementLineResponse.from(settlementReconciliationService.writeOffLine(lineId, request.getReason()));
+        return ResponseEntity.ok(response);
+    }
 
-        private static String sanitizeForLog(@Nullable Object value) {
-                if (value == null) {
-                        return "null";
-                }
-                return value.toString().replace('\n', '_').replace('\r', '_');
+    private static String sanitizeForLog(@Nullable Object value) {
+        if (value == null) {
+            return "null";
         }
+        return value.toString().replace('\n', '_').replace('\r', '_');
+    }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/TaxLiabilitySnapshotController.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/controller/TaxLiabilitySnapshotController.java
@@ -47,84 +47,167 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/v1/accounting/reports/financial/tax-liability/snapshots")
-@Tag(name = "Financial Reporting for Tax Liability", description = "Period-close-aligned freeze of the Sales-Tax Liability report")
+@Tag(
+        name = "Financial Reporting for Tax Liability",
+        description = "Period-close-aligned freeze of the Sales-Tax Liability report")
 @Validated
 public class TaxLiabilitySnapshotController {
 
-        private static final String PERIOD_CODE_PATTERN = "^\\d{4}-(0[1-9]|1[0-2])$";
+    private static final String PERIOD_CODE_PATTERN = "^\\d{4}-(0[1-9]|1[0-2])$";
 
-        private final TaxLiabilitySnapshotService snapshotService;
+    private final TaxLiabilitySnapshotService snapshotService;
 
-        public TaxLiabilitySnapshotController(@NonNull TaxLiabilitySnapshotService snapshotService) {
-                this.snapshotService = snapshotService;
-        }
+    public TaxLiabilitySnapshotController(@NonNull TaxLiabilitySnapshotService snapshotService) {
+        this.snapshotService = snapshotService;
+    }
 
-        @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-        @SecurityRequirement(name = "bearerAuth", scopes = { "accounting:tax-snapshot:freeze" })
-        @PreAuthorize("hasAuthority('accounting:tax-snapshot:freeze')")
-        @EmitEvent(id = "TAX_LIABILITY_SNAPSHOT_FREEZE", apiVersion = "1")
-        @Operation(summary = "Freeze the Sales-Tax Liability report for a closed period", description = "Generate the Sales-Tax Liability report over the accounting period's exact date range and persist"
-                        + " it as an immutable snapshot with a canonical SHA-256 content hash. The period must be"
-                        + " CLOSED. If an ACTIVE snapshot already exists for the period the request fails with 409"
-                        + " unless supersede=true, which demotes the prior snapshot to SUPERSEDED (reopen → adjust"
-                        + " → re-close flow) and preserves history.", tags = {
-                                        "Financial Reporting", "Financial Reporting for Tax Liability" })
-        @ApiResponse(responseCode = "201", description = "Snapshot frozen", content = @Content(schema = @Schema(implementation = TaxLiabilitySnapshotResponse.class)))
-        @ApiResponse(responseCode = "400", description = "Invalid period code", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "Forbidden - missing accounting:tax-snapshot:freeze", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "Accounting period not found", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "409", description = "Period not CLOSED, or an ACTIVE snapshot exists and supersede was not set", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<TaxLiabilitySnapshotResponse> freezeSnapshot(
-                        @Parameter(description = "Accounting period code (YYYY-MM)", required = true, example = "2026-06") @RequestParam @Pattern(regexp = PERIOD_CODE_PATTERN, message = "periodCode must be in YYYY-MM format") @NonNull String periodCode,
-                        @Parameter(description = "Supersede an existing ACTIVE snapshot for the period") @RequestParam(defaultValue = "false") boolean supersede) {
-                return ResponseEntity.status(HttpStatus.CREATED).body(snapshotService.freeze(periodCode, supersede));
-        }
+    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"accounting:tax-snapshot:freeze"})
+    @PreAuthorize("hasAuthority('accounting:tax-snapshot:freeze')")
+    @EmitEvent(id = "TAX_LIABILITY_SNAPSHOT_FREEZE", apiVersion = "1")
+    @Operation(
+            summary = "Freeze the Sales-Tax Liability report for a closed period",
+            description =
+                    "Generate the Sales-Tax Liability report over the accounting period's exact date range and persist"
+                            + " it as an immutable snapshot with a canonical SHA-256 content hash. The period must be"
+                            + " CLOSED. If an ACTIVE snapshot already exists for the period the request fails with 409"
+                            + " unless supersede=true, which demotes the prior snapshot to SUPERSEDED (reopen → adjust"
+                            + " → re-close flow) and preserves history.",
+            tags = {"Financial Reporting", "Financial Reporting for Tax Liability"})
+    @ApiResponse(
+            responseCode = "201",
+            description = "Snapshot frozen",
+            content = @Content(schema = @Schema(implementation = TaxLiabilitySnapshotResponse.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid period code",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "401",
+            description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Forbidden - missing accounting:tax-snapshot:freeze",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Accounting period not found",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Period not CLOSED, or an ACTIVE snapshot exists and supersede was not set",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<TaxLiabilitySnapshotResponse> freezeSnapshot(
+            @Parameter(description = "Accounting period code (YYYY-MM)", required = true, example = "2026-06")
+                    @RequestParam
+                    @Pattern(regexp = PERIOD_CODE_PATTERN, message = "periodCode must be in YYYY-MM format")
+                    @NonNull
+                    String periodCode,
+            @Parameter(description = "Supersede an existing ACTIVE snapshot for the period")
+                    @RequestParam(defaultValue = "false")
+                    boolean supersede) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(snapshotService.freeze(periodCode, supersede));
+    }
 
-        @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-        @SecurityRequirement(name = "bearerAuth", scopes = { "reporting:view:financial-statements" })
-        @PreAuthorize("hasAuthority('reporting:view:financial-statements')")
-        @EmitEvent(id = "TAX_LIABILITY_SNAPSHOT_LIST", apiVersion = "1")
-        @Operation(summary = "List Sales-Tax Liability snapshots", description = "List snapshot summaries (no rows), newest freeze first, optionally filtered by period code.", tags = {
-                        "Financial Reporting", "Financial Reporting for Tax Liability" })
-        @ApiResponse(responseCode = "200", description = "Snapshot summaries (empty list when none exist)", content = @Content(array = @ArraySchema(schema = @Schema(implementation = TaxLiabilitySnapshotSummary.class))))
-        @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "Forbidden - missing reporting:view:financial-statements", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<List<TaxLiabilitySnapshotSummary>> listSnapshots(
-                        @Parameter(description = "Optional accounting period code filter (YYYY-MM)", example = "2026-06") @RequestParam(required = false) @Pattern(regexp = PERIOD_CODE_PATTERN, message = "periodCode must be in YYYY-MM format") @Nullable String periodCode) {
-                return ResponseEntity.ok(snapshotService.list(periodCode));
-        }
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"reporting:view:financial-statements"})
+    @PreAuthorize("hasAuthority('reporting:view:financial-statements')")
+    @EmitEvent(id = "TAX_LIABILITY_SNAPSHOT_LIST", apiVersion = "1")
+    @Operation(
+            summary = "List Sales-Tax Liability snapshots",
+            description = "List snapshot summaries (no rows), newest freeze first, optionally filtered by period code.",
+            tags = {"Financial Reporting", "Financial Reporting for Tax Liability"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Snapshot summaries (empty list when none exist)",
+            content =
+                    @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = TaxLiabilitySnapshotSummary.class))))
+    @ApiResponse(
+            responseCode = "401",
+            description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Forbidden - missing reporting:view:financial-statements",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<List<TaxLiabilitySnapshotSummary>> listSnapshots(
+            @Parameter(description = "Optional accounting period code filter (YYYY-MM)", example = "2026-06")
+                    @RequestParam(required = false)
+                    @Pattern(regexp = PERIOD_CODE_PATTERN, message = "periodCode must be in YYYY-MM format")
+                    @Nullable
+                    String periodCode) {
+        return ResponseEntity.ok(snapshotService.list(periodCode));
+    }
 
-        @GetMapping(value = "/{snapshotId}", produces = MediaType.APPLICATION_JSON_VALUE)
-        @SecurityRequirement(name = "bearerAuth", scopes = { "reporting:view:financial-statements" })
-        @PreAuthorize("hasAuthority('reporting:view:financial-statements')")
-        @EmitEvent(id = "TAX_LIABILITY_SNAPSHOT_GET", apiVersion = "1")
-        @Operation(summary = "Get a Sales-Tax Liability snapshot", description = "Full frozen snapshot including per-jurisdiction rows, totals, reconciliation, and hash.", tags = {
-                        "Financial Reporting", "Financial Reporting for Tax Liability" })
-        @ApiResponse(responseCode = "200", description = "Snapshot found", content = @Content(schema = @Schema(implementation = TaxLiabilitySnapshotResponse.class)))
-        @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "Forbidden - missing reporting:view:financial-statements", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "Snapshot not found", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<TaxLiabilitySnapshotResponse> getSnapshot(
-                        @Parameter(description = "Snapshot id", required = true) @PathVariable @NonNull UUID snapshotId) {
-                return ResponseEntity.ok(snapshotService.get(snapshotId));
-        }
+    @GetMapping(value = "/{snapshotId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"reporting:view:financial-statements"})
+    @PreAuthorize("hasAuthority('reporting:view:financial-statements')")
+    @EmitEvent(id = "TAX_LIABILITY_SNAPSHOT_GET", apiVersion = "1")
+    @Operation(
+            summary = "Get a Sales-Tax Liability snapshot",
+            description = "Full frozen snapshot including per-jurisdiction rows, totals, reconciliation, and hash.",
+            tags = {"Financial Reporting", "Financial Reporting for Tax Liability"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Snapshot found",
+            content = @Content(schema = @Schema(implementation = TaxLiabilitySnapshotResponse.class)))
+    @ApiResponse(
+            responseCode = "401",
+            description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Forbidden - missing reporting:view:financial-statements",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Snapshot not found",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<TaxLiabilitySnapshotResponse> getSnapshot(
+            @Parameter(description = "Snapshot id", required = true) @PathVariable @NonNull UUID snapshotId) {
+        return ResponseEntity.ok(snapshotService.get(snapshotId));
+    }
 
-        @PostMapping(value = "/{snapshotId}/verify", produces = MediaType.APPLICATION_JSON_VALUE)
-        @SecurityRequirement(name = "bearerAuth", scopes = { "reporting:view:financial-statements" })
-        @PreAuthorize("hasAuthority('reporting:view:financial-statements')")
-        @EmitEvent(id = "TAX_LIABILITY_SNAPSHOT_VERIFY", apiVersion = "1")
-        @Operation(summary = "Verify a snapshot against live data", description = "Re-derive the Sales-Tax Liability report for the snapshot's period from the live replicas and"
-                        + " compare canonical hashes. Read-only: the snapshot is never mutated. Inconsistency"
-                        + " means underlying data moved after the freeze (e.g. postings into a reopened period);"
-                        + " re-freeze with supersede=true once the period is closed again.", tags = {
-                                        "Financial Reporting", "Financial Reporting for Tax Liability" })
-        @ApiResponse(responseCode = "200", description = "Verification result (consistent=true when hashes match)", content = @Content(schema = @Schema(implementation = TaxLiabilitySnapshotVerification.class)))
-        @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "403", description = "Forbidden - missing reporting:view:financial-statements", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        @ApiResponse(responseCode = "404", description = "Snapshot not found", content = @Content(schema = @Schema(implementation = ApiError.class)))
-        public ResponseEntity<TaxLiabilitySnapshotVerification> verifySnapshot(
-                        @Parameter(description = "Snapshot id", required = true) @PathVariable @NonNull UUID snapshotId) {
-                return ResponseEntity.ok(snapshotService.verify(snapshotId));
-        }
+    @PostMapping(value = "/{snapshotId}/verify", produces = MediaType.APPLICATION_JSON_VALUE)
+    @SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"reporting:view:financial-statements"})
+    @PreAuthorize("hasAuthority('reporting:view:financial-statements')")
+    @EmitEvent(id = "TAX_LIABILITY_SNAPSHOT_VERIFY", apiVersion = "1")
+    @Operation(
+            summary = "Verify a snapshot against live data",
+            description =
+                    "Re-derive the Sales-Tax Liability report for the snapshot's period from the live replicas and"
+                            + " compare canonical hashes. Read-only: the snapshot is never mutated. Inconsistency"
+                            + " means underlying data moved after the freeze (e.g. postings into a reopened period);"
+                            + " re-freeze with supersede=true once the period is closed again.",
+            tags = {"Financial Reporting", "Financial Reporting for Tax Liability"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Verification result (consistent=true when hashes match)",
+            content = @Content(schema = @Schema(implementation = TaxLiabilitySnapshotVerification.class)))
+    @ApiResponse(
+            responseCode = "401",
+            description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Forbidden - missing reporting:view:financial-statements",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Snapshot not found",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<TaxLiabilitySnapshotVerification> verifySnapshot(
+            @Parameter(description = "Snapshot id", required = true) @PathVariable @NonNull UUID snapshotId) {
+        return ResponseEntity.ok(snapshotService.verify(snapshotId));
+    }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/ReportExportArtifact.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/dto/ReportExportArtifact.java
@@ -12,39 +12,40 @@ import org.jspecify.annotations.NonNull;
  * @param filename    suggested download filename including extension
  */
 public record ReportExportArtifact(
-                byte @NonNull [] content,
-                @NonNull String contentType,
-                @NonNull String filename) {
+        byte @NonNull [] content,
+        @NonNull String contentType,
+        @NonNull String filename) {
 
-        @Override
-        public boolean equals(Object obj) {
-                if (this == obj) {
-                        return true;
-                }
-                if (!(obj instanceof ReportExportArtifact(byte[] otherContent, String otherContentType, String otherFilename))) {
-                        return false;
-                }
-                return Arrays.equals(content, otherContent)
-                                && contentType.equals(otherContentType)
-                                && filename.equals(otherFilename);
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
         }
+        if (!(obj
+                instanceof ReportExportArtifact(byte[] otherContent, String otherContentType, String otherFilename))) {
+            return false;
+        }
+        return Arrays.equals(content, otherContent)
+                && contentType.equals(otherContentType)
+                && filename.equals(otherFilename);
+    }
 
-        @Override
-        public int hashCode() {
-                int result = Arrays.hashCode(content);
-                result = 31 * result + contentType.hashCode();
-                result = 31 * result + filename.hashCode();
-                return result;
-        }
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(content);
+        result = 31 * result + contentType.hashCode();
+        result = 31 * result + filename.hashCode();
+        return result;
+    }
 
-        @Override
-        public String toString() {
-                return "ReportExportArtifact[content="
-                                + Arrays.toString(content)
-                                + ", contentType="
-                                + contentType
-                                + ", filename="
-                                + filename
-                                + "]";
-        }
+    @Override
+    public String toString() {
+        return "ReportExportArtifact[content="
+                + Arrays.toString(content)
+                + ", contentType="
+                + contentType
+                + ", filename="
+                + filename
+                + "]";
+    }
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/LocationFxRateRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/LocationFxRateRepository.java
@@ -16,6 +16,5 @@ public interface LocationFxRateRepository extends JpaRepository<LocationFxRate, 
      * @param fiscalYear the fiscal year the rate applies to
      * @return the configured rate, or empty when the location defaults to a US plant (1.00)
      */
-    Optional<LocationFxRate> findByLocationCodeAndFiscalYear(@NonNull String locationCode,
-            int fiscalYear);
+    Optional<LocationFxRate> findByLocationCodeAndFiscalYear(@NonNull String locationCode, int fiscalYear);
 }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
@@ -104,8 +104,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
      * for the Aged Payables report: everything except settled ({@code PAID}),
      * voided ({@code VOIDED}), and rejected ({@code REJECTED}) bills.
      */
-    private static final Set<VendorBillStatus> OPEN_PAYABLE_STATUSES = Set.of(VendorBillStatus.PENDING_RECEIPT_MATCH,
-            VendorBillStatus.MATCH_EXCEPTION, VendorBillStatus.APPROVED);
+    private static final Set<VendorBillStatus> OPEN_PAYABLE_STATUSES =
+            Set.of(VendorBillStatus.PENDING_RECEIPT_MATCH, VendorBillStatus.MATCH_EXCEPTION, VendorBillStatus.APPROVED);
 
     /**
      * Chart-of-accounts code of the single Sales-Tax Payable account (D-4: one GL
@@ -171,8 +171,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
 
         // Load all income statement mappings (ordered by display order)
-        List<StatementLineMapping> mappings = statementLineMappingRepository
-                .findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(
+        List<StatementLineMapping> mappings =
+                statementLineMappingRepository.findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(
                         StatementType.INCOME_STATEMENT);
 
         if (mappings.isEmpty()) {
@@ -252,8 +252,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         LocalDateTime asOfDateTime = asOfDate.atTime(LocalTime.MAX);
 
         // Load all balance sheet mappings (ordered by display order)
-        List<StatementLineMapping> mappings = statementLineMappingRepository
-                .findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(
+        List<StatementLineMapping> mappings =
+                statementLineMappingRepository.findByStatementTypeOrderByDisplayOrderAscStatementLineCodeAsc(
                         StatementType.BALANCE_SHEET);
 
         if (mappings.isEmpty()) {
@@ -310,7 +310,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
 
         // Validate balance sheet equation: Assets = Liabilities + Equity (within
         // tolerance)
-        BigDecimal difference = totalAssets.subtract(totalLiabilities.add(totalEquity)).abs();
+        BigDecimal difference =
+                totalAssets.subtract(totalLiabilities.add(totalEquity)).abs();
         boolean balanced = difference.compareTo(BALANCE_TOLERANCE) <= 0;
 
         if (!balanced) {
@@ -349,8 +350,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         // Per-account aggregation happens in the database (grouped JPQL over
         // POSTED lines, ordered by account code) — the line set is never
         // materialized in memory.
-        List<TrialBalanceAccountTotal> accountTotals = journalEntryRepository
-                .sumPostedDebitsCreditsByAccountAsOf(asOfDateTime);
+        List<TrialBalanceAccountTotal> accountTotals =
+                journalEntryRepository.sumPostedDebitsCreditsByAccountAsOf(asOfDateTime);
 
         List<TrialBalanceRow> rows = accountTotals.stream()
                 .map(total -> TrialBalanceRow.builder()
@@ -363,10 +364,10 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
                         .build())
                 .toList();
 
-        BigDecimal totalDebit = rows.stream().map(TrialBalanceRow::getTotalDebit).reduce(BigDecimal.ZERO,
-                BigDecimal::add);
-        BigDecimal totalCredit = rows.stream().map(TrialBalanceRow::getTotalCredit).reduce(BigDecimal.ZERO,
-                BigDecimal::add);
+        BigDecimal totalDebit =
+                rows.stream().map(TrialBalanceRow::getTotalDebit).reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal totalCredit =
+                rows.stream().map(TrialBalanceRow::getTotalCredit).reduce(BigDecimal.ZERO, BigDecimal::add);
 
         // Computed, never assumed: an unbalanced ledger (A1 constraint
         // violation) must surface operationally as balanced = false.
@@ -414,13 +415,13 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
      * chronological cut. A clean ledger yields an empty footnote.
      */
     private List<EntryNumberGapCheck> checkEntryNumberGaps(LocalDate asOf) {
-        String asOfScopeBoundary = String.format("%s%04d%02d", ENTRY_NUMBER_SCOPE_PREFIX, asOf.getYear(),
-                asOf.getMonthValue());
+        String asOfScopeBoundary =
+                String.format("%s%04d%02d", ENTRY_NUMBER_SCOPE_PREFIX, asOf.getYear(), asOf.getMonthValue());
 
         return accountingSequenceRepository.findAllByOrderByScopeKeyAsc().stream()
                 .map(AccountingSequence::getScopeKey)
-                .filter(scopeKey -> scopeKey.startsWith(ENTRY_NUMBER_SCOPE_PREFIX)
-                        && scopeKey.compareTo(asOfScopeBoundary) <= 0)
+                .filter(scopeKey ->
+                        scopeKey.startsWith(ENTRY_NUMBER_SCOPE_PREFIX) && scopeKey.compareTo(asOfScopeBoundary) <= 0)
                 .map(scopeKey -> EntryNumberGapCheck.builder()
                         .scopeKey(scopeKey)
                         .missingNumbers(accountingSequenceRepository.findMissingEntryNumbers(scopeKey))
@@ -496,8 +497,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
 
         // Find all posted journal entries affecting this account
-        List<JournalEntry> entries = journalEntryRepository.findPostedEntriesForAccount(glAccountId, startDateTime,
-                endDateTime);
+        List<JournalEntry> entries =
+                journalEntryRepository.findPostedEntriesForAccount(glAccountId, startDateTime, endDateTime);
 
         // Extract journal lines for this account
         return entries.stream()
@@ -538,8 +539,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         if (accountId != null) {
             UUID glAccountId = parseAccountId(accountId);
             log.info("Generating general ledger for account {} for period {} to {}", glAccountId, startDate, endDate);
-            List<JournalEntry> entries = journalEntryRepository.findPostedEntriesForAccount(glAccountId, startDateTime,
-                    endDateTime);
+            List<JournalEntry> entries =
+                    journalEntryRepository.findPostedEntriesForAccount(glAccountId, startDateTime, endDateTime);
             collectAccountLines(entries, glAccountId, linesByAccount);
         } else {
             log.info("Generating general ledger for all accounts for period {} to {}", startDate, endDate);
@@ -711,8 +712,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
             if (daysPastDue < 0) {
                 continue; // future-dated as of asOfDate — not yet an outstanding item (finding 10)
             }
-            VendorAging aging = byVendor.computeIfAbsent(bill.getVendorId(),
-                    key -> new VendorAging(bill.getVendorName()));
+            VendorAging aging =
+                    byVendor.computeIfAbsent(bill.getVendorId(), key -> new VendorAging(bill.getVendorName()));
             aging.buckets.add(daysPastDue, openBalance);
         }
 
@@ -730,7 +731,7 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
                             .build();
                 })
                 .sorted(Comparator.comparing(
-                        AgedPayablesRow::getVendorName, Comparator.nullsLast(Comparator.naturalOrder()))
+                                AgedPayablesRow::getVendorName, Comparator.nullsLast(Comparator.naturalOrder()))
                         .thenComparing(AgedPayablesRow::getVendorId))
                 .toList();
 
@@ -774,9 +775,10 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         // --- Invoice side (accrual): tax bucketed by the invoice's finalization period
         // ---
         List<ExtInvoice> invoices = extInvoiceRepository.findByFinalizedAtBetween(startInstant, endInstant);
-        List<UUID> invoiceIds = invoices.stream().map(ExtInvoice::getInvoiceId).distinct().toList();
-        List<ExtInvoiceTax> invoiceTaxRows = invoiceIds.isEmpty() ? List.of()
-                : extInvoiceTaxRepository.findByInvoiceIdIn(invoiceIds);
+        List<UUID> invoiceIds =
+                invoices.stream().map(ExtInvoice::getInvoiceId).distinct().toList();
+        List<ExtInvoiceTax> invoiceTaxRows =
+                invoiceIds.isEmpty() ? List.of() : extInvoiceTaxRepository.findByInvoiceIdIn(invoiceIds);
 
         for (ExtInvoiceTax row : invoiceTaxRows) {
             JurisdictionAccumulator acc = accumulatorFor(byJurisdiction, row);
@@ -807,14 +809,15 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
                     .map(CreditMemo::getOriginalInvoiceId)
                     .distinct()
                     .toList();
-            Map<UUID, List<ExtInvoiceTax>> taxByOriginalInvoice = extInvoiceTaxRepository
-                    .findByInvoiceIdIn(originalInvoiceIds).stream()
-                    .collect(Collectors.groupingBy(ExtInvoiceTax::getInvoiceId));
+            Map<UUID, List<ExtInvoiceTax>> taxByOriginalInvoice =
+                    extInvoiceTaxRepository.findByInvoiceIdIn(originalInvoiceIds).stream()
+                            .collect(Collectors.groupingBy(ExtInvoiceTax::getInvoiceId));
 
-            List<UUID> creditMemoIds = credits.stream().map(CreditMemo::getCreditMemoId).toList();
-            Map<UUID, List<CreditMemoTax>> attributionByCredit = creditMemoTaxRepository
-                    .findByCreditMemoIdIn(creditMemoIds).stream()
-                    .collect(Collectors.groupingBy(CreditMemoTax::getCreditMemoId));
+            List<UUID> creditMemoIds =
+                    credits.stream().map(CreditMemo::getCreditMemoId).toList();
+            Map<UUID, List<CreditMemoTax>> attributionByCredit =
+                    creditMemoTaxRepository.findByCreditMemoIdIn(creditMemoIds).stream()
+                            .collect(Collectors.groupingBy(CreditMemoTax::getCreditMemoId));
 
             for (CreditMemo credit : credits) {
                 unattributedCredits = unattributedCredits.add(netCreditAcrossJurisdictions(
@@ -838,15 +841,16 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
                     .map(CreditMemo::getOriginalInvoiceId)
                     .distinct()
                     .toList();
-            Map<UUID, List<ExtInvoiceTax>> taxByVoidInvoice = extInvoiceTaxRepository.findByInvoiceIdIn(voidInvoiceIds)
-                    .stream()
-                    .collect(Collectors.groupingBy(ExtInvoiceTax::getInvoiceId));
-            Map<UUID, List<CreditMemoTax>> attributionByVoid = creditMemoTaxRepository
-                    .findByCreditMemoIdIn(voids.stream()
-                            .map(CreditMemo::getCreditMemoId)
-                            .toList())
-                    .stream()
-                    .collect(Collectors.groupingBy(CreditMemoTax::getCreditMemoId));
+            Map<UUID, List<ExtInvoiceTax>> taxByVoidInvoice =
+                    extInvoiceTaxRepository.findByInvoiceIdIn(voidInvoiceIds).stream()
+                            .collect(Collectors.groupingBy(ExtInvoiceTax::getInvoiceId));
+            Map<UUID, List<CreditMemoTax>> attributionByVoid =
+                    creditMemoTaxRepository
+                            .findByCreditMemoIdIn(voids.stream()
+                                    .map(CreditMemo::getCreditMemoId)
+                                    .toList())
+                            .stream()
+                            .collect(Collectors.groupingBy(CreditMemoTax::getCreditMemoId));
 
             for (CreditMemo voided : voids) {
                 unattributedCredits = unattributedCredits.subtract(netCreditAcrossJurisdictions(
@@ -866,8 +870,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         BigDecimal totalCreditsNetted = sum(rows, TaxLiabilityRow::getCreditsNetted);
         BigDecimal totalNetTax = sum(rows, TaxLiabilityRow::getNetTax);
 
-        TaxLiabilityReconciliation reconciliation = reconcileAgainstTaxPayable(totalNetTax, unattributedCredits,
-                startDateTime, endDateTime);
+        TaxLiabilityReconciliation reconciliation =
+                reconcileAgainstTaxPayable(totalNetTax, unattributedCredits, startDateTime, endDateTime);
 
         log.info(
                 "Sales-tax liability generated for {}..{}: jurisdictions={}, gross={}, credits={}, netTax={}, glDrift={}",
@@ -974,8 +978,8 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
             weights.merge(keyFor(row), nullSafe(row.getTaxAmount()), BigDecimal::add);
         }
 
-        Map<JurisdictionKey, BigDecimal> allocated = weights.isEmpty() ? Map.of()
-                : TaxCreditAllocator.allocate(reversed, weights);
+        Map<JurisdictionKey, BigDecimal> allocated =
+                weights.isEmpty() ? Map.of() : TaxCreditAllocator.allocate(reversed, weights);
         if (allocated.isEmpty()) {
             // Either the original invoice has no replicated tax rows at all, or every row
             // carries
@@ -1027,7 +1031,7 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         BigDecimal glNetActivity = glAccountRepository
                 .findByAccountCode(SALES_TAX_PAYABLE_ACCOUNT_CODE)
                 .map(account -> nullSafe(journalEntryRepository.sumPostedBalanceForAccount(
-                        account.getGlAccountId(), startDateTime, endDateTime))
+                                account.getGlAccountId(), startDateTime, endDateTime))
                         .negate())
                 .orElse(BigDecimal.ZERO);
 
@@ -1138,13 +1142,13 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
     private GeneralLedgerAccountSection buildAccountSection(
             UUID glAccountId, @Nullable GLAccount account, List<JournalEntryLine> lines, LocalDateTime startDateTime) {
 
-        BigDecimal openingBalance = nullSafe(
-                journalEntryRepository.sumPostedBalanceForAccountBefore(glAccountId, startDateTime));
+        BigDecimal openingBalance =
+                nullSafe(journalEntryRepository.sumPostedBalanceForAccountBefore(glAccountId, startDateTime));
 
         // Chronological order: transaction date, then entry number, with stable
         // tie-breakers so equal-keyed lines are deterministic.
         lines.sort(Comparator.comparing(
-                (JournalEntryLine line) -> line.getJournalEntry().getTransactionDate())
+                        (JournalEntryLine line) -> line.getJournalEntry().getTransactionDate())
                 .thenComparing(
                         line -> line.getJournalEntry().getEntryNumber(),
                         Comparator.nullsLast(Comparator.naturalOrder()))
@@ -1176,10 +1180,10 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
                     .build());
         }
 
-        String accountNumber = account != null ? account.getAccountCode()
-                : firstNonNull(lines, JournalEntryLine::getAccountCode);
-        String accountName = account != null ? account.getAccountName()
-                : firstNonNull(lines, JournalEntryLine::getAccountName);
+        String accountNumber =
+                account != null ? account.getAccountCode() : firstNonNull(lines, JournalEntryLine::getAccountCode);
+        String accountName =
+                account != null ? account.getAccountName() : firstNonNull(lines, JournalEntryLine::getAccountName);
 
         return GeneralLedgerAccountSection.builder()
                 .accountId(glAccountId.toString())

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/config/EventTypeInitializerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,123 @@
+package com.positivity.accounting.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(EventTypes.all().size())).header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.all()).isNotEmpty();
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/config/EventTypesTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.accounting.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-archunit/src/test/java/com/positivity/archunit/DomainWallsTest.java
+++ b/pos-archunit/src/test/java/com/positivity/archunit/DomainWallsTest.java
@@ -104,8 +104,8 @@ class DomainWallsTest {
      * Startup-infra classes exempt per ADR-0044 R2 (registration calls, best-effort
      * at boot).
      */
-    private static final Pattern EXEMPT_FILES = Pattern
-            .compile(".*(EventTypeInitializer|PermissionRegistration|PermissionInitializer|PermissionRegistry"
+    private static final Pattern EXEMPT_FILES =
+            Pattern.compile(".*(EventTypeInitializer|PermissionRegistration|PermissionInitializer|PermissionRegistry"
                     + "|TemplateInitializer|PermissionVersionStartupCheck)\\.java$");
 
     private static final Pattern POS_SERVICE_TOKEN = Pattern.compile("pos-[a-z][a-z0-9-]*");

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/config/ClockConfig.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/config/ClockConfig.java
@@ -7,8 +7,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ClockConfig {
 
-  @Bean
-  public Clock clock() {
-    return Clock.systemUTC();
-  }
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
 }

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/config/BulkLoaderEventTypeInitializerTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/config/BulkLoaderEventTypeInitializerTest.java
@@ -1,0 +1,125 @@
+package com.positivity.bulkloader.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link BulkLoaderEventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link BulkLoaderEventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BulkLoaderEventTypeInitializer — startup event-type registration")
+class BulkLoaderEventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private BulkLoaderEventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new BulkLoaderEventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(BulkLoaderEventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        BulkLoaderEventTypeInitializer sutWithSecret =
+                new BulkLoaderEventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(BulkLoaderEventTypes.all().size()))
+                .header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(BulkLoaderEventTypes.all()).isNotEmpty();
+        verify(restClient, times(BulkLoaderEventTypes.all().size())).put();
+    }
+}

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/config/BulkLoaderEventTypesTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/config/BulkLoaderEventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.bulkloader.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link BulkLoaderEventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
  * descriptions, ordered thresholds, and a threshold triple that matches a
  * declared preset rather than an ad-hoc value.
  */
-@DisplayName("EventTypes — event-type registry contract")
-class EventTypesTest {
+@DisplayName("BulkLoaderEventTypes — event-type registry contract")
+class BulkLoaderEventTypesTest {
 
     /**
      * Event type codes are upper snake case: the receiver stores them verbatim as
@@ -58,7 +58,7 @@ class EventTypesTest {
     }
 
     private static List<EventTypeRegistration> registrations() {
-        return EventTypes.all();
+        return BulkLoaderEventTypes.all();
     }
 
     @Test
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/FileUploadProcessEndToEndTest.java
+++ b/pos-bulk-loader/src/test/java/com/positivity/bulkloader/internal/controller/FileUploadProcessEndToEndTest.java
@@ -101,8 +101,7 @@ class FileUploadProcessEndToEndTest {
 
         when(restClientBuilder.baseUrl(nullable(String.class))).thenReturn(restClientBuilder);
         when(restClientBuilder.build()).thenReturn(mockRestClient);
-        when(loadBalancedRestClientBuilder.baseUrl(nullable(String.class)))
-                .thenReturn(loadBalancedRestClientBuilder);
+        when(loadBalancedRestClientBuilder.baseUrl(nullable(String.class))).thenReturn(loadBalancedRestClientBuilder);
         when(loadBalancedRestClientBuilder.build()).thenReturn(mockRestClient);
         when(mockRestClient.post()).thenReturn(requestBodyUriSpec);
         when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/config/CatalogEventTypesTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/config/CatalogEventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.catalog.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link CatalogEventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
  * descriptions, ordered thresholds, and a threshold triple that matches a
  * declared preset rather than an ad-hoc value.
  */
-@DisplayName("EventTypes — event-type registry contract")
-class EventTypesTest {
+@DisplayName("CatalogEventTypes — event-type registry contract")
+class CatalogEventTypesTest {
 
     /**
      * Event type codes are upper snake case: the receiver stores them verbatim as
@@ -58,7 +58,7 @@ class EventTypesTest {
     }
 
     private static List<EventTypeRegistration> registrations() {
-        return EventTypes.all();
+        return CatalogEventTypes.all();
     }
 
     @Test
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/config/EventTypeInitializerTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,124 @@
+package com.positivity.catalog.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link CatalogEventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(CatalogEventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(CatalogEventTypes.all().size()))
+                .header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(CatalogEventTypes.all()).isNotEmpty();
+        verify(restClient, times(CatalogEventTypes.all().size())).put();
+    }
+}

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/config/ManifestPublisherTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/config/ManifestPublisherTest.java
@@ -1,0 +1,366 @@
+package com.positivity.catalog.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.entity.OutboxEvent;
+import com.positivity.catalog.internal.repository.OutboxEventRepository;
+import com.positivity.domainevents.ReconciliationManifestV1;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for the pos-catalog {@link ManifestPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * Each closed window gets one reconciliation manifest summarizing the events
+ * published from the outbox in that window; consumers recompute the same summary
+ * and request a replay on drift. The properties that matter:
+ *
+ * <ul>
+ * <li>Window membership is decided by the <em>eventId</em> (UUIDv7) timestamp,
+ * not by {@code createdAt}. The query pads its range by a second of slack, so a
+ * row can be fetched and still belong to a neighbouring window; counting it in
+ * the wrong one would manufacture drift on both sides.</li>
+ * <li>Empty windows still publish, so consumers can alert on manifest absence
+ * rather than treating silence as health.</li>
+ * <li>A malformed row is skipped with a warning instead of failing the window
+ * forever — one bad payload must not permanently block reconciliation.</li>
+ * <li>A failed send leaves the window unadvanced so the next run retries it, and
+ * catch-up is bounded per run so a long outage cannot monopolize a poll.</li>
+ * </ul>
+ */
+@DisplayName("pos-catalog ManifestPublisher — reconciliation manifest windows")
+class ManifestPublisherTest {
+
+    /** 12:10 UTC: the [11:00, 12:00) window closed more than the 5m grace ago. */
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-08T12:10:00Z"), ZoneOffset.UTC);
+
+    private static final Instant WINDOW_START = Instant.parse("2026-07-08T11:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-07-08T12:00:00Z");
+    private static final String EVENTS_TOPIC = "catalog.events.v1";
+    private static final String MANIFEST_TOPIC = "catalog.manifest.v1";
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private SimpleMeterRegistry meterRegistry;
+    private ManifestPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry, TEST_CLOCK);
+        brokerAcknowledges();
+    }
+
+    @SuppressWarnings("unchecked")
+    private ManifestPublisher newPublisher(MeterRegistry registry, Clock clock) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        ManifestPublisher created = new ManifestPublisher(repository, kafkaTemplate, objectMapper, clock, provider);
+        ReflectionTestUtils.setField(created, "eventsTopic", EVENTS_TOPIC);
+        ReflectionTestUtils.setField(created, "manifestTopic", MANIFEST_TOPIC);
+        ReflectionTestUtils.setField(created, "window", Duration.ofHours(1));
+        ReflectionTestUtils.setField(created, "grace", Duration.ofMinutes(5));
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    /** UUIDv7-shaped id whose embedded timestamp is {@code at}. */
+    private static String eventIdAt(Instant at, int suffix) {
+        long millis = at.toEpochMilli();
+        return String.format("%08x-%04x-7000-8000-%012x", millis >>> 16, millis & 0xFFFF, suffix);
+    }
+
+    private static OutboxEvent row(String eventId, String eventType, Instant createdAt) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey(eventId)
+                .payload("{\"eventId\":\"" + eventId + "\",\"eventType\":\"" + eventType + "\",\"payload\":{}}")
+                .createdAt(createdAt)
+                .publishedAt(createdAt.plusSeconds(1))
+                .build();
+    }
+
+    private void outboxReturns(List<OutboxEvent> rows) {
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(rows);
+    }
+
+    private JsonNode capturedManifest() {
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), json.capture());
+        return objectMapper.readTree(json.getValue());
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("publishes the latest closed window with its count, checksum, and per-type counts")
+    void publishesManifestForClosedWindow() {
+        String inWindow1 = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String inWindow2 = eventIdAt(WINDOW_START.plusSeconds(120), 2);
+        outboxReturns(List.of(
+                row(inWindow1, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(inWindow2, "SomethingElseChanged", WINDOW_START.plusSeconds(120))));
+
+        publisher.publishDueManifest();
+
+        JsonNode envelope = capturedManifest();
+        assertThat(envelope.path("sourceService").stringValue()).isEqualTo("pos-catalog");
+        assertThat(envelope.path("eventType").stringValue())
+                .isEqualTo(ReconciliationManifestV1.eventTypeFor("catalog"));
+
+        JsonNode manifest = envelope.path("payload");
+        assertThat(manifest.path("windowStartUtc").stringValue()).isEqualTo(WINDOW_START.toString());
+        assertThat(manifest.path("windowEndUtc").stringValue()).isEqualTo(WINDOW_END.toString());
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(2);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow1, inWindow2)));
+        assertThat(manifest.path("eventTypeCounts").path("SomethingChanged").longValue())
+                .isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("SomethingElseChanged").longValue())
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row fetched by createdAt slack whose eventId falls outside the window")
+    void excludesRowOutsideWindowByEventIdTimestamp() {
+        String inWindow = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String justBefore = eventIdAt(WINDOW_START.minusMillis(1), 2);
+        String justAfter = eventIdAt(WINDOW_END.plusMillis(1), 3);
+        outboxReturns(List.of(
+                row(justBefore, "SomethingChanged", WINDOW_START.minusMillis(1)),
+                row(inWindow, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(justAfter, "SomethingChanged", WINDOW_END.plusMillis(1))));
+
+        publisher.publishDueManifest();
+
+        // Membership is decided by the eventId timestamp, not the padded createdAt
+        // query: counting a neighbour here would manufacture drift on both sides.
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow)));
+    }
+
+    @Test
+    @DisplayName("publishes a zero-count manifest so consumers can alert on absence rather than silence")
+    void publishesEmptyWindowManifest() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isZero();
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of()));
+    }
+
+    @Test
+    @DisplayName("counts a row with a blank event type under \"unknown\" rather than dropping it")
+    void blankEventTypeCountedAsUnknown() {
+        String eventId = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        outboxReturns(List.of(row(eventId, "", WINDOW_START.plusSeconds(60))));
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("unknown").longValue()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row with no eventId instead of failing the window")
+    void skipsRowWithoutEventId() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("{\"eventType\":\"PartyChanged\"}")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("excludes a row whose payload will not parse instead of blocking reconciliation forever")
+    void skipsRowWithUnparsablePayload() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("not json at all")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("does not re-publish a window it already published")
+    void skipsAlreadyPublishedWindow() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("waits out the grace period, publishing the previous window until the latest one settles")
+    void respectsGracePeriod() {
+        ReflectionTestUtils.setField(publisher, "grace", Duration.ofMinutes(15));
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        // 12:10 with 15m grace: [11:00, 12:00) is not yet eligible, so the
+        // published window is the previous one.
+        assertThat(capturedManifest().path("payload").path("windowEndUtc").stringValue())
+                .isEqualTo("2026-07-08T11:00:00Z");
+    }
+
+    @Test
+    @DisplayName("retries the same window on the next run when the send fails")
+    void retriesWindowAfterSendFailure() {
+        outboxReturns(List.of());
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker down")))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        // The window must not advance past a failure, or its manifest is lost.
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(counter("catalog.manifest.publish.failures")).isEqualTo(1d);
+        assertThat(counter("catalog.manifest.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("counts a successful publish")
+    void countsSuccessfulPublish() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        assertThat(counter("catalog.manifest.published")).isEqualTo(1d);
+        assertThat(counter("catalog.manifest.publish.failures")).isZero();
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        ManifestPublisher withoutMetrics = newPublisher(null, TEST_CLOCK);
+        outboxReturns(List.of());
+
+        withoutMetrics.publishDueManifest();
+
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("publishes nothing when no window has closed yet")
+    void publishesNothingBeforeTheFirstWindowCloses() {
+        // Epoch + 30m with a 1h window: no aligned window boundary has passed.
+        ManifestPublisher early = newPublisher(meterRegistry, Clock.fixed(Instant.ofEpochSecond(1800), ZoneOffset.UTC));
+
+        early.publishDueManifest();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("keys every manifest for a window deterministically, so re-publishes land on one partition")
+    void manifestRecordKeyIsStablePerWindow() {
+        outboxReturns(List.of());
+        ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+
+        publisher.publishDueManifest();
+        // A second publisher instance, same window: the key must match.
+        ManifestPublisher other = newPublisher(meterRegistry, TEST_CLOCK);
+        other.publishDueManifest();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), key.capture(), anyString());
+        assertThat(key.getAllValues()).hasSize(2);
+        assertThat(key.getAllValues().get(0)).isEqualTo(key.getAllValues().get(1));
+    }
+
+    @Test
+    @DisplayName("after a gap, catches up window by window rather than skipping to the newest")
+    void catchesUpWindowByWindow() {
+        outboxReturns(List.of());
+
+        // First run establishes [11:00, 12:00) as published.
+        publisher.publishDueManifest();
+
+        // Three hours later four windows have closed; the next run must publish the
+        // intervening ones, not jump to the newest and leave holes.
+        ManifestPublisher later = publisher;
+        ReflectionTestUtils.setField(
+                later, "clock", Clock.fixed(Instant.parse("2026-07-08T15:10:00Z"), ZoneOffset.UTC));
+        later.publishDueManifest();
+
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate, times(4)).send(anyString(), anyString(), json.capture());
+        assertThat(json.getAllValues())
+                .map(value -> objectMapper
+                        .readTree(value)
+                        .path("payload")
+                        .path("windowEndUtc")
+                        .stringValue())
+                .containsExactly(
+                        "2026-07-08T12:00:00Z", "2026-07-08T13:00:00Z", "2026-07-08T14:00:00Z", "2026-07-08T15:00:00Z");
+    }
+}

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/config/OutboxPublisherTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/config/OutboxPublisherTest.java
@@ -1,0 +1,213 @@
+package com.positivity.catalog.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.entity.OutboxEvent;
+import com.positivity.catalog.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for the pos-catalog {@link OutboxPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * The publisher drains {@code event_outbox} to Kafka with at-least-once
+ * semantics. Three properties carry the correctness weight:
+ *
+ * <ul>
+ * <li>a row is marked published <em>only</em> after the broker acknowledges, so
+ * a crash mid-send re-sends rather than silently dropping the event;</li>
+ * <li>the batch stops at the first failure, so a struggling broker cannot
+ * reorder events past a stuck row; and</li>
+ * <li>the failure path records {@code attempts} and a bounded
+ * {@code last_error} for alerting instead of throwing out of the scheduled
+ * method.</li>
+ * </ul>
+ */
+@DisplayName("pos-catalog OutboxPublisher — outbox drain contract")
+class OutboxPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-08T12:00:00Z");
+    private static final Clock TEST_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private SimpleMeterRegistry meterRegistry;
+    private OutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    private OutboxPublisher newPublisher(MeterRegistry registry) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        OutboxPublisher created = new OutboxPublisher(repository, kafkaTemplate, TEST_CLOCK, provider);
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private OutboxEvent event(String key) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("catalog.events.v1")
+                .recordKey(key)
+                .payload("{\"eventId\":\"" + key + "\"}")
+                .createdAt(NOW.minusSeconds(60))
+                .attempts(2)
+                .lastError("previous failure")
+                .build();
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    private void brokerFailsWith(Throwable failure) {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(failure));
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("marks the row published only after the broker acknowledges the send")
+    void marksPublishedAfterAcknowledgedSend() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate).send("catalog.events.v1", "k1", row.getPayload());
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        assertThat(row.getAttempts()).isZero();
+        assertThat(row.getLastError()).isNull();
+        verify(repository).save(row);
+        assertThat(counter("catalog.outbox.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("drains the whole batch in order while the broker keeps acknowledging")
+    void drainsWholeBatchWhenAllSendsSucceed() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(first.getPublishedAt()).isEqualTo(NOW);
+        assertThat(second.getPublishedAt()).isEqualTo(NOW);
+        assertThat(counter("catalog.outbox.published")).isEqualTo(2d);
+    }
+
+    @Test
+    @DisplayName("on failure: records the attempt and error, leaves the row unpublished, stops the batch")
+    void recordsFailureAndStopsBatch() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerFailsWith(new RuntimeException("broker down"));
+
+        publisher.publishPending();
+
+        assertThat(first.getPublishedAt()).isNull();
+        assertThat(first.getAttempts()).isEqualTo(3);
+        assertThat(first.getLastError()).contains("broker down");
+        verify(repository).save(first);
+
+        // The batch stops at the first failure so publish order is preserved:
+        // the second row is never attempted and keeps its prior attempt count.
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+        verify(kafkaTemplate).send("catalog.events.v1", "k1", first.getPayload());
+        assertThat(second.getAttempts()).isEqualTo(2);
+        assertThat(second.getPublishedAt()).isNull();
+        assertThat(counter("catalog.outbox.publish.failures")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("falls back to the exception class name when the failure carries no message")
+    void recordsClassNameWhenFailureMessageIsNull() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        // Thrown by send() itself rather than completing the future exceptionally:
+        // a failed future surfaces as an ExecutionException whose message is the
+        // cause's toString, so only a synchronous throw reaches the null-message
+        // fallback in recordFailure().
+        when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenThrow(new IllegalStateException());
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).isEqualTo("IllegalStateException");
+        assertThat(row.getPublishedAt()).isNull();
+        assertThat(row.getAttempts()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("truncates an oversized failure message to the 2000-character column bound")
+    void truncatesOversizedFailureMessage() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerFailsWith(new RuntimeException("x".repeat(2500)));
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).hasSize(2000);
+    }
+
+    @Test
+    @DisplayName("does nothing when the outbox is empty")
+    void doesNothingWhenNoPendingRows() {
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of());
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        verify(repository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        OutboxPublisher withoutMetrics = newPublisher(null);
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        withoutMetrics.publishPending();
+
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        verify(repository).save(row);
+    }
+}

--- a/pos-customer/src/main/java/com/positivity/customer/internal/config/CrmExceptionHandler.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/config/CrmExceptionHandler.java
@@ -39,173 +39,171 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @Slf4j
 @RequiredArgsConstructor
 public class CrmExceptionHandler {
-        private static final String X_CORRELATION_ID = "X-Correlation-Id";
-        private final Clock clock;
+    private static final String X_CORRELATION_ID = "X-Correlation-Id";
+    private final Clock clock;
 
-        @ExceptionHandler(AccessDeniedException.class)
-        public ResponseEntity<ApiError> handleAccessDenied(
-                        AccessDeniedException ex, HttpServletRequest request, HttpServletResponse response) {
-                String path = request != null ? request.getRequestURI() : "";
-                log.warn("Access denied on {}: {}", path, ex.getMessage());
-                String correlationId = resolveCorrelationId(request);
-                response.setHeader(X_CORRELATION_ID, correlationId);
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiError> handleAccessDenied(
+            AccessDeniedException ex, HttpServletRequest request, HttpServletResponse response) {
+        String path = request != null ? request.getRequestURI() : "";
+        log.warn("Access denied on {}: {}", path, ex.getMessage());
+        String correlationId = resolveCorrelationId(request);
+        response.setHeader(X_CORRELATION_ID, correlationId);
 
-                return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                                .body(ApiError.of(
-                                                "PERMISSION_DENIED",
-                                                "You do not have permission to perform this action",
-                                                HttpStatus.FORBIDDEN.value(),
-                                                Instant.now(clock).toString(),
-                                                correlationId));
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ApiError.of(
+                        "PERMISSION_DENIED",
+                        "You do not have permission to perform this action",
+                        HttpStatus.FORBIDDEN.value(),
+                        Instant.now(clock).toString(),
+                        correlationId));
+    }
+
+    @ExceptionHandler(DuplicateRedemptionException.class)
+    public ResponseEntity<ApiError> handleDuplicateRedemption(
+            DuplicateRedemptionException ex, HttpServletRequest request, HttpServletResponse response) {
+        String path = request != null ? request.getRequestURI() : "";
+        log.warn("Duplicate redemption on {}: {}", path, ex.getMessage());
+        String correlationId = resolveCorrelationId(request);
+        response.setHeader(X_CORRELATION_ID, correlationId);
+
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiError.of(
+                        "DUPLICATE_REDEMPTION",
+                        ex.getMessage(),
+                        HttpStatus.CONFLICT.value(),
+                        Instant.now(clock).toString(),
+                        correlationId));
+    }
+
+    @ExceptionHandler(CrmResourceNotFoundException.class)
+    public ResponseEntity<ApiError> handleNotFound(
+            CrmResourceNotFoundException ex, HttpServletRequest request, HttpServletResponse response) {
+        String path = request != null ? request.getRequestURI() : "";
+        log.warn("Resource not found on {}: {}", path, ex.getMessage());
+        String correlationId = resolveCorrelationId(request);
+        response.setHeader(X_CORRELATION_ID, correlationId);
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiError.of(
+                        "RESOURCE_NOT_FOUND",
+                        ex.getMessage(),
+                        HttpStatus.NOT_FOUND.value(),
+                        Instant.now(clock).toString(),
+                        correlationId));
+    }
+
+    @ExceptionHandler(CrmDuplicateResourceException.class)
+    public ResponseEntity<ApiError> handleDuplicateResource(
+            CrmDuplicateResourceException ex, HttpServletRequest request, HttpServletResponse response) {
+        String path = request != null ? request.getRequestURI() : "";
+        log.warn("Duplicate resource on {}: {}", path, ex.getMessage());
+        String correlationId = resolveCorrelationId(request);
+        response.setHeader(X_CORRELATION_ID, correlationId);
+
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiError.of(
+                        "DUPLICATE_RESOURCE",
+                        ex.getMessage(),
+                        HttpStatus.CONFLICT.value(),
+                        Instant.now(clock).toString(),
+                        correlationId));
+    }
+
+    /**
+     * A structurally valid request whose content the domain refuses — currently the
+     * segment predicate validator (Story #1137). ADR-0017 maps this to {@code 422}
+     * so callers can distinguish it from a malformed body ({@code 400}).
+     */
+    @ExceptionHandler(CrmUnprocessableEntityException.class)
+    public ResponseEntity<ApiError> handleUnprocessable(
+            CrmUnprocessableEntityException ex, HttpServletRequest request, HttpServletResponse response) {
+        String path = request != null ? request.getRequestURI() : "";
+        log.warn("Unprocessable entity on {}: {}", path, ex.getMessage());
+        String correlationId = resolveCorrelationId(request);
+        response.setHeader(X_CORRELATION_ID, correlationId);
+
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_CONTENT)
+                .body(ApiError.of(
+                        "UNPROCESSABLE_CONTENT",
+                        ex.getMessage(),
+                        HttpStatus.UNPROCESSABLE_CONTENT.value(),
+                        Instant.now(clock).toString(),
+                        correlationId));
+    }
+
+    /**
+     * Rate limit exceeded on the public inquiry form. The message is deliberately
+     * generic — a
+     * response that revealed the exact limit or remaining quota would just tell an
+     * abuser how
+     * to pace themselves.
+     */
+    @ExceptionHandler(CrmTooManyRequestsException.class)
+    public ResponseEntity<ApiError> handleTooManyRequests(
+            CrmTooManyRequestsException ex, HttpServletRequest request, HttpServletResponse response) {
+        String path = request != null ? request.getRequestURI() : "";
+        log.warn("Rate limit exceeded on {}", path);
+        String correlationId = resolveCorrelationId(request);
+        response.setHeader(X_CORRELATION_ID, correlationId);
+
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .body(ApiError.of(
+                        "TOO_MANY_REQUESTS",
+                        ex.getMessage(),
+                        HttpStatus.TOO_MANY_REQUESTS.value(),
+                        Instant.now(clock).toString(),
+                        correlationId));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpServletRequest request, HttpServletResponse response) {
+        String path = request != null ? request.getRequestURI() : "";
+        log.warn("Validation failed on {}: {}", path, ex.getMessage());
+        String correlationId = resolveCorrelationId(request);
+        response.setHeader(X_CORRELATION_ID, correlationId);
+
+        List<ApiError.FieldError> fieldErrors = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> new ApiError.FieldError(
+                        fe.getField(), fe.getDefaultMessage() != null ? fe.getDefaultMessage() : "Invalid value"))
+                .toList();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiError.withFieldErrors(
+                        "VALIDATION_FAILED",
+                        "Request validation failed",
+                        HttpStatus.BAD_REQUEST.value(),
+                        Instant.now(clock).toString(),
+                        correlationId,
+                        fieldErrors));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiError> handleIllegalArgument(
+            IllegalArgumentException ex, HttpServletRequest request, HttpServletResponse response) {
+        String path = request != null ? request.getRequestURI() : "";
+        log.warn("Invalid argument on {}: {}", path, ex.getMessage());
+        String correlationId = resolveCorrelationId(request);
+        response.setHeader(X_CORRELATION_ID, correlationId);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiError.of(
+                        "VALIDATION_ERROR",
+                        ex.getMessage(),
+                        HttpStatus.BAD_REQUEST.value(),
+                        Instant.now(clock).toString(),
+                        correlationId));
+    }
+
+    private String resolveCorrelationId(HttpServletRequest request) {
+        if (request == null) {
+            return UUIDv7Generator.generate().toString();
         }
-
-        @ExceptionHandler(DuplicateRedemptionException.class)
-        public ResponseEntity<ApiError> handleDuplicateRedemption(
-                        DuplicateRedemptionException ex, HttpServletRequest request, HttpServletResponse response) {
-                String path = request != null ? request.getRequestURI() : "";
-                log.warn("Duplicate redemption on {}: {}", path, ex.getMessage());
-                String correlationId = resolveCorrelationId(request);
-                response.setHeader(X_CORRELATION_ID, correlationId);
-
-                return ResponseEntity.status(HttpStatus.CONFLICT)
-                                .body(ApiError.of(
-                                                "DUPLICATE_REDEMPTION",
-                                                ex.getMessage(),
-                                                HttpStatus.CONFLICT.value(),
-                                                Instant.now(clock).toString(),
-                                                correlationId));
+        String correlationId = request.getHeader(X_CORRELATION_ID);
+        if (correlationId == null || correlationId.isBlank()) {
+            return UUIDv7Generator.generate().toString();
         }
-
-        @ExceptionHandler(CrmResourceNotFoundException.class)
-        public ResponseEntity<ApiError> handleNotFound(
-                        CrmResourceNotFoundException ex, HttpServletRequest request, HttpServletResponse response) {
-                String path = request != null ? request.getRequestURI() : "";
-                log.warn("Resource not found on {}: {}", path, ex.getMessage());
-                String correlationId = resolveCorrelationId(request);
-                response.setHeader(X_CORRELATION_ID, correlationId);
-
-                return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                                .body(ApiError.of(
-                                                "RESOURCE_NOT_FOUND",
-                                                ex.getMessage(),
-                                                HttpStatus.NOT_FOUND.value(),
-                                                Instant.now(clock).toString(),
-                                                correlationId));
-        }
-
-        @ExceptionHandler(CrmDuplicateResourceException.class)
-        public ResponseEntity<ApiError> handleDuplicateResource(
-                        CrmDuplicateResourceException ex, HttpServletRequest request, HttpServletResponse response) {
-                String path = request != null ? request.getRequestURI() : "";
-                log.warn("Duplicate resource on {}: {}", path, ex.getMessage());
-                String correlationId = resolveCorrelationId(request);
-                response.setHeader(X_CORRELATION_ID, correlationId);
-
-                return ResponseEntity.status(HttpStatus.CONFLICT)
-                                .body(ApiError.of(
-                                                "DUPLICATE_RESOURCE",
-                                                ex.getMessage(),
-                                                HttpStatus.CONFLICT.value(),
-                                                Instant.now(clock).toString(),
-                                                correlationId));
-        }
-
-        /**
-         * A structurally valid request whose content the domain refuses — currently the
-         * segment predicate validator (Story #1137). ADR-0017 maps this to {@code 422}
-         * so callers can distinguish it from a malformed body ({@code 400}).
-         */
-        @ExceptionHandler(CrmUnprocessableEntityException.class)
-        public ResponseEntity<ApiError> handleUnprocessable(
-                        CrmUnprocessableEntityException ex, HttpServletRequest request, HttpServletResponse response) {
-                String path = request != null ? request.getRequestURI() : "";
-                log.warn("Unprocessable entity on {}: {}", path, ex.getMessage());
-                String correlationId = resolveCorrelationId(request);
-                response.setHeader(X_CORRELATION_ID, correlationId);
-
-                return ResponseEntity.status(HttpStatus.UNPROCESSABLE_CONTENT)
-                                .body(ApiError.of(
-                                                "UNPROCESSABLE_CONTENT",
-                                                ex.getMessage(),
-                                                HttpStatus.UNPROCESSABLE_CONTENT.value(),
-                                                Instant.now(clock).toString(),
-                                                correlationId));
-        }
-
-        /**
-         * Rate limit exceeded on the public inquiry form. The message is deliberately
-         * generic — a
-         * response that revealed the exact limit or remaining quota would just tell an
-         * abuser how
-         * to pace themselves.
-         */
-        @ExceptionHandler(CrmTooManyRequestsException.class)
-        public ResponseEntity<ApiError> handleTooManyRequests(
-                        CrmTooManyRequestsException ex, HttpServletRequest request, HttpServletResponse response) {
-                String path = request != null ? request.getRequestURI() : "";
-                log.warn("Rate limit exceeded on {}", path);
-                String correlationId = resolveCorrelationId(request);
-                response.setHeader(X_CORRELATION_ID, correlationId);
-
-                return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
-                                .body(ApiError.of(
-                                                "TOO_MANY_REQUESTS",
-                                                ex.getMessage(),
-                                                HttpStatus.TOO_MANY_REQUESTS.value(),
-                                                Instant.now(clock).toString(),
-                                                correlationId));
-        }
-
-        @ExceptionHandler(MethodArgumentNotValidException.class)
-        public ResponseEntity<ApiError> handleMethodArgumentNotValid(
-                        MethodArgumentNotValidException ex, HttpServletRequest request, HttpServletResponse response) {
-                String path = request != null ? request.getRequestURI() : "";
-                log.warn("Validation failed on {}: {}", path, ex.getMessage());
-                String correlationId = resolveCorrelationId(request);
-                response.setHeader(X_CORRELATION_ID, correlationId);
-
-                List<ApiError.FieldError> fieldErrors = ex.getBindingResult().getFieldErrors().stream()
-                                .map(fe -> new ApiError.FieldError(
-                                                fe.getField(),
-                                                fe.getDefaultMessage() != null ? fe.getDefaultMessage()
-                                                                : "Invalid value"))
-                                .toList();
-
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                                .body(ApiError.withFieldErrors(
-                                                "VALIDATION_FAILED",
-                                                "Request validation failed",
-                                                HttpStatus.BAD_REQUEST.value(),
-                                                Instant.now(clock).toString(),
-                                                correlationId,
-                                                fieldErrors));
-        }
-
-        @ExceptionHandler(IllegalArgumentException.class)
-        public ResponseEntity<ApiError> handleIllegalArgument(
-                        IllegalArgumentException ex, HttpServletRequest request, HttpServletResponse response) {
-                String path = request != null ? request.getRequestURI() : "";
-                log.warn("Invalid argument on {}: {}", path, ex.getMessage());
-                String correlationId = resolveCorrelationId(request);
-                response.setHeader(X_CORRELATION_ID, correlationId);
-
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                                .body(ApiError.of(
-                                                "VALIDATION_ERROR",
-                                                ex.getMessage(),
-                                                HttpStatus.BAD_REQUEST.value(),
-                                                Instant.now(clock).toString(),
-                                                correlationId));
-        }
-
-        private String resolveCorrelationId(HttpServletRequest request) {
-                if (request == null) {
-                        return UUIDv7Generator.generate().toString();
-                }
-                String correlationId = request.getHeader(X_CORRELATION_ID);
-                if (correlationId == null || correlationId.isBlank()) {
-                        return UUIDv7Generator.generate().toString();
-                }
-                return correlationId;
-        }
+        return correlationId;
+    }
 }

--- a/pos-customer/src/test/java/com/positivity/customer/internal/config/CrmExceptionHandlerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/config/CrmExceptionHandlerTest.java
@@ -1,0 +1,214 @@
+package com.positivity.customer.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.exception.CrmDuplicateResourceException;
+import com.positivity.customer.internal.exception.CrmResourceNotFoundException;
+import com.positivity.customer.internal.exception.CrmTooManyRequestsException;
+import com.positivity.customer.internal.exception.CrmUnprocessableEntityException;
+import com.positivity.customer.internal.exception.DuplicateRedemptionException;
+import com.positivity.shared.error.ApiError;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+/**
+ * Unit tests for {@link CrmExceptionHandler} (ADR-0017 error envelope).
+ *
+ * <p>
+ * Two distinctions here are load-bearing rather than cosmetic. A structurally
+ * valid request the domain refuses is a 422, separate from a malformed body's
+ * 400, so a caller can tell "your JSON is wrong" from "your JSON is fine but
+ * this is not allowed". And two responses deliberately withhold detail: a 403
+ * says only that permission is missing, and the public inquiry form's 429 stays
+ * generic, because a response naming the exact limit or remaining quota would
+ * tell an abuser how to pace themselves.
+ *
+ * <p>
+ * The correlation id is echoed onto both the body and the
+ * {@code X-Correlation-Id} response header, preserving an inbound id so a trace
+ * started upstream survives the error; a blank inbound header counts as absent.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("CrmExceptionHandler — ApiError envelope and correlation")
+class CrmExceptionHandlerTest {
+
+    private static final String CORRELATION_HEADER = "X-Correlation-Id";
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+    private static final UUID ID = UUID.fromString("00000000-0000-0000-0000-0000000000e1");
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    private CrmExceptionHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new CrmExceptionHandler(Clock.fixed(NOW, ZoneOffset.UTC));
+        when(request.getRequestURI()).thenReturn("/v1/crm/accounts");
+        when(request.getHeader(CORRELATION_HEADER)).thenReturn("trace-1");
+    }
+
+    private void assertEnvelope(ResponseEntity<ApiError> result, HttpStatus status, String code) {
+        assertThat(result.getStatusCode()).isEqualTo(status);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().code()).isEqualTo(code);
+        assertThat(result.getBody().status()).isEqualTo(status.value());
+        assertThat(result.getBody().timestamp()).isEqualTo(NOW.toString());
+        assertThat(result.getBody().correlationId()).isEqualTo("trace-1");
+        verify(response).setHeader(CORRELATION_HEADER, "trace-1");
+    }
+
+    @Test
+    @DisplayName("maps a permission failure to 403 without naming the missing authority")
+    void accessDenied() {
+        ResponseEntity<ApiError> result =
+                handler.handleAccessDenied(new AccessDeniedException("missing crm:party:view"), request, response);
+
+        assertEnvelope(result, HttpStatus.FORBIDDEN, "PERMISSION_DENIED");
+        // The required authority is a detail of the authorization model; it stays in the log.
+        assertThat(result.getBody().message()).doesNotContain("crm:party:view");
+    }
+
+    @Test
+    @DisplayName("maps a replayed promotion redemption to 409 DUPLICATE_REDEMPTION")
+    void duplicateRedemption() {
+        assertEnvelope(
+                handler.handleDuplicateRedemption(new DuplicateRedemptionException(ID, ID), request, response),
+                HttpStatus.CONFLICT,
+                "DUPLICATE_REDEMPTION");
+    }
+
+    @Test
+    @DisplayName("maps a missing resource to 404 RESOURCE_NOT_FOUND, keeping the domain's message")
+    void notFound() {
+        ResponseEntity<ApiError> result =
+                handler.handleNotFound(new CrmResourceNotFoundException("Party", ID), request, response);
+
+        assertEnvelope(result, HttpStatus.NOT_FOUND, "RESOURCE_NOT_FOUND");
+        assertThat(result.getBody().message()).contains(ID.toString());
+    }
+
+    @Test
+    @DisplayName("maps a duplicate resource to 409 DUPLICATE_RESOURCE")
+    void duplicateResource() {
+        assertEnvelope(
+                handler.handleDuplicateResource(new CrmDuplicateResourceException("Segment", "VIP"), request, response),
+                HttpStatus.CONFLICT,
+                "DUPLICATE_RESOURCE");
+    }
+
+    @Test
+    @DisplayName("maps a refused-but-well-formed request to 422, distinct from a malformed body's 400")
+    void unprocessable() {
+        ResponseEntity<ApiError> result = handler.handleUnprocessable(
+                new CrmUnprocessableEntityException("predicate references an unknown attribute"), request, response);
+
+        assertEnvelope(result, HttpStatus.UNPROCESSABLE_CONTENT, "UNPROCESSABLE_CONTENT");
+        // 422 vs 400 is what lets a caller tell "your JSON is wrong" from "this is not allowed".
+        assertThat(result.getBody().message()).isEqualTo("predicate references an unknown attribute");
+    }
+
+    @Test
+    @DisplayName("maps a rate-limited inquiry to 429")
+    void tooManyRequests() {
+        assertEnvelope(
+                handler.handleTooManyRequests(new CrmTooManyRequestsException("Too many requests"), request, response),
+                HttpStatus.TOO_MANY_REQUESTS,
+                "TOO_MANY_REQUESTS");
+    }
+
+    @Test
+    @DisplayName("maps an invalid argument to 400 VALIDATION_ERROR")
+    void illegalArgument() {
+        ResponseEntity<ApiError> result =
+                handler.handleIllegalArgument(new IllegalArgumentException("page must be >= 0"), request, response);
+
+        assertEnvelope(result, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
+        assertThat(result.getBody().message()).isEqualTo("page must be >= 0");
+    }
+
+    @Test
+    @DisplayName("reports every rejected field, defaulting a null message rather than emitting null")
+    void bodyValidationListsFieldErrors() throws NoSuchMethodException {
+        BindingResult binding = new BeanPropertyBindingResult(new Object(), "request");
+        binding.addError(new FieldError("request", "displayName", "must not be blank"));
+        binding.addError(new FieldError("request", "partyType", null));
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(
+                new org.springframework.core.MethodParameter(
+                        CrmExceptionHandlerTest.class.getDeclaredMethod("bodyValidationListsFieldErrors"), -1),
+                binding);
+
+        ResponseEntity<ApiError> result = handler.handleMethodArgumentNotValid(ex, request, response);
+
+        assertEnvelope(result, HttpStatus.BAD_REQUEST, "VALIDATION_FAILED");
+        assertThat(result.getBody().fieldErrors())
+                .extracting(ApiError.FieldError::field, ApiError.FieldError::message)
+                .containsExactly(tuple("displayName", "must not be blank"), tuple("partyType", "Invalid value"));
+    }
+
+    @Test
+    @DisplayName("mints a correlation id when the caller sent none, and echoes it on the header")
+    void mintsCorrelationIdWhenAbsent() {
+        when(request.getHeader(CORRELATION_HEADER)).thenReturn(null);
+
+        ResponseEntity<ApiError> result =
+                handler.handleIllegalArgument(new IllegalArgumentException("bad"), request, response);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(response).setHeader(org.mockito.ArgumentMatchers.eq(CORRELATION_HEADER), captor.capture());
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().correlationId()).isNotBlank().isEqualTo(captor.getValue());
+    }
+
+    @Test
+    @DisplayName("treats a blank inbound correlation id as absent rather than echoing it")
+    void blankCorrelationIdIsReplaced() {
+        when(request.getHeader(CORRELATION_HEADER)).thenReturn("   ");
+
+        ResponseEntity<ApiError> result =
+                handler.handleIllegalArgument(new IllegalArgumentException("bad"), request, response);
+
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().correlationId()).isNotBlank().isNotEqualTo("   ");
+    }
+
+    @Test
+    @DisplayName("still produces an envelope when there is no request to read a path or id from")
+    void nullRequestIsTolerated() {
+        // The advice is also reachable from error dispatches that carry no request object; a
+        // NullPointerException here would replace the domain's error with a 500.
+        ResponseEntity<ApiError> result =
+                handler.handleNotFound(new CrmResourceNotFoundException("Party", ID), null, response);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().correlationId()).isNotBlank();
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/config/EventTypeInitializerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,123 @@
+package com.positivity.customer.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(EventTypes.all().size())).header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.all()).isNotEmpty();
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/config/ManifestPublisherTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/config/ManifestPublisherTest.java
@@ -1,0 +1,366 @@
+package com.positivity.customer.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.entity.OutboxEvent;
+import com.positivity.customer.internal.repository.OutboxEventRepository;
+import com.positivity.domainevents.ReconciliationManifestV1;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for the pos-customer {@link ManifestPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * Each closed window gets one reconciliation manifest summarizing the events
+ * published from the outbox in that window; consumers recompute the same summary
+ * and request a replay on drift. The properties that matter:
+ *
+ * <ul>
+ * <li>Window membership is decided by the <em>eventId</em> (UUIDv7) timestamp,
+ * not by {@code createdAt}. The query pads its range by a second of slack, so a
+ * row can be fetched and still belong to a neighbouring window; counting it in
+ * the wrong one would manufacture drift on both sides.</li>
+ * <li>Empty windows still publish, so consumers can alert on manifest absence
+ * rather than treating silence as health.</li>
+ * <li>A malformed row is skipped with a warning instead of failing the window
+ * forever — one bad payload must not permanently block reconciliation.</li>
+ * <li>A failed send leaves the window unadvanced so the next run retries it, and
+ * catch-up is bounded per run so a long outage cannot monopolize a poll.</li>
+ * </ul>
+ */
+@DisplayName("pos-customer ManifestPublisher — reconciliation manifest windows")
+class ManifestPublisherTest {
+
+    /** 12:10 UTC: the [11:00, 12:00) window closed more than the 5m grace ago. */
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-08T12:10:00Z"), ZoneOffset.UTC);
+
+    private static final Instant WINDOW_START = Instant.parse("2026-07-08T11:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-07-08T12:00:00Z");
+    private static final String EVENTS_TOPIC = "customer.events.v1";
+    private static final String MANIFEST_TOPIC = "customer.manifest.v1";
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private SimpleMeterRegistry meterRegistry;
+    private ManifestPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry, TEST_CLOCK);
+        brokerAcknowledges();
+    }
+
+    @SuppressWarnings("unchecked")
+    private ManifestPublisher newPublisher(MeterRegistry registry, Clock clock) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        ManifestPublisher created = new ManifestPublisher(repository, kafkaTemplate, objectMapper, clock, provider);
+        ReflectionTestUtils.setField(created, "eventsTopic", EVENTS_TOPIC);
+        ReflectionTestUtils.setField(created, "manifestTopic", MANIFEST_TOPIC);
+        ReflectionTestUtils.setField(created, "window", Duration.ofHours(1));
+        ReflectionTestUtils.setField(created, "grace", Duration.ofMinutes(5));
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    /** UUIDv7-shaped id whose embedded timestamp is {@code at}. */
+    private static String eventIdAt(Instant at, int suffix) {
+        long millis = at.toEpochMilli();
+        return String.format("%08x-%04x-7000-8000-%012x", millis >>> 16, millis & 0xFFFF, suffix);
+    }
+
+    private static OutboxEvent row(String eventId, String eventType, Instant createdAt) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey(eventId)
+                .payload("{\"eventId\":\"" + eventId + "\",\"eventType\":\"" + eventType + "\",\"payload\":{}}")
+                .createdAt(createdAt)
+                .publishedAt(createdAt.plusSeconds(1))
+                .build();
+    }
+
+    private void outboxReturns(List<OutboxEvent> rows) {
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(rows);
+    }
+
+    private JsonNode capturedManifest() {
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), json.capture());
+        return objectMapper.readTree(json.getValue());
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("publishes the latest closed window with its count, checksum, and per-type counts")
+    void publishesManifestForClosedWindow() {
+        String inWindow1 = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String inWindow2 = eventIdAt(WINDOW_START.plusSeconds(120), 2);
+        outboxReturns(List.of(
+                row(inWindow1, "PartyChanged", WINDOW_START.plusSeconds(60)),
+                row(inWindow2, "PartyTagChanged", WINDOW_START.plusSeconds(120))));
+
+        publisher.publishDueManifest();
+
+        JsonNode envelope = capturedManifest();
+        assertThat(envelope.path("sourceService").stringValue()).isEqualTo("pos-customer");
+        assertThat(envelope.path("eventType").stringValue())
+                .isEqualTo(ReconciliationManifestV1.eventTypeFor("customer"));
+
+        JsonNode manifest = envelope.path("payload");
+        assertThat(manifest.path("windowStartUtc").stringValue()).isEqualTo(WINDOW_START.toString());
+        assertThat(manifest.path("windowEndUtc").stringValue()).isEqualTo(WINDOW_END.toString());
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(2);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow1, inWindow2)));
+        assertThat(manifest.path("eventTypeCounts").path("PartyChanged").longValue())
+                .isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("PartyTagChanged").longValue())
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row fetched by createdAt slack whose eventId falls outside the window")
+    void excludesRowOutsideWindowByEventIdTimestamp() {
+        String inWindow = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String justBefore = eventIdAt(WINDOW_START.minusMillis(1), 2);
+        String justAfter = eventIdAt(WINDOW_END.plusMillis(1), 3);
+        outboxReturns(List.of(
+                row(justBefore, "PartyChanged", WINDOW_START.minusMillis(1)),
+                row(inWindow, "PartyChanged", WINDOW_START.plusSeconds(60)),
+                row(justAfter, "PartyChanged", WINDOW_END.plusMillis(1))));
+
+        publisher.publishDueManifest();
+
+        // Membership is decided by the eventId timestamp, not the padded createdAt
+        // query: counting a neighbour here would manufacture drift on both sides.
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow)));
+    }
+
+    @Test
+    @DisplayName("publishes a zero-count manifest so consumers can alert on absence rather than silence")
+    void publishesEmptyWindowManifest() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isZero();
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of()));
+    }
+
+    @Test
+    @DisplayName("counts a row with a blank event type under \"unknown\" rather than dropping it")
+    void blankEventTypeCountedAsUnknown() {
+        String eventId = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        outboxReturns(List.of(row(eventId, "", WINDOW_START.plusSeconds(60))));
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("unknown").longValue()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row with no eventId instead of failing the window")
+    void skipsRowWithoutEventId() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("{\"eventType\":\"PartyChanged\"}")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("excludes a row whose payload will not parse instead of blocking reconciliation forever")
+    void skipsRowWithUnparsablePayload() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("not json at all")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("does not re-publish a window it already published")
+    void skipsAlreadyPublishedWindow() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("waits out the grace period, publishing the previous window until the latest one settles")
+    void respectsGracePeriod() {
+        ReflectionTestUtils.setField(publisher, "grace", Duration.ofMinutes(15));
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        // 12:10 with 15m grace: [11:00, 12:00) is not yet eligible, so the
+        // published window is the previous one.
+        assertThat(capturedManifest().path("payload").path("windowEndUtc").stringValue())
+                .isEqualTo("2026-07-08T11:00:00Z");
+    }
+
+    @Test
+    @DisplayName("retries the same window on the next run when the send fails")
+    void retriesWindowAfterSendFailure() {
+        outboxReturns(List.of());
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker down")))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        // The window must not advance past a failure, or its manifest is lost.
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(counter("customer.manifest.publish.failures")).isEqualTo(1d);
+        assertThat(counter("customer.manifest.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("counts a successful publish")
+    void countsSuccessfulPublish() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        assertThat(counter("customer.manifest.published")).isEqualTo(1d);
+        assertThat(counter("customer.manifest.publish.failures")).isZero();
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        ManifestPublisher withoutMetrics = newPublisher(null, TEST_CLOCK);
+        outboxReturns(List.of());
+
+        withoutMetrics.publishDueManifest();
+
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("publishes nothing when no window has closed yet")
+    void publishesNothingBeforeTheFirstWindowCloses() {
+        // Epoch + 30m with a 1h window: no aligned window boundary has passed.
+        ManifestPublisher early = newPublisher(meterRegistry, Clock.fixed(Instant.ofEpochSecond(1800), ZoneOffset.UTC));
+
+        early.publishDueManifest();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("keys every manifest for a window deterministically, so re-publishes land on one partition")
+    void manifestRecordKeyIsStablePerWindow() {
+        outboxReturns(List.of());
+        ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+
+        publisher.publishDueManifest();
+        // A second publisher instance, same window: the key must match.
+        ManifestPublisher other = newPublisher(meterRegistry, TEST_CLOCK);
+        other.publishDueManifest();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), key.capture(), anyString());
+        assertThat(key.getAllValues()).hasSize(2);
+        assertThat(key.getAllValues().get(0)).isEqualTo(key.getAllValues().get(1));
+    }
+
+    @Test
+    @DisplayName("after a gap, catches up window by window rather than skipping to the newest")
+    void catchesUpWindowByWindow() {
+        outboxReturns(List.of());
+
+        // First run establishes [11:00, 12:00) as published.
+        publisher.publishDueManifest();
+
+        // Three hours later four windows have closed; the next run must publish the
+        // intervening ones, not jump to the newest and leave holes.
+        ManifestPublisher later = publisher;
+        ReflectionTestUtils.setField(
+                later, "clock", Clock.fixed(Instant.parse("2026-07-08T15:10:00Z"), ZoneOffset.UTC));
+        later.publishDueManifest();
+
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate, times(4)).send(anyString(), anyString(), json.capture());
+        assertThat(json.getAllValues())
+                .map(value -> objectMapper
+                        .readTree(value)
+                        .path("payload")
+                        .path("windowEndUtc")
+                        .stringValue())
+                .containsExactly(
+                        "2026-07-08T12:00:00Z", "2026-07-08T13:00:00Z", "2026-07-08T14:00:00Z", "2026-07-08T15:00:00Z");
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/config/OutboxEventWriterTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/config/OutboxEventWriterTest.java
@@ -1,0 +1,135 @@
+package com.positivity.customer.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.entity.OutboxEvent;
+import com.positivity.customer.internal.repository.OutboxEventRepository;
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.customer.CustomerPartyUpdatedV1;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link OutboxEventWriter} (ADR-0044 §4, issue #842).
+ *
+ * <p>
+ * The outbox exists so an event is queued if and only if the business
+ * transaction committed. What this class must get right is the row it writes:
+ *
+ * <ul>
+ * <li><b>The record key is the aggregate id.</b> Kafka orders only within a
+ * partition, so a key that varied per event would let two facts about one party
+ * arrive out of order.</li>
+ * <li><b>The stored payload is the whole envelope</b>, not just the domain
+ * payload — {@code OutboxPublisher} forwards the row's bytes verbatim.</li>
+ * <li><b>A serialization failure is fatal.</b> Writing an unreadable row would
+ * produce an event that can never be published; because the write is
+ * {@code MANDATORY} on the caller's transaction, throwing correctly rolls the
+ * business change back with it.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OutboxEventWriter — transactional outbox row contract")
+class OutboxEventWriterTest {
+
+    private static final UUID PARTY_ID = UUID.fromString("00000000-0000-0000-0000-0000000000f1");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
+
+    private OutboxEventWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        writer = new OutboxEventWriter(clock, new ObjectMapper(), outboxEventRepository);
+    }
+
+    private static DomainEventEnvelope<Object> envelope() {
+        return DomainEventEnvelope.of(
+                CustomerPartyUpdatedV1.EVENT_TYPE,
+                1,
+                PARTY_ID,
+                4L,
+                "pos-customer",
+                null,
+                null,
+                new CustomerPartyUpdatedV1(
+                        PARTY_ID,
+                        "PERSON",
+                        "C-1001",
+                        "Ada Lovelace",
+                        null,
+                        null,
+                        "ACTIVE",
+                        "STANDARD",
+                        true,
+                        null,
+                        null),
+                Clock.fixed(NOW, ZoneOffset.UTC));
+    }
+
+    private OutboxEvent captureSaved() {
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxEventRepository).save(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("keys the row on the aggregate id and stores the serialized envelope")
+    void publishWritesEnvelopeRow() {
+        writer.publish("customer.events.v1", envelope());
+
+        OutboxEvent saved = captureSaved();
+        assertThat(saved.getTopic()).isEqualTo("customer.events.v1");
+        assertThat(saved.getRecordKey()).isEqualTo(PARTY_ID.toString());
+        assertThat(saved.getCreatedAt()).isEqualTo(NOW);
+        assertThat(saved.getPayload())
+                .contains(CustomerPartyUpdatedV1.EVENT_TYPE)
+                .contains(PARTY_ID.toString())
+                .contains("pos-customer");
+    }
+
+    @Test
+    @DisplayName("stores a pre-serialized command verbatim under the caller's ordering key")
+    void publishRawStoresMessageUnchanged() {
+        writer.publishRaw("people.commands.v1", "person-42", "{\"commandType\":\"x\"}");
+
+        OutboxEvent saved = captureSaved();
+        assertThat(saved.getTopic()).isEqualTo("people.commands.v1");
+        assertThat(saved.getRecordKey()).isEqualTo("person-42");
+        assertThat(saved.getPayload()).isEqualTo("{\"commandType\":\"x\"}");
+        assertThat(saved.getCreatedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("fails the transaction rather than queueing an envelope it could not serialize")
+    void serializationFailureIsFatal() {
+        ObjectMapper failing = org.mockito.Mockito.mock(ObjectMapper.class);
+        when(failing.writeValueAsString(any())).thenThrow(new IllegalStateException("boom"));
+        OutboxEventWriter failingWriter = new OutboxEventWriter(clock, failing, outboxEventRepository);
+
+        assertThatThrownBy(() -> failingWriter.publish("customer.events.v1", envelope()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(CustomerPartyUpdatedV1.EVENT_TYPE);
+
+        verify(outboxEventRepository, never()).save(any());
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/config/OutboxPublisherTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/config/OutboxPublisherTest.java
@@ -1,0 +1,213 @@
+package com.positivity.customer.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.entity.OutboxEvent;
+import com.positivity.customer.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for the pos-customer {@link OutboxPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * The publisher drains {@code event_outbox} to Kafka with at-least-once
+ * semantics. Three properties carry the correctness weight:
+ *
+ * <ul>
+ * <li>a row is marked published <em>only</em> after the broker acknowledges, so
+ * a crash mid-send re-sends rather than silently dropping the event;</li>
+ * <li>the batch stops at the first failure, so a struggling broker cannot
+ * reorder events past a stuck row; and</li>
+ * <li>the failure path records {@code attempts} and a bounded
+ * {@code last_error} for alerting instead of throwing out of the scheduled
+ * method.</li>
+ * </ul>
+ */
+@DisplayName("pos-customer OutboxPublisher — outbox drain contract")
+class OutboxPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-08T12:00:00Z");
+    private static final Clock TEST_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private SimpleMeterRegistry meterRegistry;
+    private OutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    private OutboxPublisher newPublisher(MeterRegistry registry) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        OutboxPublisher created = new OutboxPublisher(repository, kafkaTemplate, TEST_CLOCK, provider);
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private OutboxEvent event(String key) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("customer.events.v1")
+                .recordKey(key)
+                .payload("{\"eventId\":\"" + key + "\"}")
+                .createdAt(NOW.minusSeconds(60))
+                .attempts(2)
+                .lastError("previous failure")
+                .build();
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    private void brokerFailsWith(Throwable failure) {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(failure));
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("marks the row published only after the broker acknowledges the send")
+    void marksPublishedAfterAcknowledgedSend() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate).send("customer.events.v1", "k1", row.getPayload());
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        assertThat(row.getAttempts()).isZero();
+        assertThat(row.getLastError()).isNull();
+        verify(repository).save(row);
+        assertThat(counter("customer.outbox.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("drains the whole batch in order while the broker keeps acknowledging")
+    void drainsWholeBatchWhenAllSendsSucceed() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(first.getPublishedAt()).isEqualTo(NOW);
+        assertThat(second.getPublishedAt()).isEqualTo(NOW);
+        assertThat(counter("customer.outbox.published")).isEqualTo(2d);
+    }
+
+    @Test
+    @DisplayName("on failure: records the attempt and error, leaves the row unpublished, stops the batch")
+    void recordsFailureAndStopsBatch() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerFailsWith(new RuntimeException("broker down"));
+
+        publisher.publishPending();
+
+        assertThat(first.getPublishedAt()).isNull();
+        assertThat(first.getAttempts()).isEqualTo(3);
+        assertThat(first.getLastError()).contains("broker down");
+        verify(repository).save(first);
+
+        // The batch stops at the first failure so publish order is preserved:
+        // the second row is never attempted and keeps its prior attempt count.
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+        verify(kafkaTemplate).send("customer.events.v1", "k1", first.getPayload());
+        assertThat(second.getAttempts()).isEqualTo(2);
+        assertThat(second.getPublishedAt()).isNull();
+        assertThat(counter("customer.outbox.publish.failures")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("falls back to the exception class name when the failure carries no message")
+    void recordsClassNameWhenFailureMessageIsNull() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        // Thrown by send() itself rather than completing the future exceptionally:
+        // a failed future surfaces as an ExecutionException whose message is the
+        // cause's toString, so only a synchronous throw reaches the null-message
+        // fallback in recordFailure().
+        when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenThrow(new IllegalStateException());
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).isEqualTo("IllegalStateException");
+        assertThat(row.getPublishedAt()).isNull();
+        assertThat(row.getAttempts()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("truncates an oversized failure message to the 2000-character column bound")
+    void truncatesOversizedFailureMessage() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerFailsWith(new RuntimeException("x".repeat(2500)));
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).hasSize(2000);
+    }
+
+    @Test
+    @DisplayName("does nothing when the outbox is empty")
+    void doesNothingWhenNoPendingRows() {
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of());
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        verify(repository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        OutboxPublisher withoutMetrics = newPublisher(null);
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        withoutMetrics.publishPending();
+
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        verify(repository).save(row);
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/security/CrmPermissionRegistryTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/security/CrmPermissionRegistryTest.java
@@ -1,0 +1,163 @@
+package com.positivity.customer.internal.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests for {@link CrmPermissionRegistry}.
+ *
+ * <p>
+ * Permission names are the strings controllers enforce with
+ * {@code @PreAuthorize("hasAuthority(...)")} and that {@code pos-security-service}
+ * stores as the authority catalog. A typo in a name is not a compile error on
+ * either side — it just produces a permission nobody holds, which fails closed
+ * and locks users out of an endpoint at runtime rather than at build time.
+ *
+ * <p>
+ * These tests therefore treat the naming convention (`domain:resource:action`,
+ * snake_case, always under the {@code crm} domain) as a hard contract, and check
+ * that every declared constant actually appears in the registration payload —
+ * otherwise a permission could be enforced by a controller but never registered,
+ * with the same lock-out effect.
+ */
+@DisplayName("CrmPermissionRegistry — permission naming and registration contract")
+class CrmPermissionRegistryTest {
+
+    /**
+     * {@code domain:resource:action}, all lower snake_case. Documented in
+     * CLAUDE.md and mirrored by every other module's registry.
+     */
+    private static final Pattern PERMISSION_NAME = Pattern.compile("^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$");
+
+    private static final Set<String> VALID_RISK_LEVELS = Set.of("LOW", "MEDIUM", "HIGH", "CRITICAL");
+
+    /** Every {@code public static final String} constant on the registry. */
+    private static List<String> declaredConstants() {
+        List<String> values = new ArrayList<>();
+        for (Field field : CrmPermissionRegistry.class.getDeclaredFields()) {
+            if (Modifier.isPublic(field.getModifiers())
+                    && Modifier.isStatic(field.getModifiers())
+                    && field.getType() == String.class) {
+                try {
+                    values.add((String) field.get(null));
+                } catch (IllegalAccessException e) {
+                    throw new AssertionError("Could not read " + field.getName(), e);
+                }
+            }
+        }
+        return values;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, String>> registeredPermissions() {
+        return (List<Map<String, String>>)
+                CrmPermissionRegistry.buildCrmPermissionRegistration().get("permissions");
+    }
+
+    @Test
+    @DisplayName("declares permission constants")
+    void registry_declaresConstants() {
+        assertThat(declaredConstants()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("every declared constant follows domain:resource:action in snake_case")
+    void constants_followNamingConvention() {
+        assertThat(declaredConstants())
+                .allSatisfy(name ->
+                        assertThat(name).as("permission constant %s", name).matches(PERMISSION_NAME));
+    }
+
+    @Test
+    @DisplayName("every declared constant sits under the crm domain")
+    void constants_areScopedToCrmDomain() {
+        assertThat(declaredConstants())
+                .allSatisfy(name -> assertThat(name).as("permission %s", name).startsWith("crm:"));
+    }
+
+    @Test
+    @DisplayName("no two constants share a permission name")
+    void constants_areUnique() {
+        assertThat(declaredConstants()).doesNotHaveDuplicates();
+    }
+
+    @Test
+    @DisplayName("the registration payload names the crm domain and this service")
+    void registration_identifiesDomainAndService() {
+        Map<String, Object> registration = CrmPermissionRegistry.buildCrmPermissionRegistration();
+
+        assertThat(registration).containsEntry("domain", "crm").containsEntry("serviceName", "pos-customer");
+        assertThat(registration.get("version")).asString().isNotBlank();
+    }
+
+    @Test
+    @DisplayName("every registered permission carries a name, a description, and a risk level")
+    void registration_entriesAreComplete() {
+        assertThat(registeredPermissions()).isNotEmpty().allSatisfy(entry -> {
+            assertThat(entry.get("name")).as("name in %s", entry).isNotBlank();
+            assertThat(entry.get("description"))
+                    .as("description for %s", entry.get("name"))
+                    .isNotBlank();
+            assertThat(entry.get("riskLevel"))
+                    .as("risk level for %s", entry.get("name"))
+                    .isIn(VALID_RISK_LEVELS);
+        });
+    }
+
+    @Test
+    @DisplayName("registered permission names match the declared constants, so none is enforced but unregistered")
+    void registration_coversEveryDeclaredConstant() {
+        List<String> registered =
+                registeredPermissions().stream().map(entry -> entry.get("name")).toList();
+
+        // A constant a controller enforces but that is never registered fails
+        // closed at runtime: nobody can hold it, so the endpoint is unreachable.
+        assertThat(registered).containsAll(declaredConstants());
+    }
+
+    @Test
+    @DisplayName("no permission is registered twice")
+    void registration_hasNoDuplicateNames() {
+        assertThat(registeredPermissions().stream()
+                        .map(entry -> entry.get("name"))
+                        .toList())
+                .doesNotHaveDuplicates();
+    }
+
+    @Test
+    @DisplayName("the grouped accessors only return permissions the registry declares")
+    void groupedAccessors_returnDeclaredPermissions() {
+        List<String> declared = declaredConstants();
+
+        assertThat(CrmPermissionRegistry.partyPermissions())
+                .isNotEmpty()
+                .allSatisfy(name -> assertThat(declared).contains(name));
+        assertThat(CrmPermissionRegistry.contactPermissions())
+                .isNotEmpty()
+                .allSatisfy(name -> assertThat(declared).contains(name));
+        assertThat(CrmPermissionRegistry.vehiclePermissions())
+                .isNotEmpty()
+                .allSatisfy(name -> assertThat(declared).contains(name));
+        assertThat(CrmPermissionRegistry.integrationPermissions())
+                .isNotEmpty()
+                .allSatisfy(name -> assertThat(declared).contains(name));
+    }
+
+    @Test
+    @DisplayName("each grouped accessor stays within the resource family its name implies")
+    void groupedAccessors_areScopedToTheirFamily() {
+        assertThat(CrmPermissionRegistry.partyPermissions())
+                .allSatisfy(name -> assertThat(name).startsWith("crm:party"));
+        assertThat(CrmPermissionRegistry.vehiclePermissions())
+                .allSatisfy(name -> assertThat(name).startsWith("crm:vehicle"));
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/AccountTierServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/AccountTierServiceImplTest.java
@@ -1,0 +1,417 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.dto.ResolveAccountTierRequest;
+import com.positivity.customer.internal.dto.ResolveAccountTierResponse;
+import com.positivity.customer.internal.entity.CommercialParty;
+import com.positivity.customer.internal.enums.AccountTier;
+import com.positivity.customer.internal.repository.CommercialPartyRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link AccountTierServiceImpl}.
+ *
+ * <p>
+ * Tier drives pricing and service level, so the calculation is worth pinning at
+ * its boundaries rather than at comfortable mid-band values: every revenue
+ * threshold is inclusive, and an account one cent below a threshold must land in
+ * the lower tier.
+ *
+ * <p>
+ * The three inputs compose in one direction only. Contract count and account age
+ * can <em>raise</em> the revenue-derived tier but never lower it — the
+ * calculation guards each upgrade on {@code tier.ordinal()}, so a high-revenue
+ * account with few contracts keeps its revenue tier. Getting that backwards
+ * would silently demote enterprise accounts.
+ *
+ * <p>
+ * Manual override is the other load-bearing rule: an operator-set tier survives
+ * recalculation unless the caller explicitly forces it, and a forced
+ * recalculation clears the override flag rather than leaving it to re-block the
+ * next run.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AccountTierServiceImpl — tier calculation and assignment")
+class AccountTierServiceImplTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-11T12:00:00Z");
+    private static final UUID ACCOUNT_ID = UUID.randomUUID();
+
+    @Mock
+    private CommercialPartyRepository commercialPartyRepository;
+
+    @Mock
+    private CustomerFactPublisher customerFactPublisher;
+
+    private AccountTierServiceImpl sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new AccountTierServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC), commercialPartyRepository, customerFactPublisher);
+    }
+
+    private static CommercialParty party(AccountTier tier, boolean manualOverride) {
+        CommercialParty party = new CommercialParty();
+        party.setPartyId(ACCOUNT_ID);
+        party.setTier(tier);
+        party.setTierManualOverride(manualOverride);
+        return party;
+    }
+
+    private static ResolveAccountTierRequest.ResolveAccountTierRequestBuilder request() {
+        return ResolveAccountTierRequest.builder().accountId(ACCOUNT_ID.toString());
+    }
+
+    private ResolveAccountTierResponse resolve(ResolveAccountTierRequest request) {
+        return sut.resolveAccountTier(request);
+    }
+
+    @Nested
+    @DisplayName("getAccountTier")
+    class GetAccountTier {
+
+        @Test
+        @DisplayName("returns the stored tier and its assignment metadata")
+        void get_returnsStoredTier() {
+            CommercialParty party = party(AccountTier.GOLD, true);
+            party.setTierAssignedAt(NOW);
+            party.setTierAssignedBy("operator");
+            when(commercialPartyRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(party));
+
+            var response = sut.getAccountTier(ACCOUNT_ID);
+
+            assertThat(response.getTier()).isEqualTo(AccountTier.GOLD);
+            assertThat(response.getTierAssignedBy()).isEqualTo("operator");
+            assertThat(response.isManualOverride()).isTrue();
+        }
+
+        @Test
+        @DisplayName("reports STANDARD when the account has no tier set")
+        void get_whenTierNull_defaultsToStandard() {
+            when(commercialPartyRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(party(null, false)));
+
+            assertThat(sut.getAccountTier(ACCOUNT_ID).getTier()).isEqualTo(AccountTier.STANDARD);
+        }
+
+        @Test
+        @DisplayName("rejects an unknown account")
+        void get_whenAbsent_throws() {
+            when(commercialPartyRepository.findById(ACCOUNT_ID)).thenReturn(Optional.empty());
+
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> sut.getAccountTier(ACCOUNT_ID))
+                    .withMessageContaining("Account not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("revenue thresholds")
+    class RevenueThresholds {
+
+        @ParameterizedTest(name = "revenue {0} resolves to {1} with score {2}")
+        @CsvSource({
+            // Each threshold is inclusive; the value one cent below falls to the band under it.
+            "0,        STANDARD,   0",
+            "49999.99, STANDARD,   0",
+            "50000,    BRONZE,     200",
+            "99999.99, BRONZE,     200",
+            "100000,   SILVER,     300",
+            "249999.99, SILVER,    300",
+            "250000,   GOLD,       400",
+            "499999.99, GOLD,      400",
+            "500000,   PLATINUM,   500",
+            "999999.99, PLATINUM,  500",
+            "1000000,  ENTERPRISE, 600",
+            "9999999,  ENTERPRISE, 600",
+        })
+        @DisplayName("maps revenue onto tiers at inclusive boundaries")
+        void revenue_mapsToTier(BigDecimal revenue, AccountTier expected, int expectedScore) {
+            when(commercialPartyRepository.findById(ACCOUNT_ID))
+                    .thenReturn(Optional.of(party(AccountTier.STANDARD, false)));
+
+            ResolveAccountTierResponse response =
+                    resolve(request().annualRevenue(revenue).build());
+
+            assertThat(response.getRecommendedTier()).isEqualTo(expected);
+            assertThat(response.getTierScore()).isEqualTo(expectedScore);
+        }
+
+        @Test
+        @DisplayName("falls back to STANDARD with a default reason when no criteria are supplied")
+        void noCriteria_yieldsStandardWithDefaultReason() {
+            when(commercialPartyRepository.findById(ACCOUNT_ID))
+                    .thenReturn(Optional.of(party(AccountTier.STANDARD, false)));
+
+            ResolveAccountTierResponse response = resolve(request().build());
+
+            assertThat(response.getRecommendedTier()).isEqualTo(AccountTier.STANDARD);
+            assertThat(response.getResolutionReason()).isEqualTo("Default tier assignment.");
+            assertThat(response.getTierScore()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("contract and age upgrades")
+    class Upgrades {
+
+        @ParameterizedTest(name = "{0} contracts alone resolves to {1}")
+        @CsvSource({"0, STANDARD", "1, STANDARD", "2, SILVER", "3, GOLD", "4, GOLD", "5, PLATINUM", "9, PLATINUM"})
+        @DisplayName("upgrades on active contract count alone")
+        void contracts_upgradeTier(int contracts, AccountTier expected) {
+            when(commercialPartyRepository.findById(ACCOUNT_ID))
+                    .thenReturn(Optional.of(party(AccountTier.STANDARD, false)));
+
+            assertThat(resolve(request().activeContractCount(contracts).build()).getRecommendedTier())
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("a contract count can raise the revenue-derived tier")
+        void contracts_canRaiseRevenueTier() {
+            when(commercialPartyRepository.findById(ACCOUNT_ID))
+                    .thenReturn(Optional.of(party(AccountTier.STANDARD, false)));
+
+            // BRONZE on revenue, five contracts lifts it to PLATINUM.
+            ResolveAccountTierResponse response = resolve(request()
+                    .annualRevenue(new BigDecimal("60000"))
+                    .activeContractCount(5)
+                    .build());
+
+            assertThat(response.getRecommendedTier()).isEqualTo(AccountTier.PLATINUM);
+            assertThat(response.getTierScore()).isEqualTo(500);
+        }
+
+        @Test
+        @DisplayName("a contract count never lowers the revenue-derived tier")
+        void contracts_neverLowerRevenueTier() {
+            when(commercialPartyRepository.findById(ACCOUNT_ID))
+                    .thenReturn(Optional.of(party(AccountTier.STANDARD, false)));
+
+            // ENTERPRISE on revenue with only two contracts must stay ENTERPRISE;
+            // demoting a high-revenue account here would be the costly failure.
+            ResolveAccountTierResponse response = resolve(request()
+                    .annualRevenue(new BigDecimal("2000000"))
+                    .activeContractCount(2)
+                    .build());
+
+            assertThat(response.getRecommendedTier()).isEqualTo(AccountTier.ENTERPRISE);
+            assertThat(response.getTierScore()).isEqualTo(600);
+        }
+
+        @ParameterizedTest(name = "an age of {0} months alone resolves to {1}")
+        @CsvSource({"0, STANDARD", "2, STANDARD", "3, BRONZE", "48, BRONZE"})
+        @DisplayName("upgrades an otherwise STANDARD account once it is established")
+        void age_upgradesStandardOnly(int ageMonths, AccountTier expected) {
+            when(commercialPartyRepository.findById(ACCOUNT_ID))
+                    .thenReturn(Optional.of(party(AccountTier.STANDARD, false)));
+
+            assertThat(resolve(request().accountAgeMonths(ageMonths).build()).getRecommendedTier())
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("account age never lowers a tier already earned on revenue")
+        void age_doesNotLowerEarnedTier() {
+            when(commercialPartyRepository.findById(ACCOUNT_ID))
+                    .thenReturn(Optional.of(party(AccountTier.STANDARD, false)));
+
+            ResolveAccountTierResponse response = resolve(request()
+                    .annualRevenue(new BigDecimal("300000"))
+                    .accountAgeMonths(120)
+                    .build());
+
+            assertThat(response.getRecommendedTier()).isEqualTo(AccountTier.GOLD);
+        }
+
+        @Test
+        @DisplayName("records every rule that contributed to the outcome")
+        void reason_recordsContributingRules() {
+            when(commercialPartyRepository.findById(ACCOUNT_ID))
+                    .thenReturn(Optional.of(party(AccountTier.STANDARD, false)));
+
+            ResolveAccountTierResponse response = resolve(request()
+                    .annualRevenue(new BigDecimal("60000"))
+                    .activeContractCount(5)
+                    .build());
+
+            assertThat(response.getResolutionReason())
+                    .contains("Annual revenue >= $50K")
+                    .contains("5+ active contracts");
+        }
+    }
+
+    @Nested
+    @DisplayName("applying the resolved tier")
+    class ApplyTier {
+
+        @Test
+        @DisplayName("does not write when the caller only asked for a recommendation")
+        void apply_whenNotRequested_writesNothing() {
+            when(commercialPartyRepository.findById(ACCOUNT_ID))
+                    .thenReturn(Optional.of(party(AccountTier.STANDARD, false)));
+
+            ResolveAccountTierResponse response = resolve(request()
+                    .annualRevenue(new BigDecimal("600000"))
+                    .applyTier(false)
+                    .build());
+
+            assertThat(response.isTierApplied()).isFalse();
+            verify(commercialPartyRepository, never()).save(any());
+            verify(customerFactPublisher, never()).partyChanged(any());
+        }
+
+        @Test
+        @DisplayName("writes the tier, stamps the assignment, and publishes the change")
+        void apply_whenRequested_writesAndPublishes() {
+            CommercialParty party = party(AccountTier.STANDARD, false);
+            when(commercialPartyRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(party));
+
+            ResolveAccountTierResponse response = resolve(request()
+                    .annualRevenue(new BigDecimal("600000"))
+                    .applyTier(true)
+                    .build());
+
+            assertThat(response.isTierApplied()).isTrue();
+            assertThat(party.getTier()).isEqualTo(AccountTier.PLATINUM);
+            assertThat(party.getTierAssignedAt()).isEqualTo(NOW);
+            assertThat(party.getTierAssignedBy()).isEqualTo("SYSTEM");
+            verify(commercialPartyRepository).save(party);
+            verify(customerFactPublisher).partyChanged(party);
+        }
+
+        @Test
+        @DisplayName("leaves an operator-set tier alone unless recalculation is forced")
+        void apply_whenManualOverride_skipsWrite() {
+            CommercialParty party = party(AccountTier.BRONZE, true);
+            when(commercialPartyRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(party));
+
+            ResolveAccountTierResponse response = resolve(request()
+                    .annualRevenue(new BigDecimal("600000"))
+                    .applyTier(true)
+                    .build());
+
+            assertThat(response.isTierApplied()).isFalse();
+            assertThat(response.getRecommendedTier()).isEqualTo(AccountTier.PLATINUM);
+            assertThat(party.getTier()).isEqualTo(AccountTier.BRONZE);
+            verify(commercialPartyRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("a forced recalculation overrides the operator and clears the override flag")
+        void apply_whenForced_overridesAndClearsFlag() {
+            CommercialParty party = party(AccountTier.BRONZE, true);
+            when(commercialPartyRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(party));
+
+            ResolveAccountTierResponse response = resolve(request()
+                    .annualRevenue(new BigDecimal("600000"))
+                    .applyTier(true)
+                    .forceRecalculation(true)
+                    .build());
+
+            assertThat(response.isTierApplied()).isTrue();
+            assertThat(party.getTier()).isEqualTo(AccountTier.PLATINUM);
+            // Left set, the flag would re-block the next automatic recalculation.
+            assertThat(party.isTierManualOverride()).isFalse();
+            verify(commercialPartyRepository).save(party);
+        }
+
+        @Test
+        @DisplayName("reports the override as inactive once a forced recalculation has run")
+        void apply_whenForced_reportsOverrideInactive() {
+            when(commercialPartyRepository.findById(ACCOUNT_ID))
+                    .thenReturn(Optional.of(party(AccountTier.BRONZE, true)));
+
+            ResolveAccountTierResponse response = resolve(request()
+                    .annualRevenue(new BigDecimal("600000"))
+                    .applyTier(true)
+                    .forceRecalculation(true)
+                    .build());
+
+            assertThat(response.isManualOverrideActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("keeps the manual override flag when applying without forcing")
+        void apply_withoutForce_keepsOverrideFlag() {
+            CommercialParty party = party(AccountTier.STANDARD, false);
+            when(commercialPartyRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(party));
+
+            resolve(request()
+                    .annualRevenue(new BigDecimal("600000"))
+                    .applyTier(true)
+                    .build());
+
+            assertThat(party.isTierManualOverride()).isFalse();
+        }
+
+        @Test
+        @DisplayName("reports the tier the account held before the call")
+        void apply_reportsPreviousTierAsCurrent() {
+            when(commercialPartyRepository.findById(ACCOUNT_ID))
+                    .thenReturn(Optional.of(party(AccountTier.SILVER, false)));
+
+            ResolveAccountTierResponse response = resolve(request()
+                    .annualRevenue(new BigDecimal("600000"))
+                    .applyTier(true)
+                    .build());
+
+            assertThat(response.getCurrentTier()).isEqualTo(AccountTier.SILVER);
+            assertThat(response.getRecommendedTier()).isEqualTo(AccountTier.PLATINUM);
+        }
+
+        @Test
+        @DisplayName("treats a null stored tier as STANDARD when reporting the current tier")
+        void apply_whenStoredTierNull_reportsStandard() {
+            when(commercialPartyRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(party(null, false)));
+
+            assertThat(resolve(request().build()).getCurrentTier()).isEqualTo(AccountTier.STANDARD);
+        }
+    }
+
+    @Nested
+    @DisplayName("input validation")
+    class InputValidation {
+
+        @Test
+        @DisplayName("rejects an account id that is not a UUID, naming the offending value")
+        void resolve_whenAccountIdMalformed_throws() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> resolve(ResolveAccountTierRequest.builder()
+                            .accountId("not-a-uuid")
+                            .build()))
+                    .withMessageContaining("Invalid account ID format");
+            verify(commercialPartyRepository, never()).findById(any());
+        }
+
+        @Test
+        @DisplayName("rejects an unknown account")
+        void resolve_whenAccountAbsent_throws() {
+            when(commercialPartyRepository.findById(ACCOUNT_ID)).thenReturn(Optional.empty());
+
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> resolve(request().build()))
+                    .withMessageContaining("Account not found");
+        }
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/CommercialPartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/CommercialPartyServiceImplTest.java
@@ -1,0 +1,315 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.dto.CustomerDTO;
+import com.positivity.customer.internal.entity.CommercialParty;
+import com.positivity.customer.internal.repository.CommercialPartyRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+/**
+ * Unit tests for {@link CommercialPartyServiceImpl}.
+ *
+ * <p>
+ * Commercial parties keep their names locally — there is no pos-people identity
+ * behind an organization — so this service is the simpler sibling of
+ * {@link PersonPartyServiceImpl}. What it does have is a
+ * {@link CustomerDTO}-shaped API that carries organization names in
+ * person-shaped fields, and the mapping between the two is <em>not</em>
+ * symmetric; see {@link Mapping#roundTripSwapsTheNameFields()}.
+ *
+ * <p>
+ * Commercial parties hold no locally searchable email, so an email-only query
+ * returns an empty page rather than scanning every row.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("CommercialPartyServiceImpl — organization parties")
+class CommercialPartyServiceImplTest {
+
+    private static final UUID PARTY_ID = UUID.fromString("00000000-0000-0000-0000-0000000000d1");
+
+    @Mock
+    private CommercialPartyRepository commercialRepository;
+
+    @Mock
+    private CustomerFactPublisher customerFactPublisher;
+
+    private CommercialPartyServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CommercialPartyServiceImpl(commercialRepository, customerFactPublisher);
+    }
+
+    private static CommercialParty party() {
+        CommercialParty party = new CommercialParty();
+        party.setPartyId(PARTY_ID);
+        party.setCustomerNumber("C-2001");
+        party.setLegalName("Fleet Co LLC");
+        party.setDisplayName("Fleet Co");
+        party.setPrimaryAddress("1 Depot Rd");
+        party.getVehicleVins().add("VIN-1");
+        return party;
+    }
+
+    @Nested
+    @DisplayName("mapping")
+    class Mapping {
+
+        @Test
+        @DisplayName("reads the legal name into lastName and the display name into firstName")
+        void readMapping() {
+            when(commercialRepository.findById(PARTY_ID)).thenReturn(Optional.of(party()));
+
+            CustomerDTO dto = service.getCustomerById(PARTY_ID).orElseThrow();
+
+            assertThat(dto.getLastName()).isEqualTo("Fleet Co LLC");
+            assertThat(dto.getFirstName()).isEqualTo("Fleet Co");
+            assertThat(dto.getCustomerType()).isEqualTo("COMMERCIAL");
+            assertThat(dto.getPartyId()).isEqualTo(PARTY_ID);
+            assertThat(dto.getVehicleVins()).containsExactly("VIN-1");
+        }
+
+        @Test
+        @DisplayName("writes firstName to the legal name and lastName to the display name")
+        void writeMapping() {
+            when(commercialRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.createCustomer(CustomerDTO.builder()
+                    .customerType("COMMERCIAL")
+                    .firstName("Fleet Co LLC")
+                    .lastName("Fleet Co")
+                    .build());
+
+            ArgumentCaptor<CommercialParty> captor = ArgumentCaptor.forClass(CommercialParty.class);
+            verify(commercialRepository).save(captor.capture());
+            assertThat(captor.getValue().getLegalName()).isEqualTo("Fleet Co LLC");
+            assertThat(captor.getValue().getDisplayName()).isEqualTo("Fleet Co");
+        }
+
+        @Test
+        @DisplayName("a create-then-read round trip returns the two names swapped")
+        void roundTripSwapsTheNameFields() {
+            when(commercialRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            CustomerDTO created = service.createCustomer(CustomerDTO.builder()
+                    .customerType("COMMERCIAL")
+                    .firstName("Fleet Co LLC")
+                    .lastName("Fleet Co")
+                    .build());
+
+            // Documents current behaviour, not desired behaviour. toEntity maps firstName ->
+            // legalName and lastName -> displayName, while toDTO maps legalName -> lastName and
+            // displayName -> firstName. The two directions disagree, so a client that POSTs a
+            // commercial party and reads it back gets its two name fields transposed.
+            // updateEntityFromDTO follows toEntity, so the same transposition applies on update.
+            assertThat(created.getFirstName()).isEqualTo("Fleet Co");
+            assertThat(created.getLastName()).isEqualTo("Fleet Co LLC");
+        }
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        @DisplayName("lists commercial parties paged and unpaged through both accessor pairs")
+        void listAccessors() {
+            when(commercialRepository.findAll()).thenReturn(List.of(party(), party()));
+            when(commercialRepository.findAll(any(org.springframework.data.domain.Pageable.class)))
+                    .thenReturn(new PageImpl<>(List.of(party()), PageRequest.of(0, 20), 31));
+
+            assertThat(service.getAllCustomers()).hasSize(2);
+            assertThat(service.getAllCommercialCustomers()).hasSize(2);
+            assertThat(service.getAllCustomers(PageRequest.of(0, 20)).getTotalElements())
+                    .isEqualTo(31);
+            assertThat(service.getAllCommercialCustomers(PageRequest.of(0, 20)).getTotalElements())
+                    .isEqualTo(31);
+        }
+
+        @Test
+        @DisplayName("returns empty for an unknown party")
+        void unknownPartyIsEmpty() {
+            when(commercialRepository.findById(PARTY_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.getCustomerById(PARTY_ID)).isEmpty();
+            assertThat(service.findPartyById(PARTY_ID)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("existsById delegates to the repository")
+        void existsDelegates() {
+            when(commercialRepository.existsById(PARTY_ID)).thenReturn(true);
+
+            assertThat(service.existsById(PARTY_ID)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("searchCustomers")
+    class Search {
+
+        @Test
+        @DisplayName("returns an empty page for an email-only query, since no email is held locally")
+        void emailOnlyQueryIsEmpty() {
+            assertThat(service.searchCustomers(null, "fleet@example.com", PageRequest.of(0, 10))
+                            .getContent())
+                    .isEmpty();
+
+            // Not a full scan filtered to nothing — the repository is never touched.
+            verifyNoInteractions(commercialRepository);
+        }
+
+        @Test
+        @DisplayName("searches by trimmed legal name")
+        void searchesByLegalName() {
+            when(commercialRepository.findByLegalNameContaining("Fleet")).thenReturn(List.of(party()));
+
+            Page<CustomerDTO> page = service.searchCustomers("  Fleet  ", null, PageRequest.of(0, 10));
+
+            assertThat(page.getTotalElements()).isEqualTo(1);
+            assertThat(page.getContent().getFirst().getLastName()).isEqualTo("Fleet Co LLC");
+        }
+
+        @Test
+        @DisplayName("pages the match list without running off the end")
+        void pagesTheMatchList() {
+            when(commercialRepository.findByLegalNameContaining("Fleet")).thenReturn(List.of(party(), party()));
+
+            assertThat(service.searchCustomers("Fleet", null, PageRequest.of(1, 1))
+                            .getContent())
+                    .hasSize(1);
+            assertThat(service.searchCustomers("Fleet", null, PageRequest.of(9, 10))
+                            .getContent())
+                    .isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("writes")
+    class Writes {
+
+        @Test
+        @DisplayName("publishes a fact on create so downstream replicas see the new party")
+        void createPublishes() {
+            when(commercialRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.createCustomer(CustomerDTO.builder()
+                    .customerType("COMMERCIAL")
+                    .customerNumber("C-2001")
+                    .primaryAddress("1 Depot Rd")
+                    .vehicleVins(List.of("VIN-1"))
+                    .build());
+
+            ArgumentCaptor<CommercialParty> captor = ArgumentCaptor.forClass(CommercialParty.class);
+            verify(commercialRepository).save(captor.capture());
+            assertThat(captor.getValue().getCustomerNumber()).isEqualTo("C-2001");
+            assertThat(captor.getValue().getVehicleVins()).containsExactly("VIN-1");
+            verify(customerFactPublisher).partyChanged(captor.getValue());
+        }
+
+        @Test
+        @DisplayName("creates a commercial party whatever type string arrives, including an unknown one")
+        void unknownTypeStillCreatesCommercial() {
+            when(commercialRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            for (String type : new String[] {null, "", "commercial", "PERSON", "NONSENSE"}) {
+                assertThat(service.createCustomer(
+                                CustomerDTO.builder().customerType(type).build()))
+                        .isNotNull();
+            }
+
+            // This service owns commercial parties only, and an unrecognized type string must not
+            // throw at the API boundary.
+            verify(commercialRepository, org.mockito.Mockito.times(5)).save(any(CommercialParty.class));
+        }
+
+        @Test
+        @DisplayName("updates only the fields the DTO supplies")
+        void updateIgnoresNulls() {
+            CommercialParty existing = party();
+            when(commercialRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
+            when(commercialRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.updateCustomer(
+                    PARTY_ID, CustomerDTO.builder().primaryAddress("2 Depot Rd").build());
+
+            assertThat(existing.getPrimaryAddress()).isEqualTo("2 Depot Rd");
+            assertThat(existing.getCustomerNumber()).isEqualTo("C-2001");
+            assertThat(existing.getLegalName()).isEqualTo("Fleet Co LLC");
+            verify(customerFactPublisher).partyChanged(existing);
+        }
+
+        @Test
+        @DisplayName("an update that names no VINs clears the ones the party had")
+        void omittingVinsClearsThem() {
+            CommercialParty existing = party();
+            when(commercialRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
+            when(commercialRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.updateCustomer(
+                    PARTY_ID, CustomerDTO.builder().primaryAddress("2 Depot Rd").build());
+
+            // Documents current behaviour, not desired behaviour — same cause as the person-party
+            // case: CustomerDTO declares vehicleVins @Builder.Default with an empty ArrayList and
+            // initializes it in the no-args constructor Jackson uses, so the `!= null` guard in
+            // updateEntityFromDTO can never be false and a partial update drops every VIN.
+            assertThat(existing.getVehicleVins()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("reports an update to an unknown party as empty without publishing")
+        void updateUnknownPartyIsEmpty() {
+            when(commercialRepository.findById(PARTY_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.updateCustomer(PARTY_ID, CustomerDTO.builder().build()))
+                    .isEmpty();
+
+            verifyNoInteractions(customerFactPublisher);
+        }
+
+        @Test
+        @DisplayName("publishes a deletion fact so downstream replicas drop the party")
+        void deletePublishes() {
+            CommercialParty existing = party();
+            when(commercialRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
+
+            assertThat(service.deleteCustomer(PARTY_ID)).isTrue();
+
+            verify(commercialRepository).deleteById(PARTY_ID);
+            verify(customerFactPublisher).partyDeleted(existing);
+        }
+
+        @Test
+        @DisplayName("reports a delete of an unknown party as false without publishing")
+        void deleteUnknownPartyIsFalse() {
+            when(commercialRepository.findById(PARTY_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.deleteCustomer(PARTY_ID)).isFalse();
+
+            verify(commercialRepository, never()).deleteById(any());
+            verifyNoInteractions(customerFactPublisher);
+        }
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/CustomerInteractionServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/CustomerInteractionServiceImplTest.java
@@ -1,0 +1,315 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.dto.CustomerInteractionResponse;
+import com.positivity.customer.internal.dto.RecordInteractionRequest;
+import com.positivity.customer.internal.entity.CustomerInteraction;
+import com.positivity.customer.internal.enums.InteractionDirection;
+import com.positivity.customer.internal.enums.InteractionType;
+import com.positivity.customer.internal.enums.MarketingChannel;
+import com.positivity.customer.internal.repository.CustomerInteractionRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Unit tests for {@link CustomerInteractionServiceImpl}.
+ *
+ * <p>
+ * Interactions are the contact history a service advisor reads before calling a
+ * customer. Two behaviours matter beyond the CRUD.
+ *
+ * <p>
+ * <b>Ingest is idempotent on {@code sourceEventId}.</b> Campaign-send and
+ * workorder facts are delivered at-least-once, so a replay must not add a second
+ * identical row to the customer's history. Ingest reports {@code false} rather
+ * than throwing, letting the caller record the event as handled either way.
+ *
+ * <p>
+ * <b>Bodies are redacted on the way out.</b> Emails and long digit runs are
+ * masked when an interaction is read, so a note pasted with a card number or an
+ * address does not leak through the history endpoint. That is applied on read,
+ * not on write, which the tests fix so it cannot be "optimized" into the write
+ * path where existing rows would escape it.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CustomerInteractionServiceImpl — contact history")
+class CustomerInteractionServiceImplTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-11T12:00:00Z");
+    private static final UUID PARTY_ID = UUID.randomUUID();
+    private static final UUID CONTACT_ID = UUID.randomUUID();
+
+    @Mock
+    private CustomerInteractionRepository interactionRepository;
+
+    @Captor
+    private ArgumentCaptor<CustomerInteraction> saved;
+
+    private CustomerInteractionServiceImpl sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new CustomerInteractionServiceImpl(Clock.fixed(NOW, ZoneOffset.UTC), interactionRepository);
+    }
+
+    private static RecordInteractionRequest request(InteractionDirection direction, Instant occurredAt) {
+        return new RecordInteractionRequest(
+                InteractionType.CALL,
+                CONTACT_ID,
+                MarketingChannel.EMAIL,
+                direction,
+                "Follow-up",
+                "Called about the estimate",
+                "Body text",
+                occurredAt);
+    }
+
+    private static CustomerInteraction interaction(String body) {
+        return CustomerInteraction.builder()
+                .interactionId(UUID.randomUUID())
+                .partyId(PARTY_ID)
+                .type(InteractionType.NOTE)
+                .direction(InteractionDirection.OUTBOUND)
+                .body(body)
+                .occurredAt(NOW)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("record")
+    class Record {
+
+        @Test
+        @DisplayName("persists the interaction against the party")
+        void record_persists() {
+            when(interactionRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            CustomerInteractionResponse response = sut.record(PARTY_ID, request(InteractionDirection.INBOUND, NOW));
+
+            assertThat(response.partyId()).isEqualTo(PARTY_ID);
+            assertThat(response.type()).isEqualTo("CALL");
+            assertThat(response.direction()).isEqualTo("INBOUND");
+            assertThat(response.channel()).isEqualTo("EMAIL");
+        }
+
+        @Test
+        @DisplayName("defaults the direction to OUTBOUND when the request omits it")
+        void record_whenDirectionOmitted_defaultsOutbound() {
+            when(interactionRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.record(PARTY_ID, request(null, NOW));
+
+            verify(interactionRepository).save(saved.capture());
+            assertThat(saved.getValue().getDirection()).isEqualTo(InteractionDirection.OUTBOUND);
+        }
+
+        @Test
+        @DisplayName("stamps the clock when the request carries no occurredAt")
+        void record_whenOccurredAtOmitted_usesClock() {
+            when(interactionRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.record(PARTY_ID, request(InteractionDirection.OUTBOUND, null));
+
+            verify(interactionRepository).save(saved.capture());
+            assertThat(saved.getValue().getOccurredAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("keeps a caller-supplied occurredAt, so backdated history stays accurate")
+        void record_keepsSuppliedOccurredAt() {
+            Instant earlier = NOW.minusSeconds(86_400);
+            when(interactionRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.record(PARTY_ID, request(InteractionDirection.OUTBOUND, earlier));
+
+            verify(interactionRepository).save(saved.capture());
+            assertThat(saved.getValue().getOccurredAt()).isEqualTo(earlier);
+        }
+
+        @Test
+        @DisplayName("redacts an email address out of the body on the way back")
+        void record_redactsEmailInResponse() {
+            when(interactionRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+            RecordInteractionRequest withEmail = new RecordInteractionRequest(
+                    InteractionType.NOTE,
+                    null,
+                    null,
+                    InteractionDirection.OUTBOUND,
+                    "Subject",
+                    "Summary",
+                    "Reach them at ada@example.com",
+                    NOW);
+
+            CustomerInteractionResponse response = sut.record(PARTY_ID, withEmail);
+
+            assertThat(response.body()).doesNotContain("ada@example.com").contains("[redacted-email]");
+        }
+    }
+
+    @Nested
+    @DisplayName("ingest")
+    class Ingest {
+
+        @Test
+        @DisplayName("writes an interaction that carries no source event id")
+        void ingest_withoutSourceEvent_writes() {
+            assertThat(sut.ingest(interaction(null))).isTrue();
+
+            verify(interactionRepository).save(any());
+            verify(interactionRepository, never()).existsBySourceEventId(anyString());
+        }
+
+        @Test
+        @DisplayName("writes the first interaction for a source event")
+        void ingest_firstTimeForSourceEvent_writes() {
+            CustomerInteraction fromEvent = interaction(null);
+            fromEvent.setSourceEventId("event-1");
+            when(interactionRepository.existsBySourceEventId("event-1")).thenReturn(false);
+
+            assertThat(sut.ingest(fromEvent)).isTrue();
+            verify(interactionRepository).save(fromEvent);
+        }
+
+        @Test
+        @DisplayName("reports false and writes nothing when the source event was already applied")
+        void ingest_whenSourceEventSeen_isNoOp() {
+            CustomerInteraction replay = interaction(null);
+            replay.setSourceEventId("event-1");
+            when(interactionRepository.existsBySourceEventId("event-1")).thenReturn(true);
+
+            // Reported, not thrown: the caller still records the event as handled.
+            assertThat(sut.ingest(replay)).isFalse();
+            verify(interactionRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("stamps the clock when the ingested interaction has no occurredAt")
+        void ingest_whenOccurredAtMissing_usesClock() {
+            CustomerInteraction withoutTime = interaction(null);
+            withoutTime.setOccurredAt(null);
+
+            sut.ingest(withoutTime);
+
+            assertThat(withoutTime.getOccurredAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("keeps an occurredAt the caller already set")
+        void ingest_keepsSuppliedOccurredAt() {
+            Instant earlier = NOW.minusSeconds(3_600);
+            CustomerInteraction withTime = interaction(null);
+            withTime.setOccurredAt(earlier);
+
+            sut.ingest(withTime);
+
+            assertThat(withTime.getOccurredAt()).isEqualTo(earlier);
+        }
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @ParameterizedTest(name = "page {0} size {1} requests page {2} size {3}")
+        @CsvSource({"0, 25, 0, 25", "-4, 25, 0, 25", "0, 0, 0, 1", "0, 5000, 0, 200"})
+        @DisplayName("clamps paging inputs rather than passing them through")
+        void listForParty_clampsPaging(int page, int size, int expectedPage, int expectedSize) {
+            ArgumentCaptor<Pageable> pageable = ArgumentCaptor.captor();
+            when(interactionRepository.findByPartyIdOrderByOccurredAtDesc(eq(PARTY_ID), pageable.capture()))
+                    .thenReturn(new PageImpl<>(List.of(interaction(null))));
+
+            sut.listForParty(PARTY_ID, null, page, size);
+
+            assertThat(pageable.getValue().getPageNumber()).isEqualTo(expectedPage);
+            assertThat(pageable.getValue().getPageSize()).isEqualTo(expectedSize);
+        }
+
+        @Test
+        @DisplayName("uses the type-filtered query when a type is supplied")
+        void listForParty_withType_usesFilteredQuery() {
+            when(interactionRepository.findByPartyIdAndTypeOrderByOccurredAtDesc(
+                            eq(PARTY_ID), eq(InteractionType.CALL), any()))
+                    .thenReturn(new PageImpl<>(List.of(interaction(null))));
+
+            assertThat(sut.listForParty(PARTY_ID, InteractionType.CALL, 0, 25).items())
+                    .hasSize(1);
+            verify(interactionRepository, never()).findByPartyIdOrderByOccurredAtDesc(any(), any());
+        }
+
+        @Test
+        @DisplayName("redacts bodies when listing, so history reads cannot leak masked content")
+        void listForParty_redactsBodies() {
+            when(interactionRepository.findByPartyIdOrderByOccurredAtDesc(eq(PARTY_ID), any()))
+                    .thenReturn(new PageImpl<>(List.of(interaction("card 4111111111111111 and ada@example.com"))));
+
+            assertThat(sut.listForParty(PARTY_ID, null, 0, 25).items())
+                    .singleElement()
+                    .satisfies(response -> assertThat(response.body())
+                            .doesNotContain("4111111111111111")
+                            .doesNotContain("ada@example.com"));
+        }
+
+        @Test
+        @DisplayName("recentForParty returns the most recent handful, redacted")
+        void recentForParty_returnsRedacted() {
+            when(interactionRepository.findTop5ByPartyIdOrderByOccurredAtDesc(PARTY_ID))
+                    .thenReturn(List.of(interaction("ada@example.com")));
+
+            assertThat(sut.recentForParty(PARTY_ID))
+                    .singleElement()
+                    .satisfies(response -> assertThat(response.body()).contains("[redacted-email]"));
+        }
+
+        @Test
+        @DisplayName("tolerates an interaction with no channel")
+        void toResponse_whenChannelNull_reportsNull() {
+            when(interactionRepository.findTop5ByPartyIdOrderByOccurredAtDesc(PARTY_ID))
+                    .thenReturn(List.of(interaction(null)));
+
+            assertThat(sut.recentForParty(PARTY_ID))
+                    .singleElement()
+                    .satisfies(response -> assertThat(response.channel()).isNull());
+        }
+    }
+
+    @Nested
+    @DisplayName("channelOrNull")
+    class ChannelOrNull {
+
+        @Test
+        @DisplayName("maps a known channel name onto the enum")
+        void mapsKnownChannel() {
+            assertThat(CustomerInteractionServiceImpl.channelOrNull("EMAIL")).isEqualTo(MarketingChannel.EMAIL);
+        }
+
+        @Test
+        @DisplayName("treats null and blank as no channel")
+        void treatsBlankAsNull() {
+            assertThat(CustomerInteractionServiceImpl.channelOrNull(null)).isNull();
+            assertThat(CustomerInteractionServiceImpl.channelOrNull("   ")).isNull();
+        }
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/MarketingConsentServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/MarketingConsentServiceImplTest.java
@@ -1,0 +1,478 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.dto.MarketingConsentDecision;
+import com.positivity.customer.internal.dto.MarketingConsentSummaryResponse;
+import com.positivity.customer.internal.dto.UpdateMarketingConsentRequest;
+import com.positivity.customer.internal.entity.CommercialParty;
+import com.positivity.customer.internal.entity.CommunicationPreference;
+import com.positivity.customer.internal.entity.ConsentEvent;
+import com.positivity.customer.internal.enums.ConsentChangeSource;
+import com.positivity.customer.internal.enums.MarketingChannel;
+import com.positivity.customer.internal.enums.MarketingConsent;
+import com.positivity.customer.internal.enums.OptOutReason;
+import com.positivity.customer.internal.exception.CrmResourceNotFoundException;
+import com.positivity.customer.internal.repository.CommercialPartyRepository;
+import com.positivity.customer.internal.repository.CommunicationPreferenceRepository;
+import com.positivity.customer.internal.repository.ConsentEventRepository;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
+import com.positivity.customer.service.SuppressionService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link MarketingConsentServiceImpl}.
+ *
+ * <p>
+ * This service decides whether a customer may be marketed to, so its failure
+ * mode is a compliance one: mailing somebody who opted out. Three rules protect
+ * against that and are asserted directly.
+ *
+ * <ul>
+ * <li><b>Suppression outranks consent.</b> An opted-in party whose address hard
+ * bounced is still ineligible — suppression is a hard block layered on top of
+ * the resolved consent, not an input to it.</li>
+ * <li><b>Both channels are republished on any change.</b> Consumers replicate
+ * the resolved decision; emitting only the channel that moved would leave a
+ * stale "allowed" on the other, which is the one failure mode that mails an
+ * opted-out customer.</li>
+ * <li><b>Audit rows are written only for channels that actually moved.</b> A
+ * replayed no-op update must not pollute the compliance trail with entries
+ * recording a change from a value to itself.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MarketingConsentServiceImpl — consent resolution and audit")
+class MarketingConsentServiceImplTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-11T12:00:00Z");
+    private static final UUID PARTY_ID = UUID.randomUUID();
+
+    @Mock
+    private MarketingConsentResolver consentResolver;
+
+    @Mock
+    private SuppressionService suppressionService;
+
+    @Mock
+    private CommunicationPreferenceRepository preferenceRepository;
+
+    @Mock
+    private CommercialPartyRepository commercialPartyRepository;
+
+    @Mock
+    private PersonPartyRepository personPartyRepository;
+
+    @Mock
+    private ConsentEventRepository consentEventRepository;
+
+    @Mock
+    private CustomerFactPublisher factPublisher;
+
+    @Captor
+    private ArgumentCaptor<List<ConsentEvent>> auditRows;
+
+    private MarketingConsentServiceImpl sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new MarketingConsentServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                consentResolver,
+                suppressionService,
+                preferenceRepository,
+                commercialPartyRepository,
+                personPartyRepository,
+                consentEventRepository,
+                factPublisher);
+    }
+
+    private static MarketingConsentDecision allowed() {
+        return new MarketingConsentDecision(PARTY_ID, "EMAIL", true, MarketingConsentDecision.REASON_OPT_IN, null);
+    }
+
+    private static MarketingConsentDecision denied() {
+        return new MarketingConsentDecision(
+                PARTY_ID, "EMAIL", false, MarketingConsentDecision.REASON_CONSENT_OPT_OUT, null);
+    }
+
+    private static CommunicationPreference preference(MarketingConsent email, MarketingConsent sms) {
+        CommunicationPreference preference = new CommunicationPreference();
+        preference.setPartyId(PARTY_ID);
+        preference.setMarketingEmailConsent(email);
+        preference.setMarketingSmsConsent(sms);
+        return preference;
+    }
+
+    private static UpdateMarketingConsentRequest update(MarketingConsent email, MarketingConsent sms) {
+        return new UpdateMarketingConsentRequest(
+                email, sms, OptOutReason.NOT_INTERESTED, ConsentChangeSource.CSR, null, null, null);
+    }
+
+    /** Party exists and every channel resolves as allowed unless a test says otherwise. */
+    private void partyExistsAndIsAllowed() {
+        lenient().when(commercialPartyRepository.existsById(PARTY_ID)).thenReturn(true);
+        lenient().when(consentResolver.resolve(eq(PARTY_ID), any())).thenReturn(allowed());
+        lenient()
+                .when(suppressionService.isPartySuppressed(eq(PARTY_ID), any()))
+                .thenReturn(false);
+        lenient().when(commercialPartyRepository.findById(PARTY_ID)).thenReturn(Optional.empty());
+    }
+
+    @Nested
+    @DisplayName("resolveEligibility")
+    class ResolveEligibility {
+
+        @Test
+        @DisplayName("allows a party whose consent resolves as opted in and is not suppressed")
+        void allowsOptedInUnsuppressedParty() {
+            when(consentResolver.resolve(PARTY_ID, MarketingChannel.EMAIL)).thenReturn(allowed());
+            when(suppressionService.isPartySuppressed(PARTY_ID, MarketingChannel.EMAIL))
+                    .thenReturn(false);
+
+            assertThat(sut.resolveEligibility(PARTY_ID, MarketingChannel.EMAIL).allowed())
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("blocks a suppressed party even when consent says opted in")
+        void suppressionOverridesConsent() {
+            when(consentResolver.resolve(PARTY_ID, MarketingChannel.EMAIL)).thenReturn(allowed());
+            when(suppressionService.isPartySuppressed(PARTY_ID, MarketingChannel.EMAIL))
+                    .thenReturn(true);
+
+            MarketingConsentDecision decision = sut.resolveEligibility(PARTY_ID, MarketingChannel.EMAIL);
+
+            // Suppression is a hard block on top of consent, not an input to it.
+            assertThat(decision.allowed()).isFalse();
+            assertThat(decision.reason()).isEqualTo(MarketingConsentDecision.REASON_SUPPRESSED);
+        }
+
+        @Test
+        @DisplayName("does not consult suppression when consent already denies")
+        void whenConsentDenies_shortCircuits() {
+            when(consentResolver.resolve(PARTY_ID, MarketingChannel.EMAIL)).thenReturn(denied());
+
+            assertThat(sut.resolveEligibility(PARTY_ID, MarketingChannel.EMAIL).reason())
+                    .isEqualTo(MarketingConsentDecision.REASON_CONSENT_OPT_OUT);
+            verify(suppressionService, never()).isPartySuppressed(any(), any());
+        }
+
+        @Test
+        @DisplayName("keeps the governing party on a suppression block, so the account link is not lost")
+        void suppressionKeepsGoverningParty() {
+            UUID governing = UUID.randomUUID();
+            when(consentResolver.resolve(PARTY_ID, MarketingChannel.EMAIL))
+                    .thenReturn(new MarketingConsentDecision(
+                            PARTY_ID, "EMAIL", true, MarketingConsentDecision.REASON_OPT_IN, governing));
+            when(suppressionService.isPartySuppressed(any(), any())).thenReturn(true);
+
+            assertThat(sut.resolveEligibility(PARTY_ID, MarketingChannel.EMAIL).governingPartyId())
+                    .isEqualTo(governing);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateConsent")
+    class UpdateConsent {
+
+        @Test
+        @DisplayName("creates a preference row for a party that has none yet")
+        void whenNoPreferenceExists_createsOne() {
+            partyExistsAndIsAllowed();
+            when(preferenceRepository.findByPartyId(PARTY_ID)).thenReturn(Optional.empty());
+
+            sut.updateConsent(PARTY_ID, update(MarketingConsent.OPT_IN, null));
+
+            ArgumentCaptor<CommunicationPreference> saved = ArgumentCaptor.captor();
+            verify(preferenceRepository).save(saved.capture());
+            assertThat(saved.getValue().getMarketingEmailConsent()).isEqualTo(MarketingConsent.OPT_IN);
+            assertThat(saved.getValue().getMarketingSmsConsent()).isEqualTo(MarketingConsent.UNSET);
+        }
+
+        @Test
+        @DisplayName("writes one audit row per channel that actually changed")
+        void writesAuditRowPerChangedChannel() {
+            partyExistsAndIsAllowed();
+            when(preferenceRepository.findByPartyId(PARTY_ID))
+                    .thenReturn(Optional.of(preference(MarketingConsent.UNSET, MarketingConsent.UNSET)));
+
+            sut.updateConsent(PARTY_ID, update(MarketingConsent.OPT_IN, MarketingConsent.OPT_OUT));
+
+            verify(consentEventRepository).saveAll(auditRows.capture());
+            assertThat(auditRows.getValue())
+                    .extracting(ConsentEvent::getChannel)
+                    .containsExactlyInAnyOrder(MarketingChannel.EMAIL, MarketingChannel.SMS);
+            assertThat(auditRows.getValue()).allSatisfy(event -> {
+                assertThat(event.getOldValue()).isEqualTo(MarketingConsent.UNSET);
+                assertThat(event.getOccurredAt()).isEqualTo(NOW);
+                assertThat(event.getSource()).isEqualTo(ConsentChangeSource.CSR);
+            });
+        }
+
+        @Test
+        @DisplayName("writes no audit row when the requested value already matches — a replay is not a change")
+        void whenValueUnchanged_writesNoAudit() {
+            partyExistsAndIsAllowed();
+            when(preferenceRepository.findByPartyId(PARTY_ID))
+                    .thenReturn(Optional.of(preference(MarketingConsent.OPT_IN, MarketingConsent.UNSET)));
+
+            sut.updateConsent(PARTY_ID, update(MarketingConsent.OPT_IN, null));
+
+            // Replaying an idempotent update must not pollute the compliance trail.
+            verify(consentEventRepository, never()).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("republishes both channels on any consent change, not just the one that moved")
+        void republishesEveryChannel() {
+            partyExistsAndIsAllowed();
+            when(preferenceRepository.findByPartyId(PARTY_ID))
+                    .thenReturn(Optional.of(preference(MarketingConsent.UNSET, MarketingConsent.UNSET)));
+
+            sut.updateConsent(PARTY_ID, update(MarketingConsent.OPT_OUT, null));
+
+            // A partial emission would leave a stale "allowed" on the other channel.
+            for (MarketingChannel channel : MarketingChannel.values()) {
+                verify(factPublisher)
+                        .consentDecisionChanged(eq(PARTY_ID), eq(channel.name()), anyBoolean(), anyString(), any());
+            }
+        }
+
+        @Test
+        @DisplayName("stamps the opt-out reason and timestamp when consent is withdrawn")
+        void whenWithdrawn_stampsOptOutMetadata() {
+            partyExistsAndIsAllowed();
+            CommunicationPreference existing = preference(MarketingConsent.OPT_IN, MarketingConsent.UNSET);
+            when(preferenceRepository.findByPartyId(PARTY_ID)).thenReturn(Optional.of(existing));
+
+            sut.updateConsent(PARTY_ID, update(MarketingConsent.OPT_OUT, null));
+
+            assertThat(existing.getOptOutReason()).isEqualTo(OptOutReason.NOT_INTERESTED);
+            assertThat(existing.getOptOutAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("leaves opt-out metadata alone when consent is granted rather than withdrawn")
+        void whenGranted_doesNotStampOptOutMetadata() {
+            partyExistsAndIsAllowed();
+            CommunicationPreference existing = preference(MarketingConsent.UNSET, MarketingConsent.UNSET);
+            when(preferenceRepository.findByPartyId(PARTY_ID)).thenReturn(Optional.of(existing));
+
+            sut.updateConsent(PARTY_ID, update(MarketingConsent.OPT_IN, null));
+
+            assertThat(existing.getOptOutAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("applies quiet hours and the send cap only when supplied")
+        void appliesOptionalPreferencesWhenSupplied() {
+            partyExistsAndIsAllowed();
+            CommunicationPreference existing = preference(MarketingConsent.UNSET, MarketingConsent.UNSET);
+            existing.setMaxMarketingSendsPerMonth(4);
+            when(preferenceRepository.findByPartyId(PARTY_ID)).thenReturn(Optional.of(existing));
+
+            sut.updateConsent(
+                    PARTY_ID,
+                    new UpdateMarketingConsentRequest(
+                            null,
+                            null,
+                            null,
+                            ConsentChangeSource.SELF_SERVICE,
+                            LocalTime.of(21, 0),
+                            LocalTime.of(8, 0),
+                            null));
+
+            assertThat(existing.getQuietHoursStart()).isEqualTo(LocalTime.of(21, 0));
+            assertThat(existing.getQuietHoursEnd()).isEqualTo(LocalTime.of(8, 0));
+            // Omitted, so the existing cap survives.
+            assertThat(existing.getMaxMarketingSendsPerMonth()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("defaults the change source to CSR when the request omits it")
+        void whenSourceOmitted_defaultsToCsr() {
+            partyExistsAndIsAllowed();
+            when(preferenceRepository.findByPartyId(PARTY_ID))
+                    .thenReturn(Optional.of(preference(MarketingConsent.UNSET, MarketingConsent.UNSET)));
+
+            sut.updateConsent(
+                    PARTY_ID,
+                    new UpdateMarketingConsentRequest(MarketingConsent.OPT_IN, null, null, null, null, null, null));
+
+            verify(consentEventRepository).saveAll(auditRows.capture());
+            assertThat(auditRows.getValue())
+                    .singleElement()
+                    .satisfies(event -> assertThat(event.getSource()).isEqualTo(ConsentChangeSource.CSR));
+        }
+
+        @Test
+        @DisplayName("rejects an update for a party that exists as neither a commercial nor a person party")
+        void whenPartyUnknown_throwsNotFound() {
+            when(commercialPartyRepository.existsById(PARTY_ID)).thenReturn(false);
+            when(personPartyRepository.existsById(PARTY_ID)).thenReturn(false);
+
+            assertThatThrownBy(() -> sut.updateConsent(PARTY_ID, update(MarketingConsent.OPT_IN, null)))
+                    .isInstanceOf(CrmResourceNotFoundException.class);
+            verify(preferenceRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("accepts a person party, not only a commercial one")
+        void whenPersonParty_isAccepted() {
+            when(commercialPartyRepository.existsById(PARTY_ID)).thenReturn(false);
+            when(personPartyRepository.existsById(PARTY_ID)).thenReturn(true);
+            when(consentResolver.resolve(eq(PARTY_ID), any())).thenReturn(allowed());
+            when(suppressionService.isPartySuppressed(any(), any())).thenReturn(false);
+            when(commercialPartyRepository.findById(PARTY_ID)).thenReturn(Optional.empty());
+            when(preferenceRepository.findByPartyId(PARTY_ID)).thenReturn(Optional.empty());
+
+            assertThat(sut.updateConsent(PARTY_ID, update(MarketingConsent.OPT_IN, null)))
+                    .isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("setAccountMarketingOptOut")
+    class AccountGate {
+
+        private CommercialParty account(boolean optOut) {
+            CommercialParty account = new CommercialParty();
+            account.setPartyId(PARTY_ID);
+            account.setAccountMarketingOptOut(optOut);
+            return account;
+        }
+
+        @Test
+        @DisplayName("sets the gate, stamps the time, and republishes the decision")
+        void whenGateChanges_savesAndRepublishes() {
+            CommercialParty account = account(false);
+            when(commercialPartyRepository.findById(PARTY_ID)).thenReturn(Optional.of(account));
+            when(consentResolver.resolve(eq(PARTY_ID), any())).thenReturn(denied());
+            when(preferenceRepository.findByPartyId(PARTY_ID)).thenReturn(Optional.empty());
+
+            sut.setAccountMarketingOptOut(PARTY_ID, true);
+
+            assertThat(account.isAccountMarketingOptOut()).isTrue();
+            assertThat(account.getAccountMarketingOptOutAt()).isEqualTo(NOW);
+            verify(commercialPartyRepository).save(account);
+            verify(factPublisher, times(MarketingChannel.values().length))
+                    .consentDecisionChanged(eq(PARTY_ID), anyString(), anyBoolean(), anyString(), any());
+        }
+
+        @Test
+        @DisplayName("clears the timestamp when the gate is lifted")
+        void whenGateLifted_clearsTimestamp() {
+            CommercialParty account = account(true);
+            account.setAccountMarketingOptOutAt(NOW.minusSeconds(3600));
+            when(commercialPartyRepository.findById(PARTY_ID)).thenReturn(Optional.of(account));
+            when(consentResolver.resolve(eq(PARTY_ID), any())).thenReturn(allowed());
+            when(suppressionService.isPartySuppressed(any(), any())).thenReturn(false);
+            when(preferenceRepository.findByPartyId(PARTY_ID)).thenReturn(Optional.empty());
+
+            sut.setAccountMarketingOptOut(PARTY_ID, false);
+
+            assertThat(account.isAccountMarketingOptOut()).isFalse();
+            assertThat(account.getAccountMarketingOptOutAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("writes and publishes nothing when the gate already holds the requested value")
+        void whenGateUnchanged_isNoOp() {
+            CommercialParty account = account(true);
+            when(commercialPartyRepository.findById(PARTY_ID)).thenReturn(Optional.of(account));
+            when(consentResolver.resolve(eq(PARTY_ID), any())).thenReturn(denied());
+            when(preferenceRepository.findByPartyId(PARTY_ID)).thenReturn(Optional.empty());
+
+            sut.setAccountMarketingOptOut(PARTY_ID, true);
+
+            verify(commercialPartyRepository, never()).save(any());
+            verify(factPublisher, never()).consentDecisionChanged(any(), anyString(), anyBoolean(), anyString(), any());
+        }
+
+        @Test
+        @DisplayName("rejects an unknown commercial party")
+        void whenAccountUnknown_throwsNotFound() {
+            when(commercialPartyRepository.findById(PARTY_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.setAccountMarketingOptOut(PARTY_ID, true))
+                    .isInstanceOf(CrmResourceNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getConsent")
+    class GetConsent {
+
+        @Test
+        @DisplayName("reports UNSET on both channels for a party with no preference row")
+        void whenNoPreference_reportsUnset() {
+            partyExistsAndIsAllowed();
+            when(preferenceRepository.findByPartyId(PARTY_ID)).thenReturn(Optional.empty());
+
+            MarketingConsentSummaryResponse summary = sut.getConsent(PARTY_ID);
+
+            assertThat(summary.marketingEmailConsent()).isEqualTo("UNSET");
+            assertThat(summary.marketingSmsConsent()).isEqualTo("UNSET");
+            assertThat(summary.accountMarketingOptOut()).isNull();
+        }
+
+        @Test
+        @DisplayName("includes the live per-channel decision alongside the stored values")
+        void includesResolvedDecisions() {
+            partyExistsAndIsAllowed();
+            when(preferenceRepository.findByPartyId(PARTY_ID))
+                    .thenReturn(Optional.of(preference(MarketingConsent.OPT_IN, MarketingConsent.OPT_IN)));
+
+            MarketingConsentSummaryResponse summary = sut.getConsent(PARTY_ID);
+
+            assertThat(summary.emailEligibility().allowed()).isTrue();
+            assertThat(summary.smsEligibility().allowed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("normalizes a null stored consent to UNSET rather than emitting null")
+        void whenStoredConsentNull_reportsUnset() {
+            partyExistsAndIsAllowed();
+            when(preferenceRepository.findByPartyId(PARTY_ID)).thenReturn(Optional.of(preference(null, null)));
+
+            MarketingConsentSummaryResponse summary = sut.getConsent(PARTY_ID);
+
+            assertThat(summary.marketingEmailConsent()).isEqualTo("UNSET");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown party")
+        void whenPartyUnknown_throwsNotFound() {
+            when(commercialPartyRepository.existsById(PARTY_ID)).thenReturn(false);
+            when(personPartyRepository.existsById(PARTY_ID)).thenReturn(false);
+
+            assertThatThrownBy(() -> sut.getConsent(PARTY_ID)).isInstanceOf(CrmResourceNotFoundException.class);
+        }
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/MarketingEventsListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/MarketingEventsListenerTest.java
@@ -1,0 +1,209 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.entity.CustomerInteraction;
+import com.positivity.customer.internal.entity.ProcessedEvent;
+import com.positivity.customer.internal.enums.InteractionDirection;
+import com.positivity.customer.internal.enums.InteractionType;
+import com.positivity.customer.internal.enums.MarketingChannel;
+import com.positivity.customer.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link MarketingEventsListener}.
+ *
+ * <p>
+ * Campaign sends become customer-interaction rows so a service advisor can see
+ * what marketing has already sent a customer. Delivery is at-least-once, so the
+ * listener is idempotent twice over: the {@code processed_events} log skips a
+ * replayed envelope, and the interaction's unique {@code source_event_id} index
+ * is the backstop if the log and the write ever diverge.
+ *
+ * <p>
+ * The partial-data handling is the subtle part and is asserted directly. A send
+ * with no recipient is dropped, because an interaction not attached to a party
+ * is unreachable. But a send whose channel this module does not model is still
+ * recorded without a channel — the touch happened, and dropping it would hide a
+ * real contact from the advisor.
+ */
+@DisplayName("MarketingEventsListener — campaign sends into customer interactions")
+class MarketingEventsListenerTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-08-11T12:00:00Z"), ZoneOffset.UTC);
+    private static final Instant NOW = Instant.parse("2026-08-11T12:00:00Z");
+    private static final String EVENT_ID = "01960000-0000-7000-8000-000000000001";
+    private static final UUID PARTY_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID CONTACT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b1");
+    private static final UUID CAMPAIGN_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c1");
+
+    private final ProcessedEventRepository processedEvents = mock(ProcessedEventRepository.class);
+    private final CustomerInteractionServiceImpl interactionService = mock(CustomerInteractionServiceImpl.class);
+
+    private MarketingEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new MarketingEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, interactionService);
+    }
+
+    private static String campaignSent(String channel, String recipientPartyId) {
+        return """
+                {"eventId":"%s","eventType":"marketing.campaign.sent",
+                 "payload":{"recipientPartyId":%s,"contactId":"%s","campaignId":"%s",
+                  "campaignCode":"SPRING24","channel":%s,"subject":"Spring service offer"}}
+                """.formatted(
+                        EVENT_ID,
+                        recipientPartyId == null ? "null" : "\"" + recipientPartyId + "\"",
+                        CONTACT_ID,
+                        CAMPAIGN_ID,
+                        channel == null ? "null" : "\"" + channel + "\"");
+    }
+
+    private CustomerInteraction capturedInteraction() {
+        ArgumentCaptor<CustomerInteraction> captor = ArgumentCaptor.captor();
+        verify(interactionService).ingest(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("records a campaign send as an outbound CAMPAIGN_SEND interaction")
+    void campaignSent_recordsInteraction() {
+        listener.onMarketingEvent(campaignSent("EMAIL", PARTY_ID.toString()));
+
+        CustomerInteraction interaction = capturedInteraction();
+        assertThat(interaction.getPartyId()).isEqualTo(PARTY_ID);
+        assertThat(interaction.getContactId()).isEqualTo(CONTACT_ID);
+        assertThat(interaction.getCampaignId()).isEqualTo(CAMPAIGN_ID);
+        assertThat(interaction.getCampaignCode()).isEqualTo("SPRING24");
+        assertThat(interaction.getType()).isEqualTo(InteractionType.CAMPAIGN_SEND);
+        assertThat(interaction.getDirection()).isEqualTo(InteractionDirection.OUTBOUND);
+        assertThat(interaction.getChannel()).isEqualTo(MarketingChannel.EMAIL);
+        assertThat(interaction.getSubject()).isEqualTo("Spring service offer");
+        assertThat(interaction.getSummary()).isEqualTo("Campaign send: SPRING24");
+        assertThat(interaction.getSourceEventId()).isEqualTo(EVENT_ID);
+        assertThat(interaction.getOccurredAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("records the event as processed, owned by pos-marketing")
+    void campaignSent_recordsProcessedEvent() {
+        listener.onMarketingEvent(campaignSent("EMAIL", PARTY_ID.toString()));
+
+        ArgumentCaptor<ProcessedEvent> saved = ArgumentCaptor.captor();
+        verify(processedEvents).save(saved.capture());
+        assertThat(saved.getValue().getEventId()).isEqualTo(EVENT_ID);
+        assertThat(saved.getValue().getOwner()).isEqualTo("pos-marketing");
+        assertThat(saved.getValue().getProcessedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("ignores an event type this listener does not handle")
+    void otherEventType_isIgnored() {
+        String message = "{\"eventId\":\"" + EVENT_ID + "\",\"eventType\":\"marketing.campaign.created\","
+                + "\"payload\":{\"recipientPartyId\":\"" + PARTY_ID + "\"}}";
+
+        listener.onMarketingEvent(message);
+
+        verify(interactionService, never()).ingest(any());
+        verify(processedEvents, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("skips an event already recorded in processed_events")
+    void duplicateEvent_isSkipped() {
+        when(processedEvents.existsById(EVENT_ID)).thenReturn(true);
+
+        listener.onMarketingEvent(campaignSent("EMAIL", PARTY_ID.toString()));
+
+        verify(interactionService, never()).ingest(any());
+        verify(processedEvents, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("skips an envelope with no eventId, since idempotency cannot be tracked without one")
+    void missingEventId_isSkipped() {
+        String message =
+                "{\"eventType\":\"marketing.campaign.sent\",\"payload\":{\"recipientPartyId\":\"" + PARTY_ID + "\"}}";
+
+        listener.onMarketingEvent(message);
+
+        verify(interactionService, never()).ingest(any());
+    }
+
+    @Test
+    @DisplayName("drops a send with no recipient — an interaction with no party is unreachable")
+    void missingRecipient_isDropped() {
+        listener.onMarketingEvent(campaignSent("EMAIL", null));
+
+        verify(interactionService, never()).ingest(any());
+        verify(processedEvents, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("drops a send whose recipient id is not a UUID")
+    void malformedRecipient_isDropped() {
+        listener.onMarketingEvent(campaignSent("EMAIL", "not-a-uuid"));
+
+        verify(interactionService, never()).ingest(any());
+    }
+
+    @Test
+    @DisplayName("records a send on an unmodelled channel without one, rather than dropping the touch")
+    void unknownChannel_isRecordedWithoutChannel() {
+        listener.onMarketingEvent(campaignSent("CARRIER_PIGEON", PARTY_ID.toString()));
+
+        // The send happened; dropping it would hide a real customer contact.
+        assertThat(capturedInteraction().getChannel()).isNull();
+    }
+
+    @Test
+    @DisplayName("records a send with no channel at all")
+    void missingChannel_isRecordedWithoutChannel() {
+        listener.onMarketingEvent(campaignSent(null, PARTY_ID.toString()));
+
+        assertThat(capturedInteraction().getChannel()).isNull();
+    }
+
+    @Test
+    @DisplayName("falls back to a generic summary when the send carries no campaign code")
+    void missingCampaignCode_usesGenericSummary() {
+        String message = """
+                {"eventId":"%s","eventType":"marketing.campaign.sent",
+                 "payload":{"recipientPartyId":"%s","channel":"SMS"}}
+                """.formatted(EVENT_ID, PARTY_ID);
+
+        listener.onMarketingEvent(message);
+
+        CustomerInteraction interaction = capturedInteraction();
+        assertThat(interaction.getSummary()).isEqualTo("Campaign send");
+        assertThat(interaction.getCampaignCode()).isNull();
+        assertThat(interaction.getContactId()).isNull();
+        assertThat(interaction.getCampaignId()).isNull();
+    }
+
+    @Test
+    @DisplayName("still records the event when the interaction was already written by its unique index")
+    void whenInteractionDeduplicated_stillRecordsProcessedEvent() {
+        // ingest() reports false when the source_event_id index rejected a duplicate;
+        // the event is still fully handled and must not be reprocessed.
+        when(interactionService.ingest(any())).thenReturn(false);
+
+        listener.onMarketingEvent(campaignSent("EMAIL", PARTY_ID.toString()));
+
+        verify(processedEvents).save(any(ProcessedEvent.class));
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/PartyServiceImplBillingAndDuplicatesTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/PartyServiceImplBillingAndDuplicatesTest.java
@@ -1,0 +1,317 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.config.OutboxEventWriter;
+import com.positivity.customer.internal.dto.DuplicateCheckResponse;
+import com.positivity.customer.internal.dto.UpsertBillingRulesRequest;
+import com.positivity.customer.internal.dto.snapshot.BillingRuleRef;
+import com.positivity.customer.internal.entity.CommercialParty;
+import com.positivity.customer.internal.enums.InvoiceDeliveryMethod;
+import com.positivity.customer.internal.repository.CommercialPartyRepository;
+import com.positivity.customer.internal.repository.ExtVehicleRepository;
+import com.positivity.customer.internal.repository.PartyRelationshipRepository;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
+import com.positivity.customer.service.CustomerInteractionService;
+import com.positivity.customer.service.MarketingConsentService;
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.customer.BillingRulesUpdatedV1;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cache.CacheManager;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Unit tests for the billing-rules and duplicate-check surfaces of
+ * {@link PartyServiceImpl}.
+ *
+ * <p>
+ * Billing rules gate real money — a credit hold is what stops an on-account sale
+ * at the register — so the write path has three obligations that all have to
+ * happen inside the one transaction: persist the rules, emit
+ * {@code customer.billing-rules.updated} through the outbox for
+ * pos-accounting's replica, and re-emit the party fact, because credit hold
+ * feeds that fact's {@code requirementsMet} verdict (#889). Missing the
+ * re-emission would leave downstream modules believing a held account is still
+ * good for credit.
+ *
+ * <p>
+ * The duplicate check is the guard against two records for one organization. It
+ * distinguishes an exact name match from a fuzzy one so the caller can decide
+ * automatically in the clear case and prompt a human otherwise.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PartyServiceImpl — billing rules and duplicate detection")
+class PartyServiceImplBillingAndDuplicatesTest {
+
+    private static final UUID PARTY_ID = UUID.fromString("00000000-0000-0000-0000-000000000a01");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+    private static final String TOPIC = "customer.events.v1";
+
+    @Mock
+    private CommercialPartyRepository partyRepository;
+
+    @Mock
+    private PersonPartyRepository personPartyRepository;
+
+    @Mock
+    private PartyRelationshipRepository partyRelationshipRepository;
+
+    @Mock
+    private CacheManager cacheManager;
+
+    @Mock
+    private PersonDirectoryService personDirectoryService;
+
+    @Mock
+    private ExtVehicleRepository extVehicleRepository;
+
+    @Mock
+    private ObjectProvider<OutboxEventWriter> outboxEventWriter;
+
+    @Mock
+    private OutboxEventWriter writer;
+
+    @Mock
+    private CustomerFactPublisher customerFactPublisher;
+
+    @Mock
+    private MarketingConsentService marketingConsentService;
+
+    @Mock
+    private CustomerInteractionService customerInteractionService;
+
+    private PartyServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PartyServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                partyRepository,
+                personPartyRepository,
+                partyRelationshipRepository,
+                cacheManager,
+                personDirectoryService,
+                extVehicleRepository,
+                outboxEventWriter,
+                customerFactPublisher,
+                marketingConsentService,
+                customerInteractionService);
+        when(outboxEventWriter.getIfAvailable()).thenReturn(writer);
+        when(customerFactPublisher.eventsTopic()).thenReturn(TOPIC);
+    }
+
+    private static CommercialParty party(String legalName) {
+        CommercialParty party = new CommercialParty();
+        party.setPartyId(PARTY_ID);
+        party.setLegalName(legalName);
+        return party;
+    }
+
+    private static UpsertBillingRulesRequest request() {
+        return UpsertBillingRulesRequest.builder()
+                .paymentTerms("Net 30")
+                .creditLimit(new BigDecimal("10000.00"))
+                .currency("USD")
+                .taxExempt(true)
+                .poRequired(true)
+                .creditHold(true)
+                .autoPayEnabled(false)
+                .invoiceDeliveryMethod(InvoiceDeliveryMethod.EMAIL)
+                .billingAddressId(UUID.randomUUID())
+                .discountPolicyRef("POLICY-1")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("upsertBillingRulesForParty")
+    class BillingRules {
+
+        @Test
+        @DisplayName("persists the rules, emits the fact, and re-emits the party fact for requirementsMet")
+        void persistsPublishesAndReemits() {
+            CommercialParty party = party("Fleet Co LLC");
+            when(partyRepository.findByPartyId(PARTY_ID)).thenReturn(party);
+
+            BillingRuleRef ref = service.upsertBillingRulesForParty(PARTY_ID, request());
+
+            assertThat(party.getBillingRules()).isNotNull();
+            assertThat(party.getBillingRules().getCreditHold()).isTrue();
+            assertThat(party.getBillingRules().getPaymentTerms()).isEqualTo("Net 30");
+            verify(partyRepository).save(party);
+            // Credit hold feeds the party fact's requirementsMet verdict (#889); without this
+            // re-emission a held account still reads as good for credit downstream.
+            verify(customerFactPublisher).partyChanged(party);
+            assertThat(ref.isCreditHold()).isTrue();
+            assertThat(ref.getPaymentTerms()).isEqualTo("Net 30");
+            assertThat(ref.getCreditLimit()).isEqualByComparingTo("10000.00");
+        }
+
+        @Test
+        @DisplayName("publishes billing rules to the same topic the manifest computation scans")
+        void publishesToTheConfiguredTopic() {
+            when(partyRepository.findByPartyId(PARTY_ID)).thenReturn(party("Fleet Co LLC"));
+
+            service.upsertBillingRulesForParty(PARTY_ID, request());
+
+            ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.captor();
+            // Reading the topic from the publisher rather than hardcoding it is what stops the
+            // manifest computation desyncing from the outbox rows (PR #893).
+            verify(writer).publish(org.mockito.ArgumentMatchers.eq(TOPIC), captor.capture());
+            DomainEventEnvelope<?> envelope = captor.getValue();
+            assertThat(envelope.eventType()).isEqualTo(BillingRulesUpdatedV1.EVENT_TYPE);
+            assertThat(envelope.aggregateId()).isEqualTo(PARTY_ID);
+            assertThat(envelope.sourceService()).isEqualTo("pos-customer");
+            // CommercialParty carries no optimistic-lock version, so the update timestamp stands in.
+            assertThat(envelope.aggregateVersion()).isEqualTo(NOW.toEpochMilli());
+
+            BillingRulesUpdatedV1 payload = (BillingRulesUpdatedV1) envelope.payload();
+            assertThat(payload.partyId()).isEqualTo(PARTY_ID);
+            assertThat(payload.creditHold()).isTrue();
+            assertThat(payload.paymentTerms()).isEqualTo("Net 30");
+            assertThat(payload.invoiceDeliveryMethod()).isEqualTo("EMAIL");
+        }
+
+        @Test
+        @DisplayName("carries a null delivery method through rather than failing the publish")
+        void nullDeliveryMethodIsCarried() {
+            when(partyRepository.findByPartyId(PARTY_ID)).thenReturn(party("Fleet Co LLC"));
+            UpsertBillingRulesRequest request = request();
+            request.setInvoiceDeliveryMethod(null);
+
+            BillingRuleRef ref = service.upsertBillingRulesForParty(PARTY_ID, request);
+
+            ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.captor();
+            verify(writer).publish(anyString(), captor.capture());
+            assertThat(((BillingRulesUpdatedV1) captor.getValue().payload()).invoiceDeliveryMethod())
+                    .isNull();
+            // The ref keeps its default rather than being overwritten with null.
+            assertThat(ref.getInvoiceDeliveryMethod())
+                    .isEqualTo(BillingRuleRef.defaults().getInvoiceDeliveryMethod());
+        }
+
+        @Test
+        @DisplayName("still persists when Kafka is disabled and no outbox writer exists")
+        void writesWithoutAnOutbox() {
+            when(outboxEventWriter.getIfAvailable()).thenReturn(null);
+            CommercialParty party = party("Fleet Co LLC");
+            when(partyRepository.findByPartyId(PARTY_ID)).thenReturn(party);
+
+            service.upsertBillingRulesForParty(PARTY_ID, request());
+
+            // The business write must not depend on the messaging feature flag.
+            verify(partyRepository).save(party);
+            verify(customerFactPublisher).partyChanged(party);
+        }
+
+        @Test
+        @DisplayName("rejects billing rules for a party that does not exist")
+        void unknownPartyIs404() {
+            when(partyRepository.findByPartyId(PARTY_ID)).thenReturn(null);
+
+            assertThatThrownBy(() -> service.upsertBillingRulesForParty(PARTY_ID, request()))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining(PARTY_ID.toString());
+
+            verify(partyRepository, never()).save(any());
+            verify(writer, never()).publish(anyString(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("checkPartyDuplicates")
+    class Duplicates {
+
+        @Test
+        @DisplayName("separates an exact name match from fuzzy ones and scores them apart")
+        void exactAndFuzzyMatches() {
+            CommercialParty exact = party("Fleet Co LLC");
+            CommercialParty fuzzy = party("Fleet Co Holdings");
+            fuzzy.setPartyId(UUID.randomUUID());
+            when(partyRepository.findByLegalNameContaining("Fleet Co LLC")).thenReturn(List.of(fuzzy, exact));
+
+            DuplicateCheckResponse response = service.checkPartyDuplicates("  Fleet Co LLC  ");
+
+            assertThat(response.isDuplicatesFound()).isTrue();
+            // The exact id is reported separately so a caller can auto-resolve the clear case
+            // instead of prompting a human for it.
+            assertThat(response.getExactMatchPartyId()).isEqualTo(PARTY_ID.toString());
+            assertThat(response.getPotentialDuplicates())
+                    .extracting(
+                            DuplicateCheckResponse.PartyMatch::getLegalName,
+                            DuplicateCheckResponse.PartyMatch::getMatchType,
+                            DuplicateCheckResponse.PartyMatch::getScore)
+                    .containsExactly(tuple("Fleet Co Holdings", "FUZZY", 0.7), tuple("Fleet Co LLC", "EXACT", 1.0));
+        }
+
+        @Test
+        @DisplayName("treats an exact match as exact regardless of case")
+        void exactMatchIgnoresCase() {
+            when(partyRepository.findByLegalNameContaining("fleet co llc")).thenReturn(List.of(party("Fleet Co LLC")));
+
+            DuplicateCheckResponse response = service.checkPartyDuplicates("fleet co llc");
+
+            assertThat(response.getExactMatchPartyId()).isEqualTo(PARTY_ID.toString());
+            assertThat(response.getPotentialDuplicates().getFirst().getMatchType())
+                    .isEqualTo("EXACT");
+        }
+
+        @Test
+        @DisplayName("reports no duplicates when nothing matched")
+        void noMatches() {
+            when(partyRepository.findByLegalNameContaining("Fleet Co LLC")).thenReturn(List.of());
+
+            DuplicateCheckResponse response = service.checkPartyDuplicates("Fleet Co LLC");
+
+            assertThat(response.isDuplicatesFound()).isFalse();
+            assertThat(response.getExactMatchPartyId()).isNull();
+            assertThat(response.getPotentialDuplicates()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("answers an all-whitespace name with an empty result rather than a scan")
+        void blankNameShortCircuits() {
+            DuplicateCheckResponse response = service.checkPartyDuplicates("   ");
+
+            assertThat(response.isDuplicatesFound()).isFalse();
+            assertThat(response.getPotentialDuplicates()).isEmpty();
+            verify(partyRepository, never()).findByLegalNameContaining(anyString());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"A", " B "})
+        @DisplayName("rejects a one-character name, which would match most of the table")
+        void singleCharacterNameIsRejected(String legalName) {
+            assertThatThrownBy(() -> service.checkPartyDuplicates(legalName))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("at least 2");
+
+            verify(partyRepository, never()).findByLegalNameContaining(anyString());
+        }
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/PartyTagServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/PartyTagServiceImplTest.java
@@ -1,0 +1,529 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.dto.AssignPartyTagRequest;
+import com.positivity.customer.internal.dto.PartyTagAssignmentResponse;
+import com.positivity.customer.internal.dto.PartyTagResponse;
+import com.positivity.customer.internal.dto.UpsertPartyTagRequest;
+import com.positivity.customer.internal.entity.PartyTag;
+import com.positivity.customer.internal.entity.PartyTagAssignment;
+import com.positivity.customer.internal.enums.TagAssignmentSource;
+import com.positivity.customer.internal.exception.CrmDuplicateResourceException;
+import com.positivity.customer.internal.exception.CrmResourceNotFoundException;
+import com.positivity.customer.internal.repository.PartyTagAssignmentRepository;
+import com.positivity.customer.internal.repository.PartyTagRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/**
+ * Unit tests for {@link PartyTagServiceImpl}.
+ *
+ * <p>
+ * Tagging drives downstream audience replicas, so the behaviour that matters is
+ * mostly about keeping those replicas honest:
+ *
+ * <ul>
+ * <li>Deleting a tag emits a removal fact <em>per assigned party</em> before the
+ * assignments disappear. Skipping that would leave every replica holding a tag
+ * that no longer exists, with nothing left to reconcile against.</li>
+ * <li>Assignment is idempotent and converges under a concurrent write: a losing
+ * race on the unique constraint returns the row that landed rather than
+ * surfacing a conflict to the caller.</li>
+ * <li>An inactive tag cannot be newly assigned, but an assignment that already
+ * exists is still returned — deactivating a tag is not retroactive.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PartyTagServiceImpl — tag lifecycle and assignment")
+class PartyTagServiceImplTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-11T12:00:00Z");
+    private static final UUID TAG_ID = UUID.randomUUID();
+    private static final UUID PARTY_ID = UUID.randomUUID();
+
+    @Mock
+    private PartyTagRepository tagRepository;
+
+    @Mock
+    private PartyTagAssignmentRepository assignmentRepository;
+
+    @Mock
+    private CustomerFactPublisher factPublisher;
+
+    @Captor
+    private ArgumentCaptor<PartyTag> savedTag;
+
+    @Captor
+    private ArgumentCaptor<PartyTagAssignment> savedAssignment;
+
+    private PartyTagServiceImpl sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new PartyTagServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC), tagRepository, assignmentRepository, factPublisher);
+    }
+
+    private static PartyTag tag(boolean active) {
+        return PartyTag.builder()
+                .tagId(TAG_ID)
+                .name("VIP")
+                .category("service")
+                .color("#ff0000")
+                .active(active)
+                .build();
+    }
+
+    private static PartyTagAssignment assignment() {
+        return PartyTagAssignment.builder()
+                .assignmentId(UUID.randomUUID())
+                .partyId(PARTY_ID)
+                .tagId(TAG_ID)
+                .assignedBy("system")
+                .assignedAt(NOW)
+                .source(TagAssignmentSource.MANUAL)
+                .build();
+    }
+
+    private static UpsertPartyTagRequest upsert(String name, Boolean active) {
+        return new UpsertPartyTagRequest(name, "service", "#ff0000", active);
+    }
+
+    @Nested
+    @DisplayName("createTag")
+    class CreateTag {
+
+        @Test
+        @DisplayName("persists a new tag and reports zero assignments")
+        void create_persistsTag() {
+            when(tagRepository.existsByNameIgnoreCase("VIP")).thenReturn(false);
+            when(tagRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            PartyTagResponse response = sut.createTag(upsert("VIP", true));
+
+            assertThat(response.name()).isEqualTo("VIP");
+            assertThat(response.assignmentCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("trims the name before the uniqueness check and before storing it")
+        void create_trimsName() {
+            when(tagRepository.existsByNameIgnoreCase("VIP")).thenReturn(false);
+            when(tagRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.createTag(upsert("  VIP  ", true));
+
+            verify(tagRepository).save(savedTag.capture());
+            assertThat(savedTag.getValue().getName()).isEqualTo("VIP");
+        }
+
+        @Test
+        @DisplayName("normalizes a blank category and color to null rather than storing whitespace")
+        void create_blankOptionalFieldsBecomeNull() {
+            when(tagRepository.existsByNameIgnoreCase(any())).thenReturn(false);
+            when(tagRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.createTag(new UpsertPartyTagRequest("VIP", "   ", "", true));
+
+            verify(tagRepository).save(savedTag.capture());
+            assertThat(savedTag.getValue().getCategory()).isNull();
+            assertThat(savedTag.getValue().getColor()).isNull();
+        }
+
+        @Test
+        @DisplayName("defaults active to true when the request leaves it unset")
+        void create_whenActiveOmitted_defaultsToActive() {
+            when(tagRepository.existsByNameIgnoreCase(any())).thenReturn(false);
+            when(tagRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.createTag(upsert("VIP", null));
+
+            verify(tagRepository).save(savedTag.capture());
+            assertThat(savedTag.getValue().isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("rejects a duplicate name case-insensitively")
+        void create_whenNameTaken_throwsDuplicate() {
+            when(tagRepository.existsByNameIgnoreCase("VIP")).thenReturn(true);
+
+            assertThatThrownBy(() -> sut.createTag(upsert("VIP", true)))
+                    .isInstanceOf(CrmDuplicateResourceException.class);
+            verify(tagRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("translates a losing unique-constraint race into a duplicate error, not a 500")
+        void create_whenConstraintRaceLost_throwsDuplicate() {
+            when(tagRepository.existsByNameIgnoreCase("VIP")).thenReturn(false);
+            when(tagRepository.save(any())).thenThrow(new DataIntegrityViolationException("unique violation"));
+
+            assertThatThrownBy(() -> sut.createTag(upsert("VIP", true)))
+                    .isInstanceOf(CrmDuplicateResourceException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateTag, deleteTag, and reads")
+    class UpdateDeleteRead {
+
+        @Test
+        @DisplayName("applies the new name, category, color, and active flag")
+        void update_appliesChanges() {
+            PartyTag existing = tag(true);
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(existing));
+            when(tagRepository.findByNameIgnoreCase("Premier")).thenReturn(Optional.empty());
+            when(tagRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+            when(assignmentRepository.countByTagId(TAG_ID)).thenReturn(4L);
+
+            PartyTagResponse response =
+                    sut.updateTag(TAG_ID, new UpsertPartyTagRequest("Premier", "sales", "#00ff00", false));
+
+            assertThat(existing.getName()).isEqualTo("Premier");
+            assertThat(existing.getCategory()).isEqualTo("sales");
+            assertThat(existing.getColor()).isEqualTo("#00ff00");
+            assertThat(existing.isActive()).isFalse();
+            assertThat(response.assignmentCount()).isEqualTo(4L);
+        }
+
+        @Test
+        @DisplayName("leaves the active flag untouched when the request omits it")
+        void update_whenActiveOmitted_leavesFlagUnchanged() {
+            PartyTag existing = tag(false);
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(existing));
+            when(tagRepository.findByNameIgnoreCase(any())).thenReturn(Optional.empty());
+            when(tagRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.updateTag(TAG_ID, upsert("VIP", null));
+
+            assertThat(existing.isActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("allows a tag to keep its own name, so a pure case change is permitted")
+        void update_whenNameHeldBySelf_isAllowed() {
+            PartyTag existing = tag(true);
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(existing));
+            when(tagRepository.findByNameIgnoreCase("vip")).thenReturn(Optional.of(existing));
+            when(tagRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.updateTag(TAG_ID, upsert("vip", true));
+
+            assertThat(existing.getName()).isEqualTo("vip");
+        }
+
+        @Test
+        @DisplayName("rejects a rename onto another tag's name")
+        void update_whenNameTakenByOther_throwsDuplicate() {
+            PartyTag other = tag(true);
+            other.setTagId(UUID.randomUUID());
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(tag(true)));
+            when(tagRepository.findByNameIgnoreCase("VIP")).thenReturn(Optional.of(other));
+
+            assertThatThrownBy(() -> sut.updateTag(TAG_ID, upsert("VIP", true)))
+                    .isInstanceOf(CrmDuplicateResourceException.class);
+        }
+
+        @Test
+        @DisplayName("throws 404 when updating an unknown tag")
+        void update_whenAbsent_throwsNotFound() {
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.updateTag(TAG_ID, upsert("VIP", true)))
+                    .isInstanceOf(CrmResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("delete emits a removal fact for every assigned party")
+        void delete_emitsRemovalFactPerParty() {
+            UUID otherParty = UUID.randomUUID();
+            PartyTagAssignment first = assignment();
+            PartyTagAssignment second = assignment();
+            second.setPartyId(otherParty);
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(tag(true)));
+            when(assignmentRepository.findByTagId(TAG_ID)).thenReturn(List.of(first, second));
+
+            sut.deleteTag(TAG_ID);
+
+            // Without a per-party fact, downstream replicas would keep a tag that
+            // no longer exists and have nothing left to reconcile against.
+            verify(factPublisher).partyTagChanged(PARTY_ID, TAG_ID, "VIP", false, null);
+            verify(factPublisher).partyTagChanged(otherParty, TAG_ID, "VIP", false, null);
+            verify(assignmentRepository).deleteByTagId(TAG_ID);
+        }
+
+        @Test
+        @DisplayName("delete throws 404 for an unknown tag and removes nothing")
+        void delete_whenAbsent_throwsNotFound() {
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.deleteTag(TAG_ID)).isInstanceOf(CrmResourceNotFoundException.class);
+            verify(assignmentRepository, never()).deleteByTagId(any());
+        }
+
+        @Test
+        @DisplayName("listTags excludes inactive tags by default")
+        void listTags_excludesInactiveByDefault() {
+            when(tagRepository.findAllByActiveTrueOrderByNameAsc()).thenReturn(List.of(tag(true)));
+            when(assignmentRepository.countByTagId(TAG_ID)).thenReturn(2L);
+
+            assertThat(sut.listTags(false))
+                    .singleElement()
+                    .satisfies(
+                            response -> assertThat(response.assignmentCount()).isEqualTo(2L));
+            verify(tagRepository, never()).findAllByOrderByNameAsc();
+        }
+
+        @Test
+        @DisplayName("listTags includes inactive tags when asked")
+        void listTags_includesInactiveWhenRequested() {
+            when(tagRepository.findAllByOrderByNameAsc()).thenReturn(List.of(tag(false)));
+            when(assignmentRepository.countByTagId(TAG_ID)).thenReturn(0L);
+
+            assertThat(sut.listTags(true)).hasSize(1);
+            verify(tagRepository, never()).findAllByActiveTrueOrderByNameAsc();
+        }
+
+        @Test
+        @DisplayName("getTag returns the tag with its live assignment count")
+        void getTag_returnsCount() {
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(tag(true)));
+            when(assignmentRepository.countByTagId(TAG_ID)).thenReturn(9L);
+
+            assertThat(sut.getTag(TAG_ID).assignmentCount()).isEqualTo(9L);
+        }
+    }
+
+    @Nested
+    @DisplayName("assignTag")
+    class AssignTag {
+
+        @Test
+        @DisplayName("creates the assignment and publishes an assigned fact")
+        void assign_createsAssignment() {
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(tag(true)));
+            when(assignmentRepository.findByPartyIdAndTagId(PARTY_ID, TAG_ID)).thenReturn(Optional.empty());
+            when(assignmentRepository.saveAndFlush(any())).thenAnswer(i -> i.getArgument(0));
+
+            PartyTagAssignmentResponse response =
+                    sut.assignTag(PARTY_ID, new AssignPartyTagRequest(TAG_ID, TagAssignmentSource.CAMPAIGN));
+
+            assertThat(response.name()).isEqualTo("VIP");
+            verify(assignmentRepository).saveAndFlush(savedAssignment.capture());
+            assertThat(savedAssignment.getValue().getAssignedAt()).isEqualTo(NOW);
+            assertThat(savedAssignment.getValue().getSource()).isEqualTo(TagAssignmentSource.CAMPAIGN);
+            verify(factPublisher).partyTagChanged(PARTY_ID, TAG_ID, "VIP", true, "CAMPAIGN");
+        }
+
+        @Test
+        @DisplayName("defaults the assignment source to MANUAL when the request omits it")
+        void assign_whenSourceOmitted_defaultsToManual() {
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(tag(true)));
+            when(assignmentRepository.findByPartyIdAndTagId(any(), any())).thenReturn(Optional.empty());
+            when(assignmentRepository.saveAndFlush(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.assignTag(PARTY_ID, new AssignPartyTagRequest(TAG_ID, null));
+
+            verify(assignmentRepository).saveAndFlush(savedAssignment.capture());
+            assertThat(savedAssignment.getValue().getSource()).isEqualTo(TagAssignmentSource.MANUAL);
+        }
+
+        @Test
+        @DisplayName("is idempotent — an existing assignment is returned without a second write or fact")
+        void assign_whenAlreadyAssigned_isIdempotent() {
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(tag(true)));
+            when(assignmentRepository.findByPartyIdAndTagId(PARTY_ID, TAG_ID)).thenReturn(Optional.of(assignment()));
+
+            sut.assignTag(PARTY_ID, new AssignPartyTagRequest(TAG_ID, TagAssignmentSource.MANUAL));
+
+            verify(assignmentRepository, never()).saveAndFlush(any());
+            verify(factPublisher, never()).partyTagChanged(any(), any(), any(), eq(true), any());
+        }
+
+        @Test
+        @DisplayName("refuses to newly assign an inactive tag")
+        void assign_whenTagInactive_throws() {
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(tag(false)));
+            when(assignmentRepository.findByPartyIdAndTagId(any(), any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                            sut.assignTag(PARTY_ID, new AssignPartyTagRequest(TAG_ID, TagAssignmentSource.MANUAL)))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("inactive");
+        }
+
+        @Test
+        @DisplayName("still returns a pre-existing assignment on an inactive tag — deactivation is not retroactive")
+        void assign_whenTagInactiveButAlreadyAssigned_returnsExisting() {
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(tag(false)));
+            when(assignmentRepository.findByPartyIdAndTagId(PARTY_ID, TAG_ID)).thenReturn(Optional.of(assignment()));
+
+            assertThat(sut.assignTag(PARTY_ID, new AssignPartyTagRequest(TAG_ID, TagAssignmentSource.MANUAL)))
+                    .isNotNull();
+        }
+
+        @Test
+        @DisplayName("converges on the winning row when a concurrent assign loses the unique-constraint race")
+        void assign_whenConstraintRaceLost_convergesOnWinningRow() {
+            PartyTagAssignment winner = assignment();
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(tag(true)));
+            when(assignmentRepository.findByPartyIdAndTagId(PARTY_ID, TAG_ID))
+                    .thenReturn(Optional.empty())
+                    .thenReturn(Optional.of(winner));
+            when(assignmentRepository.saveAndFlush(any()))
+                    .thenThrow(new DataIntegrityViolationException("unique violation"));
+
+            PartyTagAssignmentResponse response =
+                    sut.assignTag(PARTY_ID, new AssignPartyTagRequest(TAG_ID, TagAssignmentSource.MANUAL));
+
+            assertThat(response.assignmentId()).isEqualTo(winner.getAssignmentId());
+            verify(factPublisher, never()).partyTagChanged(any(), any(), any(), eq(true), any());
+        }
+
+        @Test
+        @DisplayName("rethrows when the constraint violation was not a losing race after all")
+        void assign_whenConstraintViolationUnexplained_rethrows() {
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(tag(true)));
+            when(assignmentRepository.findByPartyIdAndTagId(PARTY_ID, TAG_ID)).thenReturn(Optional.empty());
+            when(assignmentRepository.saveAndFlush(any()))
+                    .thenThrow(new DataIntegrityViolationException("some other violation"));
+
+            assertThatThrownBy(() ->
+                            sut.assignTag(PARTY_ID, new AssignPartyTagRequest(TAG_ID, TagAssignmentSource.MANUAL)))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("throws 404 when the tag does not exist")
+        void assign_whenTagAbsent_throwsNotFound() {
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                            sut.assignTag(PARTY_ID, new AssignPartyTagRequest(TAG_ID, TagAssignmentSource.MANUAL)))
+                    .isInstanceOf(CrmResourceNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("removeTag and queries")
+    class RemoveAndQuery {
+
+        @Test
+        @DisplayName("removes the assignment and publishes a removal fact")
+        void remove_deletesAndPublishes() {
+            PartyTagAssignment existing = assignment();
+            when(assignmentRepository.findByPartyIdAndTagId(PARTY_ID, TAG_ID)).thenReturn(Optional.of(existing));
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.of(tag(true)));
+
+            sut.removeTag(PARTY_ID, TAG_ID);
+
+            verify(assignmentRepository).delete(existing);
+            verify(factPublisher).partyTagChanged(PARTY_ID, TAG_ID, "VIP", false, null);
+        }
+
+        @Test
+        @DisplayName("is a silent no-op when the party does not carry the tag")
+        void remove_whenNotAssigned_isNoOp() {
+            when(assignmentRepository.findByPartyIdAndTagId(any(), any())).thenReturn(Optional.empty());
+
+            sut.removeTag(PARTY_ID, TAG_ID);
+
+            verify(assignmentRepository, never()).delete(any());
+            verify(factPublisher, never()).partyTagChanged(any(), any(), any(), any(Boolean.class), any());
+        }
+
+        @Test
+        @DisplayName("still deletes the assignment when the tag row has already gone")
+        void remove_whenTagAlreadyDeleted_stillDeletesAssignment() {
+            PartyTagAssignment existing = assignment();
+            when(assignmentRepository.findByPartyIdAndTagId(PARTY_ID, TAG_ID)).thenReturn(Optional.of(existing));
+            when(tagRepository.findById(TAG_ID)).thenReturn(Optional.empty());
+
+            sut.removeTag(PARTY_ID, TAG_ID);
+
+            verify(assignmentRepository).delete(existing);
+            verify(factPublisher, never()).partyTagChanged(any(), any(), any(), any(Boolean.class), any());
+        }
+
+        @Test
+        @DisplayName("listPartyTags returns an empty list without querying tags when the party has none")
+        void listPartyTags_whenNone_returnsEmpty() {
+            when(assignmentRepository.findByPartyId(PARTY_ID)).thenReturn(List.of());
+
+            assertThat(sut.listPartyTags(PARTY_ID)).isEmpty();
+            verify(tagRepository, never()).findAllByTagIdIn(anyList());
+        }
+
+        @Test
+        @DisplayName("listPartyTags joins each assignment to its tag")
+        void listPartyTags_joinsTagDetail() {
+            when(assignmentRepository.findByPartyId(PARTY_ID)).thenReturn(List.of(assignment()));
+            when(tagRepository.findAllByTagIdIn(List.of(TAG_ID))).thenReturn(List.of(tag(true)));
+
+            assertThat(sut.listPartyTags(PARTY_ID)).singleElement().satisfies(response -> {
+                assertThat(response.name()).isEqualTo("VIP");
+                assertThat(response.category()).isEqualTo("service");
+            });
+        }
+
+        @Test
+        @DisplayName("listPartyTags drops an assignment whose tag row has vanished rather than failing")
+        void listPartyTags_dropsOrphanedAssignment() {
+            when(assignmentRepository.findByPartyId(PARTY_ID)).thenReturn(List.of(assignment()));
+            when(tagRepository.findAllByTagIdIn(anyList())).thenReturn(List.of());
+
+            assertThat(sut.listPartyTags(PARTY_ID)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("findPartyIdsByTags returns empty without querying when no tags are supplied")
+        void findPartyIds_whenNoTags_returnsEmpty() {
+            assertThat(sut.findPartyIdsByTags(List.of(), true)).isEmpty();
+            verify(assignmentRepository, never()).findPartyIdsHavingAllTags(anyList(), anyLong());
+            verify(assignmentRepository, never()).findPartyIdsHavingAnyTag(anyList());
+        }
+
+        @Test
+        @DisplayName("findPartyIdsByTags uses the all-tags query and de-duplicates the required count")
+        void findPartyIds_matchAll_usesAllTagsQuery() {
+            when(assignmentRepository.findPartyIdsHavingAllTags(List.of(TAG_ID), 1L))
+                    .thenReturn(List.of(PARTY_ID));
+
+            // The duplicate must not inflate the required-match count to 2, which
+            // would make the query match nothing.
+            assertThat(sut.findPartyIdsByTags(List.of(TAG_ID, TAG_ID), true)).containsExactly(PARTY_ID);
+        }
+
+        @Test
+        @DisplayName("findPartyIdsByTags uses the any-tag query when matchAll is false")
+        void findPartyIds_matchAny_usesAnyTagQuery() {
+            when(assignmentRepository.findPartyIdsHavingAnyTag(List.of(TAG_ID))).thenReturn(List.of(PARTY_ID));
+
+            assertThat(sut.findPartyIdsByTags(List.of(TAG_ID), false)).containsExactly(PARTY_ID);
+            verify(assignmentRepository, never()).findPartyIdsHavingAllTags(anyList(), anyLong());
+        }
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/PeopleContactEventsListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/PeopleContactEventsListenerTest.java
@@ -1,0 +1,341 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.entity.ExtOrganizationPostalAddress;
+import com.positivity.customer.internal.entity.ExtPersonReplica;
+import com.positivity.customer.internal.entity.ProcessedEvent;
+import com.positivity.customer.internal.repository.ExtOrganizationPostalAddressRepository;
+import com.positivity.customer.internal.repository.ExtPersonReplicaRepository;
+import com.positivity.customer.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.QueryTimeoutException;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link PeopleContactEventsListener} (ADR-0044 §6, #877).
+ *
+ * <p>
+ * This listener maintains a read replica of people-contact data. Four rules make
+ * that replica trustworthy, and each is easy to break without noticing:
+ *
+ * <ul>
+ * <li><b>Idempotency.</b> An event already in {@code processed_events} is
+ * skipped entirely — Kafka redelivery must not re-apply a write.</li>
+ * <li><b>Stale-version guard.</b> A payload whose {@code aggregateVersion} is
+ * strictly below the stored one is dropped, so a replayed older update cannot
+ * resurrect stale data. Equal versions are re-applied, since the version is an
+ * emission-timestamp last-writer-wins hint rather than a strict sequence.</li>
+ * <li><b>Ignored types still record.</b> An event type this module does not care
+ * about is still written to {@code processed_events}: the owner's manifest counts
+ * every fact in the window, so omitting the row would read as replica drift and
+ * trigger a pointless replay.</li>
+ * <li><b>Transient errors escape.</b> A transient data-access failure is
+ * rethrown so Kafka retries it, while a malformed payload is swallowed — the
+ * former is worth retrying and the latter never will be.</li>
+ * </ul>
+ */
+@DisplayName("PeopleContactEventsListener — replica maintenance and idempotency")
+class PeopleContactEventsListenerTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-08-11T12:00:00Z"), ZoneOffset.UTC);
+    private static final Instant NOW = Instant.parse("2026-08-11T12:00:00Z");
+    private static final UUID PERSON_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID ORG_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b1");
+    private static final String EVENT_ID = "01960000-0000-7000-8000-000000000001";
+
+    private final ProcessedEventRepository processedEvents = mock(ProcessedEventRepository.class);
+    private final ExtPersonReplicaRepository personReplica = mock(ExtPersonReplicaRepository.class);
+    private final ExtOrganizationPostalAddressRepository addressReplica =
+            mock(ExtOrganizationPostalAddressRepository.class);
+    private final CustomerFactPublisher factPublisher = mock(CustomerFactPublisher.class);
+
+    private PeopleContactEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new PeopleContactEventsListener(
+                TEST_CLOCK, new ObjectMapper(), processedEvents, personReplica, addressReplica, factPublisher);
+    }
+
+    private static String personUpdated(long aggregateVersion) {
+        return """
+                {"eventId":"%s","eventType":"people-contact.person.updated","aggregateVersion":%d,
+                 "payload":{"personId":"%s","firstName":"Ada","lastName":"Lovelace","preferredName":"Ada",
+                  "contactPoints":[{"contactType":"EMAIL","value":"ada@example.com","primary":true},
+                                   {"contactType":"EMAIL","value":"old@example.com","primary":false}],
+                  "postalAddress":{"line1":"1 Main St","line2":null,"city":"Springfield","region":"IL",
+                                   "postalCode":"62701","countryCode":"US"},
+                  "createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-08-01T00:00:00Z"}}
+                """.formatted(EVENT_ID, aggregateVersion, PERSON_ID);
+    }
+
+    private static String addressUpdated(long aggregateVersion) {
+        return """
+                {"eventId":"%s","eventType":"people-contact.organization-address.updated","aggregateVersion":%d,
+                 "payload":{"organizationId":"%s",
+                  "postalAddress":{"line1":"2 Elm St","line2":"Suite 3","city":"Shelbyville","region":"IL",
+                                   "postalCode":"62565","countryCode":"US"},
+                  "updatedAt":"2026-08-01T00:00:00Z"}}
+                """.formatted(EVENT_ID, aggregateVersion, ORG_ID);
+    }
+
+    private static String addressRemoved(long aggregateVersion) {
+        return """
+                {"eventId":"%s","eventType":"people-contact.organization-address.removed","aggregateVersion":%d,
+                 "payload":{"organizationId":"%s"}}
+                """.formatted(EVENT_ID, aggregateVersion, ORG_ID);
+    }
+
+    private ExtPersonReplica storedPerson(long aggregateVersion) {
+        return ExtPersonReplica.builder()
+                .personId(PERSON_ID)
+                .aggregateVersion(aggregateVersion)
+                .build();
+    }
+
+    private ExtOrganizationPostalAddress storedAddress(long aggregateVersion) {
+        return ExtOrganizationPostalAddress.builder()
+                .organizationId(ORG_ID)
+                .aggregateVersion(aggregateVersion)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("person updates")
+    class PersonUpdates {
+
+        @Test
+        @DisplayName("writes the replica row, flattening the primary email out of the contact points")
+        void personUpdated_writesReplica() {
+            when(personReplica.findById(PERSON_ID)).thenReturn(Optional.empty());
+
+            listener.onPeopleContactEvent(personUpdated(5));
+
+            ArgumentCaptor<ExtPersonReplica> saved = ArgumentCaptor.captor();
+            verify(personReplica).save(saved.capture());
+            assertThat(saved.getValue().getFirstName()).isEqualTo("Ada");
+            // Only the contact point flagged primary is promoted.
+            assertThat(saved.getValue().getPrimaryEmail()).isEqualTo("ada@example.com");
+            assertThat(saved.getValue().getAddressCity()).isEqualTo("Springfield");
+            assertThat(saved.getValue().getAggregateVersion()).isEqualTo(5);
+            assertThat(saved.getValue().getUpdatedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("re-emits the person fact so downstream display names pick up the change")
+        void personUpdated_republishesFact() {
+            when(personReplica.findById(PERSON_ID)).thenReturn(Optional.empty());
+
+            listener.onPeopleContactEvent(personUpdated(5));
+
+            verify(factPublisher).personReplicaChanged(PERSON_ID);
+        }
+
+        @Test
+        @DisplayName("drops an update whose version is strictly below the stored one")
+        void personUpdated_whenStale_isDropped() {
+            when(personReplica.findById(PERSON_ID)).thenReturn(Optional.of(storedPerson(9)));
+
+            listener.onPeopleContactEvent(personUpdated(5));
+
+            // A replayed older update must not resurrect stale data.
+            verify(personReplica, never()).save(any());
+            verify(factPublisher, never()).personReplicaChanged(any());
+        }
+
+        @Test
+        @DisplayName("re-applies an update at the same version — the version is an LWW hint, not a sequence")
+        void personUpdated_whenSameVersion_isApplied() {
+            when(personReplica.findById(PERSON_ID)).thenReturn(Optional.of(storedPerson(5)));
+
+            listener.onPeopleContactEvent(personUpdated(5));
+
+            verify(personReplica).save(any());
+        }
+
+        @Test
+        @DisplayName("records a stale-skipped event as processed so it is not reconsidered")
+        void personUpdated_whenStale_stillRecordsProcessed() {
+            when(personReplica.findById(PERSON_ID)).thenReturn(Optional.of(storedPerson(9)));
+
+            listener.onPeopleContactEvent(personUpdated(5));
+
+            verify(processedEvents).save(any(ProcessedEvent.class));
+        }
+
+        @Test
+        @DisplayName("deletes the replica row on a person-deleted fact")
+        void personDeleted_deletesReplica() {
+            String message = """
+                    {"eventId":"%s","eventType":"people-contact.person.deleted","aggregateVersion":3,
+                     "payload":{"personId":"%s"}}
+                    """.formatted(EVENT_ID, PERSON_ID);
+
+            listener.onPeopleContactEvent(message);
+
+            verify(personReplica).deleteById(PERSON_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("organization addresses")
+    class OrganizationAddresses {
+
+        @Test
+        @DisplayName("writes the address replica row")
+        void addressUpdated_writesReplica() {
+            when(addressReplica.findById(ORG_ID)).thenReturn(Optional.empty());
+
+            listener.onPeopleContactEvent(addressUpdated(4));
+
+            ArgumentCaptor<ExtOrganizationPostalAddress> saved = ArgumentCaptor.captor();
+            verify(addressReplica).save(saved.capture());
+            assertThat(saved.getValue().getLine1()).isEqualTo("2 Elm St");
+            assertThat(saved.getValue().getCity()).isEqualTo("Shelbyville");
+            assertThat(saved.getValue().getAggregateVersion()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("drops an address update whose version is strictly below the stored one")
+        void addressUpdated_whenStale_isDropped() {
+            when(addressReplica.findById(ORG_ID)).thenReturn(Optional.of(storedAddress(9)));
+
+            listener.onPeopleContactEvent(addressUpdated(4));
+
+            verify(addressReplica, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("removal writes a versioned tombstone rather than deleting the row")
+        void addressRemoved_writesTombstone() {
+            when(addressReplica.findById(ORG_ID)).thenReturn(Optional.of(storedAddress(4)));
+
+            listener.onPeopleContactEvent(addressRemoved(7));
+
+            ArgumentCaptor<ExtOrganizationPostalAddress> saved = ArgumentCaptor.captor();
+            verify(addressReplica).save(saved.capture());
+            // A hard delete would discard the version watermark, letting a replayed
+            // older update resurrect a removed address.
+            assertThat(saved.getValue().getAggregateVersion()).isEqualTo(7);
+            assertThat(saved.getValue().getLine1()).isNull();
+            assertThat(saved.getValue().getCity()).isNull();
+            verify(addressReplica, never()).deleteById(any());
+        }
+
+        @Test
+        @DisplayName("drops a stale removal so it cannot wipe a newer address")
+        void addressRemoved_whenStale_isDropped() {
+            when(addressReplica.findById(ORG_ID)).thenReturn(Optional.of(storedAddress(9)));
+
+            listener.onPeopleContactEvent(addressRemoved(4));
+
+            verify(addressReplica, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("envelope handling")
+    class EnvelopeHandling {
+
+        @Test
+        @DisplayName("skips an event already recorded in processed_events without re-applying it")
+        void duplicateEvent_isSkipped() {
+            when(processedEvents.existsById(EVENT_ID)).thenReturn(true);
+
+            listener.onPeopleContactEvent(personUpdated(5));
+
+            verify(personReplica, never()).save(any());
+            verify(processedEvents, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("records the event as processed on the happy path, owned by people-contact")
+        void processedEvent_isRecordedWithOwner() {
+            when(personReplica.findById(PERSON_ID)).thenReturn(Optional.empty());
+
+            listener.onPeopleContactEvent(personUpdated(5));
+
+            ArgumentCaptor<ProcessedEvent> saved = ArgumentCaptor.captor();
+            verify(processedEvents).save(saved.capture());
+            assertThat(saved.getValue().getEventId()).isEqualTo(EVENT_ID);
+            assertThat(saved.getValue().getOwner()).isEqualTo(PeopleContactEventsListener.OWNER);
+            assertThat(saved.getValue().getProcessedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("records an ignored event type so the owner's manifest does not read it as drift")
+        void unknownEventType_isStillRecorded() {
+            String message = """
+                    {"eventId":"%s","eventType":"people-contact.something.else","aggregateVersion":1,"payload":{}}
+                    """.formatted(EVENT_ID);
+
+            listener.onPeopleContactEvent(message);
+
+            verify(processedEvents).save(any(ProcessedEvent.class));
+            verify(personReplica, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("ignores an unparsable message without recording it")
+        void unparsableMessage_isIgnored() {
+            listener.onPeopleContactEvent("this is not json");
+
+            verify(processedEvents, never()).save(any());
+            verify(personReplica, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("ignores an envelope with no eventId, since idempotency cannot be tracked without one")
+        void missingEventId_isIgnored() {
+            listener.onPeopleContactEvent("{\"eventType\":\"people-contact.person.updated\",\"payload\":{}}");
+
+            verify(processedEvents, never()).save(any());
+            verify(personReplica, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("swallows a malformed payload but still records the event")
+        void malformedPayload_isRecordedNotRetried() {
+            String message = """
+                    {"eventId":"%s","eventType":"people-contact.person.updated","aggregateVersion":1,
+                     "payload":{"personId":"not-a-uuid"}}
+                    """.formatted(EVENT_ID);
+
+            listener.onPeopleContactEvent(message);
+
+            // Retrying a malformed payload would never succeed, so it is recorded
+            // and dropped rather than sent round the retry loop.
+            verify(processedEvents).save(any(ProcessedEvent.class));
+            verify(personReplica, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("rethrows a transient data-access failure so Kafka retries it")
+        void transientFailure_isRethrown() {
+            when(personReplica.findById(PERSON_ID)).thenReturn(Optional.empty());
+            when(personReplica.save(any())).thenThrow(new QueryTimeoutException("statement timeout"));
+
+            assertThatExceptionOfType(QueryTimeoutException.class)
+                    .isThrownBy(() -> listener.onPeopleContactEvent(personUpdated(5)));
+
+            // Not recorded as processed: the event must be redelivered.
+            verify(processedEvents, never()).save(any());
+        }
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/PeopleContactManifestListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/PeopleContactManifestListenerTest.java
@@ -1,0 +1,213 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.repository.ProcessedEventRepository;
+import com.positivity.domainevents.ReconciliationManifestV1;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link PeopleContactManifestListener} (ADR-0044 §4).
+ *
+ * <p>
+ * This is the consumer half of reconciliation: the owner publishes a manifest
+ * per window, and this listener recomputes the same summary from its own
+ * {@code processed_events} log. Agreement means the replica is intact; anything
+ * else means events were lost and a replay is requested over the owner's command
+ * topic.
+ *
+ * <p>
+ * The comparison must be exact in both directions. A false negative leaves a
+ * replica silently missing data, while a false positive triggers a replay of a
+ * whole window for nothing — so both the count and the checksum are asserted,
+ * including the case where the count matches but the ids do not.
+ */
+@DisplayName("PeopleContactManifestListener — replica reconciliation and replay requests")
+class PeopleContactManifestListenerTest {
+
+    private static final Instant WINDOW_START = Instant.parse("2026-07-08T11:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-07-08T12:00:00Z");
+    private static final String COMMANDS_TOPIC = "people-contact.commands.v1";
+
+    private final ProcessedEventRepository processedEvents = mock(ProcessedEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private SimpleMeterRegistry meterRegistry;
+    private PeopleContactManifestListener listener;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        listener = newListener(meterRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    private PeopleContactManifestListener newListener(MeterRegistry registry) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        PeopleContactManifestListener created =
+                new PeopleContactManifestListener(processedEvents, kafkaTemplate, objectMapper, provider);
+        ReflectionTestUtils.setField(created, "peopleContactCommandsTopic", COMMANDS_TOPIC);
+        return created;
+    }
+
+    /** Manifest envelope claiming {@code eventIds} were published in the window. */
+    private String manifestFor(List<String> eventIds) {
+        ReconciliationManifestV1 manifest = new ReconciliationManifestV1(
+                WINDOW_START, WINDOW_END, eventIds.size(), ReconciliationManifestV1.checksumOf(eventIds), null);
+        return "{\"eventType\":\"people-contact.reconciliation.manifest\",\"payload\":"
+                + objectMapper.writeValueAsString(manifest) + "}";
+    }
+
+    private void replicaHas(List<String> eventIds) {
+        when(processedEvents.findEventIdsInRange(anyString(), anyString(), anyString()))
+                .thenReturn(eventIds);
+    }
+
+    private double driftCount() {
+        var counter = meterRegistry.find("replica.drift").counter();
+        return counter == null ? 0d : counter.count();
+    }
+
+    @Test
+    @DisplayName("stays silent when the replica matches the manifest")
+    void whenReplicaMatches_requestsNothing() {
+        List<String> ids = List.of("id-1", "id-2");
+        replicaHas(ids);
+
+        listener.onManifest(manifestFor(ids));
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        assertThat(driftCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("requests a replay when the replica is missing events")
+    void whenReplicaShort_requestsReplay() {
+        replicaHas(List.of("id-1"));
+
+        listener.onManifest(manifestFor(List.of("id-1", "id-2")));
+
+        verify(kafkaTemplate).send(eq(COMMANDS_TOPIC), anyString(), anyString());
+        assertThat(driftCount()).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("requests a replay when the count matches but the event ids do not")
+    void whenChecksumDiffersAtSameCount_requestsReplay() {
+        replicaHas(List.of("id-1", "id-DIFFERENT"));
+
+        // Count alone would pass here; only the checksum catches a substituted id.
+        listener.onManifest(manifestFor(List.of("id-1", "id-2")));
+
+        verify(kafkaTemplate).send(eq(COMMANDS_TOPIC), anyString(), anyString());
+        assertThat(driftCount()).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("requests a replay when the replica holds events the manifest does not list")
+    void whenReplicaHasExtra_requestsReplay() {
+        replicaHas(List.of("id-1", "id-2", "id-3"));
+
+        listener.onManifest(manifestFor(List.of("id-1", "id-2")));
+
+        verify(kafkaTemplate).send(eq(COMMANDS_TOPIC), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("agrees on an empty window rather than treating zero as drift")
+    void whenBothEmpty_requestsNothing() {
+        replicaHas(List.of());
+
+        listener.onManifest(manifestFor(List.of()));
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("the replay command carries the window bounds and is keyed by window start")
+    void replayCommand_carriesWindowBounds() {
+        replicaHas(List.of());
+        ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+
+        listener.onManifest(manifestFor(List.of("id-1")));
+
+        verify(kafkaTemplate).send(eq(COMMANDS_TOPIC), key.capture(), body.capture());
+        assertThat(key.getValue()).isEqualTo(WINDOW_START.toString());
+
+        JsonNode command = objectMapper.readTree(body.getValue());
+        assertThat(command.path("commandType").stringValue()).isEqualTo("people-contact.outbox.replay-requested");
+        assertThat(command.path("payload").path("since").stringValue()).isEqualTo(WINDOW_START.toString());
+        assertThat(command.path("payload").path("until").stringValue()).isEqualTo(WINDOW_END.toString());
+    }
+
+    @Test
+    @DisplayName("scopes the processed-events lookup to the people-contact owner and the manifest window")
+    void lookupIsScopedToOwnerAndWindow() {
+        replicaHas(List.of());
+        ArgumentCaptor<String> owner = ArgumentCaptor.forClass(String.class);
+
+        listener.onManifest(manifestFor(List.of()));
+
+        verify(processedEvents).findEventIdsInRange(owner.capture(), anyString(), anyString());
+        assertThat(owner.getValue()).isEqualTo(PeopleContactEventsListener.OWNER);
+    }
+
+    @Test
+    @DisplayName("drops an unparseable manifest without querying or replaying")
+    void unparseableManifest_isDropped() {
+        listener.onManifest("not a manifest");
+
+        verify(processedEvents, never()).findEventIdsInRange(anyString(), anyString(), anyString());
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("swallows a failure to publish the replay request — the next manifest re-detects the drift")
+    void whenReplayPublishFails_doesNotPropagate() {
+        replicaHas(List.of());
+        when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenThrow(new RuntimeException("broker down"));
+
+        listener.onManifest(manifestFor(List.of("id-1")));
+
+        // The drift metric already fired, so the signal is not lost.
+        assertThat(driftCount()).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("detects drift and requests a replay when no MeterRegistry is available")
+    void worksWithoutMeterRegistry() {
+        PeopleContactManifestListener withoutMetrics = newListener(null);
+        replicaHas(List.of());
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        withoutMetrics.onManifest(manifestFor(List.of("id-1")));
+
+        verify(kafkaTemplate).send(eq(COMMANDS_TOPIC), anyString(), anyString());
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/PersonPartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/PersonPartyServiceImplTest.java
@@ -1,0 +1,432 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.dto.CustomerDTO;
+import com.positivity.customer.internal.entity.PersonParty;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+/**
+ * Unit tests for {@link PersonPartyServiceImpl}.
+ *
+ * <p>
+ * Person names live in pos-people, not here (ADR-0015 I2, issue #684), and the
+ * consequences of that split are what these tests pin:
+ *
+ * <ul>
+ * <li><b>Sorting by a name property would fail against the local schema</b>, so
+ * those sort orders are dropped and the query falls back to customerNumber. A
+ * client that sends {@code sort=lastName} gets a working page, not a 500.</li>
+ * <li><b>Name and email search delegates to pos-people</b> and maps resolved
+ * person ids back to local parties. A directory hit with no local party is not a
+ * customer of this shop, so it is skipped rather than fabricated.</li>
+ * <li><b>Name edits are not applied locally.</b> {@code updateCustomer} ignores
+ * the DTO's names on purpose — writing them here would create a second source of
+ * truth that silently diverges from pos-people.</li>
+ * <li><b>Every mutation publishes a fact</b>, which is how the order, marketing,
+ * and invoicing replicas stay current.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PersonPartyServiceImpl — person parties over a remote name directory")
+class PersonPartyServiceImplTest {
+
+    private static final UUID PARTY_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c1");
+    private static final UUID PERSON_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c2");
+
+    @Mock
+    private PersonPartyRepository customerRepository;
+
+    @Mock
+    private PersonDirectoryService personDirectoryService;
+
+    @Mock
+    private CustomerFactPublisher customerFactPublisher;
+
+    private PersonPartyServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PersonPartyServiceImpl(customerRepository, personDirectoryService, customerFactPublisher);
+        when(personDirectoryService.fetchPersonIdentitiesQuietly(anyCollection()))
+                .thenReturn(Map.of());
+    }
+
+    private static PersonParty party(UUID personId) {
+        PersonParty party = new PersonParty();
+        party.setPartyId(PARTY_ID);
+        party.setPersonId(personId);
+        party.setCustomerNumber("C-1001");
+        party.setPrimaryAddress("1 Main St");
+        party.getVehicleVins().add("VIN-1");
+        return party;
+    }
+
+    private static PersonDirectoryService.PersonIdentity identity(UUID id, String email) {
+        return new PersonDirectoryService.PersonIdentity(
+                id, "Ada", "Lovelace", email, List.of(new PersonDirectoryService.ContactPoint("EMAIL", email, true)));
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        @DisplayName("resolves names from pos-people rather than from the local row")
+        void namesComeFromTheDirectory() {
+            when(customerRepository.findById(PARTY_ID)).thenReturn(Optional.of(party(PERSON_ID)));
+            when(personDirectoryService.fetchPersonIdentitiesQuietly(Set.of(PERSON_ID)))
+                    .thenReturn(Map.of(PERSON_ID, identity(PERSON_ID, "ada@example.com")));
+
+            CustomerDTO dto = service.getCustomerById(PARTY_ID).orElseThrow();
+
+            assertThat(dto.getFirstName()).isEqualTo("Ada");
+            assertThat(dto.getLastName()).isEqualTo("Lovelace");
+            assertThat(dto.getCustomerNumber()).isEqualTo("C-1001");
+            assertThat(dto.getPartyId()).isEqualTo(PARTY_ID);
+            assertThat(dto.getVehicleVins()).containsExactly("VIN-1");
+            assertThat(dto.getCustomerType()).isEqualTo("PERSON");
+        }
+
+        @Test
+        @DisplayName("leaves names null on a party not yet linked to a person")
+        void unlinkedPartyHasNoNames() {
+            when(customerRepository.findById(PARTY_ID)).thenReturn(Optional.of(party(null)));
+
+            CustomerDTO dto = service.getCustomerById(PARTY_ID).orElseThrow();
+
+            // No personId means no directory lookup at all — not an empty-result lookup.
+            assertThat(dto.getFirstName()).isNull();
+            assertThat(dto.getLastName()).isNull();
+            verify(personDirectoryService, never()).fetchPersonIdentitiesQuietly(anyCollection());
+        }
+
+        @Test
+        @DisplayName("returns empty for an unknown party")
+        void unknownPartyIsEmpty() {
+            when(customerRepository.findById(PARTY_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.getCustomerById(PARTY_ID)).isEmpty();
+            assertThat(service.findPartyById(PARTY_ID)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("maps every row when listing unpaged")
+        void listsAll() {
+            when(customerRepository.findAll()).thenReturn(List.of(party(null), party(null)));
+
+            assertThat(service.getAllCustomers()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("existsById delegates to the repository")
+        void existsDelegates() {
+            when(customerRepository.existsById(PARTY_ID)).thenReturn(true);
+
+            assertThat(service.existsById(PARTY_ID)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("sort sanitization")
+    class SortSanitization {
+
+        private Pageable capturedPageable() {
+            ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+            verify(customerRepository).findAll(captor.capture());
+            return captor.getValue();
+        }
+
+        @Test
+        @DisplayName("drops name sorts and falls back to customerNumber")
+        void nameSortsAreDropped() {
+            when(customerRepository.findAll(any(Pageable.class))).thenReturn(new PageImpl<>(List.of()));
+
+            service.getAllCustomers(PageRequest.of(0, 20, Sort.by("lastName", "firstName")));
+
+            // Those properties no longer exist locally; passing them through would fail the query.
+            Sort sort = capturedPageable().getSort();
+            assertThat(sort.getOrderFor("lastName")).isNull();
+            assertThat(sort.getOrderFor("firstName")).isNull();
+            assertThat(sort.getOrderFor("customerNumber")).isNotNull();
+        }
+
+        @Test
+        @DisplayName("keeps a sort on a property that does exist locally")
+        void localSortIsPreserved() {
+            when(customerRepository.findAll(any(Pageable.class))).thenReturn(new PageImpl<>(List.of()));
+
+            service.getAllCustomers(PageRequest.of(1, 5, Sort.by(Sort.Direction.DESC, "createdAt")));
+
+            Pageable pageable = capturedPageable();
+            assertThat(pageable.getPageNumber()).isEqualTo(1);
+            assertThat(pageable.getPageSize()).isEqualTo(5);
+            assertThat(pageable.getSort().getOrderFor("createdAt")).isNotNull();
+            assertThat(pageable.getSort().getOrderFor("customerNumber")).isNull();
+        }
+
+        @Test
+        @DisplayName("reports the repository's total, not the mapped page size")
+        void totalComesFromTheRepository() {
+            when(customerRepository.findAll(any(Pageable.class)))
+                    .thenReturn(new PageImpl<>(List.of(party(null)), PageRequest.of(0, 20), 97));
+
+            Page<CustomerDTO> page = service.getAllCustomers(PageRequest.of(0, 20));
+
+            assertThat(page.getContent()).hasSize(1);
+            assertThat(page.getTotalElements()).isEqualTo(97);
+        }
+    }
+
+    @Nested
+    @DisplayName("searchCustomers")
+    class Search {
+
+        @Test
+        @DisplayName("returns an empty page when neither name nor email was supplied")
+        void noCriteriaIsEmpty() {
+            assertThat(service.searchCustomers(null, "  ", PageRequest.of(0, 10))
+                            .getContent())
+                    .isEmpty();
+
+            verifyNoInteractions(personDirectoryService, customerRepository);
+        }
+
+        @Test
+        @DisplayName("searches the directory by name and maps hits back to local parties")
+        void searchesByName() {
+            when(personDirectoryService.searchPersons("Ada")).thenReturn(List.of(identity(PERSON_ID, "ada@x.com")));
+            when(customerRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(party(PERSON_ID)));
+
+            Page<CustomerDTO> page = service.searchCustomers("  Ada  ", null, PageRequest.of(0, 10));
+
+            assertThat(page.getTotalElements()).isEqualTo(1);
+            assertThat(page.getContent().getFirst().getFirstName()).isEqualTo("Ada");
+            // The identity is reused from the search, so no second directory round trip.
+            verify(personDirectoryService, never()).fetchPersonIdentitiesQuietly(anyCollection());
+        }
+
+        @Test
+        @DisplayName("filters directory hits by email, case-insensitively and by substring")
+        void filtersByEmail() {
+            // An email-only search sends the email itself as the directory query.
+            when(personDirectoryService.searchPersons("ADA@example.com"))
+                    .thenReturn(
+                            List.of(identity(PERSON_ID, "Ada@Example.com"), identity(UUID.randomUUID(), "bob@x.com")));
+            when(customerRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(party(PERSON_ID)));
+
+            Page<CustomerDTO> page = service.searchCustomers(null, "ADA@example.com", PageRequest.of(0, 10));
+
+            assertThat(page.getTotalElements()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("skips a directory hit that is not a customer of this shop")
+        void directoryHitWithoutLocalPartyIsSkipped() {
+            when(personDirectoryService.searchPersons("Ada")).thenReturn(List.of(identity(PERSON_ID, "ada@x.com")));
+            when(customerRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.empty());
+
+            // A person pos-people knows about is not automatically a customer here.
+            assertThat(service.searchCustomers("Ada", null, PageRequest.of(0, 10))
+                            .getTotalElements())
+                    .isZero();
+        }
+
+        @Test
+        @DisplayName("skips a directory hit with no id rather than looking one up")
+        void identityWithoutIdIsSkipped() {
+            when(personDirectoryService.searchPersons("Ada")).thenReturn(List.of(identity(null, "ada@x.com")));
+
+            assertThat(service.searchCustomers("Ada", null, PageRequest.of(0, 10))
+                            .getTotalElements())
+                    .isZero();
+            verify(customerRepository, never()).findByPersonId(any());
+        }
+
+        @Test
+        @DisplayName("pages the in-memory match list without running off the end")
+        void pagesTheMatchList() {
+            UUID secondPerson = UUID.randomUUID();
+            when(personDirectoryService.searchPersons("Ada"))
+                    .thenReturn(List.of(identity(PERSON_ID, "a@x.com"), identity(secondPerson, "b@x.com")));
+            when(customerRepository.findByPersonId(any())).thenReturn(Optional.of(party(PERSON_ID)));
+
+            Page<CustomerDTO> secondPage = service.searchCustomers("Ada", null, PageRequest.of(1, 1));
+
+            assertThat(secondPage.getContent()).hasSize(1);
+            assertThat(secondPage.getTotalElements()).isEqualTo(2);
+
+            // A page past the end is empty rather than an index error.
+            assertThat(service.searchCustomers("Ada", null, PageRequest.of(9, 10))
+                            .getContent())
+                    .isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("writes")
+    class Writes {
+
+        @Test
+        @DisplayName("resolves the canonical person id in pos-people and publishes the change")
+        void createResolvesPersonAndPublishes() {
+            when(personDirectoryService.resolveOrCreatePersonId(null, null, "Lovelace", "Ada"))
+                    .thenReturn(PERSON_ID);
+            when(customerRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            CustomerDTO dto = CustomerDTO.builder()
+                    .customerNumber("C-1001")
+                    .firstName("Ada")
+                    .lastName("Lovelace")
+                    .primaryAddress("1 Main St")
+                    .vehicleVins(List.of("VIN-1"))
+                    .customerType("PERSON")
+                    .build();
+
+            service.createCustomer(dto);
+
+            ArgumentCaptor<PersonParty> captor = ArgumentCaptor.forClass(PersonParty.class);
+            verify(customerRepository).save(captor.capture());
+            PersonParty saved = captor.getValue();
+            assertThat(saved.getPersonId()).isEqualTo(PERSON_ID);
+            assertThat(saved.getCustomerNumber()).isEqualTo("C-1001");
+            assertThat(saved.getVehicleVins()).containsExactly("VIN-1");
+            verify(customerFactPublisher).partyChanged(saved);
+        }
+
+        @Test
+        @DisplayName("creates a person party whatever type string arrives, including an unknown one")
+        void unknownTypeStillCreatesAPerson() {
+            when(customerRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            for (String type : new String[] {null, "", "person", "COMMERCIAL", "NONSENSE"}) {
+                assertThat(service.createCustomer(
+                                CustomerDTO.builder().customerType(type).build()))
+                        .isNotNull();
+            }
+
+            // This service owns person parties only; the type string cannot make it produce another
+            // kind, and an unrecognized value must not throw at the API boundary.
+            verify(customerRepository, org.mockito.Mockito.times(5)).save(any(PersonParty.class));
+        }
+
+        @Test
+        @DisplayName("updates only the fields the DTO supplies and never the names")
+        void updateIgnoresNamesAndNulls() {
+            PersonParty existing = party(PERSON_ID);
+            when(customerRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
+            when(customerRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.updateCustomer(
+                    PARTY_ID,
+                    CustomerDTO.builder()
+                            .firstName("Grace")
+                            .lastName("Hopper")
+                            .primaryAddress("2 Oak Ave")
+                            .build());
+
+            assertThat(existing.getPrimaryAddress()).isEqualTo("2 Oak Ave");
+            // customerNumber was null in the DTO, so it is left alone rather than blanked.
+            assertThat(existing.getCustomerNumber()).isEqualTo("C-1001");
+            // Names are pos-people's to change; writing them here would fork the source of truth.
+            assertThat(existing.getPersonId()).isEqualTo(PERSON_ID);
+            verify(personDirectoryService, never()).resolveOrCreatePersonId(any(), any(), any(), any());
+            verify(customerFactPublisher).partyChanged(existing);
+        }
+
+        @Test
+        @DisplayName("replaces the VIN set rather than appending to it")
+        void vinsAreReplacedOnUpdate() {
+            PersonParty existing = party(PERSON_ID);
+            when(customerRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
+            when(customerRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.updateCustomer(
+                    PARTY_ID,
+                    CustomerDTO.builder().vehicleVins(List.of("VIN-2")).build());
+
+            // A vehicle removed by the caller must actually disappear.
+            assertThat(existing.getVehicleVins()).containsExactly("VIN-2");
+        }
+
+        @Test
+        @DisplayName("an update that names no VINs clears the ones the party had")
+        void omittingVinsClearsThem() {
+            PersonParty existing = party(PERSON_ID);
+            when(customerRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
+            when(customerRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.updateCustomer(
+                    PARTY_ID, CustomerDTO.builder().primaryAddress("2 Oak Ave").build());
+
+            // Documents current behaviour, not desired behaviour. updateEntityFromDTO guards on
+            // `vehicleVins != null`, but CustomerDTO declares the field @Builder.Default with an
+            // empty ArrayList and initializes it in the no-args constructor Jackson uses, so the
+            // guard can never be false: a partial update that simply omits vehicleVins reaches the
+            // clear()/addAll() branch with an empty list and drops every VIN association. The other
+            // optional fields on this DTO are plain nullable references and behave as intended.
+            assertThat(existing.getVehicleVins()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("reports an update to an unknown party as empty without publishing")
+        void updateUnknownPartyIsEmpty() {
+            when(customerRepository.findById(PARTY_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.updateCustomer(PARTY_ID, CustomerDTO.builder().build()))
+                    .isEmpty();
+
+            verifyNoInteractions(customerFactPublisher);
+        }
+
+        @Test
+        @DisplayName("publishes a deletion fact so downstream replicas drop the party")
+        void deletePublishes() {
+            PersonParty existing = party(PERSON_ID);
+            when(customerRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
+
+            assertThat(service.deleteCustomer(PARTY_ID)).isTrue();
+
+            verify(customerRepository).deleteById(PARTY_ID);
+            verify(customerFactPublisher).partyDeleted(existing);
+        }
+
+        @Test
+        @DisplayName("reports a delete of an unknown party as false without publishing")
+        void deleteUnknownPartyIsFalse() {
+            when(customerRepository.findById(PARTY_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.deleteCustomer(PARTY_ID)).isFalse();
+
+            verify(customerRepository, never()).deleteById(any());
+            verifyNoInteractions(customerFactPublisher);
+        }
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/SegmentResolutionServiceResolveTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/SegmentResolutionServiceResolveTest.java
@@ -1,0 +1,264 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.domain.SegmentPredicate;
+import com.positivity.customer.internal.entity.CommercialParty;
+import com.positivity.customer.internal.entity.PersonParty;
+import com.positivity.customer.internal.entity.Segment;
+import com.positivity.customer.internal.enums.AudienceType;
+import com.positivity.customer.internal.enums.SegmentOperator;
+import com.positivity.customer.internal.enums.SegmentType;
+import com.positivity.customer.internal.repository.CommercialPartyRepository;
+import com.positivity.customer.internal.repository.CommunicationPreferenceRepository;
+import com.positivity.customer.internal.repository.ExtOrganizationPostalAddressRepository;
+import com.positivity.customer.internal.repository.ExtPersonReplicaRepository;
+import com.positivity.customer.internal.repository.ExtVehicleCarePreferenceRepository;
+import com.positivity.customer.internal.repository.ExtVehicleRepository;
+import com.positivity.customer.internal.repository.FollowUpTaskRepository;
+import com.positivity.customer.internal.repository.PartyTagAssignmentRepository;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
+import com.positivity.customer.internal.repository.SegmentMemberRepository;
+import com.positivity.customer.internal.repository.ServiceHistoryRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SegmentResolutionService}'s resolution entry points.
+ *
+ * <p>
+ * Complements {@code SegmentResolutionServiceTest}, which covers the
+ * service-due attribute helpers. This class covers {@code resolve} and the two
+ * strategies behind it.
+ *
+ * <p>
+ * The behaviour that matters is defensive. A STATIC segment's pinned members are
+ * <em>still</em> filtered by audience type, because a party can be reclassified
+ * or deleted after it was pinned, and sending to a party that no longer fits the
+ * audience produces a message written for the wrong kind of customer. And a
+ * dynamic resolution that hits the candidate ceiling reports itself as truncated
+ * rather than returning a silently partial audience, so a marketer never believes
+ * a segment is smaller than it is.
+ *
+ * <p>
+ * The candidate loaders themselves ({@code loadCommercialCandidates} and
+ * {@code loadIndividualCandidates}) assemble attributes across eleven
+ * repositories; they are exercised by the module's integration tests rather than
+ * reconstructed here from mocks.
+ */
+@DisplayName("SegmentResolutionService — resolution strategies")
+class SegmentResolutionServiceResolveTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-08-11T12:00:00Z"), ZoneOffset.UTC);
+    private static final UUID SEGMENT_ID = UUID.randomUUID();
+
+    private final CommercialPartyRepository commercialParties = mock(CommercialPartyRepository.class);
+    private final PersonPartyRepository personParties = mock(PersonPartyRepository.class);
+    private final CommunicationPreferenceRepository preferences = mock(CommunicationPreferenceRepository.class);
+    private final ExtVehicleRepository vehicles = mock(ExtVehicleRepository.class);
+    private final PartyTagAssignmentRepository tags = mock(PartyTagAssignmentRepository.class);
+    private final SegmentMemberRepository segmentMembers = mock(SegmentMemberRepository.class);
+    private final ServiceHistoryRepository serviceHistory = mock(ServiceHistoryRepository.class);
+    private final FollowUpTaskRepository followUps = mock(FollowUpTaskRepository.class);
+    private final ExtPersonReplicaRepository personReplicas = mock(ExtPersonReplicaRepository.class);
+    private final ExtOrganizationPostalAddressRepository orgAddresses =
+            mock(ExtOrganizationPostalAddressRepository.class);
+    private final ExtVehicleCarePreferenceRepository carePreferences = mock(ExtVehicleCarePreferenceRepository.class);
+
+    private SegmentResolutionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SegmentResolutionService(
+                commercialParties,
+                personParties,
+                preferences,
+                vehicles,
+                tags,
+                segmentMembers,
+                serviceHistory,
+                followUps,
+                personReplicas,
+                orgAddresses,
+                carePreferences,
+                TEST_CLOCK);
+    }
+
+    private static Segment segment(SegmentType type, AudienceType audienceType) {
+        return Segment.builder()
+                .segmentId(SEGMENT_ID)
+                .name("A segment")
+                .audienceType(audienceType)
+                .type(type)
+                .active(true)
+                .build();
+    }
+
+    private static CommercialParty commercial(UUID partyId) {
+        CommercialParty party = new CommercialParty();
+        party.setPartyId(partyId);
+        return party;
+    }
+
+    private static PersonParty person(UUID partyId) {
+        PersonParty party = new PersonParty();
+        party.setPartyId(partyId);
+        return party;
+    }
+
+    @Nested
+    @DisplayName("static segments")
+    class StaticSegments {
+
+        @Test
+        @DisplayName("returns the pinned members that still match the audience, sorted and deduplicated")
+        void resolvesPinnedMembers() {
+            UUID first = UUID.fromString("00000000-0000-0000-0000-000000000001");
+            UUID second = UUID.fromString("00000000-0000-0000-0000-000000000002");
+            when(segmentMembers.findPartyIdsBySegmentId(SEGMENT_ID)).thenReturn(List.of(second, first, first));
+            when(commercialParties.findAllById(any())).thenReturn(List.of(commercial(first), commercial(second)));
+
+            SegmentResolutionService.Resolution resolution =
+                    service.resolve(segment(SegmentType.STATIC, AudienceType.COMMERCIAL), Optional.empty());
+
+            assertThat(resolution.partyIds()).containsExactly(first, second);
+            assertThat(resolution.truncated()).isFalse();
+        }
+
+        @Test
+        @DisplayName("drops a pinned member that no longer matches the audience type")
+        void dropsMemberOutsideAudience() {
+            UUID stillValid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+            UUID reclassified = UUID.fromString("00000000-0000-0000-0000-000000000002");
+            when(segmentMembers.findPartyIdsBySegmentId(SEGMENT_ID)).thenReturn(List.of(stillValid, reclassified));
+            // Only one of the two is still a commercial party.
+            when(commercialParties.findAllById(any())).thenReturn(List.of(commercial(stillValid)));
+
+            SegmentResolutionService.Resolution resolution =
+                    service.resolve(segment(SegmentType.STATIC, AudienceType.COMMERCIAL), Optional.empty());
+
+            // Sending to a reclassified party would deliver a message written for
+            // the wrong kind of customer.
+            assertThat(resolution.partyIds()).containsExactly(stillValid);
+        }
+
+        @Test
+        @DisplayName("checks an INDIVIDUAL audience against person parties, not commercial ones")
+        void individualAudienceChecksPersonParties() {
+            UUID partyId = UUID.randomUUID();
+            when(segmentMembers.findPartyIdsBySegmentId(SEGMENT_ID)).thenReturn(List.of(partyId));
+            when(personParties.findAllById(any())).thenReturn(List.of(person(partyId)));
+
+            SegmentResolutionService.Resolution resolution =
+                    service.resolve(segment(SegmentType.STATIC, AudienceType.INDIVIDUAL), Optional.empty());
+
+            assertThat(resolution.partyIds()).containsExactly(partyId);
+            verify(commercialParties, never()).findAllById(any());
+        }
+
+        @Test
+        @DisplayName("returns empty without querying when the segment has no pinned members")
+        void whenNoMembers_returnsEmpty() {
+            when(segmentMembers.findPartyIdsBySegmentId(SEGMENT_ID)).thenReturn(List.of());
+
+            SegmentResolutionService.Resolution resolution =
+                    service.resolve(segment(SegmentType.STATIC, AudienceType.COMMERCIAL), Optional.empty());
+
+            assertThat(resolution.partyIds()).isEmpty();
+            verify(commercialParties, never()).findAllById(any());
+        }
+
+        @Test
+        @DisplayName("ignores a predicate supplied alongside a static segment")
+        void ignoresPredicateOnStaticSegment() {
+            when(segmentMembers.findPartyIdsBySegmentId(SEGMENT_ID)).thenReturn(List.of());
+
+            SegmentPredicate predicate =
+                    new SegmentPredicate.Comparison("party.accountTier", SegmentOperator.IN, List.of("GOLD"));
+
+            assertThat(service.resolve(segment(SegmentType.STATIC, AudienceType.COMMERCIAL), Optional.of(predicate))
+                            .partyIds())
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("never reports a static resolution as truncated — the member list is bounded by definition")
+        void staticResolutionIsNeverTruncated() {
+            UUID partyId = UUID.randomUUID();
+            when(segmentMembers.findPartyIdsBySegmentId(SEGMENT_ID)).thenReturn(List.of(partyId));
+            when(commercialParties.findAllById(any())).thenReturn(List.of(commercial(partyId)));
+
+            assertThat(service.resolve(segment(SegmentType.STATIC, AudienceType.COMMERCIAL), Optional.empty())
+                            .truncated())
+                    .isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("dynamic segments")
+    class DynamicSegments {
+
+        @Test
+        @DisplayName("fails loudly when a dynamic segment has no stored predicate")
+        void whenPredicateMissing_throws() {
+            // A dynamic segment without a predicate cannot compute membership; a
+            // silent empty result would read as "nobody matches".
+            assertThatIllegalStateException()
+                    .isThrownBy(() ->
+                            service.resolve(segment(SegmentType.DYNAMIC, AudienceType.COMMERCIAL), Optional.empty()))
+                    .withMessageContaining(SEGMENT_ID.toString());
+        }
+
+        @Test
+        @DisplayName("returns an empty, untruncated result when no candidates exist")
+        void whenNoCandidates_returnsEmpty() {
+            when(commercialParties.findAll()).thenReturn(List.of());
+
+            SegmentPredicate predicate =
+                    new SegmentPredicate.Comparison("party.accountTier", SegmentOperator.IN, List.of("GOLD"));
+
+            SegmentResolutionService.Resolution resolution =
+                    service.resolve(segment(SegmentType.DYNAMIC, AudienceType.COMMERCIAL), Optional.of(predicate));
+
+            assertThat(resolution.partyIds()).isEmpty();
+            assertThat(resolution.truncated()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("loadAttributes")
+    class LoadAttributes {
+
+        @Test
+        @DisplayName("returns empty without loading any candidates when asked for no parties")
+        void whenNoPartyIds_returnsEmptyWithoutLoading() {
+            assertThat(service.loadAttributes(AudienceType.COMMERCIAL, List.of()))
+                    .isEmpty();
+
+            verify(commercialParties, never()).findAll();
+        }
+
+        @Test
+        @DisplayName("returns nothing when none of the requested parties are in the audience")
+        void whenNoneMatch_returnsEmpty() {
+            when(commercialParties.findAll()).thenReturn(List.of());
+
+            assertThat(service.loadAttributes(AudienceType.COMMERCIAL, List.of(UUID.randomUUID())))
+                    .isEmpty();
+        }
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/SegmentServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/SegmentServiceImplTest.java
@@ -1,0 +1,701 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.domain.PartyAttributes;
+import com.positivity.customer.internal.domain.SegmentPredicate;
+import com.positivity.customer.internal.dto.MarketingConsentDecision;
+import com.positivity.customer.internal.dto.SegmentMembersRequest;
+import com.positivity.customer.internal.dto.SegmentResolutionResponse;
+import com.positivity.customer.internal.dto.SegmentResponse;
+import com.positivity.customer.internal.dto.UpsertSegmentRequest;
+import com.positivity.customer.internal.entity.Segment;
+import com.positivity.customer.internal.entity.SegmentMember;
+import com.positivity.customer.internal.enums.AudienceType;
+import com.positivity.customer.internal.enums.MarketingChannel;
+import com.positivity.customer.internal.enums.SegmentOperator;
+import com.positivity.customer.internal.enums.SegmentType;
+import com.positivity.customer.internal.exception.CrmDuplicateResourceException;
+import com.positivity.customer.internal.exception.CrmResourceNotFoundException;
+import com.positivity.customer.internal.exception.CrmUnprocessableEntityException;
+import com.positivity.customer.internal.repository.SegmentMemberRepository;
+import com.positivity.customer.internal.repository.SegmentRepository;
+import com.positivity.customer.service.MarketingConsentService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link SegmentServiceImpl}.
+ *
+ * <p>
+ * A segment is either STATIC (an explicit pinned member list) or DYNAMIC (a
+ * stored predicate evaluated on demand). Most of the behaviour worth pinning
+ * down here defends that split:
+ *
+ * <ul>
+ * <li>A STATIC segment must not carry a predicate and a DYNAMIC one must, or the
+ * stored definition stops describing the membership it produces.</li>
+ * <li>Neither {@code type} nor {@code audienceType} may change after creation —
+ * switching would strand the other kind's state.</li>
+ * <li>{@code memberCount} is only meaningful for STATIC segments and is
+ * deliberately {@code null} for DYNAMIC ones rather than a stale stored
+ * number.</li>
+ * </ul>
+ *
+ * <p>
+ * The resolve path also masks the sample labels it returns. That is a privacy
+ * control, not formatting: the endpoint exists so an operator can recognize a
+ * mis-scoped audience, and it must not double as a way to export a contact list.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SegmentServiceImpl — segment lifecycle, membership, and resolution")
+class SegmentServiceImplTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-11T12:00:00Z");
+    private static final UUID SEGMENT_ID = UUID.randomUUID();
+
+    @Mock
+    private SegmentRepository segmentRepository;
+
+    @Mock
+    private SegmentMemberRepository segmentMemberRepository;
+
+    @Mock
+    private SegmentResolutionService resolutionService;
+
+    @Mock
+    private MarketingConsentService marketingConsentService;
+
+    @Mock
+    private CustomerFactPublisher factPublisher;
+
+    @Captor
+    private ArgumentCaptor<Segment> savedSegment;
+
+    private SegmentServiceImpl sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new SegmentServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                new ObjectMapper(),
+                segmentRepository,
+                segmentMemberRepository,
+                resolutionService,
+                marketingConsentService,
+                factPublisher);
+    }
+
+    private static SegmentPredicate predicate() {
+        return new SegmentPredicate.Comparison("party.accountTier", SegmentOperator.IN, List.of("GOLD", "PLATINUM"));
+    }
+
+    private static UpsertSegmentRequest dynamicRequest(String name) {
+        return new UpsertSegmentRequest(
+                name, "a description", AudienceType.COMMERCIAL, SegmentType.DYNAMIC, predicate(), true);
+    }
+
+    private static UpsertSegmentRequest staticRequest(String name) {
+        return new UpsertSegmentRequest(name, "a description", AudienceType.COMMERCIAL, SegmentType.STATIC, null, true);
+    }
+
+    private static Segment segment(SegmentType type, String predicateJson) {
+        return Segment.builder()
+                .segmentId(SEGMENT_ID)
+                .name("Fleet accounts")
+                .description("a description")
+                .audienceType(AudienceType.COMMERCIAL)
+                .type(type)
+                .predicate(predicateJson)
+                .active(true)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        @DisplayName("persists a DYNAMIC segment with its predicate serialized")
+        void create_dynamic_persistsPredicate() {
+            when(segmentRepository.existsByNameIgnoreCase("Fleet accounts")).thenReturn(false);
+            when(segmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            SegmentResponse response = sut.create(dynamicRequest("Fleet accounts"));
+
+            verify(segmentRepository).save(savedSegment.capture());
+            assertThat(savedSegment.getValue().getPredicate()).contains("party.accountTier");
+            assertThat(response.type()).isEqualTo("DYNAMIC");
+        }
+
+        @Test
+        @DisplayName("persists a STATIC segment with a null predicate")
+        void create_static_persistsWithoutPredicate() {
+            when(segmentRepository.existsByNameIgnoreCase(any())).thenReturn(false);
+            when(segmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.create(staticRequest("Pinned accounts"));
+
+            verify(segmentRepository).save(savedSegment.capture());
+            assertThat(savedSegment.getValue().getPredicate()).isNull();
+        }
+
+        @Test
+        @DisplayName("trims the supplied name before the uniqueness check and before storing it")
+        void create_trimsName() {
+            when(segmentRepository.existsByNameIgnoreCase("Fleet accounts")).thenReturn(false);
+            when(segmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.create(new UpsertSegmentRequest(
+                    "  Fleet accounts  ", "a description", AudienceType.COMMERCIAL, SegmentType.STATIC, null, true));
+
+            verify(segmentRepository).save(savedSegment.capture());
+            assertThat(savedSegment.getValue().getName()).isEqualTo("Fleet accounts");
+        }
+
+        @Test
+        @DisplayName("rejects a duplicate name case-insensitively")
+        void create_whenNameTaken_throwsDuplicate() {
+            when(segmentRepository.existsByNameIgnoreCase("Fleet accounts")).thenReturn(true);
+
+            assertThatThrownBy(() -> sut.create(staticRequest("Fleet accounts")))
+                    .isInstanceOf(CrmDuplicateResourceException.class);
+            verify(segmentRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("defaults active to true when the request leaves it unset")
+        void create_whenActiveOmitted_defaultsToActive() {
+            when(segmentRepository.existsByNameIgnoreCase(any())).thenReturn(false);
+            when(segmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.create(new UpsertSegmentRequest(
+                    "Fleet accounts", null, AudienceType.COMMERCIAL, SegmentType.STATIC, null, null));
+
+            verify(segmentRepository).save(savedSegment.capture());
+            assertThat(savedSegment.getValue().isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("rejects a STATIC segment that carries a predicate")
+        void create_staticWithPredicate_throws() {
+            UpsertSegmentRequest invalid = new UpsertSegmentRequest(
+                    "Fleet accounts", null, AudienceType.COMMERCIAL, SegmentType.STATIC, predicate(), true);
+            when(segmentRepository.existsByNameIgnoreCase(any())).thenReturn(false);
+
+            assertThatThrownBy(() -> sut.create(invalid))
+                    .isInstanceOf(CrmUnprocessableEntityException.class)
+                    .hasMessageContaining("explicit member list");
+        }
+
+        @Test
+        @DisplayName("rejects a DYNAMIC segment with no predicate")
+        void create_dynamicWithoutPredicate_throws() {
+            UpsertSegmentRequest invalid = new UpsertSegmentRequest(
+                    "Fleet accounts", null, AudienceType.COMMERCIAL, SegmentType.DYNAMIC, null, true);
+            when(segmentRepository.existsByNameIgnoreCase(any())).thenReturn(false);
+
+            assertThatThrownBy(() -> sut.create(invalid))
+                    .isInstanceOf(CrmUnprocessableEntityException.class)
+                    .hasMessageContaining("requires a predicate");
+        }
+
+        @Test
+        @DisplayName("publishes a segment-changed fact on create")
+        void create_publishesFact() {
+            when(segmentRepository.existsByNameIgnoreCase(any())).thenReturn(false);
+            when(segmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.create(staticRequest("Fleet accounts"));
+
+            verify(factPublisher)
+                    .segmentChanged(any(), eq("Fleet accounts"), eq("COMMERCIAL"), eq("STATIC"), eq(true), eq(false));
+        }
+
+        @Test
+        @DisplayName("reports a member count of zero for a freshly created segment")
+        void create_reportsZeroMembers() {
+            when(segmentRepository.existsByNameIgnoreCase(any())).thenReturn(false);
+            when(segmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            assertThat(sut.create(staticRequest("Fleet accounts")).memberCount())
+                    .isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    class Update {
+
+        @Test
+        @DisplayName("applies the new name, description, and active flag")
+        void update_appliesChanges() {
+            Segment existing = segment(SegmentType.STATIC, null);
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.of(existing));
+            when(segmentRepository.findByNameIgnoreCase(any())).thenReturn(Optional.empty());
+            when(segmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.update(
+                    SEGMENT_ID,
+                    new UpsertSegmentRequest(
+                            "Renamed", "new description", AudienceType.COMMERCIAL, SegmentType.STATIC, null, false));
+
+            assertThat(existing.getName()).isEqualTo("Renamed");
+            assertThat(existing.getDescription()).isEqualTo("new description");
+            assertThat(existing.isActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("leaves the active flag untouched when the request omits it")
+        void update_whenActiveOmitted_leavesFlagUnchanged() {
+            Segment existing = segment(SegmentType.STATIC, null);
+            existing.setActive(false);
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.of(existing));
+            when(segmentRepository.findByNameIgnoreCase(any())).thenReturn(Optional.empty());
+            when(segmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.update(
+                    SEGMENT_ID,
+                    new UpsertSegmentRequest(
+                            "Fleet accounts", null, AudienceType.COMMERCIAL, SegmentType.STATIC, null, null));
+
+            assertThat(existing.isActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("throws 404 when the segment does not exist")
+        void update_whenAbsent_throwsNotFound() {
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.update(SEGMENT_ID, staticRequest("Fleet accounts")))
+                    .isInstanceOf(CrmResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("rejects a rename onto another segment's name")
+        void update_whenNameTakenByOther_throwsDuplicate() {
+            Segment existing = segment(SegmentType.STATIC, null);
+            Segment other = segment(SegmentType.STATIC, null);
+            other.setSegmentId(UUID.randomUUID());
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.of(existing));
+            when(segmentRepository.findByNameIgnoreCase("Fleet accounts")).thenReturn(Optional.of(other));
+
+            assertThatThrownBy(() -> sut.update(SEGMENT_ID, staticRequest("Fleet accounts")))
+                    .isInstanceOf(CrmDuplicateResourceException.class);
+        }
+
+        @Test
+        @DisplayName("allows a segment to keep its own name")
+        void update_whenNameHeldBySelf_isAllowed() {
+            Segment existing = segment(SegmentType.STATIC, null);
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.of(existing));
+            when(segmentRepository.findByNameIgnoreCase("Fleet accounts")).thenReturn(Optional.of(existing));
+            when(segmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            assertThat(sut.update(SEGMENT_ID, staticRequest("Fleet accounts"))).isNotNull();
+        }
+
+        @Test
+        @DisplayName("refuses to switch segment type after creation")
+        void update_whenTypeChanges_throws() {
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.of(segment(SegmentType.STATIC, null)));
+            when(segmentRepository.findByNameIgnoreCase(any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.update(SEGMENT_ID, dynamicRequest("Fleet accounts")))
+                    .isInstanceOf(CrmUnprocessableEntityException.class)
+                    .hasMessageContaining("type cannot change");
+        }
+
+        @Test
+        @DisplayName("refuses to switch audience type after creation")
+        void update_whenAudienceTypeChanges_throws() {
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.of(segment(SegmentType.STATIC, null)));
+            when(segmentRepository.findByNameIgnoreCase(any())).thenReturn(Optional.empty());
+
+            UpsertSegmentRequest switched = new UpsertSegmentRequest(
+                    "Fleet accounts", null, AudienceType.INDIVIDUAL, SegmentType.STATIC, null, true);
+
+            assertThatThrownBy(() -> sut.update(SEGMENT_ID, switched))
+                    .isInstanceOf(CrmUnprocessableEntityException.class)
+                    .hasMessageContaining("audienceType cannot change");
+        }
+    }
+
+    @Nested
+    @DisplayName("delete, get, and list")
+    class ReadAndDelete {
+
+        @Test
+        @DisplayName("delete removes the pinned members before the segment itself")
+        void delete_removesMembersThenSegment() {
+            Segment existing = segment(SegmentType.STATIC, null);
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.of(existing));
+
+            sut.delete(SEGMENT_ID);
+
+            verify(segmentMemberRepository).deleteBySegmentId(SEGMENT_ID);
+            verify(segmentRepository).delete(existing);
+            verify(factPublisher).segmentChanged(any(), any(), any(), any(), eq(true), eq(true));
+        }
+
+        @Test
+        @DisplayName("delete throws 404 for an unknown segment")
+        void delete_whenAbsent_throwsNotFound() {
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.delete(SEGMENT_ID)).isInstanceOf(CrmResourceNotFoundException.class);
+            verify(segmentMemberRepository, never()).deleteBySegmentId(any());
+        }
+
+        @Test
+        @DisplayName("get returns a live member count for a STATIC segment")
+        void get_static_countsMembers() {
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.of(segment(SegmentType.STATIC, null)));
+            when(segmentMemberRepository.countBySegmentId(SEGMENT_ID)).thenReturn(7L);
+
+            assertThat(sut.get(SEGMENT_ID).memberCount()).isEqualTo(7L);
+        }
+
+        @Test
+        @DisplayName("get reports a null member count for a DYNAMIC segment rather than a stale number")
+        void get_dynamic_reportsNullMemberCount() {
+            when(segmentRepository.findById(SEGMENT_ID))
+                    .thenReturn(Optional.of(segment(SegmentType.DYNAMIC, predicateJson())));
+
+            assertThat(sut.get(SEGMENT_ID).memberCount()).isNull();
+            verify(segmentMemberRepository, never()).countBySegmentId(any());
+        }
+
+        @Test
+        @DisplayName("get deserializes the stored predicate back onto the response")
+        void get_dynamic_returnsParsedPredicate() {
+            when(segmentRepository.findById(SEGMENT_ID))
+                    .thenReturn(Optional.of(segment(SegmentType.DYNAMIC, predicateJson())));
+
+            assertThat(sut.get(SEGMENT_ID).predicate()).isInstanceOf(SegmentPredicate.Comparison.class);
+        }
+
+        @Test
+        @DisplayName("list without an audience type returns every segment")
+        void list_withoutFilter_returnsAll() {
+            when(segmentRepository.findAllByOrderByNameAsc()).thenReturn(List.of(segment(SegmentType.STATIC, null)));
+
+            assertThat(sut.list(null)).hasSize(1);
+            verify(segmentRepository, never()).findByAudienceTypeOrderByNameAsc(any());
+        }
+
+        @Test
+        @DisplayName("list with an audience type uses the filtered query")
+        void list_withFilter_usesFilteredQuery() {
+            when(segmentRepository.findByAudienceTypeOrderByNameAsc(AudienceType.COMMERCIAL))
+                    .thenReturn(List.of(segment(SegmentType.STATIC, null)));
+
+            assertThat(sut.list(AudienceType.COMMERCIAL)).hasSize(1);
+            verify(segmentRepository, never()).findAllByOrderByNameAsc();
+        }
+
+        @Test
+        @DisplayName("attributeCatalog exposes the whole predicate attribute catalog")
+        void attributeCatalog_isNotEmpty() {
+            assertThat(sut.attributeCatalog()).isNotEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("membership")
+    class Membership {
+
+        @Test
+        @DisplayName("pins the supplied parties onto a STATIC segment")
+        void addMembers_pinsParties() {
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.of(segment(SegmentType.STATIC, null)));
+            when(segmentMemberRepository.findBySegmentIdAndPartyId(any(), any()))
+                    .thenReturn(Optional.empty());
+            UUID first = UUID.randomUUID();
+            UUID second = UUID.randomUUID();
+
+            sut.addMembers(SEGMENT_ID, new SegmentMembersRequest(List.of(first, second)));
+
+            ArgumentCaptor<List<SegmentMember>> added = ArgumentCaptor.captor();
+            verify(segmentMemberRepository).saveAll(added.capture());
+            assertThat(added.getValue()).extracting(SegmentMember::getPartyId).containsExactly(first, second);
+            assertThat(added.getValue())
+                    .allSatisfy(member -> assertThat(member.getAddedAt()).isEqualTo(NOW));
+        }
+
+        @Test
+        @DisplayName("de-duplicates repeated party ids within one request")
+        void addMembers_deduplicatesWithinRequest() {
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.of(segment(SegmentType.STATIC, null)));
+            when(segmentMemberRepository.findBySegmentIdAndPartyId(any(), any()))
+                    .thenReturn(Optional.empty());
+            UUID partyId = UUID.randomUUID();
+
+            sut.addMembers(SEGMENT_ID, new SegmentMembersRequest(List.of(partyId, partyId, partyId)));
+
+            ArgumentCaptor<List<SegmentMember>> added = ArgumentCaptor.captor();
+            verify(segmentMemberRepository).saveAll(added.capture());
+            assertThat(added.getValue()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("skips parties already pinned to the segment")
+        void addMembers_skipsExistingMembers() {
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.of(segment(SegmentType.STATIC, null)));
+            when(segmentMemberRepository.findBySegmentIdAndPartyId(any(), any()))
+                    .thenReturn(Optional.of(SegmentMember.builder().build()));
+
+            sut.addMembers(SEGMENT_ID, new SegmentMembersRequest(List.of(UUID.randomUUID())));
+
+            verify(segmentMemberRepository, never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("refuses to pin members onto a DYNAMIC segment")
+        void addMembers_onDynamicSegment_throws() {
+            when(segmentRepository.findById(SEGMENT_ID))
+                    .thenReturn(Optional.of(segment(SegmentType.DYNAMIC, predicateJson())));
+
+            assertThatThrownBy(() -> sut.addMembers(SEGMENT_ID, new SegmentMembersRequest(List.of(UUID.randomUUID()))))
+                    .isInstanceOf(CrmUnprocessableEntityException.class)
+                    .hasMessageContaining("STATIC");
+        }
+
+        @Test
+        @DisplayName("removeMember deletes the pin when it exists")
+        void removeMember_whenPresent_deletes() {
+            SegmentMember member = SegmentMember.builder().build();
+            UUID partyId = UUID.randomUUID();
+            when(segmentMemberRepository.findBySegmentIdAndPartyId(SEGMENT_ID, partyId))
+                    .thenReturn(Optional.of(member));
+
+            sut.removeMember(SEGMENT_ID, partyId);
+
+            verify(segmentMemberRepository).delete(member);
+        }
+
+        @Test
+        @DisplayName("removeMember is a silent no-op when the party is not pinned")
+        void removeMember_whenAbsent_isNoOp() {
+            when(segmentMemberRepository.findBySegmentIdAndPartyId(any(), any()))
+                    .thenReturn(Optional.empty());
+
+            sut.removeMember(SEGMENT_ID, UUID.randomUUID());
+
+            verify(segmentMemberRepository, never()).delete(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("resolve")
+    class Resolve {
+
+        private final UUID partyA = UUID.randomUUID();
+        private final UUID partyB = UUID.randomUUID();
+
+        private void resolutionReturns(List<UUID> partyIds, boolean truncated) {
+            when(segmentRepository.findById(SEGMENT_ID))
+                    .thenReturn(Optional.of(segment(SegmentType.DYNAMIC, predicateJson())));
+            when(resolutionService.resolve(any(), any()))
+                    .thenReturn(new SegmentResolutionService.Resolution(partyIds, truncated));
+        }
+
+        @Test
+        @DisplayName("reports the matched count and carries the truncated flag through")
+        void resolve_reportsCountAndTruncation() {
+            resolutionReturns(List.of(partyA, partyB), true);
+            lenient().when(resolutionService.loadAttributes(any(), anyList())).thenReturn(List.of());
+
+            SegmentResolutionResponse response = sut.resolve(SEGMENT_ID, null, 10);
+
+            assertThat(response.totalMatched()).isEqualTo(2);
+            assertThat(response.truncated()).isTrue();
+        }
+
+        @Test
+        @DisplayName("leaves the eligible count null when no channel is supplied")
+        void resolve_withoutChannel_leavesEligibleNull() {
+            resolutionReturns(List.of(partyA, partyB), false);
+            lenient().when(resolutionService.loadAttributes(any(), anyList())).thenReturn(List.of());
+
+            SegmentResolutionResponse response = sut.resolve(SEGMENT_ID, null, 0);
+
+            assertThat(response.eligibleCount()).isNull();
+            assertThat(response.channel()).isNull();
+            verify(marketingConsentService, never()).resolveEligibility(any(), any());
+        }
+
+        @Test
+        @DisplayName("counts only consent-eligible parties when a channel is supplied")
+        void resolve_withChannel_countsEligibleOnly() {
+            resolutionReturns(List.of(partyA, partyB), false);
+            lenient().when(resolutionService.loadAttributes(any(), anyList())).thenReturn(List.of());
+            when(marketingConsentService.resolveEligibility(partyA, MarketingChannel.EMAIL))
+                    .thenReturn(decision(partyA, true));
+            when(marketingConsentService.resolveEligibility(partyB, MarketingChannel.EMAIL))
+                    .thenReturn(decision(partyB, false));
+
+            SegmentResolutionResponse response = sut.resolve(SEGMENT_ID, MarketingChannel.EMAIL, 0);
+
+            assertThat(response.totalMatched()).isEqualTo(2);
+            assertThat(response.eligibleCount()).isEqualTo(1L);
+            assertThat(response.channel()).isEqualTo("EMAIL");
+        }
+
+        @ParameterizedTest(name = "a requested sample of {0} yields {1} entries")
+        @CsvSource({"0, 0", "1, 1", "2, 2", "50, 2", "-5, 0"})
+        @DisplayName("clamps the sample size to the 0..25 window and to what actually matched")
+        void resolve_clampsSampleSize(int requested, int expected) {
+            resolutionReturns(List.of(partyA, partyB), false);
+            lenient().when(resolutionService.loadAttributes(any(), anyList())).thenReturn(List.of());
+
+            assertThat(sut.resolve(SEGMENT_ID, null, requested).sample()).hasSize(expected);
+        }
+
+        @Test
+        @DisplayName("masks sample labels — the endpoint identifies an audience, it does not export one")
+        void resolve_masksSampleLabels() {
+            resolutionReturns(List.of(partyA), false);
+            when(resolutionService.loadAttributes(eq(AudienceType.COMMERCIAL), anyList()))
+                    .thenReturn(List.of(attributes(partyA, "Northwind Traders Incorporated")));
+
+            SegmentResolutionResponse response = sut.resolve(SEGMENT_ID, null, 5);
+
+            assertThat(response.sample()).singleElement().satisfies(entry -> {
+                assertThat(entry.maskedLabel()).isEqualTo("North***");
+                assertThat(entry.maskedLabel()).doesNotContain("Traders");
+            });
+        }
+
+        @Test
+        @DisplayName("leaves a short label unmasked — there is nothing to truncate")
+        void resolve_leavesShortLabelIntact() {
+            resolutionReturns(List.of(partyA), false);
+            when(resolutionService.loadAttributes(any(), anyList())).thenReturn(List.of(attributes(partyA, "ACME")));
+
+            assertThat(sut.resolve(SEGMENT_ID, null, 5).sample())
+                    .singleElement()
+                    .satisfies(entry -> assertThat(entry.maskedLabel()).isEqualTo("ACME"));
+        }
+
+        @Test
+        @DisplayName("emits a null label when the party has no display label")
+        void resolve_whenLabelBlank_emitsNull() {
+            resolutionReturns(List.of(partyA), false);
+            when(resolutionService.loadAttributes(any(), anyList())).thenReturn(List.of(attributes(partyA, "  ")));
+
+            assertThat(sut.resolve(SEGMENT_ID, null, 5).sample())
+                    .singleElement()
+                    .satisfies(entry -> assertThat(entry.maskedLabel()).isNull());
+        }
+
+        @Test
+        @DisplayName("throws 404 for an unknown segment")
+        void resolve_whenAbsent_throwsNotFound() {
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.resolve(SEGMENT_ID, null, 5)).isInstanceOf(CrmResourceNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("resolveAndPublish")
+    class ResolveAndPublish {
+
+        @Test
+        @DisplayName("publishes the resolved membership and reports its size")
+        void resolveAndPublish_publishesResult() {
+            UUID requestId = UUID.randomUUID();
+            UUID partyId = UUID.randomUUID();
+            when(segmentRepository.findById(SEGMENT_ID))
+                    .thenReturn(Optional.of(segment(SegmentType.DYNAMIC, predicateJson())));
+            when(resolutionService.resolve(any(), any()))
+                    .thenReturn(new SegmentResolutionService.Resolution(List.of(partyId), false));
+
+            assertThat(sut.resolveAndPublish(requestId, SEGMENT_ID)).contains(1);
+
+            verify(factPublisher).segmentResolved(requestId, SEGMENT_ID, "COMMERCIAL", List.of(partyId), false);
+        }
+
+        @Test
+        @DisplayName("returns empty and publishes nothing when the segment has since been deleted")
+        void resolveAndPublish_whenSegmentDeleted_returnsEmpty() {
+            when(segmentRepository.findById(SEGMENT_ID)).thenReturn(Optional.empty());
+
+            // Deliberately not an exception: the request is not worth retrying, so the
+            // requester is left to time out rather than the listener failing forever.
+            assertThat(sut.resolveAndPublish(UUID.randomUUID(), SEGMENT_ID)).isEmpty();
+
+            verify(factPublisher, never()).segmentResolved(any(), any(), any(), anyList(), anyBoolean());
+        }
+    }
+
+    private static MarketingConsentDecision decision(UUID partyId, boolean allowed) {
+        return new MarketingConsentDecision(partyId, "EMAIL", allowed, allowed ? "OPT_IN" : "OPT_OUT", null);
+    }
+
+    /**
+     * PartyAttributes carries 27 components; only displayLabel matters to this
+     * service, so the rest are filled with inert values.
+     */
+    private static PartyAttributes attributes(UUID partyId, String displayLabel) {
+        return new PartyAttributes(
+                partyId,
+                "COMMERCIAL",
+                null,
+                null,
+                false,
+                Map.of(),
+                Set.of(),
+                null,
+                null,
+                null,
+                "UNSET",
+                "UNSET",
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                false,
+                0L,
+                displayLabel,
+                null,
+                false,
+                null,
+                false,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    private static String predicateJson() {
+        return new ObjectMapper().writeValueAsString(predicate());
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/SuppressionServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/SuppressionServiceImplTest.java
@@ -1,0 +1,349 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.dto.AddSuppressionRequest;
+import com.positivity.customer.internal.entity.SuppressionEntry;
+import com.positivity.customer.internal.enums.ConsentChangeSource;
+import com.positivity.customer.internal.enums.MarketingChannel;
+import com.positivity.customer.internal.enums.SuppressionReason;
+import com.positivity.customer.internal.exception.CrmResourceNotFoundException;
+import com.positivity.customer.internal.repository.SuppressionEntryRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Unit tests for {@link SuppressionServiceImpl}.
+ *
+ * <p>
+ * The suppression list is the do-not-contact register: an address on it must
+ * never receive marketing. Two properties carry the weight.
+ *
+ * <p>
+ * <b>Adding is idempotent and silent on repeat.</b> Bounce feeds replay the same
+ * address routinely, so a second add returns the existing entry without touching
+ * the audit trail or re-emitting a fact. Getting that wrong would churn
+ * downstream consumers on every bounce redelivery.
+ *
+ * <p>
+ * <b>Addresses are stored hashed, never raw.</b> The entry keeps a hash for
+ * matching and a short hint for operators; the plain address is not persisted, so
+ * the register cannot become a mailing list. The tests assert the raw address
+ * never reaches the entity.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SuppressionServiceImpl — do-not-contact register")
+class SuppressionServiceImplTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-11T12:00:00Z");
+    private static final UUID SUPPRESSION_ID = UUID.randomUUID();
+    private static final UUID PARTY_ID = UUID.randomUUID();
+    private static final String ADDRESS = "Ada@Example.COM";
+
+    @Mock
+    private SuppressionEntryRepository suppressionRepository;
+
+    @Mock
+    private CustomerFactPublisher factPublisher;
+
+    @Captor
+    private ArgumentCaptor<SuppressionEntry> savedEntry;
+
+    private SuppressionServiceImpl sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new SuppressionServiceImpl(Clock.fixed(NOW, ZoneOffset.UTC), suppressionRepository, factPublisher);
+    }
+
+    private static AddSuppressionRequest request(ConsentChangeSource source) {
+        return new AddSuppressionRequest(
+                MarketingChannel.EMAIL, ADDRESS, PARTY_ID, SuppressionReason.HARD_BOUNCE, source);
+    }
+
+    private static SuppressionEntry entry() {
+        return SuppressionEntry.builder()
+                .suppressionId(SUPPRESSION_ID)
+                .channel(MarketingChannel.EMAIL)
+                .addressHash(MarketingAddressNormalizer.hash(MarketingChannel.EMAIL, ADDRESS))
+                .addressHint(MarketingAddressNormalizer.hint(MarketingChannel.EMAIL, ADDRESS))
+                .partyId(PARTY_ID)
+                .reason(SuppressionReason.HARD_BOUNCE)
+                .source(ConsentChangeSource.CSR)
+                .createdBy("system")
+                .createdAt(NOW)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("add")
+    class Add {
+
+        @Test
+        @DisplayName("stores a hashed address and a hint, never the raw address")
+        void add_storesHashNotRawAddress() {
+            when(suppressionRepository.findByChannelAndAddressHash(any(), anyString()))
+                    .thenReturn(Optional.empty());
+            when(suppressionRepository.saveAndFlush(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.add(request(ConsentChangeSource.CSR));
+
+            verify(suppressionRepository).saveAndFlush(savedEntry.capture());
+            SuppressionEntry saved = savedEntry.getValue();
+            assertThat(saved.getAddressHash())
+                    .isEqualTo(MarketingAddressNormalizer.hash(MarketingChannel.EMAIL, ADDRESS));
+            // The register must not become a mailing list.
+            assertThat(saved.getAddressHash()).isNotEqualTo(ADDRESS);
+            assertThat(saved.getAddressHint()).isNotEqualTo(ADDRESS);
+            assertThat(saved.getCreatedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("publishes a suppression fact keyed on the hash, not the address")
+        void add_publishesFactWithHash() {
+            when(suppressionRepository.findByChannelAndAddressHash(any(), anyString()))
+                    .thenReturn(Optional.empty());
+            when(suppressionRepository.saveAndFlush(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.add(request(ConsentChangeSource.CSR));
+
+            verify(factPublisher)
+                    .suppressionChanged(
+                            eq("EMAIL"),
+                            eq(MarketingAddressNormalizer.hash(MarketingChannel.EMAIL, ADDRESS)),
+                            eq(PARTY_ID),
+                            eq(true),
+                            eq("HARD_BOUNCE"));
+        }
+
+        @Test
+        @DisplayName("returns the existing entry on a repeat add without re-writing or re-emitting")
+        void add_whenAlreadySuppressed_isSilentlyIdempotent() {
+            when(suppressionRepository.findByChannelAndAddressHash(any(), anyString()))
+                    .thenReturn(Optional.of(entry()));
+
+            assertThat(sut.add(request(ConsentChangeSource.CSR)).suppressionId())
+                    .isEqualTo(SUPPRESSION_ID);
+
+            // Bounce feeds replay the same address routinely; churning the audit
+            // trail and the fact stream on every replay would be noise.
+            verify(suppressionRepository, never()).saveAndFlush(any());
+            verify(factPublisher, never()).suppressionChanged(any(), any(), any(), eq(true), any());
+        }
+
+        @Test
+        @DisplayName("matches an existing entry regardless of address casing")
+        void add_matchesExistingRegardlessOfCasing() {
+            String hash = MarketingAddressNormalizer.hash(MarketingChannel.EMAIL, ADDRESS);
+            when(suppressionRepository.findByChannelAndAddressHash(MarketingChannel.EMAIL, hash))
+                    .thenReturn(Optional.of(entry()));
+
+            AddSuppressionRequest differentCasing = new AddSuppressionRequest(
+                    MarketingChannel.EMAIL,
+                    ADDRESS.toLowerCase(),
+                    PARTY_ID,
+                    SuppressionReason.HARD_BOUNCE,
+                    ConsentChangeSource.CSR);
+
+            sut.add(differentCasing);
+
+            verify(suppressionRepository, never()).saveAndFlush(any());
+        }
+
+        @Test
+        @DisplayName("defaults the change source to CSR when the request omits it")
+        void add_whenSourceOmitted_defaultsToCsr() {
+            when(suppressionRepository.findByChannelAndAddressHash(any(), anyString()))
+                    .thenReturn(Optional.empty());
+            when(suppressionRepository.saveAndFlush(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.add(request(null));
+
+            verify(suppressionRepository).saveAndFlush(savedEntry.capture());
+            assertThat(savedEntry.getValue().getSource()).isEqualTo(ConsentChangeSource.CSR);
+        }
+
+        @Test
+        @DisplayName("keeps an explicitly supplied change source")
+        void add_keepsSuppliedSource() {
+            when(suppressionRepository.findByChannelAndAddressHash(any(), anyString()))
+                    .thenReturn(Optional.empty());
+            when(suppressionRepository.saveAndFlush(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.add(request(ConsentChangeSource.UNSUBSCRIBE_LINK));
+
+            verify(suppressionRepository).saveAndFlush(savedEntry.capture());
+            assertThat(savedEntry.getValue().getSource()).isEqualTo(ConsentChangeSource.UNSUBSCRIBE_LINK);
+        }
+
+        @Test
+        @DisplayName("converges on the winning row when a concurrent add loses the unique-constraint race")
+        void add_whenConstraintRaceLost_convergesOnWinner() {
+            when(suppressionRepository.findByChannelAndAddressHash(any(), anyString()))
+                    .thenReturn(Optional.empty())
+                    .thenReturn(Optional.of(entry()));
+            when(suppressionRepository.saveAndFlush(any()))
+                    .thenThrow(new DataIntegrityViolationException("unique violation"));
+
+            assertThat(sut.add(request(ConsentChangeSource.CSR)).suppressionId())
+                    .isEqualTo(SUPPRESSION_ID);
+            verify(factPublisher, never()).suppressionChanged(any(), any(), any(), eq(true), any());
+        }
+
+        @Test
+        @DisplayName("rethrows when the constraint violation was not a losing race after all")
+        void add_whenViolationUnexplained_rethrows() {
+            when(suppressionRepository.findByChannelAndAddressHash(any(), anyString()))
+                    .thenReturn(Optional.empty());
+            when(suppressionRepository.saveAndFlush(any()))
+                    .thenThrow(new DataIntegrityViolationException("some other violation"));
+
+            assertThatThrownBy(() -> sut.add(request(ConsentChangeSource.CSR)))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("remove")
+    class Remove {
+
+        @Test
+        @DisplayName("deletes the entry and publishes a lifted fact with no reason")
+        void remove_deletesAndPublishes() {
+            SuppressionEntry existing = entry();
+            when(suppressionRepository.findById(SUPPRESSION_ID)).thenReturn(Optional.of(existing));
+
+            sut.remove(SUPPRESSION_ID);
+
+            verify(suppressionRepository).delete(existing);
+            verify(factPublisher)
+                    .suppressionChanged(eq("EMAIL"), eq(existing.getAddressHash()), eq(PARTY_ID), eq(false), eq(null));
+        }
+
+        @Test
+        @DisplayName("throws 404 for an unknown suppression id and deletes nothing")
+        void remove_whenAbsent_throwsNotFound() {
+            when(suppressionRepository.findById(SUPPRESSION_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.remove(SUPPRESSION_ID)).isInstanceOf(CrmResourceNotFoundException.class);
+            verify(suppressionRepository, never()).delete(any());
+            verify(factPublisher, never()).suppressionChanged(any(), any(), any(), eq(false), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("queries")
+    class Queries {
+
+        private Page<SuppressionEntry> onePage() {
+            return new PageImpl<>(List.of(entry()));
+        }
+
+        @ParameterizedTest(name = "page {0} size {1} requests page {2} size {3}")
+        @CsvSource({
+            "0,   25,  0, 25",
+            "3,   50,  3, 50",
+            "-1,  25,  0, 25", // negative page floors to the first page
+            "0,   0,   0, 1", // size is clamped into 1..200
+            "0,   500, 0, 200",
+        })
+        @DisplayName("clamps paging inputs rather than passing them through to the query")
+        void list_clampsPaging(int page, int size, int expectedPage, int expectedSize) {
+            ArgumentCaptor<Pageable> pageable = ArgumentCaptor.captor();
+            when(suppressionRepository.findAll(pageable.capture())).thenReturn(onePage());
+
+            sut.list(null, page, size);
+
+            assertThat(pageable.getValue().getPageNumber()).isEqualTo(expectedPage);
+            assertThat(pageable.getValue().getPageSize()).isEqualTo(expectedSize);
+        }
+
+        @Test
+        @DisplayName("lists newest first, so the most recent suppressions surface")
+        void list_sortsByCreatedAtDescending() {
+            ArgumentCaptor<Pageable> pageable = ArgumentCaptor.captor();
+            when(suppressionRepository.findAll(pageable.capture())).thenReturn(onePage());
+
+            sut.list(null, 0, 25);
+
+            assertThat(pageable.getValue().getSort().getOrderFor("createdAt"))
+                    .isNotNull()
+                    .satisfies(order -> assertThat(order.isDescending()).isTrue());
+        }
+
+        @Test
+        @DisplayName("uses the channel-filtered query when a channel is supplied")
+        void list_withChannel_usesFilteredQuery() {
+            when(suppressionRepository.findByChannel(eq(MarketingChannel.EMAIL), any()))
+                    .thenReturn(onePage());
+
+            assertThat(sut.list(MarketingChannel.EMAIL, 0, 25).items()).hasSize(1);
+            verify(suppressionRepository, never()).findAll(any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("listForParty returns every entry held against the party")
+        void listForParty_returnsEntries() {
+            when(suppressionRepository.findByPartyId(PARTY_ID)).thenReturn(List.of(entry()));
+
+            assertThat(sut.listForParty(PARTY_ID))
+                    .singleElement()
+                    .satisfies(response -> assertThat(response.channel()).isEqualTo("EMAIL"));
+        }
+
+        @Test
+        @DisplayName("isSuppressed hashes the address before checking, so casing does not matter")
+        void isSuppressed_hashesBeforeChecking() {
+            String hash = MarketingAddressNormalizer.hash(MarketingChannel.EMAIL, ADDRESS);
+            when(suppressionRepository.existsByChannelAndAddressHash(MarketingChannel.EMAIL, hash))
+                    .thenReturn(true);
+
+            assertThat(sut.isSuppressed(MarketingChannel.EMAIL, ADDRESS.toLowerCase()))
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("isSuppressed reports false for an address not on the register")
+        void isSuppressed_whenAbsent_isFalse() {
+            when(suppressionRepository.existsByChannelAndAddressHash(any(), anyString()))
+                    .thenReturn(false);
+
+            assertThat(sut.isSuppressed(MarketingChannel.EMAIL, ADDRESS)).isFalse();
+        }
+
+        @Test
+        @DisplayName("isPartySuppressed checks the party-and-channel pair")
+        void isPartySuppressed_delegatesToRepository() {
+            when(suppressionRepository.existsByPartyIdAndChannel(PARTY_ID, MarketingChannel.SMS))
+                    .thenReturn(true);
+
+            assertThat(sut.isPartySuppressed(PARTY_ID, MarketingChannel.SMS)).isTrue();
+        }
+    }
+}

--- a/pos-documents/src/main/java/com/positivity/documents/internal/config/ClockConfig.java
+++ b/pos-documents/src/main/java/com/positivity/documents/internal/config/ClockConfig.java
@@ -7,8 +7,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ClockConfig {
 
-  @Bean
-  public Clock clock() {
-    return Clock.systemUTC();
-  }
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
 }

--- a/pos-documents/src/test/java/com/positivity/documents/internal/config/DocumentEventTypeInitializerTest.java
+++ b/pos-documents/src/test/java/com/positivity/documents/internal/config/DocumentEventTypeInitializerTest.java
@@ -1,0 +1,125 @@
+package com.positivity.documents.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link DocumentEventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link DocumentEventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DocumentEventTypeInitializer — startup event-type registration")
+class DocumentEventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private DocumentEventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new DocumentEventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(DocumentEventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        DocumentEventTypeInitializer sutWithSecret =
+                new DocumentEventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(DocumentEventTypes.all().size()))
+                .header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(DocumentEventTypes.all()).isNotEmpty();
+        verify(restClient, times(DocumentEventTypes.all().size())).put();
+    }
+}

--- a/pos-documents/src/test/java/com/positivity/documents/internal/config/DocumentEventTypesTest.java
+++ b/pos-documents/src/test/java/com/positivity/documents/internal/config/DocumentEventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.documents.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link DocumentEventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
  * descriptions, ordered thresholds, and a threshold triple that matches a
  * declared preset rather than an ad-hoc value.
  */
-@DisplayName("EventTypes — event-type registry contract")
-class EventTypesTest {
+@DisplayName("DocumentEventTypes — event-type registry contract")
+class DocumentEventTypesTest {
 
     /**
      * Event type codes are upper snake case: the receiver stores them verbatim as
@@ -58,7 +58,7 @@ class EventTypesTest {
     }
 
     private static List<EventTypeRegistration> registrations() {
-        return EventTypes.all();
+        return DocumentEventTypes.all();
     }
 
     @Test
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/config/EventTypeInitializerTest.java
+++ b/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,124 @@
+package com.positivity.poseventreceiver.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventTypeRegistration;
+import com.positivity.poseventreceiver.dao.EventDao;
+import com.positivity.poseventreceiver.internal.entity.EventType;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for the pos-event-receiver {@link EventTypeInitializer}.
+ *
+ * <p>
+ * This module is the one exception to the REST-based registration pattern: it
+ * writes its own event types through {@link EventDao} directly, because calling
+ * its own REST API at startup would be circular. That makes the upsert branch —
+ * update an existing row versus create a new one — local logic worth pinning
+ * down, along with the shared "a failure must not block startup" contract.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — direct-DAO event-type registration")
+class EventTypeInitializerTest {
+
+    @Mock
+    private EventDao eventDao;
+
+    @InjectMocks
+    private EventTypeInitializer sut;
+
+    @Captor
+    private ArgumentCaptor<EventType> savedEventType;
+
+    @Test
+    @DisplayName("run() saves one event type per declared registration")
+    void run_savesEveryEventType() {
+        when(eventDao.getEventTypeByCode(anyString())).thenReturn(Optional.empty());
+
+        sut.run(null);
+
+        List<EventTypeRegistration> declared = EventTypes.all();
+        assertThat(declared).isNotEmpty();
+        verify(eventDao, times(declared.size())).saveEventType(any(EventType.class));
+    }
+
+    @Test
+    @DisplayName("run() creates a new event type when none exists for the type code")
+    void run_whenTypeAbsent_createsNewEventType() {
+        when(eventDao.getEventTypeByCode(anyString())).thenReturn(Optional.empty());
+
+        sut.run(null);
+
+        verify(eventDao, times(EventTypes.all().size())).saveEventType(savedEventType.capture());
+
+        EventTypeRegistration first = EventTypes.all().getFirst();
+        assertThat(savedEventType.getAllValues())
+                .extracting(EventType::getTypeCode)
+                .contains(first.getTypeCode());
+    }
+
+    @Test
+    @DisplayName("run() updates the existing row in place when the type code is already registered")
+    void run_whenTypeExists_updatesExistingEventType() {
+        EventTypeRegistration first = EventTypes.all().getFirst();
+        EventType existing = new EventType(first.getTypeCode(), "stale description", first.getApiVersion(), 1L, 2L, 3L);
+
+        when(eventDao.getEventTypeByCode(anyString()))
+                .thenAnswer(invocation -> first.getTypeCode().equals(invocation.getArgument(0))
+                        ? Optional.of(existing)
+                        : Optional.empty());
+
+        sut.run(null);
+
+        verify(eventDao, times(EventTypes.all().size())).saveEventType(savedEventType.capture());
+
+        assertThat(savedEventType.getAllValues())
+                .filteredOn(saved -> saved.getTypeCode().equals(first.getTypeCode()))
+                .singleElement()
+                .satisfies(saved -> {
+                    // The same instance is mutated and re-saved, not replaced.
+                    assertThat(saved).isSameAs(existing);
+                    assertThat(saved.getDescription()).isEqualTo(first.getDescription());
+                    assertThat(saved.getP50Micros()).isEqualTo(first.getP50Micros());
+                    assertThat(saved.getP95Micros()).isEqualTo(first.getP95Micros());
+                    assertThat(saved.getP99Micros()).isEqualTo(first.getP99Micros());
+                });
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a DAO failure — startup must not block on registration")
+    void run_whenSaveFails_doesNotPropagate() {
+        when(eventDao.getEventTypeByCode(anyString())).thenReturn(Optional.empty());
+        when(eventDao.saveEventType(any(EventType.class))).thenThrow(new RuntimeException("db unavailable"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(eventDao.getEventTypeByCode(anyString())).thenReturn(Optional.empty());
+        when(eventDao.saveEventType(any(EventType.class)))
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        verify(eventDao, times(EventTypes.all().size())).saveEventType(any(EventType.class));
+    }
+}

--- a/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/config/EventTypesTest.java
+++ b/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.poseventreceiver.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/config/EventsApiSecurityFilterTest.java
+++ b/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/config/EventsApiSecurityFilterTest.java
@@ -1,0 +1,178 @@
+package com.positivity.poseventreceiver.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Unit tests for {@link EventsApiSecurityFilter}.
+ *
+ * <p>
+ * This filter is the only authentication in front of the event-ingestion API.
+ * {@code pos-event-receiver} deliberately does not validate JWTs — doing so
+ * would make it depend on {@code pos-security-service}, which depends on it at
+ * startup — so a shared secret guards every mutating request instead.
+ *
+ * <p>
+ * The tests below fix the exact shape of that gate, because each of its four
+ * pass-through branches is a deliberate hole and widening one by accident would
+ * silently expose the write path: actuator endpoints, safe HTTP methods, paths
+ * outside {@code /v1/events} and {@code /v1/eventTypes}, and the
+ * no-secret-configured development mode.
+ */
+@DisplayName("EventsApiSecurityFilter — shared-secret gate on the ingestion API")
+class EventsApiSecurityFilterTest {
+
+    private static final String SECRET_HEADER = "X-Events-Api-Secret";
+    private static final String SECRET = "correct-horse-battery-staple";
+
+    private final MockFilterChain chain = new MockFilterChain();
+    private final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    private static MockHttpServletRequest request(String method, String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+        request.setRequestURI(path);
+        return request;
+    }
+
+    private void filter(String configuredSecret, MockHttpServletRequest request) throws ServletException, IOException {
+        new EventsApiSecurityFilter(configuredSecret).doFilter(request, response, chain);
+    }
+
+    private void assertPassedThrough() {
+        assertThat(chain.getRequest())
+                .as("request should have been passed down the chain")
+                .isNotNull();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    private void assertRejected() {
+        assertThat(chain.getRequest()).as("request must not reach the chain").isNull();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Nested
+    @DisplayName("with a secret configured")
+    class SecurityEnabled {
+
+        @Test
+        @DisplayName("allows a mutating request carrying the correct secret")
+        void allowsRequestWithCorrectSecret() throws Exception {
+            MockHttpServletRequest request = request("POST", "/v1/events");
+            request.addHeader(SECRET_HEADER, SECRET);
+
+            filter(SECRET, request);
+
+            assertPassedThrough();
+        }
+
+        @Test
+        @DisplayName("rejects a mutating request with no secret header")
+        void rejectsRequestWithoutSecretHeader() throws Exception {
+            filter(SECRET, request("POST", "/v1/events"));
+
+            assertRejected();
+        }
+
+        @Test
+        @DisplayName("rejects a mutating request carrying the wrong secret")
+        void rejectsRequestWithWrongSecret() throws Exception {
+            MockHttpServletRequest request = request("POST", "/v1/events");
+            request.addHeader(SECRET_HEADER, "not-the-secret");
+
+            filter(SECRET, request);
+
+            assertRejected();
+        }
+
+        @Test
+        @DisplayName("rejection carries a JSON body and does not leak the expected secret")
+        void rejectionBodyIsJsonAndLeaksNothing() throws Exception {
+            filter(SECRET, request("POST", "/v1/eventTypes/ORDER_CREATE"));
+
+            assertThat(response.getContentType()).isEqualTo("application/json");
+            assertThat(response.getContentAsString()).contains("Unauthorized").doesNotContain(SECRET);
+        }
+
+        @ParameterizedTest(name = "{0} /v1/eventTypes is rejected without a secret")
+        @ValueSource(strings = {"POST", "PUT", "DELETE", "PATCH"})
+        @DisplayName("guards every mutating method, not just POST")
+        void rejectsEveryMutatingMethod(String method) throws Exception {
+            filter(SECRET, request(method, "/v1/eventTypes/ORDER_CREATE"));
+
+            assertRejected();
+        }
+
+        @ParameterizedTest(name = "{0} is allowed without a secret")
+        @ValueSource(strings = {"GET", "HEAD", "OPTIONS"})
+        @DisplayName("lets safe methods through unauthenticated — reads are public by design")
+        void allowsSafeMethodsWithoutSecret(String method) throws Exception {
+            filter(SECRET, request(method, "/v1/events"));
+
+            assertPassedThrough();
+        }
+
+        @ParameterizedTest(name = "{0} is allowed without a secret")
+        @ValueSource(strings = {"/actuator/health", "/actuator/prometheus"})
+        @DisplayName("lets actuator endpoints through unauthenticated")
+        void allowsActuatorWithoutSecret(String path) throws Exception {
+            filter(SECRET, request("POST", path));
+
+            assertPassedThrough();
+        }
+
+        @ParameterizedTest(name = "{0} is outside the guarded prefixes")
+        @ValueSource(strings = {"/v1/other", "/internal/thing", "/", "/v2/events"})
+        @DisplayName("only guards the /v1/events and /v1/eventTypes prefixes")
+        void allowsPathsOutsideGuardedPrefixes(String path) throws Exception {
+            filter(SECRET, request("POST", path));
+
+            assertPassedThrough();
+        }
+
+        @Test
+        @DisplayName("prefix matching is literal — /v1/eventsomething is also guarded")
+        void guardsAnyPathStartingWithTheEventsPrefix() throws Exception {
+            filter(SECRET, request("POST", "/v1/events/emit"));
+
+            assertRejected();
+        }
+    }
+
+    @Nested
+    @DisplayName("with no secret configured (development mode)")
+    class SecurityDisabled {
+
+        @ParameterizedTest(name = "configured secret = [{0}] disables the gate")
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        @DisplayName("allows mutating requests through when no secret is configured")
+        void allowsEverythingWhenNoSecretConfigured(String configuredSecret) throws Exception {
+            filter(configuredSecret, request("POST", "/v1/events"));
+
+            assertPassedThrough();
+        }
+
+        @Test
+        @DisplayName("ignores a supplied secret header when none is configured")
+        void ignoresSuppliedSecretWhenNoneConfigured() throws Exception {
+            MockHttpServletRequest request = request("POST", "/v1/events");
+            request.addHeader(SECRET_HEADER, "anything-at-all");
+
+            filter("", request);
+
+            assertPassedThrough();
+        }
+    }
+}

--- a/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/controller/EventTypeControllerTest.java
+++ b/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/controller/EventTypeControllerTest.java
@@ -1,0 +1,346 @@
+package com.positivity.poseventreceiver.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.poseventreceiver.internal.dto.EventTypeRequest;
+import com.positivity.poseventreceiver.internal.dto.EventTypeResponse;
+import com.positivity.poseventreceiver.service.EventTypeService;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for {@link EventTypeController}.
+ *
+ * <p>
+ * The controller is a thin translation layer: it maps the service's
+ * {@code Optional}/{@code boolean} results and its {@link IllegalArgumentException}
+ * validation failures onto HTTP status codes. Those mappings are the contract
+ * every registering service depends on — a create that collides on type code
+ * must read as 400 rather than 500, and a missing id must read as 404 rather
+ * than 200-with-null — so they are asserted directly here.
+ *
+ * <p>
+ * Tested without a Spring context on purpose. Every method returns a
+ * {@code ResponseEntity} it builds itself, so a mocked service reaches all of
+ * them, including the error branches; a {@code @WebMvcTest} slice would add the
+ * {@code @EmitEvent} aspect and the shared-secret filter without covering any
+ * additional controller logic.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeController — HTTP status mapping")
+class EventTypeControllerTest {
+
+    @Mock
+    private EventTypeService eventTypeService;
+
+    @InjectMocks
+    private EventTypeController sut;
+
+    private static EventTypeResponse response(String typeCode) {
+        return new EventTypeResponse(
+                UUID.randomUUID(), typeCode, "a description", true, "1", 200_000L, 1_000_000L, 3_000_000L);
+    }
+
+    private static EventTypeRequest request() {
+        EventTypeRequest request = new EventTypeRequest();
+        request.setTypeCode("ORDER_CREATE");
+        request.setDescription("Create an order");
+        return request;
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        @DisplayName("getAllEventTypes returns 200 with the full list")
+        void getAll_returnsOk() {
+            when(eventTypeService.getAllEventTypes()).thenReturn(List.of(response("A_ONE"), response("A_TWO")));
+
+            ResponseEntity<List<EventTypeResponse>> result = sut.getAllEventTypes();
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(result.getBody()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("getAllEventTypes returns 200 with an empty list rather than 404")
+        void getAll_whenEmpty_stillReturnsOk() {
+            when(eventTypeService.getAllEventTypes()).thenReturn(List.of());
+
+            ResponseEntity<List<EventTypeResponse>> result = sut.getAllEventTypes();
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(result.getBody()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("getActiveEventTypes returns 200 from the active-only query")
+        void getActive_returnsOk() {
+            when(eventTypeService.getActiveEventTypes()).thenReturn(List.of(response("A_ONE")));
+
+            assertThat(sut.getActiveEventTypes().getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(eventTypeService, never()).getAllEventTypes();
+        }
+
+        @Test
+        @DisplayName("getEventTypeById returns 200 when the id resolves")
+        void getById_whenPresent_returnsOk() {
+            UUID id = UUID.randomUUID();
+            when(eventTypeService.getEventTypeById(id)).thenReturn(Optional.of(response("A_ONE")));
+
+            ResponseEntity<EventTypeResponse> result = sut.getEventTypeById(id);
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(result.getBody()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("getEventTypeById returns 404 when the id is unknown")
+        void getById_whenAbsent_returnsNotFound() {
+            UUID id = UUID.randomUUID();
+            when(eventTypeService.getEventTypeById(id)).thenReturn(Optional.empty());
+
+            assertThat(sut.getEventTypeById(id).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("getEventTypeByCode returns 200 when the code resolves")
+        void getByCode_whenPresent_returnsOk() {
+            when(eventTypeService.getEventTypeByCode("ORDER_CREATE")).thenReturn(Optional.of(response("ORDER_CREATE")));
+
+            ResponseEntity<EventTypeResponse> result = sut.getEventTypeByCode("ORDER_CREATE");
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(result.getBody()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("getEventTypeByCode returns 404 when the code is unknown")
+        void getByCode_whenAbsent_returnsNotFound() {
+            when(eventTypeService.getEventTypeByCode("NOPE")).thenReturn(Optional.empty());
+
+            assertThat(sut.getEventTypeByCode("NOPE").getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("getEventTypeByCode returns 400 when the code itself is malformed")
+        void getByCode_whenCodeInvalid_returnsBadRequest() {
+            when(eventTypeService.getEventTypeByCode(anyString()))
+                    .thenThrow(new IllegalArgumentException("typeCode must contain only uppercase letters"));
+
+            assertThat(sut.getEventTypeByCode("bad code!").getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("createEventType")
+    class Create {
+
+        @Test
+        @DisplayName("returns 201 with the created body")
+        void create_whenAccepted_returnsCreated() {
+            when(eventTypeService.createEventType(any())).thenReturn(Optional.of(response("ORDER_CREATE")));
+
+            ResponseEntity<EventTypeResponse> result = sut.createEventType(request());
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+            assertThat(result.getBody()).isNotNull();
+            assertThat(result.getBody().typeCode()).isEqualTo("ORDER_CREATE");
+        }
+
+        @Test
+        @DisplayName("returns 400, not 409, when the type code already exists")
+        void create_whenDuplicate_returnsBadRequest() {
+            // The service signals a collision with an empty Optional; the controller
+            // must not let that surface as a 200 with no body.
+            when(eventTypeService.createEventType(any())).thenReturn(Optional.empty());
+
+            ResponseEntity<EventTypeResponse> result = sut.createEventType(request());
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(result.getBody()).isNull();
+        }
+
+        @Test
+        @DisplayName("returns 400 when the service rejects the request as invalid")
+        void create_whenValidationFails_returnsBadRequest() {
+            when(eventTypeService.createEventType(any()))
+                    .thenThrow(new IllegalArgumentException("description is required"));
+
+            assertThat(sut.createEventType(request()).getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("upsertEventType")
+    class Upsert {
+
+        @Test
+        @DisplayName("returns 200 for both the create and update outcomes")
+        void upsert_whenAccepted_returnsOk() {
+            when(eventTypeService.upsertEventType(anyString(), any())).thenReturn(response("ORDER_CREATE"));
+
+            ResponseEntity<EventTypeResponse> result = sut.upsertEventType("ORDER_CREATE", request());
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(result.getBody()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("returns 400 when the path code contradicts the request code")
+        void upsert_whenCodesContradict_returnsBadRequest() {
+            when(eventTypeService.upsertEventType(anyString(), any()))
+                    .thenThrow(new IllegalArgumentException("Path typeCode must match request typeCode when provided"));
+
+            assertThat(sut.upsertEventType("ORDER_CREATE", request()).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateEventType")
+    class Update {
+
+        @Test
+        @DisplayName("returns 200 with the updated body")
+        void update_whenPresent_returnsOk() {
+            UUID id = UUID.randomUUID();
+            when(eventTypeService.updateEventType(any(), any())).thenReturn(Optional.of(response("ORDER_CREATE")));
+
+            ResponseEntity<EventTypeResponse> result = sut.updateEventType(id, request());
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(result.getBody()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("returns 404 when the id is unknown")
+        void update_whenAbsent_returnsNotFound() {
+            when(eventTypeService.updateEventType(any(), any())).thenReturn(Optional.empty());
+
+            assertThat(sut.updateEventType(UUID.randomUUID(), request()).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("returns 400 when the service rejects the request as invalid")
+        void update_whenValidationFails_returnsBadRequest() {
+            when(eventTypeService.updateEventType(any(), any()))
+                    .thenThrow(new IllegalArgumentException("p50Micros must be positive"));
+
+            assertThat(sut.updateEventType(UUID.randomUUID(), request()).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteEventType")
+    class Delete {
+
+        @Test
+        @DisplayName("returns 204 with no body when the row was deleted")
+        void delete_whenPresent_returnsNoContent() {
+            UUID id = UUID.randomUUID();
+            when(eventTypeService.deleteEventType(id)).thenReturn(true);
+
+            ResponseEntity<Void> result = sut.deleteEventType(id);
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+            assertThat(result.getBody()).isNull();
+        }
+
+        @Test
+        @DisplayName("returns 404 when the id is unknown")
+        void delete_whenAbsent_returnsNotFound() {
+            when(eventTypeService.deleteEventType(any())).thenReturn(false);
+
+            assertThat(sut.deleteEventType(UUID.randomUUID()).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("returns 400 when the id is rejected as invalid")
+        void delete_whenValidationFails_returnsBadRequest() {
+            when(eventTypeService.deleteEventType(any())).thenThrow(new IllegalArgumentException("id is required"));
+
+            assertThat(sut.deleteEventType(UUID.randomUUID()).getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    /**
+     * The controller logs caller-supplied type codes, so it masks them first. The
+     * masking is a log-injection control, not cosmetics: a type code containing a
+     * newline could otherwise forge a whole log line.
+     */
+    @Nested
+    @DisplayName("log masking")
+    class LogMasking {
+
+        private String mask(Object value) {
+            return (String) ReflectionTestUtils.invokeMethod(sut, "maskForLog", value);
+        }
+
+        @Test
+        @DisplayName("renders null as the literal \"null\"")
+        void mask_null() {
+            assertThat(mask(null)).isEqualTo("null");
+        }
+
+        @ParameterizedTest(name = "\"{0}\" is fully masked (length <= 4)")
+        @ValueSource(strings = {"a", "ab", "abc", "abcd"})
+        @DisplayName("fully masks short values, which would otherwise be mostly readable")
+        void mask_shortValues(String value) {
+            assertThat(mask(value)).isEqualTo("****");
+        }
+
+        @ParameterizedTest(name = "\"{0}\" masks to \"{1}\"")
+        @CsvSource({"ORDER_CREATE, OR***TE", "abcde, ab***de"})
+        @DisplayName("keeps two leading and two trailing characters for longer values")
+        void mask_longValues(String value, String expected) {
+            assertThat(mask(value)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest(name = "no control character survives masking of {1}")
+        @CsvSource({
+            "'AA\rBBBB', a carriage return",
+            "'AA\nBBBB', a line feed",
+            "'AA\tBBBB', a tab",
+        })
+        @DisplayName("never emits CR, LF, or tab, so a crafted type code cannot forge a log line")
+        void mask_neverEmitsControlCharacters(String value, String description) {
+            assertThat(mask(value)).doesNotContain("\r", "\n", "\t");
+        }
+
+        @ParameterizedTest(name = "a control character at {1} is replaced with an underscore")
+        @CsvSource({
+            "'\rABCDE', the start,  _A***DE",
+            "'ABCDE\r', the end,    AB***E_",
+        })
+        @DisplayName("replaces a control character that lands in the retained prefix or suffix")
+        void mask_replacesControlCharacterInRetainedPositions(String value, String position, String expected) {
+            // Masking keeps only the first two and last two characters, so a control
+            // character in the middle is dropped by truncation regardless. The
+            // replacement is what protects the positions that do survive.
+            assertThat(mask(value)).isEqualTo(expected);
+        }
+    }
+}

--- a/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/dto/EventTypeMapperTest.java
+++ b/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/dto/EventTypeMapperTest.java
@@ -1,0 +1,194 @@
+package com.positivity.poseventreceiver.internal.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.poseventreceiver.internal.entity.EventType;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link EventTypeMapper}.
+ *
+ * <p>
+ * {@code applyRequest} is a partial update: {@code description} and
+ * {@code active} are always written, but {@code apiVersion} and the three
+ * latency thresholds are only written when the request supplies them. That
+ * asymmetry is the whole point of the mapper and the easiest thing to break —
+ * dropping the null guards would silently reset every threshold to the entity
+ * default whenever a caller omitted them, re-baselining the SLO of an event that
+ * nobody intended to change.
+ */
+@DisplayName("EventTypeMapper — entity/DTO mapping")
+class EventTypeMapperTest {
+
+    private static EventTypeRequest fullRequest() {
+        EventTypeRequest request = new EventTypeRequest();
+        request.setTypeCode("ORDER_CREATE");
+        request.setDescription("Create an order");
+        request.setActive(true);
+        request.setApiVersion("2");
+        request.setP50Micros(11L);
+        request.setP95Micros(22L);
+        request.setP99Micros(33L);
+        return request;
+    }
+
+    private static EventTypeRequest sparseRequest() {
+        EventTypeRequest request = new EventTypeRequest();
+        request.setDescription("Only a description");
+        request.setActive(false);
+        request.setApiVersion(null);
+        request.setP50Micros(null);
+        request.setP95Micros(null);
+        request.setP99Micros(null);
+        return request;
+    }
+
+    @Nested
+    @DisplayName("toResponse")
+    class ToResponse {
+
+        @Test
+        @DisplayName("copies every field onto the response")
+        void toResponse_copiesAllFields() {
+            EventType entity = new EventType("ORDER_CREATE", "Create an order", "2", 11L, 22L, 33L);
+            UUID id = UUID.randomUUID();
+            entity.setId(id);
+            entity.setActive(true);
+
+            EventTypeResponse response = EventTypeMapper.toResponse(entity);
+
+            assertThat(response.id()).isEqualTo(id);
+            assertThat(response.typeCode()).isEqualTo("ORDER_CREATE");
+            assertThat(response.description()).isEqualTo("Create an order");
+            assertThat(response.active()).isTrue();
+            assertThat(response.apiVersion()).isEqualTo("2");
+            assertThat(response.p50Micros()).isEqualTo(11L);
+            assertThat(response.p95Micros()).isEqualTo(22L);
+            assertThat(response.p99Micros()).isEqualTo(33L);
+        }
+
+        @Test
+        @DisplayName("carries the inactive flag through rather than defaulting it")
+        void toResponse_preservesInactiveFlag() {
+            EventType entity = new EventType("ORDER_CREATE", "Create an order");
+            entity.setActive(false);
+
+            assertThat(EventTypeMapper.toResponse(entity).active()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("toNewEntity")
+    class ToNewEntity {
+
+        @Test
+        @DisplayName("uses the supplied type code, not the one on the request")
+        void toNewEntity_usesSuppliedTypeCode() {
+            EventTypeRequest request = fullRequest();
+            request.setTypeCode("SOMETHING_ELSE");
+
+            // The caller passes the normalized code separately; the request's own
+            // typeCode must not win, or normalization would be bypassed here.
+            EventType entity = EventTypeMapper.toNewEntity("ORDER_CREATE", request);
+
+            assertThat(entity.getTypeCode()).isEqualTo("ORDER_CREATE");
+        }
+
+        @Test
+        @DisplayName("applies every supplied field to the new entity")
+        void toNewEntity_appliesSuppliedFields() {
+            EventType entity = EventTypeMapper.toNewEntity("ORDER_CREATE", fullRequest());
+
+            assertThat(entity.getDescription()).isEqualTo("Create an order");
+            assertThat(entity.isActive()).isTrue();
+            assertThat(entity.getApiVersion()).isEqualTo("2");
+            assertThat(entity.getP50Micros()).isEqualTo(11L);
+            assertThat(entity.getP95Micros()).isEqualTo(22L);
+            assertThat(entity.getP99Micros()).isEqualTo(33L);
+        }
+
+        @Test
+        @DisplayName("leaves entity defaults in place for fields the request omits")
+        void toNewEntity_keepsDefaultsForOmittedFields() {
+            EventType entity = EventTypeMapper.toNewEntity("ORDER_CREATE", sparseRequest());
+
+            assertThat(entity.getApiVersion()).isEqualTo(EventType.DEFAULT_API_VERSION);
+            assertThat(entity.getP50Micros()).isEqualTo(EventType.DEFAULT_THRESHOLD_MICROS);
+            assertThat(entity.getP95Micros()).isEqualTo(EventType.DEFAULT_THRESHOLD_MICROS);
+            assertThat(entity.getP99Micros()).isEqualTo(EventType.DEFAULT_THRESHOLD_MICROS);
+        }
+    }
+
+    @Nested
+    @DisplayName("applyRequest")
+    class ApplyRequest {
+
+        @Test
+        @DisplayName("overwrites description and active unconditionally")
+        void applyRequest_alwaysWritesDescriptionAndActive() {
+            EventType existing = new EventType("ORDER_CREATE", "stale description");
+            existing.setActive(true);
+
+            EventTypeMapper.applyRequest(existing, sparseRequest());
+
+            assertThat(existing.getDescription()).isEqualTo("Only a description");
+            assertThat(existing.isActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("leaves the existing apiVersion and thresholds untouched when the request omits them")
+        void applyRequest_preservesExistingValuesForOmittedFields() {
+            EventType existing = new EventType("ORDER_CREATE", "stale description", "7", 111L, 222L, 333L);
+
+            EventTypeMapper.applyRequest(existing, sparseRequest());
+
+            // A partial update must not silently reset an event's SLO.
+            assertThat(existing.getApiVersion()).isEqualTo("7");
+            assertThat(existing.getP50Micros()).isEqualTo(111L);
+            assertThat(existing.getP95Micros()).isEqualTo(222L);
+            assertThat(existing.getP99Micros()).isEqualTo(333L);
+        }
+
+        @Test
+        @DisplayName("overwrites apiVersion and thresholds when the request supplies them")
+        void applyRequest_writesSuppliedValues() {
+            EventType existing = new EventType("ORDER_CREATE", "stale description", "7", 111L, 222L, 333L);
+
+            EventTypeMapper.applyRequest(existing, fullRequest());
+
+            assertThat(existing.getApiVersion()).isEqualTo("2");
+            assertThat(existing.getP50Micros()).isEqualTo(11L);
+            assertThat(existing.getP95Micros()).isEqualTo(22L);
+            assertThat(existing.getP99Micros()).isEqualTo(33L);
+        }
+
+        @Test
+        @DisplayName("never rewrites the type code — the natural key is immutable through an update")
+        void applyRequest_neverRewritesTypeCode() {
+            EventType existing = new EventType("ORDER_CREATE", "stale description");
+            EventTypeRequest renaming = fullRequest();
+            renaming.setTypeCode("SOMETHING_ELSE");
+
+            EventTypeMapper.applyRequest(existing, renaming);
+
+            assertThat(existing.getTypeCode()).isEqualTo("ORDER_CREATE");
+        }
+
+        @Test
+        @DisplayName("applies thresholds independently — supplying one does not disturb the others")
+        void applyRequest_appliesThresholdsIndependently() {
+            EventType existing = new EventType("ORDER_CREATE", "stale description", "7", 111L, 222L, 333L);
+            EventTypeRequest onlyP95 = sparseRequest();
+            onlyP95.setP95Micros(999L);
+
+            EventTypeMapper.applyRequest(existing, onlyP95);
+
+            assertThat(existing.getP50Micros()).isEqualTo(111L);
+            assertThat(existing.getP95Micros()).isEqualTo(999L);
+            assertThat(existing.getP99Micros()).isEqualTo(333L);
+        }
+    }
+}

--- a/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/service/EmitEventServiceImplTest.java
+++ b/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/service/EmitEventServiceImplTest.java
@@ -1,0 +1,234 @@
+package com.positivity.poseventreceiver.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.poseventreceiver.dao.EventDao;
+import com.positivity.poseventreceiver.internal.dto.EmitEventRequest;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link EmitEventServiceImpl}.
+ *
+ * <p>
+ * This is the ingestion path: every {@code @EmitEvent}-annotated endpoint across
+ * the platform ends up here. Two properties matter.
+ *
+ * <p>
+ * <b>Preregistration is enforced, and rejection is not an exception.</b> An event
+ * whose id was never registered is dropped and reported as {@code false} rather
+ * than throwing, so an unregistered id degrades to lost telemetry instead of
+ * failing the caller's business operation. That distinction is easy to erase by
+ * "improving" the method to throw.
+ *
+ * <p>
+ * <b>Validation runs before the preregistration lookup.</b> A malformed id must
+ * be rejected outright rather than probed against the database.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EmitEventServiceImpl — event ingestion and validation")
+class EmitEventServiceImplTest {
+
+    @Mock
+    private EventDao eventDao;
+
+    @InjectMocks
+    private EmitEventServiceImpl sut;
+
+    private static EmitEventRequest request() {
+        return new EmitEventRequest(
+                "ORDER_ORDER_CREATE", "1", 1_730_809_200_000L, 42L, Instant.parse("2026-03-05T21:15:00Z"));
+    }
+
+    private static EmitEventRequest requestWithId(String id) {
+        return new EmitEventRequest(id, "1", 1L, 0L, Instant.EPOCH);
+    }
+
+    @Nested
+    @DisplayName("receiveEvent")
+    class ReceiveEvent {
+
+        @Test
+        @DisplayName("stores the event and reports true when the id is preregistered")
+        void receiveEvent_whenPreregistered_storesAndReportsTrue() {
+            when(eventDao.isPreregistered("ORDER_ORDER_CREATE")).thenReturn(true);
+
+            assertThat(sut.receiveEvent(request())).isTrue();
+
+            verify(eventDao).saveEmittedEvent(request());
+        }
+
+        @Test
+        @DisplayName("drops the event and reports false when the id is not preregistered")
+        void receiveEvent_whenNotPreregistered_dropsAndReportsFalse() {
+            when(eventDao.isPreregistered("ORDER_ORDER_CREATE")).thenReturn(false);
+
+            // Reported, not thrown: an unregistered id must degrade to lost
+            // telemetry rather than failing the caller's business operation.
+            assertThat(sut.receiveEvent(request())).isFalse();
+
+            verify(eventDao, never()).saveEmittedEvent(any(EmitEventRequest.class));
+        }
+
+        @Test
+        @DisplayName("accepts an elapsedMs of zero — an instantaneous operation is legitimate")
+        void receiveEvent_withZeroElapsed_isAccepted() {
+            when(eventDao.isPreregistered(anyString())).thenReturn(true);
+
+            EmitEventRequest instantaneous = new EmitEventRequest("ORDER_ORDER_CREATE", "1", 1L, 0L, Instant.EPOCH);
+
+            assertThat(sut.receiveEvent(instantaneous)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("onEventEmitted")
+    class OnEventEmitted {
+
+        @Test
+        @DisplayName("delegates to receiveEvent and stores a preregistered event")
+        void onEventEmitted_storesPreregisteredEvent() {
+            when(eventDao.isPreregistered("ORDER_ORDER_CREATE")).thenReturn(true);
+
+            sut.onEventEmitted(request());
+
+            verify(eventDao).saveEmittedEvent(request());
+        }
+
+        @Test
+        @DisplayName("swallows the false outcome for an unregistered id — it returns void")
+        void onEventEmitted_whenNotPreregistered_storesNothing() {
+            when(eventDao.isPreregistered(anyString())).thenReturn(false);
+
+            sut.onEventEmitted(request());
+
+            verify(eventDao, never()).saveEmittedEvent(any(EmitEventRequest.class));
+        }
+
+        @Test
+        @DisplayName("propagates a validation failure rather than silently dropping a malformed event")
+        void onEventEmitted_whenInvalid_throws() {
+            assertThatIllegalArgumentException().isThrownBy(() -> sut.onEventEmitted(requestWithId("lower_case")));
+        }
+    }
+
+    @Nested
+    @DisplayName("validation")
+    class Validation {
+
+        @Test
+        @DisplayName("rejects a null request")
+        void reject_nullRequest() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> sut.receiveEvent(null))
+                    .withMessageContaining("cannot be null");
+        }
+
+        @ParameterizedTest(name = "id [{0}] is rejected as missing")
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        @DisplayName("rejects a missing id")
+        void reject_missingId(String id) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> sut.receiveEvent(requestWithId(id)))
+                    .withMessageContaining("id is required");
+        }
+
+        @ParameterizedTest(name = "id \"{0}\" is rejected as malformed")
+        @ValueSource(strings = {"lower_case", "ORDER-CREATE", "ORDER CREATE", "ORDER.CREATE", "ORDÉR"})
+        @DisplayName("rejects an id that is not uppercase letters, digits, and underscores")
+        void reject_malformedId(String id) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> sut.receiveEvent(requestWithId(id)))
+                    .withMessageContaining("uppercase letters");
+        }
+
+        @ParameterizedTest(name = "id \"{0}\" is accepted")
+        @ValueSource(strings = {"ORDER_CREATE", "ORDER2", "A", "A_1_B"})
+        @DisplayName("accepts a well-formed id")
+        void accept_wellFormedId(String id) {
+            when(eventDao.isPreregistered(id)).thenReturn(true);
+
+            assertThat(sut.receiveEvent(requestWithId(id))).isTrue();
+        }
+
+        @Test
+        @DisplayName("validates before touching the database — a malformed id is never looked up")
+        void validation_runsBeforePreregistrationLookup() {
+            assertThatIllegalArgumentException().isThrownBy(() -> sut.receiveEvent(requestWithId("bad id")));
+
+            verify(eventDao, never()).isPreregistered(anyString());
+        }
+
+        @ParameterizedTest(name = "apiVersion [{0}] is rejected")
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        @DisplayName("rejects a missing apiVersion")
+        void reject_missingApiVersion(String apiVersion) {
+            EmitEventRequest invalid = new EmitEventRequest("ORDER_CREATE", apiVersion, 1L, 0L, Instant.EPOCH);
+
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> sut.receiveEvent(invalid))
+                    .withMessageContaining("apiVersion is required");
+        }
+
+        @ParameterizedTest(name = "apiVersion \"{0}\" is rejected as non-numeric")
+        @ValueSource(strings = {"v1", "1.0", "one", "-1"})
+        @DisplayName("rejects a non-numeric apiVersion")
+        void reject_nonNumericApiVersion(String apiVersion) {
+            EmitEventRequest invalid = new EmitEventRequest("ORDER_CREATE", apiVersion, 1L, 0L, Instant.EPOCH);
+
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> sut.receiveEvent(invalid))
+                    .withMessageContaining("apiVersion must be numeric");
+        }
+
+        @ParameterizedTest(name = "timestamp {0} is rejected: {1}")
+        @CsvSource({"0, zero is not a valid epoch millisecond", "-1, negative epoch millisecond"})
+        @DisplayName("rejects a non-positive timestamp")
+        void reject_nonPositiveTimestamp(long timestamp, String why) {
+            EmitEventRequest invalid = new EmitEventRequest("ORDER_CREATE", "1", timestamp, 0L, Instant.EPOCH);
+
+            assertThatIllegalArgumentException()
+                    .as(why)
+                    .isThrownBy(() -> sut.receiveEvent(invalid))
+                    .withMessageContaining("timestamp must be positive");
+        }
+
+        @Test
+        @DisplayName("rejects a negative elapsedMs")
+        void reject_negativeElapsed() {
+            EmitEventRequest invalid = new EmitEventRequest("ORDER_CREATE", "1", 1L, -1L, Instant.EPOCH);
+
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> sut.receiveEvent(invalid))
+                    .withMessageContaining("elapsedMs must be zero or positive");
+        }
+
+        @Test
+        @DisplayName("rejects a missing publishedAt")
+        void reject_missingPublishedAt() {
+            EmitEventRequest invalid = new EmitEventRequest("ORDER_CREATE", "1", 1L, 0L, null);
+
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> sut.receiveEvent(invalid))
+                    .withMessageContaining("publishedAt is required");
+        }
+    }
+}

--- a/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/service/EventTypeServiceImplTest.java
+++ b/pos-event-receiver/src/test/java/com/positivity/poseventreceiver/internal/service/EventTypeServiceImplTest.java
@@ -1,0 +1,411 @@
+package com.positivity.poseventreceiver.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.poseventreceiver.dao.EventDao;
+import com.positivity.poseventreceiver.internal.dto.EventTypeRequest;
+import com.positivity.poseventreceiver.internal.dto.EventTypeResponse;
+import com.positivity.poseventreceiver.internal.entity.EventType;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link EventTypeServiceImpl}.
+ *
+ * <p>
+ * This is the write path behind {@code pos-event-receiver}'s event-type API,
+ * which every other service calls at startup to register the events it emits.
+ * Two things carry the weight here:
+ *
+ * <ul>
+ * <li><b>Type-code normalization.</b> Codes are trimmed and upper-cased before
+ * any lookup or write. Because the code is the natural key used for upsert, a
+ * normalization gap would let {@code order_create} and {@code ORDER_CREATE}
+ * become two rows, and a registering service would then silently fail to update
+ * the row it thought it owned.</li>
+ * <li><b>Threshold validation.</b> The p50/p95/p99 values become the latency
+ * SLO for the event, so the service rejects non-positive and out-of-order
+ * triples rather than storing an SLO that can never be met or never be
+ * breached.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeServiceImpl — event-type lifecycle and validation")
+class EventTypeServiceImplTest {
+
+    @Mock
+    private EventDao eventDao;
+
+    @InjectMocks
+    private EventTypeServiceImpl sut;
+
+    @Captor
+    private ArgumentCaptor<EventType> savedEventType;
+
+    private static EventTypeRequest request() {
+        EventTypeRequest request = new EventTypeRequest();
+        request.setTypeCode("ORDER_CREATE");
+        request.setDescription("Create an order");
+        request.setActive(true);
+        request.setApiVersion("1");
+        request.setP50Micros(200_000L);
+        request.setP95Micros(1_000_000L);
+        request.setP99Micros(3_000_000L);
+        return request;
+    }
+
+    private static EventType entity(String typeCode) {
+        EventType eventType = new EventType(typeCode, "existing description");
+        eventType.setId(UUID.randomUUID());
+        return eventType;
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        @DisplayName("getAllEventTypes maps every row to a response")
+        void getAllEventTypes_mapsAllRows() {
+            when(eventDao.getAllEventTypes()).thenReturn(List.of(entity("ORDER_CREATE"), entity("ORDER_CANCEL")));
+
+            assertThat(sut.getAllEventTypes())
+                    .extracting(EventTypeResponse::typeCode)
+                    .containsExactly("ORDER_CREATE", "ORDER_CANCEL");
+        }
+
+        @Test
+        @DisplayName("getActiveEventTypes delegates to the active-only query")
+        void getActiveEventTypes_usesActiveQuery() {
+            when(eventDao.getActiveEventTypes()).thenReturn(List.of(entity("ORDER_CREATE")));
+
+            assertThat(sut.getActiveEventTypes()).hasSize(1);
+            verify(eventDao, never()).getAllEventTypes();
+        }
+
+        @Test
+        @DisplayName("getEventTypeById returns empty when the id is unknown")
+        void getEventTypeById_whenAbsent_returnsEmpty() {
+            UUID id = UUID.randomUUID();
+            when(eventDao.getEventType(id)).thenReturn(Optional.empty());
+
+            assertThat(sut.getEventTypeById(id)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("getEventTypeById maps the row when present")
+        void getEventTypeById_whenPresent_mapsRow() {
+            EventType existing = entity("ORDER_CREATE");
+            when(eventDao.getEventType(existing.getId())).thenReturn(Optional.of(existing));
+
+            assertThat(sut.getEventTypeById(existing.getId()))
+                    .get()
+                    .extracting(EventTypeResponse::typeCode)
+                    .isEqualTo("ORDER_CREATE");
+        }
+
+        @ParameterizedTest(name = "getEventTypeByCode normalizes \"{0}\" to ORDER_CREATE")
+        @ValueSource(strings = {"ORDER_CREATE", "order_create", "  ORDER_CREATE  ", "Order_Create"})
+        @DisplayName("getEventTypeByCode trims and upper-cases before lookup")
+        void getEventTypeByCode_normalizesBeforeLookup(String supplied) {
+            when(eventDao.getEventTypeByCode("ORDER_CREATE")).thenReturn(Optional.of(entity("ORDER_CREATE")));
+
+            assertThat(sut.getEventTypeByCode(supplied)).isPresent();
+            verify(eventDao).getEventTypeByCode("ORDER_CREATE");
+        }
+    }
+
+    @Nested
+    @DisplayName("createEventType")
+    class Create {
+
+        @Test
+        @DisplayName("persists a new row and returns its response")
+        void create_whenCodeUnused_persists() {
+            when(eventDao.getEventTypeByCode("ORDER_CREATE")).thenReturn(Optional.empty());
+            when(eventDao.saveEventType(any(EventType.class))).thenAnswer(i -> i.getArgument(0));
+
+            assertThat(sut.createEventType(request()))
+                    .get()
+                    .extracting(EventTypeResponse::typeCode)
+                    .isEqualTo("ORDER_CREATE");
+
+            verify(eventDao).saveEventType(savedEventType.capture());
+            assertThat(savedEventType.getValue().getDescription()).isEqualTo("Create an order");
+            assertThat(savedEventType.getValue().getP50Micros()).isEqualTo(200_000L);
+        }
+
+        @Test
+        @DisplayName("returns empty and writes nothing when the type code already exists")
+        void create_whenCodeTaken_returnsEmptyWithoutWriting() {
+            when(eventDao.getEventTypeByCode("ORDER_CREATE")).thenReturn(Optional.of(entity("ORDER_CREATE")));
+
+            assertThat(sut.createEventType(request())).isEmpty();
+            verify(eventDao, never()).saveEventType(any());
+        }
+
+        @Test
+        @DisplayName("normalizes the request type code before the uniqueness check")
+        void create_normalizesCodeBeforeUniquenessCheck() {
+            EventTypeRequest lowercase = request();
+            lowercase.setTypeCode("order_create");
+            when(eventDao.getEventTypeByCode("ORDER_CREATE")).thenReturn(Optional.of(entity("ORDER_CREATE")));
+
+            // Without normalization this would look up "order_create", miss, and
+            // create a duplicate row for an event that is already registered.
+            assertThat(sut.createEventType(lowercase)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("upsertEventType")
+    class Upsert {
+
+        @Test
+        @DisplayName("updates the existing row in place when the code is already registered")
+        void upsert_whenPresent_updatesInPlace() {
+            EventType existing = entity("ORDER_CREATE");
+            when(eventDao.getEventTypeByCode("ORDER_CREATE")).thenReturn(Optional.of(existing));
+            when(eventDao.saveEventType(any(EventType.class))).thenAnswer(i -> i.getArgument(0));
+
+            EventTypeResponse response = sut.upsertEventType("ORDER_CREATE", request());
+
+            assertThat(response.description()).isEqualTo("Create an order");
+            verify(eventDao).saveEventType(savedEventType.capture());
+            assertThat(savedEventType.getValue()).isSameAs(existing);
+        }
+
+        @Test
+        @DisplayName("creates the row when the code is not yet registered")
+        void upsert_whenAbsent_creates() {
+            when(eventDao.getEventTypeByCode("ORDER_CREATE")).thenReturn(Optional.empty());
+            when(eventDao.saveEventType(any(EventType.class))).thenAnswer(i -> i.getArgument(0));
+
+            assertThat(sut.upsertEventType("ORDER_CREATE", request()).typeCode())
+                    .isEqualTo("ORDER_CREATE");
+        }
+
+        @Test
+        @DisplayName("accepts a request whose type code matches the path once both are normalized")
+        void upsert_whenRequestCodeMatchesAfterNormalization_succeeds() {
+            EventTypeRequest lowercase = request();
+            lowercase.setTypeCode("order_create");
+            when(eventDao.getEventTypeByCode("ORDER_CREATE")).thenReturn(Optional.empty());
+            when(eventDao.saveEventType(any(EventType.class))).thenAnswer(i -> i.getArgument(0));
+
+            assertThat(sut.upsertEventType("ORDER_CREATE", lowercase).typeCode())
+                    .isEqualTo("ORDER_CREATE");
+        }
+
+        @Test
+        @DisplayName("rejects a request whose type code contradicts the path")
+        void upsert_whenRequestCodeContradictsPath_throws() {
+            EventTypeRequest mismatched = request();
+            mismatched.setTypeCode("ORDER_CANCEL");
+
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> sut.upsertEventType("ORDER_CREATE", mismatched))
+                    .withMessageContaining("must match");
+            verify(eventDao, never()).saveEventType(any());
+        }
+
+        @ParameterizedTest(name = "omitted request type code ({0}) falls back to the path code")
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        @DisplayName("treats an absent request type code as agreement with the path")
+        void upsert_whenRequestCodeAbsent_usesPathCode(String supplied) {
+            EventTypeRequest withoutCode = request();
+            withoutCode.setTypeCode(supplied);
+            when(eventDao.getEventTypeByCode("ORDER_CREATE")).thenReturn(Optional.empty());
+            when(eventDao.saveEventType(any(EventType.class))).thenAnswer(i -> i.getArgument(0));
+
+            assertThat(sut.upsertEventType("ORDER_CREATE", withoutCode).typeCode())
+                    .isEqualTo("ORDER_CREATE");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateEventType and deleteEventType")
+    class UpdateAndDelete {
+
+        @Test
+        @DisplayName("updateEventType returns empty and writes nothing when the id is unknown")
+        void update_whenAbsent_returnsEmpty() {
+            UUID id = UUID.randomUUID();
+            when(eventDao.getEventType(id)).thenReturn(Optional.empty());
+
+            assertThat(sut.updateEventType(id, request())).isEmpty();
+            verify(eventDao, never()).saveEventType(any());
+        }
+
+        @Test
+        @DisplayName("updateEventType applies the request to the existing row")
+        void update_whenPresent_appliesRequest() {
+            EventType existing = entity("ORDER_CREATE");
+            when(eventDao.getEventType(existing.getId())).thenReturn(Optional.of(existing));
+            when(eventDao.saveEventType(any(EventType.class))).thenAnswer(i -> i.getArgument(0));
+
+            assertThat(sut.updateEventType(existing.getId(), request()))
+                    .get()
+                    .extracting(EventTypeResponse::description)
+                    .isEqualTo("Create an order");
+            assertThat(existing.getP99Micros()).isEqualTo(3_000_000L);
+        }
+
+        @Test
+        @DisplayName("deleteEventType reports false and deletes nothing when the id is unknown")
+        void delete_whenAbsent_returnsFalse() {
+            UUID id = UUID.randomUUID();
+            when(eventDao.eventTypeExists(id)).thenReturn(false);
+
+            assertThat(sut.deleteEventType(id)).isFalse();
+            verify(eventDao, never()).deleteEventType(any());
+        }
+
+        @Test
+        @DisplayName("deleteEventType deletes and reports true when the id exists")
+        void delete_whenPresent_deletes() {
+            UUID id = UUID.randomUUID();
+            when(eventDao.eventTypeExists(id)).thenReturn(true);
+
+            assertThat(sut.deleteEventType(id)).isTrue();
+            verify(eventDao).deleteEventType(id);
+        }
+    }
+
+    @Nested
+    @DisplayName("validation")
+    class Validation {
+
+        @ParameterizedTest(name = "type code \"{0}\" is rejected")
+        @NullAndEmptySource
+        @ValueSource(strings = {"   ", "order-create", "ORDER CREATE", "ORDER.CREATE", "ORDÉR"})
+        @DisplayName("rejects a missing or non-conforming type code on create")
+        void create_withInvalidTypeCode_throws(String typeCode) {
+            EventTypeRequest invalid = request();
+            invalid.setTypeCode(typeCode);
+
+            assertThatIllegalArgumentException().isThrownBy(() -> sut.createEventType(invalid));
+            verify(eventDao, never()).saveEventType(any());
+        }
+
+        @ParameterizedTest(name = "description \"{0}\" is rejected")
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        @DisplayName("rejects a missing description")
+        void create_withBlankDescription_throws(String description) {
+            EventTypeRequest invalid = request();
+            invalid.setDescription(description);
+
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> sut.createEventType(invalid))
+                    .withMessageContaining("description");
+        }
+
+        @ParameterizedTest(name = "apiVersion \"{0}\" is rejected")
+        @ValueSource(strings = {"", "   ", "v1", "1.0", "one"})
+        @DisplayName("rejects a non-numeric apiVersion")
+        void create_withNonNumericApiVersion_throws(String apiVersion) {
+            EventTypeRequest invalid = request();
+            invalid.setApiVersion(apiVersion);
+
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> sut.createEventType(invalid))
+                    .withMessageContaining("apiVersion");
+        }
+
+        @Test
+        @DisplayName("accepts a null apiVersion — the entity default applies")
+        void create_withNullApiVersion_isAccepted() {
+            EventTypeRequest withoutVersion = request();
+            withoutVersion.setApiVersion(null);
+            when(eventDao.getEventTypeByCode(anyString())).thenReturn(Optional.empty());
+            when(eventDao.saveEventType(any(EventType.class))).thenAnswer(i -> i.getArgument(0));
+
+            assertThat(sut.createEventType(withoutVersion)).isPresent();
+        }
+
+        @ParameterizedTest(name = "thresholds {0}/{1}/{2} are rejected: {3}")
+        @CsvSource({
+            "0,      1000000, 3000000, p50 must be positive",
+            "-1,     1000000, 3000000, negative p50",
+            "200000, 0,       3000000, p95 must be positive",
+            "200000, 1000000, 0,       p99 must be positive",
+            "2000000, 1000000, 3000000, p50 above p95",
+            "200000, 4000000, 3000000, p95 above p99",
+            "4000000, 4000000, 3000000, p50 above p99",
+        })
+        @DisplayName("rejects non-positive or out-of-order latency thresholds")
+        void create_withInvalidThresholds_throws(long p50, long p95, long p99, String why) {
+            EventTypeRequest invalid = request();
+            invalid.setP50Micros(p50);
+            invalid.setP95Micros(p95);
+            invalid.setP99Micros(p99);
+
+            assertThatIllegalArgumentException().as(why).isThrownBy(() -> sut.createEventType(invalid));
+            verify(eventDao, never()).saveEventType(any());
+        }
+
+        @Test
+        @DisplayName("accepts equal thresholds — the bound is inclusive")
+        void create_withEqualThresholds_isAccepted() {
+            EventTypeRequest flat = request();
+            flat.setP50Micros(1_000L);
+            flat.setP95Micros(1_000L);
+            flat.setP99Micros(1_000L);
+            when(eventDao.getEventTypeByCode(anyString())).thenReturn(Optional.empty());
+            when(eventDao.saveEventType(any(EventType.class))).thenAnswer(i -> i.getArgument(0));
+
+            assertThat(sut.createEventType(flat)).isPresent();
+        }
+
+        @Test
+        @DisplayName("accepts null thresholds — the entity defaults apply")
+        void create_withNullThresholds_isAccepted() {
+            EventTypeRequest withoutThresholds = request();
+            withoutThresholds.setP50Micros(null);
+            withoutThresholds.setP95Micros(null);
+            withoutThresholds.setP99Micros(null);
+            when(eventDao.getEventTypeByCode(anyString())).thenReturn(Optional.empty());
+            when(eventDao.saveEventType(any(EventType.class))).thenAnswer(i -> i.getArgument(0));
+
+            assertThat(sut.createEventType(withoutThresholds)).isPresent();
+        }
+
+        @Test
+        @DisplayName("rejects a null request")
+        void create_withNullRequest_throws() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> sut.createEventType(null))
+                    .withMessageContaining("request is required");
+        }
+
+        @Test
+        @DisplayName("rejects a null id")
+        void getById_withNullId_throws() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> sut.getEventTypeById(null))
+                    .withMessageContaining("id is required");
+        }
+    }
+}

--- a/pos-events/src/test/java/com/positivity/events/EventTypeInitializerSupportTest.java
+++ b/pos-events/src/test/java/com/positivity/events/EventTypeInitializerSupportTest.java
@@ -1,0 +1,112 @@
+package com.positivity.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link EventTypeInitializerSupport}, the shared loop every module's
+ * {@code EventTypeInitializer} delegates to at startup.
+ *
+ * <p>
+ * Its contract is deliberately fault-tolerant: a registration that throws is
+ * logged and counted as a failure, and the loop continues. That is what keeps a
+ * down {@code pos-event-receiver} from preventing ~20 services from starting, so
+ * it is worth pinning down rather than inferring from each module's initializer.
+ */
+@DisplayName("EventTypeInitializerSupport — fault-tolerant registration loop")
+class EventTypeInitializerSupportTest {
+
+    private final EventTypeInitializerSupport sut = new EventTypeInitializerSupport("pos-test");
+
+    private static EventTypeRegistration registration(String typeCode) {
+        return EventTypeRegistration.write(typeCode, "description for " + typeCode)
+                .build();
+    }
+
+    @Test
+    @DisplayName("invokes the registration function once per event type, in iteration order")
+    void registerEventTypes_invokesFunctionForEveryType() {
+        List<EventTypeRegistration> types =
+                List.of(registration("A_ONE"), registration("A_TWO"), registration("A_THREE"));
+        List<String> seen = new ArrayList<>();
+
+        int registered = sut.registerEventTypes(types, r -> seen.add(r.getTypeCode()));
+
+        assertThat(seen).containsExactly("A_ONE", "A_TWO", "A_THREE");
+        assertThat(registered).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("returns the success count, not the input size, when some registrations fail")
+    void registerEventTypes_returnsSuccessCount() {
+        List<EventTypeRegistration> types =
+                List.of(registration("B_ONE"), registration("B_TWO"), registration("B_THREE"));
+
+        int registered = sut.registerEventTypes(types, r -> {
+            if (r.getTypeCode().equals("B_TWO")) {
+                throw new IllegalStateException("receiver rejected " + r.getTypeCode());
+            }
+        });
+
+        assertThat(registered).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("keeps going after a failure — a down receiver must not abort startup")
+    void registerEventTypes_continuesAfterFailure() {
+        List<EventTypeRegistration> types =
+                List.of(registration("C_ONE"), registration("C_TWO"), registration("C_THREE"));
+        List<String> attempted = new ArrayList<>();
+
+        assertThatNoException()
+                .isThrownBy(() -> sut.registerEventTypes(types, r -> {
+                    attempted.add(r.getTypeCode());
+                    throw new RuntimeException("connection refused");
+                }));
+
+        assertThat(attempted).containsExactly("C_ONE", "C_TWO", "C_THREE");
+    }
+
+    @Test
+    @DisplayName("tolerates a failure whose exception carries no message")
+    void registerEventTypes_toleratesNullExceptionMessage() {
+        List<EventTypeRegistration> types = List.of(registration("D_ONE"));
+
+        int registered = sut.registerEventTypes(types, r -> {
+            throw new IllegalStateException();
+        });
+
+        assertThat(registered).isZero();
+    }
+
+    @Test
+    @DisplayName("an empty collection registers nothing and reports zero")
+    void registerEventTypes_withEmptyCollection_registersNothing() {
+        List<String> seen = new ArrayList<>();
+
+        int registered = sut.registerEventTypes(List.of(), r -> seen.add(r.getTypeCode()));
+
+        assertThat(seen).isEmpty();
+        assertThat(registered).isZero();
+    }
+
+    @Test
+    @DisplayName("rejects a null event-type collection")
+    void registerEventTypes_withNullTypes_throws() {
+        assertThatNullPointerException().isThrownBy(() -> sut.registerEventTypes(null, r -> {}));
+    }
+
+    @Test
+    @DisplayName("rejects a null registration function")
+    void registerEventTypes_withNullFunction_throws() {
+        List<EventTypeRegistration> types = List.of(registration("E_ONE"));
+
+        assertThatNullPointerException().isThrownBy(() -> sut.registerEventTypes(types, null));
+    }
+}

--- a/pos-events/src/test/java/com/positivity/events/EventTypeRegistrationTest.java
+++ b/pos-events/src/test/java/com/positivity/events/EventTypeRegistrationTest.java
@@ -1,0 +1,127 @@
+package com.positivity.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link EventTypeRegistration} and its four threshold presets.
+ *
+ * <p>
+ * Every module's event-type registry is built from these four factory methods,
+ * so the latency thresholds they stamp on a registration are the repo-wide
+ * definition of "how fast is this operation supposed to be". A preset that
+ * silently changed value, or that stopped applying its thresholds, would
+ * re-baseline the SLO of every event in every module at once.
+ */
+@DisplayName("EventTypeRegistration — threshold presets and defaults")
+class EventTypeRegistrationTest {
+
+    private static Stream<Arguments> presets() {
+        return Stream.of(
+                Arguments.of(
+                        "fastRead",
+                        EventTypeRegistration.fastRead("X_FAST", "fast").build(),
+                        EventTypeRegistration.FAST_READ_P50,
+                        EventTypeRegistration.FAST_READ_P95,
+                        EventTypeRegistration.FAST_READ_P99),
+                Arguments.of(
+                        "search",
+                        EventTypeRegistration.search("X_SEARCH", "search").build(),
+                        EventTypeRegistration.SEARCH_P50,
+                        EventTypeRegistration.SEARCH_P95,
+                        EventTypeRegistration.SEARCH_P99),
+                Arguments.of(
+                        "write",
+                        EventTypeRegistration.write("X_WRITE", "write").build(),
+                        EventTypeRegistration.WRITE_P50,
+                        EventTypeRegistration.WRITE_P95,
+                        EventTypeRegistration.WRITE_P99),
+                Arguments.of(
+                        "approval",
+                        EventTypeRegistration.approval("X_APPROVAL", "approval").build(),
+                        EventTypeRegistration.APPROVAL_P50,
+                        EventTypeRegistration.APPROVAL_P95,
+                        EventTypeRegistration.APPROVAL_P99));
+    }
+
+    @ParameterizedTest(name = "{0}() stamps its declared thresholds")
+    @MethodSource("presets")
+    void preset_stampsItsThresholds(
+            String presetName, EventTypeRegistration registration, long p50, long p95, long p99) {
+        assertThat(registration.getP50Micros()).isEqualTo(p50);
+        assertThat(registration.getP95Micros()).isEqualTo(p95);
+        assertThat(registration.getP99Micros()).isEqualTo(p99);
+    }
+
+    @ParameterizedTest(name = "{0}() carries the supplied type code and description")
+    @MethodSource("presets")
+    void preset_carriesTypeCodeAndDescription(
+            String presetName, EventTypeRegistration registration, long p50, long p95, long p99) {
+        assertThat(registration.getTypeCode()).isNotBlank();
+        assertThat(registration.getDescription()).isNotBlank();
+    }
+
+    @ParameterizedTest(name = "{0}() defaults to apiVersion 1 and active")
+    @MethodSource("presets")
+    void preset_appliesBuilderDefaults(
+            String presetName, EventTypeRegistration registration, long p50, long p95, long p99) {
+        assertThat(registration.getApiVersion()).isEqualTo("1");
+        assertThat(registration.isActive()).isTrue();
+    }
+
+    @ParameterizedTest(name = "{0}() thresholds are strictly increasing")
+    @MethodSource("presets")
+    void preset_thresholdsAreStrictlyIncreasing(
+            String presetName, EventTypeRegistration registration, long p50, long p95, long p99) {
+        assertThat(p50).isPositive().isLessThan(p95);
+        assertThat(p95).isLessThan(p99);
+    }
+
+    @Test
+    @DisplayName("the four presets are mutually distinct — no two share a threshold triple")
+    void presets_areMutuallyDistinct() {
+        assertThat(presets()
+                        .map(args -> (EventTypeRegistration) args.get()[1])
+                        .map(r -> r.getP50Micros() + ":" + r.getP95Micros() + ":" + r.getP99Micros())
+                        .toList())
+                .doesNotHaveDuplicates();
+    }
+
+    @Test
+    @DisplayName("presets are ordered fastRead < search < write < approval at every percentile")
+    void presets_areOrderedByCost() {
+        assertThat(EventTypeRegistration.FAST_READ_P50).isLessThan(EventTypeRegistration.SEARCH_P50);
+        assertThat(EventTypeRegistration.SEARCH_P50).isLessThan(EventTypeRegistration.WRITE_P50);
+        assertThat(EventTypeRegistration.WRITE_P50).isLessThan(EventTypeRegistration.APPROVAL_P50);
+
+        assertThat(EventTypeRegistration.FAST_READ_P95).isLessThan(EventTypeRegistration.SEARCH_P95);
+        assertThat(EventTypeRegistration.SEARCH_P95).isLessThan(EventTypeRegistration.WRITE_P95);
+        assertThat(EventTypeRegistration.WRITE_P95).isLessThan(EventTypeRegistration.APPROVAL_P95);
+
+        assertThat(EventTypeRegistration.FAST_READ_P99).isLessThan(EventTypeRegistration.SEARCH_P99);
+        assertThat(EventTypeRegistration.SEARCH_P99).isLessThan(EventTypeRegistration.WRITE_P99);
+        assertThat(EventTypeRegistration.WRITE_P99).isLessThan(EventTypeRegistration.APPROVAL_P99);
+    }
+
+    @Test
+    @DisplayName("a preset builder can be overridden before build()")
+    void preset_builderCanBeOverridden() {
+        EventTypeRegistration overridden = EventTypeRegistration.write("X_WRITE", "write")
+                .apiVersion("2")
+                .active(false)
+                .p99Micros(9_000_000L)
+                .build();
+
+        assertThat(overridden.getApiVersion()).isEqualTo("2");
+        assertThat(overridden.isActive()).isFalse();
+        assertThat(overridden.getP99Micros()).isEqualTo(9_000_000L);
+        // Untouched thresholds keep the preset's values.
+        assertThat(overridden.getP50Micros()).isEqualTo(EventTypeRegistration.WRITE_P50);
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AllocationConsistencyVerifier.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AllocationConsistencyVerifier.java
@@ -111,7 +111,9 @@ public class AllocationConsistencyVerifier {
         this.violationCounter = meterRegistry.counter("inventory.allocation.consistency.violations.total");
     }
 
-    @Scheduled(fixedDelayString = "${pos.inventory.allocation-verify.interval-ms:3600000}", initialDelayString = "${pos.inventory.allocation-verify.initial-delay-ms:600000}")
+    @Scheduled(
+            fixedDelayString = "${pos.inventory.allocation-verify.interval-ms:3600000}",
+            initialDelayString = "${pos.inventory.allocation-verify.initial-delay-ms:600000}")
     @Transactional(readOnly = true)
     public void verifyScheduled() {
         try {
@@ -129,10 +131,10 @@ public class AllocationConsistencyVerifier {
         String created = InventoryLedgerEventType.ALLOCATION_CREATED.name();
         String released = InventoryLedgerEventType.ALLOCATION_RELEASED.name();
 
-        List<AllocationRepository.AllocationConsistencyRow> perAllocation = allocationRepository
-                .findConsistencyViolations(created, released);
-        List<InventoryStockSummaryRepository.AllocatedDriftRow> perLocation = summaryRepository
-                .findAllocatedDriftByLocation(created, released);
+        List<AllocationRepository.AllocationConsistencyRow> perAllocation =
+                allocationRepository.findConsistencyViolations(created, released);
+        List<InventoryStockSummaryRepository.AllocatedDriftRow> perLocation =
+                summaryRepository.findAllocatedDriftByLocation(created, released);
 
         int logged = 0;
         for (AllocationRepository.AllocationConsistencyRow row : perAllocation) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SerialUnitOnHandVerifier.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SerialUnitOnHandVerifier.java
@@ -45,7 +45,9 @@ public class SerialUnitOnHandVerifier {
         this.driftCounter = meterRegistry.counter("inventory.serial_unit.drift.total");
     }
 
-    @Scheduled(fixedDelayString = "${pos.inventory.serial-unit.verify-interval-ms:3600000}", initialDelayString = "${pos.inventory.serial-unit.verify-initial-delay-ms:600000}")
+    @Scheduled(
+            fixedDelayString = "${pos.inventory.serial-unit.verify-interval-ms:3600000}",
+            initialDelayString = "${pos.inventory.serial-unit.verify-initial-delay-ms:600000}")
     @Transactional(readOnly = true)
     public void verifyScheduled() {
         try {
@@ -72,8 +74,8 @@ public class SerialUnitOnHandVerifier {
      * @return number of drifted keys
      */
     public int verify() {
-        List<InventorySerialUnitRepository.SerialOnHandRow> rows = serialRepository
-                .serialOnHandByStockItemAndLocation(InventorySerialStatus.IN_STOCK);
+        List<InventorySerialUnitRepository.SerialOnHandRow> rows =
+                serialRepository.serialOnHandByStockItemAndLocation(InventorySerialStatus.IN_STOCK);
 
         int driftedKeys = 0;
         for (InventorySerialUnitRepository.SerialOnHandRow row : rows) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryDriftVerifier.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryDriftVerifier.java
@@ -29,7 +29,9 @@ public class StockSummaryDriftVerifier {
         this.driftCounter = meterRegistry.counter("inventory.stock_summary.drift.total");
     }
 
-    @Scheduled(fixedDelayString = "${pos.inventory.stock-summary.verify-interval-ms:3600000}", initialDelayString = "${pos.inventory.stock-summary.verify-initial-delay-ms:600000}")
+    @Scheduled(
+            fixedDelayString = "${pos.inventory.stock-summary.verify-interval-ms:3600000}",
+            initialDelayString = "${pos.inventory.stock-summary.verify-initial-delay-ms:600000}")
     @Transactional(readOnly = true)
     public void verifyScheduled() {
         try {
@@ -59,7 +61,8 @@ public class StockSummaryDriftVerifier {
         List<String> onHandTypes = InventoryLedgerEventType.onHandAffectingTypes().stream()
                 .map(Enum::name)
                 .toList();
-        List<String> summaryTypes = StockSummaryEventSets.SUMMARY_TYPES.stream().map(Enum::name).toList();
+        List<String> summaryTypes =
+                StockSummaryEventSets.SUMMARY_TYPES.stream().map(Enum::name).toList();
 
         List<InventoryStockSummaryRepository.DriftRow> drifted = summaryRepository.findDriftRows(
                 onHandTypes,

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/config/EventTypeInitializerTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,123 @@
+package com.positivity.inventory.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(EventTypes.all().size())).header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.all()).isNotEmpty();
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/config/EventTypesTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.inventory.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/config/ManifestPublisherTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/config/ManifestPublisherTest.java
@@ -1,0 +1,366 @@
+package com.positivity.inventory.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.inventory.internal.entity.OutboxEvent;
+import com.positivity.inventory.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for the pos-inventory {@link ManifestPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * Each closed window gets one reconciliation manifest summarizing the events
+ * published from the outbox in that window; consumers recompute the same summary
+ * and request a replay on drift. The properties that matter:
+ *
+ * <ul>
+ * <li>Window membership is decided by the <em>eventId</em> (UUIDv7) timestamp,
+ * not by {@code createdAt}. The query pads its range by a second of slack, so a
+ * row can be fetched and still belong to a neighbouring window; counting it in
+ * the wrong one would manufacture drift on both sides.</li>
+ * <li>Empty windows still publish, so consumers can alert on manifest absence
+ * rather than treating silence as health.</li>
+ * <li>A malformed row is skipped with a warning instead of failing the window
+ * forever — one bad payload must not permanently block reconciliation.</li>
+ * <li>A failed send leaves the window unadvanced so the next run retries it, and
+ * catch-up is bounded per run so a long outage cannot monopolize a poll.</li>
+ * </ul>
+ */
+@DisplayName("pos-inventory ManifestPublisher — reconciliation manifest windows")
+class ManifestPublisherTest {
+
+    /** 12:10 UTC: the [11:00, 12:00) window closed more than the 5m grace ago. */
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-08T12:10:00Z"), ZoneOffset.UTC);
+
+    private static final Instant WINDOW_START = Instant.parse("2026-07-08T11:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-07-08T12:00:00Z");
+    private static final String EVENTS_TOPIC = "inventory.events.v1";
+    private static final String MANIFEST_TOPIC = "inventory.manifest.v1";
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private SimpleMeterRegistry meterRegistry;
+    private ManifestPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry, TEST_CLOCK);
+        brokerAcknowledges();
+    }
+
+    @SuppressWarnings("unchecked")
+    private ManifestPublisher newPublisher(MeterRegistry registry, Clock clock) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        ManifestPublisher created = new ManifestPublisher(repository, kafkaTemplate, objectMapper, clock, provider);
+        ReflectionTestUtils.setField(created, "eventsTopic", EVENTS_TOPIC);
+        ReflectionTestUtils.setField(created, "manifestTopic", MANIFEST_TOPIC);
+        ReflectionTestUtils.setField(created, "window", Duration.ofHours(1));
+        ReflectionTestUtils.setField(created, "grace", Duration.ofMinutes(5));
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    /** UUIDv7-shaped id whose embedded timestamp is {@code at}. */
+    private static String eventIdAt(Instant at, int suffix) {
+        long millis = at.toEpochMilli();
+        return String.format("%08x-%04x-7000-8000-%012x", millis >>> 16, millis & 0xFFFF, suffix);
+    }
+
+    private static OutboxEvent row(String eventId, String eventType, Instant createdAt) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey(eventId)
+                .payload("{\"eventId\":\"" + eventId + "\",\"eventType\":\"" + eventType + "\",\"payload\":{}}")
+                .createdAt(createdAt)
+                .publishedAt(createdAt.plusSeconds(1))
+                .build();
+    }
+
+    private void outboxReturns(List<OutboxEvent> rows) {
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(rows);
+    }
+
+    private JsonNode capturedManifest() {
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), json.capture());
+        return objectMapper.readTree(json.getValue());
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("publishes the latest closed window with its count, checksum, and per-type counts")
+    void publishesManifestForClosedWindow() {
+        String inWindow1 = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String inWindow2 = eventIdAt(WINDOW_START.plusSeconds(120), 2);
+        outboxReturns(List.of(
+                row(inWindow1, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(inWindow2, "SomethingElseChanged", WINDOW_START.plusSeconds(120))));
+
+        publisher.publishDueManifest();
+
+        JsonNode envelope = capturedManifest();
+        assertThat(envelope.path("sourceService").stringValue()).isEqualTo("pos-inventory");
+        assertThat(envelope.path("eventType").stringValue())
+                .isEqualTo(ReconciliationManifestV1.eventTypeFor("inventory"));
+
+        JsonNode manifest = envelope.path("payload");
+        assertThat(manifest.path("windowStartUtc").stringValue()).isEqualTo(WINDOW_START.toString());
+        assertThat(manifest.path("windowEndUtc").stringValue()).isEqualTo(WINDOW_END.toString());
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(2);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow1, inWindow2)));
+        assertThat(manifest.path("eventTypeCounts").path("SomethingChanged").longValue())
+                .isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("SomethingElseChanged").longValue())
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row fetched by createdAt slack whose eventId falls outside the window")
+    void excludesRowOutsideWindowByEventIdTimestamp() {
+        String inWindow = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String justBefore = eventIdAt(WINDOW_START.minusMillis(1), 2);
+        String justAfter = eventIdAt(WINDOW_END.plusMillis(1), 3);
+        outboxReturns(List.of(
+                row(justBefore, "SomethingChanged", WINDOW_START.minusMillis(1)),
+                row(inWindow, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(justAfter, "SomethingChanged", WINDOW_END.plusMillis(1))));
+
+        publisher.publishDueManifest();
+
+        // Membership is decided by the eventId timestamp, not the padded createdAt
+        // query: counting a neighbour here would manufacture drift on both sides.
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow)));
+    }
+
+    @Test
+    @DisplayName("publishes a zero-count manifest so consumers can alert on absence rather than silence")
+    void publishesEmptyWindowManifest() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isZero();
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of()));
+    }
+
+    @Test
+    @DisplayName("counts a row with a blank event type under \"unknown\" rather than dropping it")
+    void blankEventTypeCountedAsUnknown() {
+        String eventId = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        outboxReturns(List.of(row(eventId, "", WINDOW_START.plusSeconds(60))));
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("unknown").longValue()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row with no eventId instead of failing the window")
+    void skipsRowWithoutEventId() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("{\"eventType\":\"PartyChanged\"}")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("excludes a row whose payload will not parse instead of blocking reconciliation forever")
+    void skipsRowWithUnparsablePayload() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("not json at all")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("does not re-publish a window it already published")
+    void skipsAlreadyPublishedWindow() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("waits out the grace period, publishing the previous window until the latest one settles")
+    void respectsGracePeriod() {
+        ReflectionTestUtils.setField(publisher, "grace", Duration.ofMinutes(15));
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        // 12:10 with 15m grace: [11:00, 12:00) is not yet eligible, so the
+        // published window is the previous one.
+        assertThat(capturedManifest().path("payload").path("windowEndUtc").stringValue())
+                .isEqualTo("2026-07-08T11:00:00Z");
+    }
+
+    @Test
+    @DisplayName("retries the same window on the next run when the send fails")
+    void retriesWindowAfterSendFailure() {
+        outboxReturns(List.of());
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker down")))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        // The window must not advance past a failure, or its manifest is lost.
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(counter("inventory.manifest.publish.failures")).isEqualTo(1d);
+        assertThat(counter("inventory.manifest.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("counts a successful publish")
+    void countsSuccessfulPublish() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        assertThat(counter("inventory.manifest.published")).isEqualTo(1d);
+        assertThat(counter("inventory.manifest.publish.failures")).isZero();
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        ManifestPublisher withoutMetrics = newPublisher(null, TEST_CLOCK);
+        outboxReturns(List.of());
+
+        withoutMetrics.publishDueManifest();
+
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("publishes nothing when no window has closed yet")
+    void publishesNothingBeforeTheFirstWindowCloses() {
+        // Epoch + 30m with a 1h window: no aligned window boundary has passed.
+        ManifestPublisher early = newPublisher(meterRegistry, Clock.fixed(Instant.ofEpochSecond(1800), ZoneOffset.UTC));
+
+        early.publishDueManifest();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("keys every manifest for a window deterministically, so re-publishes land on one partition")
+    void manifestRecordKeyIsStablePerWindow() {
+        outboxReturns(List.of());
+        ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+
+        publisher.publishDueManifest();
+        // A second publisher instance, same window: the key must match.
+        ManifestPublisher other = newPublisher(meterRegistry, TEST_CLOCK);
+        other.publishDueManifest();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), key.capture(), anyString());
+        assertThat(key.getAllValues()).hasSize(2);
+        assertThat(key.getAllValues().get(0)).isEqualTo(key.getAllValues().get(1));
+    }
+
+    @Test
+    @DisplayName("after a gap, catches up window by window rather than skipping to the newest")
+    void catchesUpWindowByWindow() {
+        outboxReturns(List.of());
+
+        // First run establishes [11:00, 12:00) as published.
+        publisher.publishDueManifest();
+
+        // Three hours later four windows have closed; the next run must publish the
+        // intervening ones, not jump to the newest and leave holes.
+        ManifestPublisher later = publisher;
+        ReflectionTestUtils.setField(
+                later, "clock", Clock.fixed(Instant.parse("2026-07-08T15:10:00Z"), ZoneOffset.UTC));
+        later.publishDueManifest();
+
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate, times(4)).send(anyString(), anyString(), json.capture());
+        assertThat(json.getAllValues())
+                .map(value -> objectMapper
+                        .readTree(value)
+                        .path("payload")
+                        .path("windowEndUtc")
+                        .stringValue())
+                .containsExactly(
+                        "2026-07-08T12:00:00Z", "2026-07-08T13:00:00Z", "2026-07-08T14:00:00Z", "2026-07-08T15:00:00Z");
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/config/OutboxPublisherTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/config/OutboxPublisherTest.java
@@ -1,0 +1,213 @@
+package com.positivity.inventory.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.inventory.internal.entity.OutboxEvent;
+import com.positivity.inventory.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for the pos-inventory {@link OutboxPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * The publisher drains {@code event_outbox} to Kafka with at-least-once
+ * semantics. Three properties carry the correctness weight:
+ *
+ * <ul>
+ * <li>a row is marked published <em>only</em> after the broker acknowledges, so
+ * a crash mid-send re-sends rather than silently dropping the event;</li>
+ * <li>the batch stops at the first failure, so a struggling broker cannot
+ * reorder events past a stuck row; and</li>
+ * <li>the failure path records {@code attempts} and a bounded
+ * {@code last_error} for alerting instead of throwing out of the scheduled
+ * method.</li>
+ * </ul>
+ */
+@DisplayName("pos-inventory OutboxPublisher — outbox drain contract")
+class OutboxPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-08T12:00:00Z");
+    private static final Clock TEST_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private SimpleMeterRegistry meterRegistry;
+    private OutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    private OutboxPublisher newPublisher(MeterRegistry registry) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        OutboxPublisher created = new OutboxPublisher(repository, kafkaTemplate, TEST_CLOCK, provider);
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private OutboxEvent event(String key) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("inventory.events.v1")
+                .recordKey(key)
+                .payload("{\"eventId\":\"" + key + "\"}")
+                .createdAt(NOW.minusSeconds(60))
+                .attempts(2)
+                .lastError("previous failure")
+                .build();
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    private void brokerFailsWith(Throwable failure) {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(failure));
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("marks the row published only after the broker acknowledges the send")
+    void marksPublishedAfterAcknowledgedSend() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate).send("inventory.events.v1", "k1", row.getPayload());
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        assertThat(row.getAttempts()).isZero();
+        assertThat(row.getLastError()).isNull();
+        verify(repository).save(row);
+        assertThat(counter("inventory.outbox.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("drains the whole batch in order while the broker keeps acknowledging")
+    void drainsWholeBatchWhenAllSendsSucceed() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(first.getPublishedAt()).isEqualTo(NOW);
+        assertThat(second.getPublishedAt()).isEqualTo(NOW);
+        assertThat(counter("inventory.outbox.published")).isEqualTo(2d);
+    }
+
+    @Test
+    @DisplayName("on failure: records the attempt and error, leaves the row unpublished, stops the batch")
+    void recordsFailureAndStopsBatch() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerFailsWith(new RuntimeException("broker down"));
+
+        publisher.publishPending();
+
+        assertThat(first.getPublishedAt()).isNull();
+        assertThat(first.getAttempts()).isEqualTo(3);
+        assertThat(first.getLastError()).contains("broker down");
+        verify(repository).save(first);
+
+        // The batch stops at the first failure so publish order is preserved:
+        // the second row is never attempted and keeps its prior attempt count.
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+        verify(kafkaTemplate).send("inventory.events.v1", "k1", first.getPayload());
+        assertThat(second.getAttempts()).isEqualTo(2);
+        assertThat(second.getPublishedAt()).isNull();
+        assertThat(counter("inventory.outbox.publish.failures")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("falls back to the exception class name when the failure carries no message")
+    void recordsClassNameWhenFailureMessageIsNull() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        // Thrown by send() itself rather than completing the future exceptionally:
+        // a failed future surfaces as an ExecutionException whose message is the
+        // cause's toString, so only a synchronous throw reaches the null-message
+        // fallback in recordFailure().
+        when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenThrow(new IllegalStateException());
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).isEqualTo("IllegalStateException");
+        assertThat(row.getPublishedAt()).isNull();
+        assertThat(row.getAttempts()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("truncates an oversized failure message to the 2000-character column bound")
+    void truncatesOversizedFailureMessage() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerFailsWith(new RuntimeException("x".repeat(2500)));
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).hasSize(2000);
+    }
+
+    @Test
+    @DisplayName("does nothing when the outbox is empty")
+    void doesNothingWhenNoPendingRows() {
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of());
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        verify(repository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        OutboxPublisher withoutMetrics = newPublisher(null);
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        withoutMetrics.publishPending();
+
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        verify(repository).save(row);
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/DepositCreditController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/DepositCreditController.java
@@ -39,54 +39,61 @@ import org.springframework.web.bind.annotation.RestController;
 @PreAuthorize("hasAuthority('invoice:manage')")
 public class DepositCreditController {
 
-        private final DepositCreditService depositCreditService;
+    private final DepositCreditService depositCreditService;
 
-        @Operation(summary = "Register a deposit credit taken by a sales order", description = "Creates a deposit credit record tied to the provided source transaction.", tags = {
-                        "Deposit Credits" })
-        @PostMapping
-        @EmitEvent(id = "INVOICE_DEPOSIT_CREATE", apiVersion = "1")
-        @SecurityRequirement(name = "bearerAuth")
-        public ResponseEntity<DepositCreditResponse> createDeposit(@Valid @RequestBody CreateDepositRequest request) {
-                DepositCreditResponse response = DepositCreditResponse
-                                .from(depositCreditService.createDeposit(new CreateDepositCommand(
-                                                request.getOrderId(),
-                                                request.getSourceType(),
-                                                request.getSourceId(),
-                                                request.getPartyId(),
-                                                request.getAmount(),
-                                                request.getCurrencyCode())));
-                return ResponseEntity.status(HttpStatus.CREATED).body(response);
-        }
+    @Operation(
+            summary = "Register a deposit credit taken by a sales order",
+            description = "Creates a deposit credit record tied to the provided source transaction.",
+            tags = {"Deposit Credits"})
+    @PostMapping
+    @EmitEvent(id = "INVOICE_DEPOSIT_CREATE", apiVersion = "1")
+    @SecurityRequirement(name = "bearerAuth")
+    public ResponseEntity<DepositCreditResponse> createDeposit(@Valid @RequestBody CreateDepositRequest request) {
+        DepositCreditResponse response =
+                DepositCreditResponse.from(depositCreditService.createDeposit(new CreateDepositCommand(
+                        request.getOrderId(),
+                        request.getSourceType(),
+                        request.getSourceId(),
+                        request.getPartyId(),
+                        request.getAmount(),
+                        request.getCurrencyCode())));
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 
-        @Operation(summary = "Get a deposit credit by id", description = "Retrieves a single deposit credit by its identifier.", tags = {
-                        "Deposit Credits" })
-        @GetMapping("/{depositCreditId}")
-        @SecurityRequirement(name = "bearerAuth")
-        public ResponseEntity<DepositCreditResponse> getDeposit(@PathVariable UUID depositCreditId) {
-                return ResponseEntity.ok(DepositCreditResponse.from(depositCreditService.getDeposit(depositCreditId)));
-        }
+    @Operation(
+            summary = "Get a deposit credit by id",
+            description = "Retrieves a single deposit credit by its identifier.",
+            tags = {"Deposit Credits"})
+    @GetMapping("/{depositCreditId}")
+    @SecurityRequirement(name = "bearerAuth")
+    public ResponseEntity<DepositCreditResponse> getDeposit(@PathVariable UUID depositCreditId) {
+        return ResponseEntity.ok(DepositCreditResponse.from(depositCreditService.getDeposit(depositCreditId)));
+    }
 
-        @Operation(summary = "List deposit credits held against a source document", description = "Lists all deposit credits associated with the given source type and source id.", tags = {
-                        "Deposit Credits" })
-        @GetMapping
-        @SecurityRequirement(name = "bearerAuth")
-        public ResponseEntity<List<DepositCreditResponse>> listBySource(
-                        @RequestParam String sourceType, @RequestParam UUID sourceId) {
-                DepositSourceType type = DepositSourceType.valueOf(sourceType.trim().toUpperCase(Locale.ROOT));
-                return ResponseEntity.ok(depositCreditService.listBySource(type, sourceId).stream()
-                                .map(DepositCreditResponse::from)
-                                .toList());
-        }
+    @Operation(
+            summary = "List deposit credits held against a source document",
+            description = "Lists all deposit credits associated with the given source type and source id.",
+            tags = {"Deposit Credits"})
+    @GetMapping
+    @SecurityRequirement(name = "bearerAuth")
+    public ResponseEntity<List<DepositCreditResponse>> listBySource(
+            @RequestParam String sourceType, @RequestParam UUID sourceId) {
+        DepositSourceType type = DepositSourceType.valueOf(sourceType.trim().toUpperCase(Locale.ROOT));
+        return ResponseEntity.ok(depositCreditService.listBySource(type, sourceId).stream()
+                .map(DepositCreditResponse::from)
+                .toList());
+    }
 
-        @Operation(summary = "Refund a deposit credit's remaining balance", description = "Used when the deposit's source is cancelled after the deposit was taken (spec R7.4).", tags = {
-                        "Deposit Credits" })
-        @PostMapping("/{depositCreditId}/refund")
-        @EmitEvent(id = "INVOICE_DEPOSIT_REFUND", apiVersion = "1")
-        @SecurityRequirement(name = "bearerAuth")
-        public ResponseEntity<DepositCreditResponse> refundDeposit(
-                        @PathVariable UUID depositCreditId,
-                        @RequestParam(name = "reason", required = false) String reason) {
-                depositCreditService.refundDeposit(depositCreditId, reason == null ? "source cancelled" : reason);
-                return ResponseEntity.ok(DepositCreditResponse.from(depositCreditService.getDeposit(depositCreditId)));
-        }
+    @Operation(
+            summary = "Refund a deposit credit's remaining balance",
+            description = "Used when the deposit's source is cancelled after the deposit was taken (spec R7.4).",
+            tags = {"Deposit Credits"})
+    @PostMapping("/{depositCreditId}/refund")
+    @EmitEvent(id = "INVOICE_DEPOSIT_REFUND", apiVersion = "1")
+    @SecurityRequirement(name = "bearerAuth")
+    public ResponseEntity<DepositCreditResponse> refundDeposit(
+            @PathVariable UUID depositCreditId, @RequestParam(name = "reason", required = false) String reason) {
+        depositCreditService.refundDeposit(depositCreditId, reason == null ? "source cancelled" : reason);
+        return ResponseEntity.ok(DepositCreditResponse.from(depositCreditService.getDeposit(depositCreditId)));
+    }
 }

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/config/EventTypeInitializerTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,123 @@
+package com.positivity.invoice.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(EventTypes.all().size())).header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.all()).isNotEmpty();
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+}

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/config/EventTypesTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.invoice.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/config/ManifestPublisherTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/config/ManifestPublisherTest.java
@@ -1,0 +1,366 @@
+package com.positivity.invoice.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.invoice.internal.entity.OutboxEvent;
+import com.positivity.invoice.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for the pos-invoice {@link ManifestPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * Each closed window gets one reconciliation manifest summarizing the events
+ * published from the outbox in that window; consumers recompute the same summary
+ * and request a replay on drift. The properties that matter:
+ *
+ * <ul>
+ * <li>Window membership is decided by the <em>eventId</em> (UUIDv7) timestamp,
+ * not by {@code createdAt}. The query pads its range by a second of slack, so a
+ * row can be fetched and still belong to a neighbouring window; counting it in
+ * the wrong one would manufacture drift on both sides.</li>
+ * <li>Empty windows still publish, so consumers can alert on manifest absence
+ * rather than treating silence as health.</li>
+ * <li>A malformed row is skipped with a warning instead of failing the window
+ * forever — one bad payload must not permanently block reconciliation.</li>
+ * <li>A failed send leaves the window unadvanced so the next run retries it, and
+ * catch-up is bounded per run so a long outage cannot monopolize a poll.</li>
+ * </ul>
+ */
+@DisplayName("pos-invoice ManifestPublisher — reconciliation manifest windows")
+class ManifestPublisherTest {
+
+    /** 12:10 UTC: the [11:00, 12:00) window closed more than the 5m grace ago. */
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-08T12:10:00Z"), ZoneOffset.UTC);
+
+    private static final Instant WINDOW_START = Instant.parse("2026-07-08T11:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-07-08T12:00:00Z");
+    private static final String EVENTS_TOPIC = "invoice.events.v1";
+    private static final String MANIFEST_TOPIC = "invoice.manifest.v1";
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private SimpleMeterRegistry meterRegistry;
+    private ManifestPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry, TEST_CLOCK);
+        brokerAcknowledges();
+    }
+
+    @SuppressWarnings("unchecked")
+    private ManifestPublisher newPublisher(MeterRegistry registry, Clock clock) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        ManifestPublisher created = new ManifestPublisher(repository, kafkaTemplate, objectMapper, clock, provider);
+        ReflectionTestUtils.setField(created, "eventsTopic", EVENTS_TOPIC);
+        ReflectionTestUtils.setField(created, "manifestTopic", MANIFEST_TOPIC);
+        ReflectionTestUtils.setField(created, "window", Duration.ofHours(1));
+        ReflectionTestUtils.setField(created, "grace", Duration.ofMinutes(5));
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    /** UUIDv7-shaped id whose embedded timestamp is {@code at}. */
+    private static String eventIdAt(Instant at, int suffix) {
+        long millis = at.toEpochMilli();
+        return String.format("%08x-%04x-7000-8000-%012x", millis >>> 16, millis & 0xFFFF, suffix);
+    }
+
+    private static OutboxEvent row(String eventId, String eventType, Instant createdAt) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey(eventId)
+                .payload("{\"eventId\":\"" + eventId + "\",\"eventType\":\"" + eventType + "\",\"payload\":{}}")
+                .createdAt(createdAt)
+                .publishedAt(createdAt.plusSeconds(1))
+                .build();
+    }
+
+    private void outboxReturns(List<OutboxEvent> rows) {
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(rows);
+    }
+
+    private JsonNode capturedManifest() {
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), json.capture());
+        return objectMapper.readTree(json.getValue());
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("publishes the latest closed window with its count, checksum, and per-type counts")
+    void publishesManifestForClosedWindow() {
+        String inWindow1 = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String inWindow2 = eventIdAt(WINDOW_START.plusSeconds(120), 2);
+        outboxReturns(List.of(
+                row(inWindow1, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(inWindow2, "SomethingElseChanged", WINDOW_START.plusSeconds(120))));
+
+        publisher.publishDueManifest();
+
+        JsonNode envelope = capturedManifest();
+        assertThat(envelope.path("sourceService").stringValue()).isEqualTo("pos-invoice");
+        assertThat(envelope.path("eventType").stringValue())
+                .isEqualTo(ReconciliationManifestV1.eventTypeFor("invoice"));
+
+        JsonNode manifest = envelope.path("payload");
+        assertThat(manifest.path("windowStartUtc").stringValue()).isEqualTo(WINDOW_START.toString());
+        assertThat(manifest.path("windowEndUtc").stringValue()).isEqualTo(WINDOW_END.toString());
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(2);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow1, inWindow2)));
+        assertThat(manifest.path("eventTypeCounts").path("SomethingChanged").longValue())
+                .isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("SomethingElseChanged").longValue())
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row fetched by createdAt slack whose eventId falls outside the window")
+    void excludesRowOutsideWindowByEventIdTimestamp() {
+        String inWindow = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String justBefore = eventIdAt(WINDOW_START.minusMillis(1), 2);
+        String justAfter = eventIdAt(WINDOW_END.plusMillis(1), 3);
+        outboxReturns(List.of(
+                row(justBefore, "SomethingChanged", WINDOW_START.minusMillis(1)),
+                row(inWindow, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(justAfter, "SomethingChanged", WINDOW_END.plusMillis(1))));
+
+        publisher.publishDueManifest();
+
+        // Membership is decided by the eventId timestamp, not the padded createdAt
+        // query: counting a neighbour here would manufacture drift on both sides.
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow)));
+    }
+
+    @Test
+    @DisplayName("publishes a zero-count manifest so consumers can alert on absence rather than silence")
+    void publishesEmptyWindowManifest() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isZero();
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of()));
+    }
+
+    @Test
+    @DisplayName("counts a row with a blank event type under \"unknown\" rather than dropping it")
+    void blankEventTypeCountedAsUnknown() {
+        String eventId = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        outboxReturns(List.of(row(eventId, "", WINDOW_START.plusSeconds(60))));
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("unknown").longValue()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row with no eventId instead of failing the window")
+    void skipsRowWithoutEventId() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("{\"eventType\":\"PartyChanged\"}")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("excludes a row whose payload will not parse instead of blocking reconciliation forever")
+    void skipsRowWithUnparsablePayload() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("not json at all")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("does not re-publish a window it already published")
+    void skipsAlreadyPublishedWindow() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("waits out the grace period, publishing the previous window until the latest one settles")
+    void respectsGracePeriod() {
+        ReflectionTestUtils.setField(publisher, "grace", Duration.ofMinutes(15));
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        // 12:10 with 15m grace: [11:00, 12:00) is not yet eligible, so the
+        // published window is the previous one.
+        assertThat(capturedManifest().path("payload").path("windowEndUtc").stringValue())
+                .isEqualTo("2026-07-08T11:00:00Z");
+    }
+
+    @Test
+    @DisplayName("retries the same window on the next run when the send fails")
+    void retriesWindowAfterSendFailure() {
+        outboxReturns(List.of());
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker down")))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        // The window must not advance past a failure, or its manifest is lost.
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(counter("invoice.manifest.publish.failures")).isEqualTo(1d);
+        assertThat(counter("invoice.manifest.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("counts a successful publish")
+    void countsSuccessfulPublish() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        assertThat(counter("invoice.manifest.published")).isEqualTo(1d);
+        assertThat(counter("invoice.manifest.publish.failures")).isZero();
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        ManifestPublisher withoutMetrics = newPublisher(null, TEST_CLOCK);
+        outboxReturns(List.of());
+
+        withoutMetrics.publishDueManifest();
+
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("publishes nothing when no window has closed yet")
+    void publishesNothingBeforeTheFirstWindowCloses() {
+        // Epoch + 30m with a 1h window: no aligned window boundary has passed.
+        ManifestPublisher early = newPublisher(meterRegistry, Clock.fixed(Instant.ofEpochSecond(1800), ZoneOffset.UTC));
+
+        early.publishDueManifest();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("keys every manifest for a window deterministically, so re-publishes land on one partition")
+    void manifestRecordKeyIsStablePerWindow() {
+        outboxReturns(List.of());
+        ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+
+        publisher.publishDueManifest();
+        // A second publisher instance, same window: the key must match.
+        ManifestPublisher other = newPublisher(meterRegistry, TEST_CLOCK);
+        other.publishDueManifest();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), key.capture(), anyString());
+        assertThat(key.getAllValues()).hasSize(2);
+        assertThat(key.getAllValues().get(0)).isEqualTo(key.getAllValues().get(1));
+    }
+
+    @Test
+    @DisplayName("after a gap, catches up window by window rather than skipping to the newest")
+    void catchesUpWindowByWindow() {
+        outboxReturns(List.of());
+
+        // First run establishes [11:00, 12:00) as published.
+        publisher.publishDueManifest();
+
+        // Three hours later four windows have closed; the next run must publish the
+        // intervening ones, not jump to the newest and leave holes.
+        ManifestPublisher later = publisher;
+        ReflectionTestUtils.setField(
+                later, "clock", Clock.fixed(Instant.parse("2026-07-08T15:10:00Z"), ZoneOffset.UTC));
+        later.publishDueManifest();
+
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate, times(4)).send(anyString(), anyString(), json.capture());
+        assertThat(json.getAllValues())
+                .map(value -> objectMapper
+                        .readTree(value)
+                        .path("payload")
+                        .path("windowEndUtc")
+                        .stringValue())
+                .containsExactly(
+                        "2026-07-08T12:00:00Z", "2026-07-08T13:00:00Z", "2026-07-08T14:00:00Z", "2026-07-08T15:00:00Z");
+    }
+}

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/config/OutboxPublisherTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/config/OutboxPublisherTest.java
@@ -1,0 +1,213 @@
+package com.positivity.invoice.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.invoice.internal.entity.OutboxEvent;
+import com.positivity.invoice.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for the pos-invoice {@link OutboxPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * The publisher drains {@code event_outbox} to Kafka with at-least-once
+ * semantics. Three properties carry the correctness weight:
+ *
+ * <ul>
+ * <li>a row is marked published <em>only</em> after the broker acknowledges, so
+ * a crash mid-send re-sends rather than silently dropping the event;</li>
+ * <li>the batch stops at the first failure, so a struggling broker cannot
+ * reorder events past a stuck row; and</li>
+ * <li>the failure path records {@code attempts} and a bounded
+ * {@code last_error} for alerting instead of throwing out of the scheduled
+ * method.</li>
+ * </ul>
+ */
+@DisplayName("pos-invoice OutboxPublisher — outbox drain contract")
+class OutboxPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-08T12:00:00Z");
+    private static final Clock TEST_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private SimpleMeterRegistry meterRegistry;
+    private OutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    private OutboxPublisher newPublisher(MeterRegistry registry) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        OutboxPublisher created = new OutboxPublisher(repository, kafkaTemplate, TEST_CLOCK, provider);
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private OutboxEvent event(String key) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("invoice.events.v1")
+                .recordKey(key)
+                .payload("{\"eventId\":\"" + key + "\"}")
+                .createdAt(NOW.minusSeconds(60))
+                .attempts(2)
+                .lastError("previous failure")
+                .build();
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    private void brokerFailsWith(Throwable failure) {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(failure));
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("marks the row published only after the broker acknowledges the send")
+    void marksPublishedAfterAcknowledgedSend() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate).send("invoice.events.v1", "k1", row.getPayload());
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        assertThat(row.getAttempts()).isZero();
+        assertThat(row.getLastError()).isNull();
+        verify(repository).save(row);
+        assertThat(counter("invoice.outbox.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("drains the whole batch in order while the broker keeps acknowledging")
+    void drainsWholeBatchWhenAllSendsSucceed() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(first.getPublishedAt()).isEqualTo(NOW);
+        assertThat(second.getPublishedAt()).isEqualTo(NOW);
+        assertThat(counter("invoice.outbox.published")).isEqualTo(2d);
+    }
+
+    @Test
+    @DisplayName("on failure: records the attempt and error, leaves the row unpublished, stops the batch")
+    void recordsFailureAndStopsBatch() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerFailsWith(new RuntimeException("broker down"));
+
+        publisher.publishPending();
+
+        assertThat(first.getPublishedAt()).isNull();
+        assertThat(first.getAttempts()).isEqualTo(3);
+        assertThat(first.getLastError()).contains("broker down");
+        verify(repository).save(first);
+
+        // The batch stops at the first failure so publish order is preserved:
+        // the second row is never attempted and keeps its prior attempt count.
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+        verify(kafkaTemplate).send("invoice.events.v1", "k1", first.getPayload());
+        assertThat(second.getAttempts()).isEqualTo(2);
+        assertThat(second.getPublishedAt()).isNull();
+        assertThat(counter("invoice.outbox.publish.failures")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("falls back to the exception class name when the failure carries no message")
+    void recordsClassNameWhenFailureMessageIsNull() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        // Thrown by send() itself rather than completing the future exceptionally:
+        // a failed future surfaces as an ExecutionException whose message is the
+        // cause's toString, so only a synchronous throw reaches the null-message
+        // fallback in recordFailure().
+        when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenThrow(new IllegalStateException());
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).isEqualTo("IllegalStateException");
+        assertThat(row.getPublishedAt()).isNull();
+        assertThat(row.getAttempts()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("truncates an oversized failure message to the 2000-character column bound")
+    void truncatesOversizedFailureMessage() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerFailsWith(new RuntimeException("x".repeat(2500)));
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).hasSize(2000);
+    }
+
+    @Test
+    @DisplayName("does nothing when the outbox is empty")
+    void doesNothingWhenNoPendingRows() {
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of());
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        verify(repository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        OutboxPublisher withoutMetrics = newPublisher(null);
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        withoutMetrics.publishPending();
+
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        verify(repository).save(row);
+    }
+}

--- a/pos-location/src/test/java/com/positivity/location/internal/config/LocationEventTypeInitializerTest.java
+++ b/pos-location/src/test/java/com/positivity/location/internal/config/LocationEventTypeInitializerTest.java
@@ -1,0 +1,125 @@
+package com.positivity.location.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link LocationEventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link LocationEventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LocationEventTypeInitializer — startup event-type registration")
+class LocationEventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private LocationEventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new LocationEventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(LocationEventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        LocationEventTypeInitializer sutWithSecret =
+                new LocationEventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(LocationEventTypes.all().size()))
+                .header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(LocationEventTypes.all()).isNotEmpty();
+        verify(restClient, times(LocationEventTypes.all().size())).put();
+    }
+}

--- a/pos-location/src/test/java/com/positivity/location/internal/config/LocationEventTypesTest.java
+++ b/pos-location/src/test/java/com/positivity/location/internal/config/LocationEventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.location.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link LocationEventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
  * descriptions, ordered thresholds, and a threshold triple that matches a
  * declared preset rather than an ad-hoc value.
  */
-@DisplayName("EventTypes — event-type registry contract")
-class EventTypesTest {
+@DisplayName("LocationEventTypes — event-type registry contract")
+class LocationEventTypesTest {
 
     /**
      * Event type codes are upper snake case: the receiver stores them verbatim as
@@ -58,7 +58,7 @@ class EventTypesTest {
     }
 
     private static List<EventTypeRegistration> registrations() {
-        return EventTypes.all();
+        return LocationEventTypes.all();
     }
 
     @Test
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-location/src/test/java/com/positivity/location/internal/config/ManifestPublisherTest.java
+++ b/pos-location/src/test/java/com/positivity/location/internal/config/ManifestPublisherTest.java
@@ -1,0 +1,366 @@
+package com.positivity.location.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.location.internal.entity.OutboxEvent;
+import com.positivity.location.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for the pos-location {@link ManifestPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * Each closed window gets one reconciliation manifest summarizing the events
+ * published from the outbox in that window; consumers recompute the same summary
+ * and request a replay on drift. The properties that matter:
+ *
+ * <ul>
+ * <li>Window membership is decided by the <em>eventId</em> (UUIDv7) timestamp,
+ * not by {@code createdAt}. The query pads its range by a second of slack, so a
+ * row can be fetched and still belong to a neighbouring window; counting it in
+ * the wrong one would manufacture drift on both sides.</li>
+ * <li>Empty windows still publish, so consumers can alert on manifest absence
+ * rather than treating silence as health.</li>
+ * <li>A malformed row is skipped with a warning instead of failing the window
+ * forever — one bad payload must not permanently block reconciliation.</li>
+ * <li>A failed send leaves the window unadvanced so the next run retries it, and
+ * catch-up is bounded per run so a long outage cannot monopolize a poll.</li>
+ * </ul>
+ */
+@DisplayName("pos-location ManifestPublisher — reconciliation manifest windows")
+class ManifestPublisherTest {
+
+    /** 12:10 UTC: the [11:00, 12:00) window closed more than the 5m grace ago. */
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-08T12:10:00Z"), ZoneOffset.UTC);
+
+    private static final Instant WINDOW_START = Instant.parse("2026-07-08T11:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-07-08T12:00:00Z");
+    private static final String EVENTS_TOPIC = "location.events.v1";
+    private static final String MANIFEST_TOPIC = "location.manifest.v1";
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private SimpleMeterRegistry meterRegistry;
+    private ManifestPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry, TEST_CLOCK);
+        brokerAcknowledges();
+    }
+
+    @SuppressWarnings("unchecked")
+    private ManifestPublisher newPublisher(MeterRegistry registry, Clock clock) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        ManifestPublisher created = new ManifestPublisher(repository, kafkaTemplate, objectMapper, clock, provider);
+        ReflectionTestUtils.setField(created, "eventsTopic", EVENTS_TOPIC);
+        ReflectionTestUtils.setField(created, "manifestTopic", MANIFEST_TOPIC);
+        ReflectionTestUtils.setField(created, "window", Duration.ofHours(1));
+        ReflectionTestUtils.setField(created, "grace", Duration.ofMinutes(5));
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    /** UUIDv7-shaped id whose embedded timestamp is {@code at}. */
+    private static String eventIdAt(Instant at, int suffix) {
+        long millis = at.toEpochMilli();
+        return String.format("%08x-%04x-7000-8000-%012x", millis >>> 16, millis & 0xFFFF, suffix);
+    }
+
+    private static OutboxEvent row(String eventId, String eventType, Instant createdAt) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey(eventId)
+                .payload("{\"eventId\":\"" + eventId + "\",\"eventType\":\"" + eventType + "\",\"payload\":{}}")
+                .createdAt(createdAt)
+                .publishedAt(createdAt.plusSeconds(1))
+                .build();
+    }
+
+    private void outboxReturns(List<OutboxEvent> rows) {
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(rows);
+    }
+
+    private JsonNode capturedManifest() {
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), json.capture());
+        return objectMapper.readTree(json.getValue());
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("publishes the latest closed window with its count, checksum, and per-type counts")
+    void publishesManifestForClosedWindow() {
+        String inWindow1 = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String inWindow2 = eventIdAt(WINDOW_START.plusSeconds(120), 2);
+        outboxReturns(List.of(
+                row(inWindow1, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(inWindow2, "SomethingElseChanged", WINDOW_START.plusSeconds(120))));
+
+        publisher.publishDueManifest();
+
+        JsonNode envelope = capturedManifest();
+        assertThat(envelope.path("sourceService").stringValue()).isEqualTo("pos-location");
+        assertThat(envelope.path("eventType").stringValue())
+                .isEqualTo(ReconciliationManifestV1.eventTypeFor("location"));
+
+        JsonNode manifest = envelope.path("payload");
+        assertThat(manifest.path("windowStartUtc").stringValue()).isEqualTo(WINDOW_START.toString());
+        assertThat(manifest.path("windowEndUtc").stringValue()).isEqualTo(WINDOW_END.toString());
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(2);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow1, inWindow2)));
+        assertThat(manifest.path("eventTypeCounts").path("SomethingChanged").longValue())
+                .isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("SomethingElseChanged").longValue())
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row fetched by createdAt slack whose eventId falls outside the window")
+    void excludesRowOutsideWindowByEventIdTimestamp() {
+        String inWindow = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String justBefore = eventIdAt(WINDOW_START.minusMillis(1), 2);
+        String justAfter = eventIdAt(WINDOW_END.plusMillis(1), 3);
+        outboxReturns(List.of(
+                row(justBefore, "SomethingChanged", WINDOW_START.minusMillis(1)),
+                row(inWindow, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(justAfter, "SomethingChanged", WINDOW_END.plusMillis(1))));
+
+        publisher.publishDueManifest();
+
+        // Membership is decided by the eventId timestamp, not the padded createdAt
+        // query: counting a neighbour here would manufacture drift on both sides.
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow)));
+    }
+
+    @Test
+    @DisplayName("publishes a zero-count manifest so consumers can alert on absence rather than silence")
+    void publishesEmptyWindowManifest() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isZero();
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of()));
+    }
+
+    @Test
+    @DisplayName("counts a row with a blank event type under \"unknown\" rather than dropping it")
+    void blankEventTypeCountedAsUnknown() {
+        String eventId = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        outboxReturns(List.of(row(eventId, "", WINDOW_START.plusSeconds(60))));
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("unknown").longValue()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row with no eventId instead of failing the window")
+    void skipsRowWithoutEventId() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("{\"eventType\":\"PartyChanged\"}")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("excludes a row whose payload will not parse instead of blocking reconciliation forever")
+    void skipsRowWithUnparsablePayload() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("not json at all")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("does not re-publish a window it already published")
+    void skipsAlreadyPublishedWindow() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("waits out the grace period, publishing the previous window until the latest one settles")
+    void respectsGracePeriod() {
+        ReflectionTestUtils.setField(publisher, "grace", Duration.ofMinutes(15));
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        // 12:10 with 15m grace: [11:00, 12:00) is not yet eligible, so the
+        // published window is the previous one.
+        assertThat(capturedManifest().path("payload").path("windowEndUtc").stringValue())
+                .isEqualTo("2026-07-08T11:00:00Z");
+    }
+
+    @Test
+    @DisplayName("retries the same window on the next run when the send fails")
+    void retriesWindowAfterSendFailure() {
+        outboxReturns(List.of());
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker down")))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        // The window must not advance past a failure, or its manifest is lost.
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(counter("location.manifest.publish.failures")).isEqualTo(1d);
+        assertThat(counter("location.manifest.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("counts a successful publish")
+    void countsSuccessfulPublish() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        assertThat(counter("location.manifest.published")).isEqualTo(1d);
+        assertThat(counter("location.manifest.publish.failures")).isZero();
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        ManifestPublisher withoutMetrics = newPublisher(null, TEST_CLOCK);
+        outboxReturns(List.of());
+
+        withoutMetrics.publishDueManifest();
+
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("publishes nothing when no window has closed yet")
+    void publishesNothingBeforeTheFirstWindowCloses() {
+        // Epoch + 30m with a 1h window: no aligned window boundary has passed.
+        ManifestPublisher early = newPublisher(meterRegistry, Clock.fixed(Instant.ofEpochSecond(1800), ZoneOffset.UTC));
+
+        early.publishDueManifest();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("keys every manifest for a window deterministically, so re-publishes land on one partition")
+    void manifestRecordKeyIsStablePerWindow() {
+        outboxReturns(List.of());
+        ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+
+        publisher.publishDueManifest();
+        // A second publisher instance, same window: the key must match.
+        ManifestPublisher other = newPublisher(meterRegistry, TEST_CLOCK);
+        other.publishDueManifest();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), key.capture(), anyString());
+        assertThat(key.getAllValues()).hasSize(2);
+        assertThat(key.getAllValues().get(0)).isEqualTo(key.getAllValues().get(1));
+    }
+
+    @Test
+    @DisplayName("after a gap, catches up window by window rather than skipping to the newest")
+    void catchesUpWindowByWindow() {
+        outboxReturns(List.of());
+
+        // First run establishes [11:00, 12:00) as published.
+        publisher.publishDueManifest();
+
+        // Three hours later four windows have closed; the next run must publish the
+        // intervening ones, not jump to the newest and leave holes.
+        ManifestPublisher later = publisher;
+        ReflectionTestUtils.setField(
+                later, "clock", Clock.fixed(Instant.parse("2026-07-08T15:10:00Z"), ZoneOffset.UTC));
+        later.publishDueManifest();
+
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate, times(4)).send(anyString(), anyString(), json.capture());
+        assertThat(json.getAllValues())
+                .map(value -> objectMapper
+                        .readTree(value)
+                        .path("payload")
+                        .path("windowEndUtc")
+                        .stringValue())
+                .containsExactly(
+                        "2026-07-08T12:00:00Z", "2026-07-08T13:00:00Z", "2026-07-08T14:00:00Z", "2026-07-08T15:00:00Z");
+    }
+}

--- a/pos-location/src/test/java/com/positivity/location/internal/config/OutboxPublisherTest.java
+++ b/pos-location/src/test/java/com/positivity/location/internal/config/OutboxPublisherTest.java
@@ -1,0 +1,213 @@
+package com.positivity.location.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.location.internal.entity.OutboxEvent;
+import com.positivity.location.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for the pos-location {@link OutboxPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * The publisher drains {@code event_outbox} to Kafka with at-least-once
+ * semantics. Three properties carry the correctness weight:
+ *
+ * <ul>
+ * <li>a row is marked published <em>only</em> after the broker acknowledges, so
+ * a crash mid-send re-sends rather than silently dropping the event;</li>
+ * <li>the batch stops at the first failure, so a struggling broker cannot
+ * reorder events past a stuck row; and</li>
+ * <li>the failure path records {@code attempts} and a bounded
+ * {@code last_error} for alerting instead of throwing out of the scheduled
+ * method.</li>
+ * </ul>
+ */
+@DisplayName("pos-location OutboxPublisher — outbox drain contract")
+class OutboxPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-08T12:00:00Z");
+    private static final Clock TEST_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private SimpleMeterRegistry meterRegistry;
+    private OutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    private OutboxPublisher newPublisher(MeterRegistry registry) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        OutboxPublisher created = new OutboxPublisher(repository, kafkaTemplate, TEST_CLOCK, provider);
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private OutboxEvent event(String key) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("location.events.v1")
+                .recordKey(key)
+                .payload("{\"eventId\":\"" + key + "\"}")
+                .createdAt(NOW.minusSeconds(60))
+                .attempts(2)
+                .lastError("previous failure")
+                .build();
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    private void brokerFailsWith(Throwable failure) {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(failure));
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("marks the row published only after the broker acknowledges the send")
+    void marksPublishedAfterAcknowledgedSend() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate).send("location.events.v1", "k1", row.getPayload());
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        assertThat(row.getAttempts()).isZero();
+        assertThat(row.getLastError()).isNull();
+        verify(repository).save(row);
+        assertThat(counter("location.outbox.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("drains the whole batch in order while the broker keeps acknowledging")
+    void drainsWholeBatchWhenAllSendsSucceed() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(first.getPublishedAt()).isEqualTo(NOW);
+        assertThat(second.getPublishedAt()).isEqualTo(NOW);
+        assertThat(counter("location.outbox.published")).isEqualTo(2d);
+    }
+
+    @Test
+    @DisplayName("on failure: records the attempt and error, leaves the row unpublished, stops the batch")
+    void recordsFailureAndStopsBatch() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerFailsWith(new RuntimeException("broker down"));
+
+        publisher.publishPending();
+
+        assertThat(first.getPublishedAt()).isNull();
+        assertThat(first.getAttempts()).isEqualTo(3);
+        assertThat(first.getLastError()).contains("broker down");
+        verify(repository).save(first);
+
+        // The batch stops at the first failure so publish order is preserved:
+        // the second row is never attempted and keeps its prior attempt count.
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+        verify(kafkaTemplate).send("location.events.v1", "k1", first.getPayload());
+        assertThat(second.getAttempts()).isEqualTo(2);
+        assertThat(second.getPublishedAt()).isNull();
+        assertThat(counter("location.outbox.publish.failures")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("falls back to the exception class name when the failure carries no message")
+    void recordsClassNameWhenFailureMessageIsNull() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        // Thrown by send() itself rather than completing the future exceptionally:
+        // a failed future surfaces as an ExecutionException whose message is the
+        // cause's toString, so only a synchronous throw reaches the null-message
+        // fallback in recordFailure().
+        when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenThrow(new IllegalStateException());
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).isEqualTo("IllegalStateException");
+        assertThat(row.getPublishedAt()).isNull();
+        assertThat(row.getAttempts()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("truncates an oversized failure message to the 2000-character column bound")
+    void truncatesOversizedFailureMessage() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerFailsWith(new RuntimeException("x".repeat(2500)));
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).hasSize(2000);
+    }
+
+    @Test
+    @DisplayName("does nothing when the outbox is empty")
+    void doesNothingWhenNoPendingRows() {
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of());
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        verify(repository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        OutboxPublisher withoutMetrics = newPublisher(null);
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        withoutMetrics.publishPending();
+
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        verify(repository).save(row);
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/config/MarketingEventTypeInitializerTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/config/MarketingEventTypeInitializerTest.java
@@ -1,0 +1,125 @@
+package com.positivity.marketing.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link MarketingEventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link MarketingEventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MarketingEventTypeInitializer — startup event-type registration")
+class MarketingEventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private MarketingEventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new MarketingEventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(MarketingEventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        MarketingEventTypeInitializer sutWithSecret =
+                new MarketingEventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(MarketingEventTypes.all().size()))
+                .header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(MarketingEventTypes.all()).isNotEmpty();
+        verify(restClient, times(MarketingEventTypes.all().size())).put();
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/config/MarketingEventTypesTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/config/MarketingEventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.marketing.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link MarketingEventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
  * descriptions, ordered thresholds, and a threshold triple that matches a
  * declared preset rather than an ad-hoc value.
  */
-@DisplayName("EventTypes — event-type registry contract")
-class EventTypesTest {
+@DisplayName("MarketingEventTypes — event-type registry contract")
+class MarketingEventTypesTest {
 
     /**
      * Event type codes are upper snake case: the receiver stores them verbatim as
@@ -58,7 +58,7 @@ class EventTypesTest {
     }
 
     private static List<EventTypeRegistration> registrations() {
-        return EventTypes.all();
+        return MarketingEventTypes.all();
     }
 
     @Test
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/config/MarketingExceptionHandlerTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/config/MarketingExceptionHandlerTest.java
@@ -1,0 +1,179 @@
+package com.positivity.marketing.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.marketing.internal.exception.MarketingDuplicateResourceException;
+import com.positivity.marketing.internal.exception.MarketingResourceNotFoundException;
+import com.positivity.marketing.internal.exception.MarketingUnprocessableEntityException;
+import com.positivity.shared.error.ApiError;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+/**
+ * Unit tests for {@link MarketingExceptionHandler} (ADR-0017 error envelope).
+ *
+ * <p>
+ * Two things are worth pinning here. The <b>status and code pairing</b> is the
+ * contract clients branch on — a duplicate campaign code has to read as 409
+ * with {@code DUPLICATE_RESOURCE}, not as a generic 400 — and the <b>correlation
+ * id is echoed onto both the body and the response header</b>, since that id is
+ * how a report of "it failed" is turned into a log search. An inbound
+ * correlation id is preserved rather than replaced, so a trace started upstream
+ * survives the error.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MarketingExceptionHandler — ApiError envelope and correlation")
+class MarketingExceptionHandlerTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+    private static final String CORRELATION_HEADER = "X-Correlation-Id";
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    private MarketingExceptionHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new MarketingExceptionHandler(Clock.fixed(NOW, ZoneOffset.UTC));
+    }
+
+    private void inboundCorrelationId(String value) {
+        when(request.getHeader(CORRELATION_HEADER)).thenReturn(value);
+    }
+
+    private String capturedCorrelationHeader() {
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(response).setHeader(org.mockito.ArgumentMatchers.eq(CORRELATION_HEADER), captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("maps a missing resource to 404 RESOURCE_NOT_FOUND")
+    void notFound() {
+        inboundCorrelationId("trace-1");
+
+        ResponseEntity<ApiError> result = handler.handleNotFound(
+                new MarketingResourceNotFoundException("Campaign", UUID.randomUUID()), request, response);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().code()).isEqualTo("RESOURCE_NOT_FOUND");
+        assertThat(result.getBody().status()).isEqualTo(404);
+        assertThat(result.getBody().timestamp()).isEqualTo(NOW.toString());
+        // An upstream trace must survive the error rather than being replaced.
+        assertThat(result.getBody().correlationId()).isEqualTo("trace-1");
+        assertThat(capturedCorrelationHeader()).isEqualTo("trace-1");
+    }
+
+    @Test
+    @DisplayName("maps a duplicate to 409 DUPLICATE_RESOURCE")
+    void duplicate() {
+        inboundCorrelationId(null);
+
+        ResponseEntity<ApiError> result = handler.handleDuplicate(
+                new MarketingDuplicateResourceException("Campaign", "SPRING"), request, response);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().code()).isEqualTo("DUPLICATE_RESOURCE");
+        // No inbound id: one is minted so the failure is still traceable.
+        assertThat(result.getBody().correlationId()).isNotBlank();
+        assertThat(capturedCorrelationHeader()).isEqualTo(result.getBody().correlationId());
+    }
+
+    @Test
+    @DisplayName("maps a rejected state change to 422 UNPROCESSABLE_ENTITY")
+    void unprocessable() {
+        inboundCorrelationId("  ");
+
+        ResponseEntity<ApiError> result = handler.handleUnprocessable(
+                new MarketingUnprocessableEntityException("Campaign has no segment bound"), request, response);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().code()).isEqualTo("UNPROCESSABLE_ENTITY");
+        assertThat(result.getBody().message()).isEqualTo("Campaign has no segment bound");
+        // A blank inbound header is treated as absent, not echoed back as blank.
+        assertThat(result.getBody().correlationId()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("maps a permission failure to 403 without leaking why")
+    void accessDenied() {
+        inboundCorrelationId("trace-2");
+
+        ResponseEntity<ApiError> result = handler.handleAccessDenied(
+                new AccessDeniedException("missing marketing:campaign:send"), request, response);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().code()).isEqualTo("PERMISSION_DENIED");
+        // The required authority is a detail of the authorization model; it stays in the log.
+        assertThat(result.getBody().message()).doesNotContain("marketing:campaign:send");
+    }
+
+    @Test
+    @DisplayName("maps an illegal argument to 400 VALIDATION_ERROR")
+    void illegalArgument() {
+        inboundCorrelationId("trace-3");
+
+        ResponseEntity<ApiError> result =
+                handler.handleIllegalArgument(new IllegalArgumentException("bad page size"), request, response);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().code()).isEqualTo("VALIDATION_ERROR");
+        assertThat(result.getBody().message()).isEqualTo("bad page size");
+    }
+
+    @Test
+    @DisplayName("reports every rejected field, defaulting a null message rather than emitting null")
+    void bodyValidationListsFieldErrors() throws NoSuchMethodException {
+        inboundCorrelationId("trace-4");
+        BindingResult binding = new BeanPropertyBindingResult(new Object(), "request");
+        binding.addError(new FieldError("request", "name", "must not be blank"));
+        binding.addError(new FieldError("request", "channel", null));
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(
+                new org.springframework.core.MethodParameter(
+                        MarketingExceptionHandlerTest.class.getDeclaredMethod("bodyValidationListsFieldErrors"), -1),
+                binding);
+
+        ResponseEntity<ApiError> result = handler.handleMethodArgumentNotValid(ex, request, response);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().code()).isEqualTo("VALIDATION_FAILED");
+        assertThat(result.getBody().correlationId()).isEqualTo("trace-4");
+        List<ApiError.FieldError> fieldErrors = result.getBody().fieldErrors();
+        assertThat(fieldErrors)
+                .extracting(ApiError.FieldError::field, ApiError.FieldError::message)
+                .containsExactly(
+                        org.assertj.core.api.Assertions.tuple("name", "must not be blank"),
+                        org.assertj.core.api.Assertions.tuple("channel", "Invalid value"));
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/config/OutboxEventWriterTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/config/OutboxEventWriterTest.java
@@ -1,0 +1,126 @@
+package com.positivity.marketing.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.marketing.MarketingCampaignScheduledV1;
+import com.positivity.marketing.internal.entity.OutboxEvent;
+import com.positivity.marketing.internal.repository.OutboxEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link OutboxEventWriter}.
+ *
+ * <p>
+ * The outbox exists so an event is queued if and only if the business
+ * transaction committed. What this class must get right is the row it writes:
+ *
+ * <ul>
+ * <li><b>The record key is the aggregate id.</b> Kafka only orders within a
+ * partition, so a key that varied per event would let two facts about one
+ * aggregate arrive out of order.</li>
+ * <li><b>The stored payload is the whole envelope</b>, not just the domain
+ * payload — the publisher forwards the row's bytes verbatim.</li>
+ * <li><b>A serialization failure is fatal, not swallowed.</b> Writing an
+ * unreadable row would produce an event that can never be published, and
+ * because the write is transactional, throwing correctly rolls the business
+ * change back with it.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OutboxEventWriter — transactional outbox row contract")
+class OutboxEventWriterTest {
+
+    private static final UUID AGGREGATE_ID = UUID.fromString("01960004-0000-7000-8000-0000000000c1");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
+
+    private OutboxEventWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        writer = new OutboxEventWriter(clock, new ObjectMapper(), outboxEventRepository);
+    }
+
+    private static DomainEventEnvelope<Object> envelope() {
+        return DomainEventEnvelope.of(
+                MarketingCampaignScheduledV1.EVENT_TYPE,
+                1,
+                AGGREGATE_ID,
+                0L,
+                "pos-marketing",
+                null,
+                null,
+                new MarketingCampaignScheduledV1(AGGREGATE_ID, "SPRING", "COMMERCIAL", UUID.randomUUID(), NOW),
+                Clock.fixed(NOW, ZoneOffset.UTC));
+    }
+
+    private OutboxEvent captureSaved() {
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxEventRepository).save(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("keys the row on the aggregate id and stores the serialized envelope")
+    void publishWritesEnvelopeRow() {
+        writer.publish("marketing.events.v1", envelope());
+
+        OutboxEvent saved = captureSaved();
+        assertThat(saved.getTopic()).isEqualTo("marketing.events.v1");
+        assertThat(saved.getRecordKey()).isEqualTo(AGGREGATE_ID.toString());
+        assertThat(saved.getCreatedAt()).isEqualTo(NOW);
+        assertThat(saved.getPayload())
+                .contains(MarketingCampaignScheduledV1.EVENT_TYPE)
+                .contains(AGGREGATE_ID.toString())
+                .contains("pos-marketing");
+        // Not yet drained: publishedAt is what OutboxPublisher stamps.
+        assertThat(saved.getPublishedAt()).isNull();
+        assertThat(saved.getAttempts()).isZero();
+    }
+
+    @Test
+    @DisplayName("stores a pre-serialized command verbatim under the caller's ordering key")
+    void publishRawStoresMessageUnchanged() {
+        writer.publishRaw("customer.commands.v1", "segment-42", "{\"commandType\":\"x\"}");
+
+        OutboxEvent saved = captureSaved();
+        assertThat(saved.getTopic()).isEqualTo("customer.commands.v1");
+        assertThat(saved.getRecordKey()).isEqualTo("segment-42");
+        assertThat(saved.getPayload()).isEqualTo("{\"commandType\":\"x\"}");
+        assertThat(saved.getCreatedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("fails the transaction rather than queueing an envelope it could not serialize")
+    void serializationFailureIsFatal() {
+        ObjectMapper failing = org.mockito.Mockito.mock(ObjectMapper.class);
+        when(failing.writeValueAsString(org.mockito.ArgumentMatchers.any()))
+                .thenThrow(new IllegalStateException("boom"));
+        OutboxEventWriter failingWriter = new OutboxEventWriter(clock, failing, outboxEventRepository);
+
+        assertThatThrownBy(() -> failingWriter.publish("marketing.events.v1", envelope()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(MarketingCampaignScheduledV1.EVENT_TYPE);
+
+        verify(outboxEventRepository, org.mockito.Mockito.never()).save(org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/config/OutboxPublisherTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/config/OutboxPublisherTest.java
@@ -1,0 +1,213 @@
+package com.positivity.marketing.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.marketing.internal.entity.OutboxEvent;
+import com.positivity.marketing.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for the pos-marketing {@link OutboxPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * The publisher drains {@code event_outbox} to Kafka with at-least-once
+ * semantics. Three properties carry the correctness weight:
+ *
+ * <ul>
+ * <li>a row is marked published <em>only</em> after the broker acknowledges, so
+ * a crash mid-send re-sends rather than silently dropping the event;</li>
+ * <li>the batch stops at the first failure, so a struggling broker cannot
+ * reorder events past a stuck row; and</li>
+ * <li>the failure path records {@code attempts} and a bounded
+ * {@code last_error} for alerting instead of throwing out of the scheduled
+ * method.</li>
+ * </ul>
+ */
+@DisplayName("pos-marketing OutboxPublisher — outbox drain contract")
+class OutboxPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-08T12:00:00Z");
+    private static final Clock TEST_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private SimpleMeterRegistry meterRegistry;
+    private OutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    private OutboxPublisher newPublisher(MeterRegistry registry) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        OutboxPublisher created = new OutboxPublisher(repository, kafkaTemplate, TEST_CLOCK, provider);
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private OutboxEvent event(String key) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("marketing.events.v1")
+                .recordKey(key)
+                .payload("{\"eventId\":\"" + key + "\"}")
+                .createdAt(NOW.minusSeconds(60))
+                .attempts(2)
+                .lastError("previous failure")
+                .build();
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    private void brokerFailsWith(Throwable failure) {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(failure));
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("marks the row published only after the broker acknowledges the send")
+    void marksPublishedAfterAcknowledgedSend() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate).send("marketing.events.v1", "k1", row.getPayload());
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        assertThat(row.getAttempts()).isZero();
+        assertThat(row.getLastError()).isNull();
+        verify(repository).save(row);
+        assertThat(counter("marketing.outbox.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("drains the whole batch in order while the broker keeps acknowledging")
+    void drainsWholeBatchWhenAllSendsSucceed() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(first.getPublishedAt()).isEqualTo(NOW);
+        assertThat(second.getPublishedAt()).isEqualTo(NOW);
+        assertThat(counter("marketing.outbox.published")).isEqualTo(2d);
+    }
+
+    @Test
+    @DisplayName("on failure: records the attempt and error, leaves the row unpublished, stops the batch")
+    void recordsFailureAndStopsBatch() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerFailsWith(new RuntimeException("broker down"));
+
+        publisher.publishPending();
+
+        assertThat(first.getPublishedAt()).isNull();
+        assertThat(first.getAttempts()).isEqualTo(3);
+        assertThat(first.getLastError()).contains("broker down");
+        verify(repository).save(first);
+
+        // The batch stops at the first failure so publish order is preserved:
+        // the second row is never attempted and keeps its prior attempt count.
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+        verify(kafkaTemplate).send("marketing.events.v1", "k1", first.getPayload());
+        assertThat(second.getAttempts()).isEqualTo(2);
+        assertThat(second.getPublishedAt()).isNull();
+        assertThat(counter("marketing.outbox.publish.failures")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("falls back to the exception class name when the failure carries no message")
+    void recordsClassNameWhenFailureMessageIsNull() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        // Thrown by send() itself rather than completing the future exceptionally:
+        // a failed future surfaces as an ExecutionException whose message is the
+        // cause's toString, so only a synchronous throw reaches the null-message
+        // fallback in recordFailure().
+        when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenThrow(new IllegalStateException());
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).isEqualTo("IllegalStateException");
+        assertThat(row.getPublishedAt()).isNull();
+        assertThat(row.getAttempts()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("truncates an oversized failure message to the 2000-character column bound")
+    void truncatesOversizedFailureMessage() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerFailsWith(new RuntimeException("x".repeat(2500)));
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).hasSize(2000);
+    }
+
+    @Test
+    @DisplayName("does nothing when the outbox is empty")
+    void doesNothingWhenNoPendingRows() {
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of());
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        verify(repository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        OutboxPublisher withoutMetrics = newPublisher(null);
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        withoutMetrics.publishPending();
+
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        verify(repository).save(row);
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignSendServiceImplTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignSendServiceImplTest.java
@@ -1,0 +1,331 @@
+package com.positivity.marketing.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.marketing.internal.dto.CampaignSendResponse;
+import com.positivity.marketing.internal.dto.PagedResponse;
+import com.positivity.marketing.internal.entity.Campaign;
+import com.positivity.marketing.internal.entity.CampaignSend;
+import com.positivity.marketing.internal.enums.CampaignChannel;
+import com.positivity.marketing.internal.enums.CampaignStatus;
+import com.positivity.marketing.internal.enums.SendStatus;
+import com.positivity.marketing.internal.exception.MarketingResourceNotFoundException;
+import com.positivity.marketing.internal.exception.MarketingUnprocessableEntityException;
+import com.positivity.marketing.internal.repository.CampaignAudienceMemberRepository;
+import com.positivity.marketing.internal.repository.CampaignRepository;
+import com.positivity.marketing.internal.repository.CampaignSendRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+/**
+ * Unit tests for {@link CampaignSendServiceImpl}.
+ *
+ * <p>
+ * Dispatch is the point of no return for a campaign, so the behaviour worth
+ * pinning is what it refuses to do and what it survives:
+ *
+ * <ul>
+ * <li><b>An unresolved audience queues nothing.</b> Zero resolved members is
+ * ambiguous — it can mean "the segment matched nobody" or "the CRM has not
+ * replied yet" — so the service asks for a resolve and returns zero rather than
+ * declaring the campaign sent to an empty audience.</li>
+ * <li><b>Re-dispatch is expected, not exceptional.</b> An operator retrying
+ * after a partial failure must not be punished: rows are saved one at a time so
+ * a uniqueness collision costs that single recipient, not the batch.</li>
+ * <li><b>Status governs whether dispatch may start at all</b>, and a campaign
+ * already SENDING is not re-saved back to SENDING.</li>
+ * <li><b>Page size is clamped.</b> An unbounded {@code size} on a bulk campaign
+ * would materialize an entire audience into one response.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CampaignSendServiceImpl — dispatch materialization and send listing")
+class CampaignSendServiceImplTest {
+
+    private static final UUID CAMPAIGN_ID = UUID.randomUUID();
+    private static final UUID SEGMENT_ID = UUID.randomUUID();
+    private static final UUID PARTY_A = UUID.randomUUID();
+    private static final UUID PARTY_B = UUID.randomUUID();
+    private static final Instant NOW = Instant.parse("2026-08-11T10:15:30Z");
+
+    @Mock
+    private CampaignRepository campaignRepository;
+
+    @Mock
+    private CampaignSendRepository sendRepository;
+
+    @Mock
+    private CampaignAudienceMemberRepository audienceRepository;
+
+    @Mock
+    private SegmentResolveRequester resolveRequester;
+
+    private CampaignSendServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CampaignSendServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                campaignRepository,
+                sendRepository,
+                audienceRepository,
+                resolveRequester);
+    }
+
+    private static Campaign campaign(CampaignStatus status, UUID segmentId, CampaignChannel... channels) {
+        Set<CampaignChannel> channelSet = new LinkedHashSet<>(List.of(channels));
+        return Campaign.builder()
+                .campaignId(CAMPAIGN_ID)
+                .code("SPRING-TUNE-UP")
+                .status(status)
+                .segmentId(segmentId)
+                .channels(channelSet)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("dispatch")
+    class Dispatch {
+
+        @Test
+        @DisplayName("rejects a campaign that does not exist")
+        void unknownCampaign() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.dispatch(CAMPAIGN_ID))
+                    .isInstanceOf(MarketingResourceNotFoundException.class);
+
+            verifyNoInteractions(audienceRepository, sendRepository, resolveRequester);
+        }
+
+        @ParameterizedTest
+        @EnumSource(
+                value = CampaignStatus.class,
+                names = {"SCHEDULED", "SENDING"},
+                mode = EnumSource.Mode.EXCLUDE)
+        @DisplayName("refuses to dispatch from any status other than SCHEDULED or SENDING")
+        void wrongStatus(CampaignStatus status) {
+            when(campaignRepository.findById(CAMPAIGN_ID))
+                    .thenReturn(Optional.of(campaign(status, SEGMENT_ID, CampaignChannel.EMAIL)));
+
+            assertThatThrownBy(() -> service.dispatch(CAMPAIGN_ID))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class)
+                    .hasMessageContaining(status.name());
+
+            verifyNoInteractions(audienceRepository, sendRepository);
+        }
+
+        @Test
+        @DisplayName("refuses to dispatch a campaign with no segment bound")
+        void noSegment() {
+            when(campaignRepository.findById(CAMPAIGN_ID))
+                    .thenReturn(Optional.of(campaign(CampaignStatus.SCHEDULED, null, CampaignChannel.EMAIL)));
+
+            assertThatThrownBy(() -> service.dispatch(CAMPAIGN_ID))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class)
+                    .hasMessageContaining("no segment bound");
+
+            verifyNoInteractions(audienceRepository, sendRepository);
+        }
+
+        @Test
+        @DisplayName("requests a resolve and queues nothing when the audience has not arrived yet")
+        void unresolvedAudienceQueuesNothing() {
+            Campaign scheduled = campaign(CampaignStatus.SCHEDULED, SEGMENT_ID, CampaignChannel.EMAIL);
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(scheduled));
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of());
+
+            assertThat(service.dispatch(CAMPAIGN_ID)).isZero();
+
+            verify(resolveRequester).requestResolve(CAMPAIGN_ID, SEGMENT_ID);
+            verify(sendRepository, never()).saveAndFlush(any());
+            // The campaign must stay SCHEDULED — flipping it to SENDING with an empty audience
+            // would report the campaign as under way when nothing has been queued.
+            verify(campaignRepository, never()).save(any());
+            assertThat(scheduled.getStatus()).isEqualTo(CampaignStatus.SCHEDULED);
+        }
+
+        @Test
+        @DisplayName("queues one PENDING row per recipient per channel and moves SCHEDULED to SENDING")
+        void queuesRecipientChannelMatrix() {
+            Campaign scheduled =
+                    campaign(CampaignStatus.SCHEDULED, SEGMENT_ID, CampaignChannel.EMAIL, CampaignChannel.SMS);
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(scheduled));
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of(PARTY_A, PARTY_B));
+            when(sendRepository.findByCampaignIdAndRecipientPartyIdAndChannel(eq(CAMPAIGN_ID), any(), any()))
+                    .thenReturn(Optional.empty());
+
+            assertThat(service.dispatch(CAMPAIGN_ID)).isEqualTo(4);
+
+            ArgumentCaptor<CampaignSend> saved = ArgumentCaptor.forClass(CampaignSend.class);
+            verify(sendRepository, times(4)).saveAndFlush(saved.capture());
+            assertThat(saved.getAllValues())
+                    .allSatisfy(send -> {
+                        assertThat(send.getCampaignId()).isEqualTo(CAMPAIGN_ID);
+                        assertThat(send.getStatus()).isEqualTo(SendStatus.PENDING);
+                        assertThat(send.getQueuedAt()).isEqualTo(NOW);
+                        assertThat(send.getUpdatedAt()).isEqualTo(NOW);
+                    })
+                    .extracting(CampaignSend::getRecipientPartyId, CampaignSend::getChannel)
+                    .containsExactlyInAnyOrder(
+                            tuple(PARTY_A, CampaignChannel.EMAIL),
+                            tuple(PARTY_A, CampaignChannel.SMS),
+                            tuple(PARTY_B, CampaignChannel.EMAIL),
+                            tuple(PARTY_B, CampaignChannel.SMS));
+
+            assertThat(scheduled.getStatus()).isEqualTo(CampaignStatus.SENDING);
+            verify(campaignRepository).save(scheduled);
+            verifyNoInteractions(resolveRequester);
+        }
+
+        @Test
+        @DisplayName("skips a recipient-channel pair that is already queued")
+        void skipsAlreadyQueuedPairs() {
+            Campaign sending = campaign(CampaignStatus.SENDING, SEGMENT_ID, CampaignChannel.EMAIL);
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(sending));
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of(PARTY_A, PARTY_B));
+            when(sendRepository.findByCampaignIdAndRecipientPartyIdAndChannel(
+                            CAMPAIGN_ID, PARTY_A, CampaignChannel.EMAIL))
+                    .thenReturn(Optional.of(new CampaignSend()));
+            when(sendRepository.findByCampaignIdAndRecipientPartyIdAndChannel(
+                            CAMPAIGN_ID, PARTY_B, CampaignChannel.EMAIL))
+                    .thenReturn(Optional.empty());
+
+            assertThat(service.dispatch(CAMPAIGN_ID)).isEqualTo(1);
+
+            ArgumentCaptor<CampaignSend> saved = ArgumentCaptor.forClass(CampaignSend.class);
+            verify(sendRepository).saveAndFlush(saved.capture());
+            assertThat(saved.getValue().getRecipientPartyId()).isEqualTo(PARTY_B);
+            // Already SENDING: no redundant write back to the same status.
+            verify(campaignRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("counts only the rows that survived a uniqueness collision and keeps going")
+        void collisionCostsOnlyThatRecipient() {
+            when(campaignRepository.findById(CAMPAIGN_ID))
+                    .thenReturn(Optional.of(campaign(CampaignStatus.SENDING, SEGMENT_ID, CampaignChannel.EMAIL)));
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of(PARTY_A, PARTY_B));
+            when(sendRepository.findByCampaignIdAndRecipientPartyIdAndChannel(eq(CAMPAIGN_ID), any(), any()))
+                    .thenReturn(Optional.empty());
+            when(sendRepository.saveAndFlush(any()))
+                    .thenThrow(new DataIntegrityViolationException("duplicate key"))
+                    .thenReturn(new CampaignSend());
+
+            assertThat(service.dispatch(CAMPAIGN_ID)).isEqualTo(1);
+
+            // The loser of the race must not abort the batch: the second recipient still gets a row.
+            verify(sendRepository, times(2)).saveAndFlush(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("listSends")
+    class ListSends {
+
+        @Test
+        @DisplayName("maps a send row onto the response contract")
+        void mapsResponseFields() {
+            UUID sendId = UUID.randomUUID();
+            UUID contactId = UUID.randomUUID();
+            CampaignSend send = CampaignSend.builder()
+                    .campaignSendId(sendId)
+                    .campaignId(CAMPAIGN_ID)
+                    .recipientPartyId(PARTY_A)
+                    .contactId(contactId)
+                    .channel(CampaignChannel.EMAIL)
+                    .status(SendStatus.BOUNCED)
+                    .failureReason("mailbox full")
+                    .providerMessageId("prov-1")
+                    .attempts(3)
+                    .queuedAt(NOW)
+                    .sentAt(NOW.plusSeconds(5))
+                    .build();
+            when(sendRepository.findByCampaignId(eq(CAMPAIGN_ID), any(Pageable.class)))
+                    .thenReturn(new PageImpl<>(List.of(send), PageRequest.of(0, 50), 1));
+
+            PagedResponse<CampaignSendResponse> response = service.listSends(CAMPAIGN_ID, 0, 50);
+
+            assertThat(response.totalElements()).isEqualTo(1);
+            assertThat(response.items())
+                    .singleElement()
+                    .isEqualTo(new CampaignSendResponse(
+                            sendId,
+                            CAMPAIGN_ID,
+                            PARTY_A,
+                            contactId,
+                            "EMAIL",
+                            "BOUNCED",
+                            "mailbox full",
+                            "prov-1",
+                            3,
+                            NOW,
+                            NOW.plusSeconds(5)));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {0, 1, 201, 5_000, Integer.MAX_VALUE})
+        @DisplayName("clamps page size into 1..200 so one request cannot pull a whole audience")
+        void clampsSize(int requestedSize) {
+            when(sendRepository.findByCampaignId(eq(CAMPAIGN_ID), any(Pageable.class)))
+                    .thenReturn(new PageImpl<>(List.of()));
+
+            service.listSends(CAMPAIGN_ID, 0, requestedSize);
+
+            assertThat(capturedPageable().getPageSize()).isBetween(1, 200);
+        }
+
+        @Test
+        @DisplayName("treats a negative page index as the first page and sorts oldest-queued first")
+        void negativePageAndSortOrder() {
+            when(sendRepository.findByCampaignId(eq(CAMPAIGN_ID), any(Pageable.class)))
+                    .thenReturn(new PageImpl<>(List.of()));
+
+            service.listSends(CAMPAIGN_ID, -3, 50);
+
+            Pageable pageable = capturedPageable();
+            assertThat(pageable.getPageNumber()).isZero();
+            assertThat(pageable.getSort().getOrderFor("queuedAt"))
+                    .isNotNull()
+                    .extracting(Sort.Order::getDirection)
+                    .isEqualTo(Sort.Direction.ASC);
+        }
+
+        private Pageable capturedPageable() {
+            ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+            verify(sendRepository).findByCampaignId(eq(CAMPAIGN_ID), captor.capture());
+            return captor.getValue();
+        }
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignServiceImplTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignServiceImplTest.java
@@ -1,0 +1,566 @@
+package com.positivity.marketing.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.marketing.internal.dto.AudiencePreviewResponse;
+import com.positivity.marketing.internal.dto.CampaignResponse;
+import com.positivity.marketing.internal.dto.UpsertCampaignRequest;
+import com.positivity.marketing.internal.entity.Campaign;
+import com.positivity.marketing.internal.entity.MessageTemplate;
+import com.positivity.marketing.internal.entity.SegmentReplica;
+import com.positivity.marketing.internal.enums.AudienceType;
+import com.positivity.marketing.internal.enums.CampaignChannel;
+import com.positivity.marketing.internal.enums.CampaignStatus;
+import com.positivity.marketing.internal.enums.ScheduleType;
+import com.positivity.marketing.internal.exception.MarketingDuplicateResourceException;
+import com.positivity.marketing.internal.exception.MarketingResourceNotFoundException;
+import com.positivity.marketing.internal.exception.MarketingUnprocessableEntityException;
+import com.positivity.marketing.internal.repository.CampaignAudienceMemberRepository;
+import com.positivity.marketing.internal.repository.CampaignRepository;
+import com.positivity.marketing.internal.repository.MessageTemplateRepository;
+import com.positivity.marketing.internal.repository.SegmentReplicaRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link CampaignServiceImpl}.
+ *
+ * <p>
+ * A campaign that goes out wrong cannot be recalled, so most of the behaviour
+ * worth pinning here is what stops one going out at all:
+ *
+ * <ul>
+ * <li><b>Readiness problems are gathered, not thrown one at a time.</b> A
+ * marketer fixing a campaign wants the whole list rather than a game of
+ * whack-a-mole, so {@code schedule} reports every problem at once.</li>
+ * <li><b>A dangling template is as broken as a missing one.</b> The template id
+ * is verified to still resolve, not merely to be non-null.</li>
+ * <li><b>Audience type is immutable and must match the bound segment.</b> A
+ * commercial campaign on an individual segment would render templates written
+ * for organizations against people, for every recipient.</li>
+ * <li><b>Editing stops once recipients may have been contacted.</b> Status
+ * governs editability, and resume returns to SCHEDULED rather than SENDING so
+ * the worker decides when dispatch restarts.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CampaignServiceImpl — campaign lifecycle and readiness")
+class CampaignServiceImplTest {
+
+    private static final UUID CAMPAIGN_ID = UUID.randomUUID();
+    private static final UUID SEGMENT_ID = UUID.randomUUID();
+    private static final UUID EMAIL_TEMPLATE_ID = UUID.randomUUID();
+
+    @Mock
+    private CampaignRepository campaignRepository;
+
+    @Mock
+    private MessageTemplateRepository templateRepository;
+
+    @Mock
+    private SegmentReplicaRepository segmentReplicaRepository;
+
+    @Mock
+    private CampaignAudienceMemberRepository audienceRepository;
+
+    @Mock
+    private AudienceEligibilityService eligibilityService;
+
+    @Mock
+    private SegmentResolveRequester resolveRequester;
+
+    @Mock
+    private MarketingFactPublisher factPublisher;
+
+    @InjectMocks
+    private CampaignServiceImpl sut;
+
+    private static Campaign campaign(CampaignStatus status) {
+        return Campaign.builder()
+                .campaignId(CAMPAIGN_ID)
+                .code("SPRING24")
+                .name("Spring service push")
+                .audienceType(AudienceType.COMMERCIAL)
+                .status(status)
+                .channels(new java.util.HashSet<>(Set.of(CampaignChannel.EMAIL)))
+                .segmentId(SEGMENT_ID)
+                .scheduleType(ScheduleType.IMMEDIATE)
+                .emailTemplateId(EMAIL_TEMPLATE_ID)
+                .build();
+    }
+
+    private static UpsertCampaignRequest request() {
+        return new UpsertCampaignRequest(
+                "SPRING24",
+                "Spring service push",
+                "desc",
+                AudienceType.COMMERCIAL,
+                null,
+                Set.of(CampaignChannel.EMAIL),
+                SEGMENT_ID,
+                null,
+                null,
+                null,
+                null,
+                ScheduleType.IMMEDIATE,
+                null,
+                EMAIL_TEMPLATE_ID,
+                null);
+    }
+
+    private static SegmentReplica segmentReplica(boolean active, String audienceType) {
+        return SegmentReplica.builder()
+                .segmentId(SEGMENT_ID)
+                .name("Fleet accounts")
+                .audienceType(audienceType)
+                .active(active)
+                .build();
+    }
+
+    /** Segment replica present and matching, email template resolvable. */
+    private void campaignIsReady() {
+        lenient()
+                .when(segmentReplicaRepository.findById(SEGMENT_ID))
+                .thenReturn(Optional.of(segmentReplica(true, "COMMERCIAL")));
+        lenient().when(templateRepository.findById(EMAIL_TEMPLATE_ID)).thenReturn(Optional.of(new MessageTemplate()));
+    }
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        @DisplayName("persists a new campaign in DRAFT with a trimmed code")
+        void create_persistsDraft() {
+            when(campaignRepository.existsByCodeIgnoreCase("SPRING24")).thenReturn(false);
+            when(campaignRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            CampaignResponse response = sut.create(request());
+
+            assertThat(response.status()).isEqualTo("DRAFT");
+            assertThat(response.code()).isEqualTo("SPRING24");
+        }
+
+        @Test
+        @DisplayName("rejects a duplicate code case-insensitively")
+        void create_whenCodeTaken_throws() {
+            when(campaignRepository.existsByCodeIgnoreCase("SPRING24")).thenReturn(true);
+
+            assertThatThrownBy(() -> sut.create(request())).isInstanceOf(MarketingDuplicateResourceException.class);
+            verify(campaignRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("rejects a SCHEDULED campaign with no scheduledAt — it would never dispatch")
+        void create_scheduledWithoutTime_throws() {
+            UpsertCampaignRequest invalid = new UpsertCampaignRequest(
+                    "SPRING24",
+                    "n",
+                    null,
+                    AudienceType.COMMERCIAL,
+                    null,
+                    Set.of(CampaignChannel.EMAIL),
+                    SEGMENT_ID,
+                    null,
+                    null,
+                    null,
+                    null,
+                    ScheduleType.SCHEDULED,
+                    null,
+                    EMAIL_TEMPLATE_ID,
+                    null);
+            when(campaignRepository.existsByCodeIgnoreCase(any())).thenReturn(false);
+
+            assertThatThrownBy(() -> sut.create(invalid))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class)
+                    .hasMessageContaining("scheduledAt");
+        }
+
+        @Test
+        @DisplayName("rejects a send window that ends before it starts")
+        void create_invertedWindow_throws() {
+            Instant start = Instant.parse("2026-08-11T12:00:00Z");
+            UpsertCampaignRequest invalid = new UpsertCampaignRequest(
+                    "SPRING24",
+                    "n",
+                    null,
+                    AudienceType.COMMERCIAL,
+                    null,
+                    Set.of(CampaignChannel.EMAIL),
+                    SEGMENT_ID,
+                    null,
+                    null,
+                    start,
+                    start.minusSeconds(60),
+                    ScheduleType.IMMEDIATE,
+                    null,
+                    EMAIL_TEMPLATE_ID,
+                    null);
+            when(campaignRepository.existsByCodeIgnoreCase(any())).thenReturn(false);
+
+            assertThatThrownBy(() -> sut.create(invalid))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class)
+                    .hasMessageContaining("windowEnd");
+        }
+
+        @Test
+        @DisplayName("defaults the schedule type to IMMEDIATE when the request omits it")
+        void create_whenScheduleTypeOmitted_defaultsImmediate() {
+            UpsertCampaignRequest withoutType = new UpsertCampaignRequest(
+                    "SPRING24",
+                    "n",
+                    null,
+                    AudienceType.COMMERCIAL,
+                    null,
+                    Set.of(CampaignChannel.EMAIL),
+                    SEGMENT_ID,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    EMAIL_TEMPLATE_ID,
+                    null);
+            when(campaignRepository.existsByCodeIgnoreCase(any())).thenReturn(false);
+            when(campaignRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            assertThat(sut.create(withoutType).scheduleType()).isEqualTo("IMMEDIATE");
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    class Update {
+
+        @Test
+        @DisplayName("applies the changes to an editable campaign")
+        void update_appliesChanges() {
+            Campaign existing = campaign(CampaignStatus.DRAFT);
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(existing));
+            when(campaignRepository.findByCodeIgnoreCase(any())).thenReturn(Optional.empty());
+            when(campaignRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            sut.update(CAMPAIGN_ID, request());
+
+            assertThat(existing.getName()).isEqualTo("Spring service push");
+        }
+
+        @ParameterizedTest(name = "a {0} campaign cannot be edited")
+        @EnumSource(
+                value = CampaignStatus.class,
+                names = {"SENDING", "SENT", "CANCELLED", "CLOSED"})
+        @DisplayName("refuses to edit once recipients may already have been contacted")
+        void update_whenNotEditable_throws(CampaignStatus status) {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(status)));
+
+            assertThatThrownBy(() -> sut.update(CAMPAIGN_ID, request()))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class);
+            verify(campaignRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("refuses to change audience type, which its segment and templates are bound to")
+        void update_whenAudienceTypeChanges_throws() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
+            UpsertCampaignRequest switched = new UpsertCampaignRequest(
+                    "SPRING24",
+                    "n",
+                    null,
+                    AudienceType.INDIVIDUAL,
+                    null,
+                    Set.of(CampaignChannel.EMAIL),
+                    SEGMENT_ID,
+                    null,
+                    null,
+                    null,
+                    null,
+                    ScheduleType.IMMEDIATE,
+                    null,
+                    EMAIL_TEMPLATE_ID,
+                    null);
+
+            assertThatThrownBy(() -> sut.update(CAMPAIGN_ID, switched))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class)
+                    .hasMessageContaining("immutable");
+        }
+
+        @Test
+        @DisplayName("rejects a rename onto another campaign's code")
+        void update_whenCodeTakenByOther_throws() {
+            Campaign other = campaign(CampaignStatus.DRAFT);
+            other.setCampaignId(UUID.randomUUID());
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
+            when(campaignRepository.findByCodeIgnoreCase("SPRING24")).thenReturn(Optional.of(other));
+
+            assertThatThrownBy(() -> sut.update(CAMPAIGN_ID, request()))
+                    .isInstanceOf(MarketingDuplicateResourceException.class);
+        }
+
+        @Test
+        @DisplayName("throws 404 for an unknown campaign")
+        void update_whenAbsent_throws() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.update(CAMPAIGN_ID, request()))
+                    .isInstanceOf(MarketingResourceNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("schedule readiness")
+    class ScheduleReadiness {
+
+        @Test
+        @DisplayName("schedules a ready campaign and publishes the fact")
+        void schedule_whenReady_transitionsAndPublishes() {
+            Campaign existing = campaign(CampaignStatus.DRAFT);
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(existing));
+            when(campaignRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+            campaignIsReady();
+
+            assertThat(sut.schedule(CAMPAIGN_ID).status()).isEqualTo("SCHEDULED");
+            verify(factPublisher).campaignScheduled(existing);
+        }
+
+        @Test
+        @DisplayName("reports every readiness problem at once rather than one at a time")
+        void schedule_gathersAllProblems() {
+            Campaign broken = campaign(CampaignStatus.DRAFT);
+            broken.setChannels(new java.util.HashSet<>());
+            broken.setSegmentId(null);
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(broken));
+
+            // A marketer fixing a campaign wants the whole list, not whack-a-mole.
+            assertThatThrownBy(() -> sut.schedule(CAMPAIGN_ID))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class)
+                    .hasMessageContaining("no delivery channel selected")
+                    .hasMessageContaining("no segment bound");
+            verify(factPublisher, never()).campaignScheduled(any());
+        }
+
+        @Test
+        @DisplayName("refuses to schedule against a segment this module has not replicated yet")
+        void schedule_whenSegmentUnknown_reportsProblem() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
+            when(segmentReplicaRepository.findById(SEGMENT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.schedule(CAMPAIGN_ID)).hasMessageContaining("is not known to this module yet");
+        }
+
+        @Test
+        @DisplayName("refuses to schedule against an inactive segment")
+        void schedule_whenSegmentInactive_reportsProblem() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
+            when(segmentReplicaRepository.findById(SEGMENT_ID))
+                    .thenReturn(Optional.of(segmentReplica(false, "COMMERCIAL")));
+            lenient()
+                    .when(templateRepository.findById(EMAIL_TEMPLATE_ID))
+                    .thenReturn(Optional.of(new MessageTemplate()));
+
+            assertThatThrownBy(() -> sut.schedule(CAMPAIGN_ID)).hasMessageContaining("is inactive");
+        }
+
+        @Test
+        @DisplayName("refuses to schedule a campaign whose segment targets a different audience")
+        void schedule_whenAudienceMismatched_reportsProblem() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
+            when(segmentReplicaRepository.findById(SEGMENT_ID))
+                    .thenReturn(Optional.of(segmentReplica(true, "INDIVIDUAL")));
+            lenient()
+                    .when(templateRepository.findById(EMAIL_TEMPLATE_ID))
+                    .thenReturn(Optional.of(new MessageTemplate()));
+
+            // Templates written for organizations would render against people.
+            assertThatThrownBy(() -> sut.schedule(CAMPAIGN_ID)).hasMessageContaining("does not match campaign");
+        }
+
+        @Test
+        @DisplayName("treats a dangling template id as a missing template")
+        void schedule_whenTemplateDangling_reportsProblem() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
+            when(segmentReplicaRepository.findById(SEGMENT_ID))
+                    .thenReturn(Optional.of(segmentReplica(true, "COMMERCIAL")));
+            // Set on the campaign but no longer resolvable.
+            when(templateRepository.findById(EMAIL_TEMPLATE_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.schedule(CAMPAIGN_ID)).hasMessageContaining("no EMAIL template attached");
+        }
+    }
+
+    @Nested
+    @DisplayName("state transitions")
+    class Transitions {
+
+        @Test
+        @DisplayName("resume returns a paused campaign to SCHEDULED, not straight back to SENDING")
+        void resume_returnsToScheduled() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.PAUSED)));
+            when(campaignRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            // The worker decides when dispatch restarts; a resumed campaign
+            // re-enters the queue rather than jumping into send.
+            assertThat(sut.resume(CAMPAIGN_ID).status()).isEqualTo("SCHEDULED");
+        }
+
+        @Test
+        @DisplayName("pause moves a sending campaign to PAUSED")
+        void pause_movesToPaused() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.SENDING)));
+            when(campaignRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            assertThat(sut.pause(CAMPAIGN_ID).status()).isEqualTo("PAUSED");
+        }
+
+        @Test
+        @DisplayName("refuses an illegal transition rather than silently accepting it")
+        void transition_whenIllegal_throws() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.SENT)));
+
+            assertThatThrownBy(() -> sut.pause(CAMPAIGN_ID))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class)
+                    .hasMessageContaining("Cannot move campaign");
+        }
+    }
+
+    @Nested
+    @DisplayName("previewAudience")
+    class PreviewAudience {
+
+        @Test
+        @DisplayName("reports the last snapshot with its age and asks for a fresher one")
+        void preview_reportsSnapshotAndRequestsRefresh() {
+            Instant resolvedAt = Instant.parse("2026-08-11T11:00:00Z");
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID))
+                    .thenReturn(List.of(UUID.randomUUID(), UUID.randomUUID()));
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.of(resolvedAt));
+            when(eligibilityService.countEligible(anyCollection(), any())).thenReturn(1L);
+            campaignIsReady();
+
+            AudiencePreviewResponse preview = sut.previewAudience(CAMPAIGN_ID);
+
+            // The snapshot's age travels with the numbers so a marketer can see how
+            // current they are rather than assuming they are live.
+            assertThat(preview.segmentMatched()).isEqualTo(2);
+            assertThat(preview.resolvedAt()).isEqualTo(resolvedAt);
+            verify(resolveRequester).requestResolve(CAMPAIGN_ID, SEGMENT_ID);
+        }
+
+        @Test
+        @DisplayName("reports per-channel eligibility and whether a template is attached")
+        void preview_reportsPerChannelDetail() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of(UUID.randomUUID()));
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
+            when(eligibilityService.countEligible(anyCollection(), any())).thenReturn(0L);
+            campaignIsReady();
+
+            AudiencePreviewResponse preview = sut.previewAudience(CAMPAIGN_ID);
+
+            assertThat(preview.channels()).singleElement().satisfies(channel -> {
+                assertThat(channel.channel()).isEqualTo("EMAIL");
+                assertThat(channel.targeted()).isEqualTo(1);
+                assertThat(channel.eligible()).isZero();
+                assertThat(channel.templateAttached()).isTrue();
+            });
+        }
+
+        @Test
+        @DisplayName("does not request a refresh once the audience is frozen")
+        void preview_whenAudienceImmutable_doesNotRequestRefresh() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.SENT)));
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of());
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
+            when(eligibilityService.countEligible(anyCollection(), any())).thenReturn(0L);
+            campaignIsReady();
+
+            sut.previewAudience(CAMPAIGN_ID);
+
+            verify(resolveRequester, never()).requestResolve(any(), any());
+        }
+
+        @Test
+        @DisplayName("refuses to preview a campaign with no segment bound")
+        void preview_whenNoSegment_throws() {
+            Campaign unbound = campaign(CampaignStatus.DRAFT);
+            unbound.setSegmentId(null);
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(unbound));
+
+            assertThatThrownBy(() -> sut.previewAudience(CAMPAIGN_ID))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class)
+                    .hasMessageContaining("nothing to preview");
+        }
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        @DisplayName("get returns the campaign")
+        void get_returnsCampaign() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
+
+            assertThat(sut.get(CAMPAIGN_ID).code()).isEqualTo("SPRING24");
+        }
+
+        @Test
+        @DisplayName("get throws 404 for an unknown campaign")
+        void get_whenAbsent_throws() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.get(CAMPAIGN_ID)).isInstanceOf(MarketingResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("list without filters returns everything, newest first")
+        void list_withoutFilters_returnsAll() {
+            when(campaignRepository.findAllByOrderByCreatedAtDesc())
+                    .thenReturn(List.of(campaign(CampaignStatus.DRAFT)));
+
+            assertThat(sut.list(null, null)).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("list by status uses the status query")
+        void list_byStatus_usesStatusQuery() {
+            when(campaignRepository.findByStatusOrderByCreatedAtDesc(CampaignStatus.DRAFT))
+                    .thenReturn(List.of(campaign(CampaignStatus.DRAFT)));
+
+            assertThat(sut.list(CampaignStatus.DRAFT, null)).hasSize(1);
+            verify(campaignRepository, never()).findAllByOrderByCreatedAtDesc();
+        }
+
+        @Test
+        @DisplayName("list by program narrows to that program, then applies any status filter in memory")
+        void list_byProgram_filtersStatusInMemory() {
+            UUID programId = UUID.randomUUID();
+            when(campaignRepository.findByCampaignProgramId(programId))
+                    .thenReturn(List.of(campaign(CampaignStatus.DRAFT), campaign(CampaignStatus.SENT)));
+
+            assertThat(sut.list(CampaignStatus.SENT, programId))
+                    .singleElement()
+                    .satisfies(response -> assertThat(response.status()).isEqualTo("SENT"));
+        }
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignStatsServiceImplTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignStatsServiceImplTest.java
@@ -1,0 +1,224 @@
+package com.positivity.marketing.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.when;
+
+import com.positivity.marketing.internal.dto.CampaignStatsResponse;
+import com.positivity.marketing.internal.dto.ProgramStatsResponse;
+import com.positivity.marketing.internal.entity.Campaign;
+import com.positivity.marketing.internal.enums.AudienceType;
+import com.positivity.marketing.internal.enums.CampaignChannel;
+import com.positivity.marketing.internal.enums.SendStatus;
+import com.positivity.marketing.internal.exception.MarketingResourceNotFoundException;
+import com.positivity.marketing.internal.repository.CampaignAttributionRepository;
+import com.positivity.marketing.internal.repository.CampaignRepository;
+import com.positivity.marketing.internal.repository.CampaignSendRepository;
+import java.math.BigDecimal;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link CampaignStatsServiceImpl}.
+ *
+ * <p>
+ * These numbers are what a marketer decides next quarter's spend on, so the
+ * arithmetic is the contract:
+ *
+ * <ul>
+ * <li><b>"Sent" is cumulative down the funnel.</b> A delivered, bounced, or
+ * complained message was also sent; counting only rows still sitting in
+ * {@code SENT} would understate reach by exactly the messages that worked.</li>
+ * <li><b>Every bound channel appears, even with no rows.</b> A channel silently
+ * missing from the funnel reads as "not configured" rather than "nothing has
+ * gone out yet".</li>
+ * <li><b>A campaign with no attributed redemptions reports zero, not null</b> —
+ * {@code SUM} over an empty set is null in SQL and would serialize as a missing
+ * figure.</li>
+ * <li><b>A program with no arms is a 404</b>, not an empty comparison; the
+ * whole point of the rollup is the side-by-side.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CampaignStatsServiceImpl — reach funnel and program rollup")
+class CampaignStatsServiceImplTest {
+
+    private static final UUID CAMPAIGN_ID = UUID.randomUUID();
+    private static final UUID PROGRAM_ID = UUID.randomUUID();
+
+    @Mock
+    private CampaignRepository campaignRepository;
+
+    @Mock
+    private CampaignSendRepository sendRepository;
+
+    @Mock
+    private CampaignAttributionRepository attributionRepository;
+
+    @InjectMocks
+    private CampaignStatsServiceImpl service;
+
+    private static Campaign campaign(UUID campaignId, String code, CampaignChannel... channels) {
+        Set<CampaignChannel> channelSet = new LinkedHashSet<>(List.of(channels));
+        return Campaign.builder()
+                .campaignId(campaignId)
+                .code(code)
+                .audienceType(AudienceType.INDIVIDUAL)
+                .campaignProgramId(PROGRAM_ID)
+                .channels(channelSet)
+                .build();
+    }
+
+    private static Object[] row(CampaignChannel channel, SendStatus status, long count) {
+        return new Object[] {channel, status, count};
+    }
+
+    @Nested
+    @DisplayName("campaignStats")
+    class CampaignStats {
+
+        @Test
+        @DisplayName("rejects a campaign that does not exist")
+        void unknownCampaign() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.campaignStats(CAMPAIGN_ID))
+                    .isInstanceOf(MarketingResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("rolls delivered, bounced, and complained back up into the sent total")
+        void sentIsCumulative() {
+            when(campaignRepository.findById(CAMPAIGN_ID))
+                    .thenReturn(Optional.of(campaign(CAMPAIGN_ID, "SPRING", CampaignChannel.EMAIL)));
+            when(sendRepository.countByChannelAndStatus(CAMPAIGN_ID))
+                    .thenReturn(List.<Object[]>of(
+                            row(CampaignChannel.EMAIL, SendStatus.PENDING, 5),
+                            row(CampaignChannel.EMAIL, SendStatus.SUPPRESSED, 12),
+                            row(CampaignChannel.EMAIL, SendStatus.SENT, 3),
+                            row(CampaignChannel.EMAIL, SendStatus.DELIVERED, 40),
+                            row(CampaignChannel.EMAIL, SendStatus.BOUNCED, 2),
+                            row(CampaignChannel.EMAIL, SendStatus.COMPLAINED, 1),
+                            row(CampaignChannel.EMAIL, SendStatus.FAILED, 7)));
+            when(attributionRepository.sumDiscountByCampaignId(CAMPAIGN_ID)).thenReturn(new BigDecimal("125.50"));
+            when(attributionRepository.countByCampaignId(CAMPAIGN_ID)).thenReturn(9L);
+
+            CampaignStatsResponse stats = service.campaignStats(CAMPAIGN_ID);
+
+            assertThat(stats.campaignId()).isEqualTo(CAMPAIGN_ID);
+            assertThat(stats.code()).isEqualTo("SPRING");
+            assertThat(stats.audienceType()).isEqualTo("INDIVIDUAL");
+            assertThat(stats.campaignProgramId()).isEqualTo(PROGRAM_ID);
+            assertThat(stats.redeemed()).isEqualTo(9);
+            assertThat(stats.attributedDiscount()).isEqualByComparingTo("125.50");
+
+            CampaignStatsResponse.ChannelFunnel email = stats.channels().getFirst();
+            assertThat(email.channel()).isEqualTo("EMAIL");
+            // 3 SENT + 40 DELIVERED + 2 BOUNCED + 1 COMPLAINED
+            assertThat(email.sent()).isEqualTo(46);
+            // sent total + 5 PENDING + 12 SUPPRESSED + 7 FAILED
+            assertThat(email.targeted()).isEqualTo(70);
+            assertThat(email.suppressed()).isEqualTo(12);
+            assertThat(email.delivered()).isEqualTo(40);
+            assertThat(email.bounced()).isEqualTo(2);
+            assertThat(email.complained()).isEqualTo(1);
+            assertThat(email.failed()).isEqualTo(7);
+        }
+
+        @Test
+        @DisplayName("reports a zeroed funnel for a bound channel that has no rows yet")
+        void channelWithNoRowsStillAppears() {
+            when(campaignRepository.findById(CAMPAIGN_ID))
+                    .thenReturn(
+                            Optional.of(campaign(CAMPAIGN_ID, "SPRING", CampaignChannel.EMAIL, CampaignChannel.SMS)));
+            when(sendRepository.countByChannelAndStatus(CAMPAIGN_ID))
+                    .thenReturn(List.<Object[]>of(row(CampaignChannel.EMAIL, SendStatus.SENT, 4)));
+            when(attributionRepository.sumDiscountByCampaignId(CAMPAIGN_ID)).thenReturn(BigDecimal.TEN);
+
+            CampaignStatsResponse stats = service.campaignStats(CAMPAIGN_ID);
+
+            assertThat(stats.channels())
+                    .extracting(
+                            CampaignStatsResponse.ChannelFunnel::channel,
+                            CampaignStatsResponse.ChannelFunnel::targeted,
+                            CampaignStatsResponse.ChannelFunnel::sent)
+                    .containsExactlyInAnyOrder(tuple("EMAIL", 4L, 4L), tuple("SMS", 0L, 0L));
+        }
+
+        @Test
+        @DisplayName("sums repeated channel-status rows rather than letting the last one win")
+        void mergesDuplicateRows() {
+            when(campaignRepository.findById(CAMPAIGN_ID))
+                    .thenReturn(Optional.of(campaign(CAMPAIGN_ID, "SPRING", CampaignChannel.SMS)));
+            when(sendRepository.countByChannelAndStatus(CAMPAIGN_ID))
+                    .thenReturn(List.<Object[]>of(
+                            row(CampaignChannel.SMS, SendStatus.DELIVERED, 6),
+                            row(CampaignChannel.SMS, SendStatus.DELIVERED, 4)));
+            when(attributionRepository.sumDiscountByCampaignId(CAMPAIGN_ID)).thenReturn(BigDecimal.ZERO);
+
+            assertThat(service.campaignStats(CAMPAIGN_ID).channels().getFirst().delivered())
+                    .isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("reports zero attributed discount when nothing has been redeemed")
+        void nullDiscountSumBecomesZero() {
+            when(campaignRepository.findById(CAMPAIGN_ID))
+                    .thenReturn(Optional.of(campaign(CAMPAIGN_ID, "SPRING", CampaignChannel.EMAIL)));
+            when(sendRepository.countByChannelAndStatus(CAMPAIGN_ID)).thenReturn(List.of());
+            when(attributionRepository.sumDiscountByCampaignId(CAMPAIGN_ID)).thenReturn(null);
+
+            assertThat(service.campaignStats(CAMPAIGN_ID).attributedDiscount()).isEqualByComparingTo(BigDecimal.ZERO);
+        }
+    }
+
+    @Nested
+    @DisplayName("programStats")
+    class ProgramStats {
+
+        @Test
+        @DisplayName("rejects a program with no campaigns")
+        void unknownProgram() {
+            when(campaignRepository.findByCampaignProgramId(PROGRAM_ID)).thenReturn(List.of());
+
+            assertThatThrownBy(() -> service.programStats(PROGRAM_ID))
+                    .isInstanceOf(MarketingResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("returns one funnel set per arm so the arms can be compared")
+        void oneEntryPerArm() {
+            UUID commercialArm = UUID.randomUUID();
+            Campaign individual = campaign(CAMPAIGN_ID, "SPRING-IND", CampaignChannel.EMAIL);
+            Campaign commercial = campaign(commercialArm, "SPRING-COM", CampaignChannel.EMAIL);
+            commercial.setAudienceType(AudienceType.COMMERCIAL);
+            when(campaignRepository.findByCampaignProgramId(PROGRAM_ID)).thenReturn(List.of(individual, commercial));
+            when(sendRepository.countByChannelAndStatus(CAMPAIGN_ID))
+                    .thenReturn(List.<Object[]>of(row(CampaignChannel.EMAIL, SendStatus.DELIVERED, 100)));
+            when(sendRepository.countByChannelAndStatus(commercialArm))
+                    .thenReturn(List.<Object[]>of(row(CampaignChannel.EMAIL, SendStatus.DELIVERED, 3)));
+            when(attributionRepository.sumDiscountByCampaignId(CAMPAIGN_ID)).thenReturn(BigDecimal.ONE);
+            when(attributionRepository.sumDiscountByCampaignId(commercialArm)).thenReturn(BigDecimal.ONE);
+
+            ProgramStatsResponse stats = service.programStats(PROGRAM_ID);
+
+            assertThat(stats.campaignProgramId()).isEqualTo(PROGRAM_ID);
+            assertThat(stats.arms())
+                    .extracting(CampaignStatsResponse::code, CampaignStatsResponse::audienceType)
+                    .containsExactly(tuple("SPRING-IND", "INDIVIDUAL"), tuple("SPRING-COM", "COMMERCIAL"));
+            assertThat(stats.arms().getFirst().channels().getFirst().delivered())
+                    .isEqualTo(100);
+        }
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CustomerEventsListenerTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CustomerEventsListenerTest.java
@@ -1,0 +1,506 @@
+package com.positivity.marketing.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.customer.CustomerConsentDecisionChangedV1;
+import com.positivity.domainevents.customer.CustomerRedemptionRecordedV1;
+import com.positivity.domainevents.customer.CustomerSegmentChangedV1;
+import com.positivity.domainevents.customer.CustomerSegmentResolvedV1;
+import com.positivity.domainevents.customer.CustomerSuppressionChangedV1;
+import com.positivity.marketing.internal.entity.Campaign;
+import com.positivity.marketing.internal.entity.CampaignAttribution;
+import com.positivity.marketing.internal.entity.CampaignAudienceMember;
+import com.positivity.marketing.internal.entity.PartyConsentReplica;
+import com.positivity.marketing.internal.entity.ProcessedEvent;
+import com.positivity.marketing.internal.entity.SegmentReplica;
+import com.positivity.marketing.internal.entity.SuppressionReplica;
+import com.positivity.marketing.internal.enums.CampaignStatus;
+import com.positivity.marketing.internal.repository.CampaignAttributionRepository;
+import com.positivity.marketing.internal.repository.CampaignAudienceMemberRepository;
+import com.positivity.marketing.internal.repository.CampaignRepository;
+import com.positivity.marketing.internal.repository.PartyConsentReplicaRepository;
+import com.positivity.marketing.internal.repository.ProcessedEventRepository;
+import com.positivity.marketing.internal.repository.SegmentReplicaRepository;
+import com.positivity.marketing.internal.repository.SuppressionReplicaRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link CustomerEventsListener}, this module's entire CRM
+ * integration (ADR-0044 R3).
+ *
+ * <p>
+ * Delivery is at-least-once and the payloads come from another service, so the
+ * behaviour worth pinning is what survives repetition and malformed input:
+ *
+ * <ul>
+ * <li><b>Replays apply nothing twice.</b> The {@code processed_events} log
+ * guards the envelope, and attribution is additionally keyed on the CRM's
+ * {@code redemptionId} so one conversion can only ever be counted once.</li>
+ * <li><b>An event this module does not care about is not recorded.</b> Writing
+ * a processed-event row for every customer fact would make the log useless as a
+ * record of what was actually applied.</li>
+ * <li><b>Consent freshness comes from the envelope, not the clock.</b> Stamping
+ * arrival time would make a backlogged consumer look perfectly fresh to the
+ * send worker's staleness check.</li>
+ * <li><b>A resolved audience never replaces one mid-send.</b> Only campaigns
+ * whose status still allows audience mutation are refreshed.</li>
+ * <li><b>Missing or malformed fields degrade to a skip, not an exception</b> —
+ * a poison message must not wedge the partition.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CustomerEventsListener — CRM fact replication and attribution")
+class CustomerEventsListenerTest {
+
+    private static final UUID SEGMENT_ID = UUID.fromString("01960004-0000-7000-8000-0000000000a1");
+    private static final UUID PARTY_ID = UUID.fromString("01960004-0000-7000-8000-0000000000a2");
+    private static final UUID CAMPAIGN_ID = UUID.fromString("01960004-0000-7000-8000-0000000000a3");
+    private static final UUID REDEMPTION_ID = UUID.fromString("01960004-0000-7000-8000-0000000000a4");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+    private static final Instant OCCURRED_AT = Instant.parse("2026-08-10T07:30:00Z");
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private SuppressionReplicaRepository suppressionRepository;
+
+    @Mock
+    private PartyConsentReplicaRepository consentRepository;
+
+    @Mock
+    private SegmentReplicaRepository segmentRepository;
+
+    @Mock
+    private CampaignAudienceMemberRepository audienceRepository;
+
+    @Mock
+    private CampaignAttributionRepository attributionRepository;
+
+    @Mock
+    private CampaignRepository campaignRepository;
+
+    private CustomerEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new CustomerEventsListener(
+                clock,
+                objectMapper,
+                processedEventRepository,
+                suppressionRepository,
+                consentRepository,
+                segmentRepository,
+                audienceRepository,
+                attributionRepository,
+                campaignRepository);
+    }
+
+    private static String envelope(String eventId, String eventType, String payloadJson) {
+        return """
+                {"eventId":"%s","eventType":"%s","occurredAtUtc":"%s","payload":%s}""".formatted(eventId, eventType, OCCURRED_AT, payloadJson);
+    }
+
+    private void expectUnprocessed(String eventId) {
+        when(processedEventRepository.existsById(eventId)).thenReturn(false);
+    }
+
+    @Nested
+    @DisplayName("envelope handling")
+    class Envelope {
+
+        @Test
+        @DisplayName("skips a replay of an event already in the processed log")
+        void skipsReplay() {
+            when(processedEventRepository.existsById("evt-1")).thenReturn(true);
+
+            listener.onCustomerEvent(envelope("evt-1", CustomerSuppressionChangedV1.EVENT_TYPE, """
+                    {"channel":"EMAIL","addressHash":"abc","suppressed":true}"""));
+
+            verifyNoInteractions(suppressionRepository);
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("skips an event with no id, since it cannot be de-duplicated")
+        void skipsUnidentifiedEvent() {
+            listener.onCustomerEvent(envelope("", CustomerSuppressionChangedV1.EVENT_TYPE, """
+                    {"channel":"EMAIL","addressHash":"abc","suppressed":true}"""));
+
+            verifyNoInteractions(suppressionRepository);
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("ignores a customer fact this module does not consume, without logging it as processed")
+        void unknownEventTypeIsNotRecorded() {
+            expectUnprocessed("evt-2");
+
+            listener.onCustomerEvent(envelope("evt-2", "customer.party.updated", "{}"));
+
+            verify(processedEventRepository, never()).save(any());
+            verifyNoInteractions(suppressionRepository, consentRepository, segmentRepository, attributionRepository);
+        }
+
+        @Test
+        @DisplayName("records the event as processed once a handler has applied it")
+        void recordsProcessedEvent() {
+            expectUnprocessed("evt-3");
+
+            listener.onCustomerEvent(envelope("evt-3", CustomerSuppressionChangedV1.EVENT_TYPE, """
+                    {"channel":"EMAIL","addressHash":"abc","suppressed":true}"""));
+
+            ArgumentCaptor<ProcessedEvent> captor = ArgumentCaptor.forClass(ProcessedEvent.class);
+            verify(processedEventRepository).save(captor.capture());
+            assertThat(captor.getValue().getEventId()).isEqualTo("evt-3");
+            assertThat(captor.getValue().getOwner()).isEqualTo("pos-customer");
+            assertThat(captor.getValue().getProcessedAt()).isEqualTo(NOW);
+        }
+    }
+
+    @Nested
+    @DisplayName("customer.suppression.changed")
+    class Suppression {
+
+        @Test
+        @DisplayName("stores a suppression under its channel-address key")
+        void storesSuppression() {
+            expectUnprocessed("evt-s1");
+
+            listener.onCustomerEvent(
+                    envelope("evt-s1", CustomerSuppressionChangedV1.EVENT_TYPE, """
+                    {"channel":"EMAIL","addressHash":"abc","suppressed":true,"reason":"BOUNCE","partyId":"%s"}""".formatted(PARTY_ID)));
+
+            ArgumentCaptor<SuppressionReplica> captor = ArgumentCaptor.forClass(SuppressionReplica.class);
+            verify(suppressionRepository).save(captor.capture());
+            SuppressionReplica saved = captor.getValue();
+            assertThat(saved.getSuppressionKey()).isEqualTo(SuppressionReplica.keyOf("EMAIL", "abc"));
+            assertThat(saved.getChannel()).isEqualTo("EMAIL");
+            assertThat(saved.getPartyId()).isEqualTo(PARTY_ID);
+            assertThat(saved.getReason()).isEqualTo("BOUNCE");
+            assertThat(saved.getUpdatedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("lifts a suppression by deleting the replica row")
+        void liftsSuppression() {
+            expectUnprocessed("evt-s2");
+
+            listener.onCustomerEvent(envelope("evt-s2", CustomerSuppressionChangedV1.EVENT_TYPE, """
+                    {"channel":"SMS","addressHash":"xyz","suppressed":false}"""));
+
+            verify(suppressionRepository).deleteById(SuppressionReplica.keyOf("SMS", "xyz"));
+            verify(suppressionRepository, never()).save(any());
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+                strings = {
+                    "{\"addressHash\":\"abc\",\"suppressed\":true}",
+                    "{\"channel\":\"EMAIL\",\"suppressed\":true}",
+                    "{\"channel\":\"\",\"addressHash\":\"\",\"suppressed\":true}"
+                })
+        @DisplayName("ignores a suppression fact missing the fields that form its key")
+        void ignoresIncompleteSuppression(String payload) {
+            expectUnprocessed("evt-s3");
+
+            listener.onCustomerEvent(envelope("evt-s3", CustomerSuppressionChangedV1.EVENT_TYPE, payload));
+
+            verifyNoInteractions(suppressionRepository);
+            // Still recorded: the event was consumed and deliberately dropped, not left unhandled.
+            verify(processedEventRepository).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("customer.consent.decision-changed")
+    class Consent {
+
+        @Test
+        @DisplayName("takes decidedAt from the envelope so a backlogged consumer does not look fresh")
+        void decidedAtComesFromEnvelope() {
+            expectUnprocessed("evt-c1");
+            UUID governingParty = UUID.randomUUID();
+
+            listener.onCustomerEvent(envelope(
+                    "evt-c1", CustomerConsentDecisionChangedV1.EVENT_TYPE, """
+                    {"partyId":"%s","channel":"EMAIL","allowed":true,"reason":"OPT_IN","governingPartyId":"%s"}""".formatted(PARTY_ID, governingParty)));
+
+            ArgumentCaptor<PartyConsentReplica> captor = ArgumentCaptor.forClass(PartyConsentReplica.class);
+            verify(consentRepository).save(captor.capture());
+            PartyConsentReplica saved = captor.getValue();
+            assertThat(saved.getConsentKey()).isEqualTo(PartyConsentReplica.keyOf(PARTY_ID, "EMAIL"));
+            assertThat(saved.isAllowed()).isTrue();
+            assertThat(saved.getReason()).isEqualTo("OPT_IN");
+            assertThat(saved.getGoverningPartyId()).isEqualTo(governingParty);
+            assertThat(saved.getDecidedAt()).isEqualTo(OCCURRED_AT);
+        }
+
+        @Test
+        @DisplayName("falls back to the local clock when the envelope carries no usable timestamp")
+        void unparseableTimestampFallsBackToClock() {
+            expectUnprocessed("evt-c2");
+
+            listener.onCustomerEvent("""
+                    {"eventId":"evt-c2","eventType":"%s","occurredAtUtc":"not-a-timestamp",\
+                    "payload":{"partyId":"%s","channel":"EMAIL","allowed":false}}""".formatted(CustomerConsentDecisionChangedV1.EVENT_TYPE, PARTY_ID));
+
+            ArgumentCaptor<PartyConsentReplica> captor = ArgumentCaptor.forClass(PartyConsentReplica.class);
+            verify(consentRepository).save(captor.capture());
+            assertThat(captor.getValue().getDecidedAt()).isEqualTo(NOW);
+            // An absent reason must not be null: the send worker branches on it.
+            assertThat(captor.getValue().getReason()).isEqualTo("UNKNOWN");
+        }
+
+        @Test
+        @DisplayName("ignores a consent fact whose party id is not a UUID")
+        void ignoresMalformedPartyId() {
+            expectUnprocessed("evt-c3");
+
+            listener.onCustomerEvent(envelope("evt-c3", CustomerConsentDecisionChangedV1.EVENT_TYPE, """
+                    {"partyId":"not-a-uuid","channel":"EMAIL","allowed":true}"""));
+
+            verifyNoInteractions(consentRepository);
+        }
+    }
+
+    @Nested
+    @DisplayName("customer.segment.changed")
+    class Segment {
+
+        @Test
+        @DisplayName("replicates segment metadata")
+        void replicatesSegment() {
+            expectUnprocessed("evt-g1");
+
+            listener.onCustomerEvent(
+                    envelope("evt-g1", CustomerSegmentChangedV1.EVENT_TYPE, """
+                    {"segmentId":"%s","name":"Fleet owners","audienceType":"COMMERCIAL",\
+                    "type":"DYNAMIC","active":true}""".formatted(SEGMENT_ID)));
+
+            ArgumentCaptor<SegmentReplica> captor = ArgumentCaptor.forClass(SegmentReplica.class);
+            verify(segmentRepository).save(captor.capture());
+            SegmentReplica saved = captor.getValue();
+            assertThat(saved.getSegmentId()).isEqualTo(SEGMENT_ID);
+            assertThat(saved.getName()).isEqualTo("Fleet owners");
+            assertThat(saved.getAudienceType()).isEqualTo("COMMERCIAL");
+            assertThat(saved.isActive()).isTrue();
+            assertThat(saved.getUpdatedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("removes the replica when the segment is deleted upstream")
+        void deletesSegment() {
+            expectUnprocessed("evt-g2");
+
+            listener.onCustomerEvent(
+                    envelope("evt-g2", CustomerSegmentChangedV1.EVENT_TYPE, """
+                    {"segmentId":"%s","deleted":true}""".formatted(SEGMENT_ID)));
+
+            verify(segmentRepository).deleteById(SEGMENT_ID);
+            verify(segmentRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("ignores a segment fact with no segment id")
+        void ignoresSegmentWithoutId() {
+            expectUnprocessed("evt-g3");
+
+            listener.onCustomerEvent(envelope("evt-g3", CustomerSegmentChangedV1.EVENT_TYPE, "{}"));
+
+            verifyNoInteractions(segmentRepository);
+        }
+    }
+
+    @Nested
+    @DisplayName("customer.segment.resolved")
+    class SegmentResolved {
+
+        private Campaign campaign(UUID campaignId, UUID segmentId, CampaignStatus status) {
+            return Campaign.builder()
+                    .campaignId(campaignId)
+                    .segmentId(segmentId)
+                    .status(status)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("replaces the audience snapshot of every campaign on the resolved segment")
+        void refreshesAudienceForMatchingCampaigns() {
+            expectUnprocessed("evt-r1");
+            UUID secondCampaign = UUID.randomUUID();
+            when(campaignRepository.findAll())
+                    .thenReturn(List.of(
+                            campaign(CAMPAIGN_ID, SEGMENT_ID, CampaignStatus.SCHEDULED),
+                            campaign(secondCampaign, SEGMENT_ID, CampaignStatus.DRAFT)));
+
+            listener.onCustomerEvent(
+                    envelope("evt-r1", CustomerSegmentResolvedV1.EVENT_TYPE, """
+                    {"segmentId":"%s","partyIds":["%s"]}""".formatted(SEGMENT_ID, PARTY_ID)));
+
+            // Delete-then-insert: a snapshot is a replacement, not an accumulation.
+            verify(audienceRepository).deleteByCampaignId(CAMPAIGN_ID);
+            verify(audienceRepository).deleteByCampaignId(secondCampaign);
+            ArgumentCaptor<List<CampaignAudienceMember>> captor = ArgumentCaptor.captor();
+            verify(audienceRepository, org.mockito.Mockito.times(2)).saveAll(captor.capture());
+            assertThat(captor.getAllValues())
+                    .allSatisfy(members -> assertThat(members).singleElement().satisfies(member -> {
+                        assertThat(member.getPartyId()).isEqualTo(PARTY_ID);
+                        assertThat(member.getResolvedAt()).isEqualTo(NOW);
+                    }));
+        }
+
+        @Test
+        @DisplayName("leaves a campaign that is already sending untouched")
+        void skipsCampaignsMidSend() {
+            expectUnprocessed("evt-r2");
+            when(campaignRepository.findAll())
+                    .thenReturn(List.of(
+                            campaign(CAMPAIGN_ID, SEGMENT_ID, CampaignStatus.SENDING),
+                            campaign(UUID.randomUUID(), UUID.randomUUID(), CampaignStatus.DRAFT)));
+
+            listener.onCustomerEvent(
+                    envelope("evt-r2", CustomerSegmentResolvedV1.EVENT_TYPE, """
+                    {"segmentId":"%s","partyIds":["%s"]}""".formatted(SEGMENT_ID, PARTY_ID)));
+
+            verifyNoInteractions(audienceRepository);
+        }
+
+        @Test
+        @DisplayName("drops a malformed party id rather than failing the whole snapshot")
+        void skipsMalformedPartyIds() {
+            expectUnprocessed("evt-r3");
+            when(campaignRepository.findAll())
+                    .thenReturn(List.of(campaign(CAMPAIGN_ID, SEGMENT_ID, CampaignStatus.SCHEDULED)));
+
+            listener.onCustomerEvent(
+                    envelope("evt-r3", CustomerSegmentResolvedV1.EVENT_TYPE, """
+                    {"segmentId":"%s","partyIds":["%s","not-a-uuid",""]}""".formatted(SEGMENT_ID, PARTY_ID)));
+
+            ArgumentCaptor<List<CampaignAudienceMember>> captor = ArgumentCaptor.captor();
+            verify(audienceRepository).saveAll(captor.capture());
+            assertThat(captor.getValue())
+                    .singleElement()
+                    .satisfies(member -> assertThat(member.getPartyId()).isEqualTo(PARTY_ID));
+        }
+
+        @Test
+        @DisplayName("ignores a resolve reply with no segment id")
+        void ignoresResolveWithoutSegment() {
+            expectUnprocessed("evt-r4");
+
+            listener.onCustomerEvent(envelope("evt-r4", CustomerSegmentResolvedV1.EVENT_TYPE, "{}"));
+
+            verifyNoInteractions(audienceRepository, campaignRepository);
+        }
+    }
+
+    @Nested
+    @DisplayName("customer.redemption.recorded")
+    class Redemption {
+
+        @Test
+        @DisplayName("attributes a redemption to the campaign whose code it carries")
+        void attributesToCampaign() {
+            expectUnprocessed("evt-x1");
+            UUID workorderId = UUID.randomUUID();
+            when(attributionRepository.existsById(REDEMPTION_ID)).thenReturn(false);
+            when(campaignRepository.findByCodeIgnoreCase("SPRING"))
+                    .thenReturn(Optional.of(Campaign.builder()
+                            .campaignId(CAMPAIGN_ID)
+                            .code("SPRING")
+                            .build()));
+
+            listener.onCustomerEvent(envelope("evt-x1", CustomerRedemptionRecordedV1.EVENT_TYPE, """
+                    {"campaignCode":"SPRING","redemptionId":"%s","customerId":"%s",\
+                    "workorderId":"%s","discountAmount":42.50}""".formatted(
+                            REDEMPTION_ID, PARTY_ID, workorderId)));
+
+            ArgumentCaptor<CampaignAttribution> captor = ArgumentCaptor.forClass(CampaignAttribution.class);
+            verify(attributionRepository).save(captor.capture());
+            CampaignAttribution saved = captor.getValue();
+            assertThat(saved.getRedemptionId()).isEqualTo(REDEMPTION_ID);
+            assertThat(saved.getCampaignId()).isEqualTo(CAMPAIGN_ID);
+            assertThat(saved.getCampaignCode()).isEqualTo("SPRING");
+            assertThat(saved.getPartyId()).isEqualTo(PARTY_ID);
+            assertThat(saved.getWorkorderId()).isEqualTo(workorderId);
+            assertThat(saved.getDiscountAmount()).isEqualByComparingTo("42.50");
+            assertThat(saved.getAttributedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("counts a redemption once even if the fact is redelivered under a new event id")
+        void redemptionIdIsTheIdempotencyKey() {
+            expectUnprocessed("evt-x2");
+            when(attributionRepository.existsById(REDEMPTION_ID)).thenReturn(true);
+
+            listener.onCustomerEvent(
+                    envelope("evt-x2", CustomerRedemptionRecordedV1.EVENT_TYPE, """
+                    {"campaignCode":"SPRING","redemptionId":"%s"}""".formatted(REDEMPTION_ID)));
+
+            verify(attributionRepository, never()).save(any());
+            verify(campaignRepository, never()).findByCodeIgnoreCase(any());
+        }
+
+        @Test
+        @DisplayName("ignores an organic redemption that names no campaign")
+        void organicRedemptionAttributesToNothing() {
+            expectUnprocessed("evt-x3");
+
+            listener.onCustomerEvent(
+                    envelope("evt-x3", CustomerRedemptionRecordedV1.EVENT_TYPE, """
+                    {"redemptionId":"%s","discountAmount":10}""".formatted(REDEMPTION_ID)));
+
+            verifyNoInteractions(attributionRepository);
+        }
+
+        @Test
+        @DisplayName("refuses to attribute a redemption with no redemption id, since it could not be de-duplicated")
+        void missingRedemptionIdIsNotAttributed() {
+            expectUnprocessed("evt-x4");
+
+            listener.onCustomerEvent(envelope("evt-x4", CustomerRedemptionRecordedV1.EVENT_TYPE, """
+                    {"campaignCode":"SPRING"}"""));
+
+            verifyNoInteractions(attributionRepository);
+        }
+
+        @Test
+        @DisplayName("does not attribute a redemption naming a campaign code this module has never seen")
+        void unknownCampaignCodeIsNotAttributed() {
+            expectUnprocessed("evt-x5");
+            when(attributionRepository.existsById(REDEMPTION_ID)).thenReturn(false);
+            when(campaignRepository.findByCodeIgnoreCase("GHOST")).thenReturn(Optional.empty());
+
+            listener.onCustomerEvent(
+                    envelope("evt-x5", CustomerRedemptionRecordedV1.EVENT_TYPE, """
+                    {"campaignCode":"GHOST","redemptionId":"%s"}""".formatted(REDEMPTION_ID)));
+
+            verify(attributionRepository, never()).save(any());
+        }
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/MarketingFactPublisherTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/MarketingFactPublisherTest.java
@@ -1,0 +1,220 @@
+package com.positivity.marketing.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.marketing.MarketingCampaignScheduledV1;
+import com.positivity.domainevents.marketing.MarketingCampaignSendOutcomeV1;
+import com.positivity.domainevents.marketing.MarketingCampaignSentV1;
+import com.positivity.marketing.internal.config.OutboxEventWriter;
+import com.positivity.marketing.internal.entity.Campaign;
+import com.positivity.marketing.internal.entity.CampaignSend;
+import com.positivity.marketing.internal.enums.AudienceType;
+import com.positivity.marketing.internal.enums.CampaignChannel;
+import com.positivity.marketing.internal.enums.SendStatus;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+/**
+ * Unit tests for {@link MarketingFactPublisher}.
+ *
+ * <p>
+ * Two properties matter to consumers of {@code marketing.events.v1}:
+ *
+ * <ul>
+ * <li><b>Kafka being disabled is a no-op, not a failure.</b> The outbox writer
+ * bean is simply absent in that configuration, so every method must return
+ * quietly rather than force each caller to guard the call.</li>
+ * <li><b>Send facts are keyed on the recipient party, not the campaign.</b>
+ * pos-customer keys the resulting interaction per party, and per-party ordering
+ * is what a customer timeline needs; keying on the campaign would serialize a
+ * whole bulk send onto one partition and interleave parties arbitrarily.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MarketingFactPublisher — outbox envelopes for marketing facts")
+class MarketingFactPublisherTest {
+
+    private static final UUID CAMPAIGN_ID = UUID.fromString("01960004-0000-7000-8000-0000000000b1");
+    private static final UUID SEGMENT_ID = UUID.fromString("01960004-0000-7000-8000-0000000000b2");
+    private static final UUID PARTY_ID = UUID.fromString("01960004-0000-7000-8000-0000000000b3");
+    private static final UUID SEND_ID = UUID.fromString("01960004-0000-7000-8000-0000000000b4");
+    private static final UUID CONTACT_ID = UUID.fromString("01960004-0000-7000-8000-0000000000b5");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+    private static final String TOPIC = "marketing.events.v1";
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @Mock
+    private ObjectProvider<OutboxEventWriter> outboxProvider;
+
+    @Mock
+    private OutboxEventWriter outboxWriter;
+
+    private MarketingFactPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new MarketingFactPublisher(outboxProvider, clock, TOPIC);
+    }
+
+    private void kafkaEnabled() {
+        when(outboxProvider.getIfAvailable()).thenReturn(outboxWriter);
+    }
+
+    private void kafkaDisabled() {
+        when(outboxProvider.getIfAvailable()).thenReturn(null);
+    }
+
+    private DomainEventEnvelope<?> captureEnvelope() {
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.captor();
+        verify(outboxWriter).publish(org.mockito.ArgumentMatchers.eq(TOPIC), captor.capture());
+        return captor.getValue();
+    }
+
+    private static Campaign campaign() {
+        return Campaign.builder()
+                .campaignId(CAMPAIGN_ID)
+                .code("SPRING")
+                .audienceType(AudienceType.COMMERCIAL)
+                .segmentId(SEGMENT_ID)
+                .scheduledAt(NOW.plusSeconds(3_600))
+                .build();
+    }
+
+    private static CampaignSend send() {
+        return CampaignSend.builder()
+                .campaignSendId(SEND_ID)
+                .campaignId(CAMPAIGN_ID)
+                .recipientPartyId(PARTY_ID)
+                .contactId(CONTACT_ID)
+                .channel(CampaignChannel.EMAIL)
+                .status(SendStatus.BOUNCED)
+                .failureReason("mailbox full")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("when Kafka is disabled")
+    class KafkaDisabled {
+
+        @Test
+        @DisplayName("every publish is a quiet no-op so callers need no guard of their own")
+        void allMethodsAreNoOps() {
+            kafkaDisabled();
+
+            publisher.campaignScheduled(campaign());
+            publisher.campaignSent(send(), "SPRING", "Subject");
+            publisher.sendOutcome(send(), "SPRING", MarketingCampaignSendOutcomeV1.EVENT_TYPE_BOUNCED);
+
+            verifyNoInteractions(outboxWriter);
+        }
+    }
+
+    @Nested
+    @DisplayName("campaignScheduled")
+    class CampaignScheduled {
+
+        @Test
+        @DisplayName("publishes the campaign as its own aggregate")
+        void publishesScheduledFact() {
+            kafkaEnabled();
+
+            publisher.campaignScheduled(campaign());
+
+            DomainEventEnvelope<?> envelope = captureEnvelope();
+            assertThat(envelope.eventType()).isEqualTo(MarketingCampaignScheduledV1.EVENT_TYPE);
+            assertThat(envelope.aggregateId()).isEqualTo(CAMPAIGN_ID);
+            assertThat(envelope.sourceService()).isEqualTo("pos-marketing");
+            assertThat(envelope.schemaVersion()).isEqualTo(1);
+            assertThat(envelope.occurredAtUtc()).isEqualTo(NOW);
+            assertThat(envelope.payload())
+                    .isEqualTo(new MarketingCampaignScheduledV1(
+                            CAMPAIGN_ID, "SPRING", "COMMERCIAL", SEGMENT_ID, NOW.plusSeconds(3_600)));
+        }
+    }
+
+    @Nested
+    @DisplayName("campaignSent")
+    class CampaignSent {
+
+        @Test
+        @DisplayName("keys the fact on the recipient party so a customer timeline stays ordered")
+        void keyedOnRecipientParty() {
+            kafkaEnabled();
+
+            publisher.campaignSent(send(), "SPRING", "Time for a tune-up");
+
+            DomainEventEnvelope<?> envelope = captureEnvelope();
+            assertThat(envelope.eventType()).isEqualTo(MarketingCampaignSentV1.EVENT_TYPE);
+            assertThat(envelope.aggregateId()).isEqualTo(PARTY_ID).isNotEqualTo(CAMPAIGN_ID);
+            assertThat(envelope.payload())
+                    .isEqualTo(new MarketingCampaignSentV1(
+                            SEND_ID, CAMPAIGN_ID, "SPRING", PARTY_ID, CONTACT_ID, "EMAIL", "Time for a tune-up"));
+        }
+
+        @Test
+        @DisplayName("carries a null subject through for an SMS send rather than inventing one")
+        void nullSubjectIsPreserved() {
+            kafkaEnabled();
+            CampaignSend sms = send();
+            sms.setChannel(CampaignChannel.SMS);
+
+            publisher.campaignSent(sms, "SPRING", null);
+
+            assertThat(captureEnvelope().payload())
+                    .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.type(MarketingCampaignSentV1.class))
+                    .satisfies(payload -> {
+                        assertThat(payload.channel()).isEqualTo("SMS");
+                        assertThat(payload.subject()).isNull();
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("sendOutcome")
+    class SendOutcome {
+
+        @Test
+        @DisplayName("emits the caller's event type while reporting the send's own status")
+        void eventTypeMirrorsTheTransition() {
+            kafkaEnabled();
+
+            publisher.sendOutcome(send(), "SPRING", MarketingCampaignSendOutcomeV1.EVENT_TYPE_BOUNCED);
+
+            DomainEventEnvelope<?> envelope = captureEnvelope();
+            assertThat(envelope.eventType()).isEqualTo(MarketingCampaignSendOutcomeV1.EVENT_TYPE_BOUNCED);
+            assertThat(envelope.aggregateId()).isEqualTo(PARTY_ID);
+            assertThat(envelope.payload())
+                    .isEqualTo(new MarketingCampaignSendOutcomeV1(
+                            SEND_ID, CAMPAIGN_ID, "SPRING", PARTY_ID, "EMAIL", "BOUNCED", "mailbox full"));
+        }
+
+        @Test
+        @DisplayName("does not publish when the outbox writer is unavailable")
+        void noOutboxNoPublish() {
+            kafkaDisabled();
+
+            publisher.sendOutcome(send(), "SPRING", MarketingCampaignSendOutcomeV1.EVENT_TYPE_DELIVERED);
+
+            verify(outboxWriter, never()).publish(anyString(), any());
+        }
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/MessageTemplateServiceImplTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/MessageTemplateServiceImplTest.java
@@ -1,0 +1,391 @@
+package com.positivity.marketing.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.marketing.internal.domain.TemplateToken;
+import com.positivity.marketing.internal.dto.MessageTemplateResponse;
+import com.positivity.marketing.internal.dto.UpsertMessageTemplateRequest;
+import com.positivity.marketing.internal.entity.Campaign;
+import com.positivity.marketing.internal.entity.MessageTemplate;
+import com.positivity.marketing.internal.enums.AudienceType;
+import com.positivity.marketing.internal.enums.CampaignChannel;
+import com.positivity.marketing.internal.exception.MarketingDuplicateResourceException;
+import com.positivity.marketing.internal.exception.MarketingResourceNotFoundException;
+import com.positivity.marketing.internal.exception.MarketingUnprocessableEntityException;
+import com.positivity.marketing.internal.repository.CampaignRepository;
+import com.positivity.marketing.internal.repository.MessageTemplateRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link MessageTemplateServiceImpl}.
+ *
+ * <p>
+ * A template is shared state: one edit reaches every campaign bound to it and
+ * every recipient of those campaigns. The rules that matter here all exist to
+ * stop one edit breaking many sends:
+ *
+ * <ul>
+ * <li><b>Channel and audience type are immutable.</b> Flipping either silently
+ * invalidates campaigns already bound to the template — an SMS campaign would
+ * hold an email body, a fleet campaign a template written with individual
+ * tokens.</li>
+ * <li><b>An in-use template cannot be deleted.</b> The failure would otherwise
+ * surface at dispatch, across the whole audience at once.</li>
+ * <li><b>SMS templates carry no subject.</b> The field is nulled on write, not
+ * merely ignored on render, so nothing downstream can resurrect it.</li>
+ * <li><b>Names are unique case-insensitively, but a template does not collide
+ * with itself</b> — renaming to a different case must stay possible.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MessageTemplateServiceImpl — template CRUD and immutability rules")
+class MessageTemplateServiceImplTest {
+
+    private static final UUID TEMPLATE_ID = UUID.randomUUID();
+
+    @Mock
+    private MessageTemplateRepository templateRepository;
+
+    @Mock
+    private CampaignRepository campaignRepository;
+
+    @Mock
+    private TemplateRenderService renderService;
+
+    @InjectMocks
+    private MessageTemplateServiceImpl service;
+
+    private static UpsertMessageTemplateRequest request(
+            String name, CampaignChannel channel, AudienceType audienceType, String subject, String body) {
+        return new UpsertMessageTemplateRequest(name, channel, audienceType, subject, body);
+    }
+
+    private static MessageTemplate existing(CampaignChannel channel, AudienceType audienceType) {
+        return MessageTemplate.builder()
+                .templateId(TEMPLATE_ID)
+                .name("Spring reminder")
+                .channel(channel)
+                .audienceType(audienceType)
+                .subject(channel == CampaignChannel.SMS ? null : "Time for a tune-up")
+                .body("Hello")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        @DisplayName("rejects a name already taken, before rendering is even validated")
+        void duplicateName() {
+            when(templateRepository.existsByNameIgnoreCase("Spring reminder")).thenReturn(true);
+
+            assertThatThrownBy(() -> service.create(
+                            request("  Spring reminder  ", CampaignChannel.EMAIL, AudienceType.INDIVIDUAL, "Hi", "Hi")))
+                    .isInstanceOf(MarketingDuplicateResourceException.class);
+
+            verifyNoInteractions(renderService);
+            verify(templateRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("trims the name, validates the tokens, and stamps the current user")
+        void savesTrimmedAndValidated() {
+            when(templateRepository.existsByNameIgnoreCase("Spring reminder")).thenReturn(false);
+            when(templateRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.create(request(
+                    "  Spring reminder  ",
+                    CampaignChannel.EMAIL,
+                    AudienceType.INDIVIDUAL,
+                    "Time for a tune-up",
+                    "Hello {{firstName}}"));
+
+            verify(renderService)
+                    .validate(
+                            CampaignChannel.EMAIL,
+                            AudienceType.INDIVIDUAL,
+                            "Time for a tune-up",
+                            "Hello {{firstName}}");
+            MessageTemplate saved = captureSaved();
+            assertThat(saved.getName()).isEqualTo("Spring reminder");
+            assertThat(saved.getSubject()).isEqualTo("Time for a tune-up");
+            assertThat(saved.getBody()).isEqualTo("Hello {{firstName}}");
+            // No authenticated principal in a unit test, so the documented fallback applies.
+            assertThat(saved.getCreatedBy()).isEqualTo("system");
+        }
+
+        @Test
+        @DisplayName("drops the subject on an SMS template so it cannot resurface downstream")
+        void smsSubjectIsNulled() {
+            when(templateRepository.existsByNameIgnoreCase(any())).thenReturn(false);
+            when(templateRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.create(request("Blast", CampaignChannel.SMS, AudienceType.INDIVIDUAL, null, "Short body"));
+
+            assertThat(captureSaved().getSubject()).isNull();
+        }
+
+        @Test
+        @DisplayName("does not save when token validation rejects the body")
+        void validationFailureBlocksSave() {
+            when(templateRepository.existsByNameIgnoreCase(any())).thenReturn(false);
+            doThrow(new MarketingUnprocessableEntityException("unknown token"))
+                    .when(renderService)
+                    .validate(any(), any(), any(), any());
+
+            assertThatThrownBy(() -> service.create(
+                            request("Blast", CampaignChannel.EMAIL, AudienceType.COMMERCIAL, "Hi", "{{nope}}")))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class);
+
+            verify(templateRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    class Update {
+
+        @Test
+        @DisplayName("rejects an unknown template")
+        void unknownTemplate() {
+            when(templateRepository.findById(TEMPLATE_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.update(
+                            TEMPLATE_ID, request("New", CampaignChannel.EMAIL, AudienceType.INDIVIDUAL, "Hi", "Hi")))
+                    .isInstanceOf(MarketingResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("rejects a rename onto another template's name")
+        void renameOntoAnother() {
+            when(templateRepository.findById(TEMPLATE_ID))
+                    .thenReturn(Optional.of(existing(CampaignChannel.EMAIL, AudienceType.INDIVIDUAL)));
+            MessageTemplate other = existing(CampaignChannel.EMAIL, AudienceType.INDIVIDUAL);
+            other.setTemplateId(UUID.randomUUID());
+            when(templateRepository.findByNameIgnoreCase("Autumn check")).thenReturn(Optional.of(other));
+
+            assertThatThrownBy(() -> service.update(
+                            TEMPLATE_ID,
+                            request("Autumn check", CampaignChannel.EMAIL, AudienceType.INDIVIDUAL, "Hi", "Hi")))
+                    .isInstanceOf(MarketingDuplicateResourceException.class);
+
+            verify(templateRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("allows a template to keep its own name, so a case-only rename still works")
+        void doesNotCollideWithItself() {
+            MessageTemplate template = existing(CampaignChannel.EMAIL, AudienceType.INDIVIDUAL);
+            when(templateRepository.findById(TEMPLATE_ID)).thenReturn(Optional.of(template));
+            when(templateRepository.findByNameIgnoreCase("SPRING REMINDER")).thenReturn(Optional.of(template));
+            when(templateRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            MessageTemplateResponse response = service.update(
+                    TEMPLATE_ID,
+                    request("SPRING REMINDER", CampaignChannel.EMAIL, AudienceType.INDIVIDUAL, "Subject", "Body"));
+
+            assertThat(response.name()).isEqualTo("SPRING REMINDER");
+            assertThat(response.subject()).isEqualTo("Subject");
+            assertThat(response.body()).isEqualTo("Body");
+        }
+
+        @Test
+        @DisplayName("refuses to change the channel of an existing template")
+        void channelIsImmutable() {
+            when(templateRepository.findById(TEMPLATE_ID))
+                    .thenReturn(Optional.of(existing(CampaignChannel.EMAIL, AudienceType.INDIVIDUAL)));
+            when(templateRepository.findByNameIgnoreCase(any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.update(
+                            TEMPLATE_ID,
+                            request("Spring reminder", CampaignChannel.SMS, AudienceType.INDIVIDUAL, null, "Body")))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class)
+                    .hasMessageContaining("immutable");
+
+            verifyNoInteractions(renderService);
+            verify(templateRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("refuses to change the audience type of an existing template")
+        void audienceTypeIsImmutable() {
+            when(templateRepository.findById(TEMPLATE_ID))
+                    .thenReturn(Optional.of(existing(CampaignChannel.EMAIL, AudienceType.INDIVIDUAL)));
+            when(templateRepository.findByNameIgnoreCase(any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.update(
+                            TEMPLATE_ID,
+                            request("Spring reminder", CampaignChannel.EMAIL, AudienceType.COMMERCIAL, "Hi", "Body")))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class)
+                    .hasMessageContaining("immutable");
+
+            verify(templateRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("nulls the subject when updating an SMS template")
+        void smsUpdateDropsSubject() {
+            MessageTemplate template = existing(CampaignChannel.SMS, AudienceType.INDIVIDUAL);
+            when(templateRepository.findById(TEMPLATE_ID)).thenReturn(Optional.of(template));
+            when(templateRepository.findByNameIgnoreCase(any())).thenReturn(Optional.empty());
+            when(templateRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.update(
+                    TEMPLATE_ID,
+                    request("Spring reminder", CampaignChannel.SMS, AudienceType.INDIVIDUAL, "leaked", "Body"));
+
+            assertThat(template.getSubject()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    class Delete {
+
+        @Test
+        @DisplayName("rejects an unknown template")
+        void unknownTemplate() {
+            when(templateRepository.findById(TEMPLATE_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.delete(TEMPLATE_ID))
+                    .isInstanceOf(MarketingResourceNotFoundException.class);
+
+            verify(templateRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("refuses to delete a template an email campaign still points at")
+        void inUseAsEmailTemplate() {
+            when(templateRepository.findById(TEMPLATE_ID))
+                    .thenReturn(Optional.of(existing(CampaignChannel.EMAIL, AudienceType.INDIVIDUAL)));
+            when(campaignRepository.findAll())
+                    .thenReturn(List.of(Campaign.builder()
+                            .campaignId(UUID.randomUUID())
+                            .emailTemplateId(TEMPLATE_ID)
+                            .build()));
+
+            assertThatThrownBy(() -> service.delete(TEMPLATE_ID))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class)
+                    .hasMessageContaining("attached to at least one campaign");
+
+            verify(templateRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("refuses to delete a template an SMS campaign still points at")
+        void inUseAsSmsTemplate() {
+            when(templateRepository.findById(TEMPLATE_ID))
+                    .thenReturn(Optional.of(existing(CampaignChannel.SMS, AudienceType.INDIVIDUAL)));
+            when(campaignRepository.findAll())
+                    .thenReturn(List.of(Campaign.builder()
+                            .campaignId(UUID.randomUUID())
+                            .smsTemplateId(TEMPLATE_ID)
+                            .build()));
+
+            assertThatThrownBy(() -> service.delete(TEMPLATE_ID))
+                    .isInstanceOf(MarketingUnprocessableEntityException.class);
+        }
+
+        @Test
+        @DisplayName("deletes a template no campaign references")
+        void deletesUnusedTemplate() {
+            MessageTemplate template = existing(CampaignChannel.EMAIL, AudienceType.INDIVIDUAL);
+            when(templateRepository.findById(TEMPLATE_ID)).thenReturn(Optional.of(template));
+            when(campaignRepository.findAll())
+                    .thenReturn(List.of(Campaign.builder()
+                            .campaignId(UUID.randomUUID())
+                            .emailTemplateId(UUID.randomUUID())
+                            .build()));
+
+            service.delete(TEMPLATE_ID);
+
+            verify(templateRepository).delete(template);
+        }
+    }
+
+    @Nested
+    @DisplayName("get and list")
+    class Reads {
+
+        @Test
+        @DisplayName("reports the tokens available to the template's audience alongside the body")
+        void getExposesAvailableTokens() {
+            when(templateRepository.findById(TEMPLATE_ID))
+                    .thenReturn(Optional.of(existing(CampaignChannel.EMAIL, AudienceType.COMMERCIAL)));
+
+            MessageTemplateResponse response = service.get(TEMPLATE_ID);
+
+            assertThat(response.templateId()).isEqualTo(TEMPLATE_ID);
+            assertThat(response.channel()).isEqualTo("EMAIL");
+            assertThat(response.audienceType()).isEqualTo("COMMERCIAL");
+            assertThat(response.availableTokens())
+                    .isEqualTo(TemplateToken.namesFor(AudienceType.COMMERCIAL))
+                    .isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("uses the indexed query only when both filters are supplied")
+        void bothFiltersUseIndexedQuery() {
+            when(templateRepository.findByChannelAndAudienceTypeOrderByNameAsc(
+                            CampaignChannel.EMAIL, AudienceType.INDIVIDUAL))
+                    .thenReturn(List.of(existing(CampaignChannel.EMAIL, AudienceType.INDIVIDUAL)));
+
+            assertThat(service.list(CampaignChannel.EMAIL, AudienceType.INDIVIDUAL))
+                    .hasSize(1);
+
+            verify(templateRepository, never()).findAllByOrderByNameAsc();
+        }
+
+        @Test
+        @DisplayName("filters in memory when only one of the two filters is supplied")
+        void singleFilterStillFilters() {
+            when(templateRepository.findAllByOrderByNameAsc())
+                    .thenReturn(List.of(
+                            existing(CampaignChannel.EMAIL, AudienceType.INDIVIDUAL),
+                            existing(CampaignChannel.SMS, AudienceType.INDIVIDUAL),
+                            existing(CampaignChannel.EMAIL, AudienceType.COMMERCIAL)));
+
+            assertThat(service.list(CampaignChannel.EMAIL, null))
+                    .extracting(MessageTemplateResponse::channel)
+                    .containsOnly("EMAIL");
+            assertThat(service.list(null, AudienceType.COMMERCIAL))
+                    .extracting(MessageTemplateResponse::audienceType)
+                    .containsOnly("COMMERCIAL");
+        }
+
+        @Test
+        @DisplayName("returns everything when no filter is supplied")
+        void noFilterReturnsAll() {
+            when(templateRepository.findAllByOrderByNameAsc())
+                    .thenReturn(List.of(
+                            existing(CampaignChannel.EMAIL, AudienceType.INDIVIDUAL),
+                            existing(CampaignChannel.SMS, AudienceType.COMMERCIAL)));
+
+            assertThat(service.list(null, null)).hasSize(2);
+        }
+    }
+
+    private MessageTemplate captureSaved() {
+        ArgumentCaptor<MessageTemplate> captor = ArgumentCaptor.forClass(MessageTemplate.class);
+        verify(templateRepository).save(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/SegmentResolveRequesterTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/SegmentResolveRequesterTest.java
@@ -1,0 +1,115 @@
+package com.positivity.marketing.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.marketing.internal.config.OutboxEventWriter;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link SegmentResolveRequester}.
+ *
+ * <p>
+ * This is the outbound half of the segment-resolution round trip, and the reply
+ * has to find its way home without this module keeping a correlation table. Two
+ * details carry that:
+ *
+ * <ul>
+ * <li><b>The campaign id travels inside the command</b> alongside the request
+ * id, so {@code customer.segment.resolved} can be matched back to the campaign
+ * that asked.</li>
+ * <li><b>The record key is the segment id</b>, so repeated requests for one
+ * segment stay ordered on the same partition.</li>
+ * </ul>
+ *
+ * <p>
+ * With Kafka disabled the writer bean is absent; the requester reports an empty
+ * correlation id rather than throwing, which is what lets dispatch degrade to
+ * "queued nothing" instead of failing the caller's request.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SegmentResolveRequester — outbound segment-resolve command")
+class SegmentResolveRequesterTest {
+
+    private static final UUID CAMPAIGN_ID = UUID.fromString("01960004-0000-7000-8000-0000000000d1");
+    private static final UUID SEGMENT_ID = UUID.fromString("01960004-0000-7000-8000-0000000000d2");
+    private static final String TOPIC = "customer.commands.v1";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private ObjectProvider<OutboxEventWriter> outboxProvider;
+
+    @Mock
+    private OutboxEventWriter outboxWriter;
+
+    private SegmentResolveRequester requester;
+
+    @BeforeEach
+    void setUp() {
+        requester = new SegmentResolveRequester(outboxProvider, objectMapper, TOPIC);
+    }
+
+    @Test
+    @DisplayName("keys the command on the segment and carries the campaign id for the reply")
+    void writesCorrelatedCommand() {
+        when(outboxProvider.getIfAvailable()).thenReturn(outboxWriter);
+
+        Optional<UUID> requestId = requester.requestResolve(CAMPAIGN_ID, SEGMENT_ID);
+
+        assertThat(requestId).isPresent();
+        ArgumentCaptor<String> message = ArgumentCaptor.forClass(String.class);
+        verify(outboxWriter)
+                .publishRaw(
+                        org.mockito.ArgumentMatchers.eq(TOPIC),
+                        org.mockito.ArgumentMatchers.eq(SEGMENT_ID.toString()),
+                        message.capture());
+
+        JsonNode command = objectMapper.readTree(message.getValue());
+        assertThat(command.path("commandType").asString()).isEqualTo("customer.segment.resolve-requested");
+        assertThat(command.path("eventId").asString())
+                .isEqualTo(requestId.orElseThrow().toString());
+        JsonNode payload = command.path("payload");
+        assertThat(payload.path("requestId").asString())
+                .isEqualTo(requestId.orElseThrow().toString());
+        assertThat(payload.path("segmentId").asString()).isEqualTo(SEGMENT_ID.toString());
+        assertThat(payload.path("campaignId").asString()).isEqualTo(CAMPAIGN_ID.toString());
+    }
+
+    @Test
+    @DisplayName("issues a fresh request id per call so replies cannot be confused")
+    void requestIdIsUniquePerCall() {
+        when(outboxProvider.getIfAvailable()).thenReturn(outboxWriter);
+
+        Optional<UUID> first = requester.requestResolve(CAMPAIGN_ID, SEGMENT_ID);
+        Optional<UUID> second = requester.requestResolve(CAMPAIGN_ID, SEGMENT_ID);
+
+        assertThat(first).isPresent().isNotEqualTo(second);
+    }
+
+    @Test
+    @DisplayName("reports no request when Kafka is disabled instead of failing the caller")
+    void kafkaDisabledYieldsEmpty() {
+        when(outboxProvider.getIfAvailable()).thenReturn(null);
+
+        assertThat(requester.requestResolve(CAMPAIGN_ID, SEGMENT_ID)).isEmpty();
+
+        verify(outboxWriter, never()).publishRaw(anyString(), anyString(), anyString());
+        verify(outboxWriter, never()).publish(anyString(), any());
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/RerankedContentRetriever.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/RerankedContentRetriever.java
@@ -58,8 +58,8 @@ final class RerankedContentRetriever implements QueryDocumentRetriever {
      * refunds" never splits —
      * or (b) a sentence boundary ({@code ?} / {@code ;}) with trailing text.
      */
-    private static final Pattern SUB_QUERY_BOUNDARY_CANDIDATE = Pattern.compile(" (and|plus|but) |(?<=[?;]) ",
-            Pattern.CASE_INSENSITIVE);
+    private static final Pattern SUB_QUERY_BOUNDARY_CANDIDATE =
+            Pattern.compile(" (and|plus|but) |(?<=[?;]) ", Pattern.CASE_INSENSITIVE);
 
     private static final Set<String> SUB_QUERY_STARTERS = Set.of(
             "what", "which", "who", "whom", "whose", "when", "where", "why", "how", "is", "are", "was", "were", "do",
@@ -71,8 +71,8 @@ final class RerankedContentRetriever implements QueryDocumentRetriever {
      */
     private static final int MIN_SUB_QUERY_TOKENS = 3;
 
-    private static final Comparator<RankedContent> OVERALL_SCORE_ORDER = Comparator
-            .comparingDouble(RankedContent::score).reversed().thenComparingInt(RankedContent::originalRank);
+    private static final Comparator<RankedContent> OVERALL_SCORE_ORDER =
+            Comparator.comparingDouble(RankedContent::score).reversed().thenComparingInt(RankedContent::originalRank);
 
     private final QueryDocumentRetriever delegate;
     private final int topK;
@@ -113,7 +113,8 @@ final class RerankedContentRetriever implements QueryDocumentRetriever {
             deduped.merge(key, candidate, (left, right) -> left.score() >= right.score() ? left : right);
         }
 
-        List<RankedContent> overallOrder = deduped.values().stream().sorted(OVERALL_SCORE_ORDER).toList();
+        List<RankedContent> overallOrder =
+                deduped.values().stream().sorted(OVERALL_SCORE_ORDER).toList();
         if (!compoundSlotsEnabled || overallOrder.size() <= topK) {
             return topKOf(overallOrder);
         }
@@ -217,7 +218,7 @@ final class RerankedContentRetriever implements QueryDocumentRetriever {
         Set<String> subQueryTokens = tokens(subQuery);
         return candidates.stream()
                 .max(Comparator.<RankedContent>comparingDouble(
-                        candidate -> subQueryScore(candidate.content(), subQuery, subQueryTokens))
+                                candidate -> subQueryScore(candidate.content(), subQuery, subQueryTokens))
                         .thenComparing(Comparator.comparingInt(RankedContent::originalRank)
                                 .reversed()))
                 .orElseThrow();
@@ -243,10 +244,10 @@ final class RerankedContentRetriever implements QueryDocumentRetriever {
         }
         double lexicalScore = subQueryTokens.isEmpty() ? 0.0 : (double) overlap / subQueryTokens.size();
         double phraseBoost = contentText
-                .toLowerCase(Locale.ROOT)
-                .contains(normalize(subQuery).toLowerCase(Locale.ROOT))
-                        ? 0.2
-                        : 0.0;
+                        .toLowerCase(Locale.ROOT)
+                        .contains(normalize(subQuery).toLowerCase(Locale.ROOT))
+                ? 0.2
+                : 0.0;
         return (0.6 * lexicalScore) + phraseBoost;
     }
 
@@ -262,8 +263,8 @@ final class RerankedContentRetriever implements QueryDocumentRetriever {
         }
 
         double lexicalScore = queryTokens.isEmpty() ? 0.0 : (double) overlap / queryTokens.size();
-        double phraseBoost = contentText.toLowerCase(Locale.ROOT).contains(queryText.toLowerCase(Locale.ROOT)) ? 0.2
-                : 0.0;
+        double phraseBoost =
+                contentText.toLowerCase(Locale.ROOT).contains(queryText.toLowerCase(Locale.ROOT)) ? 0.2 : 0.0;
         double rankScore = 1.0 / (index + 1);
         double totalScore = (0.6 * lexicalScore) + (0.3 * rankScore) + phraseBoost;
         return new RankedContent(document, totalScore, index);
@@ -294,6 +295,5 @@ final class RerankedContentRetriever implements QueryDocumentRetriever {
                 .toList());
     }
 
-    private record RankedContent(@NonNull Document content, double score, int originalRank) {
-    }
+    private record RankedContent(@NonNull Document content, double score, int originalRank) {}
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/EventTypeInitializerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,123 @@
+package com.positivity.mcp.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(EventTypes.all().size())).header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.all()).isNotEmpty();
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/EventTypesTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.mcp.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/RerankedContentRetrieverTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/RerankedContentRetrieverTest.java
@@ -16,10 +16,12 @@ import org.springframework.ai.document.Document;
  */
 class RerankedContentRetrieverTest {
 
-    private static final String COMPOUND_QUERY = "what does an invoice number look like and what permission is needed to read an invoice";
+    private static final String COMPOUND_QUERY =
+            "what does an invoice number look like and what permission is needed to read an invoice";
     private static final String SINGLE_NEED_QUERY = "what permission is needed to read an invoice";
 
-    private static final String GLOSSARY_TEXT = "an invoice number will look like INV-2025-000123 with the INV prefix then year then sequence";
+    private static final String GLOSSARY_TEXT =
+            "an invoice number will look like INV-2025-000123 with the INV prefix then year then sequence";
 
     private static Document doc(String id, String text) {
         return new Document(id, text, Map.of("rag_scope", "master"));
@@ -129,7 +131,7 @@ class RerankedContentRetrieverTest {
         assertThat(RerankedContentRetriever.splitSubQueries("what is a VIN? how do I decode the check digit", 3))
                 .containsExactly("what is a VIN?", "how do I decode the check digit");
         assertThat(RerankedContentRetriever.splitSubQueries(
-                "where is the invoice PLUS ALSO what permission is required", 3))
+                        "where is the invoice PLUS ALSO what permission is required", 3))
                 .containsExactly("where is the invoice", "ALSO what permission is required");
         assertThat(RerankedContentRetriever.splitSubQueries("where is the VIN; how do I decode it", 3))
                 .containsExactly("where is the VIN;", "how do I decode it");

--- a/pos-order/src/main/java/com/positivity/order/internal/controller/RegisterSessionController.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/controller/RegisterSessionController.java
@@ -46,104 +46,123 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Register Sessions", description = "POS register session and cash management")
 public class RegisterSessionController {
 
-        private final RegisterSessionService registerSessionService;
+    private final RegisterSessionService registerSessionService;
 
-        @Operation(summary = "Open a register session", description = "Opens a new register session for the provided terminal, location, and clerk context.", tags = {
-                        "Register Sessions" })
-        @PostMapping
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_OPEN + "')")
-        @EmitEvent(id = "ORDER_SESSION_OPEN", apiVersion = "1")
-        public ResponseEntity<RegisterSessionResponse> openSession(@Valid @RequestBody OpenSessionRequest request) {
-                RegisterSessionSummary summary = registerSessionService.openSession(new OpenSessionCommand(
-                                request.getTerminalId(),
-                                request.getLocationId(),
-                                request.getOpeningFloat(),
-                                request.getOpenedByClerkId()));
-                return ResponseEntity.status(HttpStatus.CREATED).body(RegisterSessionResponse.from(summary));
-        }
+    @Operation(
+            summary = "Open a register session",
+            description = "Opens a new register session for the provided terminal, location, and clerk context.",
+            tags = {"Register Sessions"})
+    @PostMapping
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_OPEN + "')")
+    @EmitEvent(id = "ORDER_SESSION_OPEN", apiVersion = "1")
+    public ResponseEntity<RegisterSessionResponse> openSession(@Valid @RequestBody OpenSessionRequest request) {
+        RegisterSessionSummary summary = registerSessionService.openSession(new OpenSessionCommand(
+                request.getTerminalId(),
+                request.getLocationId(),
+                request.getOpeningFloat(),
+                request.getOpenedByClerkId()));
+        return ResponseEntity.status(HttpStatus.CREATED).body(RegisterSessionResponse.from(summary));
+    }
 
-        @Operation(summary = "Get a register session by id", description = "Retrieves register session details and balances for the given session id.", tags = {
-                        "Register Sessions" })
-        @GetMapping("/{sessionId}")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
-        public ResponseEntity<RegisterSessionResponse> getSession(@PathVariable UUID sessionId) {
-                return ResponseEntity.ok(RegisterSessionResponse.from(registerSessionService.getSession(sessionId)));
-        }
+    @Operation(
+            summary = "Get a register session by id",
+            description = "Retrieves register session details and balances for the given session id.",
+            tags = {"Register Sessions"})
+    @GetMapping("/{sessionId}")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
+    public ResponseEntity<RegisterSessionResponse> getSession(@PathVariable UUID sessionId) {
+        return ResponseEntity.ok(RegisterSessionResponse.from(registerSessionService.getSession(sessionId)));
+    }
 
-        @Operation(summary = "Get the current open session for a terminal", description = "Returns the OPEN (or CLOSING) session on the terminal, or 204 if none is open.", tags = {
-                        "Register Sessions" })
-        @GetMapping("/current")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
-        public ResponseEntity<RegisterSessionResponse> currentSession(@RequestParam String terminalId) {
-                return registerSessionService
-                                .currentSessionForTerminal(terminalId)
-                                .map(RegisterSessionResponse::from)
-                                .map(ResponseEntity::ok)
-                                .orElseGet(() -> ResponseEntity.noContent().build());
-        }
+    @Operation(
+            summary = "Get the current open session for a terminal",
+            description = "Returns the OPEN (or CLOSING) session on the terminal, or 204 if none is open.",
+            tags = {"Register Sessions"})
+    @GetMapping("/current")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
+    public ResponseEntity<RegisterSessionResponse> currentSession(@RequestParam String terminalId) {
+        return registerSessionService
+                .currentSessionForTerminal(terminalId)
+                .map(RegisterSessionResponse::from)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.noContent().build());
+    }
 
-        @Operation(summary = "Record a drawer cash movement", description = "Records a cash in/out drawer movement against the specified register session.", tags = {
-                        "Register Sessions" })
-        @PostMapping("/{sessionId}/cash-movements")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_CASH_MOVEMENT + "')")
-        @EmitEvent(id = "ORDER_SESSION_CASH_MOVEMENT", apiVersion = "1")
-        public ResponseEntity<CashMovementResponse> recordCashMovement(
-                        @PathVariable UUID sessionId, @Valid @RequestBody CashMovementRequest request) {
-                CashMovementResponse response = CashMovementResponse
-                                .from(registerSessionService.recordCashMovement(new CashMovementCommand(
-                                                sessionId,
-                                                request.getMovementType(),
-                                                request.getAmount(),
-                                                request.getReason(),
-                                                request.getClerkId())));
-                return ResponseEntity.status(HttpStatus.CREATED).body(response);
-        }
+    @Operation(
+            summary = "Record a drawer cash movement",
+            description = "Records a cash in/out drawer movement against the specified register session.",
+            tags = {"Register Sessions"})
+    @PostMapping("/{sessionId}/cash-movements")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_CASH_MOVEMENT + "')")
+    @EmitEvent(id = "ORDER_SESSION_CASH_MOVEMENT", apiVersion = "1")
+    public ResponseEntity<CashMovementResponse> recordCashMovement(
+            @PathVariable UUID sessionId, @Valid @RequestBody CashMovementRequest request) {
+        CashMovementResponse response =
+                CashMovementResponse.from(registerSessionService.recordCashMovement(new CashMovementCommand(
+                        sessionId,
+                        request.getMovementType(),
+                        request.getAmount(),
+                        request.getReason(),
+                        request.getClerkId())));
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 
-        @Operation(summary = "List a session's cash movements", description = "Lists all recorded cash movements for the specified register session.", tags = {
-                        "Register Sessions" })
-        @GetMapping("/{sessionId}/cash-movements")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
-        public ResponseEntity<List<CashMovementResponse>> listCashMovements(@PathVariable UUID sessionId) {
-                return ResponseEntity.ok(registerSessionService.listCashMovements(sessionId).stream()
-                                .map(CashMovementResponse::from)
-                                .toList());
-        }
+    @Operation(
+            summary = "List a session's cash movements",
+            description = "Lists all recorded cash movements for the specified register session.",
+            tags = {"Register Sessions"})
+    @GetMapping("/{sessionId}/cash-movements")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
+    public ResponseEntity<List<CashMovementResponse>> listCashMovements(@PathVariable UUID sessionId) {
+        return ResponseEntity.ok(registerSessionService.listCashMovements(sessionId).stream()
+                .map(CashMovementResponse::from)
+                .toList());
+    }
 
-        @Operation(summary = "Begin closing a register session", description = "Records the counted cash and moves the session to CLOSING. Blocked while any of "
-                        + "its orders are in PENDING_PAYMENT.", tags = { "Register Sessions" })
-        @PostMapping("/{sessionId}/begin-close")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_CLOSE + "')")
-        @EmitEvent(id = "ORDER_SESSION_BEGIN_CLOSE", apiVersion = "1")
-        public ResponseEntity<RegisterSessionResponse> beginClose(
-                        @PathVariable UUID sessionId, @Valid @RequestBody BeginCloseRequest request) {
-                return ResponseEntity.ok(
-                                RegisterSessionResponse.from(registerSessionService.beginClose(sessionId,
-                                                request.getCountedCash())));
-        }
+    @Operation(
+            summary = "Begin closing a register session",
+            description = "Records the counted cash and moves the session to CLOSING. Blocked while any of "
+                    + "its orders are in PENDING_PAYMENT.",
+            tags = {"Register Sessions"})
+    @PostMapping("/{sessionId}/begin-close")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_CLOSE + "')")
+    @EmitEvent(id = "ORDER_SESSION_BEGIN_CLOSE", apiVersion = "1")
+    public ResponseEntity<RegisterSessionResponse> beginClose(
+            @PathVariable UUID sessionId, @Valid @RequestBody BeginCloseRequest request) {
+        return ResponseEntity.ok(
+                RegisterSessionResponse.from(registerSessionService.beginClose(sessionId, request.getCountedCash())));
+    }
 
-        @Operation(summary = "Confirm a register session close", description = "Snapshots theoretical cash, computes over/short, and moves the session to CLOSED. "
-                        + "An over/short beyond the authorized difference limit requires "
-                        + "order:session:approve_variance.", tags = { "Register Sessions" })
-        @PostMapping("/{sessionId}/confirm-close")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_CLOSE + "')")
-        @EmitEvent(id = "ORDER_SESSION_CONFIRM_CLOSE", apiVersion = "1")
-        public ResponseEntity<RegisterSessionResponse> confirmClose(@PathVariable UUID sessionId) {
-                return ResponseEntity.ok(RegisterSessionResponse.from(registerSessionService.confirmClose(sessionId)));
-        }
+    @Operation(
+            summary = "Confirm a register session close",
+            description = "Snapshots theoretical cash, computes over/short, and moves the session to CLOSED. "
+                    + "An over/short beyond the authorized difference limit requires "
+                    + "order:session:approve_variance.",
+            tags = {"Register Sessions"})
+    @PostMapping("/{sessionId}/confirm-close")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_CLOSE + "')")
+    @EmitEvent(id = "ORDER_SESSION_CONFIRM_CLOSE", apiVersion = "1")
+    public ResponseEntity<RegisterSessionResponse> confirmClose(@PathVariable UUID sessionId) {
+        return ResponseEntity.ok(RegisterSessionResponse.from(registerSessionService.confirmClose(sessionId)));
+    }
 
-        @Operation(summary = "X-report (mid-day figures for an open session)", description = "Returns an interim session report for an open or in-progress register session.", tags = {
-                        "Register Sessions" })
-        @GetMapping("/{sessionId}/x-report")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
-        public ResponseEntity<SessionReportResponse> xReport(@PathVariable UUID sessionId) {
-                return ResponseEntity.ok(SessionReportResponse.from(registerSessionService.xReport(sessionId)));
-        }
+    @Operation(
+            summary = "X-report (mid-day figures for an open session)",
+            description = "Returns an interim session report for an open or in-progress register session.",
+            tags = {"Register Sessions"})
+    @GetMapping("/{sessionId}/x-report")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
+    public ResponseEntity<SessionReportResponse> xReport(@PathVariable UUID sessionId) {
+        return ResponseEntity.ok(SessionReportResponse.from(registerSessionService.xReport(sessionId)));
+    }
 
-        @Operation(summary = "Z-report (close summary)", description = "Returns the end-of-session close summary, including totals and variance metrics.", tags = {
-                        "Register Sessions" })
-        @GetMapping("/{sessionId}/z-report")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
-        public ResponseEntity<SessionReportResponse> zReport(@PathVariable UUID sessionId) {
-                return ResponseEntity.ok(SessionReportResponse.from(registerSessionService.zReport(sessionId)));
-        }
+    @Operation(
+            summary = "Z-report (close summary)",
+            description = "Returns the end-of-session close summary, including totals and variance metrics.",
+            tags = {"Register Sessions"})
+    @GetMapping("/{sessionId}/z-report")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
+    public ResponseEntity<SessionReportResponse> zReport(@PathVariable UUID sessionId) {
+        return ResponseEntity.ok(SessionReportResponse.from(registerSessionService.zReport(sessionId)));
+    }
 }

--- a/pos-order/src/main/java/com/positivity/order/internal/controller/ReturnOrderController.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/controller/ReturnOrderController.java
@@ -45,102 +45,119 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Returns", description = "Returns & refunds against completed orders")
 public class ReturnOrderController {
 
-        private final ReturnOrderService returnOrderService;
+    private final ReturnOrderService returnOrderService;
 
-        @Operation(summary = "Create a return against a completed order", description = "Idempotency-Key header supported: a replayed key returns the original return. Over-cap "
-                        + "requests return 422 listing each line's returnableQty.", tags = { "Returns" })
-        @PostMapping
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_CREATE + "')")
-        @EmitEvent(id = "ORDER_RETURN_CREATE", apiVersion = "1")
-        public ResponseEntity<ReturnOrderResponse> createReturn(
-                        @Parameter(description = "Client idempotency key; replays return the original return") @RequestHeader(name = "Idempotency-Key", required = false) String idempotencyKey,
-                        @Valid @RequestBody CreateReturnRequest request) {
-                List<ReturnLineCommand> lines = request.getLines().stream()
-                                .map(ReturnOrderController::toLineCommand)
-                                .toList();
-                ReturnOrderResponse response = ReturnOrderResponse
-                                .from(returnOrderService.createReturn(new CreateReturnCommand(
-                                                request.getOriginalOrderId(),
-                                                request.getRefundMethod(),
-                                                request.getReasonCode(),
-                                                lines,
-                                                idempotencyKey)));
-                return ResponseEntity.status(HttpStatus.CREATED).body(response);
-        }
+    @Operation(
+            summary = "Create a return against a completed order",
+            description = "Idempotency-Key header supported: a replayed key returns the original return. Over-cap "
+                    + "requests return 422 listing each line's returnableQty.",
+            tags = {"Returns"})
+    @PostMapping
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_CREATE + "')")
+    @EmitEvent(id = "ORDER_RETURN_CREATE", apiVersion = "1")
+    public ResponseEntity<ReturnOrderResponse> createReturn(
+            @Parameter(description = "Client idempotency key; replays return the original return")
+                    @RequestHeader(name = "Idempotency-Key", required = false)
+                    String idempotencyKey,
+            @Valid @RequestBody CreateReturnRequest request) {
+        List<ReturnLineCommand> lines = request.getLines().stream()
+                .map(ReturnOrderController::toLineCommand)
+                .toList();
+        ReturnOrderResponse response = ReturnOrderResponse.from(returnOrderService.createReturn(new CreateReturnCommand(
+                request.getOriginalOrderId(),
+                request.getRefundMethod(),
+                request.getReasonCode(),
+                lines,
+                idempotencyKey)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 
-        @Operation(summary = "Get a return by id", description = "Fetches a return order by return order identifier.", tags = {
-                        "Returns" })
-        @GetMapping("/{returnOrderId}")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_VIEW + "')")
-        @EmitEvent(id = "ORDER_RETURN_GET", apiVersion = "1")
-        public ResponseEntity<ReturnOrderResponse> getReturn(@PathVariable UUID returnOrderId) {
-                return ResponseEntity.ok(ReturnOrderResponse.from(returnOrderService.getReturn(returnOrderId)));
-        }
+    @Operation(
+            summary = "Get a return by id",
+            description = "Fetches a return order by return order identifier.",
+            tags = {"Returns"})
+    @GetMapping("/{returnOrderId}")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_VIEW + "')")
+    @EmitEvent(id = "ORDER_RETURN_GET", apiVersion = "1")
+    public ResponseEntity<ReturnOrderResponse> getReturn(@PathVariable UUID returnOrderId) {
+        return ResponseEntity.ok(ReturnOrderResponse.from(returnOrderService.getReturn(returnOrderId)));
+    }
 
-        @Operation(summary = "List returns for an original order", description = "Lists return orders created from the specified original order.", tags = {
-                        "Returns" })
-        @GetMapping
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_VIEW + "')")
-        @EmitEvent(id = "ORDER_RETURN_LIST", apiVersion = "1")
-        public ResponseEntity<List<ReturnOrderResponse>> listReturns(@RequestParam UUID originalOrderId) {
-                return ResponseEntity.ok(returnOrderService.listByOriginalOrder(originalOrderId).stream()
-                                .map(ReturnOrderResponse::from)
-                                .toList());
-        }
+    @Operation(
+            summary = "List returns for an original order",
+            description = "Lists return orders created from the specified original order.",
+            tags = {"Returns"})
+    @GetMapping
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_VIEW + "')")
+    @EmitEvent(id = "ORDER_RETURN_LIST", apiVersion = "1")
+    public ResponseEntity<List<ReturnOrderResponse>> listReturns(@RequestParam UUID originalOrderId) {
+        return ResponseEntity.ok(returnOrderService.listByOriginalOrder(originalOrderId).stream()
+                .map(ReturnOrderResponse::from)
+                .toList());
+    }
 
-        @Operation(summary = "Per-line returnable quantities for a completed order", description = "Returns each completed-order line with its currently returnable quantity.", tags = {
-                        "Returns" })
-        @GetMapping("/returnable")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_VIEW + "')")
-        @EmitEvent(id = "ORDER_RETURN_RETURNABLE", apiVersion = "1")
-        public ResponseEntity<List<ReturnableLineResponse>> returnableLines(@RequestParam UUID orderId) {
-                return ResponseEntity.ok(returnOrderService.returnableLines(orderId).stream()
-                                .map(ReturnableLineResponse::from)
-                                .toList());
-        }
+    @Operation(
+            summary = "Per-line returnable quantities for a completed order",
+            description = "Returns each completed-order line with its currently returnable quantity.",
+            tags = {"Returns"})
+    @GetMapping("/returnable")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_VIEW + "')")
+    @EmitEvent(id = "ORDER_RETURN_RETURNABLE", apiVersion = "1")
+    public ResponseEntity<List<ReturnableLineResponse>> returnableLines(@RequestParam UUID orderId) {
+        return ResponseEntity.ok(returnOrderService.returnableLines(orderId).stream()
+                .map(ReturnableLineResponse::from)
+                .toList());
+    }
 
-        @Operation(summary = "Approve a pending return", description = "Approves a pending return so it can continue through the return workflow.", tags = {
-                        "Returns" })
-        @PostMapping("/{returnOrderId}/approve")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_APPROVE + "')")
-        @EmitEvent(id = "ORDER_RETURN_APPROVE", apiVersion = "1")
-        public ResponseEntity<ReturnOrderResponse> approveReturn(@PathVariable UUID returnOrderId) {
-                return ResponseEntity.ok(ReturnOrderResponse.from(returnOrderService.approveReturn(returnOrderId)));
-        }
+    @Operation(
+            summary = "Approve a pending return",
+            description = "Approves a pending return so it can continue through the return workflow.",
+            tags = {"Returns"})
+    @PostMapping("/{returnOrderId}/approve")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_APPROVE + "')")
+    @EmitEvent(id = "ORDER_RETURN_APPROVE", apiVersion = "1")
+    public ResponseEntity<ReturnOrderResponse> approveReturn(@PathVariable UUID returnOrderId) {
+        return ResponseEntity.ok(ReturnOrderResponse.from(returnOrderService.approveReturn(returnOrderId)));
+    }
 
-        @Operation(summary = "Reject a pending return", description = "Rejects a pending return with a provided rejection reason.", tags = {
-                        "Returns" })
-        @PostMapping("/{returnOrderId}/reject")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_APPROVE + "')")
-        @EmitEvent(id = "ORDER_RETURN_REJECT", apiVersion = "1")
-        public ResponseEntity<ReturnOrderResponse> rejectReturn(
-                        @PathVariable UUID returnOrderId, @Valid @RequestBody RejectReturnRequest request) {
-                return ResponseEntity.ok(
-                                ReturnOrderResponse.from(
-                                                returnOrderService.rejectReturn(returnOrderId, request.getReason())));
-        }
+    @Operation(
+            summary = "Reject a pending return",
+            description = "Rejects a pending return with a provided rejection reason.",
+            tags = {"Returns"})
+    @PostMapping("/{returnOrderId}/reject")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_APPROVE + "')")
+    @EmitEvent(id = "ORDER_RETURN_REJECT", apiVersion = "1")
+    public ResponseEntity<ReturnOrderResponse> rejectReturn(
+            @PathVariable UUID returnOrderId, @Valid @RequestBody RejectReturnRequest request) {
+        return ResponseEntity.ok(
+                ReturnOrderResponse.from(returnOrderService.rejectReturn(returnOrderId, request.getReason())));
+    }
 
-        @Operation(summary = "Run the return orchestration saga (refund + restock signal)", description = "From RETURN_REQUESTED: issues the refund and emits order.order.returned. A refund "
-                        + "failure parks the return at REFUND_FAILED before any stock movement.", tags = { "Returns" })
-        @PostMapping("/{returnOrderId}/process")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_CREATE + "')")
-        @EmitEvent(id = "ORDER_RETURN_PROCESS", apiVersion = "1")
-        public ResponseEntity<ReturnOrderResponse> processReturn(@PathVariable UUID returnOrderId) {
-                return ResponseEntity.ok(ReturnOrderResponse.from(returnOrderService.processReturn(returnOrderId)));
-        }
+    @Operation(
+            summary = "Run the return orchestration saga (refund + restock signal)",
+            description = "From RETURN_REQUESTED: issues the refund and emits order.order.returned. A refund "
+                    + "failure parks the return at REFUND_FAILED before any stock movement.",
+            tags = {"Returns"})
+    @PostMapping("/{returnOrderId}/process")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_CREATE + "')")
+    @EmitEvent(id = "ORDER_RETURN_PROCESS", apiVersion = "1")
+    public ResponseEntity<ReturnOrderResponse> processReturn(@PathVariable UUID returnOrderId) {
+        return ResponseEntity.ok(ReturnOrderResponse.from(returnOrderService.processReturn(returnOrderId)));
+    }
 
-        @Operation(summary = "Retry a return saga after a refund failure", description = "Retries return processing for a return currently in a retryable failed state.", tags = {
-                        "Returns" })
-        @PostMapping("/{returnOrderId}/retry")
-        @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_CREATE + "')")
-        @EmitEvent(id = "ORDER_RETURN_RETRY", apiVersion = "1")
-        public ResponseEntity<ReturnOrderResponse> retryReturn(@PathVariable UUID returnOrderId) {
-                return ResponseEntity.ok(ReturnOrderResponse.from(returnOrderService.retryReturn(returnOrderId)));
-        }
+    @Operation(
+            summary = "Retry a return saga after a refund failure",
+            description = "Retries return processing for a return currently in a retryable failed state.",
+            tags = {"Returns"})
+    @PostMapping("/{returnOrderId}/retry")
+    @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_CREATE + "')")
+    @EmitEvent(id = "ORDER_RETURN_RETRY", apiVersion = "1")
+    public ResponseEntity<ReturnOrderResponse> retryReturn(@PathVariable UUID returnOrderId) {
+        return ResponseEntity.ok(ReturnOrderResponse.from(returnOrderService.retryReturn(returnOrderId)));
+    }
 
-        private static ReturnLineCommand toLineCommand(ReturnLineRequest line) {
-                return new ReturnLineCommand(
-                                line.getOriginalOrderLineId(), line.getReturnQty(), line.getCondition(),
-                                line.getSerialNumbers());
-        }
+    private static ReturnLineCommand toLineCommand(ReturnLineRequest line) {
+        return new ReturnLineCommand(
+                line.getOriginalOrderLineId(), line.getReturnQty(), line.getCondition(), line.getSerialNumbers());
+    }
 }

--- a/pos-order/src/test/java/com/positivity/order/internal/client/RestInvoicingPortAdapterTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/client/RestInvoicingPortAdapterTest.java
@@ -1,0 +1,226 @@
+package com.positivity.order.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.positivity.order.internal.exception.InvoicingUnavailableException;
+import com.positivity.shared.dto.OrderInvoiceCreationRequest;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link RestInvoicingPortAdapter} (parity stories C1/C3).
+ *
+ * <p>
+ * This adapter is synchronous by ADR-0044 amendment, and the two directions have
+ * deliberately opposite failure policies:
+ *
+ * <ul>
+ * <li><b>Invoice creation and cancellation fail loudly.</b> Checkout must not
+ * complete without an invoice, so anything short of a usable response — a
+ * transport error, a 5xx, or a 200 carrying no invoice id — becomes
+ * {@link InvoicingUnavailableException}.</li>
+ * <li><b>Payment reversal reports failure instead of throwing.</b> It runs inside
+ * the cancellation saga, which needs the outcome to decide its next compensating
+ * step; an exception there would abort the saga midway and strand the order.</li>
+ * </ul>
+ *
+ * <p>
+ * The VOID/REFUND split is also pinned: a void targets a different endpoint and
+ * authority than a refund and carries no amount, because there are no captured
+ * funds to return.
+ */
+@DisplayName("RestInvoicingPortAdapter — pos-invoice money flows")
+class RestInvoicingPortAdapterTest {
+
+    private static final UUID ORDER_ID = UUID.fromString("00000000-0000-0000-0000-000000000071");
+    private static final UUID INVOICE_ID = UUID.fromString("00000000-0000-0000-0000-000000000072");
+    private static final UUID PAYMENT_INTENT_ID = UUID.fromString("00000000-0000-0000-0000-000000000073");
+
+    private MockRestServiceServer server;
+    private RestInvoicingPortAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder().baseUrl("http://invoice");
+        server = MockRestServiceServer.bindTo(builder).build();
+        adapter = new RestInvoicingPortAdapter(builder.build());
+    }
+
+    private static OrderInvoiceCreationRequest creationRequest() {
+        OrderInvoiceCreationRequest request = new OrderInvoiceCreationRequest();
+        request.setOrderId(ORDER_ID);
+        request.setCustomerId(UUID.randomUUID());
+        request.setLocationId(UUID.randomUUID());
+        request.setSubtotal(new BigDecimal("100.00"));
+        request.setTaxAmount(new BigDecimal("8.25"));
+        request.setTotalAmount(new BigDecimal("108.25"));
+        return request;
+    }
+
+    private static ReversePaymentCommand command(String type, String amount) {
+        return new ReversePaymentCommand(
+                type, amount == null ? null : new BigDecimal(amount), "USD", "CUSTOMER_REQUEST", ORDER_ID, "idem-1");
+    }
+
+    @Test
+    @DisplayName("returns the invoice reference and reports a replayed invoice as existing")
+    void createsInvoice() {
+        server.expect(requestTo("http://invoice/v1/invoices/from-order"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("X-User", "pos-order"))
+                .andExpect(header("X-Authorities", "invoice:manage"))
+                .andExpect(jsonPath("$.orderId").value(ORDER_ID.toString()))
+                .andRespond(withSuccess("""
+                        {"invoiceId":"%s","invoiceNumber":"INV-9","status":"OPEN",
+                         "totalAmount":108.25,"existing":true}""".formatted(INVOICE_ID), MediaType.APPLICATION_JSON));
+
+        InvoiceRef ref = adapter.createInvoiceForOrder(creationRequest());
+
+        assertThat(ref.invoiceId()).isEqualTo(INVOICE_ID);
+        assertThat(ref.invoiceNumber()).isEqualTo("INV-9");
+        assertThat(ref.status()).isEqualTo("OPEN");
+        assertThat(ref.totalAmount()).isEqualByComparingTo("108.25");
+        // "existing" is how the caller knows a retry replayed rather than double-invoiced.
+        assertThat(ref.existing()).isTrue();
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("fails the checkout when pos-invoice answers without an invoice id")
+    void emptyResponseIsFatal() {
+        server.expect(requestTo("http://invoice/v1/invoices/from-order"))
+                .andRespond(
+                        withSuccess("{\"invoiceNumber\":\"INV-9\",\"existing\":false}", MediaType.APPLICATION_JSON));
+
+        // A 200 with no id is not a usable invoice; treating it as success would complete a
+        // checkout with nothing to collect against.
+        assertThatThrownBy(() -> adapter.createInvoiceForOrder(creationRequest()))
+                .isInstanceOf(InvoicingUnavailableException.class)
+                .hasMessageContaining("empty from-order response");
+    }
+
+    @Test
+    @DisplayName("fails the checkout when pos-invoice errors, naming the order")
+    void serverErrorIsFatal() {
+        server.expect(requestTo("http://invoice/v1/invoices/from-order")).andRespond(withServerError());
+
+        assertThatThrownBy(() -> adapter.createInvoiceForOrder(creationRequest()))
+                .isInstanceOf(InvoicingUnavailableException.class)
+                .hasMessageContaining(ORDER_ID.toString());
+    }
+
+    @Test
+    @DisplayName("voids an uncaptured authorization without sending an amount")
+    void voidsPayment() {
+        server.expect(requestTo(
+                        "http://invoice/v1/invoices/%s/payments/%s/void".formatted(INVOICE_ID, PAYMENT_INTENT_ID)))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("X-Authorities", "invoice:manage,VOID_PAYMENT"))
+                .andExpect(jsonPath("$.reason").value("CUSTOMER_REQUEST"))
+                // No funds were captured, so there is no amount to return.
+                .andExpect(jsonPath("$.amount").doesNotExist())
+                .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+        PaymentReversalResult result = adapter.reversePayment(INVOICE_ID, PAYMENT_INTENT_ID, command("VOID", null));
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.paymentReversalType()).isEqualTo("VOID");
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("refunds settled funds with the amount and the saga's idempotency key")
+    void refundsPayment() {
+        server.expect(requestTo(
+                        "http://invoice/v1/invoices/%s/payments/%s/refunds".formatted(INVOICE_ID, PAYMENT_INTENT_ID)))
+                .andExpect(header("X-Authorities", "invoice:manage,REFUND_PAYMENT"))
+                .andExpect(jsonPath("$.amount").value(40.00))
+                .andExpect(jsonPath("$.reason").value("CUSTOMER_RETURN"))
+                // The key is what stops a saga retry refunding twice.
+                .andExpect(jsonPath("$.externalReference").value("idem-1"))
+                .andExpect(jsonPath("$.notes").value(org.hamcrest.Matchers.containsString(ORDER_ID.toString())))
+                .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+        PaymentReversalResult result =
+                adapter.reversePayment(INVOICE_ID, PAYMENT_INTENT_ID, command("REFUND", "40.00"));
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.paymentReversalType()).isEqualTo("REFUND");
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("reports a failed reversal rather than throwing, so the saga can decide what to do")
+    void reversalFailureIsReportedNotThrown() {
+        server.expect(requestTo(
+                        "http://invoice/v1/invoices/%s/payments/%s/refunds".formatted(INVOICE_ID, PAYMENT_INTENT_ID)))
+                .andRespond(withServerError());
+
+        PaymentReversalResult result =
+                adapter.reversePayment(INVOICE_ID, PAYMENT_INTENT_ID, command("REFUND", "40.00"));
+
+        assertThat(result.success()).isFalse();
+        // The command's own type is echoed back, since no reversal actually took a form.
+        assertThat(result.paymentReversalType()).isEqualTo("REFUND");
+        assertThat(result.resultMessage()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("falls back to a default reason when the command carries none")
+    void reversalWithoutReasonCode() {
+        server.expect(requestTo(
+                        "http://invoice/v1/invoices/%s/payments/%s/void".formatted(INVOICE_ID, PAYMENT_INTENT_ID)))
+                .andExpect(jsonPath("$.notes").value(org.hamcrest.Matchers.containsString("order cancellation")))
+                .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+        PaymentReversalResult result = adapter.reversePayment(
+                INVOICE_ID,
+                PAYMENT_INTENT_ID,
+                new ReversePaymentCommand("void", null, "USD", null, ORDER_ID, "idem-2"));
+
+        // Type matching is case-insensitive: "void" must not fall through to the refund path.
+        assertThat(result.paymentReversalType()).isEqualTo("VOID");
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("raises InvoicingUnavailable when a cancel cannot be delivered")
+    void cancelFailureIsFatal() {
+        server.expect(requestTo("http://invoice/v1/invoices/%s/cancel".formatted(INVOICE_ID)))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withServerError());
+
+        assertThatThrownBy(() -> adapter.cancelInvoice(INVOICE_ID))
+                .isInstanceOf(InvoicingUnavailableException.class)
+                .hasMessageContaining(INVOICE_ID.toString());
+    }
+
+    @Test
+    @DisplayName("cancels an invoice against the invoice-manage authority")
+    void cancelsInvoice() {
+        server.expect(requestTo("http://invoice/v1/invoices/%s/cancel".formatted(INVOICE_ID)))
+                .andExpect(header("X-User", "pos-order"))
+                .andExpect(header("X-Authorities", "invoice:manage"))
+                .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+        adapter.cancelInvoice(INVOICE_ID);
+
+        server.verify();
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/config/EventTypeInitializerTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,124 @@
+package com.positivity.order.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "", true);
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(EventTypes.ALL_EVENT_TYPES.size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret, true);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(EventTypes.ALL_EVENT_TYPES.size()))
+                .header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.ALL_EVENT_TYPES).isNotEmpty();
+        verify(restClient, times(EventTypes.ALL_EVENT_TYPES.size())).put();
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/config/EventTypesTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.order.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -58,7 +58,7 @@ class EventTypesTest {
     }
 
     private static List<EventTypeRegistration> registrations() {
-        return EventTypes.all();
+        return EventTypes.ALL_EVENT_TYPES;
     }
 
     @Test
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-order/src/test/java/com/positivity/order/internal/config/OrderDomainEventPublisherTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/config/OrderDomainEventPublisherTest.java
@@ -1,0 +1,484 @@
+package com.positivity.order.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.DomainTopics;
+import com.positivity.domainevents.order.OrderCancelReviewRequiredV1;
+import com.positivity.domainevents.order.OrderCancelledV1;
+import com.positivity.domainevents.order.OrderCommissionImpactV1;
+import com.positivity.domainevents.order.OrderCompletedV1;
+import com.positivity.domainevents.order.OrderPaymentIntegrityAlertV1;
+import com.positivity.domainevents.order.OrderReturnedV1;
+import com.positivity.domainevents.order.RegisterSessionClosedV1;
+import com.positivity.order.internal.entity.PriceOverride;
+import com.positivity.order.internal.entity.PriceOverrideReasonCode;
+import com.positivity.order.internal.entity.PriceSource;
+import com.positivity.order.internal.entity.RefundMethod;
+import com.positivity.order.internal.entity.RegisterSession;
+import com.positivity.order.internal.entity.ReturnCondition;
+import com.positivity.order.internal.entity.ReturnOrder;
+import com.positivity.order.internal.entity.ReturnOrderLine;
+import com.positivity.order.internal.entity.SalesOrder;
+import com.positivity.order.internal.entity.SalesOrderLine;
+import com.positivity.order.internal.entity.SourceType;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+
+/**
+ * Unit tests for {@link OrderDomainEventPublisher} (ADR-0044, stories D1/D2/D3).
+ *
+ * <p>
+ * These facts are what pos-inventory, pos-accounting, and the CRM act on, so the
+ * details that decide downstream behaviour are the ones worth pinning:
+ *
+ * <ul>
+ * <li><b>A WORKORDER-sourced line is not fulfillable</b> (spec R7.5). The source
+ * document already fulfilled it; marking it fulfillable would have pos-inventory
+ * consume the stock a second time.</li>
+ * <li><b>The aggregate id is the aggregate the fact is about</b> — the return for
+ * {@code order.order.returned}, the session for {@code order.session.closed} —
+ * not the order in every case, because the aggregate id is the Kafka key and
+ * therefore what orders the stream.</li>
+ * <li><b>A persisted completion timestamp wins over the clock</b>, so the fact
+ * matches the aggregate state rather than the moment it happened to be
+ * published.</li>
+ * <li><b>Every method is a no-op while the Kafka flag is off.</b> The writer bean
+ * is conditional, and these are called inside mutating transactions that must
+ * still commit.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("OrderDomainEventPublisher — order domain facts")
+class OrderDomainEventPublisherTest {
+
+    private static final UUID ORDER_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID LINE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a2");
+    private static final UUID RETURN_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a3");
+    private static final UUID SESSION_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a4");
+    private static final UUID OVERRIDE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a5");
+    private static final UUID PRODUCT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a6");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+    private static final String TOPIC = DomainTopics.events("order");
+
+    @Mock
+    private ObjectProvider<OutboxEventWriter> outboxProvider;
+
+    @Mock
+    private OutboxEventWriter outboxWriter;
+
+    private OrderDomainEventPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new OrderDomainEventPublisher(Clock.fixed(NOW, ZoneOffset.UTC), outboxProvider);
+        when(outboxProvider.getIfAvailable()).thenReturn(outboxWriter);
+    }
+
+    private DomainEventEnvelope<?> captureEnvelope() {
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.captor();
+        verify(outboxWriter).publish(org.mockito.ArgumentMatchers.eq(TOPIC), captor.capture());
+        return captor.getValue();
+    }
+
+    private static SalesOrder order(Long version, SalesOrderLine... lines) {
+        return SalesOrder.builder()
+                .orderId(ORDER_ID)
+                .version(version)
+                .orderNumber("SO-1001")
+                .locationId(UUID.randomUUID())
+                .sessionId(SESSION_ID)
+                .clerkId("clerk-1")
+                .terminalId("terminal-1")
+                .subtotal(new BigDecimal("100.00"))
+                .discountTotal(new BigDecimal("5.00"))
+                .taxTotal(new BigDecimal("8.25"))
+                .grandTotal(new BigDecimal("103.25"))
+                .amountPaid(new BigDecimal("120.00"))
+                .cancellationReason("Customer changed mind")
+                .lines(new ArrayList<>(Arrays.asList(lines)))
+                .build();
+    }
+
+    private static SalesOrderLine line(SourceType sourceType, PriceSource priceSource, List<String> serials) {
+        return SalesOrderLine.builder()
+                .orderLineId(LINE_ID)
+                .itemSku("BRK-100")
+                .itemDescription("Brake pad")
+                .quantity(2)
+                .unitPrice(new BigDecimal("45.50"))
+                .discountAmount(new BigDecimal("1.00"))
+                .lineSubtotal(new BigDecimal("90.00"))
+                .taxAmount(new BigDecimal("7.42"))
+                .lineTotal(new BigDecimal("97.42"))
+                .priceSource(priceSource)
+                .sourceType(sourceType)
+                .sourceId("wo-1")
+                .sourceLineId("wol-1")
+                .returnable(true)
+                .serialNumbers(serials)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("when the Kafka flag is off")
+    class KafkaDisabled {
+
+        @Test
+        @DisplayName("every publish is a no-op so the mutating transaction still commits")
+        void allMethodsNoOp() {
+            when(outboxProvider.getIfAvailable()).thenReturn(null);
+            SalesOrder order = order(1L);
+
+            publisher.publishOrderCancelled(order);
+            publisher.publishCancelReviewRequired(order, "inventory unavailable");
+            publisher.publishOrderCompleted(order, List.of());
+            publisher.publishPaymentIntegrityAlert(order);
+            publisher.publishCommissionImpact(override(null, null));
+            publisher.publishOrderReturned(returnOrder(null, null));
+            publisher.publishRegisterSessionClosed(session(null), sessionClosedPayload());
+
+            verifyNoInteractions(outboxWriter);
+        }
+    }
+
+    @Nested
+    @DisplayName("order.order.completed")
+    class Completed {
+
+        @Test
+        @DisplayName("marks a WORKORDER-sourced line unfulfillable so inventory does not double-consume it")
+        void workorderSourcedLineIsNotFulfillable() {
+            publisher.publishOrderCompleted(
+                    order(4L, line(SourceType.WORKORDER, PriceSource.MANUAL, List.of("SN-1"))),
+                    List.of(new OrderCompletedV1.Tender("CARD", new BigDecimal("103.25"))));
+
+            OrderCompletedV1 payload = (OrderCompletedV1) captureEnvelope().payload();
+            OrderCompletedV1.Line eventLine = payload.lines().getFirst();
+            assertThat(eventLine.fulfillable()).isFalse();
+            assertThat(eventLine.sku()).isEqualTo("BRK-100");
+            assertThat(eventLine.priceSource()).isEqualTo("MANUAL");
+            assertThat(eventLine.sourceType()).isEqualTo("WORKORDER");
+            assertThat(eventLine.serialNumbers()).containsExactly("SN-1");
+            assertThat(payload.tenders()).hasSize(1);
+            assertThat(payload.currencyCode()).isEqualTo("USD");
+            assertThat(payload.completedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("marks a line with no source document fulfillable")
+        void ordinaryLineIsFulfillable() {
+            publisher.publishOrderCompleted(order(4L, line(null, null, null)), List.of());
+
+            OrderCompletedV1.Line eventLine =
+                    ((OrderCompletedV1) captureEnvelope().payload()).lines().getFirst();
+            assertThat(eventLine.fulfillable()).isTrue();
+            assertThat(eventLine.sourceType()).isNull();
+            // Defaults rather than nulls: the field is @NonNull on the event contract.
+            assertThat(eventLine.priceSource()).isEqualTo("PRICING_SERVICE");
+            assertThat(eventLine.serialNumbers()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("skips a null line rather than failing the whole fact")
+        void nullLinesAreSkipped() {
+            SalesOrder order = order(4L, line(null, PriceSource.PRICING_SERVICE, List.of()));
+            order.getLines().add(null);
+
+            publisher.publishOrderCompleted(order, List.of());
+
+            assertThat(((OrderCompletedV1) captureEnvelope().payload()).lines()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("keys the fact on the order and carries its optimistic-lock version")
+        void keyedOnOrderWithVersion() {
+            publisher.publishOrderCompleted(order(7L), List.of());
+
+            DomainEventEnvelope<?> envelope = captureEnvelope();
+            assertThat(envelope.eventType()).isEqualTo(OrderCompletedV1.EVENT_TYPE);
+            assertThat(envelope.aggregateId()).isEqualTo(ORDER_ID);
+            assertThat(envelope.aggregateVersion()).isEqualTo(7L);
+            assertThat(envelope.sourceService()).isEqualTo("pos-order");
+            assertThat(envelope.actor()).isEqualTo("system");
+        }
+
+        @Test
+        @DisplayName("treats an unversioned order as version zero rather than failing envelope validation")
+        void nullVersionBecomesZero() {
+            publisher.publishOrderCompleted(order(null), List.of());
+
+            assertThat(captureEnvelope().aggregateVersion()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("cancellation facts")
+    class Cancellation {
+
+        @Test
+        @DisplayName("emits order.order.cancelled with the recorded reason")
+        void cancelled() {
+            publisher.publishOrderCancelled(order(2L));
+
+            DomainEventEnvelope<?> envelope = captureEnvelope();
+            assertThat(envelope.eventType()).isEqualTo(OrderCancelledV1.EVENT_TYPE);
+            OrderCancelledV1 payload = (OrderCancelledV1) envelope.payload();
+            assertThat(payload.orderId()).isEqualTo(ORDER_ID);
+            assertThat(payload.orderNumber()).isEqualTo("SO-1001");
+            assertThat(payload.cancellationReason()).isEqualTo("Customer changed mind");
+        }
+
+        @Test
+        @DisplayName("emits order.order.cancel-review-required carrying why the cancel could not complete")
+        void cancelReviewRequired() {
+            publisher.publishCancelReviewRequired(order(2L), "inventory release failed");
+
+            DomainEventEnvelope<?> envelope = captureEnvelope();
+            assertThat(envelope.eventType()).isEqualTo(OrderCancelReviewRequiredV1.EVENT_TYPE);
+            assertThat(((OrderCancelReviewRequiredV1) envelope.payload()).failureReason())
+                    .isEqualTo("inventory release failed");
+        }
+    }
+
+    @Nested
+    @DisplayName("order.payment.integrity-alert")
+    class IntegrityAlert {
+
+        @Test
+        @DisplayName("carries both figures that disagree, so the discrepancy is in the fact itself")
+        void carriesBothAmounts() {
+            publisher.publishPaymentIntegrityAlert(order(1L));
+
+            DomainEventEnvelope<?> envelope = captureEnvelope();
+            assertThat(envelope.eventType()).isEqualTo(OrderPaymentIntegrityAlertV1.EVENT_TYPE);
+            OrderPaymentIntegrityAlertV1 payload = (OrderPaymentIntegrityAlertV1) envelope.payload();
+            assertThat(payload.grandTotal()).isEqualByComparingTo("103.25");
+            assertThat(payload.amountPaid()).isEqualByComparingTo("120.00");
+        }
+    }
+
+    @Nested
+    @DisplayName("order.line.commission-impact")
+    class CommissionImpact {
+
+        @Test
+        @DisplayName("reports the discount delta and the approval timestamp the override actually carries")
+        void usesApprovedAtAndComputesDelta() {
+            Instant approvedAt = NOW.minusSeconds(600);
+
+            publisher.publishCommissionImpact(override(PriceOverrideReasonCode.PRICE_MATCH, approvedAt));
+
+            OrderCommissionImpactV1 payload =
+                    (OrderCommissionImpactV1) captureEnvelope().payload();
+            assertThat(payload.overrideId()).isEqualTo(OVERRIDE_ID);
+            assertThat(payload.orderLineId()).isEqualTo(LINE_ID);
+            assertThat(payload.productId()).isEqualTo(PRODUCT_ID);
+            assertThat(payload.affectsCommission()).isTrue();
+            assertThat(payload.discountDelta()).isEqualByComparingTo("15.00");
+            assertThat(payload.reasonCode()).isEqualTo("PRICE_MATCH");
+            assertThat(payload.effectiveAt()).isEqualTo(approvedAt);
+        }
+
+        @Test
+        @DisplayName("falls back to UNSPECIFIED and the current clock when the override records neither")
+        void defaultsReasonCodeAndTimestamp() {
+            publisher.publishCommissionImpact(override(null, null));
+
+            OrderCommissionImpactV1 payload =
+                    (OrderCommissionImpactV1) captureEnvelope().payload();
+            assertThat(payload.reasonCode()).isEqualTo("UNSPECIFIED");
+            assertThat(payload.effectiveAt()).isEqualTo(NOW);
+        }
+    }
+
+    @Nested
+    @DisplayName("order.order.returned")
+    class Returned {
+
+        @Test
+        @DisplayName("keys the fact on the return, not the original order")
+        void keyedOnTheReturn() {
+            publisher.publishOrderReturned(returnOrder(3L, NOW.minusSeconds(60)));
+
+            DomainEventEnvelope<?> envelope = captureEnvelope();
+            assertThat(envelope.eventType()).isEqualTo(OrderReturnedV1.EVENT_TYPE);
+            assertThat(envelope.aggregateId()).isEqualTo(RETURN_ID).isNotEqualTo(ORDER_ID);
+            assertThat(envelope.aggregateVersion()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("carries the persisted completion time so the fact matches the aggregate state")
+        void usesPersistedReturnedAt() {
+            Instant returnedAt = NOW.minusSeconds(3_600);
+
+            publisher.publishOrderReturned(returnOrder(1L, returnedAt));
+
+            OrderReturnedV1 payload = (OrderReturnedV1) captureEnvelope().payload();
+            assertThat(payload.returnedAt()).isEqualTo(returnedAt);
+            assertThat(payload.refundMethod()).isEqualTo("ORIGINAL_TENDER");
+            assertThat(payload.lines()).singleElement().satisfies(l -> {
+                assertThat(l.condition()).isEqualTo(ReturnCondition.RESTOCK.name());
+                assertThat(l.quantity()).isEqualTo(1);
+                assertThat(l.serialNumbers()).containsExactly("SN-9");
+            });
+        }
+
+        @Test
+        @DisplayName("falls back to the clock and an empty serial list when neither is recorded")
+        void defaultsWhenUnrecorded() {
+            ReturnOrder returnOrder = returnOrder(null, null);
+            returnOrder.getLines().getFirst().setSerialNumbers(null);
+
+            publisher.publishOrderReturned(returnOrder);
+
+            DomainEventEnvelope<?> envelope = captureEnvelope();
+            assertThat(envelope.aggregateVersion()).isZero();
+            OrderReturnedV1 payload = (OrderReturnedV1) envelope.payload();
+            assertThat(payload.returnedAt()).isEqualTo(NOW);
+            assertThat(payload.lines().getFirst().serialNumbers()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("skips a null line rather than failing the whole fact")
+        void nullLineIsSkipped() {
+            ReturnOrder returnOrder = returnOrder(1L, NOW);
+            returnOrder.getLines().add(null);
+
+            publisher.publishOrderReturned(returnOrder);
+
+            assertThat(((OrderReturnedV1) captureEnvelope().payload()).lines()).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("order.session.closed")
+    class SessionClosed {
+
+        @Test
+        @DisplayName("keys the fact on the session and forwards the caller's payload unchanged")
+        void keyedOnSession() {
+            RegisterSessionClosedV1 payload = sessionClosedPayload();
+
+            publisher.publishRegisterSessionClosed(session(5L), payload);
+
+            DomainEventEnvelope<?> envelope = captureEnvelope();
+            assertThat(envelope.eventType()).isEqualTo(RegisterSessionClosedV1.EVENT_TYPE);
+            assertThat(envelope.aggregateId()).isEqualTo(SESSION_ID);
+            assertThat(envelope.aggregateVersion()).isEqualTo(5L);
+            assertThat(envelope.payload()).isSameAs(payload);
+        }
+
+        @Test
+        @DisplayName("treats an unversioned session as version zero")
+        void nullVersionBecomesZero() {
+            publisher.publishRegisterSessionClosed(session(null), sessionClosedPayload());
+
+            assertThat(captureEnvelope().aggregateVersion()).isZero();
+        }
+
+        @Test
+        @DisplayName("does not publish when the writer bean is absent")
+        void noWriterNoPublish() {
+            when(outboxProvider.getIfAvailable()).thenReturn(null);
+
+            publisher.publishRegisterSessionClosed(session(1L), sessionClosedPayload());
+
+            verify(outboxWriter, never()).publish(anyString(), any());
+        }
+    }
+
+    private static PriceOverride override(PriceOverrideReasonCode reasonCode, Instant approvedAt) {
+        return PriceOverride.builder()
+                .overrideId(OVERRIDE_ID)
+                .order(order(1L))
+                .orderLine(SalesOrderLine.builder().orderLineId(LINE_ID).build())
+                .productId(PRODUCT_ID)
+                .originalPrice(new BigDecimal("60.00"))
+                .overridePrice(new BigDecimal("45.00"))
+                .reasonCode(reasonCode)
+                .affectsCommission(true)
+                .requestedByUserId(UUID.randomUUID())
+                .approvedByUserId(UUID.randomUUID())
+                .approvedAt(approvedAt)
+                .build();
+    }
+
+    private static ReturnOrder returnOrder(Long version, Instant returnedAt) {
+        ReturnOrderLine line = ReturnOrderLine.builder()
+                .returnLineId(UUID.randomUUID())
+                .originalOrderLineId(LINE_ID)
+                .itemSku("BRK-100")
+                .returnQty(1)
+                .condition(ReturnCondition.RESTOCK)
+                .lineRefund(new BigDecimal("45.50"))
+                .serialNumbers(new ArrayList<>(List.of("SN-9")))
+                .build();
+        return ReturnOrder.builder()
+                .returnOrderId(RETURN_ID)
+                .version(version)
+                .originalOrderId(ORDER_ID)
+                .originalOrderNumber("SO-1001")
+                .locationId(UUID.randomUUID())
+                .customerId(UUID.randomUUID())
+                .refundMethod(RefundMethod.ORIGINAL_TENDER)
+                .totalRefund(new BigDecimal("45.50"))
+                .returnedAt(returnedAt)
+                .lines(new ArrayList<>(List.of(line)))
+                .build();
+    }
+
+    private static RegisterSession session(Long version) {
+        return RegisterSession.builder()
+                .sessionId(SESSION_ID)
+                .version(version)
+                .terminalId("terminal-1")
+                .locationId(UUID.randomUUID())
+                .openedByClerkId("clerk-1")
+                .openingFloat(new BigDecimal("200.00"))
+                .build();
+    }
+
+    private static RegisterSessionClosedV1 sessionClosedPayload() {
+        return new RegisterSessionClosedV1(
+                SESSION_ID,
+                "terminal-1",
+                UUID.randomUUID(),
+                "clerk-1",
+                "clerk-2",
+                new BigDecimal("200.00"),
+                new BigDecimal("450.00"),
+                new BigDecimal("452.00"),
+                new BigDecimal("-2.00"),
+                false,
+                "USD",
+                List.of(),
+                BigDecimal.ZERO,
+                NOW.minusSeconds(28_800),
+                NOW);
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/config/OutboxPublisherTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/config/OutboxPublisherTest.java
@@ -1,0 +1,190 @@
+package com.positivity.order.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.order.internal.entity.OutboxEvent;
+import com.positivity.order.internal.repository.OutboxEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for the pos-order {@link OutboxPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * This publisher deliberately diverges from its siblings in catalog, invoice,
+ * inventory and the rest: it carries no Micrometer counters, it does not reset
+ * {@code attempts} on a successful publish, and it stores the raw exception
+ * message without a class-name fallback or length cap. The divergences are safe
+ * — {@code last_error} is a {@code TEXT} column, so an unbounded message cannot
+ * overflow it — but they are easy to "fix" by accident when someone copies a
+ * sibling publisher over this one, so the tests below pin them down explicitly.
+ *
+ * <p>
+ * The shared contract still holds and is what carries the correctness weight: a
+ * row is marked published only after the broker acknowledges, and the batch
+ * stops at the first failure so a struggling broker cannot reorder events.
+ */
+@DisplayName("pos-order OutboxPublisher — outbox drain contract")
+class OutboxPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-08T12:00:00Z");
+    private static final Clock TEST_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+    private static final String TOPIC = "order.events.v1";
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private OutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new OutboxPublisher(repository, kafkaTemplate, TEST_CLOCK);
+        ReflectionTestUtils.setField(publisher, "sendTimeoutMs", 1000L);
+    }
+
+    private OutboxEvent event(String key) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(TOPIC)
+                .recordKey(key)
+                .payload("{\"eventId\":\"" + key + "\"}")
+                .createdAt(NOW.minusSeconds(60))
+                .attempts(2)
+                .lastError("previous failure")
+                .build();
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    private void brokerFailsWith(Throwable failure) {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(failure));
+    }
+
+    @Test
+    @DisplayName("marks the row published only after the broker acknowledges the send")
+    void marksPublishedAfterAcknowledgedSend() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate).send(TOPIC, "k1", row.getPayload());
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        assertThat(row.getLastError()).isNull();
+        verify(repository).save(row);
+    }
+
+    @Test
+    @DisplayName("keeps the prior attempt count on success — unlike the sibling publishers, which reset it")
+    void doesNotResetAttemptsOnSuccess() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        assertThat(row.getAttempts()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("drains the whole batch in order while the broker keeps acknowledging")
+    void drainsWholeBatchWhenAllSendsSucceed() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(first.getPublishedAt()).isEqualTo(NOW);
+        assertThat(second.getPublishedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("on failure: records the attempt and error, leaves the row unpublished, stops the batch")
+    void recordsFailureAndStopsBatch() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerFailsWith(new RuntimeException("broker down"));
+
+        publisher.publishPending();
+
+        assertThat(first.getPublishedAt()).isNull();
+        assertThat(first.getAttempts()).isEqualTo(3);
+        assertThat(first.getLastError()).contains("broker down");
+        verify(repository).save(first);
+
+        // The batch stops at the first failure so publish order is preserved:
+        // the second row is never attempted and keeps its prior attempt count.
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+        verify(kafkaTemplate).send(TOPIC, "k1", first.getPayload());
+        assertThat(second.getAttempts()).isEqualTo(2);
+        assertThat(second.getPublishedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("stores a null last_error when the failure carries no message — no class-name fallback here")
+    void recordsNullWhenFailureMessageIsNull() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        // Thrown by send() itself: a failed future surfaces as an ExecutionException
+        // whose message is the cause's toString, so only a synchronous throw
+        // produces a null message here.
+        when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenThrow(new IllegalStateException());
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).isNull();
+        assertThat(row.getAttempts()).isEqualTo(3);
+        assertThat(row.getPublishedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("stores an oversized failure message untruncated — last_error is an unbounded TEXT column")
+    void storesOversizedFailureMessageUntruncated() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerFailsWith(new RuntimeException("x".repeat(2500)));
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).hasSizeGreaterThan(2000);
+    }
+
+    @Test
+    @DisplayName("does nothing when the outbox is empty")
+    void doesNothingWhenNoPendingRows() {
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of());
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        verify(repository, never()).save(any());
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/controller/OrderExceptionHandlerTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/controller/OrderExceptionHandlerTest.java
@@ -1,0 +1,366 @@
+package com.positivity.order.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.when;
+
+import com.positivity.order.internal.exception.InvalidCustomerException;
+import com.positivity.order.internal.exception.InvalidPriceOverrideException;
+import com.positivity.order.internal.exception.InvalidSkuException;
+import com.positivity.order.internal.exception.InvoicingUnavailableException;
+import com.positivity.order.internal.exception.OrderVoidBlockedException;
+import com.positivity.order.internal.exception.OverCapReturnException;
+import com.positivity.order.internal.exception.PriceOverrideIdempotencyConflictException;
+import com.positivity.order.internal.exception.PriceOverrideNotFoundException;
+import com.positivity.order.internal.exception.RegisterSessionConflictException;
+import com.positivity.order.internal.exception.RegisterSessionNotFoundException;
+import com.positivity.order.internal.exception.ReturnOrderNotFoundException;
+import com.positivity.order.internal.exception.SalesOrderNotFoundException;
+import com.positivity.order.internal.exception.SessionCloseBlockedException;
+import com.positivity.order.internal.exception.TaxUnavailableException;
+import com.positivity.order.internal.exception.WarrantyReturnRoutingException;
+import com.positivity.shared.error.ApiError;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+/**
+ * ApiError mapping for the four controller-scoped advices in pos-order.
+ *
+ * <p>
+ * Each advice is deliberately scoped with {@code assignableTypes} so it does not
+ * shadow its siblings, and that scoping is the reason the same exception type
+ * maps to different codes and statuses per endpoint family — an
+ * {@link IllegalStateException} is a 422 on the sales-order endpoints and a 409
+ * on the returns endpoints. Clients branch on those codes, so this test pins the
+ * pairings rather than trusting them to stay aligned by convention.
+ *
+ * <p>
+ * The other property worth pinning is that the correlation id appears on both
+ * the body and the {@code X-Correlation-Id} response header, and that an inbound
+ * id is preserved so a trace started upstream survives the error. A blank
+ * inbound header counts as absent.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("pos-order exception advices — ApiError mapping")
+class OrderExceptionHandlerTest {
+
+    private static final String CORRELATION_HEADER = "X-Correlation-Id";
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+    private static final UUID ID = UUID.fromString("00000000-0000-0000-0000-0000000000d1");
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @Mock
+    private HttpServletRequest request;
+
+    private SalesOrderExceptionHandler salesOrder;
+    private ReturnOrderExceptionHandler returns;
+    private RegisterSessionExceptionHandler sessions;
+    private PriceOverrideExceptionHandler overrides;
+
+    @BeforeEach
+    void setUp() {
+        salesOrder = new SalesOrderExceptionHandler(clock);
+        returns = new ReturnOrderExceptionHandler(clock);
+        sessions = new RegisterSessionExceptionHandler(clock);
+        overrides = new PriceOverrideExceptionHandler(clock);
+        when(request.getHeader(CORRELATION_HEADER)).thenReturn("trace-1");
+    }
+
+    private static void assertEnvelope(ResponseEntity<ApiError> result, HttpStatus status, String code) {
+        assertThat(result.getStatusCode()).isEqualTo(status);
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().code()).isEqualTo(code);
+        assertThat(result.getBody().status()).isEqualTo(status.value());
+        assertThat(result.getBody().timestamp()).isEqualTo(NOW.toString());
+        assertThat(result.getBody().correlationId()).isEqualTo("trace-1");
+        // The header must carry the same id, since that is what a caller reports back.
+        assertThat(result.getHeaders().getFirst(CORRELATION_HEADER)).isEqualTo("trace-1");
+    }
+
+    @Nested
+    @DisplayName("SalesOrderExceptionHandler")
+    class SalesOrders {
+
+        @Test
+        @DisplayName("maps a missing order to 404 ORDER_NOT_FOUND")
+        void notFound() {
+            assertEnvelope(
+                    salesOrder.handleSalesOrderNotFound(new SalesOrderNotFoundException(ID), request),
+                    HttpStatus.NOT_FOUND,
+                    "ORDER_NOT_FOUND");
+        }
+
+        @Test
+        @DisplayName("maps an unreachable tax service to 503, not a client error")
+        void taxUnavailable() {
+            // 503 tells the caller to retry; a 4xx would suggest the request itself was wrong.
+            assertEnvelope(
+                    salesOrder.handleTaxUnavailable(new TaxUnavailableException("tax down"), request),
+                    HttpStatus.SERVICE_UNAVAILABLE,
+                    "ORDER_TAX_UNAVAILABLE");
+        }
+
+        @Test
+        @DisplayName("maps an unreachable invoicing service to 503")
+        void invoicingUnavailable() {
+            assertEnvelope(
+                    salesOrder.handleInvoicingUnavailable(new InvoicingUnavailableException("invoicing down"), request),
+                    HttpStatus.SERVICE_UNAVAILABLE,
+                    "ORDER_INVOICING_UNAVAILABLE");
+        }
+
+        @Test
+        @DisplayName("maps a blocked void to 409 ORDER_VOID_BLOCKED")
+        void voidBlocked() {
+            assertEnvelope(
+                    salesOrder.handleVoidBlocked(new OrderVoidBlockedException(ID), request),
+                    HttpStatus.CONFLICT,
+                    "ORDER_VOID_BLOCKED");
+        }
+
+        @Test
+        @DisplayName("maps an invalid customer to 422 and an invalid SKU to 400")
+        void customerAndSku() {
+            assertEnvelope(
+                    salesOrder.handleInvalidCustomer(new InvalidCustomerException("unknown party"), request),
+                    HttpStatus.UNPROCESSABLE_CONTENT,
+                    "ORDER_INVALID_CUSTOMER");
+            // A bad SKU is a malformed request; an unknown customer is a well-formed request the
+            // domain refuses. The two statuses reflect that difference.
+            assertEnvelope(
+                    salesOrder.handleInvalidSku(new InvalidSkuException("BAD", "no such sku"), request),
+                    HttpStatus.BAD_REQUEST,
+                    "ORDER_INVALID_SKU");
+        }
+
+        @Test
+        @DisplayName("maps a rejected state transition to 422 UNPROCESSABLE_REQUEST")
+        void illegalState() {
+            assertEnvelope(
+                    salesOrder.handleUnprocessableRequest(new IllegalStateException("already closed"), request),
+                    HttpStatus.UNPROCESSABLE_CONTENT,
+                    "UNPROCESSABLE_REQUEST");
+        }
+
+        @Test
+        @DisplayName("mints a correlation id when the caller sent none")
+        void mintsCorrelationIdWhenAbsent() {
+            when(request.getHeader(CORRELATION_HEADER)).thenReturn(null);
+
+            ResponseEntity<ApiError> result =
+                    salesOrder.handleIllegalArgument(new IllegalArgumentException("bad qty"), request);
+
+            assertThat(result.getBody()).isNotNull();
+            assertThat(result.getBody().correlationId()).isNotBlank();
+            assertThat(result.getHeaders().getFirst(CORRELATION_HEADER))
+                    .isEqualTo(result.getBody().correlationId());
+        }
+
+        @Test
+        @DisplayName("treats a blank inbound correlation id as absent rather than echoing it")
+        void blankCorrelationIdIsReplaced() {
+            when(request.getHeader(CORRELATION_HEADER)).thenReturn("   ");
+
+            ResponseEntity<ApiError> result =
+                    salesOrder.handleAccessDenied(new AccessDeniedException("denied"), request);
+
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+            assertThat(result.getBody()).isNotNull();
+            assertThat(result.getBody().code()).isEqualTo("ORDER_FORBIDDEN");
+            assertThat(result.getBody().correlationId()).isNotBlank().isNotEqualTo("   ");
+        }
+    }
+
+    @Nested
+    @DisplayName("ReturnOrderExceptionHandler")
+    class Returns {
+
+        @Test
+        @DisplayName("maps either missing document to 404 RETURN_NOT_FOUND")
+        void notFound() {
+            assertEnvelope(
+                    returns.handleNotFound(new ReturnOrderNotFoundException(ID), request),
+                    HttpStatus.NOT_FOUND,
+                    "RETURN_NOT_FOUND");
+            // The original order missing is equally a "return not found" to this endpoint family.
+            assertEnvelope(
+                    returns.handleNotFound(new SalesOrderNotFoundException(ID), request),
+                    HttpStatus.NOT_FOUND,
+                    "RETURN_NOT_FOUND");
+        }
+
+        @Test
+        @DisplayName("reports each over-cap line with its returnable quantity (spec R5.2)")
+        void overCapCarriesPerLineCaps() {
+            UUID secondLine = UUID.randomUUID();
+
+            ResponseEntity<ApiError> result = returns.handleOverCap(
+                    new OverCapReturnException(List.of(
+                            new OverCapReturnException.LineCap(ID, 5, 2),
+                            new OverCapReturnException.LineCap(secondLine, 3, 0))),
+                    request);
+
+            assertEnvelope(result, HttpStatus.UNPROCESSABLE_CONTENT, "RETURN_OVER_CAP");
+            // Without the per-line caps the client cannot tell the operator what to change.
+            assertThat(result.getBody().fieldErrors())
+                    .extracting(ApiError.FieldError::field, ApiError.FieldError::message)
+                    .containsExactly(
+                            tuple(ID.toString(), "requested 5 but returnableQty is 2"),
+                            tuple(secondLine.toString(), "requested 3 but returnableQty is 0"));
+        }
+
+        @Test
+        @DisplayName("maps a warranty-routed line to 422 RETURN_WARRANTY_ROUTING")
+        void warrantyRouting() {
+            assertEnvelope(
+                    returns.handleWarrantyRouting(new WarrantyReturnRoutingException(ID), request),
+                    HttpStatus.UNPROCESSABLE_CONTENT,
+                    "RETURN_WARRANTY_ROUTING");
+        }
+
+        @Test
+        @DisplayName("maps a rejected state transition to 409, unlike the sales-order advice's 422")
+        void illegalStateIsAConflictHere() {
+            assertEnvelope(
+                    returns.handleConflict(new IllegalStateException("already returned"), request),
+                    HttpStatus.CONFLICT,
+                    "RETURN_INVALID_STATE");
+        }
+
+        @Test
+        @DisplayName("maps an invalid argument to 422 RETURN_INVALID_ARGUMENT")
+        void invalidArgument() {
+            assertEnvelope(
+                    returns.handleInvalidArgument(new IllegalArgumentException("qty must be positive"), request),
+                    HttpStatus.UNPROCESSABLE_CONTENT,
+                    "RETURN_INVALID_ARGUMENT");
+        }
+    }
+
+    @Nested
+    @DisplayName("RegisterSessionExceptionHandler")
+    class Sessions {
+
+        @Test
+        @DisplayName("maps a missing session to 404 and an open-session conflict to 409")
+        void notFoundAndConflict() {
+            assertEnvelope(
+                    sessions.handleNotFound(new RegisterSessionNotFoundException(ID), request),
+                    HttpStatus.NOT_FOUND,
+                    "REGISTER_SESSION_NOT_FOUND");
+            assertEnvelope(
+                    sessions.handleConflict(new RegisterSessionConflictException("terminal already open"), request),
+                    HttpStatus.CONFLICT,
+                    "REGISTER_SESSION_CONFLICT");
+        }
+
+        @Test
+        @DisplayName("maps a blocked close to 409 SESSION_CLOSE_BLOCKED")
+        void closeBlocked() {
+            assertEnvelope(
+                    sessions.handleCloseBlocked(new SessionCloseBlockedException(ID), request),
+                    HttpStatus.CONFLICT,
+                    "SESSION_CLOSE_BLOCKED");
+        }
+
+        @Test
+        @DisplayName("maps an invalid argument to 422 and a permission failure to 403")
+        void invalidArgumentAndAccessDenied() {
+            assertEnvelope(
+                    sessions.handleIllegalArgument(new IllegalArgumentException("negative float"), request),
+                    HttpStatus.UNPROCESSABLE_CONTENT,
+                    "REGISTER_SESSION_INVALID_ARGUMENT");
+            assertEnvelope(
+                    sessions.handleAccessDenied(new AccessDeniedException("denied"), request),
+                    HttpStatus.FORBIDDEN,
+                    "ORDER_FORBIDDEN");
+        }
+    }
+
+    @Nested
+    @DisplayName("PriceOverrideExceptionHandler")
+    class Overrides {
+
+        @Test
+        @DisplayName("maps a missing override to 404 and an invalid one to 422")
+        void notFoundAndInvalid() {
+            assertEnvelope(
+                    overrides.handleOverrideNotFound(new PriceOverrideNotFoundException(ID), request),
+                    HttpStatus.NOT_FOUND,
+                    "ORDER_PRICE_OVERRIDE_NOT_FOUND");
+            assertEnvelope(
+                    overrides.handleInvalidOverride(new InvalidPriceOverrideException("below floor"), request),
+                    HttpStatus.UNPROCESSABLE_CONTENT,
+                    "ORDER_PRICE_OVERRIDE_INVALID");
+        }
+
+        @Test
+        @DisplayName("maps a reused idempotency key with different content to 409")
+        void idempotencyConflict() {
+            assertEnvelope(
+                    overrides.handleIdempotencyConflict(
+                            new PriceOverrideIdempotencyConflictException("key reused"), request),
+                    HttpStatus.CONFLICT,
+                    "ORDER_PRICE_OVERRIDE_IDEMPOTENCY_CONFLICT");
+        }
+
+        @Test
+        @DisplayName("maps an invalid argument to 400 here, unlike the 422 the other advices use")
+        void illegalArgumentIsABadRequestHere() {
+            assertEnvelope(
+                    overrides.handleIllegalArgument(new IllegalArgumentException("bad price"), request),
+                    HttpStatus.BAD_REQUEST,
+                    "ORDER_PRICE_OVERRIDE_BAD_REQUEST");
+        }
+
+        @Test
+        @DisplayName("reports every rejected field, defaulting a null message rather than emitting null")
+        void bodyValidationListsFieldErrors() throws NoSuchMethodException {
+            BindingResult binding = new BeanPropertyBindingResult(new Object(), "request");
+            binding.addError(new FieldError("request", "overridePrice", "must be positive"));
+            binding.addError(new FieldError("request", "reasonCode", null));
+            MethodArgumentNotValidException ex = new MethodArgumentNotValidException(
+                    new org.springframework.core.MethodParameter(
+                            Overrides.class.getDeclaredMethod("bodyValidationListsFieldErrors"), -1),
+                    binding);
+
+            ResponseEntity<ApiError> result = overrides.handleValidation(ex, request);
+
+            assertEnvelope(result, HttpStatus.BAD_REQUEST, "VALIDATION_FAILED");
+            assertThat(result.getBody().fieldErrors())
+                    .extracting(ApiError.FieldError::field, ApiError.FieldError::message)
+                    .containsExactly(tuple("overridePrice", "must be positive"), tuple("reasonCode", "invalid"));
+        }
+
+        @Test
+        @DisplayName("maps a permission failure to 403 ORDER_FORBIDDEN")
+        void accessDenied() {
+            assertEnvelope(
+                    overrides.handleAccessDenied(new AccessDeniedException("denied"), request),
+                    HttpStatus.FORBIDDEN,
+                    "ORDER_FORBIDDEN");
+        }
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/service/CatalogPricePricingAdapterTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/CatalogPricePricingAdapterTest.java
@@ -1,0 +1,211 @@
+package com.positivity.order.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withResourceNotFound;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.positivity.order.internal.client.PricingQuote;
+import com.positivity.order.internal.entity.ExtProduct;
+import com.positivity.order.internal.repository.ExtProductRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link CatalogPricePricingAdapter} (parity story B1).
+ *
+ * <p>
+ * The three {@link PricingQuote.Status} values mean different things to the
+ * clerk, and conflating them is the failure this test guards against.
+ * UNKNOWN_SKU says the catalog has no active product — a clear signal to fix the
+ * SKU. UNAVAILABLE says the module cannot answer right now, either because the
+ * product replica is cold or pos-price is unreachable, and the clerk falls back
+ * to a permissioned manual price. Neither may silently become a price.
+ *
+ * <p>
+ * A 404 from pos-price is deliberately mapped to UNKNOWN_SKU rather than
+ * UNAVAILABLE: the product exists but is not priced, and a manual-price fallback
+ * would hide a catalog gap behind a made-up number.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("CatalogPricePricingAdapter — SKU resolution and pos-price quoting")
+class CatalogPricePricingAdapterTest {
+
+    private static final UUID PRODUCT_ID = UUID.fromString("00000000-0000-0000-0000-000000000061");
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000062");
+    private static final UUID TIER_ID = UUID.fromString("00000000-0000-0000-0000-000000000063");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+
+    @Mock
+    private ExtProductRepository extProductRepository;
+
+    private MockRestServiceServer server;
+
+    private CatalogPricePricingAdapter adapter(boolean eventFeedEnabled) {
+        RestClient.Builder builder = RestClient.builder().baseUrl("http://price");
+        server = MockRestServiceServer.bindTo(builder).build();
+        return new CatalogPricePricingAdapter(
+                extProductRepository, builder.build(), Clock.fixed(NOW, ZoneOffset.UTC), eventFeedEnabled, TIER_ID);
+    }
+
+    private static ExtProduct product(String name) {
+        ExtProduct product = new ExtProduct();
+        product.setProductId(PRODUCT_ID);
+        product.setSku("BRK-100");
+        product.setName(name);
+        product.setActive(true);
+        product.setTrackingLevel("SERIAL");
+        return product;
+    }
+
+    private void replicaHas(ExtProduct product) {
+        when(extProductRepository.count()).thenReturn(25L);
+        when(extProductRepository.findFirstBySkuIgnoreCaseAndActiveTrue("BRK-100"))
+                .thenReturn(Optional.ofNullable(product));
+    }
+
+    @Test
+    @DisplayName("quotes a known SKU and carries the rule breakdown for line-level audit")
+    void quotesKnownSku() {
+        CatalogPricePricingAdapter adapter = adapter(true);
+        replicaHas(product("Brake pad"));
+        server.expect(requestTo("http://price/v1/price/quotes"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("X-Authorities", "price:quote"))
+                .andExpect(jsonPath("$.productId").value(PRODUCT_ID.toString()))
+                .andExpect(jsonPath("$.quantity").value(2))
+                .andExpect(jsonPath("$.locationId").value(LOCATION_ID.toString()))
+                .andExpect(jsonPath("$.customerTierId").value(TIER_ID.toString()))
+                .andExpect(jsonPath("$.effectiveTimestamp").value(NOW.toString()))
+                .andRespond(withSuccess("""
+                        {"unitPrice":{"amount":45.50,"currency":"USD"},
+                         "pricingBreakdown":{"rules":["BASE"]}}""", MediaType.APPLICATION_JSON));
+
+        PricingQuote quote = adapter.quoteForSku("BRK-100", 2, LOCATION_ID, UUID.randomUUID());
+
+        assertThat(quote.status()).isEqualTo(PricingQuote.Status.PRICED);
+        assertThat(quote.unitPrice()).isEqualByComparingTo("45.50");
+        assertThat(quote.productId()).isEqualTo(PRODUCT_ID);
+        assertThat(quote.description()).isEqualTo("Brake pad");
+        assertThat(quote.trackingLevel()).isEqualTo("SERIAL");
+        // pos-price exposes no snapshot id, so the breakdown JSON is the audit artifact.
+        assertThat(quote.breakdownJson()).contains("BASE");
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("substitutes a nil location when the cart has none, since the quote API requires one")
+    void nilLocationIsSubstituted() {
+        CatalogPricePricingAdapter adapter = adapter(true);
+        replicaHas(product("Brake pad"));
+        server.expect(requestTo("http://price/v1/price/quotes"))
+                .andExpect(jsonPath("$.locationId").value(new UUID(0L, 0L).toString()))
+                .andRespond(withSuccess("{\"unitPrice\":{\"amount\":10.00}}", MediaType.APPLICATION_JSON));
+
+        assertThat(adapter.quoteForSku("BRK-100", 1, null, null).status()).isEqualTo(PricingQuote.Status.PRICED);
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("falls back to the SKU when the replica row carries no product name")
+    void namelessProductFallsBackToSku() {
+        CatalogPricePricingAdapter adapter = adapter(true);
+        replicaHas(product(null));
+        server.expect(requestTo("http://price/v1/price/quotes"))
+                .andRespond(withSuccess("{\"unitPrice\":{\"amount\":10.00}}", MediaType.APPLICATION_JSON));
+
+        PricingQuote quote = adapter.quoteForSku("BRK-100", 1, LOCATION_ID, null);
+
+        // The description reaches the receipt, so it must never be blank.
+        assertThat(quote.description()).isEqualTo("BRK-100");
+        assertThat(quote.breakdownJson()).isNull();
+    }
+
+    @Test
+    @DisplayName("reports UNAVAILABLE while the event feed is off, without calling pos-price")
+    void coldReplicaByFlag() {
+        CatalogPricePricingAdapter adapter = adapter(false);
+        when(extProductRepository.count()).thenReturn(25L);
+
+        assertThat(adapter.quoteForSku("BRK-100", 1, LOCATION_ID, null).status())
+                .isEqualTo(PricingQuote.Status.UNAVAILABLE);
+
+        // Cold means "cannot distinguish unknown from unsynced", so no lookup and no quote call.
+        verify(extProductRepository, never()).findFirstBySkuIgnoreCaseAndActiveTrue(any());
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("reports UNAVAILABLE on an empty replica rather than calling the SKU unknown")
+    void coldReplicaByEmptyTable() {
+        CatalogPricePricingAdapter adapter = adapter(true);
+        when(extProductRepository.count()).thenReturn(0L);
+
+        assertThat(adapter.quoteForSku("BRK-100", 1, LOCATION_ID, null).status())
+                .isEqualTo(PricingQuote.Status.UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("reports UNKNOWN_SKU when the replica has no active product for it")
+    void unknownSku() {
+        CatalogPricePricingAdapter adapter = adapter(true);
+        replicaHas(null);
+
+        assertThat(adapter.quoteForSku("BRK-100", 1, LOCATION_ID, null).status())
+                .isEqualTo(PricingQuote.Status.UNKNOWN_SKU);
+    }
+
+    @Test
+    @DisplayName("maps a 404 from pos-price to UNKNOWN_SKU so a catalog gap is visible")
+    void notPricedIsUnknownSku() {
+        CatalogPricePricingAdapter adapter = adapter(true);
+        replicaHas(product("Brake pad"));
+        server.expect(requestTo("http://price/v1/price/quotes")).andRespond(withResourceNotFound());
+
+        // Not UNAVAILABLE: a manual-price fallback here would hide the gap behind a made-up number.
+        assertThat(adapter.quoteForSku("BRK-100", 1, LOCATION_ID, null).status())
+                .isEqualTo(PricingQuote.Status.UNKNOWN_SKU);
+    }
+
+    @Test
+    @DisplayName("reports UNAVAILABLE when pos-price errors or answers without a unit price")
+    void unpricedOrUnreachableIsUnavailable() {
+        CatalogPricePricingAdapter adapter = adapter(true);
+        replicaHas(product("Brake pad"));
+        server.expect(requestTo("http://price/v1/price/quotes")).andRespond(withServerError());
+
+        assertThat(adapter.quoteForSku("BRK-100", 1, LOCATION_ID, null).status())
+                .isEqualTo(PricingQuote.Status.UNAVAILABLE);
+
+        CatalogPricePricingAdapter second = adapter(true);
+        replicaHas(product("Brake pad"));
+        server.expect(requestTo("http://price/v1/price/quotes"))
+                .andRespond(withSuccess("{\"currency\":\"USD\"}", MediaType.APPLICATION_JSON));
+
+        assertThat(second.quoteForSku("BRK-100", 1, LOCATION_ID, null).status())
+                .isEqualTo(PricingQuote.Status.UNAVAILABLE);
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/service/CustomerEventsListenerTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/CustomerEventsListenerTest.java
@@ -1,0 +1,191 @@
+package com.positivity.order.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.customer.BillingRulesUpdatedV1;
+import com.positivity.domainevents.customer.CustomerPartyDeletedV1;
+import com.positivity.domainevents.customer.CustomerPartyUpdatedV1;
+import com.positivity.order.internal.entity.ExtBillingRules;
+import com.positivity.order.internal.entity.ExtCustomer;
+import com.positivity.order.internal.repository.ExtBillingRulesRepository;
+import com.positivity.order.internal.repository.ExtCustomerRepository;
+import com.positivity.order.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link CustomerEventsListener} (parity story I2, story C4 /
+ * spec R4.5 for billing rules).
+ *
+ * <p>
+ * The billing-rules replica gates the on-account tender at checkout, and there
+ * the difference between "not stated" and "false" is real money: a null
+ * {@code creditHold} means the CRM has said nothing, while {@code false} means it
+ * has explicitly cleared the customer. The tests pin that those stay distinct
+ * rather than collapsing to a primitive default.
+ *
+ * <p>
+ * The delivery contract shared with the other replica listeners is covered once
+ * in {@link ReplicaListenerContractTest}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("CustomerEventsListener — customer and billing-rules replicas")
+class CustomerEventsListenerTest {
+
+    private static final UUID PARTY_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c1");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private ExtCustomerRepository extCustomerRepository;
+
+    @Mock
+    private ExtBillingRulesRepository extBillingRulesRepository;
+
+    private CustomerEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new CustomerEventsListener(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                new ObjectMapper(),
+                processedEventRepository,
+                extCustomerRepository,
+                extBillingRulesRepository);
+        when(processedEventRepository.existsById(any())).thenReturn(false);
+        when(extCustomerRepository.findById(any())).thenReturn(Optional.empty());
+        when(extBillingRulesRepository.findById(any())).thenReturn(Optional.empty());
+    }
+
+    private static String updateEnvelope(long version) {
+        return """
+                {"eventId":"evt-1","eventType":"%s","aggregateVersion":%d,
+                 "payload":{"partyId":"%s","status":"ACTIVE","displayName":"Fleet Co",
+                   "partyType":"ORGANIZATION","requirementsMet":true}}
+                """.formatted(CustomerPartyUpdatedV1.EVENT_TYPE, version, PARTY_ID);
+    }
+
+    private static String billingRulesEnvelope(String creditLimit, String creditHold, String poRequired) {
+        return """
+                {"eventId":"evt-2","eventType":"%s","aggregateVersion":2,
+                 "payload":{"partyId":"%s","paymentTerms":"NET30","creditLimit":%s,
+                   "creditHold":%s,"poRequired":%s}}
+                """.formatted(BillingRulesUpdatedV1.EVENT_TYPE, PARTY_ID, creditLimit, creditHold, poRequired);
+    }
+
+    @Test
+    @DisplayName("replicates a customer party")
+    void replicatesCustomer() {
+        listener.onCustomerEvent(updateEnvelope(3));
+
+        ArgumentCaptor<ExtCustomer> captor = ArgumentCaptor.forClass(ExtCustomer.class);
+        verify(extCustomerRepository).save(captor.capture());
+        ExtCustomer saved = captor.getValue();
+        assertThat(saved.getPartyId()).isEqualTo(PARTY_ID);
+        assertThat(saved.getStatus()).isEqualTo("ACTIVE");
+        assertThat(saved.getDisplayName()).isEqualTo("Fleet Co");
+        assertThat(saved.getPartyType()).isEqualTo("ORGANIZATION");
+        assertThat(saved.isRequirementsMet()).isTrue();
+        assertThat(saved.getAggregateVersion()).isEqualTo(3);
+        assertThat(saved.getSyncedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("defaults a missing status to UNKNOWN rather than storing null")
+    void missingStatusBecomesUnknown() {
+        listener.onCustomerEvent("""
+                {"eventId":"evt-1","eventType":"%s","aggregateVersion":1,"payload":{"partyId":"%s"}}""".formatted(CustomerPartyUpdatedV1.EVENT_TYPE, PARTY_ID));
+
+        ArgumentCaptor<ExtCustomer> captor = ArgumentCaptor.forClass(ExtCustomer.class);
+        verify(extCustomerRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo("UNKNOWN");
+        assertThat(captor.getValue().isRequirementsMet()).isFalse();
+    }
+
+    @Test
+    @DisplayName("ignores an update no newer than the replica it already holds")
+    void staleUpdateIsIgnored() {
+        ExtCustomer existing = new ExtCustomer();
+        existing.setPartyId(PARTY_ID);
+        existing.setAggregateVersion(7);
+        when(extCustomerRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
+
+        listener.onCustomerEvent(updateEnvelope(7));
+
+        verify(extCustomerRepository, never()).save(any());
+        verify(processedEventRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("removes the replica on a party deletion")
+    void deleteRemovesReplica() {
+        listener.onCustomerEvent("""
+                {"eventId":"evt-3","eventType":"%s","payload":{"partyId":"%s"}}""".formatted(CustomerPartyDeletedV1.EVENT_TYPE, PARTY_ID));
+
+        verify(extCustomerRepository).deleteById(PARTY_ID);
+        verify(extCustomerRepository, never()).save(any());
+        verify(processedEventRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("replicates AR billing terms that gate the on-account tender")
+    void replicatesBillingRules() {
+        listener.onCustomerEvent(billingRulesEnvelope("5000.00", "false", "true"));
+
+        ArgumentCaptor<ExtBillingRules> captor = ArgumentCaptor.forClass(ExtBillingRules.class);
+        verify(extBillingRulesRepository).save(captor.capture());
+        ExtBillingRules saved = captor.getValue();
+        assertThat(saved.getPartyId()).isEqualTo(PARTY_ID);
+        assertThat(saved.getPaymentTerms()).isEqualTo("NET30");
+        assertThat(saved.getCreditLimit()).isEqualByComparingTo("5000.00");
+        assertThat(saved.getCreditHold()).isFalse();
+        assertThat(saved.getPoRequired()).isTrue();
+    }
+
+    @Test
+    @DisplayName("keeps an unstated billing flag null rather than collapsing it to false")
+    void unstatedBillingFlagsStayNull() {
+        listener.onCustomerEvent(billingRulesEnvelope("null", "null", "null"));
+
+        ArgumentCaptor<ExtBillingRules> captor = ArgumentCaptor.forClass(ExtBillingRules.class);
+        verify(extBillingRulesRepository).save(captor.capture());
+        // Null means "the CRM has said nothing", which the checkout gate must not read as an
+        // explicit clearance.
+        assertThat(captor.getValue().getCreditLimit()).isNull();
+        assertThat(captor.getValue().getCreditHold()).isNull();
+        assertThat(captor.getValue().getPoRequired()).isNull();
+    }
+
+    @Test
+    @DisplayName("ignores billing rules no newer than the replica it already holds")
+    void staleBillingRulesAreIgnored() {
+        ExtBillingRules existing = new ExtBillingRules();
+        existing.setPartyId(PARTY_ID);
+        existing.setAggregateVersion(4);
+        when(extBillingRulesRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
+
+        listener.onCustomerEvent(billingRulesEnvelope("100", "false", "false"));
+
+        verify(extBillingRulesRepository, never()).save(any());
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/service/OrderNumberServiceTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/OrderNumberServiceTest.java
@@ -1,0 +1,125 @@
+package com.positivity.order.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.order.internal.entity.OrderNumberSequence;
+import com.positivity.order.internal.repository.OrderNumberSequenceRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/**
+ * Unit tests for {@link OrderNumberService} (plan story A2).
+ *
+ * <p>
+ * The order number is what a customer reads back over the phone, so the format
+ * is a contract: {@code SO-{locationCode}-{yyMM}-{seq}}, zero-padded, with the
+ * period taken from the injected clock so a sequence rolls over on the calendar
+ * month rather than on service restart.
+ *
+ * <p>
+ * The interesting path is the insert race. Two carts created in the same new
+ * month for the same location both find no sequence row; the loser of the insert
+ * takes the lock on the winner's row instead of failing the cart. Gapless
+ * numbering is explicitly not guaranteed (recorded decision), so the tests pin
+ * allocation and recovery, not contiguity.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("OrderNumberService — per-location monthly sequence")
+class OrderNumberServiceTest {
+
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-0000abcdef12");
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-11T09:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private OrderNumberSequenceRepository sequenceRepository;
+
+    private OrderNumberService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new OrderNumberService(sequenceRepository, CLOCK);
+    }
+
+    private static OrderNumberSequence sequence(long nextValue) {
+        return OrderNumberSequence.builder()
+                .key(new OrderNumberSequence.Key(LOCATION_ID, "2608"))
+                .nextValue(nextValue)
+                .build();
+    }
+
+    @Test
+    @DisplayName("formats the number from the location tail, the clock's month, and the sequence")
+    void formatsNumber() {
+        when(sequenceRepository.findForUpdate(LOCATION_ID, "2608")).thenReturn(Optional.of(sequence(42L)));
+
+        // Location code is the uppercased tail of the location UUID; period is yyMM from the clock.
+        assertThat(service.nextNumber(LOCATION_ID)).isEqualTo("SO-ABCDEF12-2608-000042");
+    }
+
+    @Test
+    @DisplayName("advances the stored sequence so the next cart gets a different number")
+    void advancesTheSequence() {
+        OrderNumberSequence existing = sequence(7L);
+        when(sequenceRepository.findForUpdate(LOCATION_ID, "2608")).thenReturn(Optional.of(existing));
+
+        service.nextNumber(LOCATION_ID);
+
+        assertThat(existing.getNextValue()).isEqualTo(8L);
+        verify(sequenceRepository).save(existing);
+    }
+
+    @Test
+    @DisplayName("starts a new location-month at one")
+    void firstOrderOfTheMonthStartsAtOne() {
+        when(sequenceRepository.findForUpdate(LOCATION_ID, "2608")).thenReturn(Optional.empty());
+        when(sequenceRepository.saveAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThat(service.nextNumber(LOCATION_ID)).isEqualTo("SO-ABCDEF12-2608-000001");
+
+        ArgumentCaptor<OrderNumberSequence> captor = ArgumentCaptor.forClass(OrderNumberSequence.class);
+        verify(sequenceRepository).saveAndFlush(captor.capture());
+        assertThat(captor.getValue().getKey().getPeriod()).isEqualTo("2608");
+        assertThat(captor.getValue().getKey().getLocationId()).isEqualTo(LOCATION_ID);
+    }
+
+    @Test
+    @DisplayName("takes the winner's row when a concurrent cart inserted the sequence first")
+    void losesTheInsertRaceGracefully() {
+        when(sequenceRepository.findForUpdate(LOCATION_ID, "2608"))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(sequence(3L)));
+        when(sequenceRepository.saveAndFlush(any())).thenThrow(new DataIntegrityViolationException("duplicate key"));
+
+        // Losing the race must cost a re-read, not the cart.
+        assertThat(service.nextNumber(LOCATION_ID)).isEqualTo("SO-ABCDEF12-2608-000003");
+    }
+
+    @Test
+    @DisplayName("fails loudly if the row is neither insertable nor readable")
+    void vanishedRowIsAnError() {
+        when(sequenceRepository.findForUpdate(LOCATION_ID, "2608")).thenReturn(Optional.empty());
+        when(sequenceRepository.saveAndFlush(any())).thenThrow(new DataIntegrityViolationException("duplicate key"));
+
+        assertThatThrownBy(() -> service.nextNumber(LOCATION_ID))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("vanished");
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/service/OrderTaxServiceTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/OrderTaxServiceTest.java
@@ -1,0 +1,264 @@
+package com.positivity.order.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.order.internal.client.TaxPort;
+import com.positivity.order.internal.entity.ExtLocation;
+import com.positivity.order.internal.entity.SalesOrder;
+import com.positivity.order.internal.entity.SalesOrderLine;
+import com.positivity.order.internal.exception.TaxUnavailableException;
+import com.positivity.order.internal.repository.ExtLocationRepository;
+import com.positivity.tax.common.dto.TaxCalculationRequest;
+import com.positivity.tax.common.dto.TaxCalculationResponse;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Unit tests for {@link OrderTaxService} (parity story B3, spec R3.4).
+ *
+ * <p>
+ * The governing rule is that a quote or checkout must never complete on absent
+ * or stale tax, so every way the calculation can fail to produce a real number
+ * — no location on the order, no replica row for it, a replica row missing the
+ * postal code or country, or pos-tax being unreachable — raises
+ * {@link TaxUnavailableException} rather than defaulting to zero. A zero default
+ * would be indistinguishable from a genuinely untaxed order and would undercharge
+ * the customer.
+ *
+ * <p>
+ * The other detail worth pinning is the ordering: line subtotals are recomputed
+ * <em>before</em> the tax call, because tax is charged on the discounted base,
+ * and again afterwards to roll the per-line tax into the order total.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("OrderTaxService — jurisdiction resolution and batch recompute")
+class OrderTaxServiceTest {
+
+    private static final UUID ORDER_ID = UUID.fromString("00000000-0000-0000-0000-000000000091");
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000092");
+    private static final UUID LINE_ID = UUID.fromString("00000000-0000-0000-0000-000000000093");
+    private static final UUID OTHER_LINE_ID = UUID.fromString("00000000-0000-0000-0000-000000000094");
+
+    @Mock
+    private TaxPort taxPort;
+
+    @Mock
+    private ExtLocationRepository extLocationRepository;
+
+    @Mock
+    private OrderTotalsCalculator totalsCalculator;
+
+    private OrderTaxService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new OrderTaxService(taxPort, extLocationRepository, totalsCalculator);
+    }
+
+    private static ExtLocation location(String postalCode, String country) {
+        ExtLocation location = new ExtLocation();
+        location.setLocationId(LOCATION_ID);
+        location.setAddressLine1("1 Main St");
+        location.setCity("Austin");
+        location.setRegion("TX");
+        location.setPostalCode(postalCode);
+        location.setCountry(country);
+        return location;
+    }
+
+    private static SalesOrderLine line(UUID lineId) {
+        return SalesOrderLine.builder()
+                .orderLineId(lineId)
+                .itemSku("BRK-100")
+                .itemDescription("Brake pad")
+                .quantity(2)
+                .unitPrice(new BigDecimal("45.50"))
+                .lineSubtotal(new BigDecimal("90.00"))
+                .taxAmount(BigDecimal.ZERO)
+                .build();
+    }
+
+    private static SalesOrder order(UUID locationId, SalesOrderLine... lines) {
+        return SalesOrder.builder()
+                .orderId(ORDER_ID)
+                .locationId(locationId)
+                .customerId(UUID.randomUUID())
+                .taxStale(true)
+                .lines(new ArrayList<>(Arrays.asList(lines)))
+                .build();
+    }
+
+    private static TaxCalculationResponse.LineItemTax lineTax(UUID lineId, String amount) {
+        TaxCalculationResponse.LineItemTax tax = new TaxCalculationResponse.LineItemTax();
+        tax.setLineItemId(lineId.toString());
+        tax.setTaxAmount(amount == null ? null : new BigDecimal(amount));
+        return tax;
+    }
+
+    @Test
+    @DisplayName("applies each line's tax and clears the stale flag")
+    void appliesPerLineTax() {
+        SalesOrderLine first = line(LINE_ID);
+        SalesOrderLine second = line(OTHER_LINE_ID);
+        SalesOrder order = order(LOCATION_ID, first, second);
+        when(extLocationRepository.findById(LOCATION_ID)).thenReturn(Optional.of(location("78701", "US")));
+        TaxCalculationResponse response = new TaxCalculationResponse();
+        response.setLineItemTaxes(List.of(lineTax(LINE_ID, "7.42"), lineTax(OTHER_LINE_ID, "3.10")));
+        when(taxPort.calculate(any())).thenReturn(Optional.of(response));
+
+        service.recomputeTax(order);
+
+        assertThat(first.getTaxAmount()).isEqualByComparingTo("7.42");
+        assertThat(second.getTaxAmount()).isEqualByComparingTo("3.10");
+        assertThat(order.isTaxStale()).isFalse();
+        // Once before the call so tax is charged on the current discounted base, once after so the
+        // per-line tax rolls into the order total.
+        verify(totalsCalculator, org.mockito.Mockito.times(2)).recalculate(order);
+    }
+
+    @Test
+    @DisplayName("sends the replica's address as the tax jurisdiction")
+    void sendsReplicaAddress() {
+        SalesOrder order = order(LOCATION_ID, line(LINE_ID));
+        when(extLocationRepository.findById(LOCATION_ID)).thenReturn(Optional.of(location("78701", "US")));
+        when(taxPort.calculate(any())).thenReturn(Optional.of(new TaxCalculationResponse()));
+
+        service.recomputeTax(order);
+
+        ArgumentCaptor<TaxCalculationRequest> captor = ArgumentCaptor.forClass(TaxCalculationRequest.class);
+        verify(taxPort).calculate(captor.capture());
+        TaxCalculationRequest request = captor.getValue();
+        assertThat(request.getCurrencyCode()).isEqualTo("USD");
+        assertThat(request.getDestinationAddress().getPostalCode()).isEqualTo("78701");
+        assertThat(request.getDestinationAddress().getCountryCode()).isEqualTo("US");
+        assertThat(request.getDestinationAddress().getRegionCode()).isEqualTo("TX");
+        assertThat(request.getLineItems()).singleElement().satisfies(item -> {
+            assertThat(item.getLineItemId()).isEqualTo(LINE_ID.toString());
+            assertThat(item.getQuantity()).isEqualByComparingTo("2");
+            assertThat(item.getSubtotal()).isEqualByComparingTo("90.00");
+        });
+    }
+
+    @Test
+    @DisplayName("zeroes tax on an empty order without calling pos-tax")
+    void emptyOrderSkipsTheTaxCall() {
+        SalesOrder order = order(LOCATION_ID);
+
+        service.recomputeTax(order);
+
+        assertThat(order.getTaxTotal()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(order.isTaxStale()).isFalse();
+        verifyNoInteractions(taxPort, extLocationRepository);
+        verify(totalsCalculator).recalculate(order);
+    }
+
+    @Test
+    @DisplayName("ignores a null line rather than failing the recompute")
+    void nullLineIsSkipped() {
+        SalesOrder order = order(LOCATION_ID, line(LINE_ID));
+        order.getLines().add(null);
+        when(extLocationRepository.findById(LOCATION_ID)).thenReturn(Optional.of(location("78701", "US")));
+        when(taxPort.calculate(any())).thenReturn(Optional.of(new TaxCalculationResponse()));
+
+        service.recomputeTax(order);
+
+        ArgumentCaptor<TaxCalculationRequest> captor = ArgumentCaptor.forClass(TaxCalculationRequest.class);
+        verify(taxPort).calculate(captor.capture());
+        assertThat(captor.getValue().getLineItems()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("leaves a line untouched when the response carries no amount for it")
+    void unmatchedOrAmountlessLineTaxIsIgnored() {
+        SalesOrderLine only = line(LINE_ID);
+        only.setTaxAmount(new BigDecimal("1.11"));
+        SalesOrder order = order(LOCATION_ID, only);
+        when(extLocationRepository.findById(LOCATION_ID)).thenReturn(Optional.of(location("78701", "US")));
+        TaxCalculationResponse response = new TaxCalculationResponse();
+        // One entry for a line that is not on this order, one for a line with no amount.
+        response.setLineItemTaxes(List.of(lineTax(OTHER_LINE_ID, "9.99"), lineTax(LINE_ID, null)));
+        when(taxPort.calculate(any())).thenReturn(Optional.of(response));
+
+        service.recomputeTax(order);
+
+        assertThat(only.getTaxAmount()).isEqualByComparingTo("1.11");
+        assertThat(order.isTaxStale()).isFalse();
+    }
+
+    @Test
+    @DisplayName("refuses to finalize when pos-tax returns nothing")
+    void unreachableTaxServiceIsFatal() {
+        SalesOrder order = order(LOCATION_ID, line(LINE_ID));
+        when(extLocationRepository.findById(LOCATION_ID)).thenReturn(Optional.of(location("78701", "US")));
+        when(taxPort.calculate(any())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.recomputeTax(order))
+                .isInstanceOf(TaxUnavailableException.class)
+                .hasMessageContaining(ORDER_ID.toString());
+
+        // Left stale on purpose: a zero default would read as a genuinely untaxed order.
+        assertThat(order.isTaxStale()).isTrue();
+    }
+
+    @Test
+    @DisplayName("refuses to finalize an order with no location")
+    void missingLocationIsFatal() {
+        SalesOrder order = order(null, line(LINE_ID));
+
+        assertThatThrownBy(() -> service.recomputeTax(order))
+                .isInstanceOf(TaxUnavailableException.class)
+                .hasMessageContaining("no location");
+
+        verify(taxPort, never()).calculate(any());
+    }
+
+    @Test
+    @DisplayName("refuses to finalize when the location replica has not arrived yet")
+    void missingReplicaRowIsFatal() {
+        SalesOrder order = order(LOCATION_ID, line(LINE_ID));
+        when(extLocationRepository.findById(LOCATION_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.recomputeTax(order))
+                .isInstanceOf(TaxUnavailableException.class)
+                .hasMessageContaining("No location replica row");
+
+        verify(taxPort, never()).calculate(any());
+    }
+
+    @Test
+    @DisplayName("refuses to finalize when the replica lacks the fields a jurisdiction needs")
+    void incompleteReplicaAddressIsFatal() {
+        SalesOrder order = order(LOCATION_ID, line(LINE_ID));
+        when(extLocationRepository.findById(LOCATION_ID)).thenReturn(Optional.of(location(null, "US")));
+
+        assertThatThrownBy(() -> service.recomputeTax(order))
+                .isInstanceOf(TaxUnavailableException.class)
+                .hasMessageContaining("postalCode/country");
+
+        when(extLocationRepository.findById(LOCATION_ID)).thenReturn(Optional.of(location("78701", null)));
+
+        assertThatThrownBy(() -> service.recomputeTax(order)).isInstanceOf(TaxUnavailableException.class);
+
+        verify(taxPort, never()).calculate(any());
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/service/ProductVehicleLocationReplicaTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/ProductVehicleLocationReplicaTest.java
@@ -1,0 +1,241 @@
+package com.positivity.order.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.catalog.ProductUpdatedV1;
+import com.positivity.domainevents.location.LocationDeletedV1;
+import com.positivity.domainevents.location.LocationUpdatedV1;
+import com.positivity.domainevents.vehicle.VehicleUpdatedV1;
+import com.positivity.order.internal.entity.ExtLocation;
+import com.positivity.order.internal.entity.ExtProduct;
+import com.positivity.order.internal.entity.ExtVehicle;
+import com.positivity.order.internal.repository.ExtLocationRepository;
+import com.positivity.order.internal.repository.ExtProductRepository;
+import com.positivity.order.internal.repository.ExtVehicleRepository;
+import com.positivity.order.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Field mapping for the three single-entity replica listeners — product (parity
+ * story B1), vehicle (story I2), and location (story B3).
+ *
+ * <p>
+ * Each exists so pricing, ownership validation, and tax-jurisdiction resolution
+ * can read local rows instead of making a synchronous REST call per order line.
+ * The delivery contract they share is covered once in
+ * {@link ReplicaListenerContractTest}; what is left here is the mapping itself
+ * and the aggregate-version guard that stops a late snapshot overwriting a newer
+ * one.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Product, vehicle, and location replica mapping")
+class ProductVehicleLocationReplicaTest {
+
+    private static final UUID PRODUCT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b1");
+    private static final UUID VEHICLE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b2");
+    private static final UUID ACCOUNT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b3");
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b4");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private ExtProductRepository extProductRepository;
+
+    @Mock
+    private ExtVehicleRepository extVehicleRepository;
+
+    @Mock
+    private ExtLocationRepository extLocationRepository;
+
+    @BeforeEach
+    void setUp() {
+        when(processedEventRepository.existsById(any())).thenReturn(false);
+        when(extProductRepository.findById(any())).thenReturn(Optional.empty());
+        when(extVehicleRepository.findById(any())).thenReturn(Optional.empty());
+        when(extLocationRepository.findById(any())).thenReturn(Optional.empty());
+    }
+
+    @Nested
+    @DisplayName("ProductEventsListener")
+    class Products {
+
+        private ProductEventsListener listener() {
+            return new ProductEventsListener(clock, objectMapper, processedEventRepository, extProductRepository);
+        }
+
+        private String envelope(long version, String active) {
+            return """
+                    {"eventId":"evt-1","eventType":"%s","aggregateVersion":%d,
+                     "payload":{"productId":"%s","sku":"BRK-100","name":"Brake pad",
+                       "active":%s,"trackingLevel":"SERIAL"}}
+                    """.formatted(ProductUpdatedV1.EVENT_TYPE, version, PRODUCT_ID, active);
+        }
+
+        @Test
+        @DisplayName("replicates the SKU, name, and tracking level pricing needs")
+        void replicatesProduct() {
+            listener().onCatalogEvent(envelope(2, "true"));
+
+            ArgumentCaptor<ExtProduct> captor = ArgumentCaptor.forClass(ExtProduct.class);
+            verify(extProductRepository).save(captor.capture());
+            ExtProduct saved = captor.getValue();
+            assertThat(saved.getProductId()).isEqualTo(PRODUCT_ID);
+            assertThat(saved.getSku()).isEqualTo("BRK-100");
+            assertThat(saved.getName()).isEqualTo("Brake pad");
+            assertThat(saved.isActive()).isTrue();
+            assertThat(saved.getTrackingLevel()).isEqualTo("SERIAL");
+            assertThat(saved.getAggregateVersion()).isEqualTo(2);
+            assertThat(saved.getSyncedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("carries a deactivation through rather than defaulting it to active")
+        void inactiveProductIsReplicatedAsInactive() {
+            listener().onCatalogEvent(envelope(2, "false"));
+
+            ArgumentCaptor<ExtProduct> captor = ArgumentCaptor.forClass(ExtProduct.class);
+            verify(extProductRepository).save(captor.capture());
+            assertThat(captor.getValue().isActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("ignores a snapshot no newer than the replica it already holds")
+        void staleSnapshotIsIgnored() {
+            ExtProduct existing = new ExtProduct();
+            existing.setProductId(PRODUCT_ID);
+            existing.setAggregateVersion(9);
+            when(extProductRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(existing));
+
+            listener().onCatalogEvent(envelope(2, "true"));
+
+            verify(extProductRepository, never()).save(any());
+            verify(processedEventRepository).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("VehicleEventsListener")
+    class Vehicles {
+
+        private VehicleEventsListener listener() {
+            return new VehicleEventsListener(clock, objectMapper, processedEventRepository, extVehicleRepository);
+        }
+
+        private String envelope(long version) {
+            return """
+                    {"eventId":"evt-1","eventType":"%s","aggregateVersion":%d,
+                     "payload":{"vehicleId":"%s","accountId":"%s","active":true}}
+                    """.formatted(VehicleUpdatedV1.EVENT_TYPE, version, VEHICLE_ID, ACCOUNT_ID);
+        }
+
+        @Test
+        @DisplayName("replicates the owning account, which is what ownership validation reads")
+        void replicatesVehicleOwnership() {
+            listener().onVehicleEvent(envelope(1));
+
+            ArgumentCaptor<ExtVehicle> captor = ArgumentCaptor.forClass(ExtVehicle.class);
+            verify(extVehicleRepository).save(captor.capture());
+            assertThat(captor.getValue().getVehicleId()).isEqualTo(VEHICLE_ID);
+            assertThat(captor.getValue().getAccountId()).isEqualTo(ACCOUNT_ID);
+            assertThat(captor.getValue().isActive()).isTrue();
+            assertThat(captor.getValue().getSyncedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("ignores a snapshot no newer than the replica it already holds")
+        void staleSnapshotIsIgnored() {
+            ExtVehicle existing = new ExtVehicle();
+            existing.setVehicleId(VEHICLE_ID);
+            existing.setAggregateVersion(3);
+            when(extVehicleRepository.findById(VEHICLE_ID)).thenReturn(Optional.of(existing));
+
+            listener().onVehicleEvent(envelope(3));
+
+            verify(extVehicleRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("LocationEventsListener")
+    class Locations {
+
+        private LocationEventsListener listener() {
+            return new LocationEventsListener(clock, objectMapper, processedEventRepository, extLocationRepository);
+        }
+
+        private String envelope(long version) {
+            return """
+                    {"eventId":"evt-1","eventType":"%s","aggregateVersion":%d,
+                     "payload":{"locationId":"%s","code":"SHOP-1","name":"Main Shop","active":true,
+                       "addressLine1":"1 Main St","addressLine2":null,"city":"Austin",
+                       "region":"TX","postalCode":"78701","country":"US"}}
+                    """.formatted(LocationUpdatedV1.EVENT_TYPE, version, LOCATION_ID);
+        }
+
+        @Test
+        @DisplayName("replicates the full address that tax jurisdiction resolution depends on")
+        void replicatesAddress() {
+            listener().onLocationEvent(envelope(1));
+
+            ArgumentCaptor<ExtLocation> captor = ArgumentCaptor.forClass(ExtLocation.class);
+            verify(extLocationRepository).save(captor.capture());
+            ExtLocation saved = captor.getValue();
+            assertThat(saved.getCode()).isEqualTo("SHOP-1");
+            assertThat(saved.getAddressLine1()).isEqualTo("1 Main St");
+            assertThat(saved.getAddressLine2()).isNull();
+            assertThat(saved.getCity()).isEqualTo("Austin");
+            assertThat(saved.getRegion()).isEqualTo("TX");
+            assertThat(saved.getPostalCode()).isEqualTo("78701");
+            assertThat(saved.getCountry()).isEqualTo("US");
+        }
+
+        @Test
+        @DisplayName("removes the replica when the location is deleted upstream")
+        void deleteRemovesReplica() {
+            listener().onLocationEvent("""
+                            {"eventId":"evt-2","eventType":"%s","payload":{"locationId":"%s"}}""".formatted(LocationDeletedV1.EVENT_TYPE, LOCATION_ID));
+
+            verify(extLocationRepository).deleteById(LOCATION_ID);
+            verify(extLocationRepository, never()).save(any());
+            verify(processedEventRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("ignores a snapshot no newer than the replica it already holds")
+        void staleSnapshotIsIgnored() {
+            ExtLocation existing = new ExtLocation();
+            existing.setLocationId(LOCATION_ID);
+            existing.setAggregateVersion(6);
+            when(extLocationRepository.findById(LOCATION_ID)).thenReturn(Optional.of(existing));
+
+            listener().onLocationEvent(envelope(5));
+
+            verify(extLocationRepository, never()).save(any());
+        }
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/service/ReplicaCustomerPortAdapterTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/ReplicaCustomerPortAdapterTest.java
@@ -1,0 +1,142 @@
+package com.positivity.order.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.order.internal.client.CustomerLookupResult;
+import com.positivity.order.internal.entity.ExtVehicle;
+import com.positivity.order.internal.repository.ExtCustomerRepository;
+import com.positivity.order.internal.repository.ExtVehicleRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for {@link ReplicaCustomerPortAdapter} (ADR-0044 domain wall, PR
+ * #1089 resolution).
+ *
+ * <p>
+ * The distinction this class exists to make is between <em>NOT_FOUND</em> and
+ * <em>UNAVAILABLE</em>. A cold replica — the event feed disabled, or a table that
+ * has never been populated — cannot tell the two apart, so it reports
+ * UNAVAILABLE and the cart proceeds as VALIDATION_PENDING. Reporting NOT_FOUND
+ * there would reject a perfectly valid customer for the accident of this module
+ * not having caught up yet.
+ *
+ * <p>
+ * Ownership is also enforced, not just existence: a vehicle that belongs to a
+ * different account reads as NOT_FOUND for this customer, which is what stops a
+ * clerk attaching someone else's vehicle to an order.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ReplicaCustomerPortAdapter — cold-replica and ownership semantics")
+class ReplicaCustomerPortAdapterTest {
+
+    private static final UUID CUSTOMER_ID = UUID.fromString("00000000-0000-0000-0000-000000000081");
+    private static final UUID OTHER_CUSTOMER_ID = UUID.fromString("00000000-0000-0000-0000-000000000082");
+    private static final UUID VEHICLE_ID = UUID.fromString("00000000-0000-0000-0000-000000000083");
+
+    @Mock
+    private ExtCustomerRepository extCustomerRepository;
+
+    @Mock
+    private ExtVehicleRepository extVehicleRepository;
+
+    private ReplicaCustomerPortAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new ReplicaCustomerPortAdapter(extCustomerRepository, extVehicleRepository);
+        eventFeed(true);
+    }
+
+    private void eventFeed(boolean enabled) {
+        ReflectionTestUtils.setField(adapter, "eventFeedEnabled", enabled);
+    }
+
+    private static ExtVehicle vehicle(UUID accountId, boolean active) {
+        ExtVehicle vehicle = new ExtVehicle();
+        vehicle.setVehicleId(VEHICLE_ID);
+        vehicle.setAccountId(accountId);
+        vehicle.setActive(active);
+        return vehicle;
+    }
+
+    @Test
+    @DisplayName("reports UNAVAILABLE while the event feed is switched off")
+    void feedDisabledIsUnavailable() {
+        eventFeed(false);
+        when(extCustomerRepository.count()).thenReturn(500L);
+
+        assertThat(adapter.lookupCustomer(CUSTOMER_ID)).isEqualTo(CustomerLookupResult.UNAVAILABLE);
+        assertThat(adapter.lookupVehicle(CUSTOMER_ID, VEHICLE_ID)).isEqualTo(CustomerLookupResult.UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("reports UNAVAILABLE on an empty replica rather than rejecting a valid customer")
+    void emptyReplicaIsUnavailable() {
+        when(extCustomerRepository.count()).thenReturn(0L);
+        when(extVehicleRepository.count()).thenReturn(0L);
+
+        assertThat(adapter.lookupCustomer(CUSTOMER_ID)).isEqualTo(CustomerLookupResult.UNAVAILABLE);
+        assertThat(adapter.lookupVehicle(CUSTOMER_ID, VEHICLE_ID)).isEqualTo(CustomerLookupResult.UNAVAILABLE);
+        // An empty table means "not caught up", so the row lookup is not even attempted.
+        verify(extCustomerRepository, never()).existsById(any());
+        verify(extVehicleRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("resolves a known customer to FOUND and an unknown one to NOT_FOUND")
+    void customerLookup() {
+        when(extCustomerRepository.count()).thenReturn(10L);
+        when(extCustomerRepository.existsById(CUSTOMER_ID)).thenReturn(true);
+        when(extCustomerRepository.existsById(OTHER_CUSTOMER_ID)).thenReturn(false);
+
+        assertThat(adapter.lookupCustomer(CUSTOMER_ID)).isEqualTo(CustomerLookupResult.FOUND);
+        assertThat(adapter.lookupCustomer(OTHER_CUSTOMER_ID)).isEqualTo(CustomerLookupResult.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("resolves a vehicle the customer owns to FOUND")
+    void ownedVehicleIsFound() {
+        when(extVehicleRepository.count()).thenReturn(10L);
+        when(extVehicleRepository.findById(VEHICLE_ID)).thenReturn(Optional.of(vehicle(CUSTOMER_ID, true)));
+
+        assertThat(adapter.lookupVehicle(CUSTOMER_ID, VEHICLE_ID)).isEqualTo(CustomerLookupResult.FOUND);
+    }
+
+    @Test
+    @DisplayName("refuses a vehicle owned by a different account")
+    void vehicleOwnedByAnotherAccountIsNotFound() {
+        when(extVehicleRepository.count()).thenReturn(10L);
+        when(extVehicleRepository.findById(VEHICLE_ID)).thenReturn(Optional.of(vehicle(OTHER_CUSTOMER_ID, true)));
+
+        // Existence alone is not enough: this is what stops someone else's vehicle being attached.
+        assertThat(adapter.lookupVehicle(CUSTOMER_ID, VEHICLE_ID)).isEqualTo(CustomerLookupResult.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("refuses an inactive vehicle and one with no replica row")
+    void inactiveOrMissingVehicleIsNotFound() {
+        when(extVehicleRepository.count()).thenReturn(10L);
+        when(extVehicleRepository.findById(VEHICLE_ID)).thenReturn(Optional.of(vehicle(CUSTOMER_ID, false)));
+
+        assertThat(adapter.lookupVehicle(CUSTOMER_ID, VEHICLE_ID)).isEqualTo(CustomerLookupResult.NOT_FOUND);
+
+        when(extVehicleRepository.findById(VEHICLE_ID)).thenReturn(Optional.empty());
+
+        assertThat(adapter.lookupVehicle(CUSTOMER_ID, VEHICLE_ID)).isEqualTo(CustomerLookupResult.NOT_FOUND);
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/service/ReplicaListenerContractTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/ReplicaListenerContractTest.java
@@ -1,0 +1,290 @@
+package com.positivity.order.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.catalog.ProductUpdatedV1;
+import com.positivity.domainevents.customer.CustomerPartyUpdatedV1;
+import com.positivity.domainevents.location.LocationUpdatedV1;
+import com.positivity.domainevents.vehicle.VehicleUpdatedV1;
+import com.positivity.domainevents.workorder.WorkorderUpdatedV1;
+import com.positivity.order.internal.entity.ProcessedEvent;
+import com.positivity.order.internal.repository.ExtBillingRulesRepository;
+import com.positivity.order.internal.repository.ExtCustomerRepository;
+import com.positivity.order.internal.repository.ExtEstimateLineRepository;
+import com.positivity.order.internal.repository.ExtEstimateRepository;
+import com.positivity.order.internal.repository.ExtLocationRepository;
+import com.positivity.order.internal.repository.ExtProductRepository;
+import com.positivity.order.internal.repository.ExtVehicleRepository;
+import com.positivity.order.internal.repository.ExtWorkorderLineRepository;
+import com.positivity.order.internal.repository.ExtWorkorderRepository;
+import com.positivity.order.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.QueryTimeoutException;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * The five {@code ext_*} replica listeners are documented as sharing one consumer
+ * contract, and each of their class comments points at the others for it. This
+ * test holds that shared contract in one place so a listener cannot quietly drop
+ * half of it:
+ *
+ * <ul>
+ * <li><b>A message that is not JSON, or not a type this module replicates, is
+ * skipped without a dedup row.</b> Recording it would make
+ * {@code processed_events} a log of what arrived rather than what was applied,
+ * and would hide a later genuine delivery of the same id.</li>
+ * <li><b>An envelope with no {@code eventId} is skipped</b>, because there is
+ * nothing to de-duplicate it by and at-least-once delivery would let it apply
+ * twice.</li>
+ * <li><b>A replayed {@code eventId} is a no-op.</b></li>
+ * <li><b>A transient database error is rethrown</b> so the Kafka container
+ * retries. Swallowing it would silently drop the fact and leave the replica
+ * permanently behind.</li>
+ * <li><b>A malformed payload is swallowed and left unrecorded.</b> A poison
+ * message must not wedge the partition — but it also must not be marked
+ * processed, so a corrected redelivery still applies.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ext_* replica listeners — shared consumer contract")
+class ReplicaListenerContractTest {
+
+    private static final UUID ID = UUID.fromString("00000000-0000-0000-0000-0000000000f1");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private ExtCustomerRepository extCustomerRepository;
+
+    @Mock
+    private ExtBillingRulesRepository extBillingRulesRepository;
+
+    @Mock
+    private ExtVehicleRepository extVehicleRepository;
+
+    @Mock
+    private ExtProductRepository extProductRepository;
+
+    @Mock
+    private ExtLocationRepository extLocationRepository;
+
+    @Mock
+    private ExtWorkorderRepository extWorkorderRepository;
+
+    @Mock
+    private ExtWorkorderLineRepository extWorkorderLineRepository;
+
+    @Mock
+    private ExtEstimateRepository extEstimateRepository;
+
+    @Mock
+    private ExtEstimateLineRepository extEstimateLineRepository;
+
+    /**
+     * One listener under test: how to hand it a message, the event type and id field it
+     * replicates, the owner it stamps on the dedup row, and how to make its replica repository
+     * fail transiently.
+     */
+    private record Listener(
+            String name, String eventType, String idField, String owner, Consumer<String> dispatch, Runnable failHard) {
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    static final List<String> LISTENERS = List.of("customer", "vehicle", "catalog", "location", "workorder");
+
+    private java.util.Map<String, Listener> listeners;
+
+    @BeforeEach
+    void setUp() {
+        when(extCustomerRepository.findById(any())).thenReturn(Optional.empty());
+        when(extVehicleRepository.findById(any())).thenReturn(Optional.empty());
+        when(extProductRepository.findById(any())).thenReturn(Optional.empty());
+        when(extLocationRepository.findById(any())).thenReturn(Optional.empty());
+        when(extWorkorderRepository.findById(any())).thenReturn(Optional.empty());
+        when(processedEventRepository.existsById(any())).thenReturn(false);
+
+        CustomerEventsListener customer = new CustomerEventsListener(
+                clock, objectMapper, processedEventRepository, extCustomerRepository, extBillingRulesRepository);
+        VehicleEventsListener vehicle =
+                new VehicleEventsListener(clock, objectMapper, processedEventRepository, extVehicleRepository);
+        ProductEventsListener product =
+                new ProductEventsListener(clock, objectMapper, processedEventRepository, extProductRepository);
+        LocationEventsListener location =
+                new LocationEventsListener(clock, objectMapper, processedEventRepository, extLocationRepository);
+        WorkorderEventsListener workorder = new WorkorderEventsListener(
+                clock,
+                objectMapper,
+                processedEventRepository,
+                extWorkorderRepository,
+                extWorkorderLineRepository,
+                extEstimateRepository,
+                extEstimateLineRepository);
+
+        listeners = java.util.Map.of(
+                "customer",
+                        new Listener(
+                                "customer",
+                                CustomerPartyUpdatedV1.EVENT_TYPE,
+                                "partyId",
+                                CustomerEventsListener.OWNER,
+                                customer::onCustomerEvent,
+                                () -> when(extCustomerRepository.findById(any()))
+                                        .thenThrow(new QueryTimeoutException("lock wait"))),
+                "vehicle",
+                        new Listener(
+                                "vehicle",
+                                VehicleUpdatedV1.EVENT_TYPE,
+                                "vehicleId",
+                                VehicleEventsListener.OWNER,
+                                vehicle::onVehicleEvent,
+                                () -> when(extVehicleRepository.findById(any()))
+                                        .thenThrow(new QueryTimeoutException("lock wait"))),
+                "catalog",
+                        new Listener(
+                                "catalog",
+                                ProductUpdatedV1.EVENT_TYPE,
+                                "productId",
+                                ProductEventsListener.OWNER,
+                                product::onCatalogEvent,
+                                () -> when(extProductRepository.findById(any()))
+                                        .thenThrow(new QueryTimeoutException("lock wait"))),
+                "location",
+                        new Listener(
+                                "location",
+                                LocationUpdatedV1.EVENT_TYPE,
+                                "locationId",
+                                LocationEventsListener.OWNER,
+                                location::onLocationEvent,
+                                () -> when(extLocationRepository.findById(any()))
+                                        .thenThrow(new QueryTimeoutException("lock wait"))),
+                "workorder",
+                        new Listener(
+                                "workorder",
+                                WorkorderUpdatedV1.EVENT_TYPE,
+                                "workorderId",
+                                WorkorderEventsListener.OWNER,
+                                workorder::onWorkorderEvent,
+                                () -> when(extWorkorderRepository.findById(any()))
+                                        .thenThrow(new QueryTimeoutException("lock wait"))));
+    }
+
+    private Listener listener(String name) {
+        return listeners.get(name);
+    }
+
+    private String envelope(Listener listener, String eventId, String idValue) {
+        return """
+                {"eventId":"%s","eventType":"%s","aggregateVersion":3,"payload":{"%s":"%s","accountId":"%s"}}""".formatted(eventId, listener.eventType(), listener.idField(), idValue, ID);
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("applies a well-formed fact and stamps its own owner on the dedup row")
+    void happyPathRecordsProcessedEvent(String name) {
+        Listener listener = listener(name);
+
+        listener.dispatch().accept(envelope(listener, "evt-1", ID.toString()));
+
+        ArgumentCaptor<ProcessedEvent> captor = ArgumentCaptor.forClass(ProcessedEvent.class);
+        verify(processedEventRepository).save(captor.capture());
+        assertThat(captor.getValue().getEventId()).isEqualTo("evt-1");
+        assertThat(captor.getValue().getOwner()).isEqualTo(listener.owner());
+        assertThat(captor.getValue().getProcessedAt()).isEqualTo(NOW);
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("skips a message that is not JSON without recording it")
+    void unparsableMessageIsSkipped(String name) {
+        listener(name).dispatch().accept("{not json");
+
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("skips an event type this module does not replicate without recording it")
+    void unrelatedEventTypeIsSkipped(String name) {
+        listener(name).dispatch().accept("""
+                        {"eventId":"evt-1","eventType":"some.other.thing","payload":{}}""");
+
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("skips an envelope with no eventId, since nothing could de-duplicate it")
+    void missingEventIdIsSkipped(String name) {
+        Listener listener = listener(name);
+
+        listener.dispatch().accept(envelope(listener, "", ID.toString()));
+
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("no-ops on a replayed eventId")
+    void replayIsIgnored(String name) {
+        when(processedEventRepository.existsById("evt-1")).thenReturn(true);
+        Listener listener = listener(name);
+
+        listener.dispatch().accept(envelope(listener, "evt-1", ID.toString()));
+
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("rethrows a transient database error so the container retries instead of losing the fact")
+    void transientDatabaseErrorIsRethrown(String name) {
+        Listener listener = listener(name);
+        listener.failHard().run();
+
+        assertThatThrownBy(() -> listener.dispatch().accept(envelope(listener, "evt-1", ID.toString())))
+                .isInstanceOf(QueryTimeoutException.class);
+
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("swallows a malformed payload but leaves it unrecorded so a corrected redelivery still applies")
+    void malformedPayloadIsSkippedButNotRecorded(String name) {
+        Listener listener = listener(name);
+
+        listener.dispatch().accept(envelope(listener, "evt-1", "not-a-uuid"));
+
+        verify(processedEventRepository, never()).save(any());
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/service/WorkorderEventsListenerTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/WorkorderEventsListenerTest.java
@@ -1,0 +1,244 @@
+package com.positivity.order.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.workorder.EstimateUpdatedV1;
+import com.positivity.domainevents.workorder.WorkorderUpdatedV1;
+import com.positivity.order.internal.entity.ExtEstimate;
+import com.positivity.order.internal.entity.ExtEstimateLine;
+import com.positivity.order.internal.entity.ExtWorkorder;
+import com.positivity.order.internal.entity.ExtWorkorderLine;
+import com.positivity.order.internal.repository.ExtEstimateLineRepository;
+import com.positivity.order.internal.repository.ExtEstimateRepository;
+import com.positivity.order.internal.repository.ExtWorkorderLineRepository;
+import com.positivity.order.internal.repository.ExtWorkorderRepository;
+import com.positivity.order.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link WorkorderEventsListener} (parity story E1, spec R7.1).
+ *
+ * <p>
+ * The source-document import reads these replicas to build an order, so what
+ * matters is that a snapshot is a <em>replacement</em>: every fact fully
+ * replaces the document's line set, because a line removed upstream would
+ * otherwise linger and be imported onto an order that should not contain it. The
+ * aggregate-version guard is the other half — Kafka only orders within a
+ * partition, so an older snapshot arriving late must not overwrite newer prices.
+ *
+ * <p>
+ * The delivery contract this shares with the other replica listeners is covered
+ * once in {@link ReplicaListenerContractTest}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("WorkorderEventsListener — workorder and estimate replicas")
+class WorkorderEventsListenerTest {
+
+    private static final UUID WORKORDER_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e1");
+    private static final UUID ESTIMATE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e2");
+    private static final UUID CUSTOMER_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e3");
+    private static final UUID VEHICLE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e4");
+    private static final UUID LINE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e5");
+    private static final UUID SERVICE_LINE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e6");
+    private static final UUID ITEM_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e7");
+    private static final UUID PRODUCT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e8");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private ExtWorkorderRepository extWorkorderRepository;
+
+    @Mock
+    private ExtWorkorderLineRepository extWorkorderLineRepository;
+
+    @Mock
+    private ExtEstimateRepository extEstimateRepository;
+
+    @Mock
+    private ExtEstimateLineRepository extEstimateLineRepository;
+
+    private WorkorderEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new WorkorderEventsListener(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                new ObjectMapper(),
+                processedEventRepository,
+                extWorkorderRepository,
+                extWorkorderLineRepository,
+                extEstimateRepository,
+                extEstimateLineRepository);
+        when(processedEventRepository.existsById(any())).thenReturn(false);
+        when(extWorkorderRepository.findById(any())).thenReturn(Optional.empty());
+        when(extEstimateRepository.findById(any())).thenReturn(Optional.empty());
+    }
+
+    private static String workorderEnvelope(long version) {
+        return """
+                {"eventId":"evt-1","eventType":"%s","aggregateVersion":%d,
+                 "payload":{"workorderId":"%s","workorderNumber":"WO-1001","status":"CLOSED",
+                   "customerId":"%s","vehicleId":"%s","shopId":null,"invoiceId":null,
+                   "parts":[{"workorderLineId":"%s","productEntityId":"%s","description":"Brake pad",
+                     "quantity":2,"unitPrice":45.50,"lineTotal":91.00,"declined":false,"returnable":true}],
+                   "services":[{"workorderLineId":"%s","description":"Labor",
+                     "quantity":1.5,"unitPrice":100,"lineTotal":150,"declined":true}]}}
+                """.formatted(
+                        WorkorderUpdatedV1.EVENT_TYPE,
+                        version,
+                        WORKORDER_ID,
+                        CUSTOMER_ID,
+                        VEHICLE_ID,
+                        LINE_ID,
+                        PRODUCT_ID,
+                        SERVICE_LINE_ID);
+    }
+
+    private static String estimateEnvelope(long version) {
+        return """
+                {"eventId":"evt-2","eventType":"%s","aggregateVersion":%d,
+                 "payload":{"estimateId":"%s","estimateNumber":"EST-7","status":"APPROVED",
+                   "customerId":"%s","vehicleId":"%s","locationId":null,
+                   "items":[{"estimateItemId":"%s","itemType":"PART","description":"Filter",
+                     "quantity":1,"unitPrice":19.99,"lineTotal":19.99,"productId":"%s",
+                     "serviceId":null,"approvalStatus":"APPROVED","deleted":false}]}}
+                """.formatted(
+                EstimateUpdatedV1.EVENT_TYPE, version, ESTIMATE_ID, CUSTOMER_ID, VEHICLE_ID, ITEM_ID, PRODUCT_ID);
+    }
+
+    @Test
+    @DisplayName("replicates a workorder header and both line kinds")
+    void replicatesWorkorderAndLines() {
+        listener.onWorkorderEvent(workorderEnvelope(3));
+
+        ArgumentCaptor<ExtWorkorder> header = ArgumentCaptor.forClass(ExtWorkorder.class);
+        verify(extWorkorderRepository).save(header.capture());
+        assertThat(header.getValue().getWorkorderNumber()).isEqualTo("WO-1001");
+        assertThat(header.getValue().getStatus()).isEqualTo("CLOSED");
+        assertThat(header.getValue().getCustomerId()).isEqualTo(CUSTOMER_ID);
+        assertThat(header.getValue().getVehicleId()).isEqualTo(VEHICLE_ID);
+        // A null id in the payload must land as null, not as a parse failure.
+        assertThat(header.getValue().getShopId()).isNull();
+        assertThat(header.getValue().getAggregateVersion()).isEqualTo(3);
+        assertThat(header.getValue().getSyncedAt()).isEqualTo(NOW);
+
+        ArgumentCaptor<ExtWorkorderLine> lines = ArgumentCaptor.forClass(ExtWorkorderLine.class);
+        verify(extWorkorderLineRepository, org.mockito.Mockito.times(2)).save(lines.capture());
+        assertThat(lines.getAllValues())
+                .extracting(
+                        ExtWorkorderLine::getLineId,
+                        ExtWorkorderLine::getLineKind,
+                        ExtWorkorderLine::getDescription,
+                        ExtWorkorderLine::getDeclined)
+                .containsExactly(
+                        tuple(LINE_ID, ExtWorkorderLine.LineKind.PART, "Brake pad", false),
+                        tuple(SERVICE_LINE_ID, ExtWorkorderLine.LineKind.SERVICE, "Labor", true));
+        // A service line carries no product; the part line does.
+        assertThat(lines.getAllValues().getFirst().getProductId()).isEqualTo(PRODUCT_ID);
+        assertThat(lines.getAllValues().getFirst().getUnitPrice()).isEqualByComparingTo("45.50");
+        assertThat(lines.getAllValues().getLast().getProductId()).isNull();
+        assertThat(lines.getAllValues().getLast().getReturnable()).isNull();
+    }
+
+    @Test
+    @DisplayName("replaces the whole line set on each snapshot rather than accumulating")
+    void linesAreFullyReplaced() {
+        listener.onWorkorderEvent(workorderEnvelope(3));
+
+        // Delete precedes the inserts: a line removed upstream must not survive the refresh.
+        org.mockito.InOrder order = org.mockito.Mockito.inOrder(extWorkorderLineRepository);
+        order.verify(extWorkorderLineRepository).deleteByWorkorderId(WORKORDER_ID);
+        order.verify(extWorkorderLineRepository, org.mockito.Mockito.times(2)).save(any());
+    }
+
+    @Test
+    @DisplayName("ignores a snapshot no newer than the replica it already holds")
+    void staleWorkorderSnapshotIsIgnored() {
+        ExtWorkorder existing = new ExtWorkorder();
+        existing.setWorkorderId(WORKORDER_ID);
+        existing.setAggregateVersion(5);
+        when(extWorkorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(existing));
+
+        listener.onWorkorderEvent(workorderEnvelope(5));
+
+        verify(extWorkorderRepository, never()).save(any());
+        verify(extWorkorderLineRepository, never()).deleteByWorkorderId(any());
+        // Still recorded: the event was consumed and correctly decided against.
+        verify(processedEventRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("updates the existing replica row in place when the snapshot is newer")
+    void newerSnapshotUpdatesInPlace() {
+        ExtWorkorder existing = new ExtWorkorder();
+        existing.setWorkorderId(WORKORDER_ID);
+        existing.setAggregateVersion(2);
+        existing.setStatus("OPEN");
+        when(extWorkorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(existing));
+
+        listener.onWorkorderEvent(workorderEnvelope(3));
+
+        verify(extWorkorderRepository).save(existing);
+        assertThat(existing.getStatus()).isEqualTo("CLOSED");
+        assertThat(existing.getAggregateVersion()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("replicates an estimate and its items")
+    void replicatesEstimateAndItems() {
+        listener.onWorkorderEvent(estimateEnvelope(4));
+
+        ArgumentCaptor<ExtEstimate> header = ArgumentCaptor.forClass(ExtEstimate.class);
+        verify(extEstimateRepository).save(header.capture());
+        assertThat(header.getValue().getEstimateNumber()).isEqualTo("EST-7");
+        assertThat(header.getValue().getStatus()).isEqualTo("APPROVED");
+        assertThat(header.getValue().getLocationId()).isNull();
+        assertThat(header.getValue().getAggregateVersion()).isEqualTo(4);
+
+        ArgumentCaptor<ExtEstimateLine> items = ArgumentCaptor.forClass(ExtEstimateLine.class);
+        verify(extEstimateLineRepository).deleteByEstimateId(ESTIMATE_ID);
+        verify(extEstimateLineRepository).save(items.capture());
+        assertThat(items.getValue().getItemId()).isEqualTo(ITEM_ID);
+        assertThat(items.getValue().getItemType()).isEqualTo("PART");
+        assertThat(items.getValue().getApprovalStatus()).isEqualTo("APPROVED");
+        assertThat(items.getValue().getProductId()).isEqualTo(PRODUCT_ID);
+        assertThat(items.getValue().getServiceId()).isNull();
+        assertThat(items.getValue().getLineTotal()).isEqualByComparingTo("19.99");
+    }
+
+    @Test
+    @DisplayName("ignores an estimate snapshot no newer than the replica it already holds")
+    void staleEstimateSnapshotIsIgnored() {
+        ExtEstimate existing = new ExtEstimate();
+        existing.setEstimateId(ESTIMATE_ID);
+        existing.setAggregateVersion(9);
+        when(extEstimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.of(existing));
+
+        listener.onWorkorderEvent(estimateEnvelope(4));
+
+        verify(extEstimateRepository, never()).save(any());
+        verify(extEstimateLineRepository, never()).deleteByEstimateId(any());
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/config/EventTypeInitializerTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,123 @@
+package com.positivity.peoplecontact.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(EventTypes.all().size())).header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.all()).isNotEmpty();
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/config/EventTypesTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.peoplecontact.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/config/ManifestPublisherTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/config/ManifestPublisherTest.java
@@ -1,0 +1,366 @@
+package com.positivity.peoplecontact.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.peoplecontact.internal.entity.OutboxEvent;
+import com.positivity.peoplecontact.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for the pos-people-contact {@link ManifestPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * Each closed window gets one reconciliation manifest summarizing the events
+ * published from the outbox in that window; consumers recompute the same summary
+ * and request a replay on drift. The properties that matter:
+ *
+ * <ul>
+ * <li>Window membership is decided by the <em>eventId</em> (UUIDv7) timestamp,
+ * not by {@code createdAt}. The query pads its range by a second of slack, so a
+ * row can be fetched and still belong to a neighbouring window; counting it in
+ * the wrong one would manufacture drift on both sides.</li>
+ * <li>Empty windows still publish, so consumers can alert on manifest absence
+ * rather than treating silence as health.</li>
+ * <li>A malformed row is skipped with a warning instead of failing the window
+ * forever — one bad payload must not permanently block reconciliation.</li>
+ * <li>A failed send leaves the window unadvanced so the next run retries it, and
+ * catch-up is bounded per run so a long outage cannot monopolize a poll.</li>
+ * </ul>
+ */
+@DisplayName("pos-people-contact ManifestPublisher — reconciliation manifest windows")
+class ManifestPublisherTest {
+
+    /** 12:10 UTC: the [11:00, 12:00) window closed more than the 5m grace ago. */
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-08T12:10:00Z"), ZoneOffset.UTC);
+
+    private static final Instant WINDOW_START = Instant.parse("2026-07-08T11:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-07-08T12:00:00Z");
+    private static final String EVENTS_TOPIC = "people-contact.events.v1";
+    private static final String MANIFEST_TOPIC = "people-contact.manifest.v1";
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private SimpleMeterRegistry meterRegistry;
+    private ManifestPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry, TEST_CLOCK);
+        brokerAcknowledges();
+    }
+
+    @SuppressWarnings("unchecked")
+    private ManifestPublisher newPublisher(MeterRegistry registry, Clock clock) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        ManifestPublisher created = new ManifestPublisher(repository, kafkaTemplate, objectMapper, clock, provider);
+        ReflectionTestUtils.setField(created, "eventsTopic", EVENTS_TOPIC);
+        ReflectionTestUtils.setField(created, "manifestTopic", MANIFEST_TOPIC);
+        ReflectionTestUtils.setField(created, "window", Duration.ofHours(1));
+        ReflectionTestUtils.setField(created, "grace", Duration.ofMinutes(5));
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    /** UUIDv7-shaped id whose embedded timestamp is {@code at}. */
+    private static String eventIdAt(Instant at, int suffix) {
+        long millis = at.toEpochMilli();
+        return String.format("%08x-%04x-7000-8000-%012x", millis >>> 16, millis & 0xFFFF, suffix);
+    }
+
+    private static OutboxEvent row(String eventId, String eventType, Instant createdAt) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey(eventId)
+                .payload("{\"eventId\":\"" + eventId + "\",\"eventType\":\"" + eventType + "\",\"payload\":{}}")
+                .createdAt(createdAt)
+                .publishedAt(createdAt.plusSeconds(1))
+                .build();
+    }
+
+    private void outboxReturns(List<OutboxEvent> rows) {
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(rows);
+    }
+
+    private JsonNode capturedManifest() {
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), json.capture());
+        return objectMapper.readTree(json.getValue());
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("publishes the latest closed window with its count, checksum, and per-type counts")
+    void publishesManifestForClosedWindow() {
+        String inWindow1 = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String inWindow2 = eventIdAt(WINDOW_START.plusSeconds(120), 2);
+        outboxReturns(List.of(
+                row(inWindow1, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(inWindow2, "SomethingElseChanged", WINDOW_START.plusSeconds(120))));
+
+        publisher.publishDueManifest();
+
+        JsonNode envelope = capturedManifest();
+        assertThat(envelope.path("sourceService").stringValue()).isEqualTo("pos-people-contact");
+        assertThat(envelope.path("eventType").stringValue())
+                .isEqualTo(ReconciliationManifestV1.eventTypeFor("people-contact"));
+
+        JsonNode manifest = envelope.path("payload");
+        assertThat(manifest.path("windowStartUtc").stringValue()).isEqualTo(WINDOW_START.toString());
+        assertThat(manifest.path("windowEndUtc").stringValue()).isEqualTo(WINDOW_END.toString());
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(2);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow1, inWindow2)));
+        assertThat(manifest.path("eventTypeCounts").path("SomethingChanged").longValue())
+                .isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("SomethingElseChanged").longValue())
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row fetched by createdAt slack whose eventId falls outside the window")
+    void excludesRowOutsideWindowByEventIdTimestamp() {
+        String inWindow = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String justBefore = eventIdAt(WINDOW_START.minusMillis(1), 2);
+        String justAfter = eventIdAt(WINDOW_END.plusMillis(1), 3);
+        outboxReturns(List.of(
+                row(justBefore, "SomethingChanged", WINDOW_START.minusMillis(1)),
+                row(inWindow, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(justAfter, "SomethingChanged", WINDOW_END.plusMillis(1))));
+
+        publisher.publishDueManifest();
+
+        // Membership is decided by the eventId timestamp, not the padded createdAt
+        // query: counting a neighbour here would manufacture drift on both sides.
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow)));
+    }
+
+    @Test
+    @DisplayName("publishes a zero-count manifest so consumers can alert on absence rather than silence")
+    void publishesEmptyWindowManifest() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isZero();
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of()));
+    }
+
+    @Test
+    @DisplayName("counts a row with a blank event type under \"unknown\" rather than dropping it")
+    void blankEventTypeCountedAsUnknown() {
+        String eventId = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        outboxReturns(List.of(row(eventId, "", WINDOW_START.plusSeconds(60))));
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("unknown").longValue()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row with no eventId instead of failing the window")
+    void skipsRowWithoutEventId() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("{\"eventType\":\"PartyChanged\"}")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("excludes a row whose payload will not parse instead of blocking reconciliation forever")
+    void skipsRowWithUnparsablePayload() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("not json at all")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("does not re-publish a window it already published")
+    void skipsAlreadyPublishedWindow() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("waits out the grace period, publishing the previous window until the latest one settles")
+    void respectsGracePeriod() {
+        ReflectionTestUtils.setField(publisher, "grace", Duration.ofMinutes(15));
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        // 12:10 with 15m grace: [11:00, 12:00) is not yet eligible, so the
+        // published window is the previous one.
+        assertThat(capturedManifest().path("payload").path("windowEndUtc").stringValue())
+                .isEqualTo("2026-07-08T11:00:00Z");
+    }
+
+    @Test
+    @DisplayName("retries the same window on the next run when the send fails")
+    void retriesWindowAfterSendFailure() {
+        outboxReturns(List.of());
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker down")))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        // The window must not advance past a failure, or its manifest is lost.
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(counter("people_contact.manifest.publish.failures")).isEqualTo(1d);
+        assertThat(counter("people_contact.manifest.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("counts a successful publish")
+    void countsSuccessfulPublish() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        assertThat(counter("people_contact.manifest.published")).isEqualTo(1d);
+        assertThat(counter("people_contact.manifest.publish.failures")).isZero();
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        ManifestPublisher withoutMetrics = newPublisher(null, TEST_CLOCK);
+        outboxReturns(List.of());
+
+        withoutMetrics.publishDueManifest();
+
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("publishes nothing when no window has closed yet")
+    void publishesNothingBeforeTheFirstWindowCloses() {
+        // Epoch + 30m with a 1h window: no aligned window boundary has passed.
+        ManifestPublisher early = newPublisher(meterRegistry, Clock.fixed(Instant.ofEpochSecond(1800), ZoneOffset.UTC));
+
+        early.publishDueManifest();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("keys every manifest for a window deterministically, so re-publishes land on one partition")
+    void manifestRecordKeyIsStablePerWindow() {
+        outboxReturns(List.of());
+        ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+
+        publisher.publishDueManifest();
+        // A second publisher instance, same window: the key must match.
+        ManifestPublisher other = newPublisher(meterRegistry, TEST_CLOCK);
+        other.publishDueManifest();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), key.capture(), anyString());
+        assertThat(key.getAllValues()).hasSize(2);
+        assertThat(key.getAllValues().get(0)).isEqualTo(key.getAllValues().get(1));
+    }
+
+    @Test
+    @DisplayName("after a gap, catches up window by window rather than skipping to the newest")
+    void catchesUpWindowByWindow() {
+        outboxReturns(List.of());
+
+        // First run establishes [11:00, 12:00) as published.
+        publisher.publishDueManifest();
+
+        // Three hours later four windows have closed; the next run must publish the
+        // intervening ones, not jump to the newest and leave holes.
+        ManifestPublisher later = publisher;
+        ReflectionTestUtils.setField(
+                later, "clock", Clock.fixed(Instant.parse("2026-07-08T15:10:00Z"), ZoneOffset.UTC));
+        later.publishDueManifest();
+
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate, times(4)).send(anyString(), anyString(), json.capture());
+        assertThat(json.getAllValues())
+                .map(value -> objectMapper
+                        .readTree(value)
+                        .path("payload")
+                        .path("windowEndUtc")
+                        .stringValue())
+                .containsExactly(
+                        "2026-07-08T12:00:00Z", "2026-07-08T13:00:00Z", "2026-07-08T14:00:00Z", "2026-07-08T15:00:00Z");
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/config/OutboxPublisherTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/config/OutboxPublisherTest.java
@@ -1,0 +1,213 @@
+package com.positivity.peoplecontact.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.peoplecontact.internal.entity.OutboxEvent;
+import com.positivity.peoplecontact.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for the pos-people-contact {@link OutboxPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * The publisher drains {@code event_outbox} to Kafka with at-least-once
+ * semantics. Three properties carry the correctness weight:
+ *
+ * <ul>
+ * <li>a row is marked published <em>only</em> after the broker acknowledges, so
+ * a crash mid-send re-sends rather than silently dropping the event;</li>
+ * <li>the batch stops at the first failure, so a struggling broker cannot
+ * reorder events past a stuck row; and</li>
+ * <li>the failure path records {@code attempts} and a bounded
+ * {@code last_error} for alerting instead of throwing out of the scheduled
+ * method.</li>
+ * </ul>
+ */
+@DisplayName("pos-people-contact OutboxPublisher — outbox drain contract")
+class OutboxPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-08T12:00:00Z");
+    private static final Clock TEST_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private SimpleMeterRegistry meterRegistry;
+    private OutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    private OutboxPublisher newPublisher(MeterRegistry registry) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        OutboxPublisher created = new OutboxPublisher(repository, kafkaTemplate, TEST_CLOCK, provider);
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private OutboxEvent event(String key) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("people_contact.events.v1")
+                .recordKey(key)
+                .payload("{\"eventId\":\"" + key + "\"}")
+                .createdAt(NOW.minusSeconds(60))
+                .attempts(2)
+                .lastError("previous failure")
+                .build();
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    private void brokerFailsWith(Throwable failure) {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(failure));
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("marks the row published only after the broker acknowledges the send")
+    void marksPublishedAfterAcknowledgedSend() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate).send("people_contact.events.v1", "k1", row.getPayload());
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        assertThat(row.getAttempts()).isZero();
+        assertThat(row.getLastError()).isNull();
+        verify(repository).save(row);
+        assertThat(counter("people_contact.outbox.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("drains the whole batch in order while the broker keeps acknowledging")
+    void drainsWholeBatchWhenAllSendsSucceed() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(first.getPublishedAt()).isEqualTo(NOW);
+        assertThat(second.getPublishedAt()).isEqualTo(NOW);
+        assertThat(counter("people_contact.outbox.published")).isEqualTo(2d);
+    }
+
+    @Test
+    @DisplayName("on failure: records the attempt and error, leaves the row unpublished, stops the batch")
+    void recordsFailureAndStopsBatch() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerFailsWith(new RuntimeException("broker down"));
+
+        publisher.publishPending();
+
+        assertThat(first.getPublishedAt()).isNull();
+        assertThat(first.getAttempts()).isEqualTo(3);
+        assertThat(first.getLastError()).contains("broker down");
+        verify(repository).save(first);
+
+        // The batch stops at the first failure so publish order is preserved:
+        // the second row is never attempted and keeps its prior attempt count.
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+        verify(kafkaTemplate).send("people_contact.events.v1", "k1", first.getPayload());
+        assertThat(second.getAttempts()).isEqualTo(2);
+        assertThat(second.getPublishedAt()).isNull();
+        assertThat(counter("people_contact.outbox.publish.failures")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("falls back to the exception class name when the failure carries no message")
+    void recordsClassNameWhenFailureMessageIsNull() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        // Thrown by send() itself rather than completing the future exceptionally:
+        // a failed future surfaces as an ExecutionException whose message is the
+        // cause's toString, so only a synchronous throw reaches the null-message
+        // fallback in recordFailure().
+        when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenThrow(new IllegalStateException());
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).isEqualTo("IllegalStateException");
+        assertThat(row.getPublishedAt()).isNull();
+        assertThat(row.getAttempts()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("truncates an oversized failure message to the 2000-character column bound")
+    void truncatesOversizedFailureMessage() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerFailsWith(new RuntimeException("x".repeat(2500)));
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).hasSize(2000);
+    }
+
+    @Test
+    @DisplayName("does nothing when the outbox is empty")
+    void doesNothingWhenNoPendingRows() {
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of());
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        verify(repository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        OutboxPublisher withoutMetrics = newPublisher(null);
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        withoutMetrics.publishPending();
+
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        verify(repository).save(row);
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/config/EventTypeInitializerTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,123 @@
+package com.positivity.people.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(EventTypes.all().size())).header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.all()).isNotEmpty();
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/config/EventTypesTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.people.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-people/src/test/java/com/positivity/people/internal/config/ManifestPublisherTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/config/ManifestPublisherTest.java
@@ -1,0 +1,365 @@
+package com.positivity.people.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.people.internal.entity.OutboxEvent;
+import com.positivity.people.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for the pos-people {@link ManifestPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * Each closed window gets one reconciliation manifest summarizing the events
+ * published from the outbox in that window; consumers recompute the same summary
+ * and request a replay on drift. The properties that matter:
+ *
+ * <ul>
+ * <li>Window membership is decided by the <em>eventId</em> (UUIDv7) timestamp,
+ * not by {@code createdAt}. The query pads its range by a second of slack, so a
+ * row can be fetched and still belong to a neighbouring window; counting it in
+ * the wrong one would manufacture drift on both sides.</li>
+ * <li>Empty windows still publish, so consumers can alert on manifest absence
+ * rather than treating silence as health.</li>
+ * <li>A malformed row is skipped with a warning instead of failing the window
+ * forever — one bad payload must not permanently block reconciliation.</li>
+ * <li>A failed send leaves the window unadvanced so the next run retries it, and
+ * catch-up is bounded per run so a long outage cannot monopolize a poll.</li>
+ * </ul>
+ */
+@DisplayName("pos-people ManifestPublisher — reconciliation manifest windows")
+class ManifestPublisherTest {
+
+    /** 12:10 UTC: the [11:00, 12:00) window closed more than the 5m grace ago. */
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-08T12:10:00Z"), ZoneOffset.UTC);
+
+    private static final Instant WINDOW_START = Instant.parse("2026-07-08T11:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-07-08T12:00:00Z");
+    private static final String EVENTS_TOPIC = "people.events.v1";
+    private static final String MANIFEST_TOPIC = "people.manifest.v1";
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private SimpleMeterRegistry meterRegistry;
+    private ManifestPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry, TEST_CLOCK);
+        brokerAcknowledges();
+    }
+
+    @SuppressWarnings("unchecked")
+    private ManifestPublisher newPublisher(MeterRegistry registry, Clock clock) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        ManifestPublisher created = new ManifestPublisher(repository, kafkaTemplate, objectMapper, clock, provider);
+        ReflectionTestUtils.setField(created, "eventsTopic", EVENTS_TOPIC);
+        ReflectionTestUtils.setField(created, "manifestTopic", MANIFEST_TOPIC);
+        ReflectionTestUtils.setField(created, "window", Duration.ofHours(1));
+        ReflectionTestUtils.setField(created, "grace", Duration.ofMinutes(5));
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    /** UUIDv7-shaped id whose embedded timestamp is {@code at}. */
+    private static String eventIdAt(Instant at, int suffix) {
+        long millis = at.toEpochMilli();
+        return String.format("%08x-%04x-7000-8000-%012x", millis >>> 16, millis & 0xFFFF, suffix);
+    }
+
+    private static OutboxEvent row(String eventId, String eventType, Instant createdAt) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey(eventId)
+                .payload("{\"eventId\":\"" + eventId + "\",\"eventType\":\"" + eventType + "\",\"payload\":{}}")
+                .createdAt(createdAt)
+                .publishedAt(createdAt.plusSeconds(1))
+                .build();
+    }
+
+    private void outboxReturns(List<OutboxEvent> rows) {
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(rows);
+    }
+
+    private JsonNode capturedManifest() {
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), json.capture());
+        return objectMapper.readTree(json.getValue());
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("publishes the latest closed window with its count, checksum, and per-type counts")
+    void publishesManifestForClosedWindow() {
+        String inWindow1 = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String inWindow2 = eventIdAt(WINDOW_START.plusSeconds(120), 2);
+        outboxReturns(List.of(
+                row(inWindow1, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(inWindow2, "SomethingElseChanged", WINDOW_START.plusSeconds(120))));
+
+        publisher.publishDueManifest();
+
+        JsonNode envelope = capturedManifest();
+        assertThat(envelope.path("sourceService").stringValue()).isEqualTo("pos-people");
+        assertThat(envelope.path("eventType").stringValue()).isEqualTo(ReconciliationManifestV1.eventTypeFor("people"));
+
+        JsonNode manifest = envelope.path("payload");
+        assertThat(manifest.path("windowStartUtc").stringValue()).isEqualTo(WINDOW_START.toString());
+        assertThat(manifest.path("windowEndUtc").stringValue()).isEqualTo(WINDOW_END.toString());
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(2);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow1, inWindow2)));
+        assertThat(manifest.path("eventTypeCounts").path("SomethingChanged").longValue())
+                .isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("SomethingElseChanged").longValue())
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row fetched by createdAt slack whose eventId falls outside the window")
+    void excludesRowOutsideWindowByEventIdTimestamp() {
+        String inWindow = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String justBefore = eventIdAt(WINDOW_START.minusMillis(1), 2);
+        String justAfter = eventIdAt(WINDOW_END.plusMillis(1), 3);
+        outboxReturns(List.of(
+                row(justBefore, "SomethingChanged", WINDOW_START.minusMillis(1)),
+                row(inWindow, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(justAfter, "SomethingChanged", WINDOW_END.plusMillis(1))));
+
+        publisher.publishDueManifest();
+
+        // Membership is decided by the eventId timestamp, not the padded createdAt
+        // query: counting a neighbour here would manufacture drift on both sides.
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow)));
+    }
+
+    @Test
+    @DisplayName("publishes a zero-count manifest so consumers can alert on absence rather than silence")
+    void publishesEmptyWindowManifest() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isZero();
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of()));
+    }
+
+    @Test
+    @DisplayName("counts a row with a blank event type under \"unknown\" rather than dropping it")
+    void blankEventTypeCountedAsUnknown() {
+        String eventId = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        outboxReturns(List.of(row(eventId, "", WINDOW_START.plusSeconds(60))));
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("unknown").longValue()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row with no eventId instead of failing the window")
+    void skipsRowWithoutEventId() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("{\"eventType\":\"PartyChanged\"}")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("excludes a row whose payload will not parse instead of blocking reconciliation forever")
+    void skipsRowWithUnparsablePayload() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("not json at all")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("does not re-publish a window it already published")
+    void skipsAlreadyPublishedWindow() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("waits out the grace period, publishing the previous window until the latest one settles")
+    void respectsGracePeriod() {
+        ReflectionTestUtils.setField(publisher, "grace", Duration.ofMinutes(15));
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        // 12:10 with 15m grace: [11:00, 12:00) is not yet eligible, so the
+        // published window is the previous one.
+        assertThat(capturedManifest().path("payload").path("windowEndUtc").stringValue())
+                .isEqualTo("2026-07-08T11:00:00Z");
+    }
+
+    @Test
+    @DisplayName("retries the same window on the next run when the send fails")
+    void retriesWindowAfterSendFailure() {
+        outboxReturns(List.of());
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker down")))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        // The window must not advance past a failure, or its manifest is lost.
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(counter("people.manifest.publish.failures")).isEqualTo(1d);
+        assertThat(counter("people.manifest.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("counts a successful publish")
+    void countsSuccessfulPublish() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        assertThat(counter("people.manifest.published")).isEqualTo(1d);
+        assertThat(counter("people.manifest.publish.failures")).isZero();
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        ManifestPublisher withoutMetrics = newPublisher(null, TEST_CLOCK);
+        outboxReturns(List.of());
+
+        withoutMetrics.publishDueManifest();
+
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("publishes nothing when no window has closed yet")
+    void publishesNothingBeforeTheFirstWindowCloses() {
+        // Epoch + 30m with a 1h window: no aligned window boundary has passed.
+        ManifestPublisher early = newPublisher(meterRegistry, Clock.fixed(Instant.ofEpochSecond(1800), ZoneOffset.UTC));
+
+        early.publishDueManifest();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("keys every manifest for a window deterministically, so re-publishes land on one partition")
+    void manifestRecordKeyIsStablePerWindow() {
+        outboxReturns(List.of());
+        ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+
+        publisher.publishDueManifest();
+        // A second publisher instance, same window: the key must match.
+        ManifestPublisher other = newPublisher(meterRegistry, TEST_CLOCK);
+        other.publishDueManifest();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), key.capture(), anyString());
+        assertThat(key.getAllValues()).hasSize(2);
+        assertThat(key.getAllValues().get(0)).isEqualTo(key.getAllValues().get(1));
+    }
+
+    @Test
+    @DisplayName("after a gap, catches up window by window rather than skipping to the newest")
+    void catchesUpWindowByWindow() {
+        outboxReturns(List.of());
+
+        // First run establishes [11:00, 12:00) as published.
+        publisher.publishDueManifest();
+
+        // Three hours later four windows have closed; the next run must publish the
+        // intervening ones, not jump to the newest and leave holes.
+        ManifestPublisher later = publisher;
+        ReflectionTestUtils.setField(
+                later, "clock", Clock.fixed(Instant.parse("2026-07-08T15:10:00Z"), ZoneOffset.UTC));
+        later.publishDueManifest();
+
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate, times(4)).send(anyString(), anyString(), json.capture());
+        assertThat(json.getAllValues())
+                .map(value -> objectMapper
+                        .readTree(value)
+                        .path("payload")
+                        .path("windowEndUtc")
+                        .stringValue())
+                .containsExactly(
+                        "2026-07-08T12:00:00Z", "2026-07-08T13:00:00Z", "2026-07-08T14:00:00Z", "2026-07-08T15:00:00Z");
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/config/OutboxPublisherTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/config/OutboxPublisherTest.java
@@ -1,0 +1,213 @@
+package com.positivity.people.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.people.internal.entity.OutboxEvent;
+import com.positivity.people.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for the pos-people {@link OutboxPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * The publisher drains {@code event_outbox} to Kafka with at-least-once
+ * semantics. Three properties carry the correctness weight:
+ *
+ * <ul>
+ * <li>a row is marked published <em>only</em> after the broker acknowledges, so
+ * a crash mid-send re-sends rather than silently dropping the event;</li>
+ * <li>the batch stops at the first failure, so a struggling broker cannot
+ * reorder events past a stuck row; and</li>
+ * <li>the failure path records {@code attempts} and a bounded
+ * {@code last_error} for alerting instead of throwing out of the scheduled
+ * method.</li>
+ * </ul>
+ */
+@DisplayName("pos-people OutboxPublisher — outbox drain contract")
+class OutboxPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-08T12:00:00Z");
+    private static final Clock TEST_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private SimpleMeterRegistry meterRegistry;
+    private OutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    private OutboxPublisher newPublisher(MeterRegistry registry) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        OutboxPublisher created = new OutboxPublisher(repository, kafkaTemplate, TEST_CLOCK, provider);
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private OutboxEvent event(String key) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("people.events.v1")
+                .recordKey(key)
+                .payload("{\"eventId\":\"" + key + "\"}")
+                .createdAt(NOW.minusSeconds(60))
+                .attempts(2)
+                .lastError("previous failure")
+                .build();
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    private void brokerFailsWith(Throwable failure) {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(failure));
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("marks the row published only after the broker acknowledges the send")
+    void marksPublishedAfterAcknowledgedSend() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate).send("people.events.v1", "k1", row.getPayload());
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        assertThat(row.getAttempts()).isZero();
+        assertThat(row.getLastError()).isNull();
+        verify(repository).save(row);
+        assertThat(counter("people.outbox.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("drains the whole batch in order while the broker keeps acknowledging")
+    void drainsWholeBatchWhenAllSendsSucceed() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(first.getPublishedAt()).isEqualTo(NOW);
+        assertThat(second.getPublishedAt()).isEqualTo(NOW);
+        assertThat(counter("people.outbox.published")).isEqualTo(2d);
+    }
+
+    @Test
+    @DisplayName("on failure: records the attempt and error, leaves the row unpublished, stops the batch")
+    void recordsFailureAndStopsBatch() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerFailsWith(new RuntimeException("broker down"));
+
+        publisher.publishPending();
+
+        assertThat(first.getPublishedAt()).isNull();
+        assertThat(first.getAttempts()).isEqualTo(3);
+        assertThat(first.getLastError()).contains("broker down");
+        verify(repository).save(first);
+
+        // The batch stops at the first failure so publish order is preserved:
+        // the second row is never attempted and keeps its prior attempt count.
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+        verify(kafkaTemplate).send("people.events.v1", "k1", first.getPayload());
+        assertThat(second.getAttempts()).isEqualTo(2);
+        assertThat(second.getPublishedAt()).isNull();
+        assertThat(counter("people.outbox.publish.failures")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("falls back to the exception class name when the failure carries no message")
+    void recordsClassNameWhenFailureMessageIsNull() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        // Thrown by send() itself rather than completing the future exceptionally:
+        // a failed future surfaces as an ExecutionException whose message is the
+        // cause's toString, so only a synchronous throw reaches the null-message
+        // fallback in recordFailure().
+        when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenThrow(new IllegalStateException());
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).isEqualTo("IllegalStateException");
+        assertThat(row.getPublishedAt()).isNull();
+        assertThat(row.getAttempts()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("truncates an oversized failure message to the 2000-character column bound")
+    void truncatesOversizedFailureMessage() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerFailsWith(new RuntimeException("x".repeat(2500)));
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).hasSize(2000);
+    }
+
+    @Test
+    @DisplayName("does nothing when the outbox is empty")
+    void doesNothingWhenNoPendingRows() {
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of());
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        verify(repository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        OutboxPublisher withoutMetrics = newPublisher(null);
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        withoutMetrics.publishPending();
+
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        verify(repository).save(row);
+    }
+}

--- a/pos-price/src/test/java/com/positivity/price/internal/config/EventTypeInitializerTest.java
+++ b/pos-price/src/test/java/com/positivity/price/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,123 @@
+package com.positivity.price.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(EventTypes.all().size())).header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.all()).isNotEmpty();
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+}

--- a/pos-price/src/test/java/com/positivity/price/internal/config/EventTypesTest.java
+++ b/pos-price/src/test/java/com/positivity/price/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.price.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -538,8 +538,8 @@ public final class DownstreamPermissionCatalog {
         "PERM_crm:interaction:manage", // 442
 
         // ── New batch (bits 443–444) ──────────────────────────────────────────
-        "PERM_people-contact:organization:edit",             // 443
-        "PERM_people-contact:organization:view"             // 444
+        "PERM_people-contact:organization:edit", // 443
+        "PERM_people-contact:organization:view" // 444
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-common/src/test/java/com/positivity/security/common/PermissionRegistrationSupportTest.java
+++ b/pos-security-common/src/test/java/com/positivity/security/common/PermissionRegistrationSupportTest.java
@@ -1,0 +1,225 @@
+package com.positivity.security.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * Unit tests for {@link PermissionRegistrationSupport}, the shared base class
+ * every service extends to publish its permission catalog to
+ * {@code pos-security-service} at startup.
+ *
+ * <p>
+ * The behaviour that matters operationally is the failure posture: registration
+ * retries a bounded number of times and then gives up with an error log, so a
+ * security service that is slow to come up delays but never blocks a service's
+ * startup. The disabled and empty-catalog short circuits matter too — they are
+ * what keeps test and offline profiles from making outbound calls at all.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PermissionRegistrationSupport — startup permission registration")
+class PermissionRegistrationSupportTest {
+
+    private static final String SECURITY_URL = "http://pos-security-service:8080";
+    private static final int MAX_RETRIES = 5;
+
+    private static final List<PermissionDefinition> PERMISSIONS = List.of(
+            PermissionDefinition.of("catalog:product:view", "View products"),
+            PermissionDefinition.of("catalog:product:create", "Create products"));
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    @Captor
+    private ArgumentCaptor<Object> requestBody;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.post()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+    }
+
+    @AfterEach
+    void clearSecretProperty() {
+        System.clearProperty(SecurityApiConstants.PERMISSION_SECRET_PROPERTY);
+    }
+
+    /** Minimal concrete subclass supplying an inline permission catalog. */
+    private final class InlineRegistration extends PermissionRegistrationSupport {
+        private final List<PermissionDefinition> permissions;
+
+        InlineRegistration(boolean enabled, List<PermissionDefinition> permissions) {
+            super(restClientBuilder, SECURITY_URL, "catalog", "pos-catalog", enabled);
+            this.permissions = permissions;
+        }
+
+        @Override
+        protected List<PermissionDefinition> getPermissions() {
+            return permissions;
+        }
+    }
+
+    /** Subclass that supplies no catalog, exercising the base-class default. */
+    private final class NoManifestRegistration extends PermissionRegistrationSupport {
+        NoManifestRegistration() {
+            super(restClientBuilder, SECURITY_URL, "catalog", "pos-catalog");
+        }
+    }
+
+    @Test
+    @DisplayName("posts the permission catalog once when the security service accepts it")
+    void run_whenRegistrationSucceeds_postsOnce() {
+        new InlineRegistration(true, PERMISSIONS).run(null);
+
+        verify(restClient, times(1)).post();
+        verify(responseSpec, times(1)).toBodilessEntity();
+    }
+
+    @Test
+    @DisplayName("sends the domain, service name, version, and every permission in the request body")
+    void run_sendsFullCatalogInRequestBody() {
+        new InlineRegistration(true, PERMISSIONS).run(null);
+
+        verify(requestBodyUriSpec).body(requestBody.capture());
+        assertThat(requestBody.getValue())
+                .isInstanceOfSatisfying(PermissionRegistrationSupport.PermissionRegistrationRequest.class, request -> {
+                    assertThat(request.domain()).isEqualTo("catalog");
+                    assertThat(request.serviceName()).isEqualTo("pos-catalog");
+                    assertThat(request.version()).isEqualTo("1.0");
+                    assertThat(request.permissions())
+                            .extracting(PermissionRegistrationSupport.PermissionDto::name)
+                            .containsExactly("catalog:product:view", "catalog:product:create");
+                });
+    }
+
+    @Test
+    @DisplayName("makes no outbound call when registration is disabled")
+    void run_whenDisabled_makesNoCall() {
+        new InlineRegistration(false, PERMISSIONS).run(null);
+
+        verify(restClient, never()).post();
+    }
+
+    @Test
+    @DisplayName("makes no outbound call when the permission catalog is empty")
+    void run_whenCatalogEmpty_makesNoCall() {
+        new InlineRegistration(true, List.of()).run(null);
+
+        verify(restClient, never()).post();
+    }
+
+    @Test
+    @DisplayName("makes no outbound call when the permission catalog is null")
+    void run_whenCatalogNull_makesNoCall() {
+        new InlineRegistration(true, null).run(null);
+
+        verify(restClient, never()).post();
+    }
+
+    @Test
+    @DisplayName("retries after a transport failure and stops once a call succeeds")
+    void run_whenFirstAttemptFails_retriesThenSucceeds() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RestClientException("connection refused"))
+                .thenReturn(null);
+
+        runUninterruptibly(() -> new InlineRegistration(true, PERMISSIONS).run(null));
+
+        verify(restClient, times(2)).post();
+    }
+
+    @Test
+    @DisplayName("gives up after the retry budget without throwing — startup must not block on the security service")
+    void run_whenAllAttemptsFail_givesUpWithoutThrowing() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RestClientException("connection refused"));
+
+        assertThatNoException()
+                .isThrownBy(() -> runUninterruptibly(() -> new InlineRegistration(true, PERMISSIONS).run(null)));
+
+        verify(restClient, times(MAX_RETRIES)).post();
+    }
+
+    @Test
+    @DisplayName("sends the shared-secret header when the registration secret is configured")
+    void run_withConfiguredSecret_sendsSecretHeader() {
+        System.setProperty(SecurityApiConstants.PERMISSION_SECRET_PROPERTY, "s3cret");
+
+        new InlineRegistration(true, PERMISSIONS).run(null);
+
+        verify(requestBodyUriSpec).header(SecurityApiConstants.PERMISSION_SECRET_HEADER, "s3cret");
+    }
+
+    @Test
+    @DisplayName("omits the shared-secret header when no registration secret is configured")
+    void run_withoutSecret_omitsSecretHeader() {
+        // The secret also resolves from the environment, which this test cannot
+        // unset; skip rather than fail when a developer machine exports it.
+        assumeTrue(
+                !SecurityApiConstants.hasSecret(System.getenv(SecurityApiConstants.PERMISSION_SECRET_ENV_VAR)),
+                SecurityApiConstants.PERMISSION_SECRET_ENV_VAR + " is set in this environment");
+
+        new InlineRegistration(true, PERMISSIONS).run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(SecurityApiConstants.PERMISSION_SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("a subclass with neither a manifest nor an override fails loudly rather than registering nothing")
+    void getPermissions_withNoManifestAndNoOverride_throws() {
+        NoManifestRegistration registration = new NoManifestRegistration();
+
+        assertThatIllegalStateException().isThrownBy(() -> registration.run(null));
+    }
+
+    /**
+     * Runs the registration with the calling thread pre-interrupted so the
+     * 2-second retry back-off returns immediately: {@code Thread.sleep} on an
+     * interrupted thread throws at once, and the production code re-sets the flag
+     * in its handler, keeping every subsequent back-off instant too. Without this
+     * the retry tests would idle for eight seconds. The flag is cleared afterwards
+     * so it cannot leak into another test on the same thread.
+     */
+    private void runUninterruptibly(Runnable registration) {
+        Thread.currentThread().interrupt();
+        try {
+            registration.run();
+        } finally {
+            Thread.interrupted();
+        }
+    }
+}

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/EventTypesTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.securityservice.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/OutboxPublisherTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/OutboxPublisherTest.java
@@ -1,0 +1,213 @@
+package com.positivity.securityservice.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.securityservice.internal.entity.OutboxEvent;
+import com.positivity.securityservice.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for the pos-security-service {@link OutboxPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * The publisher drains {@code event_outbox} to Kafka with at-least-once
+ * semantics. Three properties carry the correctness weight:
+ *
+ * <ul>
+ * <li>a row is marked published <em>only</em> after the broker acknowledges, so
+ * a crash mid-send re-sends rather than silently dropping the event;</li>
+ * <li>the batch stops at the first failure, so a struggling broker cannot
+ * reorder events past a stuck row; and</li>
+ * <li>the failure path records {@code attempts} and a bounded
+ * {@code last_error} for alerting instead of throwing out of the scheduled
+ * method.</li>
+ * </ul>
+ */
+@DisplayName("pos-security-service OutboxPublisher — outbox drain contract")
+class OutboxPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-08T12:00:00Z");
+    private static final Clock TEST_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private SimpleMeterRegistry meterRegistry;
+    private OutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    private OutboxPublisher newPublisher(MeterRegistry registry) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        OutboxPublisher created = new OutboxPublisher(repository, kafkaTemplate, TEST_CLOCK, provider);
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private OutboxEvent event(String key) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("security_service.events.v1")
+                .recordKey(key)
+                .payload("{\"eventId\":\"" + key + "\"}")
+                .createdAt(NOW.minusSeconds(60))
+                .attempts(2)
+                .lastError("previous failure")
+                .build();
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    private void brokerFailsWith(Throwable failure) {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(failure));
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("marks the row published only after the broker acknowledges the send")
+    void marksPublishedAfterAcknowledgedSend() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate).send("security_service.events.v1", "k1", row.getPayload());
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        assertThat(row.getAttempts()).isZero();
+        assertThat(row.getLastError()).isNull();
+        verify(repository).save(row);
+        assertThat(counter("security.outbox.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("drains the whole batch in order while the broker keeps acknowledging")
+    void drainsWholeBatchWhenAllSendsSucceed() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(first.getPublishedAt()).isEqualTo(NOW);
+        assertThat(second.getPublishedAt()).isEqualTo(NOW);
+        assertThat(counter("security.outbox.published")).isEqualTo(2d);
+    }
+
+    @Test
+    @DisplayName("on failure: records the attempt and error, leaves the row unpublished, stops the batch")
+    void recordsFailureAndStopsBatch() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerFailsWith(new RuntimeException("broker down"));
+
+        publisher.publishPending();
+
+        assertThat(first.getPublishedAt()).isNull();
+        assertThat(first.getAttempts()).isEqualTo(3);
+        assertThat(first.getLastError()).contains("broker down");
+        verify(repository).save(first);
+
+        // The batch stops at the first failure so publish order is preserved:
+        // the second row is never attempted and keeps its prior attempt count.
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+        verify(kafkaTemplate).send("security_service.events.v1", "k1", first.getPayload());
+        assertThat(second.getAttempts()).isEqualTo(2);
+        assertThat(second.getPublishedAt()).isNull();
+        assertThat(counter("security.outbox.publish.failures")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("falls back to the exception class name when the failure carries no message")
+    void recordsClassNameWhenFailureMessageIsNull() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        // Thrown by send() itself rather than completing the future exceptionally:
+        // a failed future surfaces as an ExecutionException whose message is the
+        // cause's toString, so only a synchronous throw reaches the null-message
+        // fallback in recordFailure().
+        when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenThrow(new IllegalStateException());
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).isEqualTo("IllegalStateException");
+        assertThat(row.getPublishedAt()).isNull();
+        assertThat(row.getAttempts()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("truncates an oversized failure message to the 2000-character column bound")
+    void truncatesOversizedFailureMessage() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerFailsWith(new RuntimeException("x".repeat(2500)));
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).hasSize(2000);
+    }
+
+    @Test
+    @DisplayName("does nothing when the outbox is empty")
+    void doesNothingWhenNoPendingRows() {
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of());
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        verify(repository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        OutboxPublisher withoutMetrics = newPublisher(null);
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        withoutMetrics.publishPending();
+
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        verify(repository).save(row);
+    }
+}

--- a/pos-shared-dtos/src/main/java/com/positivity/shared/annotation/CoverageGenerated.java
+++ b/pos-shared-dtos/src/main/java/com/positivity/shared/annotation/CoverageGenerated.java
@@ -15,6 +15,5 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR })
-public @interface CoverageGenerated {
-}
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR})
+public @interface CoverageGenerated {}

--- a/pos-shared-dtos/src/test/java/com/positivity/shared/annotation/CoverageGeneratedTest.java
+++ b/pos-shared-dtos/src/test/java/com/positivity/shared/annotation/CoverageGeneratedTest.java
@@ -21,101 +21,100 @@ import org.junit.jupiter.api.Test;
 
 class CoverageGeneratedTest {
 
-  @Test
-  void exposesBytecodeVisibleCoverageMarkerForGeneratedCodeElements() throws ClassNotFoundException {
-    Class<?> annotationType = Class.forName("com.positivity.shared.annotation.CoverageGenerated");
+    @Test
+    void exposesBytecodeVisibleCoverageMarkerForGeneratedCodeElements() throws ClassNotFoundException {
+        Class<?> annotationType = Class.forName("com.positivity.shared.annotation.CoverageGenerated");
 
-    Retention retention = annotationType.getAnnotation(Retention.class);
-    Target target = annotationType.getAnnotation(Target.class);
+        Retention retention = annotationType.getAnnotation(Retention.class);
+        Target target = annotationType.getAnnotation(Target.class);
 
-    assertThat(annotationType.isAnnotation()).isTrue();
-    assertThat(retention.value()).isEqualTo(RetentionPolicy.CLASS);
-    assertThat(target.value())
-        .containsExactlyInAnyOrder(ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR);
-  }
-
-  @Test
-  void filtersAnnotatedClassCodeFromJacocoAnalysis() throws IOException {
-    CoverageBuilder coverage = analyze(TypeLevelGeneratedFixture.class);
-    IClassCoverage classCoverage = coverage.getClasses().iterator().next();
-
-    assertThat(classCoverage.getMethods()).isEmpty();
-    assertThat(classCoverage.getInstructionCounter().getTotalCount()).isZero();
-  }
-
-  @Test
-  void filtersOnlyAnnotatedMembersFromJacocoAnalysis() throws IOException {
-    CoverageBuilder coverage = analyze(MemberLevelGeneratedFixture.class);
-    IClassCoverage classCoverage = coverage.getClasses().iterator().next();
-
-    Set<String> methodNames = methodNames(classCoverage);
-
-    assertEquals(Set.of("handwrittenMethod"), methodNames);
-  }
-
-  @Test
-  void filtersLombokGeneratedMembersFromJacocoAnalysis() throws IOException {
-    CoverageBuilder coverage = analyze(LombokGeneratedFixture.class);
-    IClassCoverage classCoverage = coverage.getClasses().iterator().next();
-
-    Set<String> methodNames = methodNames(classCoverage);
-
-    assertEquals(Set.of("<init>", "handwrittenMethod"), methodNames);
-  }
-
-  private static CoverageBuilder analyze(Class<?> fixtureType) throws IOException {
-    String resourceName = fixtureType.getName().replace('.', '/') + ".class";
-    CoverageBuilder coverage = new CoverageBuilder();
-    Analyzer analyzer = new Analyzer(new ExecutionDataStore(), coverage);
-
-    try (InputStream classBytes = fixtureType.getClassLoader().getResourceAsStream(resourceName)) {
-      assertThat(classBytes).isNotNull();
-      analyzer.analyzeClass(classBytes, resourceName);
+        assertThat(annotationType.isAnnotation()).isTrue();
+        assertThat(retention.value()).isEqualTo(RetentionPolicy.CLASS);
+        assertThat(target.value())
+                .containsExactlyInAnyOrder(ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR);
     }
 
-    return coverage;
-  }
+    @Test
+    void filtersAnnotatedClassCodeFromJacocoAnalysis() throws IOException {
+        CoverageBuilder coverage = analyze(TypeLevelGeneratedFixture.class);
+        IClassCoverage classCoverage = coverage.getClasses().iterator().next();
 
-  private static Set<String> methodNames(IClassCoverage classCoverage) {
-    Set<String> methodNames = new HashSet<>();
-    classCoverage.getMethods().forEach(method -> methodNames.add(Objects.requireNonNull(method.getName())));
-    return Set.copyOf(methodNames);
-  }
-
-  @SuppressWarnings("unused")
-  @CoverageGenerated
-  private static final class TypeLevelGeneratedFixture {
-
-    String generatedMethod() {
-      return "generated";
+        assertThat(classCoverage.getMethods()).isEmpty();
+        assertThat(classCoverage.getInstructionCounter().getTotalCount()).isZero();
     }
-  }
 
-  @SuppressWarnings("unused")
-  private static final class MemberLevelGeneratedFixture {
+    @Test
+    void filtersOnlyAnnotatedMembersFromJacocoAnalysis() throws IOException {
+        CoverageBuilder coverage = analyze(MemberLevelGeneratedFixture.class);
+        IClassCoverage classCoverage = coverage.getClasses().iterator().next();
 
+        Set<String> methodNames = methodNames(classCoverage);
+
+        assertEquals(Set.of("handwrittenMethod"), methodNames);
+    }
+
+    @Test
+    void filtersLombokGeneratedMembersFromJacocoAnalysis() throws IOException {
+        CoverageBuilder coverage = analyze(LombokGeneratedFixture.class);
+        IClassCoverage classCoverage = coverage.getClasses().iterator().next();
+
+        Set<String> methodNames = methodNames(classCoverage);
+
+        assertEquals(Set.of("<init>", "handwrittenMethod"), methodNames);
+    }
+
+    private static CoverageBuilder analyze(Class<?> fixtureType) throws IOException {
+        String resourceName = fixtureType.getName().replace('.', '/') + ".class";
+        CoverageBuilder coverage = new CoverageBuilder();
+        Analyzer analyzer = new Analyzer(new ExecutionDataStore(), coverage);
+
+        try (InputStream classBytes = fixtureType.getClassLoader().getResourceAsStream(resourceName)) {
+            assertThat(classBytes).isNotNull();
+            analyzer.analyzeClass(classBytes, resourceName);
+        }
+
+        return coverage;
+    }
+
+    private static Set<String> methodNames(IClassCoverage classCoverage) {
+        Set<String> methodNames = new HashSet<>();
+        classCoverage.getMethods().forEach(method -> methodNames.add(Objects.requireNonNull(method.getName())));
+        return Set.copyOf(methodNames);
+    }
+
+    @SuppressWarnings("unused")
     @CoverageGenerated
-    MemberLevelGeneratedFixture() {
+    private static final class TypeLevelGeneratedFixture {
+
+        String generatedMethod() {
+            return "generated";
+        }
     }
 
-    @CoverageGenerated
-    String generatedMethod() {
-      return "generated";
+    @SuppressWarnings("unused")
+    private static final class MemberLevelGeneratedFixture {
+
+        @CoverageGenerated
+        MemberLevelGeneratedFixture() {}
+
+        @CoverageGenerated
+        String generatedMethod() {
+            return "generated";
+        }
+
+        String handwrittenMethod() {
+            return "handwritten";
+        }
     }
 
-    String handwrittenMethod() {
-      return "handwritten";
+    @SuppressWarnings("unused")
+    private static final class LombokGeneratedFixture {
+
+        @Getter
+        private final String generatedValue = "generated";
+
+        String handwrittenMethod() {
+            return "handwritten";
+        }
     }
-  }
-
-  @SuppressWarnings("unused")
-  private static final class LombokGeneratedFixture {
-
-    @Getter
-    private final String generatedValue = "generated";
-
-    String handwrittenMethod() {
-      return "handwritten";
-    }
-  }
 }

--- a/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/config/EventTypeInitializerTest.java
+++ b/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,123 @@
+package com.positivity.shopmanager.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(EventTypes.all().size())).header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.all()).isNotEmpty();
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+}

--- a/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/config/EventTypesTest.java
+++ b/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.shopmanager.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-tax/src/main/java/com/positivity/tax/internal/service/TaxProviderTransactionResolver.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/service/TaxProviderTransactionResolver.java
@@ -63,52 +63,51 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 class TaxProviderTransactionResolver {
 
-        private final TaxProviderTransactionRepository repository;
-        private final Clock clock;
+    private final TaxProviderTransactionRepository repository;
+    private final Clock clock;
 
-        /**
-         * Return the id of the lifecycle row for {@code referenceId}, creating it
-         * (status
-         * {@link TaxProviderTransactionStatus#PENDING_COMMIT}) if absent.
-         * Concurrent-insert safe.
-         *
-         * @param referenceId   the source document id (commit idempotency key)
-         * @param referenceType the source transaction type label (e.g.
-         *                      {@code INVOICE}); may be null
-         * @param providerName  the selected provider label
-         * @return the persisted row id
-         */
-        @NonNull
-        @Transactional
-        public UUID resolveId(@NonNull UUID referenceId, @Nullable String referenceType, @NonNull String providerName) {
-                return repository
-                                .findByReferenceId(referenceId)
-                                .map(TaxProviderTransaction::getId)
-                                .orElseGet(() -> upsert(referenceId, referenceType, providerName));
-        }
+    /**
+     * Return the id of the lifecycle row for {@code referenceId}, creating it
+     * (status
+     * {@link TaxProviderTransactionStatus#PENDING_COMMIT}) if absent.
+     * Concurrent-insert safe.
+     *
+     * @param referenceId   the source document id (commit idempotency key)
+     * @param referenceType the source transaction type label (e.g.
+     *                      {@code INVOICE}); may be null
+     * @param providerName  the selected provider label
+     * @return the persisted row id
+     */
+    @NonNull
+    @Transactional
+    public UUID resolveId(@NonNull UUID referenceId, @Nullable String referenceType, @NonNull String providerName) {
+        return repository
+                .findByReferenceId(referenceId)
+                .map(TaxProviderTransaction::getId)
+                .orElseGet(() -> upsert(referenceId, referenceType, providerName));
+    }
 
-        @NonNull
-        private UUID upsert(@NonNull UUID referenceId, @Nullable String referenceType, @NonNull String providerName) {
-                // Atomic create: inserts a fresh PENDING_COMMIT row, or no-ops on a concurrent
-                // winner's
-                // UNIQUE(reference_id) collision — never throws, never poisons this
-                // transaction. The id
-                // is generated in Java (ADR-0013 UUID v7); it is discarded on conflict.
-                repository.insertIfAbsent(
-                                UUIDv7Generator.generate(),
-                                referenceId,
-                                referenceType,
-                                providerName,
-                                TaxProviderTransactionStatus.PENDING_COMMIT.name(),
-                                Instant.now(clock));
-                // Unconditional re-read returns the winning row id whether we inserted it or
-                // adopted the
-                // concurrent winner's.
-                return repository
-                                .findByReferenceId(referenceId)
-                                .map(TaxProviderTransaction::getId)
-                                .orElseThrow(() -> new IllegalStateException(
-                                                "tax_provider_transaction row missing after upsert for reference "
-                                                                + referenceId));
-        }
+    @NonNull
+    private UUID upsert(@NonNull UUID referenceId, @Nullable String referenceType, @NonNull String providerName) {
+        // Atomic create: inserts a fresh PENDING_COMMIT row, or no-ops on a concurrent
+        // winner's
+        // UNIQUE(reference_id) collision — never throws, never poisons this
+        // transaction. The id
+        // is generated in Java (ADR-0013 UUID v7); it is discarded on conflict.
+        repository.insertIfAbsent(
+                UUIDv7Generator.generate(),
+                referenceId,
+                referenceType,
+                providerName,
+                TaxProviderTransactionStatus.PENDING_COMMIT.name(),
+                Instant.now(clock));
+        // Unconditional re-read returns the winning row id whether we inserted it or
+        // adopted the
+        // concurrent winner's.
+        return repository
+                .findByReferenceId(referenceId)
+                .map(TaxProviderTransaction::getId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "tax_provider_transaction row missing after upsert for reference " + referenceId));
+    }
 }

--- a/pos-tax/src/test/java/com/positivity/tax/internal/config/EventTypeInitializerTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,123 @@
+package com.positivity.tax.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(EventTypes.all().size())).header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.all()).isNotEmpty();
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+}

--- a/pos-tax/src/test/java/com/positivity/tax/internal/config/EventTypesTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.tax.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-tax/src/test/java/com/positivity/tax/internal/service/TaxProviderLifecycleServiceTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/internal/service/TaxProviderLifecycleServiceTest.java
@@ -38,16 +38,17 @@ import org.springframework.test.context.ActiveProfiles;
  * {@code V2__tax_provider_transaction.sql}
  * migration and Hibernate schema validation.
  */
-@DataJpaTest(properties = {
-        "spring.datasource.url=jdbc:h2:mem:pos_tax_lifecycle;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
-        "spring.datasource.driver-class-name=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.datasource.password=",
-        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
-        "spring.jpa.hibernate.ddl-auto=validate",
-        "spring.flyway.enabled=true",
-        "spring.flyway.locations=classpath:db/migration"
-})
+@DataJpaTest(
+        properties = {
+            "spring.datasource.url=jdbc:h2:mem:pos_tax_lifecycle;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+            "spring.datasource.driver-class-name=org.h2.Driver",
+            "spring.datasource.username=sa",
+            "spring.datasource.password=",
+            "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+            "spring.jpa.hibernate.ddl-auto=validate",
+            "spring.flyway.enabled=true",
+            "spring.flyway.locations=classpath:db/migration"
+        })
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
 class TaxProviderLifecycleServiceTest {

--- a/pos-tax/src/test/java/com/positivity/tax/internal/service/TaxProviderTransactionResolverPersistenceTest.java
+++ b/pos-tax/src/test/java/com/positivity/tax/internal/service/TaxProviderTransactionResolverPersistenceTest.java
@@ -15,9 +15,9 @@ import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
@@ -53,18 +53,19 @@ import org.springframework.test.context.ActiveProfiles;
  * "Unit Tests (pos-tax)" CI job whose multi-minute hang motivated the resolver
  * rework.
  */
-@DataJpaTest(properties = {
-        "spring.datasource.url=jdbc:h2:mem:pos_tax_resolver;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
-        "spring.datasource.driver-class-name=org.h2.Driver",
-        "spring.datasource.username=sa",
-        "spring.datasource.password=",
-        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
-        "spring.jpa.hibernate.ddl-auto=validate",
-        "spring.flyway.enabled=true",
-        "spring.flyway.locations=classpath:db/migration"
-})
+@DataJpaTest(
+        properties = {
+            "spring.datasource.url=jdbc:h2:mem:pos_tax_resolver;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+            "spring.datasource.driver-class-name=org.h2.Driver",
+            "spring.datasource.username=sa",
+            "spring.datasource.password=",
+            "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+            "spring.jpa.hibernate.ddl-auto=validate",
+            "spring.flyway.enabled=true",
+            "spring.flyway.locations=classpath:db/migration"
+        })
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({ TaxProviderTransactionResolver.class, TaxProviderTransactionResolverPersistenceTest.TestClockConfig.class })
+@Import({TaxProviderTransactionResolver.class, TaxProviderTransactionResolverPersistenceTest.TestClockConfig.class})
 @ActiveProfiles("test")
 class TaxProviderTransactionResolverPersistenceTest {
 

--- a/pos-vehicle-fitment/src/test/java/com/positivity/vehiclefitment/internal/config/EventTypeInitializerTest.java
+++ b/pos-vehicle-fitment/src/test/java/com/positivity/vehiclefitment/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,123 @@
+package com.positivity.vehiclefitment.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(EventTypes.all().size())).header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.all()).isNotEmpty();
+        verify(restClient, times(EventTypes.all().size())).put();
+    }
+}

--- a/pos-vehicle-fitment/src/test/java/com/positivity/vehiclefitment/internal/config/EventTypesTest.java
+++ b/pos-vehicle-fitment/src/test/java/com/positivity/vehiclefitment/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.vehiclefitment.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/service/VehicleLegacyServiceImpl.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/service/VehicleLegacyServiceImpl.java
@@ -27,8 +27,8 @@ public class VehicleLegacyServiceImpl implements VehicleLegacyService {
 
     private static final int MIN_MODEL_YEAR = 1886;
     private static final int FUTURE_YEAR_BUFFER = 1;
-    private static final Set<String> ALLOWED_VEHICLE_TYPES = Set.of("CAR", "VAN", "COMMERCIAL_TRUCK", "PASSENGER_TRUCK",
-            "TRUCK");
+    private static final Set<String> ALLOWED_VEHICLE_TYPES =
+            Set.of("CAR", "VAN", "COMMERCIAL_TRUCK", "PASSENGER_TRUCK", "TRUCK");
 
     private final VehicleDao vehicleDao;
     private final Clock clock;

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/EventTypeInitializerTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,134 @@
+package com.positivity.vehicle.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    /** Upper bound for awaiting the registration virtual thread. */
+    private static final long AWAIT_MS = 5_000L;
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, timeout(AWAIT_MS).times(EventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, timeout(AWAIT_MS).times(EventTypes.all().size()))
+                .header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        // Await the async registration first, then assert the header was absent.
+        verify(restClient, timeout(AWAIT_MS).times(EventTypes.all().size())).put();
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() contains registration failures on the worker thread and still attempts every type")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        // run() returns before the virtual thread does any work, so "did not throw"
+        // proves nothing on its own. Await the registrations and assert every type
+        // was still attempted despite each one failing.
+        verify(restClient, timeout(AWAIT_MS).times(EventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.all()).isNotEmpty();
+        verify(restClient, timeout(AWAIT_MS).times(EventTypes.all().size())).put();
+    }
+}

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/EventTypesTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.vehicle.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/ManifestPublisherTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/ManifestPublisherTest.java
@@ -1,0 +1,366 @@
+package com.positivity.vehicle.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.vehicle.internal.entity.OutboxEvent;
+import com.positivity.vehicle.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for the pos-vehicle-inventory {@link ManifestPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * Each closed window gets one reconciliation manifest summarizing the events
+ * published from the outbox in that window; consumers recompute the same summary
+ * and request a replay on drift. The properties that matter:
+ *
+ * <ul>
+ * <li>Window membership is decided by the <em>eventId</em> (UUIDv7) timestamp,
+ * not by {@code createdAt}. The query pads its range by a second of slack, so a
+ * row can be fetched and still belong to a neighbouring window; counting it in
+ * the wrong one would manufacture drift on both sides.</li>
+ * <li>Empty windows still publish, so consumers can alert on manifest absence
+ * rather than treating silence as health.</li>
+ * <li>A malformed row is skipped with a warning instead of failing the window
+ * forever — one bad payload must not permanently block reconciliation.</li>
+ * <li>A failed send leaves the window unadvanced so the next run retries it, and
+ * catch-up is bounded per run so a long outage cannot monopolize a poll.</li>
+ * </ul>
+ */
+@DisplayName("pos-vehicle-inventory ManifestPublisher — reconciliation manifest windows")
+class ManifestPublisherTest {
+
+    /** 12:10 UTC: the [11:00, 12:00) window closed more than the 5m grace ago. */
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-07-08T12:10:00Z"), ZoneOffset.UTC);
+
+    private static final Instant WINDOW_START = Instant.parse("2026-07-08T11:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-07-08T12:00:00Z");
+    private static final String EVENTS_TOPIC = "vehicle.events.v1";
+    private static final String MANIFEST_TOPIC = "vehicle.manifest.v1";
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private SimpleMeterRegistry meterRegistry;
+    private ManifestPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry, TEST_CLOCK);
+        brokerAcknowledges();
+    }
+
+    @SuppressWarnings("unchecked")
+    private ManifestPublisher newPublisher(MeterRegistry registry, Clock clock) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        ManifestPublisher created = new ManifestPublisher(repository, kafkaTemplate, objectMapper, clock, provider);
+        ReflectionTestUtils.setField(created, "eventsTopic", EVENTS_TOPIC);
+        ReflectionTestUtils.setField(created, "manifestTopic", MANIFEST_TOPIC);
+        ReflectionTestUtils.setField(created, "window", Duration.ofHours(1));
+        ReflectionTestUtils.setField(created, "grace", Duration.ofMinutes(5));
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    /** UUIDv7-shaped id whose embedded timestamp is {@code at}. */
+    private static String eventIdAt(Instant at, int suffix) {
+        long millis = at.toEpochMilli();
+        return String.format("%08x-%04x-7000-8000-%012x", millis >>> 16, millis & 0xFFFF, suffix);
+    }
+
+    private static OutboxEvent row(String eventId, String eventType, Instant createdAt) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey(eventId)
+                .payload("{\"eventId\":\"" + eventId + "\",\"eventType\":\"" + eventType + "\",\"payload\":{}}")
+                .createdAt(createdAt)
+                .publishedAt(createdAt.plusSeconds(1))
+                .build();
+    }
+
+    private void outboxReturns(List<OutboxEvent> rows) {
+        when(repository.findByTopicAndPublishedAtIsNotNullAndCreatedAtBetween(anyString(), any(), any()))
+                .thenReturn(rows);
+    }
+
+    private JsonNode capturedManifest() {
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), json.capture());
+        return objectMapper.readTree(json.getValue());
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("publishes the latest closed window with its count, checksum, and per-type counts")
+    void publishesManifestForClosedWindow() {
+        String inWindow1 = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String inWindow2 = eventIdAt(WINDOW_START.plusSeconds(120), 2);
+        outboxReturns(List.of(
+                row(inWindow1, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(inWindow2, "SomethingElseChanged", WINDOW_START.plusSeconds(120))));
+
+        publisher.publishDueManifest();
+
+        JsonNode envelope = capturedManifest();
+        assertThat(envelope.path("sourceService").stringValue()).isEqualTo("pos-vehicle-inventory");
+        assertThat(envelope.path("eventType").stringValue())
+                .isEqualTo(ReconciliationManifestV1.eventTypeFor("vehicle"));
+
+        JsonNode manifest = envelope.path("payload");
+        assertThat(manifest.path("windowStartUtc").stringValue()).isEqualTo(WINDOW_START.toString());
+        assertThat(manifest.path("windowEndUtc").stringValue()).isEqualTo(WINDOW_END.toString());
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(2);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow1, inWindow2)));
+        assertThat(manifest.path("eventTypeCounts").path("SomethingChanged").longValue())
+                .isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("SomethingElseChanged").longValue())
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row fetched by createdAt slack whose eventId falls outside the window")
+    void excludesRowOutsideWindowByEventIdTimestamp() {
+        String inWindow = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        String justBefore = eventIdAt(WINDOW_START.minusMillis(1), 2);
+        String justAfter = eventIdAt(WINDOW_END.plusMillis(1), 3);
+        outboxReturns(List.of(
+                row(justBefore, "SomethingChanged", WINDOW_START.minusMillis(1)),
+                row(inWindow, "SomethingChanged", WINDOW_START.plusSeconds(60)),
+                row(justAfter, "SomethingChanged", WINDOW_END.plusMillis(1))));
+
+        publisher.publishDueManifest();
+
+        // Membership is decided by the eventId timestamp, not the padded createdAt
+        // query: counting a neighbour here would manufacture drift on both sides.
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of(inWindow)));
+    }
+
+    @Test
+    @DisplayName("publishes a zero-count manifest so consumers can alert on absence rather than silence")
+    void publishesEmptyWindowManifest() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isZero();
+        assertThat(manifest.path("eventIdsChecksum").stringValue())
+                .isEqualTo(ReconciliationManifestV1.checksumOf(List.of()));
+    }
+
+    @Test
+    @DisplayName("counts a row with a blank event type under \"unknown\" rather than dropping it")
+    void blankEventTypeCountedAsUnknown() {
+        String eventId = eventIdAt(WINDOW_START.plusSeconds(60), 1);
+        outboxReturns(List.of(row(eventId, "", WINDOW_START.plusSeconds(60))));
+
+        publisher.publishDueManifest();
+
+        JsonNode manifest = capturedManifest().path("payload");
+        assertThat(manifest.path("eventCount").longValue()).isEqualTo(1);
+        assertThat(manifest.path("eventTypeCounts").path("unknown").longValue()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("excludes a row with no eventId instead of failing the window")
+    void skipsRowWithoutEventId() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("{\"eventType\":\"PartyChanged\"}")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("excludes a row whose payload will not parse instead of blocking reconciliation forever")
+    void skipsRowWithUnparsablePayload() {
+        OutboxEvent broken = OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic(EVENTS_TOPIC)
+                .recordKey("k")
+                .payload("not json at all")
+                .createdAt(WINDOW_START.plusSeconds(30))
+                .publishedAt(WINDOW_START.plusSeconds(31))
+                .build();
+        outboxReturns(List.of(broken));
+
+        publisher.publishDueManifest();
+
+        assertThat(capturedManifest().path("payload").path("eventCount").longValue())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("does not re-publish a window it already published")
+    void skipsAlreadyPublishedWindow() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("waits out the grace period, publishing the previous window until the latest one settles")
+    void respectsGracePeriod() {
+        ReflectionTestUtils.setField(publisher, "grace", Duration.ofMinutes(15));
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        // 12:10 with 15m grace: [11:00, 12:00) is not yet eligible, so the
+        // published window is the previous one.
+        assertThat(capturedManifest().path("payload").path("windowEndUtc").stringValue())
+                .isEqualTo("2026-07-08T11:00:00Z");
+    }
+
+    @Test
+    @DisplayName("retries the same window on the next run when the send fails")
+    void retriesWindowAfterSendFailure() {
+        outboxReturns(List.of());
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker down")))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        publisher.publishDueManifest();
+        publisher.publishDueManifest();
+
+        // The window must not advance past a failure, or its manifest is lost.
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(counter("vehicle.manifest.publish.failures")).isEqualTo(1d);
+        assertThat(counter("vehicle.manifest.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("counts a successful publish")
+    void countsSuccessfulPublish() {
+        outboxReturns(List.of());
+
+        publisher.publishDueManifest();
+
+        assertThat(counter("vehicle.manifest.published")).isEqualTo(1d);
+        assertThat(counter("vehicle.manifest.publish.failures")).isZero();
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        ManifestPublisher withoutMetrics = newPublisher(null, TEST_CLOCK);
+        outboxReturns(List.of());
+
+        withoutMetrics.publishDueManifest();
+
+        verify(kafkaTemplate).send(eq(MANIFEST_TOPIC), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("publishes nothing when no window has closed yet")
+    void publishesNothingBeforeTheFirstWindowCloses() {
+        // Epoch + 30m with a 1h window: no aligned window boundary has passed.
+        ManifestPublisher early = newPublisher(meterRegistry, Clock.fixed(Instant.ofEpochSecond(1800), ZoneOffset.UTC));
+
+        early.publishDueManifest();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("keys every manifest for a window deterministically, so re-publishes land on one partition")
+    void manifestRecordKeyIsStablePerWindow() {
+        outboxReturns(List.of());
+        ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+
+        publisher.publishDueManifest();
+        // A second publisher instance, same window: the key must match.
+        ManifestPublisher other = newPublisher(meterRegistry, TEST_CLOCK);
+        other.publishDueManifest();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), key.capture(), anyString());
+        assertThat(key.getAllValues()).hasSize(2);
+        assertThat(key.getAllValues().get(0)).isEqualTo(key.getAllValues().get(1));
+    }
+
+    @Test
+    @DisplayName("after a gap, catches up window by window rather than skipping to the newest")
+    void catchesUpWindowByWindow() {
+        outboxReturns(List.of());
+
+        // First run establishes [11:00, 12:00) as published.
+        publisher.publishDueManifest();
+
+        // Three hours later four windows have closed; the next run must publish the
+        // intervening ones, not jump to the newest and leave holes.
+        ManifestPublisher later = publisher;
+        ReflectionTestUtils.setField(
+                later, "clock", Clock.fixed(Instant.parse("2026-07-08T15:10:00Z"), ZoneOffset.UTC));
+        later.publishDueManifest();
+
+        ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate, times(4)).send(anyString(), anyString(), json.capture());
+        assertThat(json.getAllValues())
+                .map(value -> objectMapper
+                        .readTree(value)
+                        .path("payload")
+                        .path("windowEndUtc")
+                        .stringValue())
+                .containsExactly(
+                        "2026-07-08T12:00:00Z", "2026-07-08T13:00:00Z", "2026-07-08T14:00:00Z", "2026-07-08T15:00:00Z");
+    }
+}

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/OutboxPublisherTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/config/OutboxPublisherTest.java
@@ -1,0 +1,213 @@
+package com.positivity.vehicle.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.vehicle.internal.entity.OutboxEvent;
+import com.positivity.vehicle.internal.repository.OutboxEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for the pos-vehicle-inventory {@link OutboxPublisher} (ADR-0044 §4).
+ *
+ * <p>
+ * The publisher drains {@code event_outbox} to Kafka with at-least-once
+ * semantics. Three properties carry the correctness weight:
+ *
+ * <ul>
+ * <li>a row is marked published <em>only</em> after the broker acknowledges, so
+ * a crash mid-send re-sends rather than silently dropping the event;</li>
+ * <li>the batch stops at the first failure, so a struggling broker cannot
+ * reorder events past a stuck row; and</li>
+ * <li>the failure path records {@code attempts} and a bounded
+ * {@code last_error} for alerting instead of throwing out of the scheduled
+ * method.</li>
+ * </ul>
+ */
+@DisplayName("pos-vehicle-inventory OutboxPublisher — outbox drain contract")
+class OutboxPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-08T12:00:00Z");
+    private static final Clock TEST_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    private final OutboxEventRepository repository = mock(OutboxEventRepository.class);
+
+    @SuppressWarnings("unchecked")
+    private final KafkaTemplate<String, String> kafkaTemplate = mock(KafkaTemplate.class);
+
+    private SimpleMeterRegistry meterRegistry;
+    private OutboxPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        publisher = newPublisher(meterRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    private OutboxPublisher newPublisher(MeterRegistry registry) {
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        OutboxPublisher created = new OutboxPublisher(repository, kafkaTemplate, TEST_CLOCK, provider);
+        ReflectionTestUtils.setField(created, "sendTimeoutMs", 1000L);
+        return created;
+    }
+
+    private OutboxEvent event(String key) {
+        return OutboxEvent.builder()
+                .id(UUID.randomUUID())
+                .topic("vehicle_inventory.events.v1")
+                .recordKey(key)
+                .payload("{\"eventId\":\"" + key + "\"}")
+                .createdAt(NOW.minusSeconds(60))
+                .attempts(2)
+                .lastError("previous failure")
+                .build();
+    }
+
+    private void brokerAcknowledges() {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+    }
+
+    private void brokerFailsWith(Throwable failure) {
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(failure));
+    }
+
+    private double counter(String name) {
+        var found = meterRegistry.find(name).counter();
+        return found == null ? 0d : found.count();
+    }
+
+    @Test
+    @DisplayName("marks the row published only after the broker acknowledges the send")
+    void marksPublishedAfterAcknowledgedSend() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate).send("vehicle_inventory.events.v1", "k1", row.getPayload());
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        assertThat(row.getAttempts()).isZero();
+        assertThat(row.getLastError()).isNull();
+        verify(repository).save(row);
+        assertThat(counter("vehicle.outbox.published")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("drains the whole batch in order while the broker keeps acknowledging")
+    void drainsWholeBatchWhenAllSendsSucceed() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerAcknowledges();
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, times(2)).send(anyString(), anyString(), anyString());
+        assertThat(first.getPublishedAt()).isEqualTo(NOW);
+        assertThat(second.getPublishedAt()).isEqualTo(NOW);
+        assertThat(counter("vehicle.outbox.published")).isEqualTo(2d);
+    }
+
+    @Test
+    @DisplayName("on failure: records the attempt and error, leaves the row unpublished, stops the batch")
+    void recordsFailureAndStopsBatch() {
+        OutboxEvent first = event("k1");
+        OutboxEvent second = event("k2");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(first, second));
+        brokerFailsWith(new RuntimeException("broker down"));
+
+        publisher.publishPending();
+
+        assertThat(first.getPublishedAt()).isNull();
+        assertThat(first.getAttempts()).isEqualTo(3);
+        assertThat(first.getLastError()).contains("broker down");
+        verify(repository).save(first);
+
+        // The batch stops at the first failure so publish order is preserved:
+        // the second row is never attempted and keeps its prior attempt count.
+        verify(kafkaTemplate, times(1)).send(anyString(), anyString(), anyString());
+        verify(kafkaTemplate).send("vehicle_inventory.events.v1", "k1", first.getPayload());
+        assertThat(second.getAttempts()).isEqualTo(2);
+        assertThat(second.getPublishedAt()).isNull();
+        assertThat(counter("vehicle.outbox.publish.failures")).isEqualTo(1d);
+    }
+
+    @Test
+    @DisplayName("falls back to the exception class name when the failure carries no message")
+    void recordsClassNameWhenFailureMessageIsNull() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        // Thrown by send() itself rather than completing the future exceptionally:
+        // a failed future surfaces as an ExecutionException whose message is the
+        // cause's toString, so only a synchronous throw reaches the null-message
+        // fallback in recordFailure().
+        when(kafkaTemplate.send(anyString(), anyString(), anyString())).thenThrow(new IllegalStateException());
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).isEqualTo("IllegalStateException");
+        assertThat(row.getPublishedAt()).isNull();
+        assertThat(row.getAttempts()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("truncates an oversized failure message to the 2000-character column bound")
+    void truncatesOversizedFailureMessage() {
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerFailsWith(new RuntimeException("x".repeat(2500)));
+
+        publisher.publishPending();
+
+        assertThat(row.getLastError()).hasSize(2000);
+    }
+
+    @Test
+    @DisplayName("does nothing when the outbox is empty")
+    void doesNothingWhenNoPendingRows() {
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of());
+
+        publisher.publishPending();
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        verify(repository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("publishes normally when no MeterRegistry is available")
+    void publishesWithoutMeterRegistry() {
+        OutboxPublisher withoutMetrics = newPublisher(null);
+        OutboxEvent row = event("k1");
+        when(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).thenReturn(List.of(row));
+        brokerAcknowledges();
+
+        withoutMetrics.publishPending();
+
+        assertThat(row.getPublishedAt()).isEqualTo(NOW);
+        verify(repository).save(row);
+    }
+}

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/service/EligibilityServiceImpl.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/service/EligibilityServiceImpl.java
@@ -93,7 +93,8 @@ public class EligibilityServiceImpl implements EligibilityService {
         if (saleDate == null) {
             reasons.add(reason("originSaleDate", "known original sale date", null, null));
         } else {
-            CoverageType coverageType = CoverageType.valueOf(claim.getClaimType().name());
+            CoverageType coverageType =
+                    CoverageType.valueOf(claim.getClaimType().name());
             List<WarrantyPolicy> effective = policyRepository.findEffectiveOn(saleDate).stream()
                     .filter(p -> p.getCoverageType() == coverageType)
                     .toList();
@@ -402,8 +403,8 @@ public class EligibilityServiceImpl implements EligibilityService {
             // in the replica leaves manufacturer/category facts incomplete — the
             // eligibility scope
             // matcher treats that as it did a failed CatalogClient read.
-            Optional<ExtCatalogReplica> product = cache.computeIfAbsent(productEntityId,
-                    extCatalogReplicaRepository::findById);
+            Optional<ExtCatalogReplica> product =
+                    cache.computeIfAbsent(productEntityId, extCatalogReplicaRepository::findById);
             if (product.isPresent()) {
                 if (product.get().getManufacturerId() != null) {
                     manufacturerIds.add(product.get().getManufacturerId());
@@ -475,6 +476,5 @@ public class EligibilityServiceImpl implements EligibilityService {
      * lookup failed.
      */
     private record ProductFacts(
-            Set<UUID> productIds, Set<UUID> manufacturerIds, Set<UUID> categoryIds, boolean incomplete) {
-    }
+            Set<UUID> productIds, Set<UUID> manufacturerIds, Set<UUID> categoryIds, boolean incomplete) {}
 }

--- a/pos-warranty/src/test/java/com/positivity/warranty/internal/config/WarrantyEventTypeInitializerTest.java
+++ b/pos-warranty/src/test/java/com/positivity/warranty/internal/config/WarrantyEventTypeInitializerTest.java
@@ -1,0 +1,125 @@
+package com.positivity.warranty.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link WarrantyEventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link WarrantyEventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WarrantyEventTypeInitializer — startup event-type registration")
+class WarrantyEventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private WarrantyEventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new WarrantyEventTypeInitializer(restClientBuilder, BASE_URL, "");
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(WarrantyEventTypes.all().size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        WarrantyEventTypeInitializer sutWithSecret =
+                new WarrantyEventTypeInitializer(restClientBuilder, BASE_URL, secret);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(WarrantyEventTypes.all().size()))
+                .header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(WarrantyEventTypes.all()).isNotEmpty();
+        verify(restClient, times(WarrantyEventTypes.all().size())).put();
+    }
+}

--- a/pos-warranty/src/test/java/com/positivity/warranty/internal/config/WarrantyEventTypesTest.java
+++ b/pos-warranty/src/test/java/com/positivity/warranty/internal/config/WarrantyEventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.warranty.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link WarrantyEventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
  * descriptions, ordered thresholds, and a threshold triple that matches a
  * declared preset rather than an ad-hoc value.
  */
-@DisplayName("EventTypes — event-type registry contract")
-class EventTypesTest {
+@DisplayName("WarrantyEventTypes — event-type registry contract")
+class WarrantyEventTypesTest {
 
     /**
      * Event type codes are upper snake case: the receiver stores them verbatim as
@@ -58,7 +58,7 @@ class EventTypesTest {
     }
 
     private static List<EventTypeRegistration> registrations() {
-        return EventTypes.all();
+        return WarrantyEventTypes.all();
     }
 
     @Test
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }

--- a/pos-warranty/src/test/java/com/positivity/warranty/internal/service/EligibilityServiceImplTest.java
+++ b/pos-warranty/src/test/java/com/positivity/warranty/internal/service/EligibilityServiceImplTest.java
@@ -50,546 +50,543 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class EligibilityServiceImplTest {
 
-        private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-06-15T10:15:30Z"), ZoneOffset.UTC);
-
-        private static final UUID CLAIM_ID = UUID.fromString("018f0000-0000-7000-8000-000000000001");
-        private static final UUID LINE_ID = UUID.fromString("018f0000-0000-7000-8000-000000000002");
-        private static final UUID PRODUCT_ID = UUID.fromString("018f0000-0000-7000-8000-000000000003");
-        private static final UUID MANUFACTURER_ID = UUID.fromString("018f0000-0000-7000-8000-000000000004");
-        private static final UUID CATEGORY_ID = UUID.fromString("018f0000-0000-7000-8000-000000000007");
-        private static final UUID PROVIDER_ID = UUID.fromString("018f0000-0000-7000-8000-000000000005");
-        private static final UUID CUSTOMER_ID = UUID.fromString("018f0000-0000-7000-8000-000000000006");
-        private static final LocalDate SALE_DATE = LocalDate.of(2026, java.time.Month.JANUARY, 10);
-        private static final LocalDate FAILURE_DATE = LocalDate.of(2026, java.time.Month.JUNE, 1);
-
-        @Mock
-        private WarrantyClaimRepository claimRepository;
-
-        @Mock
-        private WarrantyPolicyRepository policyRepository;
-
-        @Mock
-        private WarrantyRegistrationRepository registrationRepository;
-
-        @Mock
-        private ExtCatalogReplicaRepository extCatalogReplicaRepository;
-
-        private EligibilityServiceImpl service;
-
-        @BeforeEach
-        void setUp() {
-                service = new EligibilityServiceImpl(
-                                claimRepository,
-                                policyRepository,
-                                registrationRepository,
-                                extCatalogReplicaRepository,
-                                new ProrationService(),
-                                FIXED_CLOCK);
-        }
-
-        // -----------------------------------------------------------------------------------------
-        // Fixtures
-        // -----------------------------------------------------------------------------------------
-
-        private static WarrantyClaim claim(ClaimType claimType) {
-                WarrantyClaim claim = WarrantyClaim.builder()
-                                .id(CLAIM_ID)
-                                .claimCode("WC-2026-000001")
-                                .claimType(claimType)
-                                .customerId(CUSTOMER_ID)
-                                .originSaleDate(SALE_DATE)
-                                .failureDate(FAILURE_DATE)
-                                .originUnverified(false)
-                                .build();
-                WarrantyClaimLine line = WarrantyClaimLine.builder()
-                                .id(LINE_ID)
-                                .productEntityId(PRODUCT_ID)
-                                .originalUnitPrice(new BigDecimal("100.00"))
-                                .quantity(BigDecimal.ONE)
-                                .originalTreadDepth(10)
-                                .measuredTreadDepth(6)
-                                .build();
-                claim.addLine(line);
-                return claim;
-        }
-
-        private static WarrantyPolicy manufacturerTreadPolicy() {
-                return WarrantyPolicy.builder()
-                                .id(UUID.fromString("018f0000-0000-7000-8000-000000000010"))
-                                .providerId(PROVIDER_ID)
-                                .name("Michelin passenger replacement")
-                                .coverageType(CoverageType.MANUFACTURER_DEFECT)
-                                .appliesToType(AppliesToType.MANUFACTURER)
-                                .appliesToManufacturerId(MANUFACTURER_ID)
-                                .effectiveFrom(LocalDate.of(2025, java.time.Month.JANUARY, 1))
-                                .durationMonths(24)
-                                .treadPullPointThirtySeconds(2)
-                                .prorationMethod(ProrationMethod.TREAD_DEPTH)
-                                .build();
-        }
-
-        private static WarrantyPolicy allFreeReplacementPolicy(String name, UUID id) {
-                return WarrantyPolicy.builder()
-                                .id(id)
-                                .providerId(PROVIDER_ID)
-                                .name(name)
-                                .coverageType(CoverageType.MANUFACTURER_DEFECT)
-                                .appliesToType(AppliesToType.ALL)
-                                .effectiveFrom(LocalDate.of(2025, java.time.Month.JANUARY, 1))
-                                .prorationMethod(ProrationMethod.NONE)
-                                .build();
-        }
-
-        private static ExtCatalogReplica product() {
-                return ExtCatalogReplica.builder()
-                                .productId(PRODUCT_ID)
-                                .sku("TIRE-1")
-                                .name("SuperTire 225")
-                                .manufacturerId(MANUFACTURER_ID)
-                                .manufacturerName("Michelin")
-                                .manufacturerBrand("Michelin")
-                                .categoryId(CATEGORY_ID)
-                                .category("Tires")
-                                .active(true)
-                                .aggregateVersion(1L)
-                                .updatedAt(java.time.Instant.EPOCH)
-                                .build();
-        }
-
-        private void stubClaim(WarrantyClaim claim) {
-                when(claimRepository.findById(CLAIM_ID)).thenReturn(Optional.of(claim));
-                when(claimRepository.save(any(WarrantyClaim.class))).thenAnswer(inv -> inv.getArgument(0));
-        }
-
-        // -----------------------------------------------------------------------------------------
-        // Tests
-        // -----------------------------------------------------------------------------------------
-
-        @Test
-        void eligibleClaim_persistsResultProrationAndCoverageSelection() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                WarrantyPolicy policy = manufacturerTreadPolicy();
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(policy));
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.ELIGIBLE);
-                // persisted onto the claim
-                assertThat(claim.getEligibilityResult()).isEqualTo(EligibilityResult.ELIGIBLE);
-                assertThat(claim.getEligibilityReasons()).isEqualTo(evaluation.reasons());
-                assertThat(claim.getSuggestedOutcome()).isEqualTo(evaluation.suggestedOutcome());
-                // single winner selected onto the claim
-                assertThat(claim.getPolicyId()).isEqualTo(policy.getId());
-                assertThat(claim.getProviderId()).isEqualTo(PROVIDER_ID);
-                // per-line proration persisted: (6-2)/(10-2) = 0.5
-                WarrantyClaimLine line = claim.getLines().get(0);
-                assertThat(line.getProrationPct()).isEqualByComparingTo("0.5");
-                assertThat(line.getAmountRequested()).isEqualByComparingTo("50.00");
-                assertThat(line.getProrationInputs()).containsEntry("method", "TREAD_DEPTH");
-                // suggested outcome
-                Map<String, Object> suggested = evaluation.suggestedOutcome();
-                assertThat(suggested)
-                                .containsEntry("eligible", true)
-                                .containsEntry("policyId", policy.getId().toString())
-                                .containsEntry("providerId", PROVIDER_ID.toString())
-                                .containsEntry("settlementType", "PRORATED_CREDIT");
-                assertThat((BigDecimal) suggested.get("totalRequested")).isEqualByComparingTo("50.00");
-                @SuppressWarnings("unchecked")
-                List<Map<String, Object>> perLine = (List<Map<String, Object>>) suggested.get("perLine");
-                assertThat(perLine).hasSize(1);
-                assertThat(perLine.get(0)).containsEntry("claimLineId", LINE_ID.toString());
-                verify(claimRepository).save(claim);
-                // every reason map carries the {term, required, actual, pass} shape
-                assertThat(evaluation.reasons())
-                                .allSatisfy(reason -> assertThat(reason).containsKeys("term", "required", "actual",
-                                                "pass"));
-        }
-
-        @Test
-        void treadBelowPullPoint_isIneligibleWithFailingReason() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                claim.getLines().get(0).setMeasuredTreadDepth(2); // not > pull point 2
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(manufacturerTreadPolicy()));
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.INELIGIBLE);
-                assertThat(evaluation.reasons())
-                                .anySatisfy(reason -> assertThat(reason).containsEntry("term", "treadDepth")
-                                                .containsEntry("pass", false));
-                assertThat(evaluation.suggestedOutcome()).containsEntry("eligible", false);
-        }
-
-        @Test
-        void missingTreadMeasurement_isIndeterminate() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                claim.getLines().get(0).setMeasuredTreadDepth(null);
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(manufacturerTreadPolicy()));
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
-                assertThat(evaluation.reasons())
-                                .anySatisfy(reason -> assertThat(reason).containsEntry("term", "treadDepth")
-                                                .containsEntry("indeterminate", true));
-        }
-
-        @Test
-        void expiredDuration_isIneligible() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                claim.setFailureDate(SALE_DATE.plusMonths(30)); // past 24-month duration
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(manufacturerTreadPolicy()));
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.INELIGIBLE);
-                assertThat(evaluation.reasons())
-                                .anySatisfy(reason -> assertThat(reason).containsEntry("term", "duration")
-                                                .containsEntry("pass", false));
-        }
-
-        @Test
-        void mileageLimitWithUnknownSaleOdometer_isIndeterminate() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                claim.setOdometerAtClaim(42000L);
-                WarrantyPolicy policy = manufacturerTreadPolicy();
-                policy.setMileageLimit(40000);
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(policy));
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
-                assertThat(evaluation.reasons())
-                                .anySatisfy(reason -> assertThat(reason).containsEntry("term", "mileage")
-                                                .containsEntry("indeterminate", true));
-        }
-
-        @Test
-        void noMatchingPolicy_isIneligible() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of());
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.INELIGIBLE);
-                assertThat(claim.getPolicyId()).isNull();
-                assertThat(evaluation.suggestedOutcome()).containsEntry("policyId", null);
-                assertThat(evaluation.suggestedOutcome()).containsEntry("settlementType", null);
-        }
-
-        @Test
-        void rerunWithoutMatchingPolicy_clearsPreviouslySelectedCoverageAndProration() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE))
-                                .thenReturn(List.of(manufacturerTreadPolicy()))
-                                .thenReturn(List.of()); // second run: nothing matches (e.g. claimType corrected)
-
-                service.evaluate(CLAIM_ID);
-                assertThat(claim.getPolicyId()).isNotNull();
-                assertThat(claim.getLines().get(0).getProrationPct()).isNotNull();
-
-                EligibilityEvaluation rerun = service.evaluate(CLAIM_ID);
-
-                assertThat(rerun.result()).isEqualTo(EligibilityResult.INELIGIBLE);
-                assertThat(claim.getPolicyId()).isNull();
-                assertThat(claim.getProviderId()).isNull();
-                WarrantyClaimLine line = claim.getLines().get(0);
-                assertThat(line.getProrationPct()).isNull();
-                assertThat(line.getProrationInputs()).isNull();
-                assertThat(line.getAmountRequested()).isNull();
-                assertThat(rerun.suggestedOutcome())
-                                .containsEntry("eligible", false)
-                                .containsEntry("policyId", null)
-                                .containsEntry("providerId", null);
-        }
-
-        @Test
-        void categoryPolicy_matchesByCatalogCategoryIdAndBeatsAll() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                WarrantyPolicy categoryPolicy = WarrantyPolicy.builder()
-                                .id(UUID.fromString("018f0000-0000-7000-8000-000000000050"))
-                                .providerId(PROVIDER_ID)
-                                .name("All tires")
-                                .coverageType(CoverageType.MANUFACTURER_DEFECT)
-                                .appliesToType(AppliesToType.CATEGORY)
-                                .appliesToCategoryId(CATEGORY_ID)
-                                .effectiveFrom(LocalDate.of(2025, java.time.Month.JANUARY, 1))
-                                .prorationMethod(ProrationMethod.NONE)
-                                .build();
-                WarrantyPolicy broad = allFreeReplacementPolicy("Catch-all",
-                                UUID.fromString("018f0000-0000-7000-8000-000000000051"));
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(broad, categoryPolicy));
-
-                service.evaluate(CLAIM_ID);
-
-                assertThat(claim.getPolicyId()).isEqualTo(categoryPolicy.getId());
-        }
-
-        @Test
-        void categoryPolicy_losesToManufacturerScopedPolicy() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                WarrantyPolicy categoryPolicy = WarrantyPolicy.builder()
-                                .id(UUID.fromString("018f0000-0000-7000-8000-000000000052"))
-                                .providerId(PROVIDER_ID)
-                                .name("All tires")
-                                .coverageType(CoverageType.MANUFACTURER_DEFECT)
-                                .appliesToType(AppliesToType.CATEGORY)
-                                .appliesToCategoryId(CATEGORY_ID)
-                                .effectiveFrom(LocalDate.of(2025, java.time.Month.JANUARY, 1))
-                                .prorationMethod(ProrationMethod.NONE)
-                                .build();
-                WarrantyPolicy manufacturer = manufacturerTreadPolicy();
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(categoryPolicy, manufacturer));
-
-                service.evaluate(CLAIM_ID);
-
-                assertThat(claim.getPolicyId()).isEqualTo(manufacturer.getId());
-        }
-
-        @Test
-        void categoryPolicy_forDifferentCategoryDoesNotMatch() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                WarrantyPolicy otherCategory = WarrantyPolicy.builder()
-                                .id(UUID.fromString("018f0000-0000-7000-8000-000000000053"))
-                                .providerId(PROVIDER_ID)
-                                .name("Batteries only")
-                                .coverageType(CoverageType.MANUFACTURER_DEFECT)
-                                .appliesToType(AppliesToType.CATEGORY)
-                                .appliesToCategoryId(UUID.fromString("018f0000-0000-7000-8000-0000000000aa"))
-                                .effectiveFrom(LocalDate.of(2025, java.time.Month.JANUARY, 1))
-                                .prorationMethod(ProrationMethod.NONE)
-                                .build();
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(otherCategory));
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.INELIGIBLE);
-                assertThat(claim.getPolicyId()).isNull();
-        }
-
-        @Test
-        void noMatchingPolicy_withCatalogDown_isIndeterminate() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.empty());
-                // the manufacturer-scoped policy cannot match without product facts
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(manufacturerTreadPolicy()));
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
-                assertThat(evaluation.reasons())
-                                .anySatisfy(reason -> assertThat(reason).containsEntry("term", "policyMatch")
-                                                .containsEntry("indeterminate", true));
-        }
-
-        @Test
-        void catalogDown_withMoreSpecificScopedPolicyAndAllFallback_isIndeterminateNotSilentDowngrade() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.empty());
-                // With catalog facts missing the manufacturer policy cannot be evaluated; the
-                // ALL
-                // fallback must NOT silently win — the winner may be the wrong policy.
-                when(policyRepository.findEffectiveOn(SALE_DATE))
-                                .thenReturn(List.of(
-                                                manufacturerTreadPolicy(),
-                                                allFreeReplacementPolicy(
-                                                                "Catch-all",
-                                                                UUID.fromString("018f0000-0000-7000-8000-000000000012"))));
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
-                assertThat(claim.getPolicyId()).isNull();
-                assertThat(claim.getProviderId()).isNull();
-                assertThat(evaluation.reasons())
-                                .anySatisfy(reason -> assertThat(reason).containsEntry("term", "policyMatch")
-                                                .containsEntry("indeterminate", true));
-        }
-
-        @Test
-        void durationBoundary_dayAfterExpiryIsIneligible_expiryDateItselfPasses() {
-                // 24-month policy sold on SALE_DATE: coverage runs through SALE_DATE + 24
-                // months
-                // inclusive; ChronoUnit truncation must not grant a partial-month grace window.
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                claim.setFailureDate(SALE_DATE.plusMonths(24).plusDays(1));
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(manufacturerTreadPolicy()));
-
-                assertThat(service.evaluate(CLAIM_ID).result()).isEqualTo(EligibilityResult.INELIGIBLE);
-
-                claim.setFailureDate(SALE_DATE.plusMonths(24));
-                EligibilityEvaluation onExpiry = service.evaluate(CLAIM_ID);
-                assertThat(onExpiry.reasons())
-                                .anySatisfy(reason -> assertThat(reason).containsEntry("term", "duration")
-                                                .containsEntry("pass", true));
-        }
-
-        @Test
-        void unverifiedOrigin_isIndeterminateEvenWhenTermsPass() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                claim.setOriginUnverified(true);
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE))
-                                .thenReturn(List.of(allFreeReplacementPolicy(
-                                                "Store guarantee",
-                                                UUID.fromString("018f0000-0000-7000-8000-000000000011"))));
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
-                assertThat(evaluation.reasons())
-                                .anySatisfy(reason -> assertThat(reason)
-                                                .containsEntry("term", "originVerified")
-                                                .containsEntry("indeterminate", true));
-                // NONE proration still suggests a free replacement
-                assertThat(evaluation.suggestedOutcome()).containsEntry("settlementType", "REPLACEMENT_WORKORDER");
-                assertThat(claim.getLines().get(0).getProrationPct()).isEqualByComparingTo("1");
-        }
-
-        @Test
-        void missingSaleDate_isIndeterminate() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                claim.setOriginSaleDate(null);
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
-                assertThat(evaluation.reasons())
-                                .anySatisfy(reason -> assertThat(reason)
-                                                .containsEntry("term", "originSaleDate")
-                                                .containsEntry("indeterminate", true));
-                assertThat(claim.getLines().get(0).getProrationPct()).isNull();
-        }
-
-        @Test
-        void registrationBoundCoverage_withoutActiveRegistration_isIneligible() {
-                WarrantyClaim claim = claim(ClaimType.ROAD_HAZARD);
-                WarrantyPolicy policy = manufacturerTreadPolicy();
-                policy.setCoverageType(CoverageType.ROAD_HAZARD);
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(policy));
-                when(registrationRepository.findByCustomerIdAndStatus(CUSTOMER_ID, RegistrationStatus.ACTIVE))
-                                .thenReturn(List.of());
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.INELIGIBLE);
-                assertThat(evaluation.reasons())
-                                .anySatisfy(reason -> assertThat(reason).containsEntry("term", "registration")
-                                                .containsEntry("pass", false));
-        }
-
-        @Test
-        void registrationBoundCoverage_withActiveRegistration_selectsRegistration() {
-                WarrantyClaim claim = claim(ClaimType.ROAD_HAZARD);
-                WarrantyPolicy policy = manufacturerTreadPolicy();
-                policy.setCoverageType(CoverageType.ROAD_HAZARD);
-                WarrantyRegistration registration = WarrantyRegistration.builder()
-                                .id(UUID.fromString("018f0000-0000-7000-8000-000000000020"))
-                                .policyId(policy.getId())
-                                .customerId(CUSTOMER_ID)
-                                .purchaseDate(SALE_DATE)
-                                .status(RegistrationStatus.ACTIVE)
-                                .build();
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(policy));
-                when(registrationRepository.findByCustomerIdAndStatus(CUSTOMER_ID, RegistrationStatus.ACTIVE))
-                                .thenReturn(List.of(registration));
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.ELIGIBLE);
-                assertThat(claim.getRegistrationId()).isEqualTo(registration.getId());
-        }
-
-        @Test
-        void mostSpecificPolicyWins_productListBeatsAll() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                WarrantyPolicy specific = WarrantyPolicy.builder()
-                                .id(UUID.fromString("018f0000-0000-7000-8000-000000000030"))
-                                .providerId(PROVIDER_ID)
-                                .name("Product-specific")
-                                .coverageType(CoverageType.MANUFACTURER_DEFECT)
-                                .appliesToType(AppliesToType.PRODUCT_LIST)
-                                .appliesToProductEntityIds(List.of(PRODUCT_ID))
-                                .effectiveFrom(LocalDate.of(2025, java.time.Month.JANUARY, 1))
-                                .prorationMethod(ProrationMethod.NONE)
-                                .build();
-                WarrantyPolicy broad = allFreeReplacementPolicy("Catch-all",
-                                UUID.fromString("018f0000-0000-7000-8000-000000000031"));
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(broad, specific));
-
-                service.evaluate(CLAIM_ID);
-
-                assertThat(claim.getPolicyId()).isEqualTo(specific.getId());
-        }
-
-        @Test
-        void multipleWinnersAtSameSpecificity_doNotSelectCoverageOntoClaim() {
-                WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
-                WarrantyPolicy first = allFreeReplacementPolicy("Plan A",
-                                UUID.fromString("018f0000-0000-7000-8000-000000000040"));
-                WarrantyPolicy second = allFreeReplacementPolicy("Plan B",
-                                UUID.fromString("018f0000-0000-7000-8000-000000000041"));
-                stubClaim(claim);
-                when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
-                when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(first, second));
-
-                EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
-
-                // A tie means no policy governs: nothing is selected, no terms adjudicated, no
-                // line
-                // amounts frozen — the claim routes to human review as INDETERMINATE.
-                assertThat(claim.getPolicyId()).isNull();
-                assertThat(claim.getProviderId()).isNull();
-                assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
-                assertThat(claim.getLines().get(0).getAmountRequested()).isNull();
-                assertThat(claim.getLines().get(0).getProrationPct()).isNull();
-                assertThat(evaluation.suggestedOutcome()).containsEntry("policyId", null);
-                assertThat(evaluation.reasons()).anySatisfy(reason -> {
-                        assertThat(reason).containsEntry("term", "policyMatch");
-                        assertThat(reason.get("pass")).isNull();
-                        assertThat(String.valueOf(reason.get("actual"))).contains("Plan A").contains("Plan B");
-                });
-        }
-
-        @Test
-        void unknownClaim_throwsNotFound() {
-                when(claimRepository.findById(CLAIM_ID)).thenReturn(Optional.empty());
-
-                assertThatThrownBy(() -> service.evaluate(CLAIM_ID))
-                                .isInstanceOf(WarrantyNotFoundException.class)
-                                .hasMessageContaining(CLAIM_ID.toString());
-        }
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-06-15T10:15:30Z"), ZoneOffset.UTC);
+
+    private static final UUID CLAIM_ID = UUID.fromString("018f0000-0000-7000-8000-000000000001");
+    private static final UUID LINE_ID = UUID.fromString("018f0000-0000-7000-8000-000000000002");
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0000-0000-7000-8000-000000000003");
+    private static final UUID MANUFACTURER_ID = UUID.fromString("018f0000-0000-7000-8000-000000000004");
+    private static final UUID CATEGORY_ID = UUID.fromString("018f0000-0000-7000-8000-000000000007");
+    private static final UUID PROVIDER_ID = UUID.fromString("018f0000-0000-7000-8000-000000000005");
+    private static final UUID CUSTOMER_ID = UUID.fromString("018f0000-0000-7000-8000-000000000006");
+    private static final LocalDate SALE_DATE = LocalDate.of(2026, java.time.Month.JANUARY, 10);
+    private static final LocalDate FAILURE_DATE = LocalDate.of(2026, java.time.Month.JUNE, 1);
+
+    @Mock
+    private WarrantyClaimRepository claimRepository;
+
+    @Mock
+    private WarrantyPolicyRepository policyRepository;
+
+    @Mock
+    private WarrantyRegistrationRepository registrationRepository;
+
+    @Mock
+    private ExtCatalogReplicaRepository extCatalogReplicaRepository;
+
+    private EligibilityServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new EligibilityServiceImpl(
+                claimRepository,
+                policyRepository,
+                registrationRepository,
+                extCatalogReplicaRepository,
+                new ProrationService(),
+                FIXED_CLOCK);
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Fixtures
+    // -----------------------------------------------------------------------------------------
+
+    private static WarrantyClaim claim(ClaimType claimType) {
+        WarrantyClaim claim = WarrantyClaim.builder()
+                .id(CLAIM_ID)
+                .claimCode("WC-2026-000001")
+                .claimType(claimType)
+                .customerId(CUSTOMER_ID)
+                .originSaleDate(SALE_DATE)
+                .failureDate(FAILURE_DATE)
+                .originUnverified(false)
+                .build();
+        WarrantyClaimLine line = WarrantyClaimLine.builder()
+                .id(LINE_ID)
+                .productEntityId(PRODUCT_ID)
+                .originalUnitPrice(new BigDecimal("100.00"))
+                .quantity(BigDecimal.ONE)
+                .originalTreadDepth(10)
+                .measuredTreadDepth(6)
+                .build();
+        claim.addLine(line);
+        return claim;
+    }
+
+    private static WarrantyPolicy manufacturerTreadPolicy() {
+        return WarrantyPolicy.builder()
+                .id(UUID.fromString("018f0000-0000-7000-8000-000000000010"))
+                .providerId(PROVIDER_ID)
+                .name("Michelin passenger replacement")
+                .coverageType(CoverageType.MANUFACTURER_DEFECT)
+                .appliesToType(AppliesToType.MANUFACTURER)
+                .appliesToManufacturerId(MANUFACTURER_ID)
+                .effectiveFrom(LocalDate.of(2025, java.time.Month.JANUARY, 1))
+                .durationMonths(24)
+                .treadPullPointThirtySeconds(2)
+                .prorationMethod(ProrationMethod.TREAD_DEPTH)
+                .build();
+    }
+
+    private static WarrantyPolicy allFreeReplacementPolicy(String name, UUID id) {
+        return WarrantyPolicy.builder()
+                .id(id)
+                .providerId(PROVIDER_ID)
+                .name(name)
+                .coverageType(CoverageType.MANUFACTURER_DEFECT)
+                .appliesToType(AppliesToType.ALL)
+                .effectiveFrom(LocalDate.of(2025, java.time.Month.JANUARY, 1))
+                .prorationMethod(ProrationMethod.NONE)
+                .build();
+    }
+
+    private static ExtCatalogReplica product() {
+        return ExtCatalogReplica.builder()
+                .productId(PRODUCT_ID)
+                .sku("TIRE-1")
+                .name("SuperTire 225")
+                .manufacturerId(MANUFACTURER_ID)
+                .manufacturerName("Michelin")
+                .manufacturerBrand("Michelin")
+                .categoryId(CATEGORY_ID)
+                .category("Tires")
+                .active(true)
+                .aggregateVersion(1L)
+                .updatedAt(java.time.Instant.EPOCH)
+                .build();
+    }
+
+    private void stubClaim(WarrantyClaim claim) {
+        when(claimRepository.findById(CLAIM_ID)).thenReturn(Optional.of(claim));
+        when(claimRepository.save(any(WarrantyClaim.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    void eligibleClaim_persistsResultProrationAndCoverageSelection() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        WarrantyPolicy policy = manufacturerTreadPolicy();
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(policy));
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.ELIGIBLE);
+        // persisted onto the claim
+        assertThat(claim.getEligibilityResult()).isEqualTo(EligibilityResult.ELIGIBLE);
+        assertThat(claim.getEligibilityReasons()).isEqualTo(evaluation.reasons());
+        assertThat(claim.getSuggestedOutcome()).isEqualTo(evaluation.suggestedOutcome());
+        // single winner selected onto the claim
+        assertThat(claim.getPolicyId()).isEqualTo(policy.getId());
+        assertThat(claim.getProviderId()).isEqualTo(PROVIDER_ID);
+        // per-line proration persisted: (6-2)/(10-2) = 0.5
+        WarrantyClaimLine line = claim.getLines().get(0);
+        assertThat(line.getProrationPct()).isEqualByComparingTo("0.5");
+        assertThat(line.getAmountRequested()).isEqualByComparingTo("50.00");
+        assertThat(line.getProrationInputs()).containsEntry("method", "TREAD_DEPTH");
+        // suggested outcome
+        Map<String, Object> suggested = evaluation.suggestedOutcome();
+        assertThat(suggested)
+                .containsEntry("eligible", true)
+                .containsEntry("policyId", policy.getId().toString())
+                .containsEntry("providerId", PROVIDER_ID.toString())
+                .containsEntry("settlementType", "PRORATED_CREDIT");
+        assertThat((BigDecimal) suggested.get("totalRequested")).isEqualByComparingTo("50.00");
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> perLine = (List<Map<String, Object>>) suggested.get("perLine");
+        assertThat(perLine).hasSize(1);
+        assertThat(perLine.get(0)).containsEntry("claimLineId", LINE_ID.toString());
+        verify(claimRepository).save(claim);
+        // every reason map carries the {term, required, actual, pass} shape
+        assertThat(evaluation.reasons())
+                .allSatisfy(reason -> assertThat(reason).containsKeys("term", "required", "actual", "pass"));
+    }
+
+    @Test
+    void treadBelowPullPoint_isIneligibleWithFailingReason() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        claim.getLines().get(0).setMeasuredTreadDepth(2); // not > pull point 2
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(manufacturerTreadPolicy()));
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INELIGIBLE);
+        assertThat(evaluation.reasons())
+                .anySatisfy(reason ->
+                        assertThat(reason).containsEntry("term", "treadDepth").containsEntry("pass", false));
+        assertThat(evaluation.suggestedOutcome()).containsEntry("eligible", false);
+    }
+
+    @Test
+    void missingTreadMeasurement_isIndeterminate() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        claim.getLines().get(0).setMeasuredTreadDepth(null);
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(manufacturerTreadPolicy()));
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
+        assertThat(evaluation.reasons())
+                .anySatisfy(reason ->
+                        assertThat(reason).containsEntry("term", "treadDepth").containsEntry("indeterminate", true));
+    }
+
+    @Test
+    void expiredDuration_isIneligible() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        claim.setFailureDate(SALE_DATE.plusMonths(30)); // past 24-month duration
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(manufacturerTreadPolicy()));
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INELIGIBLE);
+        assertThat(evaluation.reasons())
+                .anySatisfy(reason ->
+                        assertThat(reason).containsEntry("term", "duration").containsEntry("pass", false));
+    }
+
+    @Test
+    void mileageLimitWithUnknownSaleOdometer_isIndeterminate() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        claim.setOdometerAtClaim(42000L);
+        WarrantyPolicy policy = manufacturerTreadPolicy();
+        policy.setMileageLimit(40000);
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(policy));
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
+        assertThat(evaluation.reasons())
+                .anySatisfy(reason ->
+                        assertThat(reason).containsEntry("term", "mileage").containsEntry("indeterminate", true));
+    }
+
+    @Test
+    void noMatchingPolicy_isIneligible() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of());
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INELIGIBLE);
+        assertThat(claim.getPolicyId()).isNull();
+        assertThat(evaluation.suggestedOutcome()).containsEntry("policyId", null);
+        assertThat(evaluation.suggestedOutcome()).containsEntry("settlementType", null);
+    }
+
+    @Test
+    void rerunWithoutMatchingPolicy_clearsPreviouslySelectedCoverageAndProration() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE))
+                .thenReturn(List.of(manufacturerTreadPolicy()))
+                .thenReturn(List.of()); // second run: nothing matches (e.g. claimType corrected)
+
+        service.evaluate(CLAIM_ID);
+        assertThat(claim.getPolicyId()).isNotNull();
+        assertThat(claim.getLines().get(0).getProrationPct()).isNotNull();
+
+        EligibilityEvaluation rerun = service.evaluate(CLAIM_ID);
+
+        assertThat(rerun.result()).isEqualTo(EligibilityResult.INELIGIBLE);
+        assertThat(claim.getPolicyId()).isNull();
+        assertThat(claim.getProviderId()).isNull();
+        WarrantyClaimLine line = claim.getLines().get(0);
+        assertThat(line.getProrationPct()).isNull();
+        assertThat(line.getProrationInputs()).isNull();
+        assertThat(line.getAmountRequested()).isNull();
+        assertThat(rerun.suggestedOutcome())
+                .containsEntry("eligible", false)
+                .containsEntry("policyId", null)
+                .containsEntry("providerId", null);
+    }
+
+    @Test
+    void categoryPolicy_matchesByCatalogCategoryIdAndBeatsAll() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        WarrantyPolicy categoryPolicy = WarrantyPolicy.builder()
+                .id(UUID.fromString("018f0000-0000-7000-8000-000000000050"))
+                .providerId(PROVIDER_ID)
+                .name("All tires")
+                .coverageType(CoverageType.MANUFACTURER_DEFECT)
+                .appliesToType(AppliesToType.CATEGORY)
+                .appliesToCategoryId(CATEGORY_ID)
+                .effectiveFrom(LocalDate.of(2025, java.time.Month.JANUARY, 1))
+                .prorationMethod(ProrationMethod.NONE)
+                .build();
+        WarrantyPolicy broad =
+                allFreeReplacementPolicy("Catch-all", UUID.fromString("018f0000-0000-7000-8000-000000000051"));
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(broad, categoryPolicy));
+
+        service.evaluate(CLAIM_ID);
+
+        assertThat(claim.getPolicyId()).isEqualTo(categoryPolicy.getId());
+    }
+
+    @Test
+    void categoryPolicy_losesToManufacturerScopedPolicy() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        WarrantyPolicy categoryPolicy = WarrantyPolicy.builder()
+                .id(UUID.fromString("018f0000-0000-7000-8000-000000000052"))
+                .providerId(PROVIDER_ID)
+                .name("All tires")
+                .coverageType(CoverageType.MANUFACTURER_DEFECT)
+                .appliesToType(AppliesToType.CATEGORY)
+                .appliesToCategoryId(CATEGORY_ID)
+                .effectiveFrom(LocalDate.of(2025, java.time.Month.JANUARY, 1))
+                .prorationMethod(ProrationMethod.NONE)
+                .build();
+        WarrantyPolicy manufacturer = manufacturerTreadPolicy();
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(categoryPolicy, manufacturer));
+
+        service.evaluate(CLAIM_ID);
+
+        assertThat(claim.getPolicyId()).isEqualTo(manufacturer.getId());
+    }
+
+    @Test
+    void categoryPolicy_forDifferentCategoryDoesNotMatch() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        WarrantyPolicy otherCategory = WarrantyPolicy.builder()
+                .id(UUID.fromString("018f0000-0000-7000-8000-000000000053"))
+                .providerId(PROVIDER_ID)
+                .name("Batteries only")
+                .coverageType(CoverageType.MANUFACTURER_DEFECT)
+                .appliesToType(AppliesToType.CATEGORY)
+                .appliesToCategoryId(UUID.fromString("018f0000-0000-7000-8000-0000000000aa"))
+                .effectiveFrom(LocalDate.of(2025, java.time.Month.JANUARY, 1))
+                .prorationMethod(ProrationMethod.NONE)
+                .build();
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(otherCategory));
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INELIGIBLE);
+        assertThat(claim.getPolicyId()).isNull();
+    }
+
+    @Test
+    void noMatchingPolicy_withCatalogDown_isIndeterminate() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+        // the manufacturer-scoped policy cannot match without product facts
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(manufacturerTreadPolicy()));
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
+        assertThat(evaluation.reasons())
+                .anySatisfy(reason ->
+                        assertThat(reason).containsEntry("term", "policyMatch").containsEntry("indeterminate", true));
+    }
+
+    @Test
+    void catalogDown_withMoreSpecificScopedPolicyAndAllFallback_isIndeterminateNotSilentDowngrade() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+        // With catalog facts missing the manufacturer policy cannot be evaluated; the
+        // ALL
+        // fallback must NOT silently win — the winner may be the wrong policy.
+        when(policyRepository.findEffectiveOn(SALE_DATE))
+                .thenReturn(List.of(
+                        manufacturerTreadPolicy(),
+                        allFreeReplacementPolicy(
+                                "Catch-all", UUID.fromString("018f0000-0000-7000-8000-000000000012"))));
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
+        assertThat(claim.getPolicyId()).isNull();
+        assertThat(claim.getProviderId()).isNull();
+        assertThat(evaluation.reasons())
+                .anySatisfy(reason ->
+                        assertThat(reason).containsEntry("term", "policyMatch").containsEntry("indeterminate", true));
+    }
+
+    @Test
+    void durationBoundary_dayAfterExpiryIsIneligible_expiryDateItselfPasses() {
+        // 24-month policy sold on SALE_DATE: coverage runs through SALE_DATE + 24
+        // months
+        // inclusive; ChronoUnit truncation must not grant a partial-month grace window.
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        claim.setFailureDate(SALE_DATE.plusMonths(24).plusDays(1));
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(manufacturerTreadPolicy()));
+
+        assertThat(service.evaluate(CLAIM_ID).result()).isEqualTo(EligibilityResult.INELIGIBLE);
+
+        claim.setFailureDate(SALE_DATE.plusMonths(24));
+        EligibilityEvaluation onExpiry = service.evaluate(CLAIM_ID);
+        assertThat(onExpiry.reasons())
+                .anySatisfy(reason ->
+                        assertThat(reason).containsEntry("term", "duration").containsEntry("pass", true));
+    }
+
+    @Test
+    void unverifiedOrigin_isIndeterminateEvenWhenTermsPass() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        claim.setOriginUnverified(true);
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE))
+                .thenReturn(List.of(allFreeReplacementPolicy(
+                        "Store guarantee", UUID.fromString("018f0000-0000-7000-8000-000000000011"))));
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
+        assertThat(evaluation.reasons())
+                .anySatisfy(reason -> assertThat(reason)
+                        .containsEntry("term", "originVerified")
+                        .containsEntry("indeterminate", true));
+        // NONE proration still suggests a free replacement
+        assertThat(evaluation.suggestedOutcome()).containsEntry("settlementType", "REPLACEMENT_WORKORDER");
+        assertThat(claim.getLines().get(0).getProrationPct()).isEqualByComparingTo("1");
+    }
+
+    @Test
+    void missingSaleDate_isIndeterminate() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        claim.setOriginSaleDate(null);
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
+        assertThat(evaluation.reasons())
+                .anySatisfy(reason -> assertThat(reason)
+                        .containsEntry("term", "originSaleDate")
+                        .containsEntry("indeterminate", true));
+        assertThat(claim.getLines().get(0).getProrationPct()).isNull();
+    }
+
+    @Test
+    void registrationBoundCoverage_withoutActiveRegistration_isIneligible() {
+        WarrantyClaim claim = claim(ClaimType.ROAD_HAZARD);
+        WarrantyPolicy policy = manufacturerTreadPolicy();
+        policy.setCoverageType(CoverageType.ROAD_HAZARD);
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(policy));
+        when(registrationRepository.findByCustomerIdAndStatus(CUSTOMER_ID, RegistrationStatus.ACTIVE))
+                .thenReturn(List.of());
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INELIGIBLE);
+        assertThat(evaluation.reasons())
+                .anySatisfy(reason ->
+                        assertThat(reason).containsEntry("term", "registration").containsEntry("pass", false));
+    }
+
+    @Test
+    void registrationBoundCoverage_withActiveRegistration_selectsRegistration() {
+        WarrantyClaim claim = claim(ClaimType.ROAD_HAZARD);
+        WarrantyPolicy policy = manufacturerTreadPolicy();
+        policy.setCoverageType(CoverageType.ROAD_HAZARD);
+        WarrantyRegistration registration = WarrantyRegistration.builder()
+                .id(UUID.fromString("018f0000-0000-7000-8000-000000000020"))
+                .policyId(policy.getId())
+                .customerId(CUSTOMER_ID)
+                .purchaseDate(SALE_DATE)
+                .status(RegistrationStatus.ACTIVE)
+                .build();
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(policy));
+        when(registrationRepository.findByCustomerIdAndStatus(CUSTOMER_ID, RegistrationStatus.ACTIVE))
+                .thenReturn(List.of(registration));
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.ELIGIBLE);
+        assertThat(claim.getRegistrationId()).isEqualTo(registration.getId());
+    }
+
+    @Test
+    void mostSpecificPolicyWins_productListBeatsAll() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        WarrantyPolicy specific = WarrantyPolicy.builder()
+                .id(UUID.fromString("018f0000-0000-7000-8000-000000000030"))
+                .providerId(PROVIDER_ID)
+                .name("Product-specific")
+                .coverageType(CoverageType.MANUFACTURER_DEFECT)
+                .appliesToType(AppliesToType.PRODUCT_LIST)
+                .appliesToProductEntityIds(List.of(PRODUCT_ID))
+                .effectiveFrom(LocalDate.of(2025, java.time.Month.JANUARY, 1))
+                .prorationMethod(ProrationMethod.NONE)
+                .build();
+        WarrantyPolicy broad =
+                allFreeReplacementPolicy("Catch-all", UUID.fromString("018f0000-0000-7000-8000-000000000031"));
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(broad, specific));
+
+        service.evaluate(CLAIM_ID);
+
+        assertThat(claim.getPolicyId()).isEqualTo(specific.getId());
+    }
+
+    @Test
+    void multipleWinnersAtSameSpecificity_doNotSelectCoverageOntoClaim() {
+        WarrantyClaim claim = claim(ClaimType.MANUFACTURER_DEFECT);
+        WarrantyPolicy first =
+                allFreeReplacementPolicy("Plan A", UUID.fromString("018f0000-0000-7000-8000-000000000040"));
+        WarrantyPolicy second =
+                allFreeReplacementPolicy("Plan B", UUID.fromString("018f0000-0000-7000-8000-000000000041"));
+        stubClaim(claim);
+        when(extCatalogReplicaRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(policyRepository.findEffectiveOn(SALE_DATE)).thenReturn(List.of(first, second));
+
+        EligibilityEvaluation evaluation = service.evaluate(CLAIM_ID);
+
+        // A tie means no policy governs: nothing is selected, no terms adjudicated, no
+        // line
+        // amounts frozen — the claim routes to human review as INDETERMINATE.
+        assertThat(claim.getPolicyId()).isNull();
+        assertThat(claim.getProviderId()).isNull();
+        assertThat(evaluation.result()).isEqualTo(EligibilityResult.INDETERMINATE);
+        assertThat(claim.getLines().get(0).getAmountRequested()).isNull();
+        assertThat(claim.getLines().get(0).getProrationPct()).isNull();
+        assertThat(evaluation.suggestedOutcome()).containsEntry("policyId", null);
+        assertThat(evaluation.reasons()).anySatisfy(reason -> {
+            assertThat(reason).containsEntry("term", "policyMatch");
+            assertThat(reason.get("pass")).isNull();
+            assertThat(String.valueOf(reason.get("actual"))).contains("Plan A").contains("Plan B");
+        });
+    }
+
+    @Test
+    void unknownClaim_throwsNotFound() {
+        when(claimRepository.findById(CLAIM_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.evaluate(CLAIM_ID))
+                .isInstanceOf(WarrantyNotFoundException.class)
+                .hasMessageContaining(CLAIM_ID.toString());
+    }
 }

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/config/EventTypeInitializerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/config/EventTypeInitializerTest.java
@@ -1,0 +1,124 @@
+package com.positivity.workorder.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link EventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link EventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EventTypeInitializer — startup event-type registration")
+class EventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private EventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new EventTypeInitializer(restClientBuilder, BASE_URL, "", true);
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(EventTypes.ALL_EVENT_TYPES.size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        EventTypeInitializer sutWithSecret = new EventTypeInitializer(restClientBuilder, BASE_URL, secret, true);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(EventTypes.ALL_EVENT_TYPES.size()))
+                .header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(EventTypes.ALL_EVENT_TYPES).isNotEmpty();
+        verify(restClient, times(EventTypes.ALL_EVENT_TYPES.size())).put();
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/config/EventTypesTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/config/EventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.workorder.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link EventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -58,7 +58,7 @@ class EventTypesTest {
     }
 
     private static List<EventTypeRegistration> registrations() {
-        return EventTypes.all();
+        return EventTypes.ALL_EVENT_TYPES;
     }
 
     @Test
@@ -107,10 +107,24 @@ class EventTypesTest {
         });
     }
 
+    /**
+     * Event types that deliberately carry hand-tuned thresholds instead of a
+     * preset. Each entry is a decision, not an oversight: the dispatch-board
+     * dashboard aggregates across every open workorder for a location, so it is
+     * budgeted above the presets at p50 while staying under the approval preset
+     * at p99.
+     *
+     * <p>
+     * Keep this list short. A new entry means someone opted an event out of the
+     * shared latency vocabulary, which should be a conscious call.
+     */
+    private static final Set<String> CUSTOM_THRESHOLD_EXEMPTIONS = Set.of("WORKEXEC_DASHBOARD_TODAY_GET");
+
     @Test
-    @DisplayName("every registration uses one of the four declared threshold presets")
+    @DisplayName("every registration uses a declared threshold preset, unless documented as an exemption")
     void thresholds_matchADeclaredPreset() {
         assertThat(registrations())
+                .filteredOn(registration -> !CUSTOM_THRESHOLD_EXEMPTIONS.contains(registration.getTypeCode()))
                 .allSatisfy(registration -> assertThat(triple(
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
@@ -118,27 +132,10 @@ class EventTypesTest {
     }
 
     @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
+    @DisplayName("every documented threshold exemption still refers to a registered event type")
+    void thresholdExemptions_areNotStale() {
+        assertThat(registrations())
                 .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
+                .containsAll(CUSTOM_THRESHOLD_EXEMPTIONS);
     }
 }

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/config/PickEventTypeInitializerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/config/PickEventTypeInitializerTest.java
@@ -1,0 +1,125 @@
+package com.positivity.workorder.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.events.EventsApiConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link PickEventTypeInitializer}.
+ *
+ * <p>
+ * The initializer runs as an {@code ApplicationRunner} at startup and PUTs every
+ * entry of {@link PickEventTypes} to {@code pos-event-receiver}. Two properties of
+ * that contract matter operationally:
+ *
+ * <ul>
+ * <li>the shared-secret header is sent when {@code pos.events.api-secret} is
+ * configured and omitted when it is blank, and</li>
+ * <li>a failing registration is swallowed — the event receiver being down must
+ * never block this service from starting.</li>
+ * </ul>
+ *
+ * <p>
+ * The fluent {@code RestClient} chain is mocked with {@link Answers#RETURNS_SELF}
+ * so {@code uri()}, {@code contentType()}, {@code body()}, and {@code header()}
+ * all return the same mock without per-method stubs.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PickEventTypeInitializer — startup event-type registration")
+class PickEventTypeInitializerTest {
+
+    private static final String BASE_URL = "http://pos-event-receiver:8080";
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    /** Initializer built with a blank api-secret. */
+    private PickEventTypeInitializer sut;
+
+    @BeforeEach
+    void setUp() {
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        lenient().when(restClient.put()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        lenient().when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+        sut = new PickEventTypeInitializer(restClientBuilder, BASE_URL, "", true);
+    }
+
+    @Test
+    @DisplayName("run() PUTs one registration per declared event type")
+    void run_registersEveryEventType() {
+        sut.run(null);
+
+        verify(restClient, times(PickEventTypes.ALL_EVENT_TYPES.size())).put();
+    }
+
+    @Test
+    @DisplayName("run() sends the shared-secret header when an api-secret is configured")
+    void run_withSecret_sendsSecretHeader() {
+        String secret = "test-api-secret-value";
+        PickEventTypeInitializer sutWithSecret =
+                new PickEventTypeInitializer(restClientBuilder, BASE_URL, secret, true);
+
+        sutWithSecret.run(null);
+
+        verify(requestBodyUriSpec, times(PickEventTypes.ALL_EVENT_TYPES.size()))
+                .header(EventsApiConstants.SECRET_HEADER, secret);
+    }
+
+    @Test
+    @DisplayName("run() omits the shared-secret header when the api-secret is blank")
+    void run_withoutSecret_omitsSecretHeader() {
+        sut.run(null);
+
+        verify(requestBodyUriSpec, never()).header(eq(EventsApiConstants.SECRET_HEADER), anyString());
+    }
+
+    @Test
+    @DisplayName("run() does not propagate a registration failure — startup must not block on the event receiver")
+    void run_whenRegistrationFails_doesNotPropagate() {
+        when(responseSpec.toBodilessEntity()).thenThrow(new RuntimeException("Connection refused"));
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+    }
+
+    @Test
+    @DisplayName("run() keeps registering the remaining types after one failure")
+    void run_whenOneRegistrationFails_continuesWithRemaining() {
+        when(responseSpec.toBodilessEntity())
+                .thenThrow(new RuntimeException("transient error"))
+                .thenReturn(null);
+
+        assertThatNoException().isThrownBy(() -> sut.run(null));
+
+        assertThat(PickEventTypes.ALL_EVENT_TYPES).isNotEmpty();
+        verify(restClient, times(PickEventTypes.ALL_EVENT_TYPES.size())).put();
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/config/PickEventTypesTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/config/PickEventTypesTest.java
@@ -1,4 +1,4 @@
-package com.positivity.customer.internal.config;
+package com.positivity.workorder.internal.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract tests for the customer {@link EventTypes} registry.
+ * Contract tests for the {@link PickEventTypes} event-type registry.
  *
  * <p>
  * Every module that emits events via {@code @EmitEvent} must publish a registry
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
  * descriptions, ordered thresholds, and a threshold triple that matches a
  * declared preset rather than an ad-hoc value.
  */
-@DisplayName("EventTypes — event-type registry contract")
-class EventTypesTest {
+@DisplayName("PickEventTypes — event-type registry contract")
+class PickEventTypesTest {
 
     /**
      * Event type codes are upper snake case: the receiver stores them verbatim as
@@ -58,7 +58,7 @@ class EventTypesTest {
     }
 
     private static List<EventTypeRegistration> registrations() {
-        return EventTypes.all();
+        return PickEventTypes.ALL_EVENT_TYPES;
     }
 
     @Test
@@ -115,30 +115,5 @@ class EventTypesTest {
                                 registration.getP50Micros(), registration.getP95Micros(), registration.getP99Micros()))
                         .as("threshold preset for %s", registration.getTypeCode())
                         .isIn(PRESET_THRESHOLDS));
-    }
-
-    @Test
-    @DisplayName("browse and search are distinct registrations, browse on the fastRead preset")
-    void all_includesBrowseEventAsDistinctFastReadRegistration() {
-        List<EventTypeRegistration> registrations = registrations();
-        assertThat(registrations)
-                .extracting(EventTypeRegistration::getTypeCode)
-                .contains("CUSTOMER_PARTY_BROWSE", "CUSTOMER_PARTY_SEARCH");
-
-        EventTypeRegistration browseRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_BROWSE".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        EventTypeRegistration searchRegistration = registrations.stream()
-                .filter(registration -> "CUSTOMER_PARTY_SEARCH".equals(registration.getTypeCode()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(browseRegistration.getDescription()).isEqualTo("Browse parties with paging and sorting");
-        assertThat(browseRegistration.getP50Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P50);
-        assertThat(browseRegistration.getP95Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P95);
-        assertThat(browseRegistration.getP99Micros()).isEqualTo(EventTypeRegistration.FAST_READ_P99);
-        assertThat(browseRegistration).isNotEqualTo(searchRegistration);
     }
 }


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — this is not capability work. It executes `docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md`, which was itself agreed in-repo rather than as a durion capability.
- Parent STORY (durion): n/a
- Child issue: n/a for the test work itself. Two defects **found** by these tests are filed as louisburroughs/durion-positivity-backend#1245 and louisburroughs/durion-positivity-backend#1246 — neither is fixed here, see "Defects found" below.
- Domain: `domain:crm`, plus `domain:workexec` / `domain:pricing` / `domain:product` incidentally (pos-order, pos-marketing) and ~24 modules touched by the Phase 1 archetype wave.

## Contract References (REQUIRED for backend PRs touching API/event behavior)
No API or event behaviour changes in this PR. **No contract guide entry applies**, because nothing contract-relevant changed semantically:

- Contract guide entry (durion): n/a — no controller, DTO, event, or error-model **semantics** were modified. Referencing `BACKEND_CONTRACT_GUIDE.md` here to satisfy the Contract Sync Enforcement check, which triggers on changed file *paths*.
- Durion contract PR (if applicable): n/a

The check fires because ~22 files under `src/main` appear in the diff, including controllers and DTOs. **Every one of those changes is indentation-only**, from commit `ce7c9f8e` ("style: apply Palantir formatting to files that drifted from Spotless") — an 8-space to 4-space reflow with no token changes. Verify with:

```bash
git diff main..HEAD -- '*/src/main/*'
```

## Contract Chain (when a Controller changed)
Controllers appear in the diff only as the formatting reflow described above; no OpenAPI-visible surface changed, so nothing needs regenerating.

- [x] OpenAPI annotations updated on the controller — n/a, no controller signature or annotation changed
- [x] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a, spec is unchanged
- [x] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a, spec is unchanged

## Scope

**What changed:** test code only, plus the plan document, one `pom.xml` build binding, and a `CLAUDE.md` note.

Executes Phases 1 and 2 of `docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md`:

**Phase 1 — cross-cutting archetype contracts.** 64 test files across 24 modules covering `{Module}EventTypes` registries, `{Module}EventTypeInitializer`s, `OutboxPublisher`, and `ManifestPublisher`. The two highest-value files are the shared-library tests every module's startup registration delegates to: `pos-events` `EventTypeInitializerSupportTest` and `pos-security-common` `PermissionRegistrationSupportTest`, both previously 0%.

**Phase 2 — worst-covered modules.** Measured **unit-only** (`-DskipITs`), so these are not comparable to the plan's §1.5 baseline, which included Failsafe ITs:

| Module | Line | Branch | Missed lines |
|---|---|---|---|
| `pos-marketing` | 28.1% → **87.9%** | 29.8% → **82.9%** | 889 → 150 |
| `pos-order` | 57.5% → **83.6%** | 44.0% → **67.7%** | 1,377 → 530 |
| `pos-customer` | 80.7% → **85.9%** | 65.9% → **70.6%** | 1,034 → 757 |
| `pos-event-receiver` | 3.0% → 19.0% | 0.0% → — | (earlier session) |

`pos-marketing`'s entire service layer is now covered; the remainder is controllers and Spring config. `pos-order`'s five `ext_*` replica listeners were all at 0% and shared one documented consumer contract, so that contract is pinned once in a parameterized `ReplicaListenerContractTest` rather than copied five times — **this closes Phase 1 wave 1e for `pos-order`** (also closed for `pos-customer` and `pos-marketing`).

Also: `spotless:check` is now bound to the `validate` phase, so an unformatted file fails the build up front instead of at the end (`ce7c9f8e` applied the resulting reflow; `4920f373` added the binding; `6805cb8e` documented it in `CLAUDE.md`).

**Why:** the plan's §1.1 finding was that the repo had no trustworthy coverage number at all — the aggregate report read 0.0% because it was generated from a run carrying no JaCoCo exec data. Phase 0 restored a real baseline; this PR is the first two waves of work against it.

## Defects found

Two live defects surfaced, **both pinned by tests and deliberately left unfixed** — each is API-visible, so the fix is a product decision rather than a mechanical change:

1. **#1245 — a partial customer update silently deletes every VIN on the party.** `CustomerDTO.vehicleVins` is `@Builder.Default` with a field initializer, so the `!= null` guard in `updateEntityFromDTO` is unreachable and a `PUT /v1/crm/{id}` omitting the field hits `clear()`/`addAll()` with an empty list. The response is built from the already-emptied entity, so the caller cannot tell its own request caused the loss, and `partyChanged` propagates it to every replica in the same transaction.
2. **#1246 — `CommercialPartyServiceImpl` transposes `legalName` and `displayName`** between its read and write mappings. A read-modify-write — the ordinary edit-form pattern — persists the swap, after which the party stops matching `checkPartyDuplicates` under its real legal name.

Both pinning tests carry an explicit "documents current behaviour, not desired behaviour" comment naming the cause, so neither can be fixed silently.

Two further observations recorded in the plan and in test comments rather than filed: `pos-order`'s `OutboxPublisher` diverges from its 12 siblings (no Micrometer counters, no `attempts` reset, no `last_error` cap — all safe, all easy to erase by copying a sibling over it, so its test pins each divergence), and Jackson 3 rejects an **absent** primitive `boolean` during deserialization, which makes `OrderInvoiceResponse.existing` a latent contract risk if pos-invoice ever omits it.

## Tests
- [x] Unit tests added/updated — this PR is almost entirely unit tests
- [ ] Integration tests added/updated — none added; every test here is a Surefire unit test with no Spring context or database
- [ ] Provider behavioral contract tests added/updated — none added

**How to run:**

```bash
# the three focus modules
./mvnw -pl pos-marketing,pos-order,pos-customer -DskipTests=false test

# per-module coverage as reported above
./mvnw -pl pos-customer -DskipTests=false verify \
  org.jacoco:jacoco-maven-plugin:0.8.14:report -DskipITs

# full reactor, as CI runs it
./mvnw -DskipTests=false verify \
  org.jacoco:jacoco-maven-plugin:0.8.14:report \
  -Darchunit.skipTests=true -DlowResourceTests=true -T 1C -B -ntp
```

All three focus modules build green with every gate enabled (Spotless, Checkstyle, SpotBugs, ArchUnit): `pos-marketing` 183 tests, `pos-order` 322, `pos-customer` 595.

## Risk & Rollback
- Risk level: **Low.** No production behaviour changes. The only non-test, non-doc changes are the `spotless:check` phase binding and the indentation reflow it required.
- Rollback plan: revert the merge commit. Nothing here is depended on by runtime code, and no schema, contract, or configuration semantics changed. If only the build gate is unwanted, revert `4920f373` alone and keep the tests.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — **intentionally not**; this is plan-driven rather than capability-driven work, and the branch (`test-coverage/phase-1-archetype-contracts`) already carried these commits before this PR
- [ ] PR title starts with `[CAP:<cap-id>]` — same reason; there is no capability id to cite
- [x] Links to parent + child issues are present — the two defect issues are linked above; there is no parent story for this work
- [x] Contract guide updated (when contract semantics changed) — n/a, no contract semantics changed
- [ ] Required CI checks passing — to be confirmed on this PR
