### PR TITLE
build: per-module coverage ratchet (plan Phase 4)

### DIFF
--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -1,17 +1,16 @@
 # Test Coverage Improvement Plan
 
-Status: Phase 0 complete. Phase 1 complete except wave 1c (see §3.3); wave 1e is
-now closed in every module that had Kafka listeners at 0% (§4.5). Phases 2–3
-substantially complete — every module in the §4 priority table has been worked
-(§4.1–§4.5) except the two structural §5 gaps: the Failsafe IT layers for
-`pos-invoice` and `pos-warranty` remain unbuilt, and controller-layer
-`@WebMvcTest` coverage across several modules remains open. Phase 4 outstanding.
+Status: Phases 0–3 complete. Phase 4 (ratchet) landed — per-module JaCoCo
+`check` floors are enforced at `verify`; see §6. Both §5 structural gaps are
+closed: `pos-invoice` and `pos-warranty` have Failsafe IT layers, and
+`pos-tax-common` has its first suite. Wave 1c (§3.3) and controller-layer
+`@WebMvcTest` coverage remain the known open work (§7).
 Date: 2026-08-11 (last updated 2026-08-12)
 
-**Before Phase 4, re-run the Phase 0 full-reactor command.** Every figure in
-§4.1–§4.3 is unit-only (`-DskipITs`) and therefore not comparable to the §1.5
-baseline, which included Failsafe ITs. No threshold should be set from the
-numbers in those sections.
+**That re-measure has now been done — see §6 for the authoritative baseline.**
+Every figure in §4.1–§4.5 is unit-only (`-DskipITs`) and is therefore *not*
+comparable to §1.5 or §6; those sections record per-module progress, not
+thresholds. Phase 4's floors come from §6 only.
 
 Method: `.agents/skills/test-coverage-improver` workflow, adapted from its pnpm/JS
 assumptions to this Maven reactor; test authoring follows `.agents/skills/java-testing`.
@@ -638,3 +637,135 @@ Per `.agents/skills/java-testing` and repo conventions:
    modules, or depth-first on `pos-customer` + `pos-marketing`?
    (Recommendation: Phase 1 first; it is cheaper per line and the tests encode a
    documented contract.) --> Phase 1 first
+
+
+## 6. Phase 4 — the ratchet (delivered 2026-08-12)
+
+### 6.1 Authoritative baseline
+
+Full-reactor `verify` including Failsafe ITs, per the Phase 0 command, on `main`
+at `683cc6381`. **These are each module's own report** — the figure a per-module
+JaCoCo `check` actually reads — not the aggregate, which credits shared
+libraries with their consumers' coverage (§1.5).
+
+Repo-wide, summing all 38 per-module reports: **81.1% line, 66.6% branch**
+(14,295 missed of 75,661 lines). Against the §1.5 baseline of 72.6% / 59.5% /
+20,265 missed, that is **+8.5 points line and ~6,000 fewer missed lines**.
+
+| Module | Lines | Line% | Branch% | `jacoco.line.min` | `jacoco.branch.min` |
+|---|---:|---:|---:|---:|---:|
+| `pos-accounting` | 10516 | 85.8 | 72.5 | 0.80 | 0.67 |
+| `pos-inventory` | 10056 | 84.6 | 68.3 | 0.79 | 0.63 |
+| `pos-workorder` | 7465 | 76.6 | 56.7 | 0.71 | 0.51 |
+| `pos-mcp-server` | 6153 | 80.2 | 68.5 | 0.75 | 0.63 |
+| `pos-customer` | 5362 | 85.9 | 70.6 | 0.80 | 0.65 |
+| `pos-security-service` | 3504 | 81.8 | 71.1 | 0.76 | 0.66 |
+| `pos-invoice` | 3308 | 78.9 | 65.3 | 0.73 | 0.60 |
+| `pos-order` | 3237 | 83.6 | 67.7 | 0.78 | 0.62 |
+| `pos-people` | 2859 | 79.4 | 63.6 | 0.74 | 0.58 |
+| `pos-catalog` | 2807 | 77.4 | 53.5 | 0.72 | 0.48 |
+| `pos-warranty` | 2562 | 90.4 | 80.7 | 0.85 | 0.75 |
+| `pos-supplier` | 2351 | 88.0 | 75.3 | 0.82 | 0.70 |
+| `pos-location` | 2167 | 81.4 | 70.1 | 0.76 | 0.65 |
+| `pos-shop-manager` | 1933 | 83.2 | 67.1 | 0.78 | 0.62 |
+| `pos-bulk-loader` | 1770 | 76.8 | 65.3 | 0.71 | 0.60 |
+| `pos-people-contact` | 1477 | 65.2 | 52.3 | 0.60 | 0.47 |
+| `pos-marketing` | 1236 | 87.9 | 82.9 | 0.82 | 0.77 |
+| `pos-price` | 1053 | 94.9 | 81.7 | 0.89 | 0.76 |
+| `pos-tax` | 984 | 78.5 | 66.8 | 0.73 | 0.61 |
+| `pos-vehicle-inventory` | 977 | 66.4 | 71.0 | 0.61 | 0.66 |
+| `pos-vehicle-fitment` | 542 | 78.4 | 63.6 | 0.73 | 0.58 |
+| `pos-domain-events` | 511 | 39.3 | 37.2 | 0.34 | 0.32 |
+| `pos-event-receiver` | 437 | 77.3 | 87.0 | 0.72 | 0.81 |
+| `pos-api-gateway` | 435 | 85.5 | 72.2 | 0.80 | 0.67 |
+| `pos-security-common` | 406 | 46.8 | 36.5 | 0.41 | 0.31 |
+| `pos-documents` | 383 | 75.2 | 52.9 | 0.70 | 0.47 |
+| `pos-document-helper` | 346 | 74.0 | 35.2 | 0.68 | 0.30 |
+| `pos-vehicle-reference-nhtsa` | 189 | 0.0 | 0.0 | — *(unguarded)* | — |
+| `pos-events` | 174 | 59.8 | 57.1 | 0.54 | 0.52 |
+| `pos-openapi-validation` | 171 | 93.6 | 82.3 | 0.88 | 0.77 |
+| `pos-tax-common` | 100 | 34.0 | 46.4 | 0.29 | 0.41 |
+| `pos-vehicle-reference-carapi` | 69 | 0.0 | 0.0 | — *(unguarded)* | — |
+| `pos-image` | 61 | 0.0 | 0.0 | — *(unguarded)* | — |
+| `pos-shared-dtos` | 34 | 0.0 | 0.0 | — *(unguarded)* | — |
+| `pos-inquiry` | 16 | 0.0 | — | — *(unguarded)* | — |
+
+`pos-archunit`, `pos-bulk-ingest-lib`, `pos-service-discovery`, and `pos-inquiry`
+are omitted — 3–16 lines each, nothing to guard.
+
+**Caveat on the aggregate figure.** The run also produced
+`jacoco-aggregate/jacoco.xml` reading 81.7% line / 67.6% branch, but over **32 of
+38 groups**: recovering from a mid-run failure required `mvn install -DskipTests`
+on the shared libraries, which wiped their `jacoco.exec` and dropped them from
+the merge. A subsequent isolated re-run of the aggregate goal then overwrote that
+XML with an empty one. The aggregate is therefore **not** currently trustworthy on
+disk; CI regenerates it on every merge to `main`, and that is the copy to wire
+into SonarCloud (§6.3). Nothing in §6.1's per-module table depends on it.
+
+### 6.2 How the ratchet works
+
+Root `pom.xml` gains a `check-ratchet` execution on the `verify` phase asserting
+`LINE` and `BRANCH` `COVEREDRATIO` against two properties, defaulted to `0.00`:
+
+```xml
+<jacoco.line.min>0.00</jacoco.line.min>
+<jacoco.branch.min>0.00</jacoco.branch.min>
+```
+
+Each module overrides them in its own `pom.xml`, set **~5 points below its
+measured baseline** — enough to catch a real regression, loose enough not to fail
+on the noise of a refactor moving a few lines. `haltOnFailure` is true, so a
+breach fails the build:
+
+```
+Rule violated for bundle pos-tax-common: lines covered ratio is 0.34,
+but expected minimum is 0.95
+```
+
+**Working rules.**
+
+- Raise a module's floor when its coverage rises — that is what makes it a
+  ratchet rather than a fixed bar.
+- Never lower a floor without saying why in the commit message.
+- The four all-zero modules (`pos-image`, `pos-inquiry`,
+  `pos-vehicle-reference-carapi`, `pos-vehicle-reference-nhtsa`) carry **no**
+  floor. A `0.00` floor is not a gate, and pretending otherwise would misrepresent
+  them as guarded. They need first tests, not thresholds — see §7.
+- Deliberately **not** a single repo-wide bar. At 81.1% a uniform 85% would fail
+  a third of the reactor on day one, and a uniform 70% would let the best modules
+  rot 15 points before anyone noticed.
+
+### 6.3 SonarCloud
+
+Not yet wired. The existing Sonar step should consume
+`pos-coverage-aggregate/target/site/jacoco-aggregate/jacoco.xml` from a CI run
+(see the §6.1 caveat about the local copy). That is the remaining Phase 4 task.
+
+## 7. What is still open
+
+1. **Wave 1c** (`{Module}PermissionRegistry`, §3.3) — three modules, small.
+2. **Controller `@WebMvcTest` slices** — `pos-vehicle-inventory` (~114 missed
+   across four controllers), `pos-customer` CRM controllers (~71),
+   `pos-marketing` (~30), `pos-people-contact`.
+3. **The four all-zero modules** — `pos-vehicle-reference-nhtsa` (189 lines),
+   `pos-vehicle-reference-carapi` (69), `pos-image` (61), `pos-inquiry` (16).
+   335 lines total; they are unguarded until they have tests.
+4. **Branch-coverage tails** — `pos-catalog` (53.5% branch against 77.4% line),
+   `pos-workorder` (56.7%), `pos-document-helper` (35.2%). Parameterized tests
+   over the uncovered branches, not more happy paths.
+5. **Low-coverage shared libraries** — `pos-tax-common` 34.0%,
+   `pos-domain-events` 39.3%, `pos-security-common` 46.8% on their own tests.
+   They read far higher in the aggregate because consumers exercise them; their
+   own floors are set from the honest per-module number.
+6. **SonarCloud wiring** (§6.3).
+
+### Defects found by this work, still open
+
+- louisburroughs/durion-positivity-backend#1245 — a partial customer update
+  silently deletes every VIN on the party.
+- louisburroughs/durion-positivity-backend#1246 — `CommercialPartyServiceImpl`
+  transposes `legalName` and `displayName` between read and write.
+- louisburroughs/durion-positivity-backend#1254 — `SubdivisionForCountryValidator`
+  rejects every real Canadian province.
+- louisburroughs/durion-positivity-backend#1255 — replica listeners silently drop
+  events whose payload omits a primitive field (Jackson 3).

--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -690,8 +690,9 @@ Repo-wide, summing all 38 per-module reports: **81.1% line, 66.6% branch**
 | `pos-shared-dtos` | 34 | 0.0 | 0.0 | — *(unguarded)* | — |
 | `pos-inquiry` | 16 | 0.0 | — | — *(unguarded)* | — |
 
-`pos-archunit`, `pos-bulk-ingest-lib`, `pos-service-discovery`, and `pos-inquiry`
-are omitted — 3–16 lines each, nothing to guard.
+`pos-archunit`, `pos-bulk-ingest-lib`, and `pos-service-discovery` are omitted
+from the table — 3–4 lines each, nothing to guard. `pos-inquiry` (16 lines, 0%)
+is listed but unguarded, with the other all-zero modules.
 
 **Caveat on the aggregate figure.** The run also produced
 `jacoco-aggregate/jacoco.xml` reading 81.7% line / 67.6% branch, but over **32 of
@@ -721,6 +722,17 @@ breach fails the build:
 Rule violated for bundle pos-tax-common: lines covered ratio is 0.34,
 but expected minimum is 0.95
 ```
+
+**`-DskipTests` is safe, and no `skip` guard is wired.** JaCoCo's `check` goal
+no-ops when there is no execution data — `Skipping JaCoCo execution due to
+missing execution data file` — so `clean install -DskipTests` passes, and an
+`install -DskipTests` over a stale `jacoco.exec` evaluates that prior data and
+also passes. Both were verified on this tree. A `<skip>${skipTests}</skip>` guard
+was considered and rejected: it would buy nothing over the goal's own behaviour
+while turning `-DskipTests` into a documented switch for bypassing the ratchet.
+The one narrow edge is a *partial* `jacoco.exec` left by an interrupted test run,
+where a later `install -DskipTests` would judge incomplete data — `clean` fixes
+that, and CI always runs tests.
 
 **Working rules.**
 

--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,10 @@
 		<spotbugs-maven-plugin.version>4.9.8.3</spotbugs-maven-plugin.version>
 		<sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
 		<sonar.organization>louisburroughs</sonar.organization>
+		<!-- Coverage ratchet defaults (plan Phase 4). Overridden per module in each
+		     module pom; 0.00 here means "unguarded" for modules that set nothing. -->
+		<jacoco.line.min>0.00</jacoco.line.min>
+		<jacoco.branch.min>0.00</jacoco.branch.min>
 		<!-- Test runtime tuning -->
 		<tests.forkCount>1</tests.forkCount>
 		<tests.reuseForks>true</tests.reuseForks>
@@ -507,6 +511,39 @@
 						<goals>
 							<goal>report</goal>
 						</goals>
+					</execution>
+					<!-- Coverage ratchet (plan Phase 4). Each module sets jacoco.line.min /
+					     jacoco.branch.min a few points BELOW its measured baseline, so the gate
+					     catches regression without failing on noise. Raise a module's floor when
+					     its coverage rises; never lower one without saying why in the commit.
+					     Modules with no floor set inherit the 0.00 defaults below and are
+					     effectively unguarded — see docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6. -->
+					<execution>
+						<id>check-ratchet</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<haltOnFailure>true</haltOnFailure>
+							<rules>
+								<rule>
+									<element>BUNDLE</element>
+									<limits>
+										<limit>
+											<counter>LINE</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>${jacoco.line.min}</minimum>
+										</limit>
+										<limit>
+											<counter>BRANCH</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>${jacoco.branch.min}</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/pos-accounting/pom.xml
+++ b/pos-accounting/pom.xml
@@ -7,9 +7,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-accounting</artifactId>
     <name>pos-accounting</name>
     <description>POS Accounting module</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 85.8% line / 72.5% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.80</jacoco.line.min>
+        <jacoco.branch.min>0.67</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
 
     <pluginRepositories>

--- a/pos-api-gateway/pom.xml
+++ b/pos-api-gateway/pom.xml
@@ -11,6 +11,11 @@
     <description>Spring Cloud API Gateway for POS modules</description>
     <packaging>jar</packaging>
     <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 85.5% line / 72.2% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.80</jacoco.line.min>
+        <jacoco.branch.min>0.67</jacoco.branch.min>
+
         <java.version>25</java.version>
     </properties>
     <dependencies>

--- a/pos-bulk-loader/pom.xml
+++ b/pos-bulk-loader/pom.xml
@@ -7,9 +7,18 @@
     <artifactId>positivity</artifactId>
     <version>${revision}</version>
   </parent>
+
+    
   <artifactId>pos-bulk-loader</artifactId>
   <name>pos-bulk-loader</name>
   <description>Bulk data import service for Durion POS</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 76.8% line / 65.3% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.71</jacoco.line.min>
+        <jacoco.branch.min>0.60</jacoco.branch.min>
+    </properties>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/pos-catalog/pom.xml
+++ b/pos-catalog/pom.xml
@@ -7,9 +7,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-catalog</artifactId>
     <name>pos-catalog</name>
     <description>POS Catalog module</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 77.4% line / 53.5% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.72</jacoco.line.min>
+        <jacoco.branch.min>0.48</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
     <dependencies>
         <!-- Spring Data JPA -->

--- a/pos-customer/pom.xml
+++ b/pos-customer/pom.xml
@@ -6,9 +6,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-customer</artifactId>
     <name>pos-customer</name>
     <description>POS Customer Module</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 85.9% line / 70.6% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.80</jacoco.line.min>
+        <jacoco.branch.min>0.65</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
 
     <pluginRepositories>

--- a/pos-document-helper/pom.xml
+++ b/pos-document-helper/pom.xml
@@ -9,9 +9,18 @@
         <version>${revision}</version>
     </parent>
 
+    
+
     <artifactId>pos-document-helper</artifactId>
     <name>pos-document-helper</name>
     <description>Helper library for document template registration and rendering requests</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 74.0% line / 35.2% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.68</jacoco.line.min>
+        <jacoco.branch.min>0.30</jacoco.branch.min>
+    </properties>
 
     <dependencies>
 

--- a/pos-documents/pom.xml
+++ b/pos-documents/pom.xml
@@ -9,9 +9,18 @@
         <version>${revision}</version>
     </parent>
 
+    
+
     <artifactId>pos-documents</artifactId>
     <name>pos-documents</name>
     <description>PDF rendering service with multi-format support</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 75.2% line / 52.9% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.70</jacoco.line.min>
+        <jacoco.branch.min>0.47</jacoco.branch.min>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/pos-domain-events/pom.xml
+++ b/pos-domain-events/pom.xml
@@ -9,9 +9,18 @@
         <version>${revision}</version>
     </parent>
 
+    
+
     <artifactId>pos-domain-events</artifactId>
     <name>pos-domain-events</name>
     <description>Shared domain event contracts (envelope, topic naming, versioned payload DTOs) per ADR-0044</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 39.3% line / 37.2% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.34</jacoco.line.min>
+        <jacoco.branch.min>0.32</jacoco.branch.min>
+    </properties>
 
     <dependencies>
         <!-- JSpecify for Nullness Annotations -->

--- a/pos-event-receiver/pom.xml
+++ b/pos-event-receiver/pom.xml
@@ -7,9 +7,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-event-receiver</artifactId>
     <name>pos-event-receiver</name>
     <description>POS Event Receiver module</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 77.3% line / 87.0% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.72</jacoco.line.min>
+        <jacoco.branch.min>0.81</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
     <dependencies>
         <!-- Lombok for annotation processing -->

--- a/pos-events/pom.xml
+++ b/pos-events/pom.xml
@@ -7,9 +7,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-events</artifactId>
     <name>pos-events</name>
     <description>Shared library for event emission and domain event tracking across Positivity microservices</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 59.8% line / 57.1% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.54</jacoco.line.min>
+        <jacoco.branch.min>0.52</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/pos-inventory/pom.xml
+++ b/pos-inventory/pom.xml
@@ -7,9 +7,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-inventory</artifactId>
     <name>pos-inventory</name>
     <description>POS Inventory module</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 84.6% line / 68.3% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.79</jacoco.line.min>
+        <jacoco.branch.min>0.63</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
 
     <pluginRepositories>

--- a/pos-invoice/pom.xml
+++ b/pos-invoice/pom.xml
@@ -7,9 +7,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-invoice</artifactId>
     <name>pos-invoice</name>
     <description>POS Invoice module</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 78.9% line / 65.3% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.73</jacoco.line.min>
+        <jacoco.branch.min>0.60</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/pos-location/pom.xml
+++ b/pos-location/pom.xml
@@ -6,9 +6,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-location</artifactId>
     <name>pos-location</name>
     <description>Module to manage locations and hierarchy</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 81.4% line / 70.1% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.76</jacoco.line.min>
+        <jacoco.branch.min>0.65</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
 
     <pluginRepositories>

--- a/pos-marketing/pom.xml
+++ b/pos-marketing/pom.xml
@@ -7,9 +7,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-marketing</artifactId>
     <name>pos-marketing</name>
     <description>POS Marketing module: campaigns, templates, audience binding, and send orchestration</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 87.9% line / 82.9% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.82</jacoco.line.min>
+        <jacoco.branch.min>0.77</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
     <dependencies>
         <!-- Lombok for annotation processing -->

--- a/pos-mcp-server/pom.xml
+++ b/pos-mcp-server/pom.xml
@@ -17,6 +17,11 @@
     <packaging>jar</packaging>
 
     <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 80.2% line / 68.5% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.75</jacoco.line.min>
+        <jacoco.branch.min>0.63</jacoco.branch.min>
+
         <java.version>25</java.version>
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>

--- a/pos-openapi-validation/pom.xml
+++ b/pos-openapi-validation/pom.xml
@@ -9,9 +9,18 @@
         <version>${revision}</version>
     </parent>
 
+    
+
     <artifactId>pos-openapi-validation</artifactId>
     <name>pos-openapi-validation</name>
     <description>OpenAPI validation policy support module</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 93.6% line / 82.3% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.88</jacoco.line.min>
+        <jacoco.branch.min>0.77</jacoco.branch.min>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/pos-order/pom.xml
+++ b/pos-order/pom.xml
@@ -7,9 +7,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-order</artifactId>
     <name>pos-order</name>
     <description>POS Order module - manages order operations including price overrides</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 83.6% line / 67.7% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.78</jacoco.line.min>
+        <jacoco.branch.min>0.62</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
 
     <pluginRepositories>

--- a/pos-people-contact/pom.xml
+++ b/pos-people-contact/pom.xml
@@ -6,9 +6,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-people-contact</artifactId>
     <name>pos-people-contact</name>
     <description>Identity/contact/user-link authority module (ADR-0044 Phase 3)</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 65.2% line / 52.3% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.60</jacoco.line.min>
+        <jacoco.branch.min>0.47</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
 
     <pluginRepositories>

--- a/pos-people/pom.xml
+++ b/pos-people/pom.xml
@@ -6,9 +6,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-people</artifactId>
     <name>pos-people</name>
     <description>Module to manage people</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 79.4% line / 63.6% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.74</jacoco.line.min>
+        <jacoco.branch.min>0.58</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
 
     <pluginRepositories>

--- a/pos-price/pom.xml
+++ b/pos-price/pom.xml
@@ -7,9 +7,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-price</artifactId>
     <name>pos-price</name>
     <description>POS Price module</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 94.9% line / 81.7% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.89</jacoco.line.min>
+        <jacoco.branch.min>0.76</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
 
     <pluginRepositories>

--- a/pos-security-common/pom.xml
+++ b/pos-security-common/pom.xml
@@ -7,9 +7,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-security-common</artifactId>
     <name>pos-security-common</name>
     <description>Shared security components for gateway-based JWT authentication</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 46.8% line / 36.5% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.41</jacoco.line.min>
+        <jacoco.branch.min>0.31</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/pos-security-service/pom.xml
+++ b/pos-security-service/pom.xml
@@ -6,9 +6,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-security-service</artifactId>
     <name>pos-security-service</name>
     <description>POS Security Service Module for IAM and JWT management</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 81.8% line / 71.1% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.76</jacoco.line.min>
+        <jacoco.branch.min>0.66</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
 
     <pluginRepositories>

--- a/pos-shop-manager/pom.xml
+++ b/pos-shop-manager/pom.xml
@@ -6,9 +6,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-shop-manager</artifactId>
     <name>pos-shop-manager</name>
     <description>Module to manage vehicle repair shops</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 83.2% line / 67.1% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.78</jacoco.line.min>
+        <jacoco.branch.min>0.62</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
     <pluginRepositories>
         <pluginRepository>

--- a/pos-supplier/pom.xml
+++ b/pos-supplier/pom.xml
@@ -7,9 +7,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-supplier</artifactId>
     <name>pos-supplier</name>
     <description>POS Supplier integration module (outbound supplier connectivity, ADR-0049..0052)</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 88.0% line / 75.3% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.82</jacoco.line.min>
+        <jacoco.branch.min>0.70</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
     <dependencies>
         <!-- Lombok for entity boilerplate (warranty entity convention) -->

--- a/pos-tax-common/pom.xml
+++ b/pos-tax-common/pom.xml
@@ -9,9 +9,18 @@
         <version>${revision}</version>
     </parent>
 
+    
+
     <artifactId>pos-tax-common</artifactId>
     <name>pos-tax-common</name>
     <description>Shared DTOs and validation types for consuming POS Tax APIs</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 34.0% line / 46.4% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.29</jacoco.line.min>
+        <jacoco.branch.min>0.41</jacoco.branch.min>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/pos-tax/pom.xml
+++ b/pos-tax/pom.xml
@@ -10,9 +10,18 @@
         <version>${revision}</version>
     </parent>
 
+    
+
     <artifactId>pos-tax</artifactId>
     <name>POS Tax Service</name>
     <description>Tax calculation service with external API passthrough and test mode support</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 78.5% line / 66.8% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.73</jacoco.line.min>
+        <jacoco.branch.min>0.61</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/pos-vehicle-fitment/pom.xml
+++ b/pos-vehicle-fitment/pom.xml
@@ -8,9 +8,18 @@
         <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+
+    
     <artifactId>pos-vehicle-fitment</artifactId>
     <name>pos-vehicle-fitment</name>
     <description>Vehicle Fitment Module</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 78.4% line / 63.6% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.73</jacoco.line.min>
+        <jacoco.branch.min>0.58</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
     <dependencies>
         <!-- Lombok -->

--- a/pos-vehicle-inventory/pom.xml
+++ b/pos-vehicle-inventory/pom.xml
@@ -7,9 +7,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-vehicle-inventory</artifactId>
     <name>pos-vehicle-inventory</name>
     <description>POS Vehicle module</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 66.4% line / 71.0% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.61</jacoco.line.min>
+        <jacoco.branch.min>0.66</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
     <dependencies>
         <!-- Lombok for annotation processing -->

--- a/pos-warranty/pom.xml
+++ b/pos-warranty/pom.xml
@@ -7,9 +7,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-warranty</artifactId>
     <name>pos-warranty</name>
     <description>POS Warranty Claims module</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 90.4% line / 80.7% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.85</jacoco.line.min>
+        <jacoco.branch.min>0.75</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
     <dependencies>
         <!-- Lombok for annotation processing -->

--- a/pos-workorder/pom.xml
+++ b/pos-workorder/pom.xml
@@ -6,9 +6,18 @@
         <artifactId>positivity</artifactId>
         <version>${revision}</version>
     </parent>
+
+    
     <artifactId>pos-workorder</artifactId>
     <name>pos-workorder</name>
     <description>Module to manage workorders for a shop</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 76.6% line / 56.7% branch.
+             Floors sit ~5 points under to catch regression without failing on noise. -->
+        <jacoco.line.min>0.71</jacoco.line.min>
+        <jacoco.branch.min>0.51</jacoco.branch.min>
+    </properties>
     <packaging>jar</packaging>
     <pluginRepositories>
         <pluginRepository>


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — plan-driven (`docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` Phase 4).
- Parent STORY (durion): n/a
- Child issue: n/a — four defects this work surfaced are open as #1245, #1246, #1254, #1255.
- Domain: build/tooling, all modules

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Build configuration and documentation only — no Java source of any kind changes in this PR. 30 module `pom.xml` files gain two properties each; the root `pom.xml` gains one plugin execution. No controller, DTO, event, or error model is touched, so no `BACKEND_CONTRACT_GUIDE.md` entry applies.

```bash
git diff --name-only main..HEAD | grep -vE 'pom\.xml|\.md$'
# (empty)
```

## Contract Chain (when a Controller changed)
No controller changed. All items n/a.
- [x] OpenAPI annotations — n/a
- [x] `openapi.yaml` regenerated — n/a
- [x] Angular SDK regenerated — n/a

## Scope

**Closes Phase 4.** A per-module JaCoCo `check` runs at `verify` with `haltOnFailure`, so a coverage regression fails the build instead of being reported and ignored.

Root `pom.xml`:

```xml
<jacoco.line.min>0.00</jacoco.line.min>
<jacoco.branch.min>0.00</jacoco.branch.min>
```

…defaults, overridden per module ~5 points below each measured baseline — tight enough to catch a real regression, loose enough not to fail when a refactor moves a few lines.

**The floors come from a real measurement**, not an estimate: a full-reactor `verify` *including Failsafe ITs* on `683cc6381`, using each module's **own** report — which is what a per-module check actually reads — rather than the aggregate, which credits shared libraries with their consumers' coverage (plan §1.5).

Repo-wide baseline: **81.1% line / 66.6% branch** across 38 modules (14,295 missed of 75,661), against the plan's original 72.6% / 59.5% / 20,265 — **+8.5 points line, ~6,000 fewer missed lines**. Full per-module table in the plan's new §6.1.

### Verified in both directions

Passing at the real floors is only half a gate. Temporarily raising `pos-tax-common`'s line floor to 0.95 produces:

```
[WARNING] Rule violated for bundle pos-tax-common: lines covered ratio is 0.34, but expected minimum is 0.95
[INFO] BUILD FAILURE
```

…then restored. The gate demonstrably bites.

### Judgement calls worth reviewing

- **No single repo-wide bar.** At 81.1%, a uniform 85% fails a third of the reactor on day one; a uniform 70% lets the strongest modules rot 15 points unnoticed.
- **The four all-zero modules get no floor at all** (`pos-image`, `pos-inquiry`, `pos-vehicle-reference-carapi`, `pos-vehicle-reference-nhtsa`). A `0.00` minimum is not a gate, and adding one would misrepresent them as guarded. They need first tests — tracked in §7.
- **Shared libraries are floored from their own coverage, not the aggregate.** `pos-security-common` is 46.8% on its own tests but reads ~81% in the aggregate; flooring it at the aggregate number would be a gate that can never fail.

## Honest note on the aggregate report

The measurement run failed mid-way twice — first a truncated jar from `-T 1C` on a 4-core box, then a stale `.m2` artifact after resuming with `-rf`. Recovering required `mvn install -DskipTests` on the shared libraries, which **wiped their `jacoco.exec`** and dropped 6 modules from the aggregate merge; a later isolated re-run of the aggregate goal then overwrote that XML with an empty one. **The local `jacoco-aggregate/jacoco.xml` is therefore not trustworthy right now.** CI regenerates it on every merge to `main`, and that is the copy to wire into SonarCloud. Nothing in the per-module table depends on it — this is recorded in plan §6.1 rather than quietly left for someone to trip over.

## Tests
- [ ] Unit tests added/updated — none; this PR adds no tests, it gates the existing ones
- [ ] Integration tests added/updated — none
- [ ] Provider behavioral contract tests — none

```bash
# any module: the gate runs in verify
./mvnw -pl pos-marketing,pos-price,pos-warranty,pos-supplier -DskipTests=false verify
```

## Risk & Rollback
- Risk level: **Medium-low.** No runtime code changes, but this *can* fail builds by design. The floors were set from a measurement of this exact tree, and a spot-check across high- and low-coverage modules passes.
- If a floor proves too tight in practice, lower that one module's property and say why in the commit — do not disable the execution.
- Rollback plan: revert the merge commit; the gate disappears and nothing else changes.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — plan-driven, no capability id
- [ ] PR title starts with `[CAP:<cap-id>]` — same
- [x] Links to parent + child issues — the four surfaced defect issues are linked above
- [x] Contract guide updated — n/a
- [ ] Required CI checks passing — to be confirmed
