### PR TITLE
test: cover pos-vehicle-inventory services and pos-document-helper (stack 1/N)

### DIFF
--- a/pos-document-helper/src/test/java/com/positivity/documents/DocumentServiceClientTest.java
+++ b/pos-document-helper/src/test/java/com/positivity/documents/DocumentServiceClientTest.java
@@ -1,0 +1,208 @@
+package com.positivity.documents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.positivity.documents.exception.DocumentRenderException;
+import com.positivity.documents.exception.TemplateRegistrationException;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Unit tests for {@link DocumentServiceClient} (ADR-0020).
+ *
+ * <p>
+ * The retry wrapper is this client's reason to exist — a receipt render at the
+ * counter should survive a transient pos-documents blip without the caller
+ * writing any retry code. So the tests pin that a failure is retried up to the
+ * configured attempts, that success on a later attempt is success, and that
+ * exhaustion surfaces as the library's own typed exceptions
+ * ({@link TemplateRegistrationException}, {@link DocumentRenderException})
+ * carrying the template id, not as a raw transport error.
+ *
+ * <p>
+ * A 200 with an empty body is also a failure: an empty PDF handed to a printer
+ * is worse than an error the caller can retry.
+ */
+@DisplayName("DocumentServiceClient — retrying template and render client")
+class DocumentServiceClientTest {
+
+    private MockRestServiceServer server;
+    private DocumentServiceClient client;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder().baseUrl("http://documents");
+        server = MockRestServiceServer.bindTo(builder).build();
+        client = new DocumentServiceClient(
+                builder.build(),
+                Retry.of(
+                        "test",
+                        RetryConfig.custom()
+                                .maxAttempts(3)
+                                .waitDuration(Duration.ofMillis(1))
+                                .build()));
+    }
+
+    private static TemplateRegistration registration() {
+        return TemplateRegistration.htmlTemplate("INVOICE_TEMPLATE", "Invoice", "<html/>")
+                .build();
+    }
+
+    private static RenderRequest renderRequest() {
+        return RenderRequest.pdf("INVOICE_TEMPLATE", Map.of("total", "10.00"))
+                .filename("invoice.pdf")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("registerTemplate")
+    class Register {
+
+        @Test
+        @DisplayName("PUTs the registration to the template's own URI (upsert semantics)")
+        void registersTemplate() {
+            server.expect(requestTo("http://documents/v1/documents/templates/INVOICE_TEMPLATE"))
+                    .andExpect(method(HttpMethod.PUT))
+                    .andExpect(jsonPath("$.templateId").value("INVOICE_TEMPLATE"))
+                    .andExpect(jsonPath("$.contentType").value("text/html"))
+                    .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+            client.registerTemplate(registration());
+
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("retries a transient failure and succeeds without the caller noticing")
+        void retriesThroughATransientFailure() {
+            server.expect(requestTo("http://documents/v1/documents/templates/INVOICE_TEMPLATE"))
+                    .andRespond(withServerError());
+            server.expect(requestTo("http://documents/v1/documents/templates/INVOICE_TEMPLATE"))
+                    .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+            // The whole point of the client: one blip must not surface to the caller.
+            client.registerTemplate(registration());
+
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("wraps exhaustion in TemplateRegistrationException naming the template")
+        void exhaustionIsTyped() {
+            for (int i = 0; i < 3; i++) {
+                server.expect(requestTo("http://documents/v1/documents/templates/INVOICE_TEMPLATE"))
+                        .andRespond(withServerError());
+            }
+
+            assertThatThrownBy(() -> client.registerTemplate(registration()))
+                    .isInstanceOf(TemplateRegistrationException.class)
+                    .hasMessageContaining("INVOICE_TEMPLATE");
+
+            // Exactly maxAttempts requests: retrying forever would hold the caller's startup.
+            server.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("renderDocument")
+    class Render {
+
+        @Test
+        @DisplayName("returns the rendered bytes with the response's content type")
+        void rendersDocument() {
+            server.expect(requestTo("http://documents/v1/documents/render"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andExpect(jsonPath("$.templateId").value("INVOICE_TEMPLATE"))
+                    .andExpect(jsonPath("$.format").value("PDF"))
+                    .andRespond(withSuccess(new byte[] {1, 2, 3}, MediaType.APPLICATION_PDF));
+
+            RenderResponse response = client.renderDocument(renderRequest());
+
+            assertThat(response.getContent()).containsExactly(1, 2, 3);
+            assertThat(response.getContentType()).isEqualTo("application/pdf");
+            assertThat(response.getSizeBytes()).isEqualTo(3);
+            assertThat(response.getFilename()).isEqualTo("invoice.pdf");
+            assertThat(response.getTemplateId()).isEqualTo("INVOICE_TEMPLATE");
+            assertThat(response.getFormat()).isEqualTo(DocumentFormat.PDF);
+        }
+
+        @Test
+        @DisplayName("defaults the content type when the service sends none")
+        void missingContentTypeDefaults() {
+            server.expect(requestTo("http://documents/v1/documents/render"))
+                    .andRespond(withSuccess(new byte[] {1}, null));
+
+            assertThat(client.renderDocument(renderRequest()).getContentType()).isEqualTo("application/octet-stream");
+        }
+
+        @Test
+        @DisplayName("treats a 200 with no body as a render failure")
+        void emptyBodyIsAFailure() {
+            for (int i = 0; i < 1; i++) {
+                server.expect(requestTo("http://documents/v1/documents/render")).andRespond(withStatus(HttpStatus.OK));
+            }
+
+            // An empty PDF handed to a printer is worse than an error the caller can retry.
+            assertThatThrownBy(() -> client.renderDocument(renderRequest()))
+                    .isInstanceOf(DocumentRenderException.class)
+                    .hasMessageContaining("INVOICE_TEMPLATE");
+        }
+
+        @Test
+        @DisplayName("retries a failed render and succeeds on a later attempt")
+        void retriesRender() {
+            server.expect(requestTo("http://documents/v1/documents/render")).andRespond(withServerError());
+            server.expect(requestTo("http://documents/v1/documents/render"))
+                    .andRespond(withSuccess(new byte[] {9}, MediaType.APPLICATION_PDF));
+
+            assertThat(client.renderDocument(renderRequest()).getContent()).containsExactly(9);
+            server.verify();
+        }
+
+        @Test
+        @DisplayName("wraps render exhaustion in DocumentRenderException with template and format")
+        void renderExhaustionIsTyped() {
+            for (int i = 0; i < 3; i++) {
+                server.expect(requestTo("http://documents/v1/documents/render")).andRespond(withServerError());
+            }
+
+            assertThatThrownBy(() -> client.renderDocument(renderRequest()))
+                    .isInstanceOf(DocumentRenderException.class)
+                    .hasMessageContaining("INVOICE_TEMPLATE")
+                    .hasMessageContaining("PDF");
+
+            server.verify();
+        }
+    }
+
+    @Test
+    @DisplayName("builder produces a working client with the configured retry budget")
+    void builderBuildsAUsableClient() {
+        // Smoke-level: the builder wires baseUrl, maxAttempts, and waitDuration together.
+        DocumentServiceClient built = DocumentServiceClient.builder()
+                .baseUrl("http://documents")
+                .maxRetries(2)
+                .waitDuration(Duration.ofMillis(1))
+                .build();
+
+        assertThat(built).isNotNull();
+    }
+}

--- a/pos-document-helper/src/test/java/com/positivity/documents/DocumentTemplateInitializerSupportTest.java
+++ b/pos-document-helper/src/test/java/com/positivity/documents/DocumentTemplateInitializerSupportTest.java
@@ -1,120 +1,88 @@
 package com.positivity.documents;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit tests for DocumentTemplateInitializerSupport.
+ * Unit tests for {@link DocumentTemplateInitializerSupport} (ADR-0020).
  *
- * Issue: ADR-0020
+ * <p>
+ * This runs inside {@code ApplicationRunner}s at service startup, so its one
+ * hard obligation is the startup-safety contract the repo applies to every
+ * registrar: a failing registration is counted and logged, and the loop moves
+ * on. One bad template — or pos-documents being down entirely — must not stop
+ * the remaining templates from registering, and must never block startup.
  */
+@DisplayName("DocumentTemplateInitializerSupport — startup template registration")
 class DocumentTemplateInitializerSupportTest {
 
-    @Test
-    void registerTemplates_AllSucceed() {
-        // Arrange
-        DocumentTemplateInitializerSupport support = new DocumentTemplateInitializerSupport("test-service");
-        AtomicInteger callCount = new AtomicInteger(0);
-
-        List<TemplateRegistration> templates = List.of(
-                TemplateRegistration.builder()
-                        .templateId("T1")
-                        .description("Template 1")
-                        .content("test1")
-                        .build(),
-                TemplateRegistration.builder()
-                        .templateId("T2")
-                        .description("Template 2")
-                        .content("test2")
-                        .build(),
-                TemplateRegistration.builder()
-                        .templateId("T3")
-                        .description("Template 3")
-                        .content("test3")
-                        .build());
-
-        // Act
-        int successCount = support.registerTemplates(templates, reg -> callCount.incrementAndGet());
-
-        // Assert
-        assertEquals(3, successCount);
-        assertEquals(3, callCount.get());
+    private static TemplateRegistration template(String id) {
+        return TemplateRegistration.htmlTemplate(id, "d", "<html/>").build();
     }
 
     @Test
-    void registerTemplates_SomeFailures() {
-        // Arrange
-        DocumentTemplateInitializerSupport support = new DocumentTemplateInitializerSupport("test-service");
-        AtomicInteger callCount = new AtomicInteger(0);
+    @DisplayName("registers every template and reports the count")
+    void registersAll() {
+        List<String> registered = new ArrayList<>();
 
-        List<TemplateRegistration> templates = List.of(
-                TemplateRegistration.builder()
-                        .templateId("T1")
-                        .description("Template 1")
-                        .content("test1")
-                        .build(),
-                TemplateRegistration.builder()
-                        .templateId("T2")
-                        .description("Template 2")
-                        .content("test2")
-                        .build(),
-                TemplateRegistration.builder()
-                        .templateId("T3")
-                        .description("Template 3")
-                        .content("test3")
-                        .build());
+        int count = new DocumentTemplateInitializerSupport("pos-test")
+                .registerTemplates(
+                        List.of(template("A"), template("B"), template("C")),
+                        registration -> registered.add(registration.getTemplateId()));
 
-        // Fail on second template
-        // Act
-        int successCount = support.registerTemplates(templates, reg -> {
-            callCount.incrementAndGet();
-            if (reg.getTemplateId().equals("T2")) {
-                throw new RuntimeException("Simulated failure");
-            }
-        });
-
-        // Assert
-        assertEquals(2, successCount); // T1 and T3 succeed
-        assertEquals(3, callCount.get()); // All 3 attempted
+        assertThat(count).isEqualTo(3);
+        assertThat(registered).containsExactly("A", "B", "C");
     }
 
     @Test
-    void registerTemplates_EmptyList() {
-        // Arrange
-        DocumentTemplateInitializerSupport support = new DocumentTemplateInitializerSupport("test-service");
-        AtomicInteger callCount = new AtomicInteger(0);
+    @DisplayName("keeps registering after a failure and counts only the successes")
+    void oneFailureDoesNotStopTheRest() {
+        List<String> registered = new ArrayList<>();
 
-        // Act
-        int successCount = support.registerTemplates(List.of(), reg -> callCount.incrementAndGet());
+        int count = new DocumentTemplateInitializerSupport("pos-test")
+                .registerTemplates(List.of(template("A"), template("BROKEN"), template("C")), registration -> {
+                    if ("BROKEN".equals(registration.getTemplateId())) {
+                        throw new IllegalStateException("boom");
+                    }
+                    registered.add(registration.getTemplateId());
+                });
 
-        // Assert
-        assertEquals(0, successCount);
-        assertEquals(0, callCount.get());
+        // The startup-safety contract: one bad template must not take the others down with it,
+        // and the exception must not escape into the ApplicationRunner.
+        assertThat(count).isEqualTo(2);
+        assertThat(registered).containsExactly("A", "C");
     }
 
     @Test
-    void registerTemplates_NullTemplates_ThrowsNPE() {
-        // Arrange
-        DocumentTemplateInitializerSupport support = new DocumentTemplateInitializerSupport("test-service");
+    @DisplayName("survives every registration failing, as when pos-documents is down at startup")
+    void totalOutageIsSurvivable() {
+        int count = new DocumentTemplateInitializerSupport("pos-test")
+                .registerTemplates(List.of(template("A"), template("B")), registration -> {
+                    throw new IllegalStateException("connection refused");
+                });
 
-        // Act & Assert
-        assertThrows(NullPointerException.class, () -> support.registerTemplates(null, reg -> {}));
+        assertThat(count).isZero();
     }
 
     @Test
-    void registerTemplates_NullFunction_ThrowsNPE() {
-        // Arrange
-        DocumentTemplateInitializerSupport support = new DocumentTemplateInitializerSupport("test-service");
-        List<TemplateRegistration> templates = List.of(TemplateRegistration.builder()
-                .templateId("T1")
-                .description("test")
-                .content("test")
-                .build());
+    @DisplayName("reports zero for an empty template collection")
+    void emptyCollection() {
+        assertThat(new DocumentTemplateInitializerSupport("pos-test").registerTemplates(List.of(), registration -> {}))
+                .isZero();
+    }
 
-        // Act & Assert
-        assertThrows(NullPointerException.class, () -> support.registerTemplates(templates, null));
+    @Test
+    @DisplayName("rejects null inputs outright — a misconfigured caller is a bug, not an outage")
+    void nullInputsAreRejected() {
+        DocumentTemplateInitializerSupport support = new DocumentTemplateInitializerSupport("pos-test");
+
+        assertThatThrownBy(() -> support.registerTemplates(null, registration -> {}))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> support.registerTemplates(List.of(), null)).isInstanceOf(NullPointerException.class);
     }
 }

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/service/VehicleLegacyServiceImplTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/service/VehicleLegacyServiceImplTest.java
@@ -1,0 +1,326 @@
+package com.positivity.vehicle.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.vehicle.internal.dao.VehicleDao;
+import com.positivity.vehicle.internal.dto.VehicleLegacyRequest;
+import com.positivity.vehicle.internal.dto.VehicleLegacyResponse;
+import com.positivity.vehicle.internal.entity.Car;
+import com.positivity.vehicle.internal.entity.CommercialTruck;
+import com.positivity.vehicle.internal.entity.PassengerTruck;
+import com.positivity.vehicle.internal.entity.Van;
+import com.positivity.vehicle.internal.entity.VehicleEntity;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Unit tests for {@link VehicleLegacyServiceImpl}.
+ *
+ * <p>
+ * The vehicle type string is the deciding input: it selects which entity
+ * subclass gets persisted, and that subclass is what the type reads back as. An
+ * unknown type deliberately degrades to {@code CAR} rather than failing at the
+ * mapper — but the service validates the type <em>first</em>, so an unsupported
+ * type is rejected at the boundary and the mapper's fallback is only reachable
+ * for null.
+ *
+ * <p>
+ * VIN handling differs by endpoint family on purpose: the id-keyed endpoints
+ * treat VIN as optional (null fine, blank rejected), while the VIN-keyed
+ * endpoints require it — an entity created by VIN without one would be
+ * unreachable through the very endpoints that manage it. The model-year window
+ * is anchored to the injected clock, allowing next year's models but not 1885.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("VehicleLegacyServiceImpl — legacy vehicle CRUD")
+class VehicleLegacyServiceImplTest {
+
+    private static final UUID ID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-11T12:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private VehicleDao vehicleDao;
+
+    private VehicleLegacyServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new VehicleLegacyServiceImpl(vehicleDao, CLOCK);
+        when(vehicleDao.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    private static VehicleLegacyRequest request(String vehicleType, String vin) {
+        VehicleLegacyRequest request = new VehicleLegacyRequest();
+        request.setMake("Toyota");
+        request.setModel("Tacoma");
+        request.setYear(2024);
+        request.setVehicleType(vehicleType);
+        request.setVin(vin);
+        return request;
+    }
+
+    private VehicleEntity captureSaved() {
+        ArgumentCaptor<VehicleEntity> captor = ArgumentCaptor.forClass(VehicleEntity.class);
+        verify(vehicleDao).save(captor.capture());
+        return captor.getValue();
+    }
+
+    @Nested
+    @DisplayName("type mapping")
+    class TypeMapping {
+
+        @ParameterizedTest
+        @CsvSource({
+            "CAR, CAR",
+            "VAN, VAN",
+            "COMMERCIAL_TRUCK, COMMERCIAL_TRUCK",
+            "PASSENGER_TRUCK, PASSENGER_TRUCK",
+            "TRUCK, PASSENGER_TRUCK",
+            "van, VAN",
+            "'  truck  ', PASSENGER_TRUCK"
+        })
+        @DisplayName("persists the entity subclass for the type, normalizing case and whitespace")
+        void mapsTypeToSubclass(String vehicleType, String expectedReadback) {
+            VehicleLegacyResponse response = service.createVehicle(request(vehicleType, null));
+
+            // The subclass is the persisted representation of the type, and TRUCK is an accepted
+            // alias for PASSENGER_TRUCK.
+            assertThat(response.getVehicleType()).isEqualTo(expectedReadback);
+        }
+
+        @Test
+        @DisplayName("defaults a missing type to CAR rather than rejecting the request")
+        void nullTypeDefaultsToCar() {
+            service.createVehicle(request(null, null));
+
+            assertThat(captureSaved()).isInstanceOf(Car.class);
+        }
+
+        @Test
+        @DisplayName("rejects an unsupported type at the boundary, before the mapper's CAR fallback")
+        void unsupportedTypeIsRejected() {
+            // Without this validation, "MOTORCYCLE" would silently persist as a Car.
+            assertThatThrownBy(() -> service.createVehicle(request("MOTORCYCLE", null)))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("MOTORCYCLE");
+
+            verifyNoInteractions(vehicleDao);
+        }
+
+        @Test
+        @DisplayName("reads each subclass back as its type")
+        void readbackResolvesSubclass() {
+            for (VehicleEntity entity :
+                    new VehicleEntity[] {new Car(), new Van(), new CommercialTruck(), new PassengerTruck()}) {
+                entity.setId(ID);
+                entity.setMake("Toyota");
+                entity.setModel("Tacoma");
+                entity.setYear(2024);
+                when(vehicleDao.findById(ID)).thenReturn(Optional.of(entity));
+
+                assertThat(service.getVehicle(ID).orElseThrow().getVehicleType())
+                        .isEqualTo(
+                                switch (entity) {
+                                    case Van v -> "VAN";
+                                    case CommercialTruck c -> "COMMERCIAL_TRUCK";
+                                    case PassengerTruck p -> "PASSENGER_TRUCK";
+                                    default -> "CAR";
+                                });
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("validation")
+    class Validation {
+
+        @ParameterizedTest
+        @CsvSource({"1885, false", "1886, true", "2027, true", "2028, false"})
+        @DisplayName("accepts model years from 1886 through next year, anchored to the clock")
+        void yearWindow(int year, boolean accepted) {
+            VehicleLegacyRequest request = request("CAR", null);
+            request.setYear(year);
+
+            if (accepted) {
+                assertThat(service.createVehicle(request)).isNotNull();
+            } else {
+                // 1886 is the first model year; the +1 buffer admits next year's models mid-cycle.
+                assertThatThrownBy(() -> service.createVehicle(request))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("year");
+            }
+        }
+
+        @Test
+        @DisplayName("requires make, model, and year")
+        void requiredFields() {
+            VehicleLegacyRequest noMake = request("CAR", null);
+            noMake.setMake("  ");
+            assertThatThrownBy(() -> service.createVehicle(noMake))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("make");
+
+            VehicleLegacyRequest noModel = request("CAR", null);
+            noModel.setModel(null);
+            assertThatThrownBy(() -> service.createVehicle(noModel))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("model");
+
+            VehicleLegacyRequest noYear = request("CAR", null);
+            noYear.setYear(null);
+            assertThatThrownBy(() -> service.createVehicle(noYear))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("year");
+        }
+
+        @Test
+        @DisplayName("treats a null VIN as absent but rejects a blank one on the id-keyed create")
+        void optionalVinSemantics() {
+            service.createVehicle(request("CAR", null));
+            assertThat(captureSaved().getVIN()).isNull();
+
+            // Null means "no VIN recorded"; blank means the caller sent something broken.
+            assertThatThrownBy(() -> service.createVehicle(request("CAR", "   ")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("blank");
+        }
+
+        @Test
+        @DisplayName("trims the VIN it stores")
+        void vinIsTrimmed() {
+            service.createVehicle(request("CAR", "  1HGCM82633A004352  "));
+
+            assertThat(captureSaved().getVIN()).isEqualTo("1HGCM82633A004352");
+        }
+    }
+
+    @Nested
+    @DisplayName("VIN-keyed endpoints")
+    class VinKeyed {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "   "})
+        @DisplayName("requires a VIN on the VIN-keyed create")
+        void vinRequired(String vin) {
+            // A vehicle created by VIN without one would be unreachable through these endpoints.
+            assertThatThrownBy(() -> service.createVehicleByVin(request("CAR", vin.isEmpty() ? null : vin)))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("vin");
+
+            verifyNoInteractions(vehicleDao);
+        }
+
+        @Test
+        @DisplayName("normalizes the VIN before lookup so a padded query still matches")
+        void lookupNormalizesVin() {
+            Car car = new Car();
+            car.setVIN("1HGCM82633A004352");
+            when(vehicleDao.findByVIN("1HGCM82633A004352")).thenReturn(Optional.of(car));
+
+            assertThat(service.getVehicleByVin("  1HGCM82633A004352  ")).isPresent();
+        }
+
+        @Test
+        @DisplayName("updates through the VIN without letting the update change identity fields")
+        void updateByVin() {
+            Car existing = new Car();
+            existing.setVIN("1HGCM82633A004352");
+            existing.setMake("Honda");
+            when(vehicleDao.findByVIN("1HGCM82633A004352")).thenReturn(Optional.of(existing));
+
+            VehicleLegacyRequest update = request("CAR", "SOMETHING-ELSE");
+            update.setMake("Toyota");
+            service.updateVehicleByVin("1HGCM82633A004352", update);
+
+            // Core fields move; the VIN key itself is not overwritten by the payload.
+            assertThat(existing.getMake()).isEqualTo("Toyota");
+            assertThat(existing.getVIN()).isEqualTo("1HGCM82633A004352");
+        }
+
+        @Test
+        @DisplayName("reports a delete of an unknown VIN as false without deleting")
+        void deleteUnknownVin() {
+            when(vehicleDao.findByVIN("1HGCM82633A004352")).thenReturn(Optional.empty());
+
+            assertThat(service.deleteVehicleByVin("1HGCM82633A004352")).isFalse();
+
+            verify(vehicleDao, never()).deleteByVIN(any());
+        }
+
+        @Test
+        @DisplayName("deletes a known VIN and reports true")
+        void deleteKnownVin() {
+            Car car = new Car();
+            when(vehicleDao.findByVIN("1HGCM82633A004352")).thenReturn(Optional.of(car));
+
+            assertThat(service.deleteVehicleByVin(" 1HGCM82633A004352 ")).isTrue();
+
+            verify(vehicleDao).deleteByVIN("1HGCM82633A004352");
+        }
+    }
+
+    @Nested
+    @DisplayName("id-keyed endpoints")
+    class IdKeyed {
+
+        @Test
+        @DisplayName("updates core fields in place and reports an unknown id as empty")
+        void updateSemantics() {
+            Car existing = new Car();
+            existing.setId(ID);
+            existing.setMake("Honda");
+            when(vehicleDao.findById(ID)).thenReturn(Optional.of(existing));
+
+            assertThat(service.updateVehicle(ID, request("CAR", null))).isPresent();
+            assertThat(existing.getMake()).isEqualTo("Toyota");
+
+            when(vehicleDao.findById(ID)).thenReturn(Optional.empty());
+            assertThat(service.updateVehicle(ID, request("CAR", null))).isEmpty();
+        }
+
+        @Test
+        @DisplayName("deletes only what exists")
+        void deleteSemantics() {
+            when(vehicleDao.findById(ID)).thenReturn(Optional.empty());
+            assertThat(service.deleteVehicle(ID)).isFalse();
+            verify(vehicleDao, never()).deleteById(any());
+
+            when(vehicleDao.findById(ID)).thenReturn(Optional.of(new Car()));
+            assertThat(service.deleteVehicle(ID)).isTrue();
+            verify(vehicleDao).deleteById(ID);
+        }
+
+        @Test
+        @DisplayName("lists all vehicles mapped to responses")
+        void listsAll() {
+            Car car = new Car();
+            car.setMake("Honda");
+            when(vehicleDao.findAll()).thenReturn(java.util.List.of(car, new Van()));
+
+            assertThat(service.getAllVehicles()).hasSize(2);
+        }
+    }
+}

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/service/VehicleSearchServiceImplTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/service/VehicleSearchServiceImplTest.java
@@ -1,0 +1,189 @@
+package com.positivity.vehicle.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.vehicle.internal.dto.SearchVehiclesRequest;
+import com.positivity.vehicle.internal.dto.SearchVehiclesResponse;
+import com.positivity.vehicle.internal.dto.VehicleSummary;
+import com.positivity.vehicle.internal.entity.VehicleRecord;
+import com.positivity.vehicle.internal.repository.VehicleRecordRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Unit tests for {@link VehicleSearchServiceImpl} (CAP:091 Story #103).
+ *
+ * <p>
+ * This search backs the service-counter typeahead, so ordering is the product:
+ * an exact match must outrank a prefix match, which must outrank a contains
+ * match — and contains-matching is off unless the caller opts in, because
+ * substring hits on short queries flood the list with noise.
+ *
+ * <p>
+ * The query's <em>shape</em> chooses the field being searched: 17 alphanumeric
+ * characters is a full VIN, 6–16 a VIN prefix, and anything shorter falls to
+ * plate and then general matching, each with its own minimum length so a
+ * one-character query cannot scan the fleet.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("VehicleSearchServiceImpl — ranked vehicle lookup")
+class VehicleSearchServiceImplTest {
+
+    @Mock
+    private VehicleRecordRepository vehicleRepository;
+
+    private VehicleSearchServiceImpl service() {
+        return new VehicleSearchServiceImpl(vehicleRepository);
+    }
+
+    private static VehicleRecord record(String vin, String plate, String unitNumber, String description) {
+        VehicleRecord record = new VehicleRecord();
+        record.setVehicleId(UUID.randomUUID());
+        record.setVin(vin);
+        record.setLicensePlate(plate);
+        record.setUnitNumber(unitNumber);
+        record.setDescription(description);
+        record.setMake("Toyota");
+        record.setModel("Tacoma");
+        record.setYear(2024);
+        return record;
+    }
+
+    private static SearchVehiclesRequest request(String query, int limit, Boolean contains) {
+        return SearchVehiclesRequest.builder()
+                .query(query)
+                .limit(limit)
+                .enableContainsMatching(contains)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("ranking")
+    class Ranking {
+
+        @Test
+        @DisplayName("orders results exact, then prefix, then contains")
+        void ranksByTier() {
+            when(vehicleRepository.searchByQuery("1HGCM8"))
+                    .thenReturn(List.of(
+                            record("XX1HGCM8YYYYYYYYY", null, "U1", "d"),
+                            record("1HGCM82633A004352", null, "U2", "d"),
+                            record("1HGCM8", null, "U3", "d")));
+
+            SearchVehiclesResponse response = service().search(request("1hgcm8", 25, true));
+
+            // The clerk reads top-down; a contains hit above the exact one buries the right answer.
+            assertThat(response.getResults())
+                    .extracting(VehicleSummary::getVin)
+                    .containsExactly("1HGCM8", "1HGCM82633A004352", "XX1HGCM8YYYYYYYYY");
+        }
+
+        @Test
+        @DisplayName("excludes contains matches unless the caller opts in")
+        void containsIsOptIn() {
+            when(vehicleRepository.searchByQuery("1HGCM8"))
+                    .thenReturn(List.of(
+                            record("XX1HGCM8YYYYYYYYY", null, "U1", "d"),
+                            record("1HGCM82633A004352", null, "U2", "d")));
+
+            SearchVehiclesResponse strict = service().search(request("1HGCM8", 25, false));
+            assertThat(strict.getResults()).extracting(VehicleSummary::getVin).containsExactly("1HGCM82633A004352");
+
+            SearchVehiclesResponse defaulted = service().search(request("1HGCM8", 25, null));
+            // Null means the caller did not opt in — same as false, never as true.
+            assertThat(defaulted.getResults()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("caps the page at 50 and reports what was cut")
+        void limitAndHasMore() {
+            List<VehicleRecord> sixty = new java.util.ArrayList<>();
+            for (int i = 0; i < 60; i++) {
+                sixty.add(record("1HGCM8%011d".formatted(i), null, "U" + i, "d"));
+            }
+            when(vehicleRepository.searchByQuery("1HGCM8")).thenReturn(sixty);
+
+            SearchVehiclesResponse response = service().search(request("1HGCM8", 100, false));
+
+            assertThat(response.getResults()).hasSize(50);
+            assertThat(response.getTotalCount()).isEqualTo(60);
+            // hasMore is what tells the UI to say "refine your search" instead of "that's all".
+            assertThat(response.getHasMore()).isTrue();
+        }
+
+        @Test
+        @DisplayName("echoes the caller's original query, not the normalized one")
+        void echoesOriginalQuery() {
+            when(vehicleRepository.searchByQuery(anyString())).thenReturn(List.of());
+
+            assertThat(service().search(request("  1hgcm8  ", 25, false)).getQuery())
+                    .isEqualTo("  1hgcm8  ");
+        }
+    }
+
+    @Nested
+    @DisplayName("query shape")
+    class QueryShape {
+
+        @Test
+        @DisplayName("a 17-character alphanumeric query is a full-VIN search")
+        void fullVin() {
+            when(vehicleRepository.searchByQuery("1HGCM82633A004352"))
+                    .thenReturn(List.of(record("1HGCM82633A004352", null, "U1", "d")));
+
+            assertThat(service().search(request("1HGCM82633A004352", 25, false)).getResults())
+                    .hasSize(1);
+        }
+
+        @Test
+        @DisplayName("a plate-shaped query searches the plate, not the VIN")
+        void plateQuery() {
+            // "AB-123" contains a hyphen, so it cannot be a VIN prefix; it matches on the plate.
+            when(vehicleRepository.searchByQuery("AB-123"))
+                    .thenReturn(List.of(
+                            record("1HGCM82633A004352", "AB-123", "U1", "d"),
+                            record("2HGCM82633A004352", "ZZ-999", "U2", "d")));
+
+            assertThat(service().search(request("ab-123", 25, false)).getResults())
+                    .extracting(VehicleSummary::getLicensePlate)
+                    .containsExactly("AB-123");
+        }
+
+        @Test
+        @DisplayName("a plate search survives records that have no plate at all")
+        void plateSearchToleratesMissingPlates() {
+            when(vehicleRepository.searchByQuery("AB-123"))
+                    .thenReturn(List.of(
+                            record("1HGCM82633A004352", null, "U1", "d"),
+                            record("2HGCM82633A004352", "AB-123", "U2", "d")));
+
+            // A fleet vehicle without a plate must not NPE the whole search.
+            assertThat(service().search(request("AB-123", 25, false)).getResults())
+                    .hasSize(1);
+        }
+
+        @Test
+        @DisplayName("rejects an empty or too-short query instead of scanning the fleet")
+        void shortQueriesRejected() {
+            assertThatThrownBy(() -> service().search(request("   ", 25, false)))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> service().search(request("AB", 25, false)))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verifyNoInteractions(vehicleRepository);
+        }
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — plan-driven work (`docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` Phases 2–3).
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:product` (vehicles), shared library (document-helper)

> **Stacked PR 1 of a series.** Base is `test-coverage/phase-2-people-invoice` (#1248), so this diff shows only the two modules named below. Merge #1248 first, then retarget/merge this.

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Nothing under `src/main` changed — the diff is two modules' test directories only. No `BACKEND_CONTRACT_GUIDE.md` entry applies.

```bash
git diff --name-only test-coverage/phase-2-people-invoice..HEAD | grep -v '/src/test/'
# (empty)
```

## Contract Chain (when a Controller changed)
No controller changed. All three checklist items n/a.

- [x] OpenAPI annotations updated on the controller — n/a
- [x] `openapi.yaml` regenerated — n/a
- [x] Angular SDK regenerated — n/a

## Scope

**What changed:** four new test classes, nothing else.

| Module | Line | Branch |
|---|---|---|
| `pos-vehicle-inventory` | 46.5% → **66.4%** | 42.4% → **71.0%** |
| `pos-document-helper` | 43.1% → **74.0%** | 25.9% → 35.2% |

(Unit-only measurement, consistent with the rest of the plan's Phase 2/3 figures.)

- **`VehicleLegacyServiceImpl`** (92 missed at 0%): type-string dispatch to entity subclasses, TRUCK→PASSENGER_TRUCK aliasing, boundary rejection of unsupported types (without which the mapper's CAR fallback silently persists a "MOTORCYCLE" as a Car), per-endpoint-family VIN semantics, clock-anchored model-year window.
- **`VehicleSearchServiceImpl`** (75 at 0%): exact>prefix>contains ranking, opt-in contains matching, the 50-result cap + `hasMore`, query-shape dispatch (VIN / VIN-prefix / plate), and plate search surviving vehicles with no plate.
- **`DocumentServiceClient`** (77 at 0%): retry-through-transient-failure, typed exhaustion (`TemplateRegistrationException` / `DocumentRenderException` naming the template), 200-with-no-body treated as a render failure.
- **`DocumentTemplateInitializerSupport`** (48 at 0%): the startup-safety contract — a bad template or a full pos-documents outage never blocks startup.

**Why:** continues the plan's priority table. `pos-vehicle-inventory` was the third-lowest-covered module in the reactor.

**Remaining in these modules:** `pos-vehicle-inventory`'s controllers (~114 missed, want `@WebMvcTest` slices) and `VehicleServiceImpl`'s tail; `pos-document-helper`'s duplicated legacy `helper` package.

## Tests
- [x] Unit tests added/updated — entirely unit tests
- [ ] Integration tests added/updated — none
- [ ] Provider behavioral contract tests added/updated — none

```bash
./mvnw -pl pos-vehicle-inventory,pos-document-helper -DskipTests=false test
```

Both modules green with all gates (Spotless, Checkstyle, SpotBugs, ArchUnit).

## Risk & Rollback
- Risk level: **Low.** Test-only.
- Rollback plan: revert the merge commit.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — plan-driven, no capability id (same as #1247/#1248)
- [ ] PR title starts with `[CAP:<cap-id>]` — same reason
- [x] Links to parent + child issues are present — none exist for this work
- [x] Contract guide updated — n/a
- [ ] Required CI checks passing — to be confirmed
