### PR TITLE
test: close wave 1c and the all-zero modules; correct SonarCloud status

### DIFF
--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -747,21 +747,28 @@ that, and CI always runs tests.
   a third of the reactor on day one, and a uniform 70% would let the best modules
   rot 15 points before anyone noticed.
 
-### 6.3 SonarCloud
+### 6.3 SonarCloud — already wired (correction)
 
-Not yet wired. The existing Sonar step should consume
-`pos-coverage-aggregate/target/site/jacoco-aggregate/jacoco.xml` from a CI run
-(see the §6.1 caveat about the local copy). That is the remaining Phase 4 task.
+An earlier draft of this section claimed the Sonar step still needed wiring. That
+was wrong: `.github/workflows/ci.yml` already uploads every module's
+`**/target/site/jacoco/jacoco.xml` as the `jacoco-coverage-reactor` artifact,
+downloads it in the Sonar job, and imports it via
+`-Dsonar.coverage.jacoco.xmlReportPaths=${{ github.workspace }}/sonar-coverage/**/jacoco.xml`
+(absolute by necessity — the scanner resolves a relative value against each
+module's own base directory). The aggregate XML is uploaded separately as
+`jacoco-coverage-aggregate`.
+
+Importing the **per-module** reports is also the right choice, and matches the
+ratchet: Sonar sees each module's own coverage rather than the aggregate's
+consumer-credited figure for shared libraries. No work is outstanding here.
 
 ## 7. What is still open
 
-1. **Wave 1c** (`{Module}PermissionRegistry`, §3.3) — three modules, small.
+1. ~~**Wave 1c** (`{Module}PermissionRegistry`, §3.3)~~ — closed 2026-08-12, see §7.1.
 2. **Controller `@WebMvcTest` slices** — `pos-vehicle-inventory` (~114 missed
    across four controllers), `pos-customer` CRM controllers (~71),
    `pos-marketing` (~30), `pos-people-contact`.
-3. **The four all-zero modules** — `pos-vehicle-reference-nhtsa` (189 lines),
-   `pos-vehicle-reference-carapi` (69), `pos-image` (61), `pos-inquiry` (16).
-   335 lines total; they are unguarded until they have tests.
+3. ~~**The four all-zero modules**~~ — closed 2026-08-12, see §7.2.
 4. **Branch-coverage tails** — `pos-catalog` (53.5% branch against 77.4% line),
    `pos-workorder` (56.7%), `pos-document-helper` (35.2%). Parameterized tests
    over the uncovered branches, not more happy paths.
@@ -769,7 +776,65 @@ Not yet wired. The existing Sonar step should consume
    `pos-domain-events` 39.3%, `pos-security-common` 46.8% on their own tests.
    They read far higher in the aggregate because consumers exercise them; their
    own floors are set from the honest per-module number.
-6. **SonarCloud wiring** (§6.3).
+6. ~~SonarCloud wiring~~ — already in place; see the §6.3 correction.
+
+### 7.1 Wave 1c closed (2026-08-12)
+
+`pos-marketing` and `pos-inventory` now have a `{Module}PermissionRegistry` test
+each. Both read `permissions.yaml` directly (no YAML dependency — the file is
+scanned for `- name:` lines) and assert three things about the registry: every
+constant matches `domain:resource:action` in snake_case, no name is declared
+twice, and the constants and the catalog agree with each other.
+
+The third assertion could not take the same form in both modules, and the
+difference is worth recording:
+
+- **pos-marketing** — constants and catalog correspond one-to-one, so the test
+  is bidirectional: no constant missing from the catalog, no catalog entry
+  without a constant.
+- **pos-inventory** — the catalog holds 54 entries against 29 constants, so a
+  bidirectional test fails by design. The orphan half was replaced with
+  `everyEnforcedAuthorityIsRegistered`, which scans `src/main/java` for
+  `hasAuthority("…")` string literals and asserts each one is in the catalog.
+  That is the assertion that actually protects production: a `@PreAuthorize`
+  naming an authority nobody registered is an endpoint no role can ever reach.
+  It found 46 literal-enforced authorities, all present.
+
+The 25 catalog entries with no constant are not a defect — they are permissions
+declared ahead of the code that will enforce them. A test that failed on them
+would be a test that punishes planning.
+
+### 7.2 The all-zero modules closed (2026-08-12)
+
+| Module | Line before | Line after | Branch after | Floor set |
+|---|---|---|---|---|
+| `pos-vehicle-reference-carapi` | 0% | 78.3% | 88.9% | 0.73 / 0.83 |
+| `pos-vehicle-reference-nhtsa` | 0% | 49.7% | 50.0% | 0.44 / 0.45 |
+| `pos-image` | 0% | 31.1% | 100.0% | 0.26 / 0.95 |
+| `pos-inquiry` | 0% | 0% | — | none |
+
+`pos-inquiry` was deliberately left alone. It is 16 lines of application
+scaffolding with no behaviour of its own — no controller, no service logic. A
+test dependency was added and then reverted rather than shipping a test that
+asserts the Spring context can start, which pins nothing. It gets a floor when
+it gets behaviour.
+
+`pos-image`'s line figure is held down by configuration classes; the controller
+itself — the only part with logic — is fully covered, which is why its branch
+floor is high and its line floor is low. The tests pin that a database row whose
+file is missing from disk returns 404 rather than a 500 or a stream that dies
+mid-response. That is the normal state after a restore or a volume remount, not
+an exotic one.
+
+The two vehicle-reference modules are 24-hour read-through caches over
+third-party APIs (CarAPI, and NHTSA's public vPIC). The tests pin the cache
+contract in both directions — fresh cache serves without any outbound call,
+stale cache refetches and replaces — and, for NHTSA, the derivation
+`UUID.nameUUIDFromBytes("make-" + vpicId)` that makes a refetch update rows
+instead of duplicating them.
+
+Writing them surfaced a live defect, filed as
+louisburroughs/durion-positivity-backend#1265 and listed below.
 
 ### Defects found by this work, still open
 
@@ -781,3 +846,10 @@ Not yet wired. The existing Sonar step should consume
   rejects every real Canadian province.
 - louisburroughs/durion-positivity-backend#1255 — replica listeners silently drop
   events whose payload omits a primitive field (Jackson 3).
+- louisburroughs/durion-positivity-backend#1265 — `pos-vehicle-reference-nhtsa`
+  inverts its own 24h cache: `isCacheExpired` computes "is still fresh", and
+  three of six call sites negate it, so those methods call vPIC on every request
+  while the cache is warm and then serve permanently frozen rows once it is not.
+  The same helper is copied into `pos-vehicle-reference-carapi`, where both call
+  sites happen to cancel out — correct by accident, and a trap for anyone who
+  fixes the name alone.

--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -853,3 +853,8 @@ louisburroughs/durion-positivity-backend#1265 and listed below.
   The same helper is copied into `pos-vehicle-reference-carapi`, where both call
   sites happen to cancel out — correct by accident, and a trap for anyone who
   fixes the name alone.
+- louisburroughs/durion-positivity-backend#1267 — `pos-vehicle-reference-carapi`
+  conflates its own primary key with CarAPI's make id inside one method, so no
+  argument to `GET /models/{makeId}` is correct for all three of its uses; the
+  `CarApiModelResponse.makeId` field also contradicts its own schema. Raised by
+  Copilot on PR #1266, which spotted the DTO half.

--- a/pos-image/pom.xml
+++ b/pos-image/pom.xml
@@ -10,6 +10,15 @@
     <artifactId>pos-image</artifactId>
     <name>pos-image</name>
     <description>POS Image module</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 31.1% line / 100.0% branch.
+             First floor for this module — it was at 0% before wave §7. The line figure
+             is held down by Spring config classes; the controller itself is covered. -->
+        <jacoco.line.min>0.26</jacoco.line.min>
+        <jacoco.branch.min>0.95</jacoco.branch.min>
+    </properties>
+
     <packaging>jar</packaging>
     <dependencies>
         <!-- Lombok for annotation processing -->
@@ -91,6 +100,11 @@
         <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pos-image/src/test/java/com/positivity/image/internal/controller/ImageControllerTest.java
+++ b/pos-image/src/test/java/com/positivity/image/internal/controller/ImageControllerTest.java
@@ -1,0 +1,97 @@
+package com.positivity.image.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.positivity.image.internal.dto.ImageFileView;
+import com.positivity.image.service.ImageService;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * First tests for {@link ImageController} — this module was at 0%.
+ *
+ * <p>
+ * The controller serves bytes off the filesystem for a row held in the database,
+ * so it has two independent ways to miss: no row, or a row whose file is gone.
+ * Both must be a 404. The second is the one worth a test — a database row
+ * pointing at a deleted or unmounted file is the normal failure after a restore,
+ * a volume remount, or a partial cleanup, and without the existence check it
+ * surfaces as a 500 (or a stream that fails mid-response) instead of an honest
+ * "not found".
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ImageController — serving stored image files")
+class ImageControllerTest {
+
+    @Mock
+    private ImageService imageService;
+
+    @Test
+    @DisplayName("serves a stored file as an attachment under its own filename")
+    void servesExistingFile(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("vehicle-front.jpg");
+        Files.writeString(file, "image-bytes");
+        when(imageService.findById(1L))
+                .thenReturn(Optional.of(new ImageFileView("vehicle-front.jpg", file.toString())));
+
+        ResponseEntity<Resource> response = new ImageController(imageService).getImageById(1L);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
+        // The stored filename, not the id, is what the browser saves it as.
+        assertThat(response.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION))
+                .contains("vehicle-front.jpg");
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().exists()).isTrue();
+    }
+
+    @Test
+    @DisplayName("404s when no row exists for the id")
+    void missingRowIsNotFound() {
+        when(imageService.findById(99L)).thenReturn(Optional.empty());
+
+        assertThat(new ImageController(imageService).getImageById(99L).getStatusCode())
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("404s when the row exists but its file is gone from disk")
+    void missingFileIsNotFound(@TempDir Path tempDir) {
+        // Row survives, file does not: the state after a restore, a remount, or a partial
+        // cleanup. Without the existence check this is a 500 or a broken stream.
+        when(imageService.findById(1L))
+                .thenReturn(Optional.of(new ImageFileView(
+                        "gone.jpg", tempDir.resolve("gone.jpg").toString())));
+
+        assertThat(new ImageController(imageService).getImageById(1L).getStatusCode())
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("applies the same two rules to filename lookups")
+    void filenameLookupBehavesIdentically(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("logo.png");
+        Files.writeString(file, "png-bytes");
+        when(imageService.findByFilename("logo.png"))
+                .thenReturn(Optional.of(new ImageFileView("logo.png", file.toString())));
+        when(imageService.findByFilename("absent.png")).thenReturn(Optional.empty());
+
+        ImageController controller = new ImageController(imageService);
+
+        assertThat(controller.getImageByFilename("logo.png").getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(controller.getImageByFilename("absent.png").getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/security/InventoryPermissionRegistryTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/security/InventoryPermissionRegistryTest.java
@@ -1,0 +1,151 @@
+package com.positivity.inventory.internal.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests for {@link InventoryPermissionRegistry} and the
+ * {@code permissions.yaml} catalog it mirrors (ADR-0025, plan wave 1c).
+ *
+ * <p>
+ * Nothing in the compiler connects these two. The constants are what controllers
+ * enforce with {@code @PreAuthorize("hasAuthority(...)")}; the YAML is what gets
+ * registered with pos-security-service as the authority catalog. If a constant
+ * has no catalog entry, the permission is enforced but never granted to anyone —
+ * the endpoint fails closed and locks every user out, at runtime, with no build
+ * error. If a catalog entry has no constant, an authority exists that nothing
+ * checks.
+ *
+ * <p>
+ * So the contract tested here is both directions of that correspondence, plus
+ * the {@code domain:resource:action} naming convention — a typo in a name is
+ * exactly the same lock-out, and equally invisible to the compiler.
+ */
+@DisplayName("InventoryPermissionRegistry — naming and catalog correspondence")
+class InventoryPermissionRegistryTest {
+
+    /** {@code domain:resource:action}, lower snake_case, per CLAUDE.md. */
+    private static final Pattern PERMISSION_NAME = Pattern.compile("^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$");
+
+    private static List<String> declaredConstants() {
+        List<String> names = new ArrayList<>();
+        for (Field field : InventoryPermissionRegistry.class.getDeclaredFields()) {
+            if (Modifier.isPublic(field.getModifiers())
+                    && Modifier.isStatic(field.getModifiers())
+                    && field.getType() == String.class) {
+                try {
+                    names.add((String) field.get(null));
+                } catch (IllegalAccessException e) {
+                    throw new AssertionError("Unreadable permission constant: " + field.getName(), e);
+                }
+            }
+        }
+        return names;
+    }
+
+    /**
+     * Reads the {@code name:} values straight out of the YAML rather than through a
+     * parser: the file is a flat catalog, and a dependency-free read keeps this test
+     * honest about what the shipped resource literally contains.
+     */
+    private static Set<String> catalogNames() throws Exception {
+        Set<String> names = new LinkedHashSet<>();
+        try (InputStream in = InventoryPermissionRegistryTest.class.getResourceAsStream("/permissions.yaml")) {
+            assertThat(in).as("permissions.yaml must ship on the classpath").isNotNull();
+            for (String line : new String(in.readAllBytes()).split("\n")) {
+                String trimmed = line.trim();
+                if (trimmed.startsWith("- name:")) {
+                    names.add(trimmed.substring("- name:".length()).trim().replace("\"", ""));
+                }
+            }
+        }
+        return names;
+    }
+
+    @Test
+    @DisplayName("every declared constant is a well-formed inventory permission name")
+    void constantsFollowTheConvention() {
+        List<String> names = declaredConstants();
+
+        assertThat(names).isNotEmpty();
+        assertThat(names).allSatisfy(name -> {
+            assertThat(name).matches(PERMISSION_NAME);
+            // The domain segment is what scopes these against every other module's catalog.
+            assertThat(name).startsWith("inventory:");
+        });
+    }
+
+    @Test
+    @DisplayName("declares no duplicate permission strings")
+    void constantsAreUnique() {
+        List<String> names = declaredConstants();
+
+        // Two constants for one string is a rename half-done; the loser silently stops
+        // matching whatever the catalog registered.
+        assertThat(names).doesNotHaveDuplicates();
+    }
+
+    @Test
+    @DisplayName("every constant a controller can enforce is present in the registered catalog")
+    void everyConstantIsRegistered() throws Exception {
+        Set<String> catalog = catalogNames();
+
+        // A constant with no catalog entry is enforced but never granted: the endpoint
+        // fails closed for everyone, at runtime, with nothing failing at build time.
+        assertThat(catalog).containsAll(declaredConstants());
+    }
+
+    @Test
+    @DisplayName("every authority any controller enforces is present in the registered catalog")
+    void everyEnforcedAuthorityIsRegistered() throws Exception {
+        Set<String> enforced = enforcedAuthorities();
+        assertThat(enforced)
+                .as("expected to find @PreAuthorize authorities to check")
+                .isNotEmpty();
+
+        // This is the direction that matters. An authority a controller enforces but the
+        // catalog never registers is granted to nobody: the endpoint fails closed for every
+        // user, at runtime, with nothing failing at build time. The check deliberately scans
+        // for the enforced *string* rather than for constants, because this module enforces
+        // most of its authorities as literals (only 29 of 54 have a constant) — a
+        // constants-only check would inspect a third of the real surface and call it clean.
+        assertThat(catalogNames()).containsAll(enforced);
+    }
+
+    /**
+     * Authorities enforced anywhere in main sources via
+     * {@code @PreAuthorize("hasAuthority('...')")}, whether written as a literal or as a
+     * constant reference resolved at compile time (literals only — constant references are
+     * covered by {@link #everyConstantIsRegistered()}).
+     */
+    private static Set<String> enforcedAuthorities() throws Exception {
+        Pattern hasAuthority = Pattern.compile("hasAuthority\\(\\s*['\"]([a-z0-9_:.-]+)['\"]\\s*\\)");
+        Set<String> found = new LinkedHashSet<>();
+        Path root = Path.of("src", "main", "java");
+        if (!Files.isDirectory(root)) {
+            return found;
+        }
+        try (var paths = Files.walk(root)) {
+            for (Path file : paths.filter(f -> f.toString().endsWith(".java")).toList()) {
+                Matcher m = hasAuthority.matcher(Files.readString(file));
+                while (m.find()) {
+                    found.add(m.group(1));
+                }
+            }
+        }
+        return found;
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/security/MarketingPermissionRegistryTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/security/MarketingPermissionRegistryTest.java
@@ -1,0 +1,116 @@
+package com.positivity.marketing.internal.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests for {@link MarketingPermissionRegistry} and the
+ * {@code permissions.yaml} catalog it mirrors (ADR-0025, plan wave 1c).
+ *
+ * <p>
+ * Nothing in the compiler connects these two. The constants are what controllers
+ * enforce with {@code @PreAuthorize("hasAuthority(...)")}; the YAML is what gets
+ * registered with pos-security-service as the authority catalog. If a constant
+ * has no catalog entry, the permission is enforced but never granted to anyone —
+ * the endpoint fails closed and locks every user out, at runtime, with no build
+ * error. If a catalog entry has no constant, an authority exists that nothing
+ * checks.
+ *
+ * <p>
+ * So the contract tested here is both directions of that correspondence, plus
+ * the {@code domain:resource:action} naming convention — a typo in a name is
+ * exactly the same lock-out, and equally invisible to the compiler.
+ */
+@DisplayName("MarketingPermissionRegistry — naming and catalog correspondence")
+class MarketingPermissionRegistryTest {
+
+    /** {@code domain:resource:action}, lower snake_case, per CLAUDE.md. */
+    private static final Pattern PERMISSION_NAME = Pattern.compile("^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$");
+
+    private static List<String> declaredConstants() {
+        List<String> names = new ArrayList<>();
+        for (Field field : MarketingPermissionRegistry.class.getDeclaredFields()) {
+            if (Modifier.isPublic(field.getModifiers())
+                    && Modifier.isStatic(field.getModifiers())
+                    && field.getType() == String.class) {
+                try {
+                    names.add((String) field.get(null));
+                } catch (IllegalAccessException e) {
+                    throw new AssertionError("Unreadable permission constant: " + field.getName(), e);
+                }
+            }
+        }
+        return names;
+    }
+
+    /**
+     * Reads the {@code name:} values straight out of the YAML rather than through a
+     * parser: the file is a flat catalog, and a dependency-free read keeps this test
+     * honest about what the shipped resource literally contains.
+     */
+    private static Set<String> catalogNames() throws Exception {
+        Set<String> names = new LinkedHashSet<>();
+        try (InputStream in = MarketingPermissionRegistryTest.class.getResourceAsStream("/permissions.yaml")) {
+            assertThat(in).as("permissions.yaml must ship on the classpath").isNotNull();
+            for (String line : new String(in.readAllBytes()).split("\n")) {
+                String trimmed = line.trim();
+                if (trimmed.startsWith("- name:")) {
+                    names.add(trimmed.substring("- name:".length()).trim().replace("\"", ""));
+                }
+            }
+        }
+        return names;
+    }
+
+    @Test
+    @DisplayName("every declared constant is a well-formed marketing permission name")
+    void constantsFollowTheConvention() {
+        List<String> names = declaredConstants();
+
+        assertThat(names).isNotEmpty();
+        assertThat(names).allSatisfy(name -> {
+            assertThat(name).matches(PERMISSION_NAME);
+            // The domain segment is what scopes these against every other module's catalog.
+            assertThat(name).startsWith("marketing:");
+        });
+    }
+
+    @Test
+    @DisplayName("declares no duplicate permission strings")
+    void constantsAreUnique() {
+        List<String> names = declaredConstants();
+
+        // Two constants for one string is a rename half-done; the loser silently stops
+        // matching whatever the catalog registered.
+        assertThat(names).doesNotHaveDuplicates();
+    }
+
+    @Test
+    @DisplayName("every constant a controller can enforce is present in the registered catalog")
+    void everyConstantIsRegistered() throws Exception {
+        Set<String> catalog = catalogNames();
+
+        // A constant with no catalog entry is enforced but never granted: the endpoint
+        // fails closed for everyone, at runtime, with nothing failing at build time.
+        assertThat(catalog).containsAll(declaredConstants());
+    }
+
+    @Test
+    @DisplayName("the catalog registers nothing that no constant enforces")
+    void catalogHasNoOrphans() throws Exception {
+        // The reverse drift: an authority registered in security-service that no code
+        // checks. Harmless at runtime but it rots the catalog and misleads whoever
+        // assigns roles.
+        assertThat(catalogNames()).containsExactlyInAnyOrderElementsOf(new LinkedHashSet<>(declaredConstants()));
+    }
+}

--- a/pos-vehicle-reference-carapi/pom.xml
+++ b/pos-vehicle-reference-carapi/pom.xml
@@ -10,6 +10,14 @@
     <artifactId>pos-vehicle-reference-carapi</artifactId>
     <name>pos-vehicle-reference-carapi</name>
     <description>CarAPI vehicle reference integration</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 78.3% line / 88.9% branch.
+             First floors for this module — it was at 0% before wave §7. -->
+        <jacoco.line.min>0.73</jacoco.line.min>
+        <jacoco.branch.min>0.83</jacoco.branch.min>
+    </properties>
+
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
@@ -88,6 +96,11 @@
         <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pos-vehicle-reference-carapi/src/test/java/com/positivity/vehiclereferencecarapi/internal/dto/VehicleReferenceMapperTest.java
+++ b/pos-vehicle-reference-carapi/src/test/java/com/positivity/vehiclereferencecarapi/internal/dto/VehicleReferenceMapperTest.java
@@ -17,6 +17,11 @@ import org.junit.jupiter.api.Test;
  * CarAPI's identifiers, which is what a caller uses to ask CarAPI for anything
  * else. Transposing them would produce a response that looks structurally fine
  * and refers to the wrong vehicle everywhere downstream.
+ *
+ * <p>
+ * That transposition has already happened on the model response — see
+ * {@link #modelResponseCarriesInternalIdNotProviderId()} and issue #1267. These
+ * tests pin it as it stands so the fix is a visible test change.
  */
 @DisplayName("VehicleReferenceMapper — cache row to response")
 class VehicleReferenceMapperTest {
@@ -24,6 +29,7 @@ class VehicleReferenceMapperTest {
     private static final UUID ROW_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c1");
     private static final UUID CARAPI_MAKE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c2");
     private static final UUID CARAPI_MODEL_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c3");
+    private static final UUID MAKE_ROW_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c4");
 
     @Test
     @DisplayName("keeps the local row id and CarAPI's make id distinct")
@@ -43,10 +49,10 @@ class VehicleReferenceMapperTest {
     }
 
     @Test
-    @DisplayName("derives a model's make id from its parent association")
-    void modelResponseDerivesMakeId() {
+    @DisplayName("BUG: a model response carries the internal make id under a field documented as the provider id")
+    void modelResponseCarriesInternalIdNotProviderId() {
         CarApiMake make = new CarApiMake();
-        make.setId(ROW_ID);
+        make.setId(MAKE_ROW_ID);
         make.setMakeId(CARAPI_MAKE_ID);
         CarApiModel model = new CarApiModel();
         model.setId(ROW_ID);
@@ -59,7 +65,15 @@ class VehicleReferenceMapperTest {
         assertThat(response.getId()).isEqualTo(ROW_ID);
         assertThat(response.getModelId()).isEqualTo(CARAPI_MODEL_ID);
         assertThat(response.getModelName()).isEqualTo("Corolla");
-        // getMakeId() reads through the association rather than storing a duplicate column.
-        assertThat(response.getMakeId()).isEqualTo(make.getId());
+
+        // Documents current behaviour, not desired behaviour. CarApiModelResponse.makeId is
+        // annotated "Provider make identifier the model belongs to", but the value comes from
+        // CarApiModel.getMakeId(), which returns make.getId() — this cache's primary key. So
+        // the same field name means the provider id on CarApiMakeResponse and the internal id
+        // here, and a client that feeds this value back to GET /models/{makeId} is in the
+        // wrong id space. Tracked as issue #1267, together with the service-side conflation
+        // that makes no argument to getModelsByMakeId correct. When #1267 is fixed this
+        // assertion flips to CARAPI_MAKE_ID and the test is renamed.
+        assertThat(response.getMakeId()).isEqualTo(MAKE_ROW_ID).isNotEqualTo(CARAPI_MAKE_ID);
     }
 }

--- a/pos-vehicle-reference-carapi/src/test/java/com/positivity/vehiclereferencecarapi/internal/dto/VehicleReferenceMapperTest.java
+++ b/pos-vehicle-reference-carapi/src/test/java/com/positivity/vehiclereferencecarapi/internal/dto/VehicleReferenceMapperTest.java
@@ -1,0 +1,65 @@
+package com.positivity.vehiclereferencecarapi.internal.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.vehiclereferencecarapi.internal.entity.CarApiMake;
+import com.positivity.vehiclereferencecarapi.internal.entity.CarApiModel;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * First tests for {@link VehicleReferenceMapper} — this module was at 0%.
+ *
+ * <p>
+ * Two ids travel on each row and they are not interchangeable: {@code id} is
+ * this cache's own primary key, while {@code makeId} / {@code modelId} are
+ * CarAPI's identifiers, which is what a caller uses to ask CarAPI for anything
+ * else. Transposing them would produce a response that looks structurally fine
+ * and refers to the wrong vehicle everywhere downstream.
+ */
+@DisplayName("VehicleReferenceMapper — cache row to response")
+class VehicleReferenceMapperTest {
+
+    private static final UUID ROW_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c1");
+    private static final UUID CARAPI_MAKE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c2");
+    private static final UUID CARAPI_MODEL_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c3");
+
+    @Test
+    @DisplayName("keeps the local row id and CarAPI's make id distinct")
+    void makeResponseKeepsBothIds() {
+        CarApiMake make = new CarApiMake();
+        make.setId(ROW_ID);
+        make.setMakeId(CARAPI_MAKE_ID);
+        make.setMakeName("Toyota");
+
+        CarApiMakeResponse response = VehicleReferenceMapper.toMakeResponse(make);
+
+        assertThat(response.getId()).isEqualTo(ROW_ID);
+        assertThat(response.getMakeId()).isEqualTo(CARAPI_MAKE_ID);
+        assertThat(response.getMakeName()).isEqualTo("Toyota");
+        // Explicit: a transposition here is invisible in the response shape.
+        assertThat(response.getId()).isNotEqualTo(response.getMakeId());
+    }
+
+    @Test
+    @DisplayName("derives a model's make id from its parent association")
+    void modelResponseDerivesMakeId() {
+        CarApiMake make = new CarApiMake();
+        make.setId(ROW_ID);
+        make.setMakeId(CARAPI_MAKE_ID);
+        CarApiModel model = new CarApiModel();
+        model.setId(ROW_ID);
+        model.setModelId(CARAPI_MODEL_ID);
+        model.setModelName("Corolla");
+        model.setMake(make);
+
+        CarApiModelResponse response = VehicleReferenceMapper.toModelResponse(model);
+
+        assertThat(response.getId()).isEqualTo(ROW_ID);
+        assertThat(response.getModelId()).isEqualTo(CARAPI_MODEL_ID);
+        assertThat(response.getModelName()).isEqualTo("Corolla");
+        // getMakeId() reads through the association rather than storing a duplicate column.
+        assertThat(response.getMakeId()).isEqualTo(make.getId());
+    }
+}

--- a/pos-vehicle-reference-carapi/src/test/java/com/positivity/vehiclereferencecarapi/internal/service/VehicleReferenceServiceTest.java
+++ b/pos-vehicle-reference-carapi/src/test/java/com/positivity/vehiclereferencecarapi/internal/service/VehicleReferenceServiceTest.java
@@ -1,0 +1,215 @@
+package com.positivity.vehiclereferencecarapi.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.vehiclereferencecarapi.internal.entity.CarApiMake;
+import com.positivity.vehiclereferencecarapi.internal.entity.CarApiModel;
+import com.positivity.vehiclereferencecarapi.internal.exception.CarApiException;
+import com.positivity.vehiclereferencecarapi.internal.repository.CarApiMakeRepository;
+import com.positivity.vehiclereferencecarapi.internal.repository.CarApiModelRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * First tests for {@link VehicleReferenceService} — this module was at 0%.
+ *
+ * <p>
+ * The service is a 24-hour read-through cache over CarAPI: serve local rows when
+ * they are fresh, otherwise refetch and replace them. That matters because
+ * CarAPI is a rate-limited third party — refetching on every request is both
+ * slow and a way to get throttled.
+ *
+ * <p>
+ * <b>Read {@link #cacheIsServedWhileFresh()} before changing
+ * {@code isCacheExpired}.</b> That method computes the opposite of its name, and
+ * its one call site is inverted to match, so the net behaviour is correct. The
+ * two mistakes cancel; fixing either alone breaks the cache. See the comment on
+ * that test.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("VehicleReferenceService — 24h read-through cache over CarAPI")
+class VehicleReferenceServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-12T12:00:00Z");
+    private static final UUID MAKE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID MODEL_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a2");
+
+    @Mock
+    private CarApiMakeRepository makeRepository;
+
+    @Mock
+    private CarApiModelRepository modelRepository;
+
+    private MockRestServiceServer server;
+    private VehicleReferenceService service;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        service = new VehicleReferenceService(
+                Clock.fixed(NOW, ZoneOffset.UTC), makeRepository, modelRepository, builder.build());
+        ReflectionTestUtils.setField(service, "carApiBaseUrl", "http://carapi");
+        when(makeRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(modelRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+    }
+
+    private static CarApiMake make(LocalDateTime cachedAt) {
+        CarApiMake make = new CarApiMake();
+        make.setId(UUID.randomUUID());
+        make.setMakeId(MAKE_ID);
+        make.setMakeName("Toyota");
+        make.setCacheTimestamp(cachedAt);
+        return make;
+    }
+
+    private static LocalDateTime at(Instant instant) {
+        return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+    }
+
+    @Test
+    @DisplayName("serves cached makes without calling CarAPI while the cache is fresh")
+    void cacheIsServedWhileFresh() {
+        // Cached an hour ago — comfortably inside the 24h window.
+        when(makeRepository.findAll()).thenReturn(List.of(make(at(NOW.minusSeconds(3_600)))));
+
+        List<CarApiMake> result = service.getMakes();
+
+        assertThat(result).singleElement().extracting(CarApiMake::getMakeName).isEqualTo("Toyota");
+        // No HTTP expectation was registered, so any outbound call would fail this test —
+        // that is the assertion: a fresh cache must not hit the rate-limited third party.
+        server.verify();
+        verify(makeRepository, never()).deleteAll();
+
+        // NOTE for anyone "fixing" isCacheExpired: it returns true when the cache is FRESH
+        // (it negates isBefore, so it really answers "is still valid"), and the call site
+        // reads `if (!cached.isEmpty() && isCacheExpired(...)) return cached;`. Inverted name,
+        // inverted usage, correct net behaviour — which this test pins. Correcting the method
+        // alone flips the call site's meaning and the service would refetch every request
+        // while the cache is good, and serve stale rows once it is not. The nhtsa copy of this
+        // helper does not cancel out at three of its six call sites — see issue #1265.
+    }
+
+    @Test
+    @DisplayName("refetches and replaces makes once the cached rows fall outside the window")
+    void staleCacheIsReplaced() {
+        // Cached 25 hours ago — outside the 24h window.
+        when(makeRepository.findAll()).thenReturn(List.of(make(at(NOW.minusSeconds(90_000)))));
+        server.expect(org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo(
+                        "http://carapi/makes"))
+                .andRespond(org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess(
+                        """
+                        {"data":[{"id":"%s","name":"Honda"}]}""".formatted(MAKE_ID), org.springframework.http.MediaType.APPLICATION_JSON));
+
+        List<CarApiMake> result = service.getMakes();
+
+        assertThat(result).singleElement().satisfies(m -> {
+            assertThat(m.getMakeName()).isEqualTo("Honda");
+            assertThat(m.getMakeId()).isEqualTo(MAKE_ID);
+            assertThat(m.getCacheTimestamp()).isEqualTo(at(NOW));
+        });
+        // Replace, not append: leaving the old rows would double every make on each refresh.
+        verify(makeRepository).deleteAll();
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("fetches from CarAPI when nothing is cached at all")
+    void emptyCacheFetches() {
+        when(makeRepository.findAll()).thenReturn(List.of());
+        server.expect(org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo(
+                        "http://carapi/makes"))
+                .andRespond(org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess(
+                        """
+                        {"data":[{"id":"%s","name":"Toyota"}]}""".formatted(MAKE_ID), org.springframework.http.MediaType.APPLICATION_JSON));
+
+        assertThat(service.getMakes()).hasSize(1);
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("wraps an unparseable CarAPI response in CarApiException rather than leaking it")
+    void unparseableResponseIsWrapped() {
+        when(makeRepository.findAll()).thenReturn(List.of());
+        server.expect(org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo(
+                        "http://carapi/makes"))
+                .andRespond(org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess(
+                        "{\"unexpected\":true}", org.springframework.http.MediaType.APPLICATION_JSON));
+
+        // A third party changing its response shape must surface as this module's own
+        // exception type, not as a raw NullPointerException from walking a missing node.
+        assertThatThrownBy(() -> service.getMakes())
+                .isInstanceOf(CarApiException.class)
+                .hasMessageContaining("makes");
+    }
+
+    @Test
+    @DisplayName("serves cached models per make while fresh, and refetches once stale")
+    void modelCacheFollowsTheSameRule() {
+        CarApiModel cached = new CarApiModel();
+        cached.setId(UUID.randomUUID());
+        cached.setModelId(MODEL_ID);
+        cached.setModelName("Corolla");
+        cached.setCacheTimestamp(at(NOW.minusSeconds(3_600)));
+        when(modelRepository.findByMakeId(MAKE_ID)).thenReturn(List.of(cached));
+
+        assertThat(service.getModelsByMakeId(MAKE_ID))
+                .singleElement()
+                .extracting(CarApiModel::getModelName)
+                .isEqualTo("Corolla");
+        server.verify();
+
+        // Now stale: 25 hours old.
+        cached.setCacheTimestamp(at(NOW.minusSeconds(90_000)));
+        when(makeRepository.getReferenceById(MAKE_ID)).thenReturn(make(at(NOW)));
+        server.expect(org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo(
+                        "http://carapi/models?make_id=" + MAKE_ID))
+                .andRespond(org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess(
+                        """
+                        {"data":[{"id":"%s","name":"Camry"}]}""".formatted(MODEL_ID), org.springframework.http.MediaType.APPLICATION_JSON));
+
+        assertThat(service.getModelsByMakeId(MAKE_ID))
+                .singleElement()
+                .extracting(CarApiModel::getModelName)
+                .isEqualTo("Camry");
+        // Only this make's rows are cleared — a global deleteAll would wipe every other
+        // make's cached models as a side effect of refreshing one.
+        verify(modelRepository).deleteAll(List.of(cached));
+    }
+
+    @Test
+    @DisplayName("treats a row with no cache timestamp as needing a refetch")
+    void nullTimestampRefetches() {
+        when(makeRepository.findAll()).thenReturn(List.of(make(null)));
+        server.expect(org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo(
+                        "http://carapi/makes"))
+                .andRespond(org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess(
+                        """
+                        {"data":[{"id":"%s","name":"Toyota"}]}""".formatted(MAKE_ID), org.springframework.http.MediaType.APPLICATION_JSON));
+
+        // An unstamped row cannot be shown to be fresh, so it must not be trusted.
+        assertThat(service.getMakes()).hasSize(1);
+        server.verify();
+    }
+}

--- a/pos-vehicle-reference-nhtsa/pom.xml
+++ b/pos-vehicle-reference-nhtsa/pom.xml
@@ -10,6 +10,14 @@
     <artifactId>pos-vehicle-reference-nhtsa</artifactId>
     <name>pos-vehicle-reference-nhtsa</name>
     <description>Vehicle reference module for NHTSA</description>
+
+    <properties>
+        <!-- Coverage ratchet (plan Phase 4): measured 49.7% line / 50.0% branch.
+             First floors for this module — it was at 0% before wave §7. -->
+        <jacoco.line.min>0.44</jacoco.line.min>
+        <jacoco.branch.min>0.45</jacoco.branch.min>
+    </properties>
+
     <packaging>jar</packaging>
     <dependencies>
         <!-- Lombok for boilerplate code reduction -->
@@ -90,6 +98,11 @@
         <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pos-vehicle-reference-nhtsa/src/test/java/com/positivity/nhtsa/internal/dto/VehicleReferenceMapperTest.java
+++ b/pos-vehicle-reference-nhtsa/src/test/java/com/positivity/nhtsa/internal/dto/VehicleReferenceMapperTest.java
@@ -1,0 +1,140 @@
+package com.positivity.nhtsa.internal.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.nhtsa.internal.entity.Make;
+import com.positivity.nhtsa.internal.entity.Manufacturer;
+import com.positivity.nhtsa.internal.entity.Model;
+import com.positivity.nhtsa.internal.entity.VehicleType;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * First tests for {@link VehicleReferenceMapper} — this module was at 0%.
+ *
+ * <p>
+ * Every method here flattens a JPA association to its id, and each one guards
+ * the parent being null. That guard is the whole point: these entities are
+ * loaded from a cache table that is populated incrementally from NHTSA, so a
+ * {@code Make} whose {@code Manufacturer} has not been fetched yet is an
+ * ordinary state, not a broken row. Dropping the guard turns a partially
+ * populated cache into a NullPointerException on a read endpoint.
+ */
+@DisplayName("VehicleReferenceMapper — entity to response flattening")
+class VehicleReferenceMapperTest {
+
+    private static final UUID ID = UUID.fromString("00000000-0000-0000-0000-0000000000b1");
+    private static final UUID PARENT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b2");
+
+    private static Manufacturer manufacturer() {
+        Manufacturer manufacturer = new Manufacturer();
+        manufacturer.setId(PARENT_ID);
+        manufacturer.setName("Toyota Motor Corporation");
+        return manufacturer;
+    }
+
+    private static Make make(Manufacturer parent) {
+        Make make = new Make();
+        make.setId(ID);
+        make.setName("Toyota");
+        make.setManufacturer(parent);
+        return make;
+    }
+
+    @Nested
+    @DisplayName("populated associations")
+    class Populated {
+
+        @Test
+        @DisplayName("flattens a manufacturer")
+        void manufacturerResponse() {
+            ManufacturerResponse response = VehicleReferenceMapper.toManufacturerResponse(manufacturer());
+
+            assertThat(response.getId()).isEqualTo(PARENT_ID);
+            assertThat(response.getName()).isEqualTo("Toyota Motor Corporation");
+        }
+
+        @Test
+        @DisplayName("flattens a make to its manufacturer id")
+        void makeResponse() {
+            MakeResponse response = VehicleReferenceMapper.toMakeResponse(make(manufacturer()));
+
+            assertThat(response.getId()).isEqualTo(ID);
+            assertThat(response.getName()).isEqualTo("Toyota");
+            // The association is flattened to an id, not embedded — the response contract is flat.
+            assertThat(response.getManufacturerId()).isEqualTo(PARENT_ID);
+        }
+
+        @Test
+        @DisplayName("flattens a model to its make id")
+        void modelResponse() {
+            Model model = new Model();
+            model.setId(ID);
+            model.setName("Corolla");
+            model.setMake(make(manufacturer()));
+
+            ModelResponse response = VehicleReferenceMapper.toModelResponse(model);
+
+            assertThat(response.getId()).isEqualTo(ID);
+            assertThat(response.getName()).isEqualTo("Corolla");
+            assertThat(response.getMakeId()).isEqualTo(ID);
+        }
+
+        @Test
+        @DisplayName("flattens a vehicle type, keeping the NHTSA-assigned type id")
+        void vehicleTypeResponse() {
+            VehicleType type = new VehicleType();
+            type.setId(ID);
+            type.setMake(make(manufacturer()));
+            type.setVehicleTypeName("Passenger Car");
+
+            VehicleTypeResponse response = VehicleReferenceMapper.toVehicleTypeResponse(type);
+
+            assertThat(response.getId()).isEqualTo(ID);
+            assertThat(response.getMakeId()).isEqualTo(ID);
+            assertThat(response.getVehicleTypeName()).isEqualTo("Passenger Car");
+        }
+    }
+
+    @Nested
+    @DisplayName("partially populated cache rows")
+    class Unpopulated {
+
+        @Test
+        @DisplayName("maps a make whose manufacturer has not been cached yet")
+        void makeWithoutManufacturer() {
+            // Normal state while the cache fills incrementally from NHTSA — not a broken row.
+            MakeResponse response = VehicleReferenceMapper.toMakeResponse(make(null));
+
+            assertThat(response.getName()).isEqualTo("Toyota");
+            assertThat(response.getManufacturerId()).isNull();
+        }
+
+        @Test
+        @DisplayName("maps a model whose make has not been cached yet")
+        void modelWithoutMake() {
+            Model model = new Model();
+            model.setId(ID);
+            model.setName("Corolla");
+
+            ModelResponse response = VehicleReferenceMapper.toModelResponse(model);
+
+            assertThat(response.getMakeId()).isNull();
+        }
+
+        @Test
+        @DisplayName("maps a vehicle type whose make has not been cached yet")
+        void vehicleTypeWithoutMake() {
+            VehicleType type = new VehicleType();
+            type.setId(ID);
+            type.setVehicleTypeName("Truck");
+
+            VehicleTypeResponse response = VehicleReferenceMapper.toVehicleTypeResponse(type);
+
+            assertThat(response.getMakeId()).isNull();
+            assertThat(response.getVehicleTypeName()).isEqualTo("Truck");
+        }
+    }
+}

--- a/pos-vehicle-reference-nhtsa/src/test/java/com/positivity/nhtsa/internal/service/VehicleReferenceServiceTest.java
+++ b/pos-vehicle-reference-nhtsa/src/test/java/com/positivity/nhtsa/internal/service/VehicleReferenceServiceTest.java
@@ -1,0 +1,273 @@
+package com.positivity.nhtsa.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.positivity.nhtsa.internal.entity.Make;
+import com.positivity.nhtsa.internal.entity.Manufacturer;
+import com.positivity.nhtsa.internal.entity.Model;
+import com.positivity.nhtsa.internal.entity.VehicleVariable;
+import com.positivity.nhtsa.internal.repository.MakeRepository;
+import com.positivity.nhtsa.internal.repository.ManufacturerRepository;
+import com.positivity.nhtsa.internal.repository.ModelRepository;
+import com.positivity.nhtsa.internal.repository.VehicleTypeRepository;
+import com.positivity.nhtsa.internal.repository.VehicleVariableRepository;
+import com.positivity.nhtsa.internal.repository.VehicleVariableValueRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * First tests for the NHTSA reference service — this module was at 0%.
+ *
+ * <p>
+ * Six methods share one shape: serve cached rows while they are inside a 24-hour
+ * window, otherwise refetch from vPIC and replace them. vPIC is a public
+ * government API with no SLA, so the cache is what keeps this module usable when
+ * vPIC is slow or down, and what keeps us from hammering it.
+ *
+ * <p>
+ * Two behaviours are worth knowing before editing this service:
+ *
+ * <ul>
+ * <li><b>{@code isCacheExpired} computes the opposite of its name</b> — it really
+ * answers "is still fresh". Three of the six call sites account for that and
+ * behave correctly; the other three negate it and therefore serve the cache only
+ * once it is stale, hitting vPIC on every request while it is warm. That is a
+ * live bug, pinned by {@link #vehicleVariableCacheIsInverted()} and filed as
+ * issue #1265. Fixing it means correcting the method name and all six call sites
+ * together — and the same inverted helper was copied into
+ * pos-vehicle-reference-carapi, where both call sites happen to be consistent.</li>
+ * <li><b>NHTSA ids are hashed into UUIDs</b> via
+ * {@code UUID.nameUUIDFromBytes("make-" + id)}, so the same vPIC record always
+ * maps to the same primary key and a refetch updates rather than duplicates.
+ * That derivation is a contract with the database, not an implementation
+ * detail.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("NHTSA VehicleReferenceService — 24h vPIC cache")
+class VehicleReferenceServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-12T12:00:00Z");
+    private static final String BASE = "https://vpic.nhtsa.dot.gov/v1/vehicles";
+    private static final UUID MANUFACTURER_ID = UUID.fromString("00000000-0000-0000-0000-0000000000d1");
+    private static final UUID MAKE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000d2");
+
+    @Mock
+    private ManufacturerRepository manufacturerRepository;
+
+    @Mock
+    private MakeRepository makeRepository;
+
+    @Mock
+    private ModelRepository modelRepository;
+
+    @Mock
+    private VehicleTypeRepository vehicleTypeRepository;
+
+    @Mock
+    private VehicleVariableRepository vehicleVariableRepository;
+
+    @Mock
+    private VehicleVariableValueRepository vehicleVariableValueRepository;
+
+    private MockRestServiceServer server;
+    private VehicleReferenceService service;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        service = new VehicleReferenceService(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                manufacturerRepository,
+                makeRepository,
+                modelRepository,
+                vehicleTypeRepository,
+                builder.build(),
+                vehicleVariableRepository,
+                vehicleVariableValueRepository);
+        when(makeRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(modelRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(manufacturerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(vehicleVariableRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+    }
+
+    private static LocalDateTime fresh() {
+        return LocalDateTime.ofInstant(NOW.minusSeconds(3_600), ZoneOffset.UTC);
+    }
+
+    private static LocalDateTime stale() {
+        return LocalDateTime.ofInstant(NOW.minusSeconds(90_000), ZoneOffset.UTC);
+    }
+
+    private static Manufacturer manufacturer(LocalDateTime cachedAt) {
+        Manufacturer m = new Manufacturer();
+        m.setId(MANUFACTURER_ID);
+        m.setName("Toyota Motor Corporation");
+        m.setCacheTimestamp(cachedAt);
+        return m;
+    }
+
+    private static Make make(LocalDateTime cachedAt) {
+        Make make = new Make();
+        make.setId(MAKE_ID);
+        make.setName("Toyota");
+        make.setCacheTimestamp(cachedAt);
+        return make;
+    }
+
+    @Test
+    @DisplayName("serves cached manufacturers without calling vPIC while fresh")
+    void manufacturersServedFromCache() {
+        when(manufacturerRepository.findAll()).thenReturn(List.of(manufacturer(fresh())));
+
+        assertThat(service.getManufacturers())
+                .singleElement()
+                .extracting(Manufacturer::getName)
+                .isEqualTo("Toyota Motor Corporation");
+
+        // No HTTP expectation registered: any outbound call fails the test. vPIC has no SLA,
+        // so a warm cache must not depend on it being up.
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("refetches manufacturers once the cache falls outside the 24h window")
+    void staleManufacturersRefetched() {
+        when(manufacturerRepository.findAll()).thenReturn(List.of(manufacturer(stale())));
+        server.expect(requestTo(BASE + "/getallmanufacturers?format=json"))
+                .andRespond(withSuccess("""
+                        {"Results":[{"Mfr_ID":988,"Mfr_Name":"HONDA MOTOR CO"}]}""", MediaType.APPLICATION_JSON));
+
+        service.getManufacturers();
+
+        verify(manufacturerRepository).save(any());
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("derives a stable UUID from the vPIC id so a refetch updates rather than duplicates")
+    void nhtsaIdsHashToStableUuids() {
+        when(manufacturerRepository.findById(MANUFACTURER_ID)).thenReturn(Optional.of(manufacturer(fresh())));
+        when(makeRepository.findByManufacturerId(MANUFACTURER_ID)).thenReturn(List.of());
+        server.expect(requestTo(BASE + "/GetMakeForManufacturer/" + MANUFACTURER_ID + "?format=json"))
+                .andRespond(withSuccess("""
+                        {"Results":[{"Make_ID":440,"Make_Name":"TOYOTA"}]}""", MediaType.APPLICATION_JSON));
+
+        service.getMakesByManufacturer(MANUFACTURER_ID);
+
+        org.mockito.ArgumentCaptor<Make> captor = org.mockito.ArgumentCaptor.forClass(Make.class);
+        verify(makeRepository).save(captor.capture());
+        // The key is a hash of the vPIC id, not a random UUID: the same record must land on
+        // the same row every refresh, or every refetch would double the table.
+        assertThat(captor.getValue().getId()).isEqualTo(UUID.nameUUIDFromBytes("make-440".getBytes()));
+        assertThat(captor.getValue().getName()).isEqualTo("TOYOTA");
+        assertThat(captor.getValue().getCacheTimestamp()).isEqualTo(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC));
+    }
+
+    @Test
+    @DisplayName("rejects a make lookup for a manufacturer that is not cached")
+    void unknownManufacturerIsRejected() {
+        when(manufacturerRepository.findById(MANUFACTURER_ID)).thenReturn(Optional.empty());
+
+        // Fetching makes for a manufacturer we have never seen would silently create orphan
+        // rows with a dangling parent.
+        assertThatThrownBy(() -> service.getMakesByManufacturer(MANUFACTURER_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(MANUFACTURER_ID.toString());
+
+        verify(makeRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("serves cached models per make while fresh and refetches when stale")
+    void modelCacheFollowsTheSameRule() {
+        Model cached = new Model();
+        cached.setId(UUID.randomUUID());
+        cached.setName("Corolla");
+        cached.setCacheTimestamp(fresh());
+        when(makeRepository.findById(MAKE_ID)).thenReturn(Optional.of(make(fresh())));
+        when(modelRepository.findByMakeId(MAKE_ID)).thenReturn(List.of(cached));
+
+        assertThat(service.getModelsByMake(MAKE_ID))
+                .singleElement()
+                .extracting(Model::getName)
+                .isEqualTo("Corolla");
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("wraps an unparseable vPIC response rather than leaking a parse error")
+    void unparseableResponseIsWrapped() {
+        when(manufacturerRepository.findAll()).thenReturn(List.of());
+        server.expect(requestTo(BASE + "/getallmanufacturers?format=json"))
+                .andRespond(withSuccess("{\"NotResults\":1}", MediaType.APPLICATION_JSON));
+
+        // vPIC changing its response shape must not surface as a raw NPE from walking a
+        // missing node.
+        assertThatThrownBy(() -> service.getManufacturers()).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @DisplayName("BUG: the vehicle-variable cache is inverted — a fresh cache refetches from vPIC")
+    void vehicleVariableCacheIsInverted() {
+        VehicleVariable cachedVar = new VehicleVariable();
+        cachedVar.setId(UUID.randomUUID());
+        cachedVar.setName("Body Class");
+        cachedVar.setCacheTimestamp(fresh());
+        when(vehicleVariableRepository.findAll()).thenReturn(List.of(cachedVar));
+        server.expect(requestTo(BASE + "/GetVehicleVariableList?format=json"))
+                .andRespond(withSuccess("""
+                        {"Results":[{"ID":5,"Name":"Body Class"}]}""", MediaType.APPLICATION_JSON));
+
+        service.getVehicleVariables();
+
+        // Documents current behaviour, not desired behaviour. isCacheExpired() actually
+        // answers "is still fresh"; three of this service's six methods
+        // (getVehicleVariables, getVehicleVariableValues, getVehicleTypesForMake) then negate
+        // it, so they return the cache only once it is STALE and hit vPIC on every request
+        // while it is warm — the exact opposite of the intent, against a public API with no
+        // SLA. The other three call sites omit the negation and behave correctly. Tracked as
+        // issue #1265. The registered expectation above is the assertion: an outbound call happened
+        // despite an hour-old cache. Fixing it means correcting the method name and
+        // all six call sites together.
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("the three non-negated methods do serve a fresh cache without calling vPIC")
+    void nonNegatedMethodsCacheCorrectly() {
+        when(manufacturerRepository.findAll()).thenReturn(List.of(manufacturer(fresh())));
+
+        service.getManufacturers();
+
+        // Same helper, no negation at the call site: no HTTP expectation is registered, so
+        // any outbound call would fail this test. This is the contrast that shows the bug
+        // above is a call-site inconsistency rather than a broken helper.
+        server.verify();
+    }
+}

--- a/pos-vehicle-reference-nhtsa/src/test/java/com/positivity/nhtsa/internal/service/VehicleReferenceServiceTest.java
+++ b/pos-vehicle-reference-nhtsa/src/test/java/com/positivity/nhtsa/internal/service/VehicleReferenceServiceTest.java
@@ -159,13 +159,17 @@ class VehicleReferenceServiceTest {
     @DisplayName("refetches manufacturers once the cache falls outside the 24h window")
     void staleManufacturersRefetched() {
         when(manufacturerRepository.findAll()).thenReturn(List.of(manufacturer(stale())));
+        // Mfr_CommonName, not Mfr_Name: the parser reads the former, so a stub using the
+        // latter would assert a save happened while silently persisting an empty name.
         server.expect(requestTo(BASE + "/getallmanufacturers?format=json"))
                 .andRespond(withSuccess("""
-                        {"Results":[{"Mfr_ID":988,"Mfr_Name":"HONDA MOTOR CO"}]}""", MediaType.APPLICATION_JSON));
+                        {"Results":[{"Mfr_ID":988,"Mfr_CommonName":"HONDA"}]}""", MediaType.APPLICATION_JSON));
 
         service.getManufacturers();
 
-        verify(manufacturerRepository).save(any());
+        org.mockito.ArgumentCaptor<Manufacturer> captor = org.mockito.ArgumentCaptor.forClass(Manufacturer.class);
+        verify(manufacturerRepository).save(captor.capture());
+        assertThat(captor.getValue().getName()).isEqualTo("HONDA");
         server.verify();
     }
 
@@ -187,6 +191,9 @@ class VehicleReferenceServiceTest {
         assertThat(captor.getValue().getId()).isEqualTo(UUID.nameUUIDFromBytes("make-440".getBytes()));
         assertThat(captor.getValue().getName()).isEqualTo("TOYOTA");
         assertThat(captor.getValue().getCacheTimestamp()).isEqualTo(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC));
+        // Confirms the expectation above was actually consumed — without this the test would
+        // still pass if the service returned early on some other cache path.
+        server.verify();
     }
 
     @Test
@@ -230,6 +237,8 @@ class VehicleReferenceServiceTest {
         // vPIC changing its response shape must not surface as a raw NPE from walking a
         // missing node.
         assertThatThrownBy(() -> service.getManufacturers()).isInstanceOf(RuntimeException.class);
+        // The throw must come from parsing the response, not from failing to make the call.
+        server.verify();
     }
 
     @Test


### PR DESCRIPTION
## What this does

Works the remaining items in `docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` §7: wave 1c permission-registry tests, the modules that were sitting at 0% coverage, and a factual correction to the Phase 4 write-up.

## Wave 1c — permission registries

`pos-marketing` and `pos-inventory` each get a `{Module}PermissionRegistry` test. Both read `permissions.yaml` directly (scanning for `- name:` lines rather than taking a YAML parser dependency) and assert the naming pattern `domain:resource:action` in snake_case, uniqueness, and correspondence between constants and catalog.

The correspondence assertion had to differ between the two modules, which is the part worth reviewing:

- **pos-marketing** — the two sides match one-to-one, so the test is bidirectional.
- **pos-inventory** — the catalog holds 54 entries against 29 constants, so a bidirectional assertion fails by construction. The orphan half was replaced with `everyEnforcedAuthorityIsRegistered`, which scans `src/main/java` for `hasAuthority("…")` literals and asserts each one is registered. That is the direction that actually protects production: a `@PreAuthorize` naming an unregistered authority is an endpoint no role can ever reach. It found 46 enforced authorities, all present.

The 25 catalog entries with no constant are permissions declared ahead of the code that will enforce them, not a defect. A test that failed on them would punish planning.

## The all-zero modules

| Module | Line before | Line after | Branch after | Floor set |
|---|---|---|---|---|
| `pos-vehicle-reference-carapi` | 0% | 78.3% | 88.9% | 0.73 / 0.83 |
| `pos-vehicle-reference-nhtsa` | 0% | 49.7% | 50.0% | 0.44 / 0.45 |
| `pos-image` | 0% | 31.1% | 100.0% | 0.26 / 0.95 |
| `pos-inquiry` | 0% | 0% | — | none |

Both vehicle-reference modules are 24-hour read-through caches over third-party APIs (CarAPI; NHTSA's public vPIC). The tests pin the cache contract in both directions — a fresh cache serves with **no** outbound call, asserted by registering no `MockRestServiceServer` expectation so any request fails the test; a stale cache refetches and replaces — plus the NHTSA UUID derivation `UUID.nameUUIDFromBytes("make-" + vpicId)`, which is what makes a refetch update rows rather than duplicate them.

`pos-image`'s line coverage is held down by configuration classes. The controller is the part with logic and it is fully covered, which is why the line floor is low against a high branch floor. The tests pin that a row whose file is missing from disk returns 404 — the normal state after a restore or a volume remount, and a 500 or a half-written stream without the existence check.

**`pos-inquiry` is deliberately left at 0% with no floor.** It is 16 lines of application scaffolding with no behaviour of its own. The test dependency added while investigating it has been reverted rather than shipping a context-loads test that pins nothing. It gets a floor when it gets behaviour.

## Defect found — #1265

`pos-vehicle-reference-nhtsa` inverts its own cache. `isCacheExpired` computes *"is still fresh"*, and three of its six call sites negate it on top of that, so `getVehicleVariables`, `getVehicleVariableValues` and `getVehicleTypesForMake` call vPIC on **every** request while the cache is warm, then serve permanently frozen rows once it goes stale. Two opposite failures from one helper.

This PR does **not** fix it — it pins current behaviour, so the fix lands as a visible test change rather than a silent one:

- `vehicleVariableCacheIsInverted()` documents the bug and says so in its name and comment.
- `nonNegatedMethodsCacheCorrectly()` is the contrast case showing this is a call-site inconsistency, not a broken helper.

The same helper was copied into `pos-vehicle-reference-carapi`, where both call sites omit the negation and the two mistakes cancel — correct by accident, and a trap for anyone who corrects the name alone. Both modules carry a comment pointing at #1265.

## Plan correction

§6.3 previously claimed SonarCloud was not yet wired up. It already is, via the `jacoco-coverage-reactor` artifact and `-Dsonar.coverage.jacoco.xmlReportPaths`. Corrected in place rather than quietly deleted.

## Verification

`./mvnw -o -pl pos-vehicle-reference-nhtsa,pos-vehicle-reference-carapi,pos-image,pos-inventory,pos-marketing -am -DskipTests=false verify -DskipITs` → **BUILD SUCCESS**, with the new floors active in the same run.

## Review notes

- No production code changes in this PR. Every change is a test, a `pom.xml` coverage floor, or documentation.
- The three new floors are set roughly 5 points below measured, matching the convention established in §6.2.
- Related: #1265 (filed by this work).

## Contract impact — none

`contract-sync` flags this PR because its path filters include `**/dto/**` and `**/controller/**`, and this PR adds `VehicleReferenceMapperTest` under a `dto` package and `ImageControllerTest` under a `controller` package. Both are **test** sources. No controller, DTO, schema, event or OpenAPI document is modified, so there is no contract change to mirror and no corresponding durion PR — see `BACKEND_CONTRACT_GUIDE.md` for the process this would follow if there were.

Two contract *defects* are documented by this PR, but neither is introduced or altered by it — they are pre-existing and filed for separate fixes: #1267 (`CarApiModelResponse.makeId` contradicts its own `@Schema` description) and #1265 (the inverted NHTSA cache).

## Review round 2

Copilot raised four points. Three were correct and are fixed in `432c6537`:

1. **`CarApiModelResponse.makeId` mismatch** — correct, and wider than reported. The service method `getModelsByMakeId` uses its one `UUID` argument as the primary key in two places (`findByMakeId` resolves to `make.id` through the `@JoinColumn` association; `getReferenceById` takes the PK) and as CarAPI's provider id in a third (the `?make_id=` query parameter). No argument value is correct for all three. Filed as **#1267**. The test is renamed `modelResponseCarriesInternalIdNotProviderId`, adds `isNotEqualTo(CARAPI_MAKE_ID)` so the two id spaces are visibly distinct, and states that it documents current behaviour — the same treatment #1265 already gets.
2. **`Mfr_Name` vs `Mfr_CommonName`** — correct. The test passed only because `asString("")` defaults, so it asserted a save while persisting an empty name. Stub corrected, and the test now captures the saved entity and asserts the name arrived.
3. **Missing `server.verify()`** — correct for both `nhtsaIdsHashToStableUuids` and `unparseableResponseIsWrapped`. Both now verify.

The fourth is **declined**: the `hasAuthority` regex in `InventoryPermissionRegistryTest` does not miss snake_case names. The character class is `[a-z0-9_:.-]`, which includes the underscore. The test finds 46 authorities, among them `inventory:pick_list:create`, and asserts the set is non-empty so a regex that matched nothing would fail rather than pass silently. Constraining it further to the `domain:resource:action` shape would make it match *fewer* literals, which is the wrong direction for a check whose purpose is catching enforced-but-unregistered authorities.