### PR TITLE
feat(archunit): exempt assigned natural-key @Id fields with @AssignedIdentifier

### DIFF
--- a/docs/UUID_V7_MIGRATION.md
+++ b/docs/UUID_V7_MIGRATION.md
@@ -238,6 +238,49 @@ public ResponseEntity<ProductDto> getProduct(@PathVariable UUID id) {
 2. **Breaking changes acceptable**: We'll fix integration issues after migration
 3. **Database support**: Postgres (UUID type) and H2 (UUID type)
 4. **No GenerationType.UUID**: Use `@PrePersist` with `UUIDv7Generator` for explicit control
+5. **Assigned natural keys are out of scope**: ADR-0013 governs identifier *generation*, so an `@Id` supplied by
+   the caller declares `@AssignedIdentifier` instead of `@UUIDv7Id` (see below)
+
+## Assigned Natural Keys (`@AssignedIdentifier`)
+
+Not every UUID `@Id` is a surrogate key. Where the identifier **is** the row's meaning — a lease keyed by the
+binding it governs, a projection keyed by the aggregate it mirrors — the value comes from the caller, and
+requiring `@UUIDv7Id` there asks a generator to invent an identifier whose whole point is that it must not be
+invented.
+
+Such a field declares `com.positivity.shared.id.AssignedIdentifier` with a reason:
+
+```java
+@Id
+@AssignedIdentifier("the binding's own id: a lease on an invented id would be a lease on nothing")
+@Column(name = "binding_id", nullable = false, updatable = false)
+private UUID bindingId;
+```
+
+The marker attaches no generator and changes no runtime behaviour. Its effects are:
+
+- **Documentation at the entity.** The next reader sees the intent instead of a generator annotation that
+  contradicts the field.
+- **Exemption from the ADR-0013 rule.** `EntityStandardsArchitectureTest` no longer requires `@UUIDv7Id` on the
+  field.
+- **A null id fails loudly.** With no generator attached, persisting a null identifier raises
+  `IdentifierGenerationException` rather than silently minting a UUID and keying the row to something that does
+  not exist.
+
+Rules the architecture test enforces:
+
+| Rule | Why |
+|---|---|
+| Never combine `@AssignedIdentifier` with `@UUIDv7Id` | They make opposite claims, and the generator stays attached |
+| The reason string must be non-blank | An unexplained opt-out from a fleet-wide rule reads as a mistake |
+| Only valid on `@Id` fields | Elsewhere it is decoration that looks significant |
+
+Use it only for genuine natural keys. If the platform is free to invent the value, it is a surrogate key and
+ADR-0013 applies in full.
+
+> **Do not reach for a `@PrePersist` null-check as an alternative guard.** The callback fires *after* identifier
+> generation, so with a generator attached it can never observe a null id. That is why the fix is to attach no
+> generator rather than to guard one.
 
 ## Testing Strategy
 

--- a/docs/UUID_V7_MIGRATION.md
+++ b/docs/UUID_V7_MIGRATION.md
@@ -275,6 +275,10 @@ Rules the architecture test enforces:
 | The reason string must be non-blank | An unexplained opt-out from a fleet-wide rule reads as a mistake |
 | Only valid on `@Id` fields | Elsewhere it is decoration that looks significant |
 
+The marker targets `FIELD` only — unlike `@UUIDv7Id`, which must also target methods because it attaches a
+generator and Hibernate permits property access. The rule inspects `@Id` *fields*, so a marker on a getter
+could exempt nothing while still drifting onto unrelated methods; the compiler rules that out.
+
 Use it only for genuine natural keys. If the platform is free to invent the value, it is a surrogate key and
 ADR-0013 applies in full.
 

--- a/pos-archunit/src/test/java/com/positivity/archunit/EntityStandardsArchitectureTest.java
+++ b/pos-archunit/src/test/java/com/positivity/archunit/EntityStandardsArchitectureTest.java
@@ -50,6 +50,7 @@ class EntityStandardsArchitectureTest {
     private static final String LAST_MODIFIED_DATE_ANNOTATION = "org.springframework.data.annotation.LastModifiedDate";
     private static final String UUIDV7_ID_ANNOTATION = "com.positivity.shared.id.UUIDv7Id";
     private static final String UUIDV7_GENERATOR = "com.positivity.shared.id.UUIDv7Generator";
+    private static final String ASSIGNED_IDENTIFIER_ANNOTATION = "com.positivity.shared.id.AssignedIdentifier";
 
     private static final DescribedPredicate<JavaCall<?>> UUID_RANDOM_UUID_CALL =
             new DescribedPredicate<>("call UUID.randomUUID()") {
@@ -81,6 +82,12 @@ class EntityStandardsArchitectureTest {
             .allowEmptyShould(true)
             .because("ADR-0013 disallows UUID.randomUUID() in entities");
 
+    /**
+     * ADR-0013 governs identifier <em>generation</em>, so a natural key assigned by the caller is outside it:
+     * requiring {@code @UUIDv7Id} there asks a generator to invent a value whose whole meaning is that it must
+     * not be invented. Such a field opts out with {@code @AssignedIdentifier} instead, which documents the
+     * intent at the entity rather than leaving a generator annotation that contradicts the field (#1261).
+     */
     @ArchTest
     static final ArchRule uuid_id_fields_should_use_adr_0013_generation = classes()
             .that()
@@ -89,7 +96,23 @@ class EntityStandardsArchitectureTest {
             .areAnnotatedWith(ENTITY_ANNOTATION)
             .should(useAdr0013IdentifierStandard())
             .allowEmptyShould(true)
-            .because("ADR-0013 requires UUID IDs to use @UUIDv7Id or UUIDv7Generator");
+            .because("ADR-0013 requires generated UUID IDs to use @UUIDv7Id or UUIDv7Generator,"
+                    + " and assigned natural keys to say so with @AssignedIdentifier");
+
+    /**
+     * {@code @AssignedIdentifier} is an opt-out from the identifier rule and means nothing anywhere else.
+     * Left to drift onto ordinary columns it reads as significant while doing nothing.
+     */
+    @ArchTest
+    static final ArchRule assigned_identifier_should_only_mark_id_fields = fields().that()
+            .areDeclaredInClassesThat()
+            .resideInAnyPackage(ENFORCED_ENTITY_PACKAGES)
+            .and()
+            .areAnnotatedWith(ASSIGNED_IDENTIFIER_ANNOTATION)
+            .should()
+            .beAnnotatedWith(ID_ANNOTATION)
+            .allowEmptyShould(true)
+            .because("@AssignedIdentifier only exempts an @Id from ADR-0013; on any other field it is decoration");
 
     @ArchTest
     static final ArchRule created_at_field_should_use_created_date = fields().that()
@@ -152,14 +175,48 @@ class EntityStandardsArchitectureTest {
                         // migrations
                     }
                     boolean hasUuidV7IdAnnotation = idField.isAnnotatedWith(UUIDV7_ID_ANNOTATION);
+                    boolean isAssignedIdentifier = idField.isAnnotatedWith(ASSIGNED_IDENTIFIER_ANNOTATION);
+
+                    if (isAssignedIdentifier && hasUuidV7IdAnnotation) {
+                        // The two make opposite claims: one says the platform mints this id, the other says
+                        // only the caller may supply it. Carrying both leaves the generator attached, which is
+                        // exactly the state @AssignedIdentifier exists to replace.
+                        events.add(SimpleConditionEvent.violated(
+                                item,
+                                item.getName() + " declares both @UUIDv7Id and @AssignedIdentifier on @Id field '"
+                                        + idField.getName()
+                                        + "'; an identifier is either generated or assigned, not both"));
+                        continue;
+                    }
+                    if (isAssignedIdentifier) {
+                        assertReasonIsGiven(item, idField, events);
+                        continue; // a natural key is not generated, so ADR-0013 does not govern it
+                    }
                     if (!hasUuidV7IdAnnotation && !dependsOnUuidV7Generator) {
                         String message = item.getName()
                                 + " has UUID @Id field '" + idField.getName()
-                                + "' but uses neither @UUIDv7Id nor UUIDv7Generator";
+                                + "' but uses neither @UUIDv7Id nor UUIDv7Generator"
+                                + " (if it is a natural key assigned by the caller, declare @AssignedIdentifier)";
                         events.add(SimpleConditionEvent.violated(item, message));
                     }
                 }
             }
         };
+    }
+
+    /**
+     * An opt-out from a fleet-wide rule with no stated reason is indistinguishable from a mistake, so the
+     * marker's reason is required to say something.
+     */
+    private static void assertReasonIsGiven(JavaClass item, JavaField idField, ConditionEvents events) {
+        String reason = String.valueOf(idField.getAnnotationOfType(ASSIGNED_IDENTIFIER_ANNOTATION)
+                .get("value")
+                .orElse(""));
+        if (reason.isBlank()) {
+            events.add(SimpleConditionEvent.violated(
+                    item,
+                    item.getName() + " marks @Id field '" + idField.getName()
+                            + "' @AssignedIdentifier without saying why it is assigned rather than generated"));
+        }
     }
 }

--- a/pos-archunit/src/test/java/com/positivity/archunit/EntityStandardsArchitectureTest.java
+++ b/pos-archunit/src/test/java/com/positivity/archunit/EntityStandardsArchitectureTest.java
@@ -102,6 +102,9 @@ class EntityStandardsArchitectureTest {
     /**
      * {@code @AssignedIdentifier} is an opt-out from the identifier rule and means nothing anywhere else.
      * Left to drift onto ordinary columns it reads as significant while doing nothing.
+     *
+     * <p>Fields are the whole surface: the annotation targets {@code FIELD} only, so a method can never carry
+     * it and no companion rule over methods is needed.
      */
     @ArchTest
     static final ArchRule assigned_identifier_should_only_mark_id_fields = fields().that()

--- a/pos-shared-dtos/src/main/java/com/positivity/shared/id/AssignedIdentifier.java
+++ b/pos-shared-dtos/src/main/java/com/positivity/shared/id/AssignedIdentifier.java
@@ -1,0 +1,61 @@
+package com.positivity.shared.id;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a JPA {@code @Id} that is a <strong>natural key assigned by the caller</strong> rather than a
+ * surrogate key the platform mints.
+ *
+ * <h2>Why this exists</h2>
+ *
+ * ADR-0013 governs identifier <em>generation</em>: every UUID identifier the platform invents must be a
+ * UUID v7, produced by {@link UUIDv7Id} or {@link UUIDv7Generator}. The fleet-wide rule that enforces it
+ * ({@code EntityStandardsArchitectureTest}) reads "every UUID {@code @Id} declares {@code @UUIDv7Id}",
+ * which is correct for surrogate keys and wrong for an identifier whose whole meaning is that it must not
+ * be invented — annotating one asks a generator to make up a value that is only valid if it comes from
+ * somewhere else.
+ *
+ * <p>Carrying {@code @UUIDv7Id} on such a field is not merely redundant. {@link UUIDv7HibernateGenerator}
+ * honours an assigned value ({@code currentValue != null ? currentValue : generate()}), so a supplied id
+ * survives — but a <em>missing</em> one is silently minted instead of failing, turning a loud
+ * {@code NOT NULL} error into a row keyed to an entity that does not exist. Declaring this annotation
+ * instead leaves the field a plain assigned identifier, so Hibernate rejects a null id at persist time.
+ *
+ * <h2>Using it</h2>
+ *
+ * Declare it <em>instead of</em> {@link UUIDv7Id}, never alongside it — the two make opposite claims, and
+ * the architecture rule fails a field carrying both:
+ *
+ * <pre>{@code
+ * @Id
+ * @AssignedIdentifier("the binding's own id; a lease on an invented id would be a lease on nothing")
+ * @Column(name = "binding_id", nullable = false, updatable = false)
+ * private UUID bindingId;
+ * }</pre>
+ *
+ * <p>This is a documentation marker: it attaches no Hibernate generator and changes no runtime behaviour.
+ * Its only mechanical effect is to exempt the field from the {@code @UUIDv7Id} requirement, and the
+ * reason it carries is what the next reader of the entity sees in place of a generator annotation that
+ * contradicts the field's purpose.
+ *
+ * <p>It does not apply to surrogate keys. If the identifier is one the platform is free to invent, it
+ * belongs under ADR-0013 and must use {@link UUIDv7Id}.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({FIELD, METHOD})
+public @interface AssignedIdentifier {
+
+    /**
+     * Why this identifier is assigned rather than generated — what supplies the value, and what a minted
+     * one would mean. Required, and required to be non-blank: an unexplained opt-out from a fleet-wide
+     * rule is indistinguishable from a mistake, so the architecture rule rejects an empty reason.
+     */
+    String value();
+}

--- a/pos-shared-dtos/src/main/java/com/positivity/shared/id/AssignedIdentifier.java
+++ b/pos-shared-dtos/src/main/java/com/positivity/shared/id/AssignedIdentifier.java
@@ -1,7 +1,6 @@
 package com.positivity.shared.id;
 
 import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
@@ -46,10 +45,18 @@ import java.lang.annotation.Target;
  *
  * <p>It does not apply to surrogate keys. If the identifier is one the platform is free to invent, it
  * belongs under ADR-0013 and must use {@link UUIDv7Id}.
+ *
+ * <h2>Fields only</h2>
+ *
+ * Unlike {@link UUIDv7Id}, which must also target methods because it attaches a generator and Hibernate
+ * allows property access, this targets {@code FIELD} alone. The rule it opts out of inspects {@code @Id}
+ * <em>fields</em>, so a marker on a getter would be unenforceable in both directions: it could not exempt
+ * anything, and nothing would stop it drifting onto unrelated methods. Restricting the target closes that
+ * at compile time rather than asking another architecture rule to notice.
  */
 @Documented
 @Retention(RUNTIME)
-@Target({FIELD, METHOD})
+@Target(FIELD)
 public @interface AssignedIdentifier {
 
     /**

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/SupplierScheduleLeaseEntity.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/SupplierScheduleLeaseEntity.java
@@ -1,6 +1,6 @@
 package com.positivity.supplier.internal.entity;
 
-import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.shared.id.AssignedIdentifier;
 import com.positivity.supplier.internal.domain.model.SupplierCapability;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -64,31 +64,30 @@ public class SupplierScheduleLeaseEntity {
     /**
      * The binding this lease governs. Also the primary key: one lease per binding, by construction.
      *
-     * <h3>An assigned identifier that still carries {@code @UUIDv7Id}</h3>
+     * <h3>Assigned, never generated</h3>
      *
-     * This id is <strong>never generated</strong> — it is the binding's own identity, so a lease row with
-     * an invented id would be a lease on nothing. {@code @UUIDv7Id} is present because the fleet-wide
-     * ADR-0013 rule ({@code EntityStandardsArchitectureTest}) requires every UUID {@code @Id} to declare
-     * it, and it is safe here only because {@code UUIDv7HibernateGenerator} returns
-     * {@code currentValue != null ? currentValue : generate()} and reports
-     * {@code allowAssignedIdentifiers() == true}: an assigned id always wins.
+     * This id is the binding's own identity, so a lease row with an invented id would be a lease on nothing.
+     * {@code @AssignedIdentifier} says exactly that and, because ADR-0013 governs identifier
+     * <em>generation</em>, exempts the field from the fleet-wide {@code @UUIDv7Id} requirement
+     * ({@code EntityStandardsArchitectureTest}). No generator is attached, so a save with a null
+     * {@code bindingId} fails loudly at persist time rather than being keyed to a binding that does not exist
+     * — {@code SupplierScheduleLeaseRepositoryTest.aLeaseWithNoBindingIdIsRejectedRatherThanKeyedToAnInventedBinding}
+     * pins that.
      *
-     * <p>What stops a <em>minted</em> id — one Hibernate generates because the caller supplied none — from
-     * becoming a lease on a binding that does not exist is {@code fk_slease_binding}: {@code binding_id} is
-     * a foreign key to {@code supplier_endpoint_binding}, so an invented UUID fails the insert. That FK is
-     * what makes the {@code @UUIDv7Id} annotation safe to carry here, not the generator's
-     * assigned-value-wins behaviour alone, and
-     * {@code SupplierScheduleLeaseRepositoryTest.aMintedBindingIdCannotBecomeAnOrphanLease} pins it. If a
-     * future migration ever drops that FK, this annotation stops being harmless and needs a guard.
+     * <p>It previously carried {@code @UUIDv7Id} to satisfy that rule (#1261), which attached a real Hibernate
+     * generator and turned the null case into a silently minted id. That was harmless only because
+     * {@code fk_slease_binding} rejected the invented UUID at the database — a safety property owned by a
+     * migration rather than by this entity. The FK is still there and still worth having as defence in depth;
+     * it is no longer the only thing standing between a missing binding id and an orphan lease.
      *
-     * <p>Note for anyone tempted by a {@code @PrePersist} null-check instead: it does not work. The callback
-     * fires <em>after</em> identifier generation, so by the time it runs the field is already populated with
-     * a generated value and the check can never see null. Verified, not assumed — an earlier attempt at
-     * exactly that guard was dead code, and the test that was written to defend it is what exposed both this
-     * ordering and the existence of the FK above.
+     * <p>Note for anyone tempted to restore a generator plus a {@code @PrePersist} null-check: that guard does
+     * not work. The callback fires <em>after</em> identifier generation, so by the time it runs the field is
+     * already populated and the check can never see null. Verified, not assumed — an earlier attempt at exactly
+     * that guard was dead code that read as protection.
      */
     @Id
-    @UUIDv7Id
+    @AssignedIdentifier("the binding's own id: one lease per binding, and a lease on an invented id"
+            + " would be a lease on nothing")
     @Column(name = "binding_id", nullable = false, updatable = false)
     private UUID bindingId;
 

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/repository/SupplierScheduleLeaseRepositoryTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/repository/SupplierScheduleLeaseRepositoryTest.java
@@ -22,12 +22,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import javax.sql.DataSource;
+import org.hibernate.id.IdentifierGenerationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.context.annotation.Import;
+import org.springframework.orm.jpa.JpaSystemException;
 
 /**
  * Lease correctness under contention (binding decision 4).
@@ -389,20 +391,16 @@ class SupplierScheduleLeaseRepositoryTest {
     }
 
     /**
-     * The lease's primary key is the <em>binding's</em> id, never a minted one. It nonetheless carries
-     * {@code @UUIDv7Id}, because the fleet-wide ADR-0013 rule requires that of every UUID {@code @Id}, and
-     * that annotation attaches a real Hibernate identifier generator. This pins the only property that
-     * makes the combination safe: an assigned id survives. If a future change to
-     * {@code UUIDv7HibernateGenerator} stopped honouring {@code currentValue}, every lease would silently
-     * be keyed to a binding that does not exist -- no constraint would catch it, because the invented id
-     * is a perfectly valid UUID and the table has no foreign key to the binding.
+     * The lease's primary key is the <em>binding's</em> id, never a minted one — {@code bindingId} is
+     * {@code @AssignedIdentifier}, so nothing generates it. This pins the property that matters: the id the
+     * caller supplies is the id the row is stored under, and no lease appears keyed to anything else.
      *
      * <p>It also proves the ADR-0024 auditing listener is wired: the builder leaves {@code createdAt} and
      * {@code updatedAt} null and both columns are NOT NULL, so the insert only succeeds because
      * {@code @CreatedDate}/{@code @LastModifiedDate} populated them.
      */
     @Test
-    void assignedBindingIdSurvivesTheIdentifierGenerator() {
+    void theLeaseIsStoredUnderTheBindingIdItWasGiven() {
         SupplierEndpointBindingEntity second = new SupplierEndpointBindingEntity();
         second.setVendorProfileId(profileId);
         second.setCapability(SupplierCapability.STOCK_REPORT);
@@ -442,35 +440,54 @@ class SupplierScheduleLeaseRepositoryTest {
      * The other half of the same concern, and the half that would actually bite: a lease saved with
      * <em>no</em> binding id must not become a lease on a binding that does not exist.
      *
-     * <p>{@code @UUIDv7Id} attaches a real Hibernate generator, so Hibernate mints an id here rather than
-     * failing on NOT NULL as it did before the annotation. What makes that harmless is
-     * {@code fk_slease_binding}: the minted UUID references no binding, so the insert is rejected. This test
-     * pins that FK, because it is the only thing standing between the annotation and a permanently
-     * unclaimable orphan lease -- a row that would look entirely valid and simply never be worked.
+     * <p>This is what {@code @AssignedIdentifier} buys over the {@code @UUIDv7Id} the field used to carry
+     * (#1261). That annotation attached a real Hibernate generator, so a null id was quietly minted and the
+     * only thing rejecting the row was {@code fk_slease_binding} at the database. With no generator attached
+     * the save fails outright, and the invariant is owned by the entity rather than by a migration that a
+     * later one could drop.
      *
      * <p>It also records a correction. A {@code @PrePersist} null-check was written for this first and was
-     * dead code: the callback fires AFTER identifier generation, so it never sees null. This test is what
-     * exposed both that ordering and the FK, and it is deliberately asserted at the database rather than in
-     * Java so it keeps testing the thing that is really doing the work.
+     * dead code: the callback fires AFTER identifier generation, so with a generator attached it never sees
+     * null. That is why the fix is to attach no generator rather than to guard one.
      */
     @Test
-    void aMintedBindingIdCannotBecomeAnOrphanLease() {
+    void aLeaseWithNoBindingIdIsRejectedRatherThanKeyedToAnInventedBinding() {
         SupplierScheduleLeaseEntity unkeyed = SupplierScheduleLeaseEntity.builder()
                 .vendorProfileId(profileId)
                 .capability(SupplierCapability.STOCK_REPORT)
                 .build();
 
         assertThatThrownBy(() -> leaseRepository.saveAndFlush(unkeyed))
-                .as("an id Hibernate invented references no binding, so fk_slease_binding must reject it")
-                .hasRootCauseInstanceOf(java.sql.SQLIntegrityConstraintViolationException.class)
+                .as("no generator may invent a binding id; the save must fail instead")
+                .isInstanceOf(JpaSystemException.class)
                 .rootCause()
-                .hasMessageContaining("FK_SLEASE_BINDING");
+                .isInstanceOf(IdentifierGenerationException.class);
 
         entityManager.clear();
         assertThat(leaseRepository.findAll())
                 .extracting(SupplierScheduleLeaseEntity::getBindingId)
                 .as("and no orphan lease may be left behind")
                 .containsExactly(bindingId);
+    }
+
+    /**
+     * Defence in depth for the case above: even if a lease were somehow inserted with a binding id nobody
+     * assigned, {@code fk_slease_binding} still rejects it. The entity is now the first line of defence and
+     * the FK the second — this asserts the second is still standing, at the database, where the work happens.
+     */
+    @Test
+    void anUnknownBindingIdIsStillRejectedByTheForeignKey() {
+        SupplierScheduleLeaseEntity orphan = SupplierScheduleLeaseEntity.builder()
+                .bindingId(UUID.randomUUID())
+                .vendorProfileId(profileId)
+                .capability(SupplierCapability.STOCK_REPORT)
+                .build();
+
+        assertThatThrownBy(() -> leaseRepository.saveAndFlush(orphan))
+                .as("a binding id referencing no binding must not become a permanently unclaimable lease")
+                .hasRootCauseInstanceOf(java.sql.SQLIntegrityConstraintViolationException.class)
+                .rootCause()
+                .hasMessageContaining("FK_SLEASE_BINDING");
     }
 
     @Test


### PR DESCRIPTION
## Capability & Traceability
- Capability: none — repo cleanup, not a capability. Surfaced during CAP-317 (#1243), where the rule was satisfied rather than amended because `EntityStandardsArchitectureTest` is shared across 9 modules.
- Parent STORY (durion): none
- Child issue: louisburroughs/durion-positivity-backend#1261
- Domain: `domain:platform` (shared architecture rules + `pos-shared-dtos`), applied in `domain:supplier`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
No API or event behavior changes: no controllers, DTOs, `*Request`/`*Response` types, events, or `openapi.yaml` are touched. The new file in `pos-shared-dtos` is an annotation under `com.positivity.shared.id`, not a transport type, so no `BACKEND_CONTRACT_GUIDE.md` entry applies.

- Contract guide entry (durion): n/a — no contract semantics changed
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
No controller changed, so none of these apply.

- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope

**What changed:**

1. **New marker** — `com.positivity.shared.id.AssignedIdentifier` (`pos-shared-dtos`). Documents an `@Id` that is a natural key supplied by the caller, and carries a required, non-blank reason. It attaches no Hibernate generator and changes no runtime behavior.
2. **Rule amended** — `EntityStandardsArchitectureTest` exempts an `@Id` marked `@AssignedIdentifier` from the `@UUIDv7Id` requirement, and additionally rejects:
   - a field carrying both `@UUIDv7Id` and `@AssignedIdentifier` (they make opposite claims, and the generator stays attached);
   - a blank reason (an unexplained opt-out from a fleet-wide rule reads as a mistake);
   - the marker on any field that is not an `@Id` (elsewhere it is decoration that looks significant).
   
   The existing violation message now also points at the marker, so the next module to hit this wall is told what to do.
3. **Applied** — `SupplierScheduleLeaseEntity.bindingId` swaps `@UUIDv7Id` for `@AssignedIdentifier`, with the entity javadoc rewritten to match.
4. **Documented** — new "Assigned Natural Keys" section in `docs/UUID_V7_MIGRATION.md`.

**Why:**

The rule required every UUID `@Id` to declare `@UUIDv7Id`. That is right for surrogate keys and wrong for an `@Id` whose whole meaning is that it must not be invented — annotating one asks a generator to make up an identifier that is only valid if it comes from somewhere else. ADR-0013 governs identifier *generation*; a natural key is not generated, so the rule should not reach it.

For `SupplierScheduleLeaseEntity` the annotation was not merely redundant. It attached a real Hibernate generator, so a save with a null `bindingId` was silently minted into a lease keyed to a binding that does not exist, instead of failing loudly on `NOT NULL`. The only thing rejecting that row was `fk_slease_binding` (`V3__supplier_exchange_audit.sql:123`) — a safety property owned by a migration rather than by the entity, and one a later migration could drop. With no generator attached, the save now fails at persist time with `IdentifierGenerationException`. The FK remains as defence in depth and keeps its own test.

Worth recording, because it is counter-intuitive: **a `@PrePersist` null-guard cannot serve as the alternative fix.** The callback fires *after* identifier generation, so with a generator attached it can never observe a null id. That is why the fix is to attach no generator rather than to guard one.

## Tests

- [x] Unit tests added/updated
- [ ] Integration tests added/updated — none needed; the lease tests are `@DataJpaTest` against real H2 and run under `test`
- [ ] Provider behavioral contract tests added/updated — no contract behavior changed

Changes in `SupplierScheduleLeaseRepositoryTest`:

| Test | Change |
|---|---|
| `aMintedBindingIdCannotBecomeAnOrphanLease` | Replaced by `aLeaseWithNoBindingIdIsRejectedRatherThanKeyedToAnInventedBinding` — asserts the save fails outright rather than being caught downstream by the FK |
| *(new)* `anUnknownBindingIdIsStillRejectedByTheForeignKey` | Keeps the FK pinned at the database as the second line of defence |
| `assignedBindingIdSurvivesTheIdentifierGenerator` | Renamed to `theLeaseIsStoredUnderTheBindingIdItWasGiven`; its premise (a generator that honours assigned values) no longer exists |

**How to run:**

```bash
# The amended rule, across all 9 enforced entity packages.
# Note: `test`, not `verify` — under `verify` the rules pass vacuously (#909).
./mvnw -pl pos-archunit -am test

# The entity that motivated the change
./mvnw -pl pos-supplier -am -Dtest=SupplierScheduleLeaseRepositoryTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

Results on this branch:

- `./mvnw -pl pos-archunit -am test` → **BUILD SUCCESS** across all 30 modules, zero failures or errors anywhere in the reactor. `EntityStandardsArchitectureTest` 6/6 (was 5 — the new not-an-`@Id` rule), `ClasspathVisibilityGuardTest` 2/2 so the rules are not passing vacuously, pos-archunit module 21/21.
- `SupplierScheduleLeaseRepositoryTest` → 16/16.

## Risk & Rollback

- Risk level: **Low**
- The rule change is strictly more permissive for compliant code — no existing entity declares the new marker, so every module's current state passes unchanged, evidenced by the full reactor run above.
- The one behavioral change is scoped to `SupplierScheduleLeaseEntity`: a save with a null `bindingId` now throws instead of being rejected by the FK. Both outcomes are failures; the new one is earlier and clearer. No main-code path constructs a lease (every write is native SQL in `SupplierScheduleLeaseRepository`), so no production call site changes behavior.
- No schema change, no migration, no API surface change.
- Rollback plan: revert this commit. The entity returns to `@UUIDv7Id`, the rule returns to requiring it, and `fk_slease_binding` — untouched by this PR — resumes being the sole guard.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, no capability; branch is issue-scoped per the assignment
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, same reason
- [x] Links to parent + child issues are present (child #1261; no parent STORY)
- [ ] Contract guide updated (when contract semantics changed) — n/a, no contract semantics changed
- [ ] Required CI checks passing — pending first run

Closes #1261

---
_Generated by [Claude Code](https://claude.ai/code/session_016Ur4MCwLvYcFBMXYuVFVha)_