### PR TITLE
test: branch-coverage tails in pos-catalog and pos-workorder (plan §7 item 4)

### DIFF
--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -767,9 +767,9 @@ consumer-credited figure for shared libraries. No work is outstanding here.
 1. ~~**Wave 1c** (`{Module}PermissionRegistry`, §3.3)~~ — closed 2026-08-12, see §7.1.
 2. ~~**Controller `@WebMvcTest` slices**~~ — closed 2026-08-12, see §7.3.
 3. ~~**The four all-zero modules**~~ — closed 2026-08-12, see §7.2.
-4. **Branch-coverage tails** — `pos-catalog` (53.5% branch against 77.4% line),
-   `pos-workorder` (56.7%), `pos-document-helper` (35.2%). Parameterized tests
-   over the uncovered branches, not more happy paths.
+4. **Branch-coverage tails** — first pass done 2026-08-12, see §7.4. `pos-catalog`
+   and `pos-workorder` still have tails worth a second pass;
+   `pos-document-helper` is blocked on #1274.
 5. **Low-coverage shared libraries** — `pos-tax-common` 34.0%,
    `pos-domain-events` 39.3%, `pos-security-common` 46.8% on their own tests.
    They read far higher in the aggregate because consumers exercise them; their
@@ -879,6 +879,59 @@ ProblemDetail.
 Two defects were found and filed by this wave (#1269 and #1270); they join the
 standing list below.
 
+### 7.4 Branch tails, first pass (2026-08-12)
+
+| Module | Branch before | Branch after | Line after | Floor |
+|---|---|---|---|---|
+| `pos-catalog` | 53.5% | 57.6% | 78.6% | 0.73 / 0.52 |
+| `pos-workorder` | 56.7% | 58.5% | 78.2% | 0.73 / 0.53 |
+| `pos-document-helper` | 35.2% | 35.2% | 74.0% | unchanged |
+
+Attacked the two worst individual classes rather than spreading thinly, on the
+view that a branch tail is not uniform — it concentrates in the places where the
+code makes a choice the caller cannot see it make.
+
+**`PriceBookServiceImpl.resolvePrice`** (47.1% → 68.8% branch, 90 → 53 missed).
+This is the read that decides what a product costs, and almost every branch in it
+is silent. It walks two independent precedence chains — which price book applies,
+then which rule inside it wins — then falls back to MSRP and finally to "no
+price". Every step produces a well-formed answer, so an error does not fail, it
+quotes a different number. Only `source` and `fallbackReason` distinguish "this
+is the contract price" from "this is list price because nothing matched", and
+nothing downstream re-derives them. The tests assert the winning rule and the
+source, not that a price came back. Specifics worth keeping:
+
+- Target specificity (SKU > CATEGORY > GLOBAL) is scored before priority, so
+  priorities in the fixtures are set to contradict the expected winner.
+- `nullsLast` on a reversed comparator decides whether an unprioritised rule
+  outranks every deliberately prioritised one; both directions are asserted.
+- A fully tied pair is broken by rule id, asserted with the inputs supplied in
+  reverse — a tie that resolved by input order would have two servers quoting
+  different prices for the same basket.
+- Currency selection refuses to guess: an unconfigured requested currency and an
+  ambiguous multi-currency rule are both errors, because substituting either
+  would hand the caller a number in the wrong denomination.
+- Zero and negative amounts are rejected. A rule resolving to nothing or to a
+  credit is a data error, and letting it through prices the product at that
+  value.
+
+**`WorkorderPickFacadeServiceImpl`** (0% → 100% branch). Turns warehouse scans
+into asynchronous inventory commands (ADR-0044, #901). Two families of branch:
+the four-way scan grade (MATCHED / SKU_MISMATCH / LOCATION_MISMATCH / NO_MATCH),
+whose two mismatch cases are decided by opposite comparisons and are trivially
+swappable — a picker acts on that word, and it tells them whether they are at the
+wrong bin or holding the wrong part; and the refusal to publish half-formed
+commands, which fails closed twice over with a 409 for an incomplete replica and
+a 503 for an absent publisher or a broker nack. Those two must stay
+distinguishable: a 409 cannot be fixed by retrying, a 503 is exactly what should
+be retried.
+
+**`pos-document-helper` is deliberately untouched.** Its entire branch tail — 32
+of 35 missed branches — sits in a duplicated copy of the library that no module
+consumes (#1274). Testing it would cement a deletion candidate and make the
+number look healthy while the duplication stayed. Its floor is unchanged pending
+that decision.
+
 ### Defects found by this work, still open
 
 - louisburroughs/durion-positivity-backend#1245 — a partial customer update
@@ -907,6 +960,10 @@ standing list below.
   fields and no `@Jacksonized`, so Jackson has no creator and message conversion
   fails before the controller is entered. The GET route builds the object in
   Java, which is why nothing caught it.
+- louisburroughs/durion-positivity-backend#1274 — `pos-document-helper` ships two
+  parallel copies of the same library, under `com.positivity.documents` and
+  `com.positivity.documents.helper`, and no module imports either. Both trees
+  landed in the same commit, so this is not a half-finished migration.
 - louisburroughs/durion-positivity-backend#1267 — `pos-vehicle-reference-carapi`
   conflates its own primary key with CarAPI's make id inside one method, so no
   argument to `GET /models/{makeId}` is correct for all three of its uses; the

--- a/pos-catalog/pom.xml
+++ b/pos-catalog/pom.xml
@@ -14,10 +14,11 @@
     <description>POS Catalog module</description>
 
     <properties>
-        <!-- Coverage ratchet (plan Phase 4): measured 77.4% line / 53.5% branch.
+        <!-- Coverage ratchet (plan Phase 4): measured 78.6% line / 57.6% branch after the
+             §7 branch-tail wave (was 77.4% / 53.5%).
              Floors sit ~5 points under to catch regression without failing on noise. -->
-        <jacoco.line.min>0.72</jacoco.line.min>
-        <jacoco.branch.min>0.48</jacoco.branch.min>
+        <jacoco.line.min>0.73</jacoco.line.min>
+        <jacoco.branch.min>0.52</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
     <dependencies>

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/PriceBookResolvePriceTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/PriceBookResolvePriceTest.java
@@ -1,0 +1,514 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.dto.ResolvePriceRequestDto;
+import com.positivity.catalog.internal.dto.ResolvePriceResponseDto;
+import com.positivity.catalog.internal.dto.ResolvePriceResponseDto.ResolvePriceSource;
+import com.positivity.catalog.internal.entity.Category;
+import com.positivity.catalog.internal.entity.PriceBookEntity;
+import com.positivity.catalog.internal.entity.PriceBookRuleConditionType;
+import com.positivity.catalog.internal.entity.PriceBookRuleEntity;
+import com.positivity.catalog.internal.entity.PriceBookRuleStatus;
+import com.positivity.catalog.internal.entity.PriceBookRuleTargetType;
+import com.positivity.catalog.internal.entity.PriceBookScope;
+import com.positivity.catalog.internal.entity.PriceBookStatus;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.ProductMsrpEntity;
+import com.positivity.catalog.internal.entity.Subcategory;
+import com.positivity.catalog.internal.exception.CatalogValidationException;
+import com.positivity.catalog.internal.repository.PriceBookRepository;
+import com.positivity.catalog.internal.repository.PriceBookRuleRepository;
+import com.positivity.catalog.internal.repository.ProductMsrpRepository;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Branch-coverage tests for {@link PriceBookServiceImpl#resolvePrice}, the read
+ * path that decides what a product costs.
+ *
+ * <p>
+ * Almost every branch in this method is a silent one. Price resolution walks two
+ * independent precedence chains — first which price book applies, then which
+ * rule inside it wins — and then falls back to MSRP and finally to "no price".
+ * Every step of both chains produces a well-formed answer, so getting one wrong
+ * does not fail, it quotes a different number. Only the {@code source} and
+ * {@code fallbackReason} fields on the response distinguish "this is the
+ * contract price" from "this is list price because no contract matched", and
+ * nothing downstream re-derives them.
+ *
+ * <p>
+ * These tests therefore assert the chosen rule and the source, not merely that a
+ * price came back.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PriceBookServiceImpl.resolvePrice — precedence and fallback")
+class PriceBookResolvePriceTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-12T00:00:00Z");
+    private static final UUID PRODUCT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID CATEGORY_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a2");
+    private static final UUID SUBCATEGORY_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a3");
+    private static final UUID BOOK_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a4");
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a5");
+    private static final UUID TIER_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a6");
+
+    @Mock
+    private PriceBookRepository priceBookRepository;
+
+    @Mock
+    private PriceBookRuleRepository priceBookRuleRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private ProductMsrpRepository productMsrpRepository;
+
+    private PriceBookServiceImpl service;
+    private ProductEntity product;
+
+    @BeforeEach
+    void setUp() {
+        service = new PriceBookServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                priceBookRepository,
+                priceBookRuleRepository,
+                productRepository,
+                productMsrpRepository,
+                new ObjectMapper());
+
+        product = new ProductEntity();
+        product.setId(PRODUCT_ID);
+        Category category = new Category();
+        category.setId(CATEGORY_ID);
+        product.setCategory(category);
+        Subcategory subcategory = new Subcategory();
+        subcategory.setId(SUBCATEGORY_ID);
+        product.setSubcategory(subcategory);
+
+        when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product));
+        when(productMsrpRepository.findActive(any(), any())).thenReturn(Optional.empty());
+        defaultBookExists();
+    }
+
+    private void defaultBookExists() {
+        PriceBookEntity book = new PriceBookEntity();
+        book.setPriceBookId(BOOK_ID);
+        when(priceBookRepository.findByScopeAndIsDefaultTrueAndStatus(
+                        PriceBookScope.COMPANY_DEFAULT, PriceBookStatus.ACTIVE))
+                .thenReturn(Optional.of(book));
+    }
+
+    private static PriceBookRuleEntity rule(
+            String id, PriceBookRuleTargetType targetType, UUID targetId, Integer priority) {
+        PriceBookRuleEntity entity = new PriceBookRuleEntity();
+        entity.setRuleId(UUID.fromString("00000000-0000-0000-0000-0000000000" + id));
+        entity.setTargetType(targetType);
+        entity.setTargetId(targetId);
+        entity.setPriority(priority);
+        entity.setConditionType(PriceBookRuleConditionType.NONE);
+        entity.setStatus(PriceBookRuleStatus.ACTIVE);
+        entity.setPricingLogic("{\"amounts\":{\"USD\":19.99}}");
+        return entity;
+    }
+
+    private void rulesReturned(PriceBookRuleEntity... rules) {
+        when(priceBookRuleRepository.findActiveRulesForBooks(any(), eq(PriceBookRuleStatus.ACTIVE), any()))
+                .thenReturn(List.of(rules));
+    }
+
+    private static ResolvePriceRequestDto request() {
+        ResolvePriceRequestDto request = new ResolvePriceRequestDto();
+        request.setProductId(PRODUCT_ID);
+        return request;
+    }
+
+    // ─── target precedence: SKU beats CATEGORY beats GLOBAL ──────────────────
+
+    @Test
+    @DisplayName("a SKU rule beats a category rule and a global rule, whatever their priorities")
+    void skuRuleWinsOverCategoryAndGlobal() {
+        // Priorities are deliberately inverted against the desired outcome: precedence by
+        // target specificity is scored first and priority only breaks ties within a score, so a
+        // high-priority global rule must still lose to a low-priority SKU rule.
+        PriceBookRuleEntity global = rule("b1", PriceBookRuleTargetType.GLOBAL, null, 100);
+        PriceBookRuleEntity category = rule("b2", PriceBookRuleTargetType.CATEGORY, CATEGORY_ID, 50);
+        PriceBookRuleEntity sku = rule("b3", PriceBookRuleTargetType.SKU, PRODUCT_ID, 1);
+        rulesReturned(global, category, sku);
+
+        ResolvePriceResponseDto response = service.resolvePrice(request());
+
+        assertThat(response.getSource()).isEqualTo(ResolvePriceSource.PRICE_BOOK_RULE);
+        assertThat(response.getSourceRuleId()).isEqualTo(sku.getRuleId());
+    }
+
+    @Test
+    @DisplayName("a category rule beats a global rule when no SKU rule applies")
+    void categoryRuleWinsOverGlobal() {
+        PriceBookRuleEntity global = rule("c1", PriceBookRuleTargetType.GLOBAL, null, 100);
+        PriceBookRuleEntity category = rule("c2", PriceBookRuleTargetType.CATEGORY, CATEGORY_ID, 1);
+        rulesReturned(global, category);
+
+        assertThat(service.resolvePrice(request()).getSourceRuleId()).isEqualTo(category.getRuleId());
+    }
+
+    @Test
+    @DisplayName("a category rule matches on the product's subcategory as well as its category")
+    void categoryRuleMatchesSubcategory() {
+        // A product sits at two taxonomy nodes and a rule may target either. Missing the
+        // subcategory branch would silently drop half the category rules in the catalog.
+        PriceBookRuleEntity onSubcategory = rule("c3", PriceBookRuleTargetType.CATEGORY, SUBCATEGORY_ID, 1);
+        rulesReturned(onSubcategory);
+
+        assertThat(service.resolvePrice(request()).getSourceRuleId()).isEqualTo(onSubcategory.getRuleId());
+    }
+
+    @Test
+    @DisplayName("a category rule pointing at some other node does not apply")
+    void unrelatedCategoryRuleDoesNotApply() {
+        rulesReturned(rule("c4", PriceBookRuleTargetType.CATEGORY, UUID.randomUUID(), 100));
+
+        // Falls all the way through to UNAVAILABLE: no rule applied and no MSRP is configured.
+        assertThat(service.resolvePrice(request()).getSource()).isEqualTo(ResolvePriceSource.UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("a product with no taxonomy at all cannot match a category rule")
+    void productWithoutTaxonomyMatchesNoCategoryRule() {
+        product.setCategory(null);
+        product.setSubcategory(null);
+        rulesReturned(rule("c5", PriceBookRuleTargetType.CATEGORY, CATEGORY_ID, 100));
+
+        assertThat(service.resolvePrice(request()).getSource()).isEqualTo(ResolvePriceSource.UNAVAILABLE);
+    }
+
+    // ─── tie-breaks within the same precedence score ─────────────────────────
+
+    @Test
+    @DisplayName("between two rules of equal specificity, the higher priority wins")
+    void higherPriorityWinsWithinTheSameScore() {
+        PriceBookRuleEntity low = rule("d1", PriceBookRuleTargetType.GLOBAL, null, 1);
+        PriceBookRuleEntity high = rule("d2", PriceBookRuleTargetType.GLOBAL, null, 9);
+        rulesReturned(low, high);
+
+        assertThat(service.resolvePrice(request()).getSourceRuleId()).isEqualTo(high.getRuleId());
+    }
+
+    @Test
+    @DisplayName("a rule with no priority ranks below one that has any priority")
+    void nullPriorityRanksLast() {
+        // nullsLast on a reversed comparator is easy to get backwards, and getting it backwards
+        // means an unprioritised rule silently outranks every deliberately prioritised one.
+        PriceBookRuleEntity noPriority = rule("d3", PriceBookRuleTargetType.GLOBAL, null, null);
+        PriceBookRuleEntity lowest = rule("d4", PriceBookRuleTargetType.GLOBAL, null, 0);
+        rulesReturned(noPriority, lowest);
+
+        assertThat(service.resolvePrice(request()).getSourceRuleId()).isEqualTo(lowest.getRuleId());
+    }
+
+    @Test
+    @DisplayName("equal priority is broken by the most recently effective rule")
+    void newerEffectiveStartWins() {
+        PriceBookRuleEntity older = rule("d5", PriceBookRuleTargetType.GLOBAL, null, 5);
+        older.setEffectiveStartAt(NOW.minusSeconds(86_400));
+        PriceBookRuleEntity newer = rule("d6", PriceBookRuleTargetType.GLOBAL, null, 5);
+        newer.setEffectiveStartAt(NOW);
+        rulesReturned(older, newer);
+
+        assertThat(service.resolvePrice(request()).getSourceRuleId()).isEqualTo(newer.getRuleId());
+    }
+
+    @Test
+    @DisplayName("a fully tied pair is broken deterministically by rule id")
+    void fullTieIsBrokenByRuleId() {
+        PriceBookRuleEntity first = rule("d7", PriceBookRuleTargetType.GLOBAL, null, 5);
+        PriceBookRuleEntity second = rule("d8", PriceBookRuleTargetType.GLOBAL, null, 5);
+        // Supplied in reverse so the result cannot come from input order. A tie must resolve the
+        // same way on every node and every request, or two servers quote different prices for
+        // the same basket.
+        rulesReturned(second, first);
+
+        assertThat(service.resolvePrice(request()).getSourceRuleId()).isEqualTo(first.getRuleId());
+    }
+
+    // ─── conditions ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("a LOCATION-conditioned rule applies only to a request carrying that location")
+    void locationConditionMustMatch() {
+        PriceBookRuleEntity conditioned = rule("e1", PriceBookRuleTargetType.GLOBAL, null, 5);
+        conditioned.setConditionType(PriceBookRuleConditionType.LOCATION);
+        conditioned.setConditionValue(LOCATION_ID.toString());
+        rulesReturned(conditioned);
+
+        // No location on the request: the rule must not apply.
+        assertThat(service.resolvePrice(request()).getSource()).isEqualTo(ResolvePriceSource.UNAVAILABLE);
+
+        ResolvePriceRequestDto withLocation = request();
+        withLocation.setLocationId(LOCATION_ID);
+        assertThat(service.resolvePrice(withLocation).getSourceRuleId()).isEqualTo(conditioned.getRuleId());
+    }
+
+    @Test
+    @DisplayName("a LOCATION-conditioned rule does not apply to a different location")
+    void locationConditionRejectsOtherLocations() {
+        PriceBookRuleEntity conditioned = rule("e2", PriceBookRuleTargetType.GLOBAL, null, 5);
+        conditioned.setConditionType(PriceBookRuleConditionType.LOCATION);
+        conditioned.setConditionValue(UUID.randomUUID().toString());
+        rulesReturned(conditioned);
+
+        ResolvePriceRequestDto withLocation = request();
+        withLocation.setLocationId(LOCATION_ID);
+        assertThat(service.resolvePrice(withLocation).getSource()).isEqualTo(ResolvePriceSource.UNAVAILABLE);
+    }
+
+    @ParameterizedTest(name = "customerTier={0} against a rule requiring GOLD")
+    @CsvSource({"GOLD,true", "SILVER,false", ",false"})
+    @DisplayName("a CUSTOMER_TIER-conditioned rule applies only to its own tier")
+    void customerTierConditionMustMatch(String tier, boolean applies) {
+        PriceBookRuleEntity conditioned = rule("e3", PriceBookRuleTargetType.GLOBAL, null, 5);
+        conditioned.setConditionType(PriceBookRuleConditionType.CUSTOMER_TIER);
+        conditioned.setConditionValue("GOLD");
+        rulesReturned(conditioned);
+
+        ResolvePriceRequestDto withTier = request();
+        withTier.setCustomerTier(tier);
+
+        ResolvePriceResponseDto response = service.resolvePrice(withTier);
+        assertThat(response.getSource())
+                .isEqualTo(applies ? ResolvePriceSource.PRICE_BOOK_RULE : ResolvePriceSource.UNAVAILABLE);
+    }
+
+    // ─── which book, and the fallback chain ──────────────────────────────────
+
+    @Test
+    @DisplayName("a location book takes precedence over the company default")
+    void locationBookBeatsCompanyDefault() {
+        PriceBookEntity locationBook = new PriceBookEntity();
+        UUID locationBookId = UUID.fromString("00000000-0000-0000-0000-0000000000f1");
+        locationBook.setPriceBookId(locationBookId);
+        when(priceBookRepository.findByScopeAndScopeIdAndStatus(
+                        PriceBookScope.LOCATION, LOCATION_ID, PriceBookStatus.ACTIVE))
+                .thenReturn(Optional.of(locationBook));
+        rulesReturned(rule("f1", PriceBookRuleTargetType.GLOBAL, null, 1));
+
+        ResolvePriceRequestDto withLocation = request();
+        withLocation.setLocationId(LOCATION_ID);
+        service.resolvePrice(withLocation);
+
+        // The company default must not even be consulted once a location book exists — a
+        // location's negotiated prices are not a fallback, they are the answer.
+        verify(priceBookRuleRepository).findActiveRulesForBooks(eq(List.of(locationBookId)), any(), any());
+        verify(priceBookRepository, never())
+                .findByScopeAndIsDefaultTrueAndStatus(PriceBookScope.COMPANY_DEFAULT, PriceBookStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("a location with no book of its own falls through to the customer tier book")
+    void missingLocationBookFallsThroughToTierBook() {
+        when(priceBookRepository.findByScopeAndScopeIdAndStatus(
+                        PriceBookScope.LOCATION, LOCATION_ID, PriceBookStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+        PriceBookEntity tierBook = new PriceBookEntity();
+        UUID tierBookId = UUID.fromString("00000000-0000-0000-0000-0000000000f2");
+        tierBook.setPriceBookId(tierBookId);
+        when(priceBookRepository.findByScopeAndScopeIdAndStatus(
+                        PriceBookScope.CUSTOMER_TIER, TIER_ID, PriceBookStatus.ACTIVE))
+                .thenReturn(Optional.of(tierBook));
+        rulesReturned(rule("f2", PriceBookRuleTargetType.GLOBAL, null, 1));
+
+        ResolvePriceRequestDto withBoth = request();
+        withBoth.setLocationId(LOCATION_ID);
+        withBoth.setCustomerTierId(TIER_ID);
+        service.resolvePrice(withBoth);
+
+        verify(priceBookRuleRepository).findActiveRulesForBooks(eq(List.of(tierBookId)), any(), any());
+    }
+
+    @Test
+    @DisplayName("with no book at all, resolution falls to MSRP and says so")
+    void noBookFallsBackToMsrp() {
+        when(priceBookRepository.findByScopeAndIsDefaultTrueAndStatus(any(), any()))
+                .thenReturn(Optional.empty());
+        ProductMsrpEntity msrp = new ProductMsrpEntity();
+        msrp.setAmount(new BigDecimal("24.50"));
+        msrp.setCurrency("USD");
+        when(productMsrpRepository.findActive(eq(PRODUCT_ID), any())).thenReturn(Optional.of(msrp));
+
+        ResolvePriceResponseDto response = service.resolvePrice(request());
+
+        // MSRP is list price, not a negotiated price. The fallbackReason is the only signal a
+        // consumer has that no contract applied, so it is part of the contract.
+        assertThat(response.getSource()).isEqualTo(ResolvePriceSource.MSRP);
+        assertThat(response.getFallbackReason()).isEqualTo("MSRP_FALLBACK");
+        assertThat(response.getResolvedAmount()).isEqualTo("24.5000");
+        assertThat(response.getSourceRuleId()).isNull();
+    }
+
+    @Test
+    @DisplayName("with neither a rule nor an MSRP, the answer is UNAVAILABLE rather than zero")
+    void noPriceAtAllIsUnavailable() {
+        rulesReturned();
+
+        ResolvePriceResponseDto response = service.resolvePrice(request());
+
+        // A missing price must never surface as an amount. Returning zero here would sell the
+        // product for nothing; returning null with a reason forces the caller to decide.
+        assertThat(response.getSource()).isEqualTo(ResolvePriceSource.UNAVAILABLE);
+        assertThat(response.getFallbackReason()).isEqualTo("PRICE_BASE_DATA_MISSING");
+        assertThat(response.getResolvedAmount()).isNull();
+    }
+
+    @Test
+    @DisplayName("resolution is rejected outright without a product id")
+    void productIdIsRequired() {
+        assertThatThrownBy(() -> service.resolvePrice(new ResolvePriceRequestDto()))
+                .isInstanceOf(CatalogValidationException.class)
+                .hasMessageContaining("productId");
+    }
+
+    // ─── currency selection on the winning rule ──────────────────────────────
+
+    @Test
+    @DisplayName("an explicitly requested currency is used when the rule configures it")
+    void requestedCurrencyIsHonoured() {
+        PriceBookRuleEntity multi = rule("1a", PriceBookRuleTargetType.GLOBAL, null, 1);
+        multi.setPricingLogic("{\"amounts\":{\"USD\":19.99,\"EUR\":17.50}}");
+        rulesReturned(multi);
+
+        ResolvePriceRequestDto inEuros = request();
+        inEuros.setCurrency("eur");
+
+        ResolvePriceResponseDto response = service.resolvePrice(inEuros);
+
+        // Case-insensitive, but the amount must be the euro one — falling back to USD here
+        // would quote a euro price at a dollar number.
+        assertThat(response.getCurrency()).isEqualTo("EUR");
+        assertThat(response.getResolvedAmount()).isEqualTo("17.5000");
+    }
+
+    @Test
+    @DisplayName("a requested currency the rule does not configure is an error, not a substitution")
+    void unconfiguredRequestedCurrencyIsRejected() {
+        PriceBookRuleEntity usdOnly = rule("1b", PriceBookRuleTargetType.GLOBAL, null, 1);
+        usdOnly.setPricingLogic("{\"amounts\":{\"USD\":19.99}}");
+        rulesReturned(usdOnly);
+
+        ResolvePriceRequestDto inYen = request();
+        inYen.setCurrency("JPY");
+
+        // Quietly answering in USD would hand the caller a number they would treat as yen.
+        assertThatThrownBy(() -> service.resolvePrice(inYen)).isInstanceOf(CatalogValidationException.class);
+    }
+
+    @Test
+    @DisplayName("with one configured currency and no request, that currency is used")
+    void singleConfiguredCurrencyIsUnambiguous() {
+        rulesReturned(rule("1c", PriceBookRuleTargetType.GLOBAL, null, 1));
+
+        ResolvePriceResponseDto response = service.resolvePrice(request());
+
+        assertThat(response.getCurrency()).isEqualTo("USD");
+        assertThat(response.getResolvedAmount()).isEqualTo("19.9900");
+    }
+
+    @Test
+    @DisplayName("with several configured currencies and no request, resolution refuses to guess")
+    void ambiguousCurrencyIsRejected() {
+        PriceBookRuleEntity multi = rule("1d", PriceBookRuleTargetType.GLOBAL, null, 1);
+        multi.setPricingLogic("{\"amounts\":{\"USD\":19.99,\"EUR\":17.50}}");
+        rulesReturned(multi);
+
+        // Picking either one arbitrarily would be a coin flip over which currency the customer
+        // is billed in.
+        assertThatThrownBy(() -> service.resolvePrice(request())).isInstanceOf(CatalogValidationException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "{\"amounts\":{}}",
+                "{\"amounts\":[]}",
+                "{\"nothing\":1}",
+                "not json at all",
+                "{\"amounts\":{\"USD\":0}}",
+                "{\"amounts\":{\"USD\":-1}}",
+                "{\"amounts\":{\"USD\":null}}"
+            })
+    @DisplayName("a malformed or non-positive pricing payload is rejected rather than resolved")
+    void malformedPricingLogicIsRejected(String pricingLogic) {
+        PriceBookRuleEntity broken = rule("2a", PriceBookRuleTargetType.GLOBAL, null, 1);
+        broken.setPricingLogic(pricingLogic);
+        rulesReturned(broken);
+
+        // Zero and negative are in this list deliberately: a rule that resolves to nothing or
+        // to a credit is a data error, and letting it through prices the product at that value.
+        assertThatThrownBy(() -> service.resolvePrice(request())).isInstanceOf(CatalogValidationException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"US", "USDD", "1"})
+    @DisplayName("a currency that is not a three-letter code is rejected")
+    void nonIsoCurrencyIsRejected(String currency) {
+        rulesReturned(rule("2b", PriceBookRuleTargetType.GLOBAL, null, 1));
+
+        ResolvePriceRequestDto bad = request();
+        bad.setCurrency(currency);
+
+        assertThatThrownBy(() -> service.resolvePrice(bad)).isInstanceOf(CatalogValidationException.class);
+    }
+
+    @Test
+    @DisplayName("a blank requested currency is treated as no request rather than as an error")
+    void blankCurrencyIsTreatedAsAbsent() {
+        rulesReturned(rule("2c", PriceBookRuleTargetType.GLOBAL, null, 1));
+
+        ResolvePriceRequestDto blank = request();
+        blank.setCurrency("   ");
+
+        // A UI that always sends its currency field, empty or not, must not be rejected.
+        assertThat(service.resolvePrice(blank).getCurrency()).isEqualTo("USD");
+    }
+
+    @Test
+    @DisplayName("an explicit asOf date is used instead of today")
+    void explicitAsOfIsUsed() {
+        LocalDate asOf = LocalDate.of(2026, 1, 1);
+        rulesReturned();
+        ResolvePriceRequestDto dated = request();
+        dated.setAsOf(asOf);
+
+        service.resolvePrice(dated);
+
+        // Backdated quoting is the whole point of asOf — resolving against today instead would
+        // reprice a historical order at current prices.
+        verify(productMsrpRepository).findActive(PRODUCT_ID, asOf);
+    }
+}

--- a/pos-workorder/pom.xml
+++ b/pos-workorder/pom.xml
@@ -13,10 +13,11 @@
     <description>Module to manage workorders for a shop</description>
 
     <properties>
-        <!-- Coverage ratchet (plan Phase 4): measured 76.6% line / 56.7% branch.
+        <!-- Coverage ratchet (plan Phase 4): measured 78.2% line / 58.5% branch after the
+             §7 branch-tail wave (was 76.6% / 56.7%).
              Floors sit ~5 points under to catch regression without failing on noise. -->
-        <jacoco.line.min>0.71</jacoco.line.min>
-        <jacoco.branch.min>0.51</jacoco.branch.min>
+        <jacoco.line.min>0.73</jacoco.line.min>
+        <jacoco.branch.min>0.53</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
     <pluginRepositories>

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderPickFacadeServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderPickFacadeServiceImplTest.java
@@ -1,0 +1,388 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.config.InventoryCommandPublisher;
+import com.positivity.workorder.internal.dto.pick.CompletePickTaskRequest;
+import com.positivity.workorder.internal.dto.pick.ConfirmPickLineRequest;
+import com.positivity.workorder.internal.dto.pick.ConsumePickedItemsRequest;
+import com.positivity.workorder.internal.dto.pick.ResolveScanRequest;
+import com.positivity.workorder.internal.dto.pick.ResolveScanResponse;
+import com.positivity.workorder.internal.entity.ExtPickListReplica;
+import com.positivity.workorder.internal.entity.ExtPickTaskReplica;
+import com.positivity.workorder.internal.repository.ExtPickListReplicaRepository;
+import com.positivity.workorder.internal.repository.ExtPickTaskReplicaRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Branch-coverage tests for {@link WorkorderPickFacadeServiceImpl}, which was at
+ * 0% branch coverage.
+ *
+ * <p>
+ * This facade sits over a replica of pos-inventory's pick state and turns
+ * warehouse scans into asynchronous commands (ADR-0044, #901). Two families of
+ * branch carry the weight:
+ *
+ * <ul>
+ * <li><b>Scan classification.</b> A scan is graded MATCHED, SKU_MISMATCH,
+ * LOCATION_MISMATCH or NO_MATCH from two independent booleans. The picker acts
+ * on that word — it tells them whether they are at the wrong bin or holding the
+ * wrong part — and the two mismatch cases are trivially swappable, since one is
+ * decided by the sku comparison and the other by the location comparison. The
+ * full truth table is asserted.</li>
+ * <li><b>Refusal to publish half-formed commands.</b> Every write here becomes a
+ * Kafka command that pos-inventory will act on, so the facade fails closed twice
+ * over: 409 if the replica is not yet complete enough to describe the task, and
+ * 503 if the publisher is absent or the broker refuses. Both must stay
+ * distinguishable — a 409 is a data-timing problem the caller cannot fix by
+ * retrying, a 503 is exactly the one they should retry.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("WorkorderPickFacadeServiceImpl — scan grading and command publishing")
+class WorkorderPickFacadeServiceImplTest {
+
+    private static final UUID WORKORDER_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID PICK_LIST_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a2");
+    private static final UUID TASK_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a3");
+    private static final UUID SKU_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a4");
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a5");
+    private static final UUID OTHER_ID = UUID.fromString("00000000-0000-0000-0000-0000000000ff");
+
+    @Mock
+    private ExtPickListReplicaRepository pickListReplicaRepository;
+
+    @Mock
+    private ExtPickTaskReplicaRepository pickTaskReplicaRepository;
+
+    @Mock
+    private ObjectProvider<InventoryCommandPublisher> publisherProvider;
+
+    @Mock
+    private InventoryCommandPublisher publisher;
+
+    private WorkorderPickFacadeServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkorderPickFacadeServiceImpl(
+                pickListReplicaRepository, pickTaskReplicaRepository, publisherProvider);
+        when(publisherProvider.getIfAvailable()).thenReturn(publisher);
+        pickListExists();
+        taskExists(task());
+    }
+
+    private void pickListExists() {
+        ExtPickListReplica list = new ExtPickListReplica();
+        list.setPickListId(PICK_LIST_ID);
+        list.setWorkorderId(WORKORDER_ID);
+        list.setStatus("OPEN");
+        when(pickListReplicaRepository.findByWorkorderIdOrderByPickListIdAsc(WORKORDER_ID))
+                .thenReturn(List.of(list));
+    }
+
+    private void taskExists(ExtPickTaskReplica task) {
+        when(pickTaskReplicaRepository.findByPickListIdOrderBySortOrderAsc(PICK_LIST_ID))
+                .thenReturn(List.of(task));
+    }
+
+    private static ExtPickTaskReplica task() {
+        ExtPickTaskReplica task = new ExtPickTaskReplica();
+        task.setPickTaskId(TASK_ID);
+        task.setPickListId(PICK_LIST_ID);
+        task.setWorkorderId(WORKORDER_ID);
+        task.setSkuId(SKU_ID);
+        task.setLocationId(LOCATION_ID);
+        task.setQuantityRequired(10);
+        task.setQuantityPicked(0);
+        task.setQuantityConsumed(0);
+        task.setStatus("OPEN");
+        return task;
+    }
+
+    private static ResolveScanRequest scan(UUID sku, UUID location) {
+        ResolveScanRequest request = new ResolveScanRequest();
+        request.setScannedSkuId(sku);
+        request.setScannedLocationId(location);
+        return request;
+    }
+
+    // ─── scan classification ─────────────────────────────────────────────────
+
+    @ParameterizedTest(name = "sku {0}, location {1} -> {2}")
+    @CsvSource({
+        "right, right, MATCHED",
+        "right, wrong, LOCATION_MISMATCH",
+        "wrong, right, SKU_MISMATCH",
+        "wrong, wrong, NO_MATCH",
+    })
+    @DisplayName("a scan is graded from the sku and location independently")
+    void scanClassificationTruthTable(String skuCase, String locationCase, String expected) {
+        UUID scannedSku = "right".equals(skuCase) ? SKU_ID : OTHER_ID;
+        UUID scannedLocation = "right".equals(locationCase) ? LOCATION_ID : OTHER_ID;
+
+        ResolveScanResponse response = service.resolveScan(WORKORDER_ID, TASK_ID, scan(scannedSku, scannedLocation));
+
+        // The picker acts on this word: LOCATION_MISMATCH sends them to another bin,
+        // SKU_MISMATCH tells them the part in their hand is wrong. The two are decided by
+        // opposite comparisons and would be silently swappable without this table.
+        assertThat(response.getMatchStatus()).isEqualTo(expected);
+        assertThat(response.isMatched()).isEqualTo("MATCHED".equals(expected));
+        // The scan is echoed back as-is, so a handheld can show what it read.
+        assertThat(response.getResolvedSkuId()).isEqualTo(scannedSku);
+        assertThat(response.getResolvedLocationId()).isEqualTo(scannedLocation);
+    }
+
+    @ParameterizedTest(name = "replica missing {0} grades as NO_MATCH rather than matching")
+    @CsvSource({"sku", "location"})
+    @DisplayName("a replica field that has not arrived yet cannot produce a match")
+    void incompleteReplicaNeverMatches(String missing) {
+        ExtPickTaskReplica task = task();
+        if ("sku".equals(missing)) {
+            task.setSkuId(null);
+        } else {
+            task.setLocationId(null);
+        }
+        taskExists(task);
+
+        // Null on the replica side must compare as "does not match", never as "matches
+        // anything" — the replica fills in asynchronously, and a null-tolerant comparison here
+        // would confirm a pick against a task we cannot yet describe.
+        ResolveScanResponse response = service.resolveScan(WORKORDER_ID, TASK_ID, scan(SKU_ID, LOCATION_ID));
+
+        assertThat(response.isMatched()).isFalse();
+        assertThat(response.getMatchStatus()).isIn("SKU_MISMATCH", "LOCATION_MISMATCH");
+    }
+
+    // ─── failing closed before publishing ────────────────────────────────────
+
+    @ParameterizedTest(name = "confirm is refused when the replica has no {0}")
+    @CsvSource({"pickListId", "skuId", "locationId"})
+    @DisplayName("an incomplete replica is a 409, and no command is published")
+    void incompleteReplicaIsConflict(String missingField) {
+        ExtPickTaskReplica task = task();
+        switch (missingField) {
+            case "pickListId" -> task.setPickListId(null);
+            case "skuId" -> task.setSkuId(null);
+            default -> task.setLocationId(null);
+        }
+        taskExists(task);
+
+        // 409, not 503: the caller cannot fix this by retrying sooner, they have to wait for
+        // the replica to catch up. Publishing a command with a null sku would have
+        // pos-inventory act on a task it cannot resolve.
+        assertThatThrownBy(() -> service.confirmPickLine(WORKORDER_ID, TASK_ID, TASK_ID, confirm(5)))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(e -> ((ResponseStatusException) e).getStatusCode())
+                .isEqualTo(HttpStatus.CONFLICT);
+
+        verify(publisher, never()).requestPickTaskConfirm(any(), any(), any(), any(), anyInt());
+    }
+
+    @Test
+    @DisplayName("an absent publisher is a 503 that names the switch to turn on")
+    void absentPublisherIsServiceUnavailable() {
+        when(publisherProvider.getIfAvailable()).thenReturn(null);
+
+        // The pick workflow is asynchronous by design (ADR-0044, #901). Running without the
+        // Kafka feed is a deployment mistake, and the message says which flag fixes it rather
+        // than leaving an operator to guess from a bare 503.
+        assertThatThrownBy(() -> service.confirmPickLine(WORKORDER_ID, TASK_ID, TASK_ID, confirm(5)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("workorder.kafka.enabled")
+                .extracting(e -> ((ResponseStatusException) e).getStatusCode())
+                .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("a broker refusal becomes a retryable 503, not a 500")
+    void brokerRefusalIsServiceUnavailable() {
+        doThrow(new IllegalStateException("no broker"))
+                .when(publisher)
+                .requestPickTaskConfirm(any(), any(), any(), any(), anyInt());
+
+        assertThatThrownBy(() -> service.confirmPickLine(WORKORDER_ID, TASK_ID, TASK_ID, confirm(5)))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(e -> ((ResponseStatusException) e).getStatusCode())
+                .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("a pickLineId that disagrees with the pickTaskId is rejected before anything else")
+    void mismatchedPickLineIdIsRejected() {
+        // The two are aliases of one another in this facade. Letting them diverge would mean
+        // confirming a quantity against a different task than the caller named.
+        assertThatThrownBy(() -> service.confirmPickLine(WORKORDER_ID, TASK_ID, OTHER_ID, confirm(5)))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(e -> ((ResponseStatusException) e).getStatusCode())
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+
+        verify(pickListReplicaRepository, never()).findByWorkorderIdOrderByPickListIdAsc(any());
+    }
+
+    // ─── completion arithmetic ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("completing a task sends the full required quantity, not the remainder")
+    void completeSendsRequiredNotRemaining() {
+        ExtPickTaskReplica task = task();
+        task.setQuantityPicked(4);
+        taskExists(task);
+
+        service.completePickTask(WORKORDER_ID, TASK_ID, new CompletePickTaskRequest());
+
+        // #901: pos-inventory sets quantityPicked to the value it receives, so sending the
+        // remaining 6 would leave the task recorded as 6 of 10 picked rather than complete.
+        verify(publisher).requestPickTaskConfirm(eq(PICK_LIST_ID), eq(TASK_ID), any(), any(), eq(10));
+    }
+
+    @ParameterizedTest(name = "picked={0} of 10 required is already complete")
+    @CsvSource({"10", "11"})
+    @DisplayName("a task already at or past its required quantity publishes nothing")
+    void alreadyCompleteTaskPublishesNothing(int picked) {
+        ExtPickTaskReplica task = task();
+        task.setQuantityPicked(picked);
+        task.setStatus("PICKED");
+        taskExists(task);
+
+        var response = service.completePickTask(WORKORDER_ID, TASK_ID, new CompletePickTaskRequest());
+
+        // Over-picking is included deliberately: the guard is `remaining <= 0`, and a strict
+        // equality check would republish forever for any task that recorded more than required.
+        assertThat(response.getStatus()).isEqualTo("PICKED");
+        verify(publisher, never()).requestPickTaskConfirm(any(), any(), any(), any(), anyInt());
+    }
+
+    // ─── reads ───────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("a workorder with no pick list is a 404 on the task read")
+    void noPickListIsNotFound() {
+        when(pickListReplicaRepository.findByWorkorderIdOrderByPickListIdAsc(WORKORDER_ID))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> service.getPickTasksForWorkorder(WORKORDER_ID))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(e -> ((ResponseStatusException) e).getStatusCode())
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("but a workorder with no pick list has an empty picked-items list, not a 404")
+    void noPickListMeansNoPickedItems() {
+        when(pickListReplicaRepository.findByWorkorderIdOrderByPickListIdAsc(WORKORDER_ID))
+                .thenReturn(List.of());
+
+        // Deliberately asymmetric with the read above: "what has been picked for this
+        // workorder" has a correct answer when nothing has, and 404 would force every caller
+        // to special-case it.
+        assertThat(service.getPickedItemsForWorkorder(WORKORDER_ID)).isEmpty();
+    }
+
+    @ParameterizedTest(name = "status={0} picked={1} included={2}")
+    @CsvSource({
+        "PICKED, 0, true",
+        "picked, 0, true",
+        "OPEN,   3, true",
+        "OPEN,   0, false",
+    })
+    @DisplayName("picked items include anything picked or marked PICKED, case-insensitively")
+    void pickedItemsFilter(String status, int picked, boolean included) {
+        ExtPickTaskReplica task = task();
+        task.setStatus(status);
+        task.setQuantityPicked(picked);
+        taskExists(task);
+
+        // The status check is case-insensitive because it comes off a replica fed by another
+        // service; the quantity check is what catches a partially picked task whose status has
+        // not advanced yet.
+        assertThat(service.getPickedItemsForWorkorder(WORKORDER_ID)).hasSize(included ? 1 : 0);
+    }
+
+    @Test
+    @DisplayName("remaining quantity never goes negative when more was consumed than picked")
+    void remainingIsClampedAtZero() {
+        ExtPickTaskReplica task = task();
+        task.setQuantityPicked(3);
+        task.setQuantityConsumed(5);
+        task.setStatus("PICKED");
+        taskExists(task);
+
+        // Consumed exceeding picked is a replica-ordering artefact, not a real state. Reporting
+        // -2 remaining would propagate a negative quantity into whatever consumes this view.
+        assertThat(service.getPickedItemsForWorkorder(WORKORDER_ID))
+                .singleElement()
+                .extracting(item -> item.getQtyRemaining())
+                .isEqualTo(0);
+    }
+
+    // ─── consumption ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("consuming an unknown pick task is a 404 and publishes nothing")
+    void consumeUnknownTaskIsNotFound() {
+        ConsumePickedItemsRequest request = new ConsumePickedItemsRequest();
+        ConsumePickedItemsRequest.ConsumeItem item = new ConsumePickedItemsRequest.ConsumeItem();
+        item.setPickTaskId(OTHER_ID);
+        item.setQuantityToConsume(2);
+        request.setItems(List.of(item));
+
+        // The whole request is rejected rather than the unknown line being skipped: a partial
+        // consume that silently drops a line would leave the caller believing it succeeded.
+        assertThatThrownBy(() -> service.consumePickedItems(WORKORDER_ID, request))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(e -> ((ResponseStatusException) e).getStatusCode())
+                .isEqualTo(HttpStatus.NOT_FOUND);
+
+        verify(publisher, never()).requestItemsConsume(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("a consume request reports PENDING and a zero total, because inventory has not acted yet")
+    void consumeReportsPendingNotDone() {
+        ConsumePickedItemsRequest request = new ConsumePickedItemsRequest();
+        ConsumePickedItemsRequest.ConsumeItem item = new ConsumePickedItemsRequest.ConsumeItem();
+        item.setPickTaskId(TASK_ID);
+        item.setQuantityToConsume(2);
+        request.setItems(List.of(item));
+
+        var response = service.consumePickedItems(WORKORDER_ID, request);
+
+        // totalItemsConsumed is 0 on purpose: the command has been queued, not applied. A
+        // non-zero total here would tell the caller stock had moved when it had not.
+        assertThat(response.getTotalItemsConsumed()).isZero();
+        assertThat(response.getResults())
+                .singleElement()
+                .satisfies(result -> assertThat(result.getStatus().name()).isEqualTo("PENDING"));
+        verify(publisher).requestItemsConsume(eq(WORKORDER_ID), eq(PICK_LIST_ID), any());
+    }
+
+    private static ConfirmPickLineRequest confirm(int quantity) {
+        ConfirmPickLineRequest request = new ConfirmPickLineRequest();
+        request.setQuantityPicked(quantity);
+        return request;
+    }
+}


### PR DESCRIPTION
## What this does

First pass at item 4 of `docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` §7: branch-coverage tails.

| Module | Branch before | Branch after | Line after | Floor |
|---|---|---|---|---|
| `pos-catalog` | 53.5% | **57.6%** | 78.6% | 0.73 / 0.52 |
| `pos-workorder` | 56.7% | **58.5%** | 78.2% | 0.73 / 0.53 |
| `pos-document-helper` | 35.2% | 35.2% | 74.0% | unchanged — see below |

Tests only. No production code changed.

I went after the two worst individual classes rather than spreading effort evenly, on the view that a branch tail is not uniform — it concentrates in the places where the code makes a choice the caller cannot see it make.

## `PriceBookServiceImpl.resolvePrice` — 47.1% → 68.8% branch (90 → 53 missed)

This is the read that decides what a product costs, and almost every branch in it is **silent**. It walks two independent precedence chains — which price book applies, then which rule inside it wins — then falls back to MSRP and finally to "no price". Every step produces a well-formed answer, so getting one wrong does not fail, it quotes a different number. Only `source` and `fallbackReason` distinguish "this is the contract price" from "this is list price because nothing matched", and nothing downstream re-derives them. So the tests assert the *winning rule* and the *source*, not that a price came back.

Cases worth a reviewer's attention:

- **Specificity is scored before priority** (SKU > CATEGORY > GLOBAL), so the fixtures deliberately set priorities that contradict the expected winner — a priority-100 global rule must still lose to a priority-1 SKU rule.
- **A category rule matches the subcategory too.** Missing that branch silently drops half the category rules in the catalog.
- **`nullsLast` on a reversed comparator** decides whether an unprioritised rule outranks every deliberately prioritised one. Both directions asserted.
- **A full tie is broken by rule id**, asserted with the inputs supplied in reverse. A tie resolving by input order would have two servers quoting different prices for the same basket.
- **Currency selection refuses to guess.** An unconfigured requested currency and an ambiguous multi-currency rule are both errors — substituting either hands the caller a number in the wrong denomination.
- **Zero and negative amounts are rejected.** A rule resolving to nothing or to a credit is a data error; letting it through prices the product at that value.

## `WorkorderPickFacadeServiceImpl` — 0% → 100% branch

Turns warehouse scans into asynchronous inventory commands (ADR-0044, #901).

**Scan grading.** A scan is graded MATCHED / SKU_MISMATCH / LOCATION_MISMATCH / NO_MATCH from two independent booleans. A picker acts on that word — it tells them whether they are standing at the wrong bin or holding the wrong part — and the two mismatch cases are decided by *opposite* comparisons, so they are trivially swappable. Full truth table asserted, plus the rule that a replica field which has not arrived yet compares as "does not match" rather than matching anything.

**Failing closed.** Every write becomes a Kafka command pos-inventory will act on, so the facade refuses twice over: **409** when the replica is not complete enough to describe the task, **503** when the publisher is absent or the broker nacks. Those must stay distinguishable — a 409 cannot be fixed by retrying, a 503 is exactly what should be retried.

Also pinned: completing a task sends the **full required** quantity, not the remainder (#901 — sending the remainder leaves the task recorded as partially picked), and the already-complete guard is `remaining <= 0` rather than equality, so an over-picked task does not republish forever.

## `pos-document-helper` deliberately untouched — #1274

Its entire branch tail (32 of 35 missed branches) sits in a **duplicated copy of the library that no module consumes**. `com.positivity.documents` and `com.positivity.documents.helper` each contain their own `DocumentFormat`, `RenderRequest`, `TemplateRegistration`, `DocumentTemplateInitializerSupport` and exception pair; both trees landed in the same commit, so this is not a half-finished migration. `pos-supplier` is the only module declaring the dependency and imports nothing from it.

Writing tests there would cement a deletion candidate and make the coverage number look healthy while the duplication stayed, so the floor is unchanged pending a decision on #1274. Flagging rather than papering over.

## Remaining after this pass

`pos-catalog` and `pos-workorder` still have tails worth a second pass — next largest are `ProductDetailServiceImpl` (71 missed) and `ChangeRequestServiceImpl` (93 missed). The plan's §7.4 records where this stopped.

## Contract impact — none

`contract-sync` matches on `**/dto/**`-adjacent paths; every file here is a test or a `pom.xml` coverage floor. No controller, DTO, schema, event or OpenAPI document changed — see `BACKEND_CONTRACT_GUIDE.md` for the process if one had.

## Verification

`./mvnw -o -pl pos-catalog,pos-workorder,pos-document-helper -DskipTests=false verify -DskipITs` → BUILD SUCCESS with the new floors active. 59 new tests (35 price book, 24 pick facade).
