### PR TITLE
test: cover pos-mcp-server orchestration; record Phase 3 state (stack 4/4)

### DIFF
--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -1,9 +1,11 @@
 # Test Coverage Improvement Plan
 
-Status: Phase 0 complete. Phase 1 complete except wave 1c (see §3.3). Phase 2 in
-progress — `pos-event-receiver` and `pos-marketing` done, `pos-order` and
-`pos-customer` substantially done (§4.1–§4.3); the remaining nine modules in the
-§4 table are untouched. Phases 3–4 outstanding.
+Status: Phase 0 complete. Phase 1 complete except wave 1c (see §3.3); wave 1e is
+now closed in every module that had Kafka listeners at 0% (§4.5). Phases 2–3
+substantially complete — every module in the §4 priority table has been worked
+(§4.1–§4.5) except the two structural §5 gaps: the Failsafe IT layers for
+`pos-invoice` and `pos-warranty` remain unbuilt, and controller-layer
+`@WebMvcTest` coverage across several modules remains open. Phase 4 outstanding.
 Date: 2026-08-11 (last updated 2026-08-11)
 
 **Before Phase 4, re-run the Phase 0 full-reactor command.** Every figure in
@@ -436,6 +438,44 @@ Remaining in `pos-customer`, largest first: `SegmentResolutionService` (64 misse
 58.5%), `SegmentPredicateValidator` (26, 71.4%), and the CRM controllers
 (`CustomerController` 26, `CrmPartyRelationshipController` 24, `CrmPersonController`
 21 — all want `@WebMvcTest` slices).
+
+### 4.5 Phase 3 completion pass (2026-08-12, stacked PRs)
+
+All figures **unit-only**. Worked in a stacked-PR series so each review stays
+small: #1249 (vehicle-inventory, document-helper) → #1250 (catalog,
+shop-manager) → #1251 (workorder, tax-common) → mcp-server.
+
+| Module | Line | Branch |
+|---|---|---|
+| pos-vehicle-inventory | 46.5% → **66.4%** | 42.4% → **71.0%** |
+| pos-document-helper | 43.1% → **74.0%** | 25.9% → 35.2% |
+| pos-catalog | 73.1% → **77.4%** | 51.5% → 53.5% |
+| pos-shop-manager | 67.5% → **83.2%** | 60.3% → **67.1%** |
+| pos-workorder | 73.1% → **76.6%** | 55.1% → 56.7% |
+| pos-tax-common | no suite → **34.0%** | — → 46.4% |
+| pos-mcp-server | 78.5% → **80.2%** | 67.5% → 68.5% |
+
+**Wave 1e is now closed reactor-wide**: the listener families in catalog (2),
+shop-manager (6), and workorder (4) were the last Kafka listeners at 0%, all
+covered with the parameterized contract-test shape. pos-workorder's
+`PeopleReplicaEventsListener` is the notable one — a single component on two
+topics stamping a different `processed_events` owner per entry point, pinned
+because the wrong owner would corrupt both reconciliation windows at once.
+
+**Defect found (pos-tax-common):** `SubdivisionForCountryValidator` rejects every
+real Canadian province — the `i18n-subdivision-enums` dataset has no CA data and
+there is no CA fallback list (the US has one). A valid Canadian `TaxAddress`
+gets a 400. Pinned by `canadianProvincesAreRejected` as documented current
+behaviour. Two more `locationCommandsTopic` copy-paste field names found
+(catalog's inventory manifest listener, matching pos-invoice's workorder one);
+routing correct in both, noted in test comments.
+
+**Still open after this pass:** the §5 Failsafe IT layers for `pos-invoice` and
+`pos-warranty` (a different shape of work: DB-backed, `verify`-phase);
+controller `@WebMvcTest` slices across vehicle-inventory, customer, marketing,
+people-contact; the service-impl branch tails in catalog/workorder/mcp-server;
+and the four small 0% modules (§4 filler list). Then Phase 4's ratchet, which
+requires the full-reactor re-measure first.
 
 ### 4.4 pos-people, pos-invoice, pos-people-contact progress (2026-08-11)
 

--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -6,7 +6,7 @@ substantially complete — every module in the §4 priority table has been worke
 (§4.1–§4.5) except the two structural §5 gaps: the Failsafe IT layers for
 `pos-invoice` and `pos-warranty` remain unbuilt, and controller-layer
 `@WebMvcTest` coverage across several modules remains open. Phase 4 outstanding.
-Date: 2026-08-11 (last updated 2026-08-11)
+Date: 2026-08-11 (last updated 2026-08-12)
 
 **Before Phase 4, re-run the Phase 0 full-reactor command.** Every figure in
 §4.1–§4.3 is unit-only (`-DskipITs`) and therefore not comparable to the §1.5
@@ -439,44 +439,6 @@ Remaining in `pos-customer`, largest first: `SegmentResolutionService` (64 misse
 (`CustomerController` 26, `CrmPartyRelationshipController` 24, `CrmPersonController`
 21 — all want `@WebMvcTest` slices).
 
-### 4.5 Phase 3 completion pass (2026-08-12, stacked PRs)
-
-All figures **unit-only**. Worked in a stacked-PR series so each review stays
-small: #1249 (vehicle-inventory, document-helper) → #1250 (catalog,
-shop-manager) → #1251 (workorder, tax-common) → mcp-server.
-
-| Module | Line | Branch |
-|---|---|---|
-| pos-vehicle-inventory | 46.5% → **66.4%** | 42.4% → **71.0%** |
-| pos-document-helper | 43.1% → **74.0%** | 25.9% → 35.2% |
-| pos-catalog | 73.1% → **77.4%** | 51.5% → 53.5% |
-| pos-shop-manager | 67.5% → **83.2%** | 60.3% → **67.1%** |
-| pos-workorder | 73.1% → **76.6%** | 55.1% → 56.7% |
-| pos-tax-common | no suite → **34.0%** | — → 46.4% |
-| pos-mcp-server | 78.5% → **80.2%** | 67.5% → 68.5% |
-
-**Wave 1e is now closed reactor-wide**: the listener families in catalog (2),
-shop-manager (6), and workorder (4) were the last Kafka listeners at 0%, all
-covered with the parameterized contract-test shape. pos-workorder's
-`PeopleReplicaEventsListener` is the notable one — a single component on two
-topics stamping a different `processed_events` owner per entry point, pinned
-because the wrong owner would corrupt both reconciliation windows at once.
-
-**Defect found (pos-tax-common):** `SubdivisionForCountryValidator` rejects every
-real Canadian province — the `i18n-subdivision-enums` dataset has no CA data and
-there is no CA fallback list (the US has one). A valid Canadian `TaxAddress`
-gets a 400. Pinned by `canadianProvincesAreRejected` as documented current
-behaviour. Two more `locationCommandsTopic` copy-paste field names found
-(catalog's inventory manifest listener, matching pos-invoice's workorder one);
-routing correct in both, noted in test comments.
-
-**Still open after this pass:** the §5 Failsafe IT layers for `pos-invoice` and
-`pos-warranty` (a different shape of work: DB-backed, `verify`-phase);
-controller `@WebMvcTest` slices across vehicle-inventory, customer, marketing,
-people-contact; the service-impl branch tails in catalog/workorder/mcp-server;
-and the four small 0% modules (§4 filler list). Then Phase 4's ratchet, which
-requires the full-reactor re-measure first.
-
 ### 4.4 pos-people, pos-invoice, pos-people-contact progress (2026-08-11)
 
 All figures **unit-only** (`-DskipITs`). As with `pos-customer`, the §1.5
@@ -561,6 +523,44 @@ the real weakness.
 
 **pos-price (94.3%)** — leave alone. Already the reference standard; use its test
 style as the template for other modules.
+
+### 4.5 Phase 3 completion pass (2026-08-12, stacked PRs)
+
+All figures **unit-only**. Worked in a stacked-PR series so each review stays
+small: #1249 (vehicle-inventory, document-helper) → #1250 (catalog,
+shop-manager) → #1251 (workorder, tax-common) → mcp-server.
+
+| Module | Line | Branch |
+|---|---|---|
+| pos-vehicle-inventory | 46.5% → **66.4%** | 42.4% → **71.0%** |
+| pos-document-helper | 43.1% → **74.0%** | 25.9% → 35.2% |
+| pos-catalog | 73.1% → **77.4%** | 51.5% → 53.5% |
+| pos-shop-manager | 67.5% → **83.2%** | 60.3% → **67.1%** |
+| pos-workorder | 73.1% → **76.6%** | 55.1% → 56.7% |
+| pos-tax-common | no suite → **34.0%** | — → 46.4% |
+| pos-mcp-server | 78.5% → **80.2%** | 67.5% → 68.5% |
+
+**Wave 1e is now closed reactor-wide**: the listener families in catalog (2),
+shop-manager (6), and workorder (4) were the last Kafka listeners at 0%, all
+covered with the parameterized contract-test shape. pos-workorder's
+`PeopleReplicaEventsListener` is the notable one — a single component on two
+topics stamping a different `processed_events` owner per entry point, pinned
+because the wrong owner would corrupt both reconciliation windows at once.
+
+**Defect found (pos-tax-common):** `SubdivisionForCountryValidator` rejects every
+real Canadian province — the `i18n-subdivision-enums` dataset has no CA data and
+there is no CA fallback list (the US has one). A valid Canadian `TaxAddress`
+gets a 400. Pinned by `canadianProvincesAreRejected` as documented current
+behaviour. Two more `locationCommandsTopic` copy-paste field names found
+(catalog's inventory manifest listener, matching pos-invoice's workorder one);
+routing correct in both, noted in test comments.
+
+**Still open after this pass:** the §5 Failsafe IT layers for `pos-invoice` and
+`pos-warranty` (a different shape of work: DB-backed, `verify`-phase);
+controller `@WebMvcTest` slices across vehicle-inventory, customer, marketing,
+people-contact; the service-impl branch tails in catalog/workorder/mcp-server;
+and the four small 0% modules (§4 filler list). Then Phase 4's ratchet, which
+requires the full-reactor re-measure first.
 
 ## 5. Phase 3 — (merged into Phase 2)
 

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/memory/SessionSummaryTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/memory/SessionSummaryTest.java
@@ -1,0 +1,149 @@
+package com.positivity.mcp.internal.orchestration.memory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingModel;
+
+/**
+ * Unit tests for {@link SessionSummary} (Tier 3 cross-session memory).
+ *
+ * <p>
+ * Everything here is best-effort by design: memory is an enhancement, and a
+ * memory failure must never fail the chat turn it decorates. So every public
+ * method has an explicit degradation pinned — summarization returns an empty
+ * string on model failure, retrieval returns an empty list with no retriever or
+ * a throwing one, and blank retrieved documents are filtered rather than
+ * injected as empty context blocks.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("SessionSummary — best-effort cross-session memory")
+class SessionSummaryTest {
+
+    @Mock
+    private ChatModel chatModel;
+
+    @Mock
+    private EmbeddingModel embeddingModel;
+
+    @Mock
+    private QueryDocumentRetriever summaryRetriever;
+
+    private SessionSummary summaryWithRetriever() {
+        return new SessionSummary(chatModel, embeddingModel, null, summaryRetriever);
+    }
+
+    private static ChatResponse reply(String text) {
+        return new ChatResponse(List.of(new Generation(new AssistantMessage(text))));
+    }
+
+    @Test
+    @DisplayName("summarizes the formatted conversation through the model")
+    void summarizes() {
+        when(chatModel.call(any(Prompt.class))).thenReturn(reply("User wanted X; concluded Y."));
+
+        String summary = summaryWithRetriever()
+                .summarize(List.of(new UserMessage("How do I do X?"), new AssistantMessage("Do Y.")));
+
+        assertThat(summary).isEqualTo("User wanted X; concluded Y.");
+        ArgumentCaptor<Prompt> prompt = ArgumentCaptor.forClass(Prompt.class);
+        verify(chatModel).call(prompt.capture());
+        // Both sides of the conversation must reach the summarizer, labeled by role.
+        assertThat(prompt.getValue().getContents()).contains("How do I do X?").contains("Do Y.");
+    }
+
+    @Test
+    @DisplayName("returns an empty summary for an empty conversation, without a model call")
+    void emptyConversationSkipsTheModel() {
+        assertThat(summaryWithRetriever().summarize(List.of())).isEmpty();
+
+        verify(chatModel, never()).call(any(Prompt.class));
+    }
+
+    @Test
+    @DisplayName("returns an empty summary when the model fails, never an exception")
+    void modelFailureDegrades() {
+        when(chatModel.call(any(Prompt.class))).thenThrow(new IllegalStateException("model down"));
+
+        // Memory is an enhancement; its failure must not fail the chat turn it decorates.
+        assertThat(summaryWithRetriever().summarize(List.of(new UserMessage("hello"))))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("retrieves cross-session context, filtering blanks and honoring topK")
+    void retrievesContext() {
+        when(summaryRetriever.retrieve("query"))
+                .thenReturn(List.of(
+                        new Document("relevant summary one"),
+                        new Document(" "),
+                        new Document("relevant summary two"),
+                        new Document("relevant summary three")));
+
+        List<String> context = summaryWithRetriever().retrieveRelevantContext("query", "user-1", 2);
+
+        // Blank documents would inject empty context blocks; they are dropped before the limit.
+        assertThat(context).containsExactly("relevant summary one", "relevant summary two");
+    }
+
+    @Test
+    @DisplayName("returns no context when no retriever is wired, rather than failing")
+    void noRetrieverMeansNoContext() {
+        SessionSummary summary = new SessionSummary(chatModel, embeddingModel, null, null);
+
+        assertThat(summary.retrieveRelevantContext("query", "user-1", 3)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns no context when the retriever throws")
+    void retrieverFailureDegrades() {
+        when(summaryRetriever.retrieve(anyString())).thenThrow(new IllegalStateException("store down"));
+
+        assertThat(summaryWithRetriever().retrieveRelevantContext("query", "user-1", 3))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("clamps a nonsensical topK up to one result")
+    void topKFloor() {
+        when(summaryRetriever.retrieve("query")).thenReturn(List.of(new Document("one"), new Document("two")));
+
+        assertThat(summaryWithRetriever().retrieveRelevantContext("query", "user-1", 0))
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("archiveSession and extractUserPreferences are safe no-ops today")
+    void placeholders() {
+        SessionSummary summary = summaryWithRetriever();
+
+        // Documented placeholders: they must be callable without error so callers can wire them
+        // now and the implementations can land later without a signature change.
+        summary.archiveSession("session-1", "summary", List.of(new UserMessage("hi")));
+        assertThat(summary.extractUserPreferences(List.of(new UserMessage("hi"))))
+                .isEmpty();
+        assertThat(summary.extractUserPreferences(List.of())).isEmpty();
+    }
+}

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/memory/SessionSummaryTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/memory/SessionSummaryTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
@@ -38,7 +36,6 @@ import org.springframework.ai.embedding.EmbeddingModel;
  * injected as empty context blocks.
  */
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 @DisplayName("SessionSummary — best-effort cross-session memory")
 class SessionSummaryTest {
 

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/ToolResultRankerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/ToolResultRankerTest.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -40,7 +38,6 @@ import org.springframework.ai.chat.prompt.Prompt;
  * </ul>
  */
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 @DisplayName("ToolResultRanker — LLM re-ranking with graceful degradation")
 class ToolResultRankerTest {
 

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/ToolResultRankerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/tools/ToolResultRankerTest.java
@@ -1,0 +1,120 @@
+package com.positivity.mcp.internal.orchestration.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+
+/**
+ * Unit tests for {@link ToolResultRanker} (Tier 3 result re-ranking).
+ *
+ * <p>
+ * This sits between tool output and the LLM's context window, so its failure
+ * modes decide what the model sees. Three properties carry the design:
+ *
+ * <ul>
+ * <li><b>Small result sets skip the LLM entirely.</b> Scoring costs one model
+ * call per result; when everything already fits in top-k there is nothing to
+ * rank and the calls would be pure latency.</li>
+ * <li><b>Ranking failure degrades to truncation, never to an error.</b> A chat
+ * turn must not die because the scoring model hiccuped; the fallback keeps the
+ * first top-k in original order.</li>
+ * <li><b>An unparseable or failed score is 0.0, not a retry</b> — the result
+ * drops to the bottom rather than blocking the batch, and ties break by
+ * original position so equal scores preserve the tool's own ordering.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ToolResultRanker — LLM re-ranking with graceful degradation")
+class ToolResultRankerTest {
+
+    @Mock
+    private ChatModel chatModel;
+
+    private static ChatResponse score(String text) {
+        return new ChatResponse(List.of(new Generation(new AssistantMessage(text))));
+    }
+
+    @Test
+    @DisplayName("returns small result sets untouched, without calling the model")
+    void smallSetsSkipTheModel() {
+        ToolResultRanker ranker = new ToolResultRanker(chatModel, 5);
+        List<String> results = List.of("a", "b", "c");
+
+        assertThat(ranker.rankResults("inventory", "query", results)).isSameAs(results);
+        assertThat(ranker.rankResults("inventory", "query", List.of())).isEmpty();
+        // Every score is a model call; ranking three results into a top-5 buys nothing.
+        verify(chatModel, never()).call(any(Prompt.class));
+    }
+
+    @Test
+    @DisplayName("keeps the top-k results by score, best first")
+    void ranksByScore() {
+        when(chatModel.call(any(Prompt.class))).thenReturn(score("0.2"), score("0.9"), score("0.5"), score("0.7"));
+        ToolResultRanker ranker = new ToolResultRanker(chatModel, 2);
+
+        assertThat(ranker.rankResults("inventory", "query", List.of("low", "best", "mid", "good")))
+                .containsExactly("best", "good");
+    }
+
+    @Test
+    @DisplayName("breaks score ties by the tool's original ordering")
+    void tiesPreserveOriginalOrder() {
+        when(chatModel.call(any(Prompt.class))).thenReturn(score("0.5"), score("0.5"), score("0.5"));
+        ToolResultRanker ranker = new ToolResultRanker(chatModel, 2);
+
+        // With equal scores, the tool's own ordering is the only signal left; reshuffling it
+        // would make ranking output nondeterministic run to run.
+        assertThat(ranker.rankResults("inventory", "query", List.of("first", "second", "third")))
+                .containsExactly("first", "second");
+    }
+
+    @Test
+    @DisplayName("scores an unparseable or out-of-range answer as 0 and clamps valid ones")
+    void scoreParsing() {
+        when(chatModel.call(any(Prompt.class))).thenReturn(score("not-a-number"), score("42"), score("0.8"));
+        ToolResultRanker ranker = new ToolResultRanker(chatModel, 2);
+
+        // "42" clamps to 1.0 and wins; "not-a-number" parses to 0.0 and drops off.
+        assertThat(ranker.rankResults("inventory", "query", List.of("garbled", "clamped", "normal")))
+                .containsExactly("clamped", "normal");
+    }
+
+    @Test
+    @DisplayName("scores a result whose model call throws as 0 instead of failing the batch")
+    void singleScoringFailureDropsThatResult() {
+        when(chatModel.call(any(Prompt.class)))
+                .thenReturn(score("0.9"))
+                .thenThrow(new IllegalStateException("model busy"))
+                .thenReturn(score("0.7"));
+        ToolResultRanker ranker = new ToolResultRanker(chatModel, 2);
+
+        assertThat(ranker.rankResults("inventory", "query", List.of("best", "failed", "good")))
+                .containsExactly("best", "good");
+    }
+
+    @Test
+    @DisplayName("clamps a nonsensical topK up to 1 rather than returning nothing")
+    void topKFloor() {
+        ToolResultRanker ranker = new ToolResultRanker(chatModel, 0);
+        when(chatModel.call(any(Prompt.class))).thenReturn(score("0.9"), score("0.1"));
+
+        assertThat(ranker.rankResults("inventory", "query", List.of("a", "b"))).hasSize(1);
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — plan-driven (`docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` Phases 2–3).
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: MCP server (AI orchestration)

> **Stacked PR 4 of 4 — closes out this series.** Base is `test-coverage/phase-3-workorder-tax` (#1251). Merge order: #1248 → #1249 → #1250 → #1251 → this.

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Non-test changes: `docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` only. No controller, DTO, event, or error model changed; no `BACKEND_CONTRACT_GUIDE.md` entry applies.

```bash
git diff --name-only test-coverage/phase-3-workorder-tax..HEAD | grep -v '/src/test/'
# docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
```

## Contract Chain (when a Controller changed)
No controller changed. All items n/a.
- [x] OpenAPI annotations — n/a
- [x] `openapi.yaml` regenerated — n/a
- [x] Angular SDK regenerated — n/a

## Scope

**`pos-mcp-server`: 78.5% → 80.2% line** (unit-only). Two Tier-3 orchestration classes that were at 0%:

- **`ToolResultRanker`** (58 missed): sits between tool output and the LLM's context window, so its failure modes decide what the model sees. Pinned: small sets skip the model (each score is a model call), batch failure degrades to first-k truncation rather than killing the chat turn, unparseable/throwing scores become 0.0 and drop that result, ties preserve the tool's own ordering, out-of-range scores clamp.
- **`SessionSummary`** (55 missed): best-effort cross-session memory — every public method's degradation is pinned explicitly (empty summary on model failure, empty context with no retriever or a throwing one, blank documents filtered before topK, placeholder methods safe no-ops).

Also updates the plan document with the **Phase 3 completion state** (§4.5): the per-module before/after table for this whole stacked series, confirmation that **wave 1e is now closed reactor-wide**, the Canadian-subdivision defect found in #1251, and what remains.

## Series summary (across #1249–this)

| Module | Line | Branch |
|---|---|---|
| pos-vehicle-inventory | 46.5% → 66.4% | 42.4% → 71.0% |
| pos-document-helper | 43.1% → 74.0% | 25.9% → 35.2% |
| pos-catalog | 73.1% → 77.4% | 51.5% → 53.5% |
| pos-shop-manager | 67.5% → 83.2% | 60.3% → 67.1% |
| pos-workorder | 73.1% → 76.6% | 55.1% → 56.7% |
| pos-tax-common | no suite → 34.0% | — → 46.4% |
| pos-mcp-server | 78.5% → 80.2% | 67.5% → 68.5% |

**Explicitly not in this series** (recorded in the plan as open): the §5 Failsafe IT layers for `pos-invoice`/`pos-warranty` (different-shaped, DB-backed work), controller `@WebMvcTest` slices across several modules, the service-impl branch tails in catalog/workorder/mcp-server, the four small 0% modules, and Phase 4's ratchet (which requires the full-reactor re-measure first).

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests — none
- [ ] Provider behavioral contract tests — none

```bash
./mvnw -pl pos-mcp-server -am -DskipTests=false test
```

Green with all gates.

## Risk & Rollback
- Risk level: **Low.** Tests plus the plan document.
- Rollback plan: revert the merge commit.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — plan-driven, no capability id
- [ ] PR title starts with `[CAP:<cap-id>]` — same
- [x] Links to parent + child issues — none exist
- [x] Contract guide updated — n/a
- [ ] Required CI checks passing — to be confirmed
