### PR TITLE
test: controller @WebMvcTest slices across four modules (plan §7 item 2)

### DIFF
--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -876,7 +876,8 @@ the module's entire error contract — twenty near-identical four-line handlers
 where a wrong `HttpStatus` still compiles and still returns a well-formed
 ProblemDetail.
 
-Four defects were found and filed; see below.
+Two defects were found and filed by this wave (#1269 and #1270); they join the
+standing list below.
 
 ### Defects found by this work, still open
 

--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -765,9 +765,7 @@ consumer-credited figure for shared libraries. No work is outstanding here.
 ## 7. What is still open
 
 1. ~~**Wave 1c** (`{Module}PermissionRegistry`, §3.3)~~ — closed 2026-08-12, see §7.1.
-2. **Controller `@WebMvcTest` slices** — `pos-vehicle-inventory` (~114 missed
-   across four controllers), `pos-customer` CRM controllers (~71),
-   `pos-marketing` (~30), `pos-people-contact`.
+2. ~~**Controller `@WebMvcTest` slices**~~ — closed 2026-08-12, see §7.3.
 3. ~~**The four all-zero modules**~~ — closed 2026-08-12, see §7.2.
 4. **Branch-coverage tails** — `pos-catalog` (53.5% branch against 77.4% line),
    `pos-workorder` (56.7%), `pos-document-helper` (35.2%). Parameterized tests
@@ -836,6 +834,50 @@ instead of duplicating them.
 Writing them surfaced a live defect, filed as
 louisburroughs/durion-positivity-backend#1265 and listed below.
 
+### 7.3 Controller web slices closed (2026-08-12)
+
+| Module | Line before | Line after | Branch after | Floor |
+|---|---|---|---|---|
+| `pos-vehicle-inventory` | 66.4% | 76.7% | 74.1% | 0.71 / 0.69 |
+| `pos-marketing` | 87.4% | 89.7% | 82.9% | 0.84 / 0.77 |
+| `pos-people-contact` | 64.1% | 70.1% | 55.9% | 0.65 / 0.50 |
+| `pos-customer` | 85.4% | 86.3% | 71.5% | 0.81 / 0.66 |
+
+The slices reuse each module's existing web-slice security config where one
+existed; `pos-marketing` needed its first, modelled on `pos-inventory`'s.
+Authorities arrive on `X-Authorities` exactly as the gateway supplies them
+(ADR-0011/0014), which is what makes per-endpoint permission assertions possible
+without standing up the gateway.
+
+**What these tests are for.** Three recurring shapes turned out to carry the risk,
+and they are worth naming because they recur across the reactor:
+
+1. *Sibling permissions on adjacent methods.* `pos-marketing`'s campaign
+   lifecycle splits across five authorities (create, edit, schedule, manage,
+   send) on methods that differ by one word. Nothing structural enforces the
+   split — a copy-paste between two of them is invisible after the fact. Each
+   action is therefore checked against a neighbouring authority that must *not*
+   open it, rather than only against the one that should.
+2. *Two implementations of one interface.* `pos-customer`'s `CustomerController`
+   holds two `CustomerService` fields, commercial and individual, assigned in the
+   opposite order to the constructor's parameters. Correct today; still compiles
+   if swapped, and a swap answers every question about the wrong kind of
+   customer. Same shape in `pos-people-contact`'s `PostalAddressController`,
+   where person and organization endpoints differ by one word in the path, one in
+   the `@PreAuthorize`, and one enum constant.
+3. *Verbs that disagree about null.* `pos-vehicle-inventory`'s preferences PUT
+   and PATCH both accept a null `serviceIntervalMonths` and mean opposite things
+   by it (#1175) — clear the override versus leave it alone. Both arrive as an
+   absent JSON field, so the verb is the only thing carrying the distinction.
+
+`pos-people-contact`'s `PeopleExceptionHandler` was the largest single uncovered
+class in the whole wave (58 missed lines) and is now covered exhaustively. It is
+the module's entire error contract — twenty near-identical four-line handlers
+where a wrong `HttpStatus` still compiles and still returns a well-formed
+ProblemDetail.
+
+Four defects were found and filed; see below.
+
 ### Defects found by this work, still open
 
 - louisburroughs/durion-positivity-backend#1245 — a partial customer update
@@ -853,6 +895,17 @@ louisburroughs/durion-positivity-backend#1265 and listed below.
   The same helper is copied into `pos-vehicle-reference-carapi`, where both call
   sites happen to cancel out — correct by accident, and a trap for anyone who
   fixes the name alone.
+- louisburroughs/durion-positivity-backend#1269 — `pos-vehicle-inventory` has no
+  `@ControllerAdvice` at all, so a wrong-length VIN on `@Validated`
+  `GET /vin/{vin}` raises `ConstraintViolationException` and surfaces as 500, and
+  no error from the module carries the `ApiError` envelope required by
+  `docs/ERROR_ENVELOPE.md` — every error return is a bare status with an empty
+  body.
+- louisburroughs/durion-positivity-backend#1270 — `POST /v1/vehicles/search` is
+  broken for every request: `SearchVehiclesRequest` is `@Builder` with final
+  fields and no `@Jacksonized`, so Jackson has no creator and message conversion
+  fails before the controller is entered. The GET route builds the object in
+  Java, which is why nothing caught it.
 - louisburroughs/durion-positivity-backend#1267 — `pos-vehicle-reference-carapi`
   conflates its own primary key with CarAPI's make id inside one method, so no
   argument to `GET /models/{makeId}` is correct for all three of its uses; the

--- a/pos-customer/pom.xml
+++ b/pos-customer/pom.xml
@@ -13,7 +13,8 @@
     <description>POS Customer Module</description>
 
     <properties>
-        <!-- Coverage ratchet (plan Phase 4): measured 85.9% line / 70.6% branch.
+        <!-- Coverage ratchet (plan Phase 4): measured 86.3% line / 71.5% branch after the
+             §7 controller web-slice wave (was 85.4% / 70.6%).
              Floors sit ~5 points under to catch regression without failing on noise. -->
         <jacoco.line.min>0.81</jacoco.line.min>
         <jacoco.branch.min>0.66</jacoco.branch.min>

--- a/pos-customer/pom.xml
+++ b/pos-customer/pom.xml
@@ -15,8 +15,8 @@
     <properties>
         <!-- Coverage ratchet (plan Phase 4): measured 85.9% line / 70.6% branch.
              Floors sit ~5 points under to catch regression without failing on noise. -->
-        <jacoco.line.min>0.80</jacoco.line.min>
-        <jacoco.branch.min>0.65</jacoco.branch.min>
+        <jacoco.line.min>0.81</jacoco.line.min>
+        <jacoco.branch.min>0.66</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
 

--- a/pos-customer/src/test/java/com/positivity/customer/internal/controller/CustomerControllerWebMvcTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/controller/CustomerControllerWebMvcTest.java
@@ -1,0 +1,275 @@
+package com.positivity.customer.internal.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.customer.config.WebMvcTestSecurityConfig;
+import com.positivity.customer.internal.config.CrmExceptionHandler;
+import com.positivity.customer.internal.dto.CustomerDTO;
+import com.positivity.customer.internal.service.CommercialPartyServiceImpl;
+import com.positivity.customer.internal.service.PersonPartyServiceImpl;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Web-slice tests for {@link CustomerController}.
+ *
+ * <p>
+ * This controller fronts two implementations of the same interface — one for
+ * commercial parties, one for individuals — and picks between them per request.
+ * Three things make that worth testing at the web layer rather than trusting:
+ *
+ * <ul>
+ * <li>Both dependencies are {@code CustomerService}, so the fields are
+ * type-identical. The constructor takes them in the opposite order to the order
+ * it assigns them, which is correct today and would still compile if it were
+ * not. Swapping them produces a service that answers every question about the
+ * wrong kind of customer.</li>
+ * <li>Routing is {@code "COMMERCIAL".equalsIgnoreCase(customerType)}, so
+ * anything that is not exactly that word — including a typo — silently falls
+ * through to the individual side rather than being rejected.</li>
+ * <li>Lookup by id tries commercial first and falls back to individual, so the
+ * two are not symmetric even though the rest of the controller treats them as
+ * if they were.</li>
+ * </ul>
+ */
+@WebMvcTest(CustomerController.class)
+@Import({WebMvcTestSecurityConfig.class, CrmExceptionHandler.class})
+@ActiveProfiles("test")
+@SuppressWarnings({"java:S6813", "java:S100", "java:S1192"})
+@DisplayName("CustomerController — commercial/individual routing")
+class CustomerControllerWebMvcTest {
+
+    private static final UUID CUSTOMER_ID = UUID.fromString("00000000-0000-0000-0000-0000000000f1");
+    private static final String PATH = "/v1/crm";
+    private static final String AUTHORITIES = "X-Authorities";
+    private static final String VIEW = "crm:party:view";
+    private static final String CREATE = "crm:party:create";
+    private static final String EDIT = "crm:party:edit";
+    private static final String DEACTIVATE = "crm:party:deactivate";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    java.time.Clock clock;
+
+    @MockitoBean
+    CommercialPartyServiceImpl commercialService;
+
+    @MockitoBean
+    PersonPartyServiceImpl personService;
+
+    private static CustomerDTO customer(String type) {
+        return CustomerDTO.builder()
+                .id(CUSTOMER_ID)
+                .customerNumber("C-1001")
+                .firstName("Jane")
+                .lastName("Smith")
+                .customerType(type)
+                .build();
+    }
+
+    private static Page<CustomerDTO> page(String type) {
+        return new PageImpl<>(List.of(customer(type)));
+    }
+
+    @ParameterizedTest(name = "customerType={0} routes to the commercial service")
+    @ValueSource(strings = {"COMMERCIAL", "commercial", "Commercial"})
+    @DisplayName("only the exact word COMMERCIAL, in any case, reaches the commercial service")
+    void commercialTypeRoutesToCommercialService(String type) throws Exception {
+        when(commercialService.getAllCustomers(any(Pageable.class))).thenReturn(page("COMMERCIAL"));
+
+        mockMvc.perform(get(PATH).param("customerType", type).header(AUTHORITIES, VIEW))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].customerType").value("COMMERCIAL"));
+
+        verify(commercialService).getAllCustomers(any(Pageable.class));
+        verifyNoInteractions(personService);
+    }
+
+    @ParameterizedTest(name = "customerType={0} falls through to the individual service")
+    @ValueSource(strings = {"PERSON", "COMERCIAL", "business", ""})
+    @DisplayName("anything that is not COMMERCIAL falls through to individuals, including a typo")
+    void everythingElseRoutesToPersonService(String type) throws Exception {
+        when(personService.getAllCustomers(any(Pageable.class))).thenReturn(page("PERSON"));
+
+        mockMvc.perform(get(PATH).param("customerType", type).header(AUTHORITIES, VIEW))
+                .andExpect(status().isOk());
+
+        // "COMERCIAL" is the case worth staring at. A caller who misspells the type is not
+        // told so — they are quietly served the individual customer list, which looks like a
+        // real answer and is the wrong one. Pinned as current behaviour; making it a 400 would
+        // be a contract change, not a bug fix.
+        verify(personService).getAllCustomers(any(Pageable.class));
+        verifyNoInteractions(commercialService);
+    }
+
+    @Test
+    @DisplayName("with no customerType at all, the default is individuals")
+    void defaultTypeIsPerson() throws Exception {
+        when(personService.getAllCustomers(any(Pageable.class))).thenReturn(page("PERSON"));
+
+        mockMvc.perform(get(PATH).header(AUTHORITIES, VIEW)).andExpect(status().isOk());
+
+        verify(personService).getAllCustomers(any(Pageable.class));
+        verifyNoInteractions(commercialService);
+    }
+
+    @ParameterizedTest(name = "name={0} email={1} searches rather than lists")
+    @CsvSource({"Smith,", ",jane@example.com", "Smith,jane@example.com"})
+    @DisplayName("a name or email filter switches the list endpoint into a search")
+    void filtersSwitchToSearch(String name, String email) throws Exception {
+        when(personService.searchCustomers(any(), any(), any(Pageable.class))).thenReturn(page("PERSON"));
+
+        var request = get(PATH).header(AUTHORITIES, VIEW);
+        if (name != null) {
+            request = request.param("name", name);
+        }
+        if (email != null) {
+            request = request.param("email", email);
+        }
+
+        mockMvc.perform(request).andExpect(status().isOk());
+
+        // Either filter alone is enough; the two are an OR, not an AND.
+        verify(personService).searchCustomers(any(), any(), any(Pageable.class));
+        verify(personService, never()).getAllCustomers(any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("a blank filter is not a filter — it still lists rather than searching")
+    void blankFilterStillLists() throws Exception {
+        when(personService.getAllCustomers(any(Pageable.class))).thenReturn(page("PERSON"));
+
+        // A UI that always sends its search box, empty or not, must not be pushed down the
+        // search path on every page load.
+        mockMvc.perform(get(PATH).param("name", "   ").header(AUTHORITIES, VIEW))
+                .andExpect(status().isOk());
+
+        verify(personService).getAllCustomers(any(Pageable.class));
+        verify(personService, never()).searchCustomers(any(), any(), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("lookup by id tries commercial first and falls back to individual")
+    void lookupFallsBackFromCommercialToPerson() throws Exception {
+        when(commercialService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.empty());
+        when(personService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.of(customer("PERSON")));
+
+        mockMvc.perform(get(PATH + "/" + CUSTOMER_ID).header(AUTHORITIES, VIEW))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.customerType").value("PERSON"));
+
+        // Unlike every other endpoint here, this one does not take a type — it asks both. The
+        // order is the contract: commercial wins if an id somehow resolves on both sides.
+        verify(commercialService).getCustomerById(CUSTOMER_ID);
+        verify(personService).getCustomerById(CUSTOMER_ID);
+    }
+
+    @Test
+    @DisplayName("an id known to neither side is a 404")
+    void unknownIdIsNotFound() throws Exception {
+        when(commercialService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.empty());
+        when(personService.getCustomerById(CUSTOMER_ID)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get(PATH + "/" + CUSTOMER_ID).header(AUTHORITIES, VIEW)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("create routes on the body's customerType, not a query parameter")
+    void createRoutesOnBodyType() throws Exception {
+        when(commercialService.createCustomer(any())).thenReturn(customer("COMMERCIAL"));
+
+        mockMvc.perform(post(PATH)
+                        .header(AUTHORITIES, CREATE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"customerType\":\"COMMERCIAL\",\"firstName\":\"Jane\",\"lastName\":\"Smith\"}"))
+                .andExpect(status().isCreated());
+
+        verify(commercialService).createCustomer(any());
+        verify(personService, never()).createCustomer(any());
+    }
+
+    @ParameterizedTest(name = "{0} is refused to a holder of {1}")
+    @CsvSource({
+        "create,     crm:party:view",
+        "update,     crm:party:view",
+        "deactivate, crm:party:edit",
+    })
+    @DisplayName("each write is gated on its own authority, and viewing grants none of them")
+    void writesAreGatedIndividually(String action, String insufficient) throws Exception {
+        String body = "{\"customerType\":\"PERSON\",\"firstName\":\"Jane\",\"lastName\":\"Smith\"}";
+
+        switch (action) {
+            case "create" ->
+                mockMvc.perform(post(PATH)
+                                .header(AUTHORITIES, insufficient)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body))
+                        .andExpect(status().isForbidden());
+            case "update" ->
+                mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put(
+                                        PATH + "/" + CUSTOMER_ID)
+                                .header(AUTHORITIES, insufficient)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body))
+                        .andExpect(status().isForbidden());
+            // Deactivating is refused to someone who may edit: removing a customer from
+            // circulation is a heavier act than correcting their details.
+            default ->
+                mockMvc.perform(delete(PATH + "/" + CUSTOMER_ID).header(AUTHORITIES, insufficient))
+                        .andExpect(status().isForbidden());
+        }
+
+        verifyNoInteractions(commercialService);
+        verifyNoInteractions(personService);
+    }
+
+    @Test
+    @DisplayName("deactivating with the right authority answers 204")
+    void deactivateReturnsNoContent() throws Exception {
+        when(personService.deleteCustomer(eq(CUSTOMER_ID))).thenReturn(true);
+
+        mockMvc.perform(delete(PATH + "/" + CUSTOMER_ID).header(AUTHORITIES, DEACTIVATE))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("updating with the right authority reaches the individual service")
+    void updateReachesService() throws Exception {
+        when(personService.updateCustomer(eq(CUSTOMER_ID), any())).thenReturn(Optional.of(customer("PERSON")));
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put(
+                                PATH + "/" + CUSTOMER_ID)
+                        .header(AUTHORITIES, EDIT)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"customerType\":\"PERSON\",\"firstName\":\"Jane\",\"lastName\":\"Smith\"}"))
+                .andExpect(status().isOk());
+    }
+}

--- a/pos-marketing/pom.xml
+++ b/pos-marketing/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <!-- Coverage ratchet (plan Phase 4): measured 87.9% line / 82.9% branch.
              Floors sit ~5 points under to catch regression without failing on noise. -->
-        <jacoco.line.min>0.82</jacoco.line.min>
+        <jacoco.line.min>0.84</jacoco.line.min>
         <jacoco.branch.min>0.77</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>

--- a/pos-marketing/pom.xml
+++ b/pos-marketing/pom.xml
@@ -14,7 +14,8 @@
     <description>POS Marketing module: campaigns, templates, audience binding, and send orchestration</description>
 
     <properties>
-        <!-- Coverage ratchet (plan Phase 4): measured 87.9% line / 82.9% branch.
+        <!-- Coverage ratchet (plan Phase 4): measured 89.7% line / 82.9% branch after the
+             §7 controller web-slice wave (was 87.4% / 82.1%).
              Floors sit ~5 points under to catch regression without failing on noise. -->
         <jacoco.line.min>0.84</jacoco.line.min>
         <jacoco.branch.min>0.77</jacoco.branch.min>

--- a/pos-marketing/src/test/java/com/positivity/marketing/config/TestSecurityConfig.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/config/TestSecurityConfig.java
@@ -1,0 +1,108 @@
+package com.positivity.marketing.config;
+
+import com.positivity.security.common.GatewaySecurityConstants;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Web-slice security for pos-marketing, mirroring the equivalent config in
+ * pos-inventory.
+ *
+ * <p>
+ * The gateway is the real authenticator (ADR-0011/0014); downstream services
+ * only ever see the authorities it decoded into {@code X-Authorities}. This
+ * config reproduces exactly that: a request's authorities come from the header,
+ * so a test can grant one specific permission and check that an endpoint gated
+ * on a different one refuses it. Without the header the request gets the full
+ * set, which keeps tests that are not about authorization short.
+ */
+@TestConfiguration(proxyBeanMethods = false)
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+@Profile("test")
+public class TestSecurityConfig {
+
+    private static final List<SimpleGrantedAuthority> TEST_AUTHORITIES = List.of(
+            new SimpleGrantedAuthority("marketing:campaign:view"),
+            new SimpleGrantedAuthority("marketing:campaign:create"),
+            new SimpleGrantedAuthority("marketing:campaign:edit"),
+            new SimpleGrantedAuthority("marketing:campaign:schedule"),
+            new SimpleGrantedAuthority("marketing:campaign:manage"),
+            new SimpleGrantedAuthority("marketing:campaign:send"),
+            new SimpleGrantedAuthority("marketing:template:view"),
+            new SimpleGrantedAuthority("marketing:template:manage"),
+            new SimpleGrantedAuthority("marketing:stats:view"));
+
+    @Bean(name = "gatewaySecurityFilterChain")
+    @Primary
+    public SecurityFilterChain gatewaySecurityFilterChain(HttpSecurity http) {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new TestAutoAuthFilter(), UsernamePasswordAuthenticationFilter.class)
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+
+    @Bean
+    @Primary
+    @SuppressWarnings("java:S1874")
+    public UserDetailsService testUserDetailsService() {
+        var user = User.withUsername("test-user")
+                .password("{noop}local-test-password-9xA7")
+                .authorities(TEST_AUTHORITIES)
+                .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    private static class TestAutoAuthFilter extends OncePerRequestFilter {
+        @Override
+        protected void doFilterInternal(
+                HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+                throws ServletException, IOException {
+            String headerAuthorities = request.getHeader("X-Authorities");
+            List<SimpleGrantedAuthority> authorities = headerAuthorities == null || headerAuthorities.isBlank()
+                    ? TEST_AUTHORITIES
+                    : Arrays.stream(headerAuthorities.split(","))
+                            .map(String::trim)
+                            .filter(value -> !value.isBlank())
+                            .map(SimpleGrantedAuthority::new)
+                            .toList();
+
+            String headerUser = request.getHeader("X-User");
+            String username = (headerUser != null && !headerUser.isBlank()) ? headerUser : "test-user";
+
+            var authentication = new UsernamePasswordAuthenticationToken(username, null, authorities);
+            // Mirror the gateway filter: SecurityContextHelper resolves the audit
+            // username from the authentication details map (ADR-0018).
+            authentication.setDetails(Map.of(GatewaySecurityConstants.DETAIL_USERNAME, username));
+            Authentication existing = SecurityContextHolder.getContext().getAuthentication();
+            if (existing == null || !existing.isAuthenticated()) {
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+            filterChain.doFilter(request, response);
+        }
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/controller/CampaignControllerWebMvcTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/controller/CampaignControllerWebMvcTest.java
@@ -1,0 +1,203 @@
+package com.positivity.marketing.internal.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.marketing.config.TestSecurityConfig;
+import com.positivity.marketing.internal.dto.CampaignResponse;
+import com.positivity.marketing.service.CampaignSendService;
+import com.positivity.marketing.service.CampaignService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Web-slice tests for {@link CampaignController}.
+ *
+ * <p>
+ * The campaign lifecycle is split across five separate permissions —
+ * {@code schedule}, {@code manage} (pause/resume/cancel), {@code send},
+ * {@code create} and {@code edit} — and that split is the whole point of the
+ * design: whoever may pause a running campaign is deliberately not whoever may
+ * push it to real customers. Nothing about the endpoints themselves enforces
+ * that; it lives entirely in one {@code @PreAuthorize} string per method, where
+ * a copy-paste between two adjacent lifecycle actions is both easy and
+ * invisible. These tests check each action against a neighbouring authority that
+ * must <em>not</em> open it.
+ */
+@WebMvcTest(CampaignController.class)
+@Import(TestSecurityConfig.class)
+@ActiveProfiles("test")
+@SuppressWarnings({"java:S6813", "java:S100", "java:S1192"})
+@DisplayName("CampaignController — web slice")
+class CampaignControllerWebMvcTest {
+
+    private static final UUID CAMPAIGN_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final String PATH = "/v1/marketing/campaigns";
+    private static final String AUTHORITIES = "X-Authorities";
+    private static final String VIEW = "marketing:campaign:view";
+    private static final String MANAGE = "marketing:campaign:manage";
+    private static final String SEND = "marketing:campaign:send";
+    private static final String SCHEDULE = "marketing:campaign:schedule";
+    private static final String VALID_CREATE_BODY = """
+            {"code":"SPRING-FLEET-2026","name":"Spring fleet service",
+             "audienceType":"COMMERCIAL","channels":["EMAIL"]}""";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    java.time.Clock clock;
+
+    @MockitoBean
+    CampaignService campaignService;
+
+    @MockitoBean
+    CampaignSendService campaignSendService;
+
+    private static CampaignResponse campaign(String status) {
+        return new CampaignResponse(
+                CAMPAIGN_ID,
+                "SPRING-FLEET-2026",
+                "Spring fleet service",
+                "Seasonal reminder",
+                "COMMERCIAL",
+                null,
+                status,
+                Set.of("EMAIL"),
+                null,
+                null,
+                null,
+                null,
+                null,
+                "IMMEDIATE",
+                null,
+                null,
+                null,
+                Instant.parse("2026-08-01T00:00:00Z"),
+                Instant.parse("2026-08-01T00:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("GET lists campaigns for a holder of campaign:view")
+    void listReturnsCampaigns() throws Exception {
+        when(campaignService.list(null, null)).thenReturn(List.of(campaign("DRAFT")));
+
+        mockMvc.perform(get(PATH).header(AUTHORITIES, VIEW))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].campaignId").value(CAMPAIGN_ID.toString()))
+                .andExpect(jsonPath("$[0].status").value("DRAFT"));
+    }
+
+    @ParameterizedTest(name = "{0} requires {1}, and {2} does not open it")
+    @CsvSource({
+        "schedule, marketing:campaign:schedule, marketing:campaign:manage",
+        "pause,    marketing:campaign:manage,   marketing:campaign:schedule",
+        "resume,   marketing:campaign:manage,   marketing:campaign:view",
+        "cancel,   marketing:campaign:manage,   marketing:campaign:send",
+    })
+    @DisplayName("each lifecycle action is gated on its own authority")
+    void lifecycleActionsAreGatedIndividually(String action, String required, String insufficient) throws Exception {
+        when(campaignService.schedule(CAMPAIGN_ID)).thenReturn(campaign("SCHEDULED"));
+        when(campaignService.pause(CAMPAIGN_ID)).thenReturn(campaign("PAUSED"));
+        when(campaignService.resume(CAMPAIGN_ID)).thenReturn(campaign("SENDING"));
+        when(campaignService.cancel(CAMPAIGN_ID)).thenReturn(campaign("CANCELLED"));
+
+        String url = PATH + "/" + CAMPAIGN_ID + "/" + action;
+
+        mockMvc.perform(post(url).header(AUTHORITIES, required)).andExpect(status().isOk());
+
+        // The negative case is the one that matters. Every one of these authorities is a
+        // plausible thing for the same operator to hold, so a mistyped @PreAuthorize would let
+        // the action through and no positive test would notice.
+        mockMvc.perform(post(url).header(AUTHORITIES, insufficient)).andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("sending is gated on campaign:send, which managing a campaign does not grant")
+    void sendRequiresItsOwnAuthority() throws Exception {
+        when(campaignSendService.dispatch(CAMPAIGN_ID)).thenReturn(42);
+
+        // Dispatch is the only action here that reaches real customers, which is why it has an
+        // authority of its own rather than riding on :manage.
+        mockMvc.perform(post(PATH + "/" + CAMPAIGN_ID + "/send").header(AUTHORITIES, MANAGE))
+                .andExpect(status().isForbidden());
+        verify(campaignSendService, never()).dispatch(any());
+
+        mockMvc.perform(post(PATH + "/" + CAMPAIGN_ID + "/send").header(AUTHORITIES, SEND))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.queued").value(42))
+                .andExpect(jsonPath("$.campaignId").value(CAMPAIGN_ID.toString()));
+    }
+
+    @Test
+    @DisplayName("dispatch answers 202, not 200 — the sends are queued, not completed")
+    void dispatchIsAccepted() throws Exception {
+        when(campaignSendService.dispatch(CAMPAIGN_ID)).thenReturn(0);
+
+        // 202 is the honest status: the endpoint hands work to the send worker and returns. A
+        // 200 would tell the caller the messages had gone out.
+        mockMvc.perform(post(PATH + "/" + CAMPAIGN_ID + "/send").header(AUTHORITIES, SEND))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.queued").value(0));
+    }
+
+    @Test
+    @DisplayName("audience preview is a read, gated on campaign:view rather than a send authority")
+    void audiencePreviewIsGatedAsARead() throws Exception {
+        // Previewing must not require the authority to actually send — checking who would
+        // receive a campaign is exactly what someone does before asking for approval.
+        mockMvc.perform(post(PATH + "/" + CAMPAIGN_ID + "/audience-preview").header(AUTHORITIES, SEND))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(campaignService);
+    }
+
+    @Test
+    @DisplayName("creating a campaign is refused to a holder of schedule alone")
+    void createRequiresCreateAuthority() throws Exception {
+        mockMvc.perform(post(PATH)
+                        .header(AUTHORITIES, SCHEDULE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_CREATE_BODY))
+                .andExpect(status().isForbidden());
+
+        verify(campaignService, never()).create(any());
+    }
+
+    @Test
+    @DisplayName("an invalid body is rejected as 400 before authorization is even considered")
+    void bodyValidationRunsBeforeAuthorization() throws Exception {
+        // Argument resolution happens before the method-security interceptor, so a caller with
+        // no relevant authority at all still gets 400 rather than 403 when the body is
+        // malformed. Worth pinning because it is the opposite of what the annotation order on
+        // the method suggests, and because it means the shape of a rejection tells an
+        // unauthorized caller whether their payload was well-formed.
+        mockMvc.perform(post(PATH)
+                        .header(AUTHORITIES, VIEW)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"code\":\"SPRING\"}"))
+                .andExpect(status().isBadRequest());
+
+        verify(campaignService, never()).create(any());
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/controller/MarketingReadControllersWebMvcTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/controller/MarketingReadControllersWebMvcTest.java
@@ -1,0 +1,161 @@
+package com.positivity.marketing.internal.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.marketing.config.TestSecurityConfig;
+import com.positivity.marketing.internal.dto.MessageTemplateResponse;
+import com.positivity.marketing.service.CampaignStatsService;
+import com.positivity.marketing.service.MessageTemplateService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Web-slice tests for {@link MessageTemplateController} and
+ * {@link CampaignStatsController}.
+ *
+ * <p>
+ * Templates split into {@code template:view} and {@code template:manage}, and
+ * the split matters more than it looks: a message template is the text that goes
+ * out to customers under the company's name, so editing one is a content-
+ * publishing act, while reading one is not. Statistics sit behind their own
+ * {@code stats:view} rather than riding on {@code campaign:view}, because
+ * campaign statistics are per-recipient delivery outcomes — who opened, who
+ * bounced, who complained — and that is a narrower audience than whoever may
+ * look at a campaign's configuration.
+ */
+@WebMvcTest({MessageTemplateController.class, CampaignStatsController.class})
+@Import(TestSecurityConfig.class)
+@ActiveProfiles("test")
+@SuppressWarnings({"java:S6813", "java:S100", "java:S1192"})
+@DisplayName("Marketing template and stats controllers — web slice")
+class MarketingReadControllersWebMvcTest {
+
+    private static final UUID TEMPLATE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b1");
+    private static final UUID CAMPAIGN_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b2");
+    private static final String TEMPLATES = "/v1/marketing/templates";
+    private static final String AUTHORITIES = "X-Authorities";
+    private static final String TEMPLATE_VIEW = "marketing:template:view";
+    private static final String TEMPLATE_MANAGE = "marketing:template:manage";
+    private static final String STATS_VIEW = "marketing:stats:view";
+    private static final String CAMPAIGN_VIEW = "marketing:campaign:view";
+    private static final String VALID_TEMPLATE_BODY = """
+            {"name":"Spring reminder","channel":"EMAIL","audienceType":"COMMERCIAL",
+             "subject":"Time for your spring service","body":"Hello {{firstName}}"}""";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    java.time.Clock clock;
+
+    @MockitoBean
+    MessageTemplateService messageTemplateService;
+
+    @MockitoBean
+    CampaignStatsService campaignStatsService;
+
+    private static MessageTemplateResponse template() {
+        return new MessageTemplateResponse(
+                TEMPLATE_ID,
+                "Spring reminder",
+                "EMAIL",
+                "COMMERCIAL",
+                "Time for your spring service",
+                "Hello {{firstName}}",
+                Set.of("firstName"),
+                Instant.parse("2026-08-01T00:00:00Z"),
+                Instant.parse("2026-08-01T00:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("GET lists templates for a holder of template:view")
+    void listTemplates() throws Exception {
+        when(messageTemplateService.list(null, null)).thenReturn(List.of(template()));
+
+        mockMvc.perform(get(TEMPLATES).header(AUTHORITIES, TEMPLATE_VIEW))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].templateId").value(TEMPLATE_ID.toString()))
+                .andExpect(jsonPath("$[0].availableTokens[0]").value("firstName"));
+    }
+
+    @Test
+    @DisplayName("GET one template exposes the token list a caller needs to fill it in")
+    void getTemplate() throws Exception {
+        when(messageTemplateService.get(TEMPLATE_ID)).thenReturn(template());
+
+        mockMvc.perform(get(TEMPLATES + "/" + TEMPLATE_ID).header(AUTHORITIES, TEMPLATE_VIEW))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subject").value("Time for your spring service"))
+                .andExpect(jsonPath("$.body").value("Hello {{firstName}}"));
+    }
+
+    @Test
+    @DisplayName("editing a template needs template:manage — reading it is not enough")
+    void editingRequiresManage() throws Exception {
+        // Changing a template changes what real customers receive, under the company's name.
+        // Read access to the template library must not carry that.
+        mockMvc.perform(post(TEMPLATES)
+                        .header(AUTHORITIES, TEMPLATE_VIEW)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_TEMPLATE_BODY))
+                .andExpect(status().isForbidden());
+
+        verify(messageTemplateService, never()).create(any());
+    }
+
+    @Test
+    @DisplayName("deleting a template needs template:manage and answers 204")
+    void deleteRequiresManage() throws Exception {
+        mockMvc.perform(delete(TEMPLATES + "/" + TEMPLATE_ID).header(AUTHORITIES, TEMPLATE_VIEW))
+                .andExpect(status().isForbidden());
+        verify(messageTemplateService, never()).delete(any());
+
+        mockMvc.perform(delete(TEMPLATES + "/" + TEMPLATE_ID).header(AUTHORITIES, TEMPLATE_MANAGE))
+                .andExpect(status().isNoContent());
+        verify(messageTemplateService).delete(TEMPLATE_ID);
+    }
+
+    @Test
+    @DisplayName("campaign statistics need stats:view, which campaign:view does not grant")
+    void statsAreGatedSeparatelyFromCampaigns() throws Exception {
+        // Delivery outcomes are per-recipient: who opened, who bounced, who complained. Being
+        // allowed to read a campaign's configuration is not the same as being allowed to read
+        // that, so the two permissions are deliberately distinct.
+        mockMvc.perform(get("/v1/marketing/campaigns/" + CAMPAIGN_ID + "/stats").header(AUTHORITIES, CAMPAIGN_VIEW))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(campaignStatsService);
+    }
+
+    @Test
+    @DisplayName("program statistics are gated on the same stats:view")
+    void programStatsUseTheSameAuthority() throws Exception {
+        mockMvc.perform(get("/v1/marketing/programs/" + CAMPAIGN_ID + "/stats").header(AUTHORITIES, TEMPLATE_VIEW))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/v1/marketing/programs/" + CAMPAIGN_ID + "/stats").header(AUTHORITIES, STATS_VIEW))
+                .andExpect(status().isOk());
+
+        verify(campaignStatsService).programStats(CAMPAIGN_ID);
+    }
+}

--- a/pos-people-contact/pom.xml
+++ b/pos-people-contact/pom.xml
@@ -15,8 +15,8 @@
     <properties>
         <!-- Coverage ratchet (plan Phase 4): measured 65.2% line / 52.3% branch.
              Floors sit ~5 points under to catch regression without failing on noise. -->
-        <jacoco.line.min>0.60</jacoco.line.min>
-        <jacoco.branch.min>0.47</jacoco.branch.min>
+        <jacoco.line.min>0.65</jacoco.line.min>
+        <jacoco.branch.min>0.50</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
 

--- a/pos-people-contact/pom.xml
+++ b/pos-people-contact/pom.xml
@@ -13,7 +13,8 @@
     <description>Identity/contact/user-link authority module (ADR-0044 Phase 3)</description>
 
     <properties>
-        <!-- Coverage ratchet (plan Phase 4): measured 65.2% line / 52.3% branch.
+        <!-- Coverage ratchet (plan Phase 4): measured 70.1% line / 55.9% branch after the
+             §7 controller web-slice wave (was 64.1% / 52.3%).
              Floors sit ~5 points under to catch regression without failing on noise. -->
         <jacoco.line.min>0.65</jacoco.line.min>
         <jacoco.branch.min>0.50</jacoco.branch.min>

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/controller/PeopleExceptionHandlerTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/controller/PeopleExceptionHandlerTest.java
@@ -1,0 +1,275 @@
+package com.positivity.peoplecontact.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.peoplecontact.internal.client.SecurityServiceException;
+import com.positivity.peoplecontact.internal.exception.NotFoundException;
+import com.positivity.peoplecontact.internal.exception.PersonHasLinkedUsersException;
+import com.positivity.peoplecontact.internal.exception.PersonNotFoundException;
+import com.positivity.peoplecontact.internal.exception.SemanticValidationException;
+import com.positivity.peoplecontact.internal.exception.UserAlreadyLinkedException;
+import com.positivity.peoplecontact.internal.exception.UserPersonLinkNotFoundException;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.FieldSource;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Tests for {@link PeopleExceptionHandler}, the module's whole error contract.
+ *
+ * <p>
+ * Every failure this service can produce passes through one of these methods, so
+ * the exception-to-status table <em>is</em> the API's error surface — a caller
+ * branches on 404 versus 409 versus 422 and cannot see anything else. The
+ * mapping is also the easiest thing in the module to get subtly wrong: the
+ * handlers are near-identical four-line blocks, so a copy-paste that leaves the
+ * wrong {@code HttpStatus} behind still compiles, still returns a well-formed
+ * ProblemDetail, and simply lies about what happened. The table below is checked
+ * exhaustively for that reason.
+ *
+ * <p>
+ * Three distinctions in it carry real meaning and are called out individually
+ * below: 409 versus 404 on delete, 422 versus 400 on validation, and the
+ * catch-all's refusal to echo the underlying message.
+ */
+@DisplayName("PeopleExceptionHandler — the module's error contract")
+class PeopleExceptionHandlerTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-12T09:15:00Z");
+    private static final UUID PERSON_ID = UUID.fromString("00000000-0000-0000-0000-0000000000d1");
+
+    private final PeopleExceptionHandler handler = new PeopleExceptionHandler(Clock.fixed(NOW, ZoneOffset.UTC));
+
+    /**
+     * Each case is a supplier of one exception plus the status it must produce.
+     * Held as a field so the mapping reads as a table rather than as prose.
+     */
+    static final List<org.junit.jupiter.params.provider.Arguments> mappings = List.of(
+            args("PersonNotFoundException", new PersonNotFoundException(PERSON_ID), HttpStatus.NOT_FOUND),
+            args(
+                    "UserPersonLinkNotFoundException",
+                    new UserPersonLinkNotFoundException("jsmith"),
+                    HttpStatus.NOT_FOUND),
+            args("NotFoundException", new NotFoundException("no such thing"), HttpStatus.NOT_FOUND),
+            args("EntityNotFoundException", new EntityNotFoundException("gone"), HttpStatus.NOT_FOUND),
+            args("PersonHasLinkedUsersException", new PersonHasLinkedUsersException(PERSON_ID), HttpStatus.CONFLICT),
+            args("UserAlreadyLinkedException", new UserAlreadyLinkedException("jsmith"), HttpStatus.CONFLICT),
+            args("IllegalStateException", new IllegalStateException("wrong state"), HttpStatus.CONFLICT),
+            args("IllegalArgumentException", new IllegalArgumentException("bad input"), HttpStatus.BAD_REQUEST),
+            args(
+                    "SemanticValidationException",
+                    new SemanticValidationException("start after end"),
+                    HttpStatus.UNPROCESSABLE_CONTENT),
+            args("AccessDeniedException", new AccessDeniedException("nope"), HttpStatus.FORBIDDEN));
+
+    private static org.junit.jupiter.params.provider.Arguments args(
+            String name, Exception exception, HttpStatus expected) {
+        return org.junit.jupiter.params.provider.Arguments.of(name, exception, expected);
+    }
+
+    private ProblemDetail dispatch(Exception exception) {
+        // Mirrors what @ExceptionHandler resolution does, without standing up an MVC context.
+        return switch (exception) {
+            case PersonNotFoundException e -> handler.handlePersonNotFound(e);
+            case UserPersonLinkNotFoundException e -> handler.handleLinkNotFound(e);
+            case PersonHasLinkedUsersException e -> handler.handlePersonHasLinkedUsers(e);
+            case UserAlreadyLinkedException e -> handler.handleUserAlreadyLinked(e);
+            case NotFoundException e -> handler.handleNotFound(e);
+            case EntityNotFoundException e -> handler.handleEntityNotFound(e);
+            case SemanticValidationException e -> handler.handleSemanticValidation(e);
+            case AccessDeniedException e -> handler.handleAccessDenied(e);
+            case IllegalStateException e -> handler.handleIllegalState(e);
+            case IllegalArgumentException e -> handler.handleIllegalArgument(e);
+            default -> handler.handleUnexpectedException(exception);
+        };
+    }
+
+    @ParameterizedTest(name = "{0} → {2}")
+    @FieldSource("mappings")
+    @DisplayName("every handled exception maps to its documented status")
+    void exceptionsMapToStatuses(String name, Exception exception, HttpStatus expected) {
+        ProblemDetail problem = dispatch(exception);
+
+        assertThat(problem.getStatus()).as(name).isEqualTo(expected.value());
+        // Every response carries a timestamp from the injected Clock, not from wall time — the
+        // reason the handler takes a Clock at all is so this is assertable.
+        assertThat(problem.getProperties()).containsEntry("timestamp", NOW);
+    }
+
+    @Test
+    @DisplayName("deleting a person who still has linked users is a 409 that says how to proceed")
+    void personWithLinkedUsersIsAConflictWithNextAction() {
+        ProblemDetail problem = handler.handlePersonHasLinkedUsers(new PersonHasLinkedUsersException(PERSON_ID));
+
+        // 409 rather than 404 or 400: the person exists and the request is well-formed, it is
+        // the current state that forbids the delete. The nextAction is the difference between
+        // a caller retrying blindly and a caller unlinking first.
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(problem.getProperties()).containsEntry("nextAction", PersonHasLinkedUsersException.NEXT_ACTION);
+    }
+
+    @Test
+    @DisplayName("a semantically invalid but well-formed request is 422, not 400")
+    void semanticValidationIsUnprocessable() {
+        ProblemDetail problem = handler.handleSemanticValidation(new SemanticValidationException("start after end"));
+
+        // 400 says "I could not parse this"; 422 says "I understood it and it is wrong". A
+        // client retrying a 400 changes its syntax, a client retrying a 422 changes its data.
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT.value());
+        assertThat(problem.getDetail()).isEqualTo("start after end");
+    }
+
+    @Test
+    @DisplayName("the catch-all reports a generic message rather than the exception's own")
+    void unexpectedExceptionDoesNotLeakItsMessage() {
+        ProblemDetail problem =
+                handler.handleUnexpectedException(new RuntimeException("jdbc://user:hunter2@db/people failed"));
+
+        // An unhandled exception's message is written by code that never expected a client to
+        // read it, so it routinely contains connection strings, SQL, or internal identifiers.
+        // It goes to the log; the client gets a fixed string.
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        assertThat(problem.getDetail()).isEqualTo("Internal server error");
+        assertThat(problem.getDetail()).doesNotContain("hunter2");
+    }
+
+    @Test
+    @DisplayName("an unknown path is a 404 that does not echo the path back")
+    void unknownEndpointIsNotFoundWithoutEchoingInput() {
+        ProblemDetail problem = handler.handleNoEndpoint();
+
+        // Deliberate (issue #820 and SonarCloud S5131): without this handler every unknown path
+        // fell through to the catch-all as a 500. The detail stays constant because reflecting
+        // a user-supplied path into the response body is an XSS vector; the path is already in
+        // ProblemDetail's `instance` field.
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(problem.getDetail()).isEqualTo("No endpoint for the requested path");
+    }
+
+    @Test
+    @DisplayName("malformed JSON answers a body-shaped error naming the request path")
+    void malformedJsonIsABadRequestBody() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/v1/people/persons");
+
+        ResponseEntity<Map<String, Object>> response = handler.handleHttpMessageNotReadable(
+                new HttpMessageNotReadableException("boom", null, null), (HttpServletRequest) request);
+
+        // This is the one handler that answers with a plain map instead of a ProblemDetail, so
+        // its shape is pinned separately — a client parsing it sees different field names.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody())
+                .containsEntry("message", "Malformed JSON request")
+                .containsEntry("path", "/v1/people/persons")
+                .containsEntry("status", HttpStatus.BAD_REQUEST.value())
+                .containsEntry("timestamp", NOW);
+    }
+
+    @ParameterizedTest(name = "security-service {0} → {1}")
+    @CsvSource({
+        "400, 400",
+        "401, 401",
+        "403, 403",
+        "404, 404",
+        "409, 409",
+        "503, 503",
+        // Unlisted 4xx collapses to 400, unlisted 5xx to 500 — a downstream status we do not
+        // recognise must never be passed through as-is, or pos-security-service's internals
+        // become this API's contract.
+        "418, 400",
+        "451, 400",
+        "502, 500",
+        "504, 500",
+        // Anything outside 4xx/5xx is treated as a server fault rather than trusted.
+        "200, 500",
+        "302, 500"
+    })
+    @DisplayName("a failure from pos-security-service is translated, never passed through blindly")
+    void securityServiceStatusesAreTranslated(int downstream, int expected) {
+        ProblemDetail problem =
+                handler.handleSecurityServiceException(new SecurityServiceException("downstream said no", downstream));
+
+        assertThat(problem.getStatus()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("a ResponseStatusException keeps its status and prefers its reason over its message")
+    void responseStatusExceptionKeepsItsStatus() {
+        ProblemDetail withReason =
+                handler.handleResponseStatusException(new ResponseStatusException(HttpStatus.GONE, "record purged"));
+        assertThat(withReason.getStatus()).isEqualTo(HttpStatus.GONE.value());
+        assertThat(withReason.getDetail()).isEqualTo("record purged");
+
+        // With no reason the exception's own message is used, which includes the status text —
+        // less useful, but it must not be null.
+        ProblemDetail withoutReason =
+                handler.handleResponseStatusException(new ResponseStatusException(HttpStatus.GONE));
+        assertThat(withoutReason.getStatus()).isEqualTo(HttpStatus.GONE.value());
+        assertThat(withoutReason.getDetail()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("parameter problems name the offending parameter without echoing its value")
+    void parameterProblemsNameTheParameterOnly() {
+        ProblemDetail missing =
+                handler.handleMissingParameter(new MissingServletRequestParameterException("personId", "UUID"));
+
+        assertThat(missing.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(missing.getDetail()).isEqualTo("Missing required parameter 'personId'");
+
+        ProblemDetail mismatch = handler.handleTypeMismatch(new MethodArgumentTypeMismatchException(
+                "<script>alert(1)</script>", UUID.class, "personId", null, new IllegalArgumentException("bad uuid")));
+
+        // The parameter *name* is safe to echo because it comes from our own method signature.
+        // The submitted value is attacker-controlled and is deliberately left out — reflecting
+        // it into the response body is the XSS vector SonarCloud S5131 flags.
+        assertThat(mismatch.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(mismatch.getDetail()).isEqualTo("Invalid value for parameter 'personId'");
+        assertThat(mismatch.getDetail()).doesNotContain("script");
+    }
+
+    @Test
+    @DisplayName("validation failures report a fixed detail rather than the binding result")
+    void validationReportsFixedDetail() throws Exception {
+        MethodParameter parameter = new MethodParameter(
+                PeopleExceptionHandlerTest.class.getDeclaredMethod("validationTarget", String.class), 0);
+        BeanPropertyBindingResult binding = new BeanPropertyBindingResult(new Object(), "person");
+        binding.reject("person.email.invalid", "email must be a valid address");
+
+        ProblemDetail problem = handler.handleValidation(new MethodArgumentNotValidException(parameter, binding));
+
+        // Whatever the binding failure was, the client is told "Validation failed" and nothing
+        // about internal field names or message codes. That is a deliberate trade — it costs
+        // the caller detail, and it keeps the module's internal property names out of a
+        // response any unauthenticated caller can provoke.
+        assertThat(problem.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problem.getDetail()).isEqualTo("Validation failed");
+        assertThat(problem.getProperties()).containsEntry("timestamp", NOW);
+    }
+
+    @SuppressWarnings("unused")
+    private void validationTarget(String value) {
+        // Exists only to give MethodParameter above something real to point at.
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/controller/PeopleExceptionHandlerTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/controller/PeopleExceptionHandlerTest.java
@@ -49,9 +49,10 @@ import org.springframework.web.server.ResponseStatusException;
  * exhaustively for that reason.
  *
  * <p>
- * Three distinctions in it carry real meaning and are called out individually
- * below: 409 versus 404 on delete, 422 versus 400 on validation, and the
- * catch-all's refusal to echo the underlying message.
+ * Four distinctions in it carry real meaning and are called out individually
+ * below: 409 versus 404 on delete, 422 versus 400 on validation, the catch-all's
+ * refusal to echo the underlying message, and the routing and binding handlers'
+ * rule of naming the offending parameter but never the submitted value.
  */
 @DisplayName("PeopleExceptionHandler — the module's error contract")
 class PeopleExceptionHandlerTest {

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/controller/PostalAddressControllerWebMvcTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/controller/PostalAddressControllerWebMvcTest.java
@@ -1,0 +1,164 @@
+package com.positivity.peoplecontact.internal.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.peoplecontact.config.TestSecurityConfig;
+import com.positivity.peoplecontact.internal.dto.PostalAddressDto;
+import com.positivity.peoplecontact.internal.enums.PartyType;
+import com.positivity.peoplecontact.service.PostalAddressService;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Web-slice tests for {@link PostalAddressController}.
+ *
+ * <p>
+ * One controller serves two subjects — people and organizations — over six
+ * endpoints that are pairwise identical apart from the {@link PartyType} passed
+ * down and the authority required. That symmetry is the risk: the person and
+ * organization halves differ by one word in the path, one word in the
+ * {@code @PreAuthorize}, and one enum constant, and getting any of the three
+ * crossed produces something that works perfectly while reading or writing the
+ * wrong party's home address.
+ *
+ * <p>
+ * So the tests check both directions of the boundary: that a person authority
+ * does not open an organization endpoint or the reverse, and that each endpoint
+ * passes the matching PartyType to the service rather than the other one.
+ */
+@WebMvcTest(PostalAddressController.class)
+@Import(TestSecurityConfig.class)
+@ActiveProfiles("test")
+@SuppressWarnings({"java:S6813", "java:S100", "java:S1192"})
+@DisplayName("PostalAddressController — web slice")
+class PostalAddressControllerWebMvcTest {
+
+    private static final UUID PARTY_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e1");
+    private static final String AUTHORITIES = "X-Authorities";
+    private static final String PERSON_VIEW = "people-contact:person:view";
+    private static final String PERSON_EDIT = "people-contact:person:edit";
+    private static final String ORG_VIEW = "people-contact:organization:view";
+    private static final String ORG_EDIT = "people-contact:organization:edit";
+    private static final String PERSON_PATH = "/v1/people/" + PARTY_ID + "/postal-address";
+    private static final String ORG_PATH = "/v1/organizations/" + PARTY_ID + "/postal-address";
+    private static final String BODY = """
+            {"line1":"1 Mill Road","city":"Leeds","postalCode":"LS1 1AA","countryCode":"GB"}""";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    java.time.Clock clock;
+
+    @MockitoBean
+    PostalAddressService postalAddressService;
+
+    private static PostalAddressDto address() {
+        PostalAddressDto dto = new PostalAddressDto();
+        dto.setLine1("1 Mill Road");
+        dto.setCity("Leeds");
+        dto.setPostalCode("LS1 1AA");
+        dto.setCountryCode("GB");
+        return dto;
+    }
+
+    @Test
+    @DisplayName("GET a person's address returns it and asks the service for a PERSON")
+    void getPersonAddressUsesPersonPartyType() throws Exception {
+        when(postalAddressService.getAddress(PartyType.PERSON, PARTY_ID)).thenReturn(Optional.of(address()));
+
+        mockMvc.perform(get(PERSON_PATH).header(AUTHORITIES, PERSON_VIEW))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.city").value("Leeds"));
+
+        // Stubbed on PERSON specifically: had the controller passed ORGANIZATION, the stub
+        // would not match and the response would be a 404 instead.
+        verify(postalAddressService).getAddress(PartyType.PERSON, PARTY_ID);
+    }
+
+    @Test
+    @DisplayName("GET an organization's address asks the service for an ORGANIZATION")
+    void getOrganizationAddressUsesOrganizationPartyType() throws Exception {
+        when(postalAddressService.getAddress(PartyType.ORGANIZATION, PARTY_ID)).thenReturn(Optional.of(address()));
+
+        mockMvc.perform(get(ORG_PATH).header(AUTHORITIES, ORG_VIEW)).andExpect(status().isOk());
+
+        verify(postalAddressService).getAddress(PartyType.ORGANIZATION, PARTY_ID);
+    }
+
+    @Test
+    @DisplayName("a party with no address on file is a 404, not an empty address")
+    void missingAddressIsNotFound() throws Exception {
+        when(postalAddressService.getAddress(PartyType.PERSON, PARTY_ID)).thenReturn(Optional.empty());
+
+        // An empty 200 body would read downstream as "this person lives nowhere" rather than
+        // "we have not recorded where they live".
+        mockMvc.perform(get(PERSON_PATH).header(AUTHORITIES, PERSON_VIEW)).andExpect(status().isNotFound());
+    }
+
+    @ParameterizedTest(name = "{0} is refused to a holder of {1}")
+    @CsvSource({
+        // A person authority must not reach an organization's address, or the reverse.
+        "/v1/organizations/%s/postal-address, people-contact:person:view",
+        "/v1/people/%s/postal-address,        people-contact:organization:view",
+    })
+    @DisplayName("person and organization authorities do not cross the party boundary on reads")
+    void readAuthoritiesDoNotCrossPartyBoundary(String pathTemplate, String authority) throws Exception {
+        mockMvc.perform(get(pathTemplate.formatted(PARTY_ID)).header(AUTHORITIES, authority))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(postalAddressService);
+    }
+
+    @Test
+    @DisplayName("writing an address needs an edit authority — viewing it is not enough")
+    void writeRequiresEditAuthority() throws Exception {
+        when(postalAddressService.putAddress(eq(PartyType.PERSON), eq(PARTY_ID), any()))
+                .thenReturn(address());
+
+        mockMvc.perform(put(PERSON_PATH)
+                        .header(AUTHORITIES, PERSON_VIEW)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BODY))
+                .andExpect(status().isForbidden());
+        verify(postalAddressService, never()).putAddress(any(), any(), any());
+
+        mockMvc.perform(put(PERSON_PATH)
+                        .header(AUTHORITIES, PERSON_EDIT)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BODY))
+                .andExpect(status().isOk());
+        verify(postalAddressService).putAddress(eq(PartyType.PERSON), eq(PARTY_ID), any());
+    }
+
+    @Test
+    @DisplayName("deleting an address needs an edit authority and answers 204")
+    void deleteRequiresEditAuthority() throws Exception {
+        mockMvc.perform(delete(ORG_PATH).header(AUTHORITIES, ORG_VIEW)).andExpect(status().isForbidden());
+        verify(postalAddressService, never()).deleteAddress(any(), any());
+
+        mockMvc.perform(delete(ORG_PATH).header(AUTHORITIES, ORG_EDIT)).andExpect(status().isNoContent());
+        verify(postalAddressService).deleteAddress(PartyType.ORGANIZATION, PARTY_ID);
+    }
+}

--- a/pos-vehicle-inventory/pom.xml
+++ b/pos-vehicle-inventory/pom.xml
@@ -14,10 +14,11 @@
     <description>POS Vehicle module</description>
 
     <properties>
-        <!-- Coverage ratchet (plan Phase 4): measured 66.4% line / 71.0% branch.
+        <!-- Coverage ratchet (plan Phase 4): measured 76.7% line / 74.1% branch after the
+             §7 controller web-slice wave (was 66.4% / 71.0%).
              Floors sit ~5 points under to catch regression without failing on noise. -->
-        <jacoco.line.min>0.61</jacoco.line.min>
-        <jacoco.branch.min>0.66</jacoco.branch.min>
+        <jacoco.line.min>0.71</jacoco.line.min>
+        <jacoco.branch.min>0.69</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
     <dependencies>

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/controller/VehicleControllerWebMvcTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/controller/VehicleControllerWebMvcTest.java
@@ -1,0 +1,192 @@
+package com.positivity.vehicle.internal.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.vehicle.config.WebMvcTestSecurityConfig;
+import com.positivity.vehicle.internal.dto.VehicleLegacyResponse;
+import com.positivity.vehicle.service.VehicleLegacyService;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Web-slice tests for {@link VehicleController}, the legacy
+ * {@code /v1/vehicles-legacy} surface.
+ *
+ * <p>
+ * Every endpoint here has an id form and a VIN form, and the two report absence
+ * through different mechanisms: the read and update paths return an
+ * {@link Optional} that {@code ResponseEntity.of} turns into a 404, while the
+ * delete paths return a boolean that the controller checks by hand. Both must
+ * produce a 404 for a vehicle that is not there, and the boolean form is the one
+ * that silently becomes a 204 if the check is dropped — telling a caller their
+ * delete succeeded when nothing was deleted. That is what these tests are for;
+ * the happy paths are here mainly to make the absence cases meaningful.
+ */
+@WebMvcTest(VehicleController.class)
+@Import(WebMvcTestSecurityConfig.class)
+@ActiveProfiles("test")
+@SuppressWarnings({"java:S6813", "java:S100", "java:S1192"})
+@DisplayName("VehicleController (legacy) — web slice")
+class VehicleControllerWebMvcTest {
+
+    private static final UUID VEHICLE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c1");
+    private static final String VIN = "1HGCM82633A004352";
+    private static final String PATH = "/v1/vehicles-legacy";
+    private static final String AUTH = "Authorization";
+    private static final String BEARER = "Bearer test";
+    private static final String BODY =
+            "{\"make\":\"Honda\",\"model\":\"Accord\",\"year\":2024,\"vin\":\"" + VIN + "\"}";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    VehicleLegacyService vehicleLegacyService;
+
+    private static VehicleLegacyResponse vehicle() {
+        return VehicleLegacyResponse.builder()
+                .id(VEHICLE_ID)
+                .make("Honda")
+                .model("Accord")
+                .year(2024)
+                .vin(VIN)
+                .build();
+    }
+
+    @Test
+    @DisplayName("POST returns the created vehicle")
+    void createReturnsVehicle() throws Exception {
+        when(vehicleLegacyService.createVehicle(any())).thenReturn(vehicle());
+
+        mockMvc.perform(post(PATH)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.vin").value(VIN));
+    }
+
+    @Test
+    @DisplayName("POST turns a rejected create into 400, not 500")
+    void createRejectionIsBadRequest() throws Exception {
+        when(vehicleLegacyService.createVehicle(any())).thenThrow(new IllegalArgumentException("bad VIN"));
+
+        mockMvc.perform(post(PATH)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BODY))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET by id returns 404 for an unknown vehicle")
+    void getUnknownIdIsNotFound() throws Exception {
+        when(vehicleLegacyService.getVehicle(VEHICLE_ID)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get(PATH + "/" + VEHICLE_ID).header(AUTH, BEARER)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET by VIN returns 404 for an unknown VIN")
+    void getUnknownVinIsNotFound() throws Exception {
+        when(vehicleLegacyService.getVehicleByVin(VIN)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get(PATH + "/vin/" + VIN).header(AUTH, BEARER)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET returns the full list")
+    void getAllReturnsList() throws Exception {
+        when(vehicleLegacyService.getAllVehicles()).thenReturn(List.of(vehicle()));
+
+        mockMvc.perform(get(PATH).header(AUTH, BEARER))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(VEHICLE_ID.toString()));
+    }
+
+    @Test
+    @DisplayName("PUT by id returns 404 when the vehicle does not exist")
+    void updateUnknownIdIsNotFound() throws Exception {
+        when(vehicleLegacyService.updateVehicle(eq(VEHICLE_ID), any())).thenReturn(Optional.empty());
+
+        // ResponseEntity.of collapses the empty Optional to a 404 — an update must not report
+        // success for a row it never touched.
+        mockMvc.perform(put(PATH + "/" + VEHICLE_ID)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BODY))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PUT by VIN returns 404 when the VIN is unknown")
+    void updateUnknownVinIsNotFound() throws Exception {
+        when(vehicleLegacyService.updateVehicleByVin(eq(VIN), any())).thenReturn(Optional.empty());
+
+        mockMvc.perform(put(PATH + "/vin/" + VIN)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BODY))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("DELETE by id reports 204 only when something was actually deleted")
+    void deleteByIdDistinguishesDeletedFromMissing() throws Exception {
+        when(vehicleLegacyService.deleteVehicle(VEHICLE_ID)).thenReturn(true).thenReturn(false);
+
+        mockMvc.perform(delete(PATH + "/" + VEHICLE_ID).header(AUTH, BEARER)).andExpect(status().isNoContent());
+
+        // The false case is the one that matters: without the explicit check this would also be
+        // a 204, telling the caller a vehicle was removed when none was.
+        mockMvc.perform(delete(PATH + "/" + VEHICLE_ID).header(AUTH, BEARER)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("DELETE by VIN reports 204 only when something was actually deleted")
+    void deleteByVinDistinguishesDeletedFromMissing() throws Exception {
+        when(vehicleLegacyService.deleteVehicleByVin(VIN)).thenReturn(true).thenReturn(false);
+
+        mockMvc.perform(delete(PATH + "/vin/" + VIN).header(AUTH, BEARER)).andExpect(status().isNoContent());
+
+        mockMvc.perform(delete(PATH + "/vin/" + VIN).header(AUTH, BEARER)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("POST /vin returns the created vehicle")
+    void createByVinReturnsVehicle() throws Exception {
+        when(vehicleLegacyService.createVehicleByVin(any())).thenReturn(vehicle());
+
+        mockMvc.perform(post(PATH + "/vin")
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.vin").value(VIN));
+    }
+
+    @Test
+    @DisplayName("rejects an unauthenticated request")
+    void unauthenticatedRequestIsRejected() throws Exception {
+        mockMvc.perform(get(PATH).header("X-Authorities", "vehicle-inventory:registry:create"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/controller/VehiclePreferencesControllerWebMvcTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/controller/VehiclePreferencesControllerWebMvcTest.java
@@ -1,0 +1,203 @@
+package com.positivity.vehicle.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.vehicle.config.WebMvcTestSecurityConfig;
+import com.positivity.vehicle.internal.dto.UpsertPreferencesRequest;
+import com.positivity.vehicle.internal.entity.VehicleCarePreference;
+import com.positivity.vehicle.service.VehiclePreferencesService;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Web-slice tests for {@link VehiclePreferencesController}.
+ *
+ * <p>
+ * The endpoint that matters here is the pair PUT/PATCH, because the two treat a
+ * null {@code serviceIntervalMonths} as opposite instructions (#1175): on PUT it
+ * <em>clears</em> the per-vehicle override so CRM falls back to its default, on
+ * PATCH it <em>leaves the current value alone</em>. Both arrive over the wire as
+ * an absent JSON field, so nothing downstream can tell them apart — the
+ * distinction lives entirely in which verb was used, and it survives only as
+ * long as the controller keeps passing the null through instead of defaulting or
+ * dropping it. These tests capture the service argument rather than asserting on
+ * the response, because that pass-through is the whole contract.
+ */
+@WebMvcTest(VehiclePreferencesController.class)
+@Import(WebMvcTestSecurityConfig.class)
+@ActiveProfiles("test")
+@SuppressWarnings({"java:S6813", "java:S100", "java:S1192"})
+@DisplayName("VehiclePreferencesController — web slice")
+class VehiclePreferencesControllerWebMvcTest {
+
+    private static final UUID VEHICLE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e1");
+    private static final UUID PREFERENCE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000e2");
+    private static final String PATH = "/v1/vehicles/" + VEHICLE_ID + "/preferences";
+    private static final String AUTH = "Authorization";
+    private static final String BEARER = "Bearer test";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    VehiclePreferencesService preferencesService;
+
+    private static VehicleCarePreference stored(Integer serviceIntervalMonths) {
+        VehicleCarePreference preference = new VehicleCarePreference();
+        preference.setId(PREFERENCE_ID);
+        preference.setPreferences(Map.of("preferredOil", "5W-30"));
+        preference.setServiceIntervalMonths(serviceIntervalMonths);
+        return preference;
+    }
+
+    @Test
+    @DisplayName("GET returns 404 when the vehicle has no preferences yet")
+    void getMissingPreferencesIsNotFound() throws Exception {
+        when(preferencesService.getPreferences(VEHICLE_ID)).thenReturn(Optional.empty());
+
+        // A vehicle with no preferences is an ordinary state, not an error — but it must not
+        // read as an empty preference set, which a 200 with a null body would.
+        mockMvc.perform(get(PATH).header(AUTH, BEARER)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET returns the stored preferences flattened onto the response")
+    void getReturnsStoredPreferences() throws Exception {
+        when(preferencesService.getPreferences(VEHICLE_ID)).thenReturn(Optional.of(stored(6)));
+
+        mockMvc.perform(get(PATH).header(AUTH, BEARER))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(PREFERENCE_ID.toString()))
+                .andExpect(jsonPath("$.serviceIntervalMonths").value(6))
+                .andExpect(jsonPath("$.preferences.preferredOil").value("5W-30"));
+    }
+
+    @Test
+    @DisplayName("PUT forwards an omitted serviceIntervalMonths as null, which clears the override")
+    void putForwardsOmittedIntervalAsNull() throws Exception {
+        when(preferencesService.upsertPreferences(any())).thenReturn(stored(null));
+
+        mockMvc.perform(put(PATH)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"preferences\":{\"preferredOil\":\"5W-30\"}}"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<UpsertPreferencesRequest> captor = ArgumentCaptor.forClass(UpsertPreferencesRequest.class);
+        verify(preferencesService).upsertPreferences(captor.capture());
+        // Per #1175 a null here means "clear the per-vehicle override". If the controller ever
+        // substituted a default, the caller would silently keep an interval they asked to drop.
+        assertThat(captor.getValue().getServiceIntervalMonths()).isNull();
+        assertThat(captor.getValue().getVehicleId()).isEqualTo(VEHICLE_ID);
+        assertThat(captor.getValue().getPreferences()).containsEntry("preferredOil", "5W-30");
+    }
+
+    @Test
+    @DisplayName("PATCH forwards an omitted serviceIntervalMonths as null, which leaves it unchanged")
+    void patchForwardsOmittedIntervalAsNull() throws Exception {
+        when(preferencesService.mergePreferences(eq(VEHICLE_ID), any(), any(), any()))
+                .thenReturn(stored(6));
+
+        mockMvc.perform(patch(PATH)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"partialPreferences\":{\"tireRotationInterval\":7500}}"))
+                .andExpect(status().isOk());
+
+        // Same null on the wire as the PUT above, opposite meaning. The verbs are the only
+        // thing separating "clear it" from "don't touch it", which is why both are pinned.
+        verify(preferencesService).mergePreferences(eq(VEHICLE_ID), any(), isNull(), isNull());
+    }
+
+    @Test
+    @DisplayName("PATCH with no partialPreferences merges an empty map rather than failing")
+    void patchWithoutPartialPreferencesMergesEmptyMap() throws Exception {
+        when(preferencesService.mergePreferences(eq(VEHICLE_ID), any(), any(), any()))
+                .thenReturn(stored(9));
+
+        // A PATCH that only changes the interval is a legitimate request; the field is
+        // optional, so the controller substitutes an empty map instead of dereferencing null.
+        mockMvc.perform(patch(PATH)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"serviceIntervalMonths\":9}"))
+                .andExpect(status().isOk());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(preferencesService).mergePreferences(eq(VEHICLE_ID), captor.capture(), eq(9), isNull());
+        assertThat(captor.getValue()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("PUT rejects a body with no preferences map")
+    void putWithoutPreferencesIsRejected() throws Exception {
+        // preferences is @NotNull on the upsert DTO: a PUT is a full replacement, so an absent
+        // map would otherwise be indistinguishable from "replace everything with nothing".
+        mockMvc.perform(put(PATH)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"serviceIntervalMonths\":6}"))
+                .andExpect(status().isBadRequest());
+
+        verify(preferencesService, never()).upsertPreferences(any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 121})
+    @DisplayName("PUT rejects a service interval outside 1..120 months")
+    void putRejectsOutOfRangeInterval(int months) throws Exception {
+        mockMvc.perform(put(PATH)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"preferences\":{},\"serviceIntervalMonths\":" + months + "}"))
+                .andExpect(status().isBadRequest());
+
+        verify(preferencesService, never()).upsertPreferences(any());
+    }
+
+    @Test
+    @DisplayName("DELETE returns 204 even when the vehicle had no preferences")
+    void deleteIsAlwaysNoContent() throws Exception {
+        // The controller does not consult the service's outcome, so the documented 404 on this
+        // endpoint is unreachable. Deleting is idempotent in practice, which is defensible —
+        // pinned here so that a later change to return 404 is a deliberate contract change and
+        // not an accident.
+        mockMvc.perform(delete(PATH).header(AUTH, BEARER)).andExpect(status().isNoContent());
+
+        verify(preferencesService).deletePreferences(VEHICLE_ID);
+    }
+
+    @Test
+    @DisplayName("rejects an unauthenticated request")
+    void unauthenticatedRequestIsRejected() throws Exception {
+        mockMvc.perform(get(PATH)).andExpect(status().isUnauthorized());
+
+        verify(preferencesService, never()).getPreferences(any());
+    }
+}

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/controller/VehicleRegistryControllerWebMvcTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/controller/VehicleRegistryControllerWebMvcTest.java
@@ -192,7 +192,8 @@ class VehicleRegistryControllerWebMvcTest {
         // issue #1269. When that is fixed this becomes status().isBadRequest() with an
         // ApiError body.
         assertThatThrownBy(() -> mockMvc.perform(get(PATH + "/vin/TOOSHORT").header(AUTH, BEARER)))
-                .hasRootCauseInstanceOf(ConstraintViolationException.class)
+                .rootCause()
+                .isInstanceOf(ConstraintViolationException.class)
                 .hasMessageContaining("size must be between 17 and 17");
 
         verifyNoInteractions(vehicleService);

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/controller/VehicleRegistryControllerWebMvcTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/controller/VehicleRegistryControllerWebMvcTest.java
@@ -1,0 +1,208 @@
+package com.positivity.vehicle.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.shared.dto.VehicleResponse;
+import com.positivity.vehicle.config.WebMvcTestSecurityConfig;
+import com.positivity.vehicle.service.VehicleService;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ConstraintViolationException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Web-slice tests for {@link VehicleRegistryController}.
+ *
+ * <p>
+ * This controller catches its own exceptions rather than letting them reach an
+ * advice, and the mapping it applies is the contract: {@link EntityNotFoundException}
+ * becomes 404 and {@link IllegalArgumentException} becomes 400. Those two arrive
+ * from the same service methods and are one {@code catch} clause apart, so an
+ * accidental reorder or a merged clause would turn "you asked for something that
+ * does not exist" into "your request was malformed", or the reverse. The pair is
+ * pinned on both update and delete.
+ */
+@WebMvcTest(VehicleRegistryController.class)
+@Import(WebMvcTestSecurityConfig.class)
+@ActiveProfiles("test")
+@SuppressWarnings({"java:S6813", "java:S100", "java:S1192"})
+@DisplayName("VehicleRegistryController — web slice")
+class VehicleRegistryControllerWebMvcTest {
+
+    private static final UUID VEHICLE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000f1");
+    private static final UUID ACCOUNT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000f2");
+    private static final String VIN = "1HGCM82633A004352";
+    private static final String PATH = "/v1/vehicle-registry";
+    private static final String AUTH = "Authorization";
+    private static final String BEARER = "Bearer test";
+    private static final String CREATE_BODY = "{\"accountId\":\"" + ACCOUNT_ID + "\",\"vin\":\"" + VIN + "\"}";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    VehicleService vehicleService;
+
+    private static VehicleResponse vehicle() {
+        return VehicleResponse.builder()
+                .vehicleId(VEHICLE_ID)
+                .accountId(ACCOUNT_ID)
+                .vin(VIN)
+                .vinNormalized(VIN)
+                .unitNumber("UNIT-001")
+                .description("2024 Honda Accord")
+                .build();
+    }
+
+    @Test
+    @DisplayName("POST returns 201 with the created vehicle")
+    void createReturnsCreated() throws Exception {
+        when(vehicleService.createVehicle(any())).thenReturn(vehicle());
+
+        // 201, not 200: this endpoint creates a registry record, and the status is what tells
+        // a client the VIN was not already present.
+        mockMvc.perform(post(PATH)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(CREATE_BODY))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.vehicleId").value(VEHICLE_ID.toString()))
+                .andExpect(jsonPath("$.vin").value(VIN));
+    }
+
+    @Test
+    @DisplayName("POST turns a rejected create into 400, not 500")
+    void createRejectionIsBadRequest() throws Exception {
+        when(vehicleService.createVehicle(any())).thenThrow(new IllegalArgumentException("duplicate VIN"));
+
+        mockMvc.perform(post(PATH)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(CREATE_BODY))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST rejects a body with no VIN before reaching the service")
+    void createWithoutVinIsRejected() throws Exception {
+        mockMvc.perform(post(PATH)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"accountId\":\"" + ACCOUNT_ID + "\"}"))
+                .andExpect(status().isBadRequest());
+
+        // Bean validation must fail closed here — a registry record with no VIN has no way to
+        // be matched to a real vehicle later.
+        verify(vehicleService, never()).createVehicle(any());
+    }
+
+    @Test
+    @DisplayName("GET by id returns 404 for an unknown vehicle")
+    void getUnknownIdIsNotFound() throws Exception {
+        when(vehicleService.getVehicle(VEHICLE_ID)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get(PATH + "/" + VEHICLE_ID).header(AUTH, BEARER)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET by VIN returns 404 for an unknown VIN")
+    void getUnknownVinIsNotFound() throws Exception {
+        when(vehicleService.getVehicleByVin(VIN)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get(PATH + "/vin/" + VIN).header(AUTH, BEARER)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PUT maps a missing vehicle to 404 and a rejected update to 400")
+    void updateDistinguishesNotFoundFromBadRequest() throws Exception {
+        when(vehicleService.updateVehicle(eq(VEHICLE_ID), any()))
+                .thenThrow(new EntityNotFoundException("no such vehicle"))
+                .thenThrow(new IllegalArgumentException("unit number too long"));
+
+        // Two consecutive calls, two different exceptions from the same method. Collapsing the
+        // catch clauses would make one of these silently report the other.
+        mockMvc.perform(put(PATH + "/" + VEHICLE_ID)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"unitNumber\":\"UNIT-002\"}"))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(put(PATH + "/" + VEHICLE_ID)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"unitNumber\":\"UNIT-002\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PUT returns 200 with the updated vehicle")
+    void updateReturnsOk() throws Exception {
+        when(vehicleService.updateVehicle(eq(VEHICLE_ID), any())).thenReturn(vehicle());
+
+        mockMvc.perform(put(PATH + "/" + VEHICLE_ID)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"unitNumber\":\"UNIT-002\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.vehicleId").value(VEHICLE_ID.toString()));
+    }
+
+    @Test
+    @DisplayName("DELETE returns 204, and 404 when the vehicle is already gone")
+    void deleteDistinguishesSuccessFromMissing() throws Exception {
+        mockMvc.perform(delete(PATH + "/" + VEHICLE_ID).header(AUTH, BEARER)).andExpect(status().isNoContent());
+
+        doThrow(new EntityNotFoundException("no such vehicle"))
+                .when(vehicleService)
+                .deleteVehicle(VEHICLE_ID);
+
+        mockMvc.perform(delete(PATH + "/" + VEHICLE_ID).header(AUTH, BEARER)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("BUG: a VIN of the wrong length escapes as a server error instead of a 400")
+    void shortVinOnPathIsAServerError() {
+        // Documents current behaviour, not desired behaviour. The class is @Validated and the
+        // path variable carries @Size(min = 17, max = 17), so a short VIN does get rejected —
+        // but as a ConstraintViolationException, and this module has no @ControllerAdvice to
+        // translate it. The client sees a 500 for what is plainly a malformed request, with no
+        // ApiError envelope (ADR-0017) and nothing naming the offending field. Tracked as
+        // issue #1269. When that is fixed this becomes status().isBadRequest() with an
+        // ApiError body.
+        assertThatThrownBy(() -> mockMvc.perform(get(PATH + "/vin/TOOSHORT").header(AUTH, BEARER)))
+                .hasRootCauseInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("size must be between 17 and 17");
+
+        verifyNoInteractions(vehicleService);
+    }
+
+    @Test
+    @DisplayName("rejects an unauthenticated request")
+    void unauthenticatedRequestIsRejected() throws Exception {
+        mockMvc.perform(get(PATH + "/" + VEHICLE_ID)).andExpect(status().isUnauthorized());
+
+        verify(vehicleService, never()).getVehicle(any());
+    }
+}

--- a/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/controller/VehicleSearchControllerWebMvcTest.java
+++ b/pos-vehicle-inventory/src/test/java/com/positivity/vehicle/internal/controller/VehicleSearchControllerWebMvcTest.java
@@ -1,0 +1,157 @@
+package com.positivity.vehicle.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.vehicle.config.WebMvcTestSecurityConfig;
+import com.positivity.vehicle.internal.dto.SearchVehiclesRequest;
+import com.positivity.vehicle.internal.dto.SearchVehiclesResponse;
+import com.positivity.vehicle.service.VehicleSearchService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Web-slice tests for {@link VehicleSearchController}.
+ *
+ * <p>
+ * Two endpoints reach the same service through different doors: POST takes a
+ * {@code SearchVehiclesRequest} straight off the body, while GET assembles one
+ * from query parameters and supplies the defaults. Those defaults are the part
+ * worth pinning — a caller who omits {@code limit} is relying on the controller
+ * to cap the result set, and a caller who omits {@code enableContains} is
+ * relying on it to stay in strict-matching mode. Both are decisions the
+ * controller makes silently on the caller's behalf, so nothing downstream would
+ * notice if they changed.
+ */
+@WebMvcTest(VehicleSearchController.class)
+@Import(WebMvcTestSecurityConfig.class)
+@ActiveProfiles("test")
+@SuppressWarnings({"java:S6813", "java:S100", "java:S1192"})
+@DisplayName("VehicleSearchController — web slice")
+class VehicleSearchControllerWebMvcTest {
+
+    private static final String PATH = "/v1/vehicles/search";
+    private static final String AUTH = "Authorization";
+    private static final String BEARER = "Bearer test";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    VehicleSearchService searchService;
+
+    private static SearchVehiclesResponse empty(String query) {
+        return SearchVehiclesResponse.builder()
+                .results(List.of())
+                .totalCount(0)
+                .hasMore(false)
+                .query(query)
+                .build();
+    }
+
+    @Test
+    @DisplayName("GET applies the documented defaults when limit and enableContains are omitted")
+    void getAppliesDefaults() throws Exception {
+        when(searchService.search(any())).thenReturn(empty("HONDA"));
+
+        mockMvc.perform(get(PATH).param("q", "HONDA").header(AUTH, BEARER))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalCount").value(0));
+
+        ArgumentCaptor<SearchVehiclesRequest> captor = ArgumentCaptor.forClass(SearchVehiclesRequest.class);
+        verify(searchService).search(captor.capture());
+        // An uncapped search over a VIN-indexed table is the kind of query that reads the whole
+        // table, so the default limit is a guard rail rather than a convenience. Strict matching
+        // is the safer default for the same reason: contains-matching is the expensive path.
+        assertThat(captor.getValue().getLimit()).isEqualTo(25);
+        assertThat(captor.getValue().getEnableContainsMatching()).isFalse();
+        assertThat(captor.getValue().getQuery()).isEqualTo("HONDA");
+    }
+
+    @Test
+    @DisplayName("GET passes explicit parameters through instead of the defaults")
+    void getPassesExplicitParameters() throws Exception {
+        when(searchService.search(any())).thenReturn(empty("1HGCM"));
+
+        mockMvc.perform(get(PATH)
+                        .param("q", "1HGCM")
+                        .param("limit", "10")
+                        .param("enableContains", "true")
+                        .header(AUTH, BEARER))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<SearchVehiclesRequest> captor = ArgumentCaptor.forClass(SearchVehiclesRequest.class);
+        verify(searchService).search(captor.capture());
+        assertThat(captor.getValue().getLimit()).isEqualTo(10);
+        assertThat(captor.getValue().getEnableContainsMatching()).isTrue();
+    }
+
+    @Test
+    @DisplayName("GET without a query parameter is rejected before reaching the service")
+    void getWithoutQueryIsRejected() throws Exception {
+        mockMvc.perform(get(PATH).header(AUTH, BEARER)).andExpect(status().isBadRequest());
+
+        verify(searchService, never()).search(any());
+    }
+
+    @Test
+    @DisplayName("BUG: POST cannot deserialize any body, so the endpoint fails for every request")
+    void postCannotDeserializeAnyBody() {
+        // Documents current behaviour, not desired behaviour. SearchVehiclesRequest is
+        // @Getter/@Builder with final fields and no @Jacksonized, so Lombok's only constructor
+        // is package-private and Jackson has no creator to call. Message conversion fails
+        // before the controller method is entered, which means this documented endpoint has
+        // never worked for any input. The GET route above is unaffected because it builds the
+        // object in Java rather than deserializing it — which is why nothing caught this.
+        // Tracked as issue #1270. When that is fixed this test becomes the ordinary
+        // pass-through assertion: the body's limit and enableContainsMatching reach the service
+        // unchanged, in contrast to the GET route, which supplies defaults.
+        assertThatThrownBy(() -> mockMvc.perform(post(PATH)
+                        .header(AUTH, BEARER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"query\":\"UNIT-001\",\"limit\":5,\"enableContainsMatching\":true}")))
+                .rootCause()
+                .hasMessageContaining("no Creators, like default constructor, exist");
+
+        verify(searchService, never()).search(any());
+    }
+
+    @Test
+    @DisplayName("GET tolerates a query containing CRLF without splitting the log line")
+    void getWithCrlfInQueryIsHandled() throws Exception {
+        when(searchService.search(any())).thenReturn(empty("x"));
+
+        // The controller masks and sanitizes the query before logging it precisely because it
+        // is attacker-controlled free text; this asserts the request still completes normally
+        // so nobody removes the sanitizing by way of "simplifying" the log statement.
+        mockMvc.perform(get(PATH).param("q", "HONDA\r\nINJECTED").header(AUTH, BEARER))
+                .andExpect(status().isOk());
+
+        verify(searchService).search(any());
+    }
+
+    @Test
+    @DisplayName("rejects an unauthenticated request")
+    void unauthenticatedRequestIsRejected() throws Exception {
+        mockMvc.perform(get(PATH).param("q", "HONDA")).andExpect(status().isUnauthorized());
+
+        verify(searchService, never()).search(any());
+    }
+}


### PR DESCRIPTION
## What this does

Closes item 2 of `docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` §7: controller `@WebMvcTest` slices across the four modules that had none.

| Module | Line before | Line after | Branch after | Floor |
|---|---|---|---|---|
| `pos-vehicle-inventory` | 66.4% | **76.7%** | 74.1% | 0.71 / 0.69 |
| `pos-marketing` | 87.4% | **89.7%** | 82.9% | 0.84 / 0.77 |
| `pos-people-contact` | 64.1% | **70.1%** | 55.9% | 0.65 / 0.50 |
| `pos-customer` | 85.4% | **86.3%** | 71.5% | 0.81 / 0.66 |

Tests only. No production code is changed anywhere in this PR.

## What the tests are actually for

Rather than covering every endpoint uniformly, the slices target three shapes that recur across the reactor and that a happy-path test cannot see:

**1. Sibling permissions on adjacent methods.** `pos-marketing`'s campaign lifecycle splits across five authorities — create, edit, schedule, manage, send — on methods that differ by one word. Whoever may pause a running campaign is deliberately not whoever may push it to real customers, and nothing structural enforces that; it lives in one `@PreAuthorize` string per method. So each action is checked against a *neighbouring* authority that must not open it (schedule against manage, pause against schedule, send against manage), not only against the one that should.

**2. Two implementations of one interface.** `pos-customer`'s `CustomerController` holds two `CustomerService` fields, commercial and individual, and the constructor takes them in the opposite order to the order it assigns them. Correct today, still compiles if swapped, and a swap answers every question about the wrong kind of customer. Same shape in `pos-people-contact`'s `PostalAddressController`, where the person and organization halves differ by one word in the path, one in the `@PreAuthorize`, and one enum constant — so both directions of that boundary are checked.

**3. Verbs that disagree about null.** `pos-vehicle-inventory`'s preferences PUT and PATCH both accept a null `serviceIntervalMonths` and mean opposite things by it (#1175): PUT clears the per-vehicle override so CRM falls back to its default, PATCH leaves it untouched. Both arrive as an absent JSON field, so the verb is the only thing carrying the distinction. Those tests capture the service argument rather than asserting on the response, because the pass-through *is* the contract.

`PeopleExceptionHandler` was the largest single uncovered class in the wave (58 missed lines) and is now covered exhaustively — twenty near-identical four-line handlers where a wrong `HttpStatus` still compiles and still returns a well-formed ProblemDetail. Four distinctions in it are called out individually: 409-not-404 on a person with linked users (plus its `nextAction`), 422-not-400 for semantic validation, the catch-all refusing to echo the exception's own message (asserted with a planted credential), and routing failures naming the parameter but never the submitted value (asserted with a script tag).

## Two defects found, filed, and pinned

Neither is fixed here — both are pinned by tests named and commented to say they document current behaviour, so the fix lands as a visible test change.

**#1269** — `pos-vehicle-inventory` has no `@ControllerAdvice` at all. `VehicleRegistryController` is `@Validated` with `@Size(min = 17, max = 17)` on its VIN path variable, so a wrong-length VIN raises `ConstraintViolationException`, which nothing handles and Spring maps to **500**. A mistyped VIN reads as a server fault, in metrics as well as to the client. The same gap means no error from this module carries the `ApiError` envelope required by `docs/ERROR_ENVELOPE.md` — every error return is a bare status with an empty body, and the rejection reason goes to the log and nowhere else.

**#1270** — `POST /v1/vehicles/search` is broken for **every** request. `SearchVehiclesRequest` is `@Getter`/`@Builder` with final fields and no `@Jacksonized`, so Lombok's only constructor is package-private and Jackson has no creator; message conversion fails before the controller is entered. The GET route is unaffected because it builds the object in Java rather than deserializing it — which is why no existing test caught it, since none posted a body to that endpoint.

One further behaviour is recorded rather than filed: in `pos-customer`, a misspelled `customerType` (`"COMERCIAL"`) silently falls through to the individual customer list instead of being rejected. That is pinned as current behaviour — turning it into a 400 is a contract change, not a bug fix, so it is left for a decision rather than made here.

## Contract impact — none

`contract-sync` matches this PR because its path filters include `**/controller/**` and `**/dto/**`, and the new files are tests under those packages. No controller, DTO, schema, event or OpenAPI document is modified, so there is no contract change to mirror and no corresponding durion PR — see `BACKEND_CONTRACT_GUIDE.md` for the process if there were.

## Verification

Each module verified with the ratchet active and the new floors in place:

`./mvnw -o -pl <module> -DskipTests=false verify -DskipITs` → BUILD SUCCESS for all four. New tests: 37 (vehicle-inventory), 16 (marketing), 37 (people-contact), 20 (customer).

## Review notes

- Every new floor is set ~5 points below measured, per the §6.2 convention.
- `pos-marketing` gains its first web-slice security config, copied in shape from `pos-inventory`'s so the two stay recognisable.
- Several slices need a `@MockitoBean java.time.Clock` because each module's `@ControllerAdvice` takes one; that is pre-existing and matches how `pos-inventory`'s slices already do it.
