### PR TITLE
test: cover pos-workorder listeners, first pos-tax-common suite (stack 3/N)

### DIFF
--- a/pos-tax-common/pom.xml
+++ b/pos-tax-common/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>nv-i18n</artifactId>
             <version>1.29</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pos-tax-common/src/test/java/com/positivity/tax/common/validation/TaxValidationTest.java
+++ b/pos-tax-common/src/test/java/com/positivity/tax/common/validation/TaxValidationTest.java
@@ -1,0 +1,144 @@
+package com.positivity.tax.common.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.tax.common.dto.TaxCalculationRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * First tests for pos-tax-common, whose own suite was empty — its aggregate
+ * coverage reading came entirely from consumers' tests, so nothing pinned these
+ * validators directly.
+ *
+ * <p>
+ * All three validators treat absence as valid on purpose: presence is
+ * {@code @NotNull}'s job on the request, and a validator that also rejected null
+ * would make every optional address field mandatory everywhere the annotation is
+ * used. What they reject is a <em>present but wrong</em> value — the case that
+ * would otherwise reach a tax provider and come back as a billing-time error.
+ *
+ * <p>
+ * The subdivision check normalizes {@code US-TX} and {@code tx} to {@code TX}
+ * before matching, and carries an explicit US fallback list because the ISO
+ * dataset alone does not cover the territories tax law cares about (PR, GU, DC,
+ * ...).
+ */
+@DisplayName("pos-tax-common validators — country, currency, subdivision")
+class TaxValidationTest {
+
+    @Nested
+    @DisplayName("IsoCountryCodeValidator")
+    class Country {
+
+        private final IsoCountryCodeValidator validator = new IsoCountryCodeValidator();
+
+        @ParameterizedTest
+        @ValueSource(strings = {"US", "CA", "DE", "JP"})
+        @DisplayName("accepts real ISO 3166-1 alpha-2 codes")
+        void acceptsRealCodes(String code) {
+            assertThat(validator.isValid(code, null)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"USA", "XX", "us", "U1"})
+        @DisplayName("rejects a present but wrong code, including lowercase")
+        void rejectsWrongCodes(String code) {
+            // Lowercase is rejected on purpose: the DTO contract is uppercase alpha-2, and
+            // accepting "us" here would let mixed-case reach providers that compare exactly.
+            assertThat(validator.isValid(code, null)).isFalse();
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = "   ")
+        @DisplayName("treats absence as valid, leaving presence to @NotNull")
+        void absentIsValid(String code) {
+            assertThat(validator.isValid(code, null)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("IsoCurrencyCodeValidator")
+    class Currency {
+
+        private final IsoCurrencyCodeValidator validator = new IsoCurrencyCodeValidator();
+
+        @ParameterizedTest
+        @CsvSource({"USD, true", "EUR, true", "CAD, true", "XYZ, false", "DOLLARS, false"})
+        @DisplayName("accepts ISO 4217 codes and rejects invented ones")
+        void currencyCodes(String code, boolean valid) {
+            assertThat(validator.isValid(code, null)).isEqualTo(valid);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @DisplayName("treats absence as valid")
+        void absentIsValid(String code) {
+            assertThat(validator.isValid(code, null)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("SubdivisionForCountryValidator")
+    class Subdivision {
+
+        private final SubdivisionForCountryValidator validator = new SubdivisionForCountryValidator();
+
+        private static TaxCalculationRequest.TaxAddress address(String country, String region) {
+            return TaxCalculationRequest.TaxAddress.builder()
+                    .countryCode(country)
+                    .regionCode(region)
+                    .build();
+        }
+
+        @ParameterizedTest
+        @CsvSource({"US, TX, true", "US, US-TX, true", "US, tx, true", "US, ZZ, false", "CA, TX, false", "DE, BY, true"
+        })
+        @DisplayName("accepts a subdivision only within its own country, normalizing prefix and case")
+        void subdivisionMembership(String country, String region, boolean valid) {
+            // TX is a real code — but not a Canadian one. Cross-country acceptance would send a
+            // Canadian address to the provider with a Texas jurisdiction.
+            assertThat(validator.isValid(address(country, region), null)).isEqualTo(valid);
+        }
+
+        @ParameterizedTest
+        @CsvSource({"CA, ON", "CA, QC", "CA, BC"})
+        @DisplayName("rejects every real Canadian province — the backing dataset has no CA data")
+        void canadianProvincesAreRejected(String country, String region) {
+            // Documents current behaviour, not desired behaviour. The i18n-subdivision-enums
+            // dataset returns no subdivisions for Canada (probing yields only "NA"), and unlike
+            // the US there is no fallback list, so a valid Canadian address fails validation.
+            // Any consumer validating a Canadian TaxAddress gets a 400 for a correct region code.
+            // The fix — a CA fallback list like the US one, or a different dataset — is a design
+            // call; this test exists so it cannot be fixed silently.
+            assertThat(validator.isValid(address(country, region), null)).isFalse();
+        }
+
+        @ParameterizedTest
+        @CsvSource({"US, PR", "US, GU", "US, DC", "US, VI"})
+        @DisplayName("accepts US territories via the explicit fallback list")
+        void usTerritories(String country, String region) {
+            // Tax law reaches the territories even where the ISO dataset is thin.
+            assertThat(validator.isValid(address(country, region), null)).isTrue();
+        }
+
+        @org.junit.jupiter.api.Test
+        @DisplayName("treats a missing address, country, or region as valid")
+        void absentPartsAreValid() {
+            assertThat(validator.isValid(null, null)).isTrue();
+            assertThat(validator.isValid(address(null, "TX"), null)).isTrue();
+            assertThat(validator.isValid(address("US", "  "), null)).isTrue();
+        }
+
+        @org.junit.jupiter.api.Test
+        @DisplayName("rejects an unknown country outright, even with a plausible region")
+        void unknownCountryIsInvalid() {
+            assertThat(validator.isValid(address("XX", "TX"), null)).isFalse();
+        }
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/ReplicaAndManifestListenerContractTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/ReplicaAndManifestListenerContractTest.java
@@ -1,0 +1,367 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.domainevents.UuidV7Timestamps;
+import com.positivity.domainevents.customer.CustomerPartyDeletedV1;
+import com.positivity.domainevents.customer.CustomerPartyUpdatedV1;
+import com.positivity.domainevents.location.LocationUpdatedV1;
+import com.positivity.domainevents.people.StaffingAssignmentUpdatedV1;
+import com.positivity.domainevents.peoplecontact.PersonUpdatedV1;
+import com.positivity.domainevents.peoplecontact.UserPersonLinkRemovedV1;
+import com.positivity.domainevents.peoplecontact.UserPersonLinkUpdatedV1;
+import com.positivity.workorder.internal.entity.ExtCustomerPartyReplica;
+import com.positivity.workorder.internal.entity.ExtLocationReplica;
+import com.positivity.workorder.internal.entity.ExtPersonReplica;
+import com.positivity.workorder.internal.entity.ExtStaffingAssignmentReplica;
+import com.positivity.workorder.internal.entity.ExtUserLinkReplica;
+import com.positivity.workorder.internal.entity.ProcessedEvent;
+import com.positivity.workorder.internal.repository.ExtCustomerPartyReplicaRepository;
+import com.positivity.workorder.internal.repository.ExtLocationReplicaRepository;
+import com.positivity.workorder.internal.repository.ExtPersonReplicaRepository;
+import com.positivity.workorder.internal.repository.ExtStaffingAssignmentReplicaRepository;
+import com.positivity.workorder.internal.repository.ExtUserLinkReplicaRepository;
+import com.positivity.workorder.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Unit tests for pos-workorder's replica and reconciliation listeners
+ * (ADR-0044 §4/§6), same contract shape as the sibling modules.
+ *
+ * <p>
+ * The distinctive piece here is {@link PeopleReplicaEventsListener}: one
+ * component subscribed to <em>two</em> topics ({@code people-contact.events.v1}
+ * and {@code people.events.v1}), stamping a different owner on the dedup row
+ * depending on which entry point delivered the message. The owner column is
+ * what the two manifest comparisons filter by, so a fact recorded under the
+ * wrong owner would corrupt both windows at once — one count too high, the
+ * other too low.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("pos-workorder replica and manifest listeners — shared contracts")
+class ReplicaAndManifestListenerContractTest {
+
+    private static final UUID ID = UUID.fromString("00000000-0000-0000-0000-0000000000e1");
+    private static final Instant NOW = Instant.parse("2026-08-11T09:00:00Z");
+    private static final Instant WINDOW_START = Instant.parse("2026-08-11T09:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-08-11T09:05:00Z");
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private ExtPersonReplicaRepository personRepository;
+
+    @Mock
+    private ExtUserLinkReplicaRepository userLinkRepository;
+
+    @Mock
+    private ExtStaffingAssignmentReplicaRepository assignmentRepository;
+
+    @Mock
+    private ExtCustomerPartyReplicaRepository customerRepository;
+
+    @Mock
+    private ExtLocationReplicaRepository locationRepository;
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Mock
+    private ObjectProvider<MeterRegistry> meterRegistryProvider;
+
+    private SimpleMeterRegistry meterRegistry;
+    private PeopleReplicaEventsListener peopleListener;
+    private CustomerEventsListener customerListener;
+    private LocationEventsListener locationListener;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        when(meterRegistryProvider.getIfAvailable()).thenReturn(meterRegistry);
+        when(processedEventRepository.existsById(any())).thenReturn(false);
+        when(personRepository.findById(any())).thenReturn(Optional.empty());
+        when(userLinkRepository.findById(any())).thenReturn(Optional.empty());
+        when(assignmentRepository.findById(any())).thenReturn(Optional.empty());
+        when(customerRepository.findById(any())).thenReturn(Optional.empty());
+        when(locationRepository.findById(any())).thenReturn(Optional.empty());
+        peopleListener = new PeopleReplicaEventsListener(
+                clock,
+                objectMapper,
+                processedEventRepository,
+                personRepository,
+                userLinkRepository,
+                assignmentRepository);
+        customerListener =
+                new CustomerEventsListener(clock, objectMapper, processedEventRepository, customerRepository);
+        locationListener =
+                new LocationEventsListener(clock, objectMapper, processedEventRepository, locationRepository);
+    }
+
+    private static String envelope(String eventId, String eventType, String payload) {
+        return """
+                {"eventId":"%s","eventType":"%s","aggregateVersion":3,"payload":%s}""".formatted(eventId, eventType, payload);
+    }
+
+    private static String personPayload() {
+        return """
+                {"personId":"%s","firstName":"Ada","lastName":"Lovelace","preferredName":null,
+                 "contactPoints":[],"postalAddress":null,
+                 "createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-08-01T00:00:00Z"}""".formatted(ID);
+    }
+
+    private ProcessedEvent capturedProcessedEvent() {
+        ArgumentCaptor<ProcessedEvent> captor = ArgumentCaptor.forClass(ProcessedEvent.class);
+        verify(processedEventRepository).save(captor.capture());
+        return captor.getValue();
+    }
+
+    @Nested
+    @DisplayName("dual-topic people listener")
+    class DualTopicOwnership {
+
+        @Test
+        @DisplayName("stamps owner people-contact on facts arriving through the people-contact entry point")
+        void peopleContactEntryPoint() {
+            peopleListener.onPeopleContactEvent(envelope("evt-1", PersonUpdatedV1.EVENT_TYPE, personPayload()));
+
+            // The owner column is what each manifest comparison filters by; the wrong owner here
+            // would corrupt both reconciliation windows at once.
+            assertThat(capturedProcessedEvent().getOwner()).isEqualTo(PeopleReplicaEventsListener.OWNER_PEOPLE_CONTACT);
+            verify(personRepository).save(any(ExtPersonReplica.class));
+        }
+
+        @Test
+        @DisplayName("stamps owner people on facts arriving through the people entry point")
+        void peopleEntryPoint() {
+            peopleListener.onPeopleEvent(
+                    envelope("evt-2", StaffingAssignmentUpdatedV1.EVENT_TYPE, """
+                    {"assignmentId":"%s","employeeId":"%s","personId":"%s","locationId":"%s",
+                     "role":"TECHNICIAN","primary":true,"status":"ACTIVE",
+                     "effectiveFrom":"2026-02-01","effectiveTo":null}""".formatted(ID, ID, ID, ID)));
+
+            assertThat(capturedProcessedEvent().getOwner()).isEqualTo(PeopleReplicaEventsListener.OWNER_PEOPLE);
+            ArgumentCaptor<ExtStaffingAssignmentReplica> captor =
+                    ArgumentCaptor.forClass(ExtStaffingAssignmentReplica.class);
+            verify(assignmentRepository).save(captor.capture());
+            assertThat(captor.getValue().getRole()).isEqualTo("TECHNICIAN");
+        }
+
+        @Test
+        @DisplayName("maintains the user-link replica through update and removal")
+        void userLinkLifecycle() {
+            peopleListener.onPeopleContactEvent(
+                    envelope("evt-3", UserPersonLinkUpdatedV1.EVENT_TYPE, """
+                    {"linkId":"%s","personId":"%s","username":"ada","status":"ACTIVE",
+                     "linkType":"PRIMARY","createdAt":"2026-01-01T00:00:00Z",
+                     "updatedAt":"2026-08-01T00:00:00Z"}""".formatted(ID, ID)));
+
+            ArgumentCaptor<ExtUserLinkReplica> captor = ArgumentCaptor.forClass(ExtUserLinkReplica.class);
+            verify(userLinkRepository).save(captor.capture());
+            assertThat(captor.getValue().getUsername()).isEqualTo("ada");
+
+            peopleListener.onPeopleContactEvent(
+                    envelope("evt-4", UserPersonLinkRemovedV1.EVENT_TYPE, """
+                    {"linkId":"%s","personId":"%s","username":"ada"}""".formatted(ID, ID)));
+            verify(userLinkRepository).deleteById(ID);
+        }
+
+        @Test
+        @DisplayName("records an ignored type under the entry point's owner, keeping both manifests honest")
+        void ignoredTypeRecordedPerEntryPoint() {
+            peopleListener.onPeopleEvent("""
+                    {"eventId":"evt-5","eventType":"people.employee.updated","payload":{}}""");
+
+            assertThat(capturedProcessedEvent().getOwner()).isEqualTo(PeopleReplicaEventsListener.OWNER_PEOPLE);
+        }
+
+        @Test
+        @DisplayName("shares one dedup log across both entry points")
+        void dedupSharedAcrossEntryPoints() {
+            when(processedEventRepository.existsById("evt-1")).thenReturn(true);
+
+            peopleListener.onPeopleContactEvent(envelope("evt-1", PersonUpdatedV1.EVENT_TYPE, personPayload()));
+            peopleListener.onPeopleEvent(envelope("evt-1", PersonUpdatedV1.EVENT_TYPE, personPayload()));
+
+            verify(personRepository, never()).save(any());
+            verify(processedEventRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("delivery contract")
+    class DeliveryContract {
+
+        @Test
+        @DisplayName("skips unparseable messages and missing eventIds across all listeners")
+        void deliveryGuards() {
+            peopleListener.onPeopleContactEvent("{not json");
+            customerListener.onCustomerEvent("{not json");
+            locationListener.onLocationEvent("{not json");
+            peopleListener.onPeopleContactEvent(envelope("", PersonUpdatedV1.EVENT_TYPE, personPayload()));
+
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("rethrows a transient database error but swallows and records a malformed payload")
+        void transientVersusMalformed() {
+            doThrow(new QueryTimeoutException("lock wait"))
+                    .when(personRepository)
+                    .findById(any());
+
+            assertThatThrownBy(() -> peopleListener.onPeopleContactEvent(
+                            envelope("evt-1", PersonUpdatedV1.EVENT_TYPE, personPayload())))
+                    .isInstanceOf(QueryTimeoutException.class);
+            verify(processedEventRepository, never()).save(any());
+
+            peopleListener.onPeopleContactEvent(
+                    envelope("evt-2", PersonUpdatedV1.EVENT_TYPE, "{\"personId\":\"not-a-uuid\"}"));
+            verify(processedEventRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("customer: maps the party gate fields and removes the row on deletion")
+        void customerMapping() {
+            customerListener.onCustomerEvent(envelope("evt-1", CustomerPartyUpdatedV1.EVENT_TYPE, """
+                    {"partyId":"%s","partyType":"ORGANIZATION","displayName":"Fleet Co",
+                     "status":"ACTIVE","requirementsMet":true}""".formatted(ID)));
+
+            ArgumentCaptor<ExtCustomerPartyReplica> captor = ArgumentCaptor.forClass(ExtCustomerPartyReplica.class);
+            verify(customerRepository).save(captor.capture());
+            assertThat(captor.getValue().getPartyId()).isEqualTo(ID);
+            // requirementsMet is the gate a workorder checks before work begins.
+            assertThat(captor.getValue().isRequirementsMet()).isTrue();
+
+            customerListener.onCustomerEvent(
+                    envelope("evt-2", CustomerPartyDeletedV1.EVENT_TYPE, "{\"partyId\":\"%s\"}".formatted(ID)));
+            verify(customerRepository).deleteById(ID);
+        }
+
+        @Test
+        @DisplayName("location: keeps the address and applies the strict stale guard")
+        void locationMappingAndStaleGuard() {
+            String payload = """
+                    {"locationId":"%s","name":"Main Shop","code":"SHOP-1","status":"OPEN",
+                     "active":true,"locationType":"SHOP","hrLocationId":null,"timezone":"America/Chicago",
+                     "addressLine1":"1 Main St","addressLine2":null,"city":"Austin","region":"TX",
+                     "postalCode":"78701","country":"US","defaultStagingLocationId":null,
+                     "defaultQuarantineLocationId":null,"parents":[],
+                     "createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-08-01T00:00:00Z"}""".formatted(ID);
+
+            locationListener.onLocationEvent(envelope("evt-1", LocationUpdatedV1.EVENT_TYPE, payload));
+
+            ArgumentCaptor<ExtLocationReplica> captor = ArgumentCaptor.forClass(ExtLocationReplica.class);
+            verify(locationRepository).save(captor.capture());
+            assertThat(captor.getValue().getCity()).isEqualTo("Austin");
+            assertThat(captor.getValue().getAggregateVersion()).isEqualTo(3);
+
+            when(locationRepository.findById(ID))
+                    .thenReturn(Optional.of(ExtLocationReplica.builder()
+                            .locationId(ID)
+                            .aggregateVersion(5)
+                            .build()));
+            locationListener.onLocationEvent(envelope("evt-2", LocationUpdatedV1.EVENT_TYPE, payload));
+            // Version 3 against a replica at 5: strictly older, skipped.
+            verify(locationRepository, org.mockito.Mockito.times(1)).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("manifest listeners")
+    class Manifests {
+
+        private String manifestMessage(long eventCount, String checksum) {
+            return """
+                    {"eventId":"evt-1","eventType":"x.reconciliation.manifest",
+                     "payload":{"windowStartUtc":"%s","windowEndUtc":"%s","eventCount":%d,
+                       "eventIdsChecksum":"%s","eventTypeCounts":null}}
+                    """.formatted(WINDOW_START, WINDOW_END, eventCount, checksum);
+        }
+
+        private double driftCount(String owner) {
+            return meterRegistry.find("replica.drift").tag("owner", owner).counters().stream()
+                    .mapToDouble(io.micrometer.core.instrument.Counter::count)
+                    .sum();
+        }
+
+        @Test
+        @DisplayName("customer manifest: silent on match, drift and replay on mismatch")
+        void customerManifest() {
+            CustomerManifestListener listener = new CustomerManifestListener(
+                    processedEventRepository, kafkaTemplate, objectMapper, meterRegistryProvider);
+            ReflectionTestUtils.setField(listener, "customerCommandsTopic", "customer.commands.v1");
+            List<String> ids = List.of("019ff000-0000-7000-8000-000000000001");
+            when(processedEventRepository.findEventIdsInRange(
+                            CustomerEventsListener.OWNER,
+                            UuidV7Timestamps.minStringAt(WINDOW_START),
+                            UuidV7Timestamps.minStringAt(WINDOW_END)))
+                    .thenReturn(ids);
+
+            listener.onManifest(manifestMessage(1, ReconciliationManifestV1.checksumOf(ids)));
+            verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+
+            listener.onManifest(manifestMessage(2, "owner-checksum"));
+            assertThat(driftCount("customer")).isEqualTo(1.0);
+            verify(kafkaTemplate)
+                    .send(
+                            org.mockito.ArgumentMatchers.eq("customer.commands.v1"),
+                            org.mockito.ArgumentMatchers.eq(WINDOW_START.toString()),
+                            anyString());
+        }
+
+        @Test
+        @DisplayName("location manifest: drops an unparseable manifest, survives a failed replay publish")
+        void locationManifestRobustness() {
+            LocationManifestListener listener = new LocationManifestListener(
+                    processedEventRepository, kafkaTemplate, objectMapper, meterRegistryProvider);
+            ReflectionTestUtils.setField(listener, "locationCommandsTopic", "location.commands.v1");
+
+            listener.onManifest("{not json");
+            verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+
+            when(processedEventRepository.findEventIdsInRange(anyString(), anyString(), anyString()))
+                    .thenReturn(List.of());
+            when(kafkaTemplate.send(anyString(), anyString(), anyString()))
+                    .thenThrow(new IllegalStateException("broker down"));
+
+            listener.onManifest(manifestMessage(3, "owner-checksum"));
+
+            assertThat(driftCount("location")).isEqualTo(1.0);
+        }
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — plan-driven (`docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` Phases 2–3 and §5).
- Parent STORY (durion): n/a
- Child issue: n/a — one defect found, see below; not yet filed as an issue pending a decision on the fix direction.
- Domain: `domain:workexec`, shared library (tax-common)

> **Stacked PR 3 of a series.** Base is `test-coverage/phase-3-catalog-shop` (#1250). Merge order: #1248 → #1249 → #1250 → this.

## Contract References (REQUIRED for backend PRs touching API/event behavior)
One non-test change: `pos-tax-common/pom.xml` gains `spring-boot-starter-test` (test scope) so the module can have a suite at all. No controller, DTO, event, or error model changed; no `BACKEND_CONTRACT_GUIDE.md` entry applies.

```bash
git diff --name-only test-coverage/phase-3-catalog-shop..HEAD | grep -v '/src/test/'
# pos-tax-common/pom.xml
```

## Contract Chain (when a Controller changed)
No controller changed. All items n/a.
- [x] OpenAPI annotations — n/a
- [x] `openapi.yaml` regenerated — n/a
- [x] Angular SDK regenerated — n/a

## Scope

| Module | Line | Branch |
|---|---|---|
| `pos-workorder` | 73.1% → **76.6%** | 55.1% → 56.7% |
| `pos-tax-common` | **no suite → 34.0%** | — → 46.4% |

- **`pos-workorder`'s four listener classes** (299 missed at 0%), same contract shape as the siblings. The distinctive piece: `PeopleReplicaEventsListener` subscribes to **two topics** and stamps a different owner on the dedup row per entry point — the owner column is what each manifest comparison filters by, so the wrong owner would corrupt both reconciliation windows at once. Both entry points, the shared dedup log, and per-entry-point owner stamping are pinned.
- **`pos-tax-common` gets its first test suite** (plan §5 gap: zero test classes; its aggregate reading came entirely from consumers). Covers the three ISO validators.

## Defect found, pinned, not fixed

**`SubdivisionForCountryValidator` rejects every real Canadian province.** The `i18n-subdivision-enums` dataset returns no subdivisions for Canada (probing yields only `NA`), and unlike the US there is no fallback list — so a valid Canadian `TaxAddress` (`CA`/`ON`, `CA`/`QC`, `CA`/`BC`) fails validation with a 400 wherever the annotation is used. Pinned by `canadianProvincesAreRejected` with a "documents current behaviour, not desired behaviour" comment. The fix — a CA fallback list like the US one, or a different dataset — is a design call; say the word and I'll file an issue.

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests — none
- [ ] Provider behavioral contract tests — none

```bash
./mvnw -pl pos-workorder,pos-tax-common -am -DskipTests=false test
```

Both modules green with all gates.

## Risk & Rollback
- Risk level: **Low.** Tests plus one test-scoped dependency.
- Rollback plan: revert the merge commit.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — plan-driven, no capability id
- [ ] PR title starts with `[CAP:<cap-id>]` — same
- [x] Links to parent + child issues — none exist yet
- [x] Contract guide updated — n/a
- [ ] Required CI checks passing — to be confirmed
