### PR TITLE
test: close wave 1e in pos-people and pos-invoice, cover the RBAC client (plan Phase 2)

### DIFF
--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -299,10 +299,10 @@ exists now that every module is measured. The merged priority order is:
 | 2 | pos-customer | 61.5 | 2,067 | **In progress — 85.9% line / 70.6% branch unit-only** (see §4.3) |
 | 3 | pos-order | 53.4 | 1,510 | **In progress — 83.6% line / 67.7% branch unit-only** (see §4.2) |
 | 4 | ~~pos-marketing~~ | 28.1 | 889 | **Done — now 87.9% line / 82.9% branch, 150 missed** (see §4.1) |
-| 5 | pos-people | 61.5 | 1,101 | Large gap, thin suite |
-| 6 | pos-invoice | 63.4 | 1,210 | Large gap, **0 ITs** |
+| 5 | pos-people | 61.5 | 1,101 | **In progress — 79.4% line / 63.6% branch unit-only** (§4.4) |
+| 6 | pos-invoice | 63.4 | 1,210 | **In progress — 77.7% line / 64.0% branch unit-only**; still **0 ITs** (§4.4) |
 | 7 | pos-workorder | 73.0 | 2,012 | Large absolute gap despite decent ratio |
-| 8 | pos-people-contact | 45.6 | 803 | Low ratio and low branch coverage (26.9%) |
+| 8 | pos-people-contact | 45.6 | 803 | **In progress — 65.2% line / 52.3% branch unit-only** (§4.4) |
 | 9 | pos-vehicle-inventory | 28.8 | 695 | Third-lowest coverage overall |
 | 10 | pos-catalog | 68.3 | 891 | Branch coverage (46.3%) is the real weakness |
 | 11 | pos-document-helper | 44.4 | 208 | Shared library; `DocumentServiceClient` 80 missed at 0% |
@@ -436,6 +436,54 @@ Remaining in `pos-customer`, largest first: `SegmentResolutionService` (64 misse
 58.5%), `SegmentPredicateValidator` (26, 71.4%), and the CRM controllers
 (`CustomerController` 26, `CrmPartyRelationshipController` 24, `CrmPersonController`
 21 — all want `@WebMvcTest` slices).
+
+### 4.4 pos-people, pos-invoice, pos-people-contact progress (2026-08-11)
+
+All figures **unit-only** (`-DskipITs`). As with `pos-customer`, the §1.5
+baselines were stale: measured starting points were `pos-people` 66.2% (not
+61.5%), `pos-invoice` 67.5% (not 63.4%), `pos-people-contact` 54.8% (not 45.6%).
+
+| Module | Line | Branch | Missed lines |
+|---|---|---|---|
+| pos-people | 66.2% → **79.4%** | 53.3% → **63.6%** | 965 → 588 |
+| pos-invoice | 67.5% → **77.7%** | 58.2% → **64.0%** | 1,075 → 739 |
+| pos-people-contact | 54.8% → **65.2%** | 38.3% → **52.3%** | 667 → 514 |
+
+The dominant find was that **wave 1e is far from closed repo-wide**: every Kafka
+listener in `pos-people` (5 classes) and `pos-invoice` (7) was at 0%. Both
+modules' listeners fall into two internally-identical families — replica
+listeners and reconciliation manifest listeners — so each family's shared
+contract is now pinned once in a parameterized contract test, with only per-owner
+field mapping covered separately. That pattern (first used for `pos-order`) is
+the cheapest way to close the remaining wave-1e surface elsewhere.
+
+One cross-module inconsistency is now pinned rather than "fixed": whether a
+replica listener records a `processed_events` row for an event type it ignores
+depends on **whether that owner has a manifest listener in the same module**.
+`pos-order`'s listeners skip the row; `pos-people`'s and `pos-invoice`'s record
+it, because their manifest listeners compare against the owner's count of every
+fact in the window. `pos-people`'s workorder listener skips it, correctly, since
+that module runs no workorder manifest listener. Aligning these without moving
+the manifest listeners would break one side or the other.
+
+**A recurring Jackson 3 hazard, worth a decision.** `FAIL_ON_NULL_FOR_PRIMITIVES`
+is on by default, so a payload that simply **omits** a primitive field
+(`boolean`, `int`) fails deserialization. In a replica listener that failure
+lands in the malformed-payload branch: the fact is **silently dropped and still
+marked processed**, so reconciliation will not flag it either. It bit three
+event records during this work (`OrderInvoiceResponse.existing`,
+`CustomerPartyUpdatedV1.requirementsMet`, `LocationUpdatedV1.active`). Producers
+in this repo always send the field, so nothing is broken today — but a producer
+that ever omits one gets silent data loss with no signal. Worth deciding whether
+to box these fields, or relax the setting on consumer mappers.
+
+Remaining in these three: `pos-people-contact` `PersonServiceImpl` (127 missed),
+`PeopleContactCommandListener` (61), `PeopleExceptionHandler` (58),
+`LinkCommandHandler` (31); `pos-invoice` `InvoiceArtifactService` (65),
+`PaymentEventPublisher` (54), `InvoiceEventPublisher` (47),
+`InvoiceExceptionHandler` (40), `TaxServiceClient` (32); `pos-people`
+`EmployeeServiceImpl` (38), `PeopleExceptionHandler` (27), and two DTO classes
+(66 combined).
 
 The per-module detail below predates the measurement and is kept for the specific
 class-level targets it names.

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/service/ManifestListenerContractTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/service/ManifestListenerContractTest.java
@@ -1,0 +1,219 @@
+package com.positivity.invoice.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.domainevents.UuidV7Timestamps;
+import com.positivity.invoice.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * pos-invoice runs one reconciliation listener per upstream owner it replicates,
+ * and all three are structurally identical, so the shared contract is pinned once
+ * here (ADR-0044 §4).
+ *
+ * <p>
+ * Reconciliation is the only thing that notices a lost fact. What makes it safe
+ * to run unattended is that the verdict is stateless — the same manifest
+ * reprocessed yields the same answer, so a redelivery costs one idempotent
+ * replay rather than corruption — and that drift both increments the metric and
+ * requests a replay naming the window that failed. Metric without replay is
+ * silent divergence; replay without metric means nobody learns it is happening.
+ *
+ * <p>
+ * Each listener must also request its replay on <em>its own</em> owner's commands
+ * topic. A misrouted replay would repair nothing and would look like a
+ * successful repair attempt in the logs. (The workorder listener's topic field is
+ * named {@code locationCommandsTopic} — a copy-paste leftover — but the
+ * {@code @Value} key and default bind the workorder topic, and the test below
+ * pins the routing rather than the field name.)
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("pos-invoice reconciliation manifest listeners — shared drift contract")
+class ManifestListenerContractTest {
+
+    private static final Instant WINDOW_START = Instant.parse("2026-08-11T09:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-08-11T09:05:00Z");
+
+    static final List<String> LISTENERS = List.of("customer", "location", "workorder");
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Mock
+    private ObjectProvider<MeterRegistry> meterRegistryProvider;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private SimpleMeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        when(meterRegistryProvider.getIfAvailable()).thenReturn(meterRegistry);
+    }
+
+    private record Listener(String owner, String commandsTopic, Consumer<String> dispatch) {}
+
+    private Listener listener(String owner) {
+        switch (owner) {
+            case "customer" -> {
+                CustomerManifestListener listener = new CustomerManifestListener(
+                        processedEventRepository, kafkaTemplate, objectMapper, meterRegistryProvider);
+                ReflectionTestUtils.setField(listener, "customerCommandsTopic", "customer.commands.v1");
+                return new Listener(CustomerEventsListener.OWNER, "customer.commands.v1", listener::onManifest);
+            }
+            case "location" -> {
+                LocationManifestListener listener = new LocationManifestListener(
+                        processedEventRepository, kafkaTemplate, objectMapper, meterRegistryProvider);
+                ReflectionTestUtils.setField(listener, "locationCommandsTopic", "location.commands.v1");
+                return new Listener(LocationEventsListener.OWNER, "location.commands.v1", listener::onManifest);
+            }
+            default -> {
+                WorkorderManifestListener listener = new WorkorderManifestListener(
+                        processedEventRepository, kafkaTemplate, objectMapper, meterRegistryProvider);
+                // Field name is a copy-paste leftover; the @Value key binds the workorder topic.
+                ReflectionTestUtils.setField(listener, "locationCommandsTopic", "workorder.commands.v1");
+                return new Listener(WorkorderEventsListener.OWNER, "workorder.commands.v1", listener::onManifest);
+            }
+        }
+    }
+
+    private String manifest(long eventCount, String checksum) {
+        return """
+                {"eventId":"evt-1","eventType":"x.reconciliation.manifest",
+                 "payload":{"windowStartUtc":"%s","windowEndUtc":"%s","eventCount":%d,
+                   "eventIdsChecksum":"%s","eventTypeCounts":null}}
+                """.formatted(WINDOW_START, WINDOW_END, eventCount, checksum);
+    }
+
+    private void replicaHolds(Listener listener, List<String> eventIds) {
+        when(processedEventRepository.findEventIdsInRange(
+                        listener.owner(),
+                        UuidV7Timestamps.minStringAt(WINDOW_START),
+                        UuidV7Timestamps.minStringAt(WINDOW_END)))
+                .thenReturn(eventIds);
+    }
+
+    private double driftCount(String owner) {
+        return meterRegistry.find("replica.drift").tag("owner", owner).counters().stream()
+                .mapToDouble(io.micrometer.core.instrument.Counter::count)
+                .sum();
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("stays silent when the local replica matches the owner's manifest")
+    void matchingWindowRequestsNothing(String owner) {
+        Listener listener = listener(owner);
+        List<String> ids = List.of("019ff000-0000-7000-8000-000000000001");
+        replicaHolds(listener, ids);
+
+        listener.dispatch().accept(manifest(ids.size(), ReconciliationManifestV1.checksumOf(ids)));
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        assertThat(driftCount(listener.owner())).isZero();
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("routes the replay to its own owner's commands topic, keyed on the window start")
+    void replayGoesToTheOwnersTopic(String owner) {
+        Listener listener = listener(owner);
+        replicaHolds(listener, List.of());
+
+        listener.dispatch().accept(manifest(2, "owner-checksum"));
+
+        ArgumentCaptor<String> command = ArgumentCaptor.forClass(String.class);
+        // A misrouted replay repairs nothing while looking like a successful attempt.
+        verify(kafkaTemplate)
+                .send(
+                        org.mockito.ArgumentMatchers.eq(listener.commandsTopic()),
+                        org.mockito.ArgumentMatchers.eq(WINDOW_START.toString()),
+                        command.capture());
+        var payload = objectMapper.readTree(command.getValue()).path("payload");
+        assertThat(payload.path("since").asString()).isEqualTo(WINDOW_START.toString());
+        assertThat(payload.path("until").asString()).isEqualTo(WINDOW_END.toString());
+        assertThat(driftCount(listener.owner())).isEqualTo(1.0);
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("treats a matching count with a different checksum as drift")
+    void checksumMismatchIsDrift(String owner) {
+        Listener listener = listener(owner);
+        List<String> ids = List.of("019ff000-0000-7000-8000-000000000001");
+        replicaHolds(listener, ids);
+
+        // Same number of events, different identities — a count-only check would have passed.
+        listener.dispatch().accept(manifest(ids.size(), "a-different-checksum"));
+
+        assertThat(driftCount(listener.owner())).isEqualTo(1.0);
+        verify(kafkaTemplate).send(anyString(), anyString(), anyString());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("reaches the same verdict every time the same manifest is reprocessed")
+    void verdictIsStateless(String owner) {
+        Listener listener = listener(owner);
+        replicaHolds(listener, List.of());
+        String message = manifest(2, "owner-checksum");
+
+        listener.dispatch().accept(message);
+        listener.dispatch().accept(message);
+
+        assertThat(driftCount(listener.owner())).isEqualTo(2.0);
+        verify(kafkaTemplate, org.mockito.Mockito.times(2)).send(anyString(), anyString(), anyString());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("drops an unparseable manifest rather than retrying it")
+    void unparseableManifestIsDropped(String owner) {
+        listener(owner).dispatch().accept("{not json");
+
+        verify(processedEventRepository, never()).findEventIdsInRange(anyString(), anyString(), anyString());
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("still counts drift when the replay request cannot be published")
+    void replayPublishFailureStillCountsDrift(String owner) {
+        Listener listener = listener(owner);
+        replicaHolds(listener, List.of());
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenThrow(new IllegalStateException("broker down"));
+
+        listener.dispatch().accept(manifest(3, "owner-checksum"));
+
+        // Best effort by design: a broker outage must not take the consumer down with it.
+        assertThat(driftCount(listener.owner())).isEqualTo(1.0);
+    }
+}

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/service/ReplicaListenerContractTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/service/ReplicaListenerContractTest.java
@@ -1,0 +1,376 @@
+package com.positivity.invoice.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.customer.CustomerPartyDeletedV1;
+import com.positivity.domainevents.customer.CustomerPartyUpdatedV1;
+import com.positivity.domainevents.location.LocationDeletedV1;
+import com.positivity.domainevents.location.LocationUpdatedV1;
+import com.positivity.domainevents.people.EmployeeUpdatedV1;
+import com.positivity.domainevents.workorder.WorkorderUpdatedV1;
+import com.positivity.invoice.internal.entity.ExtCustomerPartyReplica;
+import com.positivity.invoice.internal.entity.ExtEmployeeReplica;
+import com.positivity.invoice.internal.entity.ExtLocationReplica;
+import com.positivity.invoice.internal.entity.ExtWorkorderReplica;
+import com.positivity.invoice.internal.entity.ProcessedEvent;
+import com.positivity.invoice.internal.repository.ExtCustomerPartyReplicaRepository;
+import com.positivity.invoice.internal.repository.ExtEmployeeReplicaRepository;
+import com.positivity.invoice.internal.repository.ExtLocationReplicaRepository;
+import com.positivity.invoice.internal.repository.ExtWorkorderReplicaRepository;
+import com.positivity.invoice.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.QueryTimeoutException;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * pos-invoice keeps four {@code ext_*} replicas, one per upstream owner, and all
+ * four listeners implement the same consumer contract (ADR-0044 §6). It is pinned
+ * once here so a listener cannot quietly drop half of it, and the per-owner field
+ * mapping is covered in the mapping tests below.
+ *
+ * <p>
+ * The contract:
+ *
+ * <ul>
+ * <li><b>An unparseable message or an envelope with no {@code eventId} is
+ * skipped without a dedup row</b> — there is nothing to de-duplicate it by, and
+ * recording it would mask a later genuine delivery of the same id.</li>
+ * <li><b>A replayed {@code eventId} is a no-op</b>, which is what makes
+ * at-least-once delivery safe.</li>
+ * <li><b>A transient database error is rethrown</b> so the container retries and
+ * can reach the DLQ; swallowing it would leave the replica permanently behind
+ * with nothing to signal it.</li>
+ * <li><b>A malformed payload is swallowed but still recorded.</b> A poison
+ * message must not wedge the partition, and the row keeps this consumer's count
+ * aligned with the owner's manifest, which counts every fact in the
+ * window.</li>
+ * <li><b>The stale guard skips only strictly-lower versions.</b> The producer's
+ * {@code aggregateVersion} is an emission-timestamp hint, so an equal version
+ * re-applies a full snapshot rather than risking a dropped update.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("pos-invoice ext_* replica listeners — shared consumer contract")
+class ReplicaListenerContractTest {
+
+    private static final UUID ID = UUID.fromString("00000000-0000-0000-0000-0000000000d1");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private ExtCustomerPartyReplicaRepository customerRepository;
+
+    @Mock
+    private ExtLocationReplicaRepository locationRepository;
+
+    @Mock
+    private ExtEmployeeReplicaRepository employeeRepository;
+
+    @Mock
+    private ExtWorkorderReplicaRepository workorderRepository;
+
+    static final List<String> LISTENERS = List.of("customer", "location", "people", "workorder");
+
+    /** One listener under test: how to feed it, what it replicates, and how to make it fail hard. */
+    private record Listener(
+            String owner,
+            String eventType,
+            java.util.function.Function<String, String> payload,
+            Consumer<String> dispatch,
+            Runnable failHard) {}
+
+    @BeforeEach
+    void setUp() {
+        when(processedEventRepository.existsById(any())).thenReturn(false);
+        when(customerRepository.findById(any())).thenReturn(Optional.empty());
+        when(locationRepository.findById(any())).thenReturn(Optional.empty());
+        when(employeeRepository.findById(any())).thenReturn(Optional.empty());
+        when(workorderRepository.findById(any())).thenReturn(Optional.empty());
+    }
+
+    private Listener listener(String owner) {
+        return switch (owner) {
+            case "customer" ->
+                new Listener(
+                        CustomerEventsListener.OWNER,
+                        CustomerPartyUpdatedV1.EVENT_TYPE,
+                        id -> """
+                            {"partyId":"%s","partyType":"ORGANIZATION","displayName":"Fleet Co",
+                             "status":"ACTIVE","requirementsMet":true}""".formatted(id),
+                        new CustomerEventsListener(clock, objectMapper, processedEventRepository, customerRepository)
+                                ::onCustomerEvent,
+                        () -> doThrow(new QueryTimeoutException("lock wait"))
+                                .when(customerRepository)
+                                .findById(any()));
+            case "location" ->
+                new Listener(
+                        LocationEventsListener.OWNER,
+                        LocationUpdatedV1.EVENT_TYPE,
+                        id -> """
+                            {"locationId":"%s","name":"Main Shop","active":true}""".formatted(id),
+                        new LocationEventsListener(clock, objectMapper, processedEventRepository, locationRepository)
+                                ::onLocationEvent,
+                        () -> doThrow(new QueryTimeoutException("lock wait"))
+                                .when(locationRepository)
+                                .findById(any()));
+            case "people" ->
+                new Listener(
+                        PeopleEventsListener.OWNER,
+                        EmployeeUpdatedV1.EVENT_TYPE,
+                        id -> """
+                            {"employeeId":"%s","employeeNumber":"E-1001","status":"ACTIVE"}""".formatted(id),
+                        new PeopleEventsListener(clock, objectMapper, processedEventRepository, employeeRepository)
+                                ::onPeopleEvent,
+                        () -> doThrow(new QueryTimeoutException("lock wait"))
+                                .when(employeeRepository)
+                                .findById(any()));
+            default ->
+                new Listener(
+                        WorkorderEventsListener.OWNER,
+                        WorkorderUpdatedV1.EVENT_TYPE,
+                        id -> """
+                            {"workorderId":"%s","workorderNumber":"WO-1001","status":"CLOSED"}""".formatted(id),
+                        new WorkorderEventsListener(clock, objectMapper, processedEventRepository, workorderRepository)
+                                ::onWorkorderEvent,
+                        () -> doThrow(new QueryTimeoutException("lock wait"))
+                                .when(workorderRepository)
+                                .findById(any()));
+        };
+    }
+
+    private String envelope(Listener listener, String eventId, String idValue) {
+        return """
+                {"eventId":"%s","eventType":"%s","aggregateVersion":3,"payload":%s}""".formatted(eventId, listener.eventType(), listener.payload().apply(idValue));
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("stamps its own owner on the dedup row after applying a well-formed fact")
+    void happyPathRecordsProcessedEvent(String owner) {
+        Listener listener = listener(owner);
+
+        listener.dispatch().accept(envelope(listener, "evt-1", ID.toString()));
+
+        ArgumentCaptor<ProcessedEvent> captor = ArgumentCaptor.forClass(ProcessedEvent.class);
+        verify(processedEventRepository).save(captor.capture());
+        assertThat(captor.getValue().getEventId()).isEqualTo("evt-1");
+        assertThat(captor.getValue().getOwner()).isEqualTo(listener.owner());
+        assertThat(captor.getValue().getProcessedAt()).isEqualTo(NOW);
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("skips a message that is not JSON without recording it")
+    void unparsableMessageIsSkipped(String owner) {
+        listener(owner).dispatch().accept("{not json");
+
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("skips an envelope with no eventId, since nothing could de-duplicate it")
+    void missingEventIdIsSkipped(String owner) {
+        Listener listener = listener(owner);
+
+        listener.dispatch().accept(envelope(listener, "", ID.toString()));
+
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("no-ops on a replayed eventId")
+    void replayIsIgnored(String owner) {
+        when(processedEventRepository.existsById("evt-1")).thenReturn(true);
+        Listener listener = listener(owner);
+
+        listener.dispatch().accept(envelope(listener, "evt-1", ID.toString()));
+
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("rethrows a transient database error so the container retries instead of losing the fact")
+    void transientDatabaseErrorIsRethrown(String owner) {
+        Listener listener = listener(owner);
+        listener.failHard().run();
+
+        assertThatThrownBy(() -> listener.dispatch().accept(envelope(listener, "evt-1", ID.toString())))
+                .isInstanceOf(QueryTimeoutException.class);
+
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("swallows a malformed payload but still records it, keeping the manifest count aligned")
+    void malformedPayloadIsSwallowedAndRecorded(String owner) {
+        Listener listener = listener(owner);
+
+        listener.dispatch().accept(envelope(listener, "evt-1", "not-a-uuid"));
+
+        verify(processedEventRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("customer: replicates the party fields invoicing needs, and removes the row on deletion")
+    void customerMapping() {
+        CustomerEventsListener listener =
+                new CustomerEventsListener(clock, objectMapper, processedEventRepository, customerRepository);
+
+        listener.onCustomerEvent("""
+                {"eventId":"evt-1","eventType":"%s","aggregateVersion":3,
+                 "payload":{"partyId":"%s","partyType":"ORGANIZATION","displayName":"Fleet Co",
+                   "status":"ACTIVE","requirementsMet":true}}""".formatted(CustomerPartyUpdatedV1.EVENT_TYPE, ID));
+
+        ArgumentCaptor<ExtCustomerPartyReplica> captor = ArgumentCaptor.forClass(ExtCustomerPartyReplica.class);
+        verify(customerRepository).save(captor.capture());
+        assertThat(captor.getValue().getPartyId()).isEqualTo(ID);
+        assertThat(captor.getValue().getPartyType()).isEqualTo("ORGANIZATION");
+        assertThat(captor.getValue().getDisplayName()).isEqualTo("Fleet Co");
+        assertThat(captor.getValue().getAggregateVersion()).isEqualTo(3);
+        assertThat(captor.getValue().getUpdatedAt()).isEqualTo(NOW);
+
+        listener.onCustomerEvent("""
+                {"eventId":"evt-2","eventType":"%s","payload":{"partyId":"%s"}}""".formatted(CustomerPartyDeletedV1.EVENT_TYPE, ID));
+        verify(customerRepository).deleteById(ID);
+    }
+
+    @Test
+    @DisplayName("location: replicates the full address an invoice is stamped with")
+    void locationMapping() {
+        LocationEventsListener listener =
+                new LocationEventsListener(clock, objectMapper, processedEventRepository, locationRepository);
+
+        listener.onLocationEvent("""
+                {"eventId":"evt-1","eventType":"%s","aggregateVersion":2,
+                 "payload":{"locationId":"%s","name":"Main Shop","code":"SHOP-1","status":"OPEN",
+                   "active":true,"locationType":"SHOP","hrLocationId":null,"timezone":"America/Chicago",
+                   "addressLine1":"1 Main St","addressLine2":"Suite 2","city":"Austin","region":"TX",
+                   "postalCode":"78701","country":"US","defaultStagingLocationId":null,
+                   "defaultQuarantineLocationId":null,"parents":[],
+                   "createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-08-01T00:00:00Z"}}""".formatted(LocationUpdatedV1.EVENT_TYPE, ID));
+
+        ArgumentCaptor<ExtLocationReplica> captor = ArgumentCaptor.forClass(ExtLocationReplica.class);
+        verify(locationRepository).save(captor.capture());
+        ExtLocationReplica saved = captor.getValue();
+        // The whole address is kept: an invoice reprint has to reproduce what was billed.
+        assertThat(saved.getAddressLine1()).isEqualTo("1 Main St");
+        assertThat(saved.getAddressLine2()).isEqualTo("Suite 2");
+        assertThat(saved.getCity()).isEqualTo("Austin");
+        assertThat(saved.getRegion()).isEqualTo("TX");
+        assertThat(saved.getPostalCode()).isEqualTo("78701");
+        assertThat(saved.getCountry()).isEqualTo("US");
+        assertThat(saved.getTimezone()).isEqualTo("America/Chicago");
+        assertThat(saved.isActive()).isTrue();
+
+        listener.onLocationEvent("""
+                {"eventId":"evt-2","eventType":"%s","payload":{"locationId":"%s"}}""".formatted(LocationDeletedV1.EVENT_TYPE, ID));
+        verify(locationRepository).deleteById(ID);
+    }
+
+    @Test
+    @DisplayName("people: replicates the employee identity an invoice attributes work to")
+    void peopleMapping() {
+        UUID personId = UUID.randomUUID();
+        new PeopleEventsListener(clock, objectMapper, processedEventRepository, employeeRepository)
+                .onPeopleEvent("""
+                        {"eventId":"evt-1","eventType":"%s","aggregateVersion":1,
+                         "payload":{"employeeId":"%s","personId":"%s","employeeNumber":"E-1001",
+                           "status":"ACTIVE","hireDate":"2026-01-15","terminationDate":null,
+                           "statusEffectiveAt":"2026-01-15T00:00:00Z"}}""".formatted(EmployeeUpdatedV1.EVENT_TYPE, ID, personId));
+
+        ArgumentCaptor<ExtEmployeeReplica> captor = ArgumentCaptor.forClass(ExtEmployeeReplica.class);
+        verify(employeeRepository).save(captor.capture());
+        assertThat(captor.getValue().getEmployeeId()).isEqualTo(ID);
+        assertThat(captor.getValue().getPersonId()).isEqualTo(personId);
+        assertThat(captor.getValue().getEmployeeNumber()).isEqualTo("E-1001");
+        assertThat(captor.getValue().getStatus()).isEqualTo("ACTIVE");
+    }
+
+    @Test
+    @DisplayName("people: ignores an event type it does not consume, without a dedup row")
+    void peopleIgnoresOtherTypes() {
+        new PeopleEventsListener(clock, objectMapper, processedEventRepository, employeeRepository).onPeopleEvent("""
+                        {"eventId":"evt-9","eventType":"people.staffing-assignment.updated","payload":{}}""");
+
+        verify(employeeRepository, never()).save(any());
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("workorder: replicates the workorder an invoice is raised from")
+    void workorderMapping() {
+        UUID customerId = UUID.randomUUID();
+        new WorkorderEventsListener(clock, objectMapper, processedEventRepository, workorderRepository)
+                .onWorkorderEvent("""
+                        {"eventId":"evt-1","eventType":"%s","aggregateVersion":6,
+                         "payload":{"workorderId":"%s","workorderNumber":"WO-1001","status":"CLOSED",
+                           "customerId":"%s","vehicleId":null,"shopId":null,"invoiceId":null,
+                           "parts":[],"services":[]}}""".formatted(WorkorderUpdatedV1.EVENT_TYPE, ID, customerId));
+
+        ArgumentCaptor<ExtWorkorderReplica> captor = ArgumentCaptor.forClass(ExtWorkorderReplica.class);
+        verify(workorderRepository).save(captor.capture());
+        assertThat(captor.getValue().getWorkorderId()).isEqualTo(ID);
+        assertThat(captor.getValue().getWorkorderNumber()).isEqualTo("WO-1001");
+        assertThat(captor.getValue().getStatus()).isEqualTo("CLOSED");
+        assertThat(captor.getValue().getCustomerId()).isEqualTo(customerId);
+        assertThat(captor.getValue().getAggregateVersion()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("ignores a snapshot strictly older than the replica but re-applies an equal one")
+    void staleGuardIsStrict() {
+        when(workorderRepository.findById(ID))
+                .thenReturn(Optional.of(ExtWorkorderReplica.builder()
+                        .workorderId(ID)
+                        .aggregateVersion(6)
+                        .build()));
+        WorkorderEventsListener listener =
+                new WorkorderEventsListener(clock, objectMapper, processedEventRepository, workorderRepository);
+        String template = """
+                {"eventId":"evt-%d","eventType":"%s","aggregateVersion":%d,
+                 "payload":{"workorderId":"%s","workorderNumber":"WO-1001","status":"CLOSED",
+                   "customerId":null,"vehicleId":null,"shopId":null,"invoiceId":null,
+                   "parts":[],"services":[]}}""";
+
+        listener.onWorkorderEvent(template.formatted(1, WorkorderUpdatedV1.EVENT_TYPE, 5, ID));
+        verify(workorderRepository, never()).save(any());
+
+        // Equal versions re-apply: the version is an emission-timestamp hint and the payload is a
+        // full snapshot, so re-applying costs nothing and never drops a real update.
+        listener.onWorkorderEvent(template.formatted(2, WorkorderUpdatedV1.EVENT_TYPE, 6, ID));
+        verify(workorderRepository).save(any());
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/client/SecurityServiceClientTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/client/SecurityServiceClientTest.java
@@ -1,0 +1,400 @@
+package com.positivity.peoplecontact.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withResourceNotFound;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.positivity.peoplecontact.internal.client.dto.UserRoleAssignmentRequest;
+import com.positivity.peoplecontact.internal.client.dto.UserRoleDto;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link SecurityServiceClient}.
+ *
+ * <p>
+ * This is the RBAC edge of pos-people-contact: it is how a person's login gets
+ * its roles, and how those roles are taken away again. Two behaviours matter
+ * more than the plumbing:
+ *
+ * <ul>
+ * <li><b>Revocation ends an assignment rather than deleting history.</b> The
+ * client looks only at assignments that have not already ended, resolves the one
+ * matching the requested role, and sets an end date. An already-expired
+ * assignment must not be picked, or the revoke would target the wrong row and
+ * silently leave the live one in place.</li>
+ * <li><b>Failures are classified, not flattened.</b> A 404 is an
+ * {@link EntityNotFoundException}, a 400 an {@link IllegalArgumentException},
+ * and anything 5xx a {@link SecurityServiceException} carrying the status — so a
+ * caller can tell "you asked for something that does not exist" from "security
+ * service is down", and only retry the second.</li>
+ * </ul>
+ *
+ * <p>
+ * A {@code null} body on a 200 is also treated as a failure rather than as an
+ * empty result: silently returning "no roles" when the service answered
+ * unintelligibly would read as a valid, role-less user.
+ */
+@DisplayName("SecurityServiceClient — RBAC lookups and assignment lifecycle")
+class SecurityServiceClientTest {
+
+    private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e1");
+    private static final UUID ROLE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e2");
+    private static final UUID ASSIGNMENT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e3");
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e4");
+    private static final LocalDate TODAY = LocalDate.of(2026, 8, 11);
+
+    private MockRestServiceServer server;
+    private SecurityServiceClient client;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder().baseUrl("http://security");
+        server = MockRestServiceServer.bindTo(builder).build();
+        client = new SecurityServiceClient(
+                builder.build(), Clock.fixed(Instant.parse("2026-08-11T12:00:00Z"), ZoneOffset.UTC));
+    }
+
+    private void expectRoleLookup(String roleName) {
+        server.expect(requestTo("http://security/v1/roles/by-name/" + roleName))
+                .andRespond(withSuccess("""
+                        {"id":"%s","name":"%s","description":"d"}""".formatted(ROLE_ID, roleName), MediaType.APPLICATION_JSON));
+    }
+
+    @Nested
+    @DisplayName("getUserByUsername")
+    class UserLookup {
+
+        @Test
+        @DisplayName("matches the username case-insensitively and ignores other users")
+        void matchesCaseInsensitively() {
+            server.expect(requestTo("http://security/v1/users"))
+                    .andRespond(withSuccess("""
+                            [{"id":"%s","username":"Ada.Lovelace"},
+                             {"id":"%s","username":"someone.else"}]""".formatted(USER_ID, UUID.randomUUID()), MediaType.APPLICATION_JSON));
+
+            assertThat(client.getUserByUsername("ada.lovelace"))
+                    .get()
+                    .extracting(u -> u.getId())
+                    .isEqualTo(USER_ID);
+        }
+
+        @Test
+        @DisplayName("reports an unknown username as empty rather than as an error")
+        void unknownUsernameIsEmpty() {
+            server.expect(requestTo("http://security/v1/users"))
+                    .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
+
+            assertThat(client.getUserByUsername("nobody")).isEmpty();
+        }
+
+        @Test
+        @DisplayName("classifies 400, 401/403, and 5xx differently so callers can react correctly")
+        void failureClassification() {
+            server.expect(requestTo("http://security/v1/users")).andRespond(withBadRequest());
+            assertThatThrownBy(() -> client.getUserByUsername("bad")).isInstanceOf(IllegalArgumentException.class);
+
+            setUp();
+            server.expect(requestTo("http://security/v1/users")).andRespond(withStatus(HttpStatus.FORBIDDEN));
+            // Not authorized is a security-service condition, not a bad request from the caller.
+            assertThatThrownBy(() -> client.getUserByUsername("ada")).isInstanceOf(SecurityServiceException.class);
+
+            setUp();
+            server.expect(requestTo("http://security/v1/users")).andRespond(withServerError());
+            assertThatThrownBy(() -> client.getUserByUsername("ada")).isInstanceOf(SecurityServiceException.class);
+        }
+
+        @Test
+        @DisplayName("treats a null body on a 200 as a failure, not as an empty user list")
+        void nullBodyIsAFailure() {
+            server.expect(requestTo("http://security/v1/users"))
+                    .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
+
+            // Returning empty here would read as "this user genuinely does not exist".
+            assertThatThrownBy(() -> client.getUserByUsername("ada")).isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getAvailableRoles / getUserRoleAssignments")
+    class Reads {
+
+        @Test
+        @DisplayName("passes the scope through as a query parameter")
+        void rolesByScope() {
+            server.expect(requestTo("http://security/v1/roles?scopeType=LOCATION"))
+                    .andRespond(withSuccess("""
+                            [{"code":"TECH","name":"Technician","description":"d",
+                              "scopeType":"LOCATION","active":true}]""", MediaType.APPLICATION_JSON));
+
+            assertThat(client.getAvailableRoles("LOCATION"))
+                    .singleElement()
+                    .extracting(r -> r.getCode())
+                    .isEqualTo("TECH");
+        }
+
+        @Test
+        @DisplayName("maps a missing roles endpoint to not-found and a bad scope to illegal argument")
+        void rolesFailureClassification() {
+            server.expect(requestTo("http://security/v1/roles?scopeType=NOPE")).andRespond(withBadRequest());
+            assertThatThrownBy(() -> client.getAvailableRoles("NOPE")).isInstanceOf(IllegalArgumentException.class);
+
+            setUp();
+            server.expect(requestTo("http://security/v1/roles?scopeType=LOCATION"))
+                    .andRespond(withResourceNotFound());
+            assertThatThrownBy(() -> client.getAvailableRoles("LOCATION")).isInstanceOf(EntityNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("forwards the history and end-date filters to the assignments endpoint")
+        void assignmentsQuery() {
+            server.expect(requestTo(
+                            "http://security/v1/roles/assignments/user/%s?includeHistory=true&endDate=2026-08-31T00:00"
+                                    .formatted(USER_ID)))
+                    .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
+
+            assertThat(client.getUserRoleAssignments(USER_ID, true, LocalDateTime.of(2026, 8, 31, 0, 0)))
+                    .isEmpty();
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("treats a null assignments body as a failure rather than as no assignments")
+        void nullAssignmentsBodyIsAFailure() {
+            server.expect(requestTo(org.hamcrest.Matchers.containsString("/v1/roles/assignments/user/")))
+                    .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
+
+            assertThatThrownBy(() -> client.getUserRoleAssignments(USER_ID, false, null))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("assignRole")
+    class Assign {
+
+        @Test
+        @DisplayName("resolves the role name to an id and scopes the assignment to the given locations")
+        void locationScopedAssignment() {
+            expectRoleLookup("TECH");
+            server.expect(requestTo("http://security/v1/roles/assignments"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andExpect(jsonPath("$.userId").value(USER_ID.toString()))
+                    .andExpect(jsonPath("$.roleId").value(ROLE_ID.toString()))
+                    // Supplying any location makes this a LOCATION-scoped grant, not a global one.
+                    .andExpect(jsonPath("$.scopeType").value("LOCATION"))
+                    .andExpect(jsonPath("$.scopeLocationIds[0]").value(LOCATION_ID.toString()))
+                    .andRespond(withSuccess(assignmentJson(TODAY, null, "LOCATION"), MediaType.APPLICATION_JSON));
+
+            UserRoleDto result = client.assignRole(UserRoleAssignmentRequest.builder()
+                    .userId(USER_ID)
+                    .roleCode("TECH")
+                    .locationIds(Set.of(LOCATION_ID))
+                    .startDate(LocalDateTime.of(2026, 8, 11, 0, 0))
+                    .build());
+
+            assertThat(result.getRoleCode()).isEqualTo("TECH");
+            assertThat(result.getUserId()).isEqualTo(USER_ID.toString());
+            assertThat(result.getLocationId()).isEqualTo(LOCATION_ID);
+            assertThat(result.getActive()).isTrue();
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("falls back to a GLOBAL scope when no location is named")
+        void globalAssignment() {
+            expectRoleLookup("ADMIN");
+            server.expect(requestTo("http://security/v1/roles/assignments"))
+                    // No location means the grant applies everywhere; sending LOCATION with an
+                    // empty set would silently grant nothing.
+                    .andExpect(jsonPath("$.scopeType").value("GLOBAL"))
+                    .andExpect(jsonPath("$.scopeLocationIds").doesNotExist())
+                    .andRespond(withSuccess(assignmentJson(TODAY, null, "GLOBAL"), MediaType.APPLICATION_JSON));
+
+            assertThat(client.assignRole(UserRoleAssignmentRequest.builder()
+                                    .userId(USER_ID)
+                                    .roleCode("ADMIN")
+                                    .build())
+                            .getLocationId())
+                    .isNull();
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("reports an assignment that has already ended as inactive")
+        void endedAssignmentIsInactive() {
+            expectRoleLookup("TECH");
+            server.expect(requestTo("http://security/v1/roles/assignments"))
+                    .andRespond(withSuccess(
+                            assignmentJson(TODAY.minusDays(10), TODAY.minusDays(1), "GLOBAL"),
+                            MediaType.APPLICATION_JSON));
+
+            assertThat(client.assignRole(UserRoleAssignmentRequest.builder()
+                                    .userId(USER_ID)
+                                    .roleCode("TECH")
+                                    .build())
+                            .getActive())
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("reports an assignment that has not started yet as inactive")
+        void futureAssignmentIsInactive() {
+            expectRoleLookup("TECH");
+            server.expect(requestTo("http://security/v1/roles/assignments"))
+                    .andRespond(
+                            withSuccess(assignmentJson(TODAY.plusDays(1), null, "GLOBAL"), MediaType.APPLICATION_JSON));
+
+            assertThat(client.assignRole(UserRoleAssignmentRequest.builder()
+                                    .userId(USER_ID)
+                                    .roleCode("TECH")
+                                    .build())
+                            .getActive())
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("surfaces an unknown role name as not-found before any assignment is attempted")
+        void unknownRoleIsNotFound() {
+            server.expect(requestTo("http://security/v1/roles/by-name/GHOST")).andRespond(withResourceNotFound());
+
+            assertThatThrownBy(() -> client.assignRole(UserRoleAssignmentRequest.builder()
+                            .userId(USER_ID)
+                            .roleCode("GHOST")
+                            .build()))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("classifies assignment failures by status")
+        void assignmentFailureClassification() {
+            expectRoleLookup("TECH");
+            server.expect(requestTo("http://security/v1/roles/assignments")).andRespond(withServerError());
+
+            assertThatThrownBy(() -> client.assignRole(UserRoleAssignmentRequest.builder()
+                            .userId(USER_ID)
+                            .roleCode("TECH")
+                            .build()))
+                    .isInstanceOf(SecurityServiceException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("revokeRole")
+    class Revoke {
+
+        @Test
+        @DisplayName("ends the live assignment for that role, ignoring ones that already expired")
+        void revokesTheLiveAssignment() {
+            UUID expiredAssignment = UUID.randomUUID();
+            expectRoleLookup("TECH");
+            server.expect(requestTo(org.hamcrest.Matchers.containsString("/v1/roles/assignments/user/")))
+                    .andRespond(withSuccess(
+                            """
+                            [%s,%s]""".formatted(
+                                            assignmentJson(expiredAssignment, TODAY.minusDays(30), TODAY.minusDays(5)),
+                                            assignmentJson(ASSIGNMENT_ID, TODAY.minusDays(3), null)),
+                            MediaType.APPLICATION_JSON));
+            // The already-ended assignment must not be the one revoked, or the live grant survives.
+            server.expect(requestTo(
+                            "http://security/v1/roles/assignments/%s?endDate=2026-08-20".formatted(ASSIGNMENT_ID)))
+                    .andExpect(method(HttpMethod.DELETE))
+                    .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+            client.revokeRole(USER_ID, "TECH", LocalDateTime.of(2026, 8, 20, 0, 0));
+
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("revokes as of today when the caller names no end date")
+        void defaultsRevocationToToday() {
+            expectRoleLookup("TECH");
+            server.expect(requestTo(org.hamcrest.Matchers.containsString("/v1/roles/assignments/user/")))
+                    .andRespond(withSuccess(
+                            "[" + assignmentJson(ASSIGNMENT_ID, TODAY.minusDays(3), null) + "]",
+                            MediaType.APPLICATION_JSON));
+            server.expect(requestTo(
+                            "http://security/v1/roles/assignments/%s?endDate=%s".formatted(ASSIGNMENT_ID, TODAY)))
+                    .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+            client.revokeRole(USER_ID, "TECH", null);
+
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("keeps an assignment ending today revocable, since it has not ended yet")
+        void assignmentEndingTodayIsStillLive() {
+            expectRoleLookup("TECH");
+            server.expect(requestTo(org.hamcrest.Matchers.containsString("/v1/roles/assignments/user/")))
+                    .andRespond(withSuccess(
+                            "[" + assignmentJson(ASSIGNMENT_ID, TODAY.minusDays(3), TODAY) + "]",
+                            MediaType.APPLICATION_JSON));
+            server.expect(requestTo(org.hamcrest.Matchers.containsString("/v1/roles/assignments/" + ASSIGNMENT_ID)))
+                    .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+            client.revokeRole(USER_ID, "TECH", null);
+
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("reports not-found when the user holds no live assignment for that role")
+        void noMatchingAssignment() {
+            expectRoleLookup("TECH");
+            server.expect(requestTo(org.hamcrest.Matchers.containsString("/v1/roles/assignments/user/")))
+                    .andRespond(withSuccess(
+                            "[" + assignmentJson(ASSIGNMENT_ID, TODAY.minusDays(30), TODAY.minusDays(5)) + "]",
+                            MediaType.APPLICATION_JSON));
+
+            assertThatThrownBy(() -> client.revokeRole(USER_ID, "TECH", null))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+
+    private static String assignmentJson(LocalDate start, LocalDate end, String scopeType) {
+        return assignmentJson(ASSIGNMENT_ID, start, end, scopeType);
+    }
+
+    private static String assignmentJson(UUID assignmentId, LocalDate start, LocalDate end) {
+        return assignmentJson(assignmentId, start, end, "GLOBAL");
+    }
+
+    private static String assignmentJson(UUID assignmentId, LocalDate start, LocalDate end, String scopeType) {
+        return """
+                {"id":"%s","user":{"id":"%s","username":"ada"},
+                 "role":{"id":"%s","name":"TECH","description":"d"},
+                 "scopeType":"%s","scopeLocationIds":%s,
+                 "effectiveStartDate":%s,"effectiveEndDate":%s,"createdAt":"2026-08-01T00:00:00Z"}""".formatted(
+                        assignmentId,
+                        USER_ID,
+                        ROLE_ID,
+                        scopeType,
+                        "LOCATION".equals(scopeType) ? "[\"" + LOCATION_ID + "\"]" : "null",
+                        start == null ? "null" : "\"" + start + "\"",
+                        end == null ? "null" : "\"" + end + "\"");
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/client/SecurityServiceClientTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/client/SecurityServiceClientTest.java
@@ -99,6 +99,7 @@ class SecurityServiceClientTest {
                     .get()
                     .extracting(u -> u.getId())
                     .isEqualTo(USER_ID);
+            server.verify();
         }
 
         @Test
@@ -108,6 +109,7 @@ class SecurityServiceClientTest {
                     .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
 
             assertThat(client.getUserByUsername("nobody")).isEmpty();
+            server.verify();
         }
 
         @Test
@@ -124,6 +126,7 @@ class SecurityServiceClientTest {
             setUp();
             server.expect(requestTo("http://security/v1/users")).andRespond(withServerError());
             assertThatThrownBy(() -> client.getUserByUsername("ada")).isInstanceOf(SecurityServiceException.class);
+            server.verify();
         }
 
         @Test
@@ -134,6 +137,7 @@ class SecurityServiceClientTest {
 
             // Returning empty here would read as "this user genuinely does not exist".
             assertThatThrownBy(() -> client.getUserByUsername("ada")).isInstanceOf(IllegalStateException.class);
+            server.verify();
         }
     }
 
@@ -153,6 +157,7 @@ class SecurityServiceClientTest {
                     .singleElement()
                     .extracting(r -> r.getCode())
                     .isEqualTo("TECH");
+            server.verify();
         }
 
         @Test
@@ -165,6 +170,7 @@ class SecurityServiceClientTest {
             server.expect(requestTo("http://security/v1/roles?scopeType=LOCATION"))
                     .andRespond(withResourceNotFound());
             assertThatThrownBy(() -> client.getAvailableRoles("LOCATION")).isInstanceOf(EntityNotFoundException.class);
+            server.verify();
         }
 
         @Test
@@ -188,6 +194,7 @@ class SecurityServiceClientTest {
 
             assertThatThrownBy(() -> client.getUserRoleAssignments(USER_ID, false, null))
                     .isInstanceOf(IllegalStateException.class);
+            server.verify();
         }
     }
 
@@ -257,6 +264,7 @@ class SecurityServiceClientTest {
                                     .build())
                             .getActive())
                     .isFalse();
+            server.verify();
         }
 
         @Test
@@ -273,6 +281,7 @@ class SecurityServiceClientTest {
                                     .build())
                             .getActive())
                     .isFalse();
+            server.verify();
         }
 
         @Test
@@ -285,6 +294,7 @@ class SecurityServiceClientTest {
                             .roleCode("GHOST")
                             .build()))
                     .isInstanceOf(EntityNotFoundException.class);
+            server.verify();
         }
 
         @Test
@@ -298,6 +308,7 @@ class SecurityServiceClientTest {
                             .roleCode("TECH")
                             .build()))
                     .isInstanceOf(SecurityServiceException.class);
+            server.verify();
         }
     }
 
@@ -372,6 +383,7 @@ class SecurityServiceClientTest {
 
             assertThatThrownBy(() -> client.revokeRole(USER_ID, "TECH", null))
                     .isInstanceOf(EntityNotFoundException.class);
+            server.verify();
         }
     }
 

--- a/pos-people/src/test/java/com/positivity/people/internal/config/PeopleCommandListenerTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/config/PeopleCommandListenerTest.java
@@ -1,0 +1,213 @@
+package com.positivity.people.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.people.service.OutboxReplayService;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link PeopleCommandListener} (ADR-0044 §4).
+ *
+ * <p>
+ * This is the repair end of reconciliation: a downstream replica that detected
+ * drift asks this module to re-emit a window of its outbox. Two guards make that
+ * safe to expose over Kafka:
+ *
+ * <ul>
+ * <li><b>A `since` older than the configured lookback is refused.</b> Replay
+ * cost scales with the window, so a malformed or ancient timestamp must not
+ * trigger a re-emit of the entire outbox.</li>
+ * <li><b>The window is widened by a second at each end.</b> Outbox
+ * {@code createdAt} and the UUIDv7 timestamp inside the eventId can disagree by
+ * under a millisecond, and a window that excluded a boundary event would leave
+ * the drift it was sent to repair still in place.</li>
+ * </ul>
+ *
+ * <p>
+ * Failure handling splits by kind: a transient database error is rethrown so the
+ * container retries and eventually routes to the DLQ (replay is idempotent, so
+ * redelivery is harmless), while a malformed command is logged and dropped —
+ * retrying cannot fix it and would poison the partition.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PeopleCommandListener — outbox replay commands")
+class PeopleCommandListenerTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+
+    @Mock
+    private OutboxReplayService outboxReplayService;
+
+    private PeopleCommandListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new PeopleCommandListener(Clock.fixed(NOW, ZoneOffset.UTC), new ObjectMapper(), outboxReplayService);
+        ReflectionTestUtils.setField(listener, "replayMaxLookback", Duration.ofDays(30));
+    }
+
+    private static String command(String commandType, String since, String until) {
+        return """
+                {"commandType":"%s","payload":{"since":%s,"until":%s}}""".formatted(
+                        commandType,
+                        since == null ? "null" : "\"" + since + "\"",
+                        until == null ? "null" : "\"" + until + "\"");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "PEOPLE_OUTBOX_REPLAY_REQUESTED",
+                "people.outbox.replay-requested",
+                "People.Outbox.Replay-Requested"
+            })
+    @DisplayName("accepts the replay command in dotted, hyphenated, or already-normalized form")
+    void commandTypeIsNormalized(String commandType) {
+        listener.onCommand(command(commandType, NOW.minusSeconds(600).toString(), null));
+
+        // Producers spell this differently; normalizing here is what keeps them interoperable.
+        verify(outboxReplayService).replaySince(any());
+    }
+
+    @Test
+    @DisplayName("widens a bounded window by a second at each end to cover timestamp skew")
+    void boundedWindowGetsSlack() {
+        Instant since = NOW.minusSeconds(600);
+        Instant until = NOW.minusSeconds(300);
+
+        listener.onCommand(command("people.outbox.replay-requested", since.toString(), until.toString()));
+
+        ArgumentCaptor<Instant> from = ArgumentCaptor.forClass(Instant.class);
+        ArgumentCaptor<Instant> to = ArgumentCaptor.forClass(Instant.class);
+        verify(outboxReplayService).replayBetween(from.capture(), to.capture());
+        // Outbox createdAt and the eventId's embedded timestamp can disagree sub-millisecond; a
+        // window that clipped a boundary event would leave the drift unrepaired.
+        assertThat(from.getValue()).isEqualTo(since.minusSeconds(1));
+        assertThat(to.getValue()).isEqualTo(until.plusSeconds(1));
+    }
+
+    @Test
+    @DisplayName("falls back to an open-ended replay when no usable end is given")
+    void openEndedReplay() {
+        Instant since = NOW.minusSeconds(600);
+
+        listener.onCommand(command("people.outbox.replay-requested", since.toString(), null));
+
+        ArgumentCaptor<Instant> from = ArgumentCaptor.forClass(Instant.class);
+        verify(outboxReplayService).replaySince(from.capture());
+        assertThat(from.getValue()).isEqualTo(since.minusSeconds(1));
+        verify(outboxReplayService, never()).replayBetween(any(), any());
+    }
+
+    @Test
+    @DisplayName("treats an end at or before the start as no end at all")
+    void invertedWindowFallsBackToOpenEnded() {
+        Instant since = NOW.minusSeconds(600);
+
+        listener.onCommand(command("people.outbox.replay-requested", since.toString(), since.toString()));
+
+        // An inverted or empty window would otherwise replay nothing and silently leave the drift.
+        verify(outboxReplayService).replaySince(any());
+        verify(outboxReplayService, never()).replayBetween(any(), any());
+    }
+
+    @Test
+    @DisplayName("refuses a start older than the configured lookback")
+    void ancientSinceIsRefused() {
+        listener.onCommand(command(
+                "people.outbox.replay-requested", NOW.minus(Duration.ofDays(31)).toString(), null));
+
+        // Replay cost scales with the window; an ancient start must not re-emit the whole outbox.
+        verifyNoInteractions(outboxReplayService);
+    }
+
+    @Test
+    @DisplayName("accepts a start just inside the lookback boundary")
+    void sinceInsideLookbackIsAccepted() {
+        listener.onCommand(command(
+                "people.outbox.replay-requested", NOW.minus(Duration.ofDays(29)).toString(), null));
+
+        verify(outboxReplayService).replaySince(any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "not-a-timestamp"})
+    @DisplayName("ignores a replay command whose start is missing or unparseable")
+    void unusableSinceIsIgnored(String since) {
+        listener.onCommand(command("people.outbox.replay-requested", since.isEmpty() ? null : since, null));
+
+        verifyNoInteractions(outboxReplayService);
+    }
+
+    @Test
+    @DisplayName("ignores a command with no payload at all")
+    void missingPayloadIsIgnored() {
+        listener.onCommand("{\"commandType\":\"people.outbox.replay-requested\"}");
+
+        verifyNoInteractions(outboxReplayService);
+    }
+
+    @Test
+    @DisplayName("ignores a command with no commandType and one this module does not handle")
+    void unknownCommandsAreIgnored() {
+        listener.onCommand("{\"payload\":{}}");
+        listener.onCommand(command("people.something.else", NOW.toString(), null));
+
+        verifyNoInteractions(outboxReplayService);
+    }
+
+    @Test
+    @DisplayName("drops a malformed message rather than poisoning the partition")
+    void malformedMessageIsDropped() {
+        listener.onCommand("{not json");
+
+        verifyNoInteractions(outboxReplayService);
+    }
+
+    @Test
+    @DisplayName("rethrows a transient database error so the container retries and can reach the DLQ")
+    void transientErrorIsRethrown() {
+        when(outboxReplayService.replaySince(any())).thenThrow(new QueryTimeoutException("lock wait"));
+
+        // Replay is idempotent, so a redelivery is harmless — losing the repair request is not.
+        assertThatThrownBy(() -> listener.onCommand(command(
+                        "people.outbox.replay-requested", NOW.minusSeconds(600).toString(), null)))
+                .isInstanceOf(QueryTimeoutException.class);
+    }
+
+    @Test
+    @DisplayName("swallows a non-transient failure from the replay service")
+    void permanentFailureIsSwallowed() {
+        when(outboxReplayService.replaySince(any())).thenThrow(new IllegalStateException("bad state"));
+
+        listener.onCommand(
+                command("people.outbox.replay-requested", NOW.minusSeconds(600).toString(), null));
+
+        // Retrying cannot fix it; the next reconciliation window re-detects and re-requests.
+        verify(outboxReplayService).replaySince(any());
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/config/PeopleEventPublisherTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/config/PeopleEventPublisherTest.java
@@ -1,0 +1,266 @@
+package com.positivity.people.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.people.EmployeeUpdatedV1;
+import com.positivity.domainevents.people.StaffingAssignmentUpdatedV1;
+import com.positivity.domainevents.peoplecontact.PersonUpsertRequestedV1;
+import com.positivity.people.internal.entity.Employee;
+import com.positivity.people.internal.entity.EmployeeLocationAssignment;
+import com.positivity.people.internal.enums.AssignmentStatus;
+import com.positivity.people.internal.enums.EmployeeStatus;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link PeopleEventPublisher} (ADR-0044 §2).
+ *
+ * <p>
+ * This class emits two different shapes down two different paths, and mixing
+ * them up would be silently wrong rather than loud:
+ *
+ * <ul>
+ * <li><b>Facts</b> ({@code people.employee.updated},
+ * {@code people.staffing-assignment.updated}) go to this module's own events
+ * topic as full {@link DomainEventEnvelope}s.</li>
+ * <li><b>A person upsert is a command</b>, not a fact — it goes to
+ * pos-people-contact's commands topic as the plain
+ * {@code {commandType, eventId, payload}} message its listener expects, keyed on
+ * the person id, with the eventId serving as the receiver's idempotency key. An
+ * envelope here would simply not be understood by the receiver.</li>
+ * </ul>
+ *
+ * <p>
+ * Every method is a no-op when Kafka is disabled, since the outbox writer bean
+ * is conditional and these are called inside business transactions that must
+ * still commit.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PeopleEventPublisher — people facts and identity commands")
+class PeopleEventPublisherTest {
+
+    private static final UUID EMPLOYEE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c1");
+    private static final UUID PERSON_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c2");
+    private static final UUID ASSIGNMENT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c3");
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c4");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+    private static final String EVENTS_TOPIC = "people.events.v1";
+    private static final String COMMANDS_TOPIC = "people-contact.commands.v1";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private ObjectProvider<OutboxEventWriter> outboxEventWriter;
+
+    @Mock
+    private OutboxEventWriter writer;
+
+    private PeopleEventPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new PeopleEventPublisher(
+                Clock.fixed(NOW, ZoneOffset.UTC), objectMapper, outboxEventWriter, EVENTS_TOPIC, COMMANDS_TOPIC);
+        when(outboxEventWriter.getIfAvailable()).thenReturn(writer);
+    }
+
+    private static Employee employee(EmployeeStatus status) {
+        Employee employee = new Employee();
+        employee.setId(EMPLOYEE_ID);
+        employee.setPersonId(PERSON_ID);
+        employee.setEmployeeNumber("E-1001");
+        employee.setStatus(status);
+        employee.setHireDate(LocalDate.of(2026, 1, 15));
+        employee.setStatusEffectiveAt(NOW.minusSeconds(3_600));
+        return employee;
+    }
+
+    private static EmployeeLocationAssignment assignment(AssignmentStatus status) {
+        EmployeeLocationAssignment assignment = new EmployeeLocationAssignment();
+        assignment.setId(ASSIGNMENT_ID);
+        assignment.setEmployee(employee(EmployeeStatus.ACTIVE));
+        assignment.setLocationId(LOCATION_ID);
+        assignment.setRole("TECHNICIAN");
+        assignment.setPrimary(true);
+        assignment.setStatus(status);
+        assignment.setEffectiveFrom(LocalDate.of(2026, 2, 1));
+        return assignment;
+    }
+
+    private DomainEventEnvelope<?> captureEnvelope() {
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.captor();
+        verify(writer).publish(org.mockito.ArgumentMatchers.eq(EVENTS_TOPIC), captor.capture());
+        return captor.getValue();
+    }
+
+    @Nested
+    @DisplayName("facts")
+    class Facts {
+
+        @Test
+        @DisplayName("publishes an employee fact keyed on the employee")
+        void employeeFact() {
+            publisher.publishEmployeeUpdated(employee(EmployeeStatus.ACTIVE));
+
+            DomainEventEnvelope<?> envelope = captureEnvelope();
+            assertThat(envelope.eventType()).isEqualTo(EmployeeUpdatedV1.EVENT_TYPE);
+            assertThat(envelope.aggregateId()).isEqualTo(EMPLOYEE_ID);
+            assertThat(envelope.sourceService()).isEqualTo("pos-people");
+            // Employee has no optimistic-lock version, so the emission timestamp orders the stream.
+            assertThat(envelope.aggregateVersion()).isEqualTo(NOW.toEpochMilli());
+
+            EmployeeUpdatedV1 payload = (EmployeeUpdatedV1) envelope.payload();
+            assertThat(payload.employeeId()).isEqualTo(EMPLOYEE_ID);
+            assertThat(payload.personId()).isEqualTo(PERSON_ID);
+            assertThat(payload.employeeNumber()).isEqualTo("E-1001");
+            assertThat(payload.status()).isEqualTo("ACTIVE");
+            assertThat(payload.hireDate()).isEqualTo(LocalDate.of(2026, 1, 15));
+            assertThat(payload.terminationDate()).isNull();
+        }
+
+        @Test
+        @DisplayName("defaults a null employee status to ACTIVE rather than emitting null")
+        void nullEmployeeStatusDefaults() {
+            publisher.publishEmployeeUpdated(employee(null));
+
+            // The field is @NonNull on the event contract; emitting null would fail the consumer.
+            assertThat(((EmployeeUpdatedV1) captureEnvelope().payload()).status())
+                    .isEqualTo("ACTIVE");
+        }
+
+        @Test
+        @DisplayName("publishes a staffing fact keyed on the assignment, carrying both ids")
+        void staffingFact() {
+            publisher.publishStaffingAssignmentUpdated(assignment(AssignmentStatus.ACTIVE));
+
+            DomainEventEnvelope<?> envelope = captureEnvelope();
+            assertThat(envelope.eventType()).isEqualTo(StaffingAssignmentUpdatedV1.EVENT_TYPE);
+            // Keyed on the assignment, not the employee: one employee can hold several.
+            assertThat(envelope.aggregateId()).isEqualTo(ASSIGNMENT_ID);
+
+            StaffingAssignmentUpdatedV1 payload = (StaffingAssignmentUpdatedV1) envelope.payload();
+            assertThat(payload.assignmentId()).isEqualTo(ASSIGNMENT_ID);
+            assertThat(payload.employeeId()).isEqualTo(EMPLOYEE_ID);
+            // personId is denormalized onto the fact so consumers need no employee lookup.
+            assertThat(payload.personId()).isEqualTo(PERSON_ID);
+            assertThat(payload.locationId()).isEqualTo(LOCATION_ID);
+            assertThat(payload.role()).isEqualTo("TECHNICIAN");
+            assertThat(payload.primary()).isTrue();
+            assertThat(payload.status()).isEqualTo("ACTIVE");
+        }
+
+        @Test
+        @DisplayName("defaults a null assignment status to ACTIVE")
+        void nullAssignmentStatusDefaults() {
+            publisher.publishStaffingAssignmentUpdated(assignment(null));
+
+            assertThat(((StaffingAssignmentUpdatedV1) captureEnvelope().payload()).status())
+                    .isEqualTo("ACTIVE");
+        }
+    }
+
+    @Nested
+    @DisplayName("identity command")
+    class IdentityCommand {
+
+        private PersonUpsertRequestedV1 command() {
+            return new PersonUpsertRequestedV1(
+                    PERSON_ID, "Ada", "Lovelace", "Ada", "ada@example.com", null, List.of("555-0001"), List.of());
+        }
+
+        @Test
+        @DisplayName("sends a plain command message, not a fact envelope, keyed on the person")
+        void commandShapeAndKey() {
+            publisher.requestPersonUpsert(command());
+
+            ArgumentCaptor<String> message = ArgumentCaptor.forClass(String.class);
+            verify(writer)
+                    .publishRaw(
+                            org.mockito.ArgumentMatchers.eq(COMMANDS_TOPIC),
+                            org.mockito.ArgumentMatchers.eq(PERSON_ID.toString()),
+                            message.capture());
+            // The receiver's listener reads {commandType, eventId, payload}; a DomainEventEnvelope
+            // would not be understood.
+            var parsed = objectMapper.readTree(message.getValue());
+            assertThat(parsed.path("commandType").asString()).isEqualTo(PersonUpsertRequestedV1.COMMAND_TYPE);
+            assertThat(parsed.path("eventId").asString()).isNotBlank();
+            assertThat(parsed.path("payload").path("personId").asString()).isEqualTo(PERSON_ID.toString());
+            assertThat(parsed.path("payload").path("firstName").asString()).isEqualTo("Ada");
+            // Facts and commands must not cross paths.
+            verify(writer, never()).publish(anyString(), any());
+        }
+
+        @Test
+        @DisplayName("mints a fresh idempotency key per command so the receiver can de-duplicate")
+        void freshEventIdPerCommand() {
+            publisher.requestPersonUpsert(command());
+            publisher.requestPersonUpsert(command());
+
+            ArgumentCaptor<String> message = ArgumentCaptor.forClass(String.class);
+            verify(writer, org.mockito.Mockito.times(2)).publishRaw(anyString(), anyString(), message.capture());
+            String first = objectMapper
+                    .readTree(message.getAllValues().get(0))
+                    .path("eventId")
+                    .asString();
+            String second = objectMapper
+                    .readTree(message.getAllValues().get(1))
+                    .path("eventId")
+                    .asString();
+            assertThat(first).isNotEqualTo(second);
+        }
+
+        @Test
+        @DisplayName("fails the transaction rather than queueing a command it could not serialize")
+        void serializationFailureIsFatal() {
+            ObjectMapper failing = org.mockito.Mockito.mock(ObjectMapper.class);
+            when(failing.writeValueAsString(any())).thenThrow(new IllegalStateException("boom"));
+            PeopleEventPublisher failingPublisher = new PeopleEventPublisher(
+                    Clock.fixed(NOW, ZoneOffset.UTC), failing, outboxEventWriter, EVENTS_TOPIC, COMMANDS_TOPIC);
+
+            assertThatThrownBy(() -> failingPublisher.requestPersonUpsert(command()))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining(PERSON_ID.toString());
+
+            verify(writer, never()).publishRaw(anyString(), anyString(), anyString());
+        }
+    }
+
+    @Test
+    @DisplayName("every publish is a quiet no-op while Kafka is disabled")
+    void kafkaDisabledIsANoOp() {
+        when(outboxEventWriter.getIfAvailable()).thenReturn(null);
+
+        publisher.publishEmployeeUpdated(employee(EmployeeStatus.ACTIVE));
+        publisher.publishStaffingAssignmentUpdated(assignment(AssignmentStatus.ACTIVE));
+        publisher.requestPersonUpsert(
+                new PersonUpsertRequestedV1(PERSON_ID, "Ada", "Lovelace", null, null, null, List.of(), List.of()));
+
+        // These run inside business transactions that must still commit without the outbox bean.
+        verifyNoInteractions(writer);
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/service/LocationAndWorkorderEventsListenerTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/LocationAndWorkorderEventsListenerTest.java
@@ -1,0 +1,286 @@
+package com.positivity.people.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.location.LocationDeletedV1;
+import com.positivity.domainevents.location.LocationUpdatedV1;
+import com.positivity.domainevents.workorder.JobTimeRecordedV1;
+import com.positivity.people.internal.entity.ExtJobTimeReplica;
+import com.positivity.people.internal.entity.ExtLocationReplica;
+import com.positivity.people.internal.entity.ProcessedEvent;
+import com.positivity.people.internal.repository.ExtJobTimeReplicaRepository;
+import com.positivity.people.internal.repository.ExtLocationReplicaRepository;
+import com.positivity.people.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.QueryTimeoutException;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for the location and workorder replica listeners in pos-people
+ * (ADR-0044 §6, issues #892 and #875).
+ *
+ * <p>
+ * These two look alike but differ on one point that is easy to "fix" wrongly:
+ * <b>the location listener records a {@code processed_events} row even for event
+ * types it ignores, and the workorder listener does not.</b> That asymmetry is
+ * correct. Location has a reconciliation manifest listener
+ * ({@link LocationManifestListener}) whose count must match the owner's, which
+ * counts every fact in the window — so a skipped row would read as drift.
+ * Workorder has no manifest listener in this module, so there is no count to
+ * keep aligned and an early return costs nothing. Aligning them without moving
+ * the manifest listeners would break one side or the other.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("pos-people location and workorder replica listeners")
+class LocationAndWorkorderEventsListenerTest {
+
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b1");
+    private static final UUID LABOR_ENTRY_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b2");
+    private static final UUID WORKORDER_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b3");
+    private static final UUID TECHNICIAN_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b4");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private ExtLocationReplicaRepository extLocationReplicaRepository;
+
+    @Mock
+    private ExtJobTimeReplicaRepository extJobTimeReplicaRepository;
+
+    private LocationEventsListener locationListener;
+    private WorkorderEventsListener workorderListener;
+
+    @BeforeEach
+    void setUp() {
+        locationListener =
+                new LocationEventsListener(clock, objectMapper, processedEventRepository, extLocationReplicaRepository);
+        workorderListener =
+                new WorkorderEventsListener(clock, objectMapper, processedEventRepository, extJobTimeReplicaRepository);
+        when(processedEventRepository.existsById(any())).thenReturn(false);
+        when(extLocationReplicaRepository.findById(any())).thenReturn(Optional.empty());
+    }
+
+    @Nested
+    @DisplayName("LocationEventsListener")
+    class Locations {
+
+        private String locationUpdated(String eventId, long version, boolean active) {
+            return """
+                    {"eventId":"%s","eventType":"%s","aggregateVersion":%d,
+                     "payload":{"locationId":"%s","name":"Main Shop","code":"SHOP-1","status":"OPEN",
+                       "active":%s,"locationType":"SHOP","hrLocationId":null,"timezone":"America/Chicago",
+                       "addressLine1":"1 Main St","addressLine2":null,"city":"Austin","region":"TX",
+                       "postalCode":"78701","country":"US","defaultStagingLocationId":null,
+                       "defaultQuarantineLocationId":null,"parents":[],
+                       "createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-08-01T00:00:00Z"}}
+                    """.formatted(eventId, LocationUpdatedV1.EVENT_TYPE, version, LOCATION_ID, active);
+        }
+
+        @Test
+        @DisplayName("keeps only the fields this module needs from a much wider payload")
+        void projectsTheNeededFields() {
+            locationListener.onLocationEvent(locationUpdated("evt-1", 4, true));
+
+            ArgumentCaptor<ExtLocationReplica> captor = ArgumentCaptor.forClass(ExtLocationReplica.class);
+            verify(extLocationReplicaRepository).save(captor.capture());
+            ExtLocationReplica saved = captor.getValue();
+            assertThat(saved.getLocationId()).isEqualTo(LOCATION_ID);
+            assertThat(saved.getName()).isEqualTo("Main Shop");
+            assertThat(saved.getStatus()).isEqualTo("OPEN");
+            assertThat(saved.isActive()).isTrue();
+            assertThat(saved.getAggregateVersion()).isEqualTo(4);
+            assertThat(saved.getUpdatedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("carries a deactivation through rather than defaulting to active")
+        void deactivationIsReplicated() {
+            locationListener.onLocationEvent(locationUpdated("evt-1", 4, false));
+
+            ArgumentCaptor<ExtLocationReplica> captor = ArgumentCaptor.forClass(ExtLocationReplica.class);
+            verify(extLocationReplicaRepository).save(captor.capture());
+            assertThat(captor.getValue().isActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("ignores a snapshot strictly older than the replica but re-applies an equal one")
+        void staleGuardIsStrict() {
+            when(extLocationReplicaRepository.findById(LOCATION_ID))
+                    .thenReturn(Optional.of(ExtLocationReplica.builder()
+                            .locationId(LOCATION_ID)
+                            .aggregateVersion(5)
+                            .build()));
+
+            locationListener.onLocationEvent(locationUpdated("evt-1", 4, true));
+            verify(extLocationReplicaRepository, never()).save(any());
+
+            // Equal versions re-apply: the producer's version is an emission-timestamp hint, and
+            // the payload is a full snapshot, so re-applying is cheaper than risking a lost update.
+            locationListener.onLocationEvent(locationUpdated("evt-2", 5, true));
+            verify(extLocationReplicaRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("removes the replica row when the location is deleted upstream")
+        void deleteRemovesReplica() {
+            locationListener.onLocationEvent("""
+                    {"eventId":"evt-3","eventType":"%s","payload":{"locationId":"%s"}}""".formatted(LocationDeletedV1.EVENT_TYPE, LOCATION_ID));
+
+            verify(extLocationReplicaRepository).deleteById(LOCATION_ID);
+            verify(processedEventRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("records a dedup row for an ignored type, because a manifest listener counts it")
+        void ignoredTypeIsStillRecorded() {
+            locationListener.onLocationEvent("""
+                    {"eventId":"evt-4","eventType":"location.storage-location.updated","payload":{}}""");
+
+            // LocationManifestListener compares against the owner's count of every fact in the
+            // window, so omitting this row would register as drift.
+            ArgumentCaptor<ProcessedEvent> captor = ArgumentCaptor.forClass(ProcessedEvent.class);
+            verify(processedEventRepository).save(captor.capture());
+            assertThat(captor.getValue().getOwner()).isEqualTo("location");
+            verify(extLocationReplicaRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("skips unparsable messages and envelopes with no eventId")
+        void malformedEnvelopesAreSkipped() {
+            locationListener.onLocationEvent("{not json");
+            locationListener.onLocationEvent(locationUpdated("", 1, true));
+
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("no-ops on a replayed eventId")
+        void replayIsIgnored() {
+            when(processedEventRepository.existsById("evt-1")).thenReturn(true);
+
+            locationListener.onLocationEvent(locationUpdated("evt-1", 4, true));
+
+            verify(extLocationReplicaRepository, never()).save(any());
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("rethrows a transient database error but swallows a malformed payload")
+        void transientVersusMalformed() {
+            when(extLocationReplicaRepository.findById(LOCATION_ID)).thenThrow(new QueryTimeoutException("lock wait"));
+
+            assertThatThrownBy(() -> locationListener.onLocationEvent(locationUpdated("evt-1", 4, true)))
+                    .isInstanceOf(QueryTimeoutException.class);
+            verify(processedEventRepository, never()).save(any());
+
+            locationListener.onLocationEvent("""
+                    {"eventId":"evt-5","eventType":"%s","aggregateVersion":1,
+                     "payload":{"locationId":"not-a-uuid"}}""".formatted(LocationUpdatedV1.EVENT_TYPE));
+
+            // A poison message must not wedge the partition, and it still counts toward the window.
+            verify(processedEventRepository).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("WorkorderEventsListener")
+    class Workorders {
+
+        private String jobTime(String eventId, int minutes) {
+            return """
+                    {"eventId":"%s","eventType":"%s","aggregateVersion":1,
+                     "payload":{"laborEntryId":"%s","workOrderId":"%s","technicianId":"%s",
+                       "locationId":"%s","endAtUtc":"2026-08-11T08:30:00Z","minutes":%d}}
+                    """.formatted(
+                            eventId,
+                            JobTimeRecordedV1.EVENT_TYPE,
+                            LABOR_ENTRY_ID,
+                            WORKORDER_ID,
+                            TECHNICIAN_ID,
+                            LOCATION_ID,
+                            minutes);
+        }
+
+        @Test
+        @DisplayName("replicates the labor entry that timesheet reporting reads")
+        void replicatesJobTime() {
+            workorderListener.onWorkorderEvent(jobTime("evt-1", 90));
+
+            ArgumentCaptor<ExtJobTimeReplica> captor = ArgumentCaptor.forClass(ExtJobTimeReplica.class);
+            verify(extJobTimeReplicaRepository).save(captor.capture());
+            ExtJobTimeReplica saved = captor.getValue();
+            assertThat(saved.getLaborEntryId()).isEqualTo(LABOR_ENTRY_ID);
+            assertThat(saved.getWorkOrderId()).isEqualTo(WORKORDER_ID);
+            assertThat(saved.getTechnicianId()).isEqualTo(TECHNICIAN_ID);
+            assertThat(saved.getLocationId()).isEqualTo(LOCATION_ID);
+            assertThat(saved.getMinutes()).isEqualTo(90);
+            assertThat(saved.getEndAtUtc()).isEqualTo(Instant.parse("2026-08-11T08:30:00Z"));
+            assertThat(saved.getUpdatedAt()).isEqualTo(NOW);
+            verify(processedEventRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("returns without a dedup row for a type it does not consume")
+        void ignoredTypeIsNotRecorded() {
+            workorderListener.onWorkorderEvent("""
+                    {"eventId":"evt-2","eventType":"workorder.workorder.updated","payload":{}}""");
+
+            // Unlike the location listener: this module runs no workorder manifest listener, so
+            // there is no count to keep aligned and the early return costs nothing.
+            verify(processedEventRepository, never()).save(any());
+            verify(extJobTimeReplicaRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("skips unparsable messages, missing eventIds, and replays")
+        void deliveryGuards() {
+            workorderListener.onWorkorderEvent("{not json");
+            workorderListener.onWorkorderEvent(jobTime("", 90));
+            when(processedEventRepository.existsById("evt-1")).thenReturn(true);
+            workorderListener.onWorkorderEvent(jobTime("evt-1", 90));
+
+            verify(extJobTimeReplicaRepository, never()).save(any());
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("rethrows a transient database error but swallows a malformed payload")
+        void transientVersusMalformed() {
+            when(extJobTimeReplicaRepository.save(any())).thenThrow(new QueryTimeoutException("lock wait"));
+
+            assertThatThrownBy(() -> workorderListener.onWorkorderEvent(jobTime("evt-1", 90)))
+                    .isInstanceOf(QueryTimeoutException.class);
+            verify(processedEventRepository, never()).save(any());
+
+            workorderListener.onWorkorderEvent("""
+                    {"eventId":"evt-3","eventType":"%s","payload":{"laborEntryId":"not-a-uuid"}}""".formatted(JobTimeRecordedV1.EVENT_TYPE));
+
+            verify(processedEventRepository).save(any());
+        }
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/service/ManifestListenerContractTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/ManifestListenerContractTest.java
@@ -1,0 +1,247 @@
+package com.positivity.people.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.domainevents.UuidV7Timestamps;
+import com.positivity.people.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * The two consumer-side reconciliation listeners in this module — one per upstream
+ * owner — are structurally identical, so their shared contract is pinned once here
+ * (ADR-0044 §4, issues #875 and #892).
+ *
+ * <p>
+ * Reconciliation is the safety net under at-least-once delivery: if a fact was
+ * lost, nothing else will notice. The properties that make it safe to run
+ * automatically are:
+ *
+ * <ul>
+ * <li><b>The verdict is stateless.</b> The same manifest reprocessed — a
+ * redelivery, or the owner re-publishing after a restart — yields the same
+ * answer, so a duplicate replay request costs one idempotent re-delivery and
+ * never corruption.</li>
+ * <li><b>Window membership is the UUIDv7 timestamp inside each recorded
+ * eventId</b>, which is exactly the definition the owner used to build the
+ * manifest. Any other definition would make the two counts disagree for reasons
+ * that have nothing to do with drift.</li>
+ * <li><b>Drift both increments the metric and requests a replay.</b> Metric
+ * without replay means silent divergence; replay without metric means nobody
+ * learns it is happening.</li>
+ * <li><b>A malformed manifest is dropped, not retried</b>, because the next
+ * window repeats the check anyway — retrying a manifest that cannot be parsed
+ * would wedge the partition for no gain.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("reconciliation manifest listeners — shared drift-detection contract")
+class ManifestListenerContractTest {
+
+    private static final Instant WINDOW_START = Instant.parse("2026-08-11T09:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-08-11T09:05:00Z");
+
+    static final List<String> LISTENERS = List.of("people-contact", "location");
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Mock
+    private ObjectProvider<MeterRegistry> meterRegistryProvider;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private SimpleMeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        when(meterRegistryProvider.getIfAvailable()).thenReturn(meterRegistry);
+    }
+
+    /** How to hand a message to one listener, and the owner/topic it is wired to. */
+    private record Listener(String owner, String commandsTopic, Consumer<String> dispatch) {}
+
+    private Listener listener(String owner) {
+        if ("people-contact".equals(owner)) {
+            PeopleContactManifestListener listener = new PeopleContactManifestListener(
+                    processedEventRepository, kafkaTemplate, objectMapper, meterRegistryProvider);
+            ReflectionTestUtils.setField(listener, "peopleContactCommandsTopic", "people-contact.commands.v1");
+            return new Listener(PeopleContactEventsListener.OWNER, "people-contact.commands.v1", listener::onManifest);
+        }
+        LocationManifestListener listener = new LocationManifestListener(
+                processedEventRepository, kafkaTemplate, objectMapper, meterRegistryProvider);
+        ReflectionTestUtils.setField(listener, "locationCommandsTopic", "location.commands.v1");
+        return new Listener(LocationEventsListener.OWNER, "location.commands.v1", listener::onManifest);
+    }
+
+    private String manifest(long eventCount, String checksum) {
+        return """
+                {"eventId":"evt-1","eventType":"x.reconciliation.manifest",
+                 "payload":{"windowStartUtc":"%s","windowEndUtc":"%s","eventCount":%d,
+                   "eventIdsChecksum":"%s","eventTypeCounts":{"x.updated":%d}}}
+                """.formatted(WINDOW_START, WINDOW_END, eventCount, checksum, eventCount);
+    }
+
+    private void replicaHolds(Listener listener, List<String> eventIds) {
+        when(processedEventRepository.findEventIdsInRange(
+                        listener.owner(),
+                        UuidV7Timestamps.minStringAt(WINDOW_START),
+                        UuidV7Timestamps.minStringAt(WINDOW_END)))
+                .thenReturn(eventIds);
+    }
+
+    private double driftCount(String owner) {
+        return meterRegistry.find("replica.drift").tag("owner", owner).counters().stream()
+                .mapToDouble(io.micrometer.core.instrument.Counter::count)
+                .sum();
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("stays silent when the local replica matches the owner's manifest")
+    void matchingWindowRequestsNothing(String owner) {
+        Listener listener = listener(owner);
+        List<String> ids = List.of("019ff000-0000-7000-8000-000000000001");
+        replicaHolds(listener, ids);
+
+        listener.dispatch().accept(manifest(ids.size(), ReconciliationManifestV1.checksumOf(ids)));
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        assertThat(driftCount(listener.owner())).isZero();
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("counts drift and requests a replay for the same window when counts disagree")
+    void missingEventsTriggerReplay(String owner) {
+        Listener listener = listener(owner);
+        // The owner says two facts; this replica recorded one.
+        replicaHolds(listener, List.of("019ff000-0000-7000-8000-000000000001"));
+
+        listener.dispatch().accept(manifest(2, "whatever-the-owner-computed"));
+
+        assertThat(driftCount(listener.owner())).isEqualTo(1.0);
+        ArgumentCaptor<String> command = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate)
+                .send(
+                        org.mockito.ArgumentMatchers.eq(listener.commandsTopic()),
+                        org.mockito.ArgumentMatchers.eq(WINDOW_START.toString()),
+                        command.capture());
+        // The replay must name the window that failed, or the repair fixes the wrong range.
+        assertThat(objectMapper
+                        .readTree(command.getValue())
+                        .path("payload")
+                        .path("since")
+                        .asString())
+                .isEqualTo(WINDOW_START.toString());
+        assertThat(objectMapper
+                        .readTree(command.getValue())
+                        .path("payload")
+                        .path("until")
+                        .asString())
+                .isEqualTo(WINDOW_END.toString());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("treats a matching count with a different checksum as drift")
+    void checksumMismatchIsDrift(String owner) {
+        Listener listener = listener(owner);
+        List<String> ids = List.of("019ff000-0000-7000-8000-000000000001");
+        replicaHolds(listener, ids);
+
+        // Same number of events, different identities — the count alone would have passed.
+        listener.dispatch().accept(manifest(ids.size(), "a-different-checksum"));
+
+        assertThat(driftCount(listener.owner())).isEqualTo(1.0);
+        verify(kafkaTemplate).send(anyString(), anyString(), anyString());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("reaches the same verdict every time the same manifest is reprocessed")
+    void verdictIsStateless(String owner) {
+        Listener listener = listener(owner);
+        replicaHolds(listener, List.of("019ff000-0000-7000-8000-000000000001"));
+        String message = manifest(2, "whatever-the-owner-computed");
+
+        listener.dispatch().accept(message);
+        listener.dispatch().accept(message);
+
+        // A redelivered manifest costs one more idempotent replay, never a different answer.
+        assertThat(driftCount(listener.owner())).isEqualTo(2.0);
+        verify(kafkaTemplate, org.mockito.Mockito.times(2)).send(anyString(), anyString(), anyString());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("drops an unparseable manifest rather than retrying it")
+    void unparseableManifestIsDropped(String owner) {
+        Listener listener = listener(owner);
+
+        listener.dispatch().accept("{not json");
+
+        // The next window repeats the check, so retrying here would wedge the partition for nothing.
+        verify(processedEventRepository, never()).findEventIdsInRange(anyString(), anyString(), anyString());
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @ParameterizedTest
+    @FieldSource("LISTENERS")
+    @DisplayName("still counts drift when the replay request cannot be published")
+    void replayPublishFailureStillCountsDrift(String owner) {
+        Listener listener = listener(owner);
+        replicaHolds(listener, List.of());
+        when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                .thenThrow(new IllegalStateException("broker down"));
+
+        listener.dispatch().accept(manifest(3, "owner-checksum"));
+
+        // Best effort by design: the metric already fired and the next manifest re-detects, so a
+        // broker outage must not take the consumer down with it.
+        assertThat(driftCount(listener.owner())).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("works with no MeterRegistry present, since the metric is optional")
+    void absentMeterRegistryIsTolerated() {
+        when(meterRegistryProvider.getIfAvailable()).thenReturn(null);
+        PeopleContactManifestListener listener = new PeopleContactManifestListener(
+                processedEventRepository, kafkaTemplate, objectMapper, meterRegistryProvider);
+        ReflectionTestUtils.setField(listener, "peopleContactCommandsTopic", "people-contact.commands.v1");
+        when(processedEventRepository.findEventIdsInRange(anyString(), anyString(), anyString()))
+                .thenReturn(List.of());
+
+        listener.onManifest(manifest(3, "owner-checksum"));
+
+        // The replay still goes out; only the counter is skipped.
+        verify(kafkaTemplate).send(anyString(), anyString(), anyString());
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/service/PeopleContactEventsListenerTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/PeopleContactEventsListenerTest.java
@@ -1,0 +1,330 @@
+package com.positivity.people.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.peoplecontact.PersonDeletedV1;
+import com.positivity.domainevents.peoplecontact.PersonUpdatedV1;
+import com.positivity.domainevents.peoplecontact.UserPersonLinkRemovedV1;
+import com.positivity.domainevents.peoplecontact.UserPersonLinkUpdatedV1;
+import com.positivity.people.internal.entity.ExtPersonReplica;
+import com.positivity.people.internal.entity.ExtUserLinkReplica;
+import com.positivity.people.internal.entity.ProcessedEvent;
+import com.positivity.people.internal.repository.ExtPersonReplicaRepository;
+import com.positivity.people.internal.repository.ExtUserLinkReplicaRepository;
+import com.positivity.people.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.QueryTimeoutException;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for {@link PeopleContactEventsListener} (ADR-0044 §6, #875).
+ *
+ * <p>
+ * This listener's dedup contract is deliberately the <em>opposite</em> of the
+ * one in pos-order's replica listeners, and that difference is the thing most
+ * likely to be "corrected" by someone copying a sibling over it: an event type
+ * this module does not consume still gets a {@code processed_events} row.
+ * The owner's manifest counts every fact in the window, so skipping the insert
+ * would read as replica drift and trigger a pointless replay.
+ *
+ * <p>
+ * Two other decisions are load-bearing:
+ *
+ * <ul>
+ * <li><b>The stale guard skips only strictly-lower versions.</b> The producer's
+ * {@code aggregateVersion} is an emission-timestamp LWW hint rather than a JPA
+ * version, so an equal version re-applies — harmless, because the payload is a
+ * full snapshot, and safer than dropping a legitimate redelivery.</li>
+ * <li><b>A transient database error is rethrown</b> for container retry/DLQ,
+ * while a malformed payload is swallowed. A poison message must not wedge the
+ * partition, but a database blip must not silently drop a fact.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PeopleContactEventsListener — person and user-link replicas")
+class PeopleContactEventsListenerTest {
+
+    private static final UUID PERSON_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID LINK_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a2");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private ExtPersonReplicaRepository extPersonReplicaRepository;
+
+    @Mock
+    private ExtUserLinkReplicaRepository extUserLinkReplicaRepository;
+
+    private PeopleContactEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new PeopleContactEventsListener(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                new ObjectMapper(),
+                processedEventRepository,
+                extPersonReplicaRepository,
+                extUserLinkReplicaRepository);
+        when(processedEventRepository.existsById(any())).thenReturn(false);
+        when(extPersonReplicaRepository.findById(any())).thenReturn(Optional.empty());
+        when(extUserLinkReplicaRepository.findById(any())).thenReturn(Optional.empty());
+    }
+
+    private static String personUpdated(String eventId, long version, String contactPointsJson) {
+        return """
+                {"eventId":"%s","eventType":"%s","aggregateVersion":%d,
+                 "payload":{"personId":"%s","firstName":"Ada","lastName":"Lovelace",
+                   "preferredName":"Ada","contactPoints":%s,"postalAddress":null,
+                   "createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-08-01T00:00:00Z"}}
+                """.formatted(eventId, PersonUpdatedV1.EVENT_TYPE, version, PERSON_ID, contactPointsJson);
+    }
+
+    private static String contact(String type, String value, boolean primary) {
+        return """
+                {"contactType":"%s","value":"%s","primary":%s}""".formatted(type, value, primary);
+    }
+
+    private ExtPersonReplica capturePerson() {
+        ArgumentCaptor<ExtPersonReplica> captor = ArgumentCaptor.forClass(ExtPersonReplica.class);
+        verify(extPersonReplicaRepository).save(captor.capture());
+        return captor.getValue();
+    }
+
+    @Nested
+    @DisplayName("delivery contract")
+    class DeliveryContract {
+
+        @Test
+        @DisplayName("records a dedup row even for an event type this module does not consume")
+        void ignoredTypeStillRecordsProcessedEvent() {
+            listener.onPeopleContactEvent("""
+                    {"eventId":"evt-1","eventType":"people-contact.something.else","payload":{}}""");
+
+            // Opposite of the pos-order replica listeners on purpose: the owner's manifest counts
+            // every fact in the window, so omitting this row would look like drift and force a
+            // replay that has nothing to repair.
+            ArgumentCaptor<ProcessedEvent> captor = ArgumentCaptor.forClass(ProcessedEvent.class);
+            verify(processedEventRepository).save(captor.capture());
+            assertThat(captor.getValue().getEventId()).isEqualTo("evt-1");
+            assertThat(captor.getValue().getOwner()).isEqualTo("people-contact");
+            assertThat(captor.getValue().getProcessedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("skips a message that is not JSON without recording it")
+        void unparsableMessageIsSkipped() {
+            listener.onPeopleContactEvent("{not json");
+
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("skips an envelope with no eventId, since nothing could de-duplicate it")
+        void missingEventIdIsSkipped() {
+            listener.onPeopleContactEvent(personUpdated("", 1, "[]"));
+
+            verify(processedEventRepository, never()).save(any());
+            verify(extPersonReplicaRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("no-ops on a replayed eventId")
+        void replayIsIgnored() {
+            when(processedEventRepository.existsById("evt-1")).thenReturn(true);
+
+            listener.onPeopleContactEvent(personUpdated("evt-1", 1, "[]"));
+
+            verify(extPersonReplicaRepository, never()).save(any());
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("rethrows a transient database error so the container retries instead of losing the fact")
+        void transientErrorIsRethrown() {
+            when(extPersonReplicaRepository.findById(PERSON_ID)).thenThrow(new QueryTimeoutException("lock wait"));
+
+            assertThatThrownBy(() -> listener.onPeopleContactEvent(personUpdated("evt-1", 1, "[]")))
+                    .isInstanceOf(QueryTimeoutException.class);
+
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("swallows a malformed payload but still records the event as seen")
+        void malformedPayloadIsSwallowed() {
+            listener.onPeopleContactEvent("""
+                    {"eventId":"evt-1","eventType":"%s","aggregateVersion":1,
+                     "payload":{"personId":"not-a-uuid"}}""".formatted(PersonUpdatedV1.EVENT_TYPE));
+
+            // A poison message must not wedge the partition, and the manifest still counted it.
+            verify(extPersonReplicaRepository, never()).save(any());
+            verify(processedEventRepository).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("person replica")
+    class PersonReplica {
+
+        @Test
+        @DisplayName("splits contact points into primary and secondary email and the first two work phones")
+        void projectsContactPoints() {
+            listener.onPeopleContactEvent(personUpdated(
+                    "evt-1",
+                    3,
+                    "["
+                            + contact("EMAIL", "ada@primary.com", true) + ","
+                            + contact("EMAIL", "ada@backup.com", false) + ","
+                            + contact("PHONE_WORK", "555-0001", true) + ","
+                            + contact("PHONE_WORK", "555-0002", false) + ","
+                            + contact("PHONE_WORK", "555-0003", false) + ","
+                            + contact("PHONE_MOBILE", "555-9999", true) + "]"));
+
+            ExtPersonReplica saved = capturePerson();
+            assertThat(saved.getPersonId()).isEqualTo(PERSON_ID);
+            assertThat(saved.getFirstName()).isEqualTo("Ada");
+            assertThat(saved.getPreferredName()).isEqualTo("Ada");
+            assertThat(saved.getPrimaryEmail()).isEqualTo("ada@primary.com");
+            assertThat(saved.getSecondaryEmail()).isEqualTo("ada@backup.com");
+            // Work phones are taken in payload order, and only the first two are kept.
+            assertThat(saved.getPrimaryPhone()).isEqualTo("555-0001");
+            assertThat(saved.getSecondaryPhone()).isEqualTo("555-0002");
+            assertThat(saved.getAggregateVersion()).isEqualTo(3);
+            assertThat(saved.getUpdatedAt()).isEqualTo(NOW);
+            assertThat(saved.getPersonUpdatedAt()).isEqualTo(Instant.parse("2026-08-01T00:00:00Z"));
+        }
+
+        @Test
+        @DisplayName("leaves the projected fields null when the person has no matching contact points")
+        void missingContactPointsBecomeNull() {
+            listener.onPeopleContactEvent(
+                    personUpdated("evt-1", 1, "[" + contact("PHONE_MOBILE", "555-9999", true) + "]"));
+
+            ExtPersonReplica saved = capturePerson();
+            assertThat(saved.getPrimaryEmail()).isNull();
+            assertThat(saved.getSecondaryEmail()).isNull();
+            assertThat(saved.getPrimaryPhone()).isNull();
+            assertThat(saved.getSecondaryPhone()).isNull();
+        }
+
+        @Test
+        @DisplayName("ignores a snapshot strictly older than the replica")
+        void olderSnapshotIsIgnored() {
+            ExtPersonReplica existing = ExtPersonReplica.builder()
+                    .personId(PERSON_ID)
+                    .aggregateVersion(5)
+                    .build();
+            when(extPersonReplicaRepository.findById(PERSON_ID)).thenReturn(Optional.of(existing));
+
+            listener.onPeopleContactEvent(personUpdated("evt-1", 4, "[]"));
+
+            verify(extPersonReplicaRepository, never()).save(any());
+            verify(processedEventRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("re-applies a snapshot at the same version, since the version is only an LWW hint")
+        void equalVersionReapplies() {
+            ExtPersonReplica existing = ExtPersonReplica.builder()
+                    .personId(PERSON_ID)
+                    .aggregateVersion(5)
+                    .build();
+            when(extPersonReplicaRepository.findById(PERSON_ID)).thenReturn(Optional.of(existing));
+
+            listener.onPeopleContactEvent(personUpdated("evt-1", 5, "[]"));
+
+            // The producer's version is an emission timestamp, not a strict JPA version, so
+            // dropping an equal-version redelivery would risk discarding a legitimate update.
+            // Re-applying is harmless because the payload is a full snapshot.
+            assertThat(capturePerson().getAggregateVersion()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("removes the replica row on a deletion")
+        void deleteRemovesReplica() {
+            listener.onPeopleContactEvent("""
+                    {"eventId":"evt-2","eventType":"%s","payload":{"personId":"%s"}}""".formatted(PersonDeletedV1.EVENT_TYPE, PERSON_ID));
+
+            verify(extPersonReplicaRepository).deleteById(PERSON_ID);
+            verify(extPersonReplicaRepository, never()).save(any());
+            verify(processedEventRepository).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("user-link replica")
+    class UserLinkReplica {
+
+        private static String linkUpdated(long version) {
+            return """
+                    {"eventId":"evt-3","eventType":"%s","aggregateVersion":%d,
+                     "payload":{"linkId":"%s","personId":"%s","username":"ada","status":"ACTIVE",
+                       "linkType":"PRIMARY","createdAt":"2026-01-01T00:00:00Z",
+                       "updatedAt":"2026-08-01T00:00:00Z"}}
+                    """.formatted(UserPersonLinkUpdatedV1.EVENT_TYPE, version, LINK_ID, PERSON_ID);
+        }
+
+        @Test
+        @DisplayName("replicates the link that ties a login to a person")
+        void replicatesLink() {
+            listener.onPeopleContactEvent(linkUpdated(2));
+
+            ArgumentCaptor<ExtUserLinkReplica> captor = ArgumentCaptor.forClass(ExtUserLinkReplica.class);
+            verify(extUserLinkReplicaRepository).save(captor.capture());
+            ExtUserLinkReplica saved = captor.getValue();
+            assertThat(saved.getLinkId()).isEqualTo(LINK_ID);
+            assertThat(saved.getPersonId()).isEqualTo(PERSON_ID);
+            assertThat(saved.getUsername()).isEqualTo("ada");
+            assertThat(saved.getStatus()).isEqualTo("ACTIVE");
+            assertThat(saved.getAggregateVersion()).isEqualTo(2);
+            assertThat(saved.getUpdatedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("ignores a link snapshot strictly older than the replica")
+        void olderLinkSnapshotIsIgnored() {
+            when(extUserLinkReplicaRepository.findById(LINK_ID))
+                    .thenReturn(Optional.of(ExtUserLinkReplica.builder()
+                            .linkId(LINK_ID)
+                            .aggregateVersion(9)
+                            .build()));
+
+            listener.onPeopleContactEvent(linkUpdated(4));
+
+            verify(extUserLinkReplicaRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("removes the link replica when the link is revoked upstream")
+        void linkRemovalDeletesReplica() {
+            listener.onPeopleContactEvent("""
+                    {"eventId":"evt-4","eventType":"%s",
+                     "payload":{"linkId":"%s","personId":"%s","username":"ada"}}""".formatted(UserPersonLinkRemovedV1.EVENT_TYPE, LINK_ID, PERSON_ID));
+
+            verify(extUserLinkReplicaRepository).deleteById(LINK_ID);
+            verify(extUserLinkReplicaRepository, never()).save(any());
+        }
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — not capability work. Continues `docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` Phase 2, following #1247.
- Parent STORY (durion): n/a
- Child issue: n/a. No defects were filed from this batch; the two from the previous batch remain open as louisburroughs/durion-positivity-backend#1245 and louisburroughs/durion-positivity-backend#1246.
- Domain: `domain:people`, `domain:billing`, `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
**Nothing under `src/main` changed in this PR.** The diff is nine files: eight new test classes and `docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md`. No controller, DTO, event, `openapi.yaml`, or error model was touched, so the Contract Sync Enforcement check has no contract-relevant path to fire on and no `BACKEND_CONTRACT_GUIDE.md` entry applies.

Verify with:

```bash
git diff --name-only main..HEAD | grep -v '/src/test/'
# docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
```

(This differs from #1247, where a formatting reflow put `src/main` paths in the diff and tripped the check.)

## Contract Chain (when a Controller changed)
No controller changed.

- [x] OpenAPI annotations updated on the controller — n/a
- [x] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [x] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope

**What changed:** eight new unit-test classes across three modules, plus the plan document.

Measured **unit-only** (`-DskipITs`), so not comparable to the plan's §1.5 baseline, which included Failsafe ITs:

| Module | Line | Branch | Missed lines |
|---|---|---|---|
| `pos-people` | 66.2% → **79.4%** | 53.3% → **63.6%** | 965 → 588 |
| `pos-invoice` | 67.5% → **77.7%** | 58.2% → **64.0%** | 1,075 → 739 |
| `pos-people-contact` | 54.8% → **65.2%** | 38.3% → **52.3%** | 667 → 514 |

As with `pos-customer` in the previous batch, **the §1.5 baselines were stale in all three cases** — each module was already better covered than the plan recorded. The starting figures above are re-measured, not quoted.

The dominant find: **Phase 1 wave 1e is nowhere near closed repo-wide.** Every Kafka listener in `pos-people` (5 classes) and `pos-invoice` (7) sat at 0%. In both modules the listeners fall into two internally-identical families — `ext_*` replica listeners and reconciliation manifest listeners — so each family's shared contract is pinned once in a parameterized contract test and only the per-owner field mapping is covered separately. That is the same pattern used for `pos-order` in #1247 and is the cheapest way to close the remaining wave-1e surface elsewhere.

Also covered: `PeopleEventPublisher` (facts vs. identity commands down two different paths), `PeopleCommandListener` (the outbox-replay repair path, including the lookback guard and the window slack), and `SecurityServiceClient` — at 175 missed lines the largest single uncovered class remaining in the Phase 2 targets, and the RBAC edge through which a login gains and loses roles.

**Why:** Phase 2 of the plan, continuing straight on from #1247.

## Findings recorded, not fixed

Two things worth a reviewer's attention. Both are written into the plan doc (§4.4) and into test comments; neither is changed here.

1. **The "record a dedup row for ignored event types or not" asymmetry between modules is correct, not drift.** It depends on whether that owner has a manifest listener in the same module. `pos-order`'s replica listeners skip the row; `pos-people`'s and `pos-invoice`'s record it, because their manifest listeners compare against the owner's count of *every* fact in the window and a missing row would read as drift. `pos-people`'s workorder listener skips it — correctly — because that module runs no workorder manifest listener. Aligning them without also moving the manifest listeners would break one side or the other, so the tests pin the asymmetry with the reasoning attached.

2. **A Jackson 3 hazard that may deserve a follow-up decision.** `FAIL_ON_NULL_FOR_PRIMITIVES` is on by default, so a payload that merely *omits* a primitive field (`boolean`, `int`) fails deserialization. Inside a replica listener that failure lands in the malformed-payload branch, which means the fact is **silently dropped and still marked processed** — so reconciliation cannot flag it either. It bit three event records while writing these tests (`OrderInvoiceResponse.existing`, `CustomerPartyUpdatedV1.requirementsMet`, `LocationUpdatedV1.active`). Nothing is broken today, because producers in this repo always send the field; the exposure is that a producer which ever omits one causes silent data loss with no signal. Worth deciding whether to box these fields or relax the setting on consumer mappers. I have not filed an issue for it because the fix is a design call, not a defect report — happy to file one if you want it tracked.

Minor, no action needed: `WorkorderManifestListener`'s topic field is named `locationCommandsTopic`, a copy-paste leftover. The `@Value` key and default bind the workorder topic, so routing is correct; the test pins the routing rather than the field name.

## Tests
- [x] Unit tests added/updated — this PR is entirely unit tests
- [ ] Integration tests added/updated — none. `pos-invoice` still has **zero** integration tests; the plan's §5 records building a Failsafe IT layer for it and for `pos-warranty` as outstanding structural work
- [ ] Provider behavioral contract tests added/updated — none

**How to run:**

```bash
./mvnw -pl pos-people,pos-invoice,pos-people-contact -DskipTests=false test

# per-module coverage as reported above
./mvnw -pl pos-people -DskipTests=false verify \
  org.jacoco:jacoco-maven-plugin:0.8.14:report -DskipITs
```

All three modules build green with every gate enabled (Spotless, Checkstyle, SpotBugs, ArchUnit): `pos-people` 172 tests, `pos-invoice` 349, `pos-people-contact` 119.

## Risk & Rollback
- Risk level: **Low.** Test-only; no production code, configuration, schema, or contract changed.
- Rollback plan: revert the merge commit. Nothing at runtime depends on any of it.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — intentionally not; plan-driven rather than capability work, same as #1247
- [ ] PR title starts with `[CAP:<cap-id>]` — same reason, no capability id to cite
- [x] Links to parent + child issues are present — no parent story; the two open defect issues from the previous batch are linked above
- [x] Contract guide updated (when contract semantics changed) — n/a, no contract semantics changed
- [ ] Required CI checks passing — to be confirmed on this PR
