### PR TITLE
test: cover pos-catalog and pos-shop-manager Kafka listeners (stack 2/N)

### DIFF
--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/InventoryListenersTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/InventoryListenersTest.java
@@ -1,0 +1,315 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.entity.ExtInventoryAvailabilityReplica;
+import com.positivity.catalog.internal.entity.ExtProductLeadTimeReplica;
+import com.positivity.catalog.internal.entity.ProcessedEvent;
+import com.positivity.catalog.internal.repository.ExtInventoryAvailabilityReplicaRepository;
+import com.positivity.catalog.internal.repository.ExtProductLeadTimeReplicaRepository;
+import com.positivity.catalog.internal.repository.ProcessedEventRepository;
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.domainevents.UuidV7Timestamps;
+import com.positivity.domainevents.inventory.InventoryAvailabilityUpdatedV1;
+import com.positivity.domainevents.inventory.LeadTimeUpdatedV1;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for pos-catalog's inventory replica and reconciliation listeners
+ * (ADR-0044 §4/§6).
+ *
+ * <p>
+ * These replicas are what product detail pages read for "in stock" and
+ * "ships in N days" without a synchronous call to pos-inventory. The
+ * availability fact is keyed on the envelope's aggregateId (a per-sku-location
+ * aggregate), not on a payload field — pinned here because a refactor that
+ * switched to a payload field would silently fork the replica's identity from
+ * the producer's.
+ *
+ * <p>
+ * The delivery and reconciliation contracts are the same ones pinned in the
+ * sibling modules: dedup by eventId, malformed payloads swallowed but recorded,
+ * transient errors rethrown, strictly-lower-version stale guard, stateless
+ * drift verdict with the replay routed to the owner's commands topic.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("pos-catalog inventory listeners — availability and lead-time replicas")
+class InventoryListenersTest {
+
+    private static final UUID AGGREGATE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID PRODUCT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a2");
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a3");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+    private static final Instant WINDOW_START = Instant.parse("2026-08-11T09:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-08-11T09:05:00Z");
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private ExtInventoryAvailabilityReplicaRepository availabilityRepository;
+
+    @Mock
+    private ExtProductLeadTimeReplicaRepository leadTimeRepository;
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Mock
+    private ObjectProvider<MeterRegistry> meterRegistryProvider;
+
+    private SimpleMeterRegistry meterRegistry;
+    private InventoryEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        when(meterRegistryProvider.getIfAvailable()).thenReturn(meterRegistry);
+        when(processedEventRepository.existsById(any())).thenReturn(false);
+        when(availabilityRepository.findById(any())).thenReturn(Optional.empty());
+        when(leadTimeRepository.findById(any())).thenReturn(Optional.empty());
+        listener = new InventoryEventsListener(
+                clock, objectMapper, processedEventRepository, availabilityRepository, leadTimeRepository);
+    }
+
+    private static String availability(String eventId, long version, int atp) {
+        return """
+                {"eventId":"%s","eventType":"%s","aggregateVersion":%d,"aggregateId":"%s",
+                 "payload":{"stockItemId":"BRK-100","locationId":"%s","onHandQuantity":10,
+                   "allocatedQuantity":2,"availableToPromiseQuantity":%d,"unitOfMeasure":"EA",
+                   "incomingQuantity":5,"outgoingQuantity":1,"projectedAvailableQuantity":12}}
+                """.formatted(
+                        eventId, InventoryAvailabilityUpdatedV1.EVENT_TYPE, version, AGGREGATE_ID, LOCATION_ID, atp);
+    }
+
+    private static String leadTime(String eventId, long version) {
+        return """
+                {"eventId":"%s","eventType":"%s","aggregateVersion":%d,
+                 "payload":{"productId":"%s","minDays":2,"maxDays":5,"displayText":"2-5 days",
+                   "source":"SUPPLIER","confidence":"HIGH","asOf":"2026-08-10T00:00:00Z"}}
+                """.formatted(eventId, LeadTimeUpdatedV1.EVENT_TYPE, version, PRODUCT_ID);
+    }
+
+    @Nested
+    @DisplayName("availability replica")
+    class Availability {
+
+        @Test
+        @DisplayName("keys the replica on the envelope's aggregateId, not a payload field")
+        void keyedOnAggregateId() {
+            listener.onInventoryEvent(availability("evt-1", 3, 8));
+
+            ArgumentCaptor<ExtInventoryAvailabilityReplica> captor =
+                    ArgumentCaptor.forClass(ExtInventoryAvailabilityReplica.class);
+            verify(availabilityRepository).save(captor.capture());
+            ExtInventoryAvailabilityReplica saved = captor.getValue();
+            // The aggregateId is the producer's identity for this sku-location; deriving a key
+            // from payload fields instead would fork the replica's identity from the producer's.
+            assertThat(saved.getAggregateId()).isEqualTo(AGGREGATE_ID);
+            assertThat(saved.getStockItemId()).isEqualTo("BRK-100");
+            assertThat(saved.getLocationId()).isEqualTo(LOCATION_ID);
+            assertThat(saved.getOnHandQuantity()).isEqualTo(10);
+            assertThat(saved.getAvailableToPromiseQuantity()).isEqualTo(8);
+            assertThat(saved.getUnitOfMeasure()).isEqualTo("EA");
+            assertThat(saved.getAggregateVersion()).isEqualTo(3);
+            assertThat(saved.getUpdatedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("skips a strictly-older snapshot but re-applies an equal one")
+        void staleGuard() {
+            when(availabilityRepository.findById(AGGREGATE_ID))
+                    .thenReturn(Optional.of(ExtInventoryAvailabilityReplica.builder()
+                            .aggregateId(AGGREGATE_ID)
+                            .aggregateVersion(3)
+                            .build()));
+
+            listener.onInventoryEvent(availability("evt-1", 2, 8));
+            verify(availabilityRepository, never()).save(any());
+
+            listener.onInventoryEvent(availability("evt-2", 3, 8));
+            verify(availabilityRepository).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("lead-time replica")
+    class LeadTime {
+
+        @Test
+        @DisplayName("replicates the lead-time fields the product page displays")
+        void mapsLeadTime() {
+            listener.onInventoryEvent(leadTime("evt-1", 2));
+
+            ArgumentCaptor<ExtProductLeadTimeReplica> captor = ArgumentCaptor.forClass(ExtProductLeadTimeReplica.class);
+            verify(leadTimeRepository).save(captor.capture());
+            ExtProductLeadTimeReplica saved = captor.getValue();
+            assertThat(saved.getProductId()).isEqualTo(PRODUCT_ID);
+            assertThat(saved.getMinDays()).isEqualTo(2);
+            assertThat(saved.getMaxDays()).isEqualTo(5);
+            assertThat(saved.getDisplayText()).isEqualTo("2-5 days");
+        }
+    }
+
+    @Nested
+    @DisplayName("delivery contract")
+    class DeliveryContract {
+
+        @Test
+        @DisplayName("records a dedup row for an ignored type, keeping the manifest count aligned")
+        void ignoredTypeIsRecorded() {
+            listener.onInventoryEvent("""
+                    {"eventId":"evt-9","eventType":"inventory.something.else","payload":{}}""");
+
+            ArgumentCaptor<ProcessedEvent> captor = ArgumentCaptor.forClass(ProcessedEvent.class);
+            verify(processedEventRepository).save(captor.capture());
+            assertThat(captor.getValue().getOwner()).isEqualTo("inventory");
+        }
+
+        @Test
+        @DisplayName("skips unparseable messages, missing eventIds, and replays")
+        void deliveryGuards() {
+            listener.onInventoryEvent("{not json");
+            listener.onInventoryEvent(availability("", 1, 8));
+            when(processedEventRepository.existsById("evt-1")).thenReturn(true);
+            listener.onInventoryEvent(availability("evt-1", 1, 8));
+
+            verify(processedEventRepository, never()).save(any());
+            verify(availabilityRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("rethrows a transient database error but swallows and records a malformed payload")
+        void transientVersusMalformed() {
+            doThrow(new QueryTimeoutException("lock wait"))
+                    .when(availabilityRepository)
+                    .findById(any());
+
+            assertThatThrownBy(() -> listener.onInventoryEvent(availability("evt-1", 1, 8)))
+                    .isInstanceOf(QueryTimeoutException.class);
+            verify(processedEventRepository, never()).save(any());
+
+            listener.onInventoryEvent("""
+                    {"eventId":"evt-2","eventType":"%s","payload":{"productId":"not-a-uuid"}}""".formatted(LeadTimeUpdatedV1.EVENT_TYPE));
+            verify(processedEventRepository).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("reconciliation manifest listener")
+    class Manifest {
+
+        private InventoryManifestListener manifestListener() {
+            InventoryManifestListener manifestListener = new InventoryManifestListener(
+                    processedEventRepository, kafkaTemplate, objectMapper, meterRegistryProvider);
+            // Field name is a copy-paste leftover (same as pos-invoice's workorder listener); the
+            // @Value key binds the inventory topic, so routing is correct in production.
+            ReflectionTestUtils.setField(manifestListener, "locationCommandsTopic", "inventory.commands.v1");
+            return manifestListener;
+        }
+
+        private String manifestMessage(long eventCount, String checksum) {
+            return """
+                    {"eventId":"evt-1","eventType":"x.reconciliation.manifest",
+                     "payload":{"windowStartUtc":"%s","windowEndUtc":"%s","eventCount":%d,
+                       "eventIdsChecksum":"%s","eventTypeCounts":null}}
+                    """.formatted(WINDOW_START, WINDOW_END, eventCount, checksum);
+        }
+
+        private void replicaHolds(List<String> eventIds) {
+            when(processedEventRepository.findEventIdsInRange(
+                            InventoryEventsListener.OWNER,
+                            UuidV7Timestamps.minStringAt(WINDOW_START),
+                            UuidV7Timestamps.minStringAt(WINDOW_END)))
+                    .thenReturn(eventIds);
+        }
+
+        private double driftCount() {
+            return meterRegistry.find("replica.drift").tag("owner", "inventory").counters().stream()
+                    .mapToDouble(io.micrometer.core.instrument.Counter::count)
+                    .sum();
+        }
+
+        @Test
+        @DisplayName("stays silent on a matching window")
+        void matchingWindow() {
+            List<String> ids = List.of("019ff000-0000-7000-8000-000000000001");
+            replicaHolds(ids);
+
+            manifestListener().onManifest(manifestMessage(1, ReconciliationManifestV1.checksumOf(ids)));
+
+            verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+            assertThat(driftCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("counts drift and requests a replay for the failed window on inventory's topic")
+        void driftRequestsReplay() {
+            replicaHolds(List.of());
+
+            manifestListener().onManifest(manifestMessage(2, "owner-checksum"));
+
+            assertThat(driftCount()).isEqualTo(1.0);
+            ArgumentCaptor<String> command = ArgumentCaptor.forClass(String.class);
+            verify(kafkaTemplate)
+                    .send(
+                            org.mockito.ArgumentMatchers.eq("inventory.commands.v1"),
+                            org.mockito.ArgumentMatchers.eq(WINDOW_START.toString()),
+                            command.capture());
+            assertThat(objectMapper
+                            .readTree(command.getValue())
+                            .path("payload")
+                            .path("since")
+                            .asString())
+                    .isEqualTo(WINDOW_START.toString());
+        }
+
+        @Test
+        @DisplayName("drops an unparseable manifest and survives a failed replay publish")
+        void robustness() {
+            manifestListener().onManifest("{not json");
+            verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+
+            replicaHolds(List.of());
+            when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                    .thenThrow(new IllegalStateException("broker down"));
+
+            manifestListener().onManifest(manifestMessage(3, "owner-checksum"));
+
+            assertThat(driftCount()).isEqualTo(1.0);
+        }
+    }
+}

--- a/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/service/ReplicaAndManifestListenerContractTest.java
+++ b/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/service/ReplicaAndManifestListenerContractTest.java
@@ -1,0 +1,452 @@
+package com.positivity.shopmanager.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.domainevents.UuidV7Timestamps;
+import com.positivity.domainevents.customer.CustomerPartyDeletedV1;
+import com.positivity.domainevents.customer.CustomerPartyUpdatedV1;
+import com.positivity.domainevents.people.StaffingAssignmentUpdatedV1;
+import com.positivity.domainevents.peoplecontact.PersonUpdatedV1;
+import com.positivity.domainevents.vehicle.VehicleUpdatedV1;
+import com.positivity.shopmanager.internal.entity.ExtCustomerPartyReplica;
+import com.positivity.shopmanager.internal.entity.ExtStaffingAssignmentReplica;
+import com.positivity.shopmanager.internal.entity.ExtVehicleReplica;
+import com.positivity.shopmanager.internal.entity.ProcessedEvent;
+import com.positivity.shopmanager.internal.repository.ExtCustomerPartyReplicaRepository;
+import com.positivity.shopmanager.internal.repository.ExtPersonReplicaRepository;
+import com.positivity.shopmanager.internal.repository.ExtStaffingAssignmentReplicaRepository;
+import com.positivity.shopmanager.internal.repository.ExtVehicleReplicaRepository;
+import com.positivity.shopmanager.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * pos-shop-manager consumes four upstream owners into {@code ext_*} replicas and
+ * reconciles three of them with manifest listeners (ADR-0044 §4/§6). Both
+ * families are internally identical, so each family's contract is pinned once,
+ * parameterized — the same shape used in pos-order, pos-people, and pos-invoice.
+ *
+ * <p>
+ * Replica contract: unparseable messages and missing eventIds are skipped
+ * without a dedup row; replays are no-ops; transient database errors are
+ * rethrown for container retry; malformed payloads are swallowed but still
+ * recorded, keeping this consumer's count aligned with the owner's manifest;
+ * the stale guard skips only strictly-lower versions.
+ *
+ * <p>
+ * Manifest contract: the drift verdict is stateless; drift increments the
+ * metric and requests a replay naming the failed window on the owner's own
+ * commands topic; an unparseable manifest is dropped; a failed replay publish
+ * still counts the drift.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("pos-shop-manager replica and manifest listeners — shared contracts")
+class ReplicaAndManifestListenerContractTest {
+
+    private static final UUID ID = UUID.fromString("00000000-0000-0000-0000-0000000000f1");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+    private static final Instant WINDOW_START = Instant.parse("2026-08-11T09:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-08-11T09:05:00Z");
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private ExtCustomerPartyReplicaRepository customerRepository;
+
+    @Mock
+    private ExtVehicleReplicaRepository vehicleRepository;
+
+    @Mock
+    private ExtStaffingAssignmentReplicaRepository assignmentRepository;
+
+    @Mock
+    private ExtPersonReplicaRepository personRepository;
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Mock
+    private ObjectProvider<MeterRegistry> meterRegistryProvider;
+
+    private SimpleMeterRegistry meterRegistry;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        when(meterRegistryProvider.getIfAvailable()).thenReturn(meterRegistry);
+        when(processedEventRepository.existsById(any())).thenReturn(false);
+        when(customerRepository.findById(any())).thenReturn(Optional.empty());
+        when(vehicleRepository.findById(any())).thenReturn(Optional.empty());
+        when(assignmentRepository.findById(any())).thenReturn(Optional.empty());
+        when(personRepository.findById(any())).thenReturn(Optional.empty());
+    }
+
+    // ---------- replica listeners ----------
+
+    static final List<String> REPLICAS = List.of("customer", "vehicle", "people", "people-contact");
+
+    private record Replica(
+            String owner,
+            String eventType,
+            java.util.function.Function<String, String> payload,
+            Consumer<String> dispatch,
+            Runnable failHard) {}
+
+    private Replica replica(String owner) {
+        return switch (owner) {
+            case "customer" ->
+                new Replica(
+                        CustomerEventsListener.OWNER,
+                        CustomerPartyUpdatedV1.EVENT_TYPE,
+                        id -> """
+                            {"partyId":"%s","partyType":"ORGANIZATION","customerNumber":"C-1",
+                             "displayName":"Fleet Co","status":"ACTIVE","requirementsMet":true}""".formatted(id),
+                        new CustomerEventsListener(clock, objectMapper, processedEventRepository, customerRepository)
+                                ::onCustomerEvent,
+                        () -> doThrow(new QueryTimeoutException("lock wait"))
+                                .when(customerRepository)
+                                .findById(any()));
+            case "vehicle" ->
+                new Replica(
+                        VehicleEventsListener.OWNER,
+                        VehicleUpdatedV1.EVENT_TYPE,
+                        id -> """
+                            {"vehicleId":"%s","accountId":"%s","vin":"1HGCM82633A004352",
+                             "unitNumber":"U1","description":"d","licensePlate":"AB-123",
+                             "year":2024,"make":"Toyota","model":"Tacoma","active":true}""".formatted(id, ID),
+                        new VehicleEventsListener(clock, objectMapper, processedEventRepository, vehicleRepository)
+                                ::onVehicleEvent,
+                        () -> doThrow(new QueryTimeoutException("lock wait"))
+                                .when(vehicleRepository)
+                                .findById(any()));
+            case "people" ->
+                new Replica(
+                        PeopleEventsListener.OWNER,
+                        StaffingAssignmentUpdatedV1.EVENT_TYPE,
+                        id -> """
+                            {"assignmentId":"%s","employeeId":"%s","personId":"%s","locationId":"%s",
+                             "role":"TECHNICIAN","primary":true,"status":"ACTIVE",
+                             "effectiveFrom":"2026-02-01","effectiveTo":null}""".formatted(id, ID, ID, ID),
+                        new PeopleEventsListener(clock, objectMapper, processedEventRepository, assignmentRepository)
+                                ::onPeopleEvent,
+                        () -> doThrow(new QueryTimeoutException("lock wait"))
+                                .when(assignmentRepository)
+                                .findById(any()));
+            default ->
+                new Replica(
+                        PeopleContactEventsListener.OWNER,
+                        PersonUpdatedV1.EVENT_TYPE,
+                        id -> """
+                            {"personId":"%s","firstName":"Ada","lastName":"Lovelace",
+                             "preferredName":null,"contactPoints":[],"postalAddress":null,
+                             "createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-08-01T00:00:00Z"}""".formatted(id),
+                        new PeopleContactEventsListener(clock, objectMapper, processedEventRepository, personRepository)
+                                ::onPeopleContactEvent,
+                        () -> doThrow(new QueryTimeoutException("lock wait"))
+                                .when(personRepository)
+                                .findById(any()));
+        };
+    }
+
+    private String envelope(Replica replica, String eventId, String idValue) {
+        return """
+                {"eventId":"%s","eventType":"%s","aggregateVersion":3,"payload":%s}""".formatted(eventId, replica.eventType(), replica.payload().apply(idValue));
+    }
+
+    @Nested
+    @DisplayName("replica listeners")
+    class Replicas {
+
+        @ParameterizedTest
+        @FieldSource("com.positivity.shopmanager.internal.service.ReplicaAndManifestListenerContractTest#REPLICAS")
+        @DisplayName("stamps its own owner on the dedup row after applying a fact")
+        void happyPath(String owner) {
+            Replica replica = replica(owner);
+
+            replica.dispatch().accept(envelope(replica, "evt-1", ID.toString()));
+
+            ArgumentCaptor<ProcessedEvent> captor = ArgumentCaptor.forClass(ProcessedEvent.class);
+            verify(processedEventRepository).save(captor.capture());
+            assertThat(captor.getValue().getEventId()).isEqualTo("evt-1");
+            assertThat(captor.getValue().getOwner()).isEqualTo(replica.owner());
+            assertThat(captor.getValue().getProcessedAt()).isEqualTo(NOW);
+        }
+
+        @ParameterizedTest
+        @FieldSource("com.positivity.shopmanager.internal.service.ReplicaAndManifestListenerContractTest#REPLICAS")
+        @DisplayName("skips unparseable messages, missing eventIds, and replays")
+        void deliveryGuards(String owner) {
+            Replica replica = replica(owner);
+
+            replica.dispatch().accept("{not json");
+            replica.dispatch().accept(envelope(replica, "", ID.toString()));
+            when(processedEventRepository.existsById("evt-1")).thenReturn(true);
+            replica.dispatch().accept(envelope(replica, "evt-1", ID.toString()));
+
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @ParameterizedTest
+        @FieldSource("com.positivity.shopmanager.internal.service.ReplicaAndManifestListenerContractTest#REPLICAS")
+        @DisplayName("rethrows a transient database error so the container retries")
+        void transientErrorRethrown(String owner) {
+            Replica replica = replica(owner);
+            replica.failHard().run();
+
+            assertThatThrownBy(() -> replica.dispatch().accept(envelope(replica, "evt-1", ID.toString())))
+                    .isInstanceOf(QueryTimeoutException.class);
+
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @ParameterizedTest
+        @FieldSource("com.positivity.shopmanager.internal.service.ReplicaAndManifestListenerContractTest#REPLICAS")
+        @DisplayName("swallows a malformed payload but still records it toward the manifest count")
+        void malformedPayloadRecorded(String owner) {
+            Replica replica = replica(owner);
+
+            replica.dispatch().accept(envelope(replica, "evt-1", "not-a-uuid"));
+
+            verify(processedEventRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("customer: maps the party and removes the row on deletion")
+        void customerMapping() {
+            CustomerEventsListener listener =
+                    new CustomerEventsListener(clock, objectMapper, processedEventRepository, customerRepository);
+            Replica replica = replica("customer");
+
+            replica.dispatch().accept(envelope(replica, "evt-1", ID.toString()));
+
+            ArgumentCaptor<ExtCustomerPartyReplica> captor = ArgumentCaptor.forClass(ExtCustomerPartyReplica.class);
+            verify(customerRepository).save(captor.capture());
+            assertThat(captor.getValue().getPartyId()).isEqualTo(ID);
+            assertThat(captor.getValue().getCustomerNumber()).isEqualTo("C-1");
+            assertThat(captor.getValue().getDisplayName()).isEqualTo("Fleet Co");
+
+            listener.onCustomerEvent("""
+                    {"eventId":"evt-2","eventType":"%s","payload":{"partyId":"%s"}}""".formatted(CustomerPartyDeletedV1.EVENT_TYPE, ID));
+            verify(customerRepository).deleteById(ID);
+        }
+
+        @Test
+        @DisplayName("vehicle: maps the identity fields the appointment board displays")
+        void vehicleMapping() {
+            Replica replica = replica("vehicle");
+
+            replica.dispatch().accept(envelope(replica, "evt-1", ID.toString()));
+
+            ArgumentCaptor<ExtVehicleReplica> captor = ArgumentCaptor.forClass(ExtVehicleReplica.class);
+            verify(vehicleRepository).save(captor.capture());
+            ExtVehicleReplica saved = captor.getValue();
+            assertThat(saved.getVehicleId()).isEqualTo(ID);
+            assertThat(saved.getVin()).isEqualTo("1HGCM82633A004352");
+            assertThat(saved.getLicensePlate()).isEqualTo("AB-123");
+            assertThat(saved.getMake()).isEqualTo("Toyota");
+            assertThat(saved.isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("people: maps the staffing assignment scheduling reads")
+        void staffingMapping() {
+            Replica replica = replica("people");
+
+            replica.dispatch().accept(envelope(replica, "evt-1", ID.toString()));
+
+            ArgumentCaptor<ExtStaffingAssignmentReplica> captor =
+                    ArgumentCaptor.forClass(ExtStaffingAssignmentReplica.class);
+            verify(assignmentRepository).save(captor.capture());
+            assertThat(captor.getValue().getAssignmentId()).isEqualTo(ID);
+            assertThat(captor.getValue().getRole()).isEqualTo("TECHNICIAN");
+            assertThat(captor.getValue().isPrimary()).isTrue();
+        }
+
+        @Test
+        @DisplayName("stale guard: skips a strictly-older snapshot, re-applies an equal one")
+        void staleGuard() {
+            when(vehicleRepository.findById(ID))
+                    .thenReturn(Optional.of(ExtVehicleReplica.builder()
+                            .vehicleId(ID)
+                            .aggregateVersion(3)
+                            .build()));
+            Replica replica = replica("vehicle");
+
+            replica.dispatch()
+                    .accept("""
+                            {"eventId":"evt-1","eventType":"%s","aggregateVersion":2,"payload":%s}""".formatted(replica.eventType(), replica.payload().apply(ID.toString())));
+            verify(vehicleRepository, never()).save(any());
+
+            // Equal version re-applies: it is an emission-timestamp hint over a full snapshot.
+            replica.dispatch().accept(envelope(replica, "evt-2", ID.toString()));
+            verify(vehicleRepository).save(any());
+        }
+    }
+
+    // ---------- manifest listeners ----------
+
+    static final List<String> MANIFESTS = List.of("customer", "vehicle", "people-contact");
+
+    private record Manifest(String owner, String commandsTopic, Consumer<String> dispatch) {}
+
+    private Manifest manifest(String owner) {
+        switch (owner) {
+            case "customer" -> {
+                CustomerManifestListener listener = new CustomerManifestListener(
+                        processedEventRepository, kafkaTemplate, objectMapper, meterRegistryProvider);
+                ReflectionTestUtils.setField(listener, "customerCommandsTopic", "customer.commands.v1");
+                return new Manifest(CustomerEventsListener.OWNER, "customer.commands.v1", listener::onManifest);
+            }
+            case "vehicle" -> {
+                VehicleManifestListener listener = new VehicleManifestListener(
+                        processedEventRepository, kafkaTemplate, objectMapper, meterRegistryProvider);
+                ReflectionTestUtils.setField(listener, "vehicleCommandsTopic", "vehicle.commands.v1");
+                return new Manifest(VehicleEventsListener.OWNER, "vehicle.commands.v1", listener::onManifest);
+            }
+            default -> {
+                PeopleContactManifestListener listener = new PeopleContactManifestListener(
+                        processedEventRepository, kafkaTemplate, objectMapper, meterRegistryProvider);
+                ReflectionTestUtils.setField(listener, "peopleContactCommandsTopic", "people-contact.commands.v1");
+                return new Manifest(
+                        PeopleContactEventsListener.OWNER, "people-contact.commands.v1", listener::onManifest);
+            }
+        }
+    }
+
+    private String manifestMessage(long eventCount, String checksum) {
+        return """
+                {"eventId":"evt-1","eventType":"x.reconciliation.manifest",
+                 "payload":{"windowStartUtc":"%s","windowEndUtc":"%s","eventCount":%d,
+                   "eventIdsChecksum":"%s","eventTypeCounts":null}}
+                """.formatted(WINDOW_START, WINDOW_END, eventCount, checksum);
+    }
+
+    private void replicaHolds(Manifest manifest, List<String> eventIds) {
+        when(processedEventRepository.findEventIdsInRange(
+                        manifest.owner(),
+                        UuidV7Timestamps.minStringAt(WINDOW_START),
+                        UuidV7Timestamps.minStringAt(WINDOW_END)))
+                .thenReturn(eventIds);
+    }
+
+    private double driftCount(String owner) {
+        return meterRegistry.find("replica.drift").tag("owner", owner).counters().stream()
+                .mapToDouble(io.micrometer.core.instrument.Counter::count)
+                .sum();
+    }
+
+    @Nested
+    @DisplayName("manifest listeners")
+    class Manifests {
+
+        @ParameterizedTest
+        @FieldSource("com.positivity.shopmanager.internal.service.ReplicaAndManifestListenerContractTest#MANIFESTS")
+        @DisplayName("stays silent on a matching window")
+        void matchingWindow(String owner) {
+            Manifest manifest = manifest(owner);
+            List<String> ids = List.of("019ff000-0000-7000-8000-000000000001");
+            replicaHolds(manifest, ids);
+
+            manifest.dispatch().accept(manifestMessage(1, ReconciliationManifestV1.checksumOf(ids)));
+
+            verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+            assertThat(driftCount(manifest.owner())).isZero();
+        }
+
+        @ParameterizedTest
+        @FieldSource("com.positivity.shopmanager.internal.service.ReplicaAndManifestListenerContractTest#MANIFESTS")
+        @DisplayName("counts drift and requests a replay on its own owner's topic")
+        void driftRequestsReplay(String owner) {
+            Manifest manifest = manifest(owner);
+            replicaHolds(manifest, List.of());
+
+            manifest.dispatch().accept(manifestMessage(2, "owner-checksum"));
+
+            assertThat(driftCount(manifest.owner())).isEqualTo(1.0);
+            ArgumentCaptor<String> command = ArgumentCaptor.forClass(String.class);
+            verify(kafkaTemplate)
+                    .send(
+                            org.mockito.ArgumentMatchers.eq(manifest.commandsTopic()),
+                            org.mockito.ArgumentMatchers.eq(WINDOW_START.toString()),
+                            command.capture());
+            assertThat(objectMapper
+                            .readTree(command.getValue())
+                            .path("payload")
+                            .path("since")
+                            .asString())
+                    .isEqualTo(WINDOW_START.toString());
+        }
+
+        @ParameterizedTest
+        @FieldSource("com.positivity.shopmanager.internal.service.ReplicaAndManifestListenerContractTest#MANIFESTS")
+        @DisplayName("treats a checksum mismatch at matching counts as drift, statelessly")
+        void checksumMismatchAndStatelessness(String owner) {
+            Manifest manifest = manifest(owner);
+            List<String> ids = List.of("019ff000-0000-7000-8000-000000000001");
+            replicaHolds(manifest, ids);
+            String message = manifestMessage(1, "a-different-checksum");
+
+            manifest.dispatch().accept(message);
+            manifest.dispatch().accept(message);
+
+            // Same verdict every time; a redelivered manifest costs one more idempotent replay.
+            assertThat(driftCount(manifest.owner())).isEqualTo(2.0);
+        }
+
+        @ParameterizedTest
+        @FieldSource("com.positivity.shopmanager.internal.service.ReplicaAndManifestListenerContractTest#MANIFESTS")
+        @DisplayName("drops an unparseable manifest and survives a failed replay publish")
+        void robustness(String owner) {
+            Manifest manifest = manifest(owner);
+
+            manifest.dispatch().accept("{not json");
+            verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+
+            replicaHolds(manifest, List.of());
+            when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                    .thenThrow(new IllegalStateException("broker down"));
+
+            manifest.dispatch().accept(manifestMessage(3, "owner-checksum"));
+
+            // Metric still fired; the broker outage must not take the consumer down.
+            assertThat(driftCount(manifest.owner())).isEqualTo(1.0);
+        }
+    }
+}

--- a/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/service/ReplicaAndManifestListenerContractTest.java
+++ b/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/service/ReplicaAndManifestListenerContractTest.java
@@ -169,7 +169,7 @@ class ReplicaAndManifestListenerContractTest {
                         () -> doThrow(new QueryTimeoutException("lock wait"))
                                 .when(assignmentRepository)
                                 .findById(any()));
-            default ->
+            case "people-contact" ->
                 new Replica(
                         PeopleContactEventsListener.OWNER,
                         PersonUpdatedV1.EVENT_TYPE,
@@ -182,6 +182,7 @@ class ReplicaAndManifestListenerContractTest {
                         () -> doThrow(new QueryTimeoutException("lock wait"))
                                 .when(personRepository)
                                 .findById(any()));
+            default -> throw new IllegalArgumentException("Unknown replica owner in test fixture: " + owner);
         };
     }
 
@@ -340,13 +341,14 @@ class ReplicaAndManifestListenerContractTest {
                 ReflectionTestUtils.setField(listener, "vehicleCommandsTopic", "vehicle.commands.v1");
                 return new Manifest(VehicleEventsListener.OWNER, "vehicle.commands.v1", listener::onManifest);
             }
-            default -> {
+            case "people-contact" -> {
                 PeopleContactManifestListener listener = new PeopleContactManifestListener(
                         processedEventRepository, kafkaTemplate, objectMapper, meterRegistryProvider);
                 ReflectionTestUtils.setField(listener, "peopleContactCommandsTopic", "people-contact.commands.v1");
                 return new Manifest(
                         PeopleContactEventsListener.OWNER, "people-contact.commands.v1", listener::onManifest);
             }
+            default -> throw new IllegalArgumentException("Unknown manifest owner in test fixture: " + owner);
         }
     }
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — plan-driven (`docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` Phases 2–3).
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:product`, `domain:shopmgmt`

> **Stacked PR 2 of a series.** Base is `test-coverage/phase-3-vehicle-docs` (#1249). Merge order: #1248 → #1249 → this.

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Nothing under `src/main` changed — two test files only. No `BACKEND_CONTRACT_GUIDE.md` entry applies.

```bash
git diff --name-only test-coverage/phase-3-vehicle-docs..HEAD | grep -v '/src/test/'
# (empty)
```

## Contract Chain (when a Controller changed)
No controller changed. All items n/a.
- [x] OpenAPI annotations — n/a
- [x] `openapi.yaml` regenerated — n/a
- [x] Angular SDK regenerated — n/a

## Scope

**What changed:** two test classes covering all eight previously-untested Kafka listeners in these modules.

| Module | Line | Branch |
|---|---|---|
| `pos-catalog` | 73.1% → **77.4%** | 51.5% → 53.5% |
| `pos-shop-manager` | 67.5% → **83.2%** | 60.3% → **67.1%** |

Same parameterized contract-test shape as the earlier modules: each internally-identical listener family (replica listeners, manifest listeners) is pinned once; per-owner field mapping is covered separately. Notable specifics:

- The catalog availability replica is pinned as **keyed on the envelope's `aggregateId`** — deriving a key from payload fields would silently fork the replica's identity from the producer's.
- `pos-catalog`'s `InventoryManifestListener` has the same `locationCommandsTopic` copy-paste field name already noted on pos-invoice's workorder listener. Routing is correct (the `@Value` key binds the inventory topic); the test pins the routing, not the field name.

**Remaining in these modules:** `pos-catalog`'s service-impl branch tails (`CatalogServiceImpl` 108 missed at 57%, `ProductDetailServiceImpl` 91, `PriceBookServiceImpl` 86 — branch-coverage work, per the plan's original note that branch coverage is this module's real weakness); `pos-shop-manager`'s `AppointmentsServiceImpl` tail and `ConflictResponse` DTOs.

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests — none
- [ ] Provider behavioral contract tests — none

```bash
./mvnw -pl pos-catalog,pos-shop-manager -DskipTests=false test
```

Both modules green with all gates.

## Risk & Rollback
- Risk level: **Low.** Test-only.
- Rollback plan: revert the merge commit.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — plan-driven, no capability id
- [ ] PR title starts with `[CAP:<cap-id>]` — same
- [x] Links to parent + child issues — none exist
- [x] Contract guide updated — n/a
- [ ] Required CI checks passing — to be confirmed
