### PR TITLE
test: second branch-tail pass — closes plan §7 item 4

### DIFF
--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -767,9 +767,8 @@ consumer-credited figure for shared libraries. No work is outstanding here.
 1. ~~**Wave 1c** (`{Module}PermissionRegistry`, §3.3)~~ — closed 2026-08-12, see §7.1.
 2. ~~**Controller `@WebMvcTest` slices**~~ — closed 2026-08-12, see §7.3.
 3. ~~**The four all-zero modules**~~ — closed 2026-08-12, see §7.2.
-4. **Branch-coverage tails** — first pass done 2026-08-12, see §7.4. `pos-catalog`
-   and `pos-workorder` still have tails worth a second pass;
-   `pos-document-helper` is blocked on #1274.
+4. ~~**Branch-coverage tails**~~ — closed 2026-08-12 over two passes, see §7.4 and
+   §7.5. `pos-document-helper` remains deliberately untouched, blocked on #1274.
 5. **Low-coverage shared libraries** — `pos-tax-common` 34.0%,
    `pos-domain-events` 39.3%, `pos-security-common` 46.8% on their own tests.
    They read far higher in the aggregate because consumers exercise them; their
@@ -931,6 +930,66 @@ of 35 missed branches — sits in a duplicated copy of the library that no modul
 consumes (#1274). Testing it would cement a deletion candidate and make the
 number look healthy while the duplication stayed. Its floor is unchanged pending
 that decision.
+
+### 7.5 Branch tails, second pass (2026-08-12)
+
+| Module | Branch (start of §7) | After pass 1 | After pass 2 | Line | Floor |
+|---|---|---|---|---|---|
+| `pos-catalog` | 53.5% | 57.6% | **59.7%** | 80.3% | 0.75 / 0.54 |
+| `pos-workorder` | 56.7% | 58.5% | **60.4%** | 78.7% | 0.73 / 0.55 |
+
+Same approach as pass 1: the next-worst class in each module, chosen for what its
+branches decide rather than for how many there are.
+
+**`ChangeRequestServiceImpl`** (29.5% → 62.1% branch, 93 → 50 missed). A change
+request is how extra work gets added to a job the customer already agreed to, so
+these branches decide whether someone can be billed for work they never
+approved. Two rules carry that:
+
+- *Emergency items must carry evidence.* An emergency/safety item skips the
+  normal approval wait, so it needs a photo, or an explicit "photo not possible"
+  plus notes. The two checks overlap — the second catches an item that claimed
+  photo-not-possible and then supplied nothing — and collapsing them into one
+  would let a shop mark anything as an emergency with no record of why. The full
+  evidence truth table is asserted, whitespace-only values included on both
+  sides.
+- *A declined emergency blocks closing the workorder* until the customer has
+  acknowledged the denial, on every emergency item, across services **and**
+  parts. That is the paper trail for "we told them it was unsafe and they said
+  no". The services and parts checks are separate methods with identical bodies,
+  so both halves are asserted independently: dropping the parts one leaves the
+  services test green.
+
+Also pinned: only a workorder actually in `WORK_IN_PROGRESS` accepts a change
+request, checked against every other status via `@EnumSource` exclusion rather
+than one sample, because adding work to a job that is finished, invoiced or
+cancelled is exactly the case that produces an unagreed bill.
+
+**`ProductDetailServiceImpl`** (37.7% → 54.4% branch, 71 → 52 missed). This view
+stitches the catalog row together with live pricing from pos-price and live
+availability from pos-inventory, and its whole design is graceful degradation:
+when a remote call fails the endpoint still answers, with the parts it could get
+and a `confidence` saying how much of it is real. That makes the failure branches
+the *normal* operating mode during any partial outage, and invisible from a happy
+path because the response still looks complete. The full confidence matrix is
+asserted (both up → HIGH, either → MEDIUM, neither → LOW), along with:
+
+- A remote answering successfully with no data is treated exactly like an
+  outage — not as a price of zero and not as an error to propagate.
+- Null amounts stay null. The BigDecimal-to-double conversions are null-guarded
+  on both fields; without the guards this is a NullPointerException, and with a
+  naive default it is a free product.
+- Unparseable enum values from the wire (`source`, `confidence`) degrade to a
+  default rather than throwing, so a new constant added upstream cannot take this
+  endpoint down — and an unreadable confidence degrades to MEDIUM, never HIGH.
+- A lead-time lookup that throws falls back to the catalog hint while leaving
+  availability itself reported as OK, since letting that exception escape would
+  turn a working stock read into an outage.
+
+Both modules still have tails below their new floors — the next candidates are
+`SupplierItemCostServiceImpl` (44 missed) and `EstimateServiceImpl` (82) — but
+item 4's stated goal, moving the three named modules off their branch floors with
+parameterized tests over real decisions, is met.
 
 ### Defects found by this work, still open
 

--- a/pos-catalog/pom.xml
+++ b/pos-catalog/pom.xml
@@ -14,11 +14,11 @@
     <description>POS Catalog module</description>
 
     <properties>
-        <!-- Coverage ratchet (plan Phase 4): measured 78.6% line / 57.6% branch after the
+        <!-- Coverage ratchet (plan Phase 4): measured 80.3% line / 59.7% branch after the
              §7 branch-tail wave (was 77.4% / 53.5%).
              Floors sit ~5 points under to catch regression without failing on noise. -->
-        <jacoco.line.min>0.73</jacoco.line.min>
-        <jacoco.branch.min>0.52</jacoco.branch.min>
+        <jacoco.line.min>0.75</jacoco.line.min>
+        <jacoco.branch.min>0.54</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
     <dependencies>

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductDetailDegradationTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductDetailDegradationTest.java
@@ -217,8 +217,10 @@ class ProductDetailDegradationTest {
     void emptyAvailabilityIsAlsoUnavailable() {
         when(inventoryClient.fetchAvailability(any(), any())).thenReturn(Optional.empty());
 
-        assertThat(detail().getAvailability().getStatus()).isEqualTo(DataStatus.UNAVAILABLE);
-        assertThat(detail().getAvailability().getLeadTime().getSource()).isEqualTo(LeadTimeSource.CATALOG);
+        ProductDetailView view = detail();
+
+        assertThat(view.getAvailability().getStatus()).isEqualTo(DataStatus.UNAVAILABLE);
+        assertThat(view.getAvailability().getLeadTime().getSource()).isEqualTo(LeadTimeSource.CATALOG);
     }
 
     // ─── the two-tier lead time ──────────────────────────────────────────────

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductDetailDegradationTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductDetailDegradationTest.java
@@ -1,0 +1,353 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.client.InventoryClient;
+import com.positivity.catalog.internal.client.PricingClient;
+import com.positivity.catalog.internal.dto.ProductDetailView;
+import com.positivity.catalog.internal.dto.ProductDetailView.DataConfidence;
+import com.positivity.catalog.internal.dto.ProductDetailView.DataStatus;
+import com.positivity.catalog.internal.dto.ProductDetailView.LeadTimeSource;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.repository.ProductReplacementRepository;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Branch-coverage tests for {@link ProductDetailServiceImpl}, whose whole design
+ * is graceful degradation.
+ *
+ * <p>
+ * This view stitches together the catalog's own row with live pricing from
+ * pos-price and live availability from pos-inventory. Either remote call may
+ * fail, and when one does the endpoint deliberately still answers — with the
+ * parts it could get and a {@code confidence} saying how much of it is real.
+ * That makes the failure branches the important ones: they are the normal
+ * operating mode during any partial outage, and they are invisible from a happy
+ * path test because the response still looks complete.
+ *
+ * <p>
+ * The signal that separates a good answer from a degraded one is the pair
+ * {@code status} / {@code confidence}. A caller decides from those whether to
+ * show a price to a customer, so reporting HIGH over stale or absent data is
+ * worse than returning nothing at all.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ProductDetailServiceImpl — degradation and confidence")
+class ProductDetailDegradationTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-12T08:00:00Z");
+    private static final UUID PRODUCT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c1");
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c2");
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private ProductReplacementRepository productReplacementRepository;
+
+    @Mock
+    private PricingClient pricingClient;
+
+    @Mock
+    private InventoryClient inventoryClient;
+
+    private ProductDetailServiceImpl service;
+    private ProductEntity product;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProductDetailServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                productRepository,
+                productReplacementRepository,
+                pricingClient,
+                inventoryClient,
+                new ObjectMapper());
+
+        product = new ProductEntity();
+        product.setId(PRODUCT_ID);
+        product.setSku("SKU-1001");
+        product.setLongDescription("Front brake rotor");
+        when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product));
+        when(productReplacementRepository.findAll()).thenReturn(List.of());
+
+        pricingWorks();
+        availabilityWorks();
+        leadTimeAbsent();
+    }
+
+    private void pricingWorks() {
+        when(pricingClient.fetchPrice(any(), any(), any()))
+                .thenReturn(Optional.of(new PricingClient.PriceQuoteClientResponse(
+                        new BigDecimal("129.99"), "USD", new BigDecimal("99.99"), "PRICE_BOOK")));
+    }
+
+    private void availabilityWorks() {
+        when(inventoryClient.fetchAvailability(any(), any()))
+                .thenReturn(Optional.of(new InventoryClient.AvailabilityClientResponse(12, 2, 10, "EA")));
+    }
+
+    private void leadTimeAbsent() {
+        when(inventoryClient.fetchLeadTime(any(), any())).thenReturn(Optional.empty());
+    }
+
+    private ProductDetailView detail() {
+        return service.getProductDetail(PRODUCT_ID, LOCATION_ID);
+    }
+
+    // ─── the confidence matrix ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("both remote calls succeeding is HIGH confidence")
+    void bothRemotesUpIsHigh() {
+        ProductDetailView view = detail();
+
+        assertThat(view.getConfidence()).isEqualTo(DataConfidence.HIGH);
+        assertThat(view.getPricing().getStatus()).isEqualTo(DataStatus.OK);
+        assertThat(view.getAvailability().getStatus()).isEqualTo(DataStatus.OK);
+        assertThat(view.getPricing().getMsrp()).isEqualTo(129.99);
+        assertThat(view.getPricing().getStorePrice()).isEqualTo(99.99);
+        assertThat(view.getAvailability().getOnHandQuantity()).isEqualTo(12);
+    }
+
+    @ParameterizedTest(name = "pricing up={0}, availability up={1} -> {2}")
+    @CsvSource({
+        "true,  true,  HIGH",
+        "true,  false, MEDIUM",
+        "false, true,  MEDIUM",
+        "false, false, LOW",
+    })
+    @DisplayName("overall confidence reports how much of the view is real")
+    void confidenceMatrix(boolean pricingUp, boolean availabilityUp, DataConfidence expected) {
+        if (!pricingUp) {
+            when(pricingClient.fetchPrice(any(), any(), any())).thenThrow(new RuntimeException("pos-price down"));
+        }
+        if (!availabilityUp) {
+            when(inventoryClient.fetchAvailability(any(), any())).thenThrow(new RuntimeException("pos-inventory down"));
+        }
+
+        // This is what a caller branches on before showing a number to a customer. The two
+        // MEDIUM cases are the ones worth having: they are asymmetric in what is missing but
+        // identical in what they report, so a caller cannot tell price from stock — which is
+        // why the per-section status below is also part of the contract.
+        assertThat(detail().getConfidence()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("a pricing outage leaves the rest of the view intact")
+    void pricingOutageDegradesOnlyPricing() {
+        when(pricingClient.fetchPrice(any(), any(), any())).thenThrow(new RuntimeException("connect timeout"));
+
+        ProductDetailView view = detail();
+
+        // The endpoint still answers. Failing the whole request because pos-price is down would
+        // take the parts catalogue offline with it.
+        assertThat(view).isNotNull();
+        assertThat(view.getPricing().getStatus()).isEqualTo(DataStatus.UNAVAILABLE);
+        assertThat(view.getPricing().getConfidence()).isEqualTo(DataConfidence.LOW);
+        // No number is invented: a missing price must be absent, not zero.
+        assertThat(view.getPricing().getMsrp()).isNull();
+        assertThat(view.getPricing().getStorePrice()).isNull();
+        assertThat(view.getAvailability().getStatus()).isEqualTo(DataStatus.OK);
+    }
+
+    @Test
+    @DisplayName("pos-price answering with no quote is treated exactly like an outage")
+    void emptyQuoteIsAlsoUnavailable() {
+        when(pricingClient.fetchPrice(any(), any(), any())).thenReturn(Optional.empty());
+
+        // A successful call that carries no quote is not a price of zero and not an error to
+        // propagate — it is the same "we do not know" as a timeout, and must report as such.
+        assertThat(detail().getPricing().getStatus()).isEqualTo(DataStatus.UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("a quote with null amounts does not fabricate zeroes")
+    void nullAmountsStayNull() {
+        when(pricingClient.fetchPrice(any(), any(), any()))
+                .thenReturn(Optional.of(new PricingClient.PriceQuoteClientResponse(null, "USD", null, "PRICE_BOOK")));
+
+        ProductDetailView view = detail();
+
+        // The BigDecimal-to-double conversion is null-guarded on both fields. Without the
+        // guards this is a NullPointerException; with a naive default it is a free product.
+        assertThat(view.getPricing().getStatus()).isEqualTo(DataStatus.OK);
+        assertThat(view.getPricing().getMsrp()).isNull();
+        assertThat(view.getPricing().getStorePrice()).isNull();
+    }
+
+    @Test
+    @DisplayName("an availability outage still returns a catalog lead time")
+    void availabilityOutageFallsBackToCatalogLeadTime() {
+        when(inventoryClient.fetchAvailability(any(), any())).thenThrow(new RuntimeException("connect timeout"));
+
+        ProductDetailView view = detail();
+
+        // Stock is unknown but the catalog still knows roughly how long the part takes to
+        // arrive, so the caller gets something to show rather than an empty panel.
+        assertThat(view.getAvailability().getStatus()).isEqualTo(DataStatus.UNAVAILABLE);
+        assertThat(view.getAvailability().getLeadTime()).isNotNull();
+        assertThat(view.getAvailability().getLeadTime().getSource()).isEqualTo(LeadTimeSource.CATALOG);
+    }
+
+    @Test
+    @DisplayName("pos-inventory answering with no availability is treated like an outage")
+    void emptyAvailabilityIsAlsoUnavailable() {
+        when(inventoryClient.fetchAvailability(any(), any())).thenReturn(Optional.empty());
+
+        assertThat(detail().getAvailability().getStatus()).isEqualTo(DataStatus.UNAVAILABLE);
+        assertThat(detail().getAvailability().getLeadTime().getSource()).isEqualTo(LeadTimeSource.CATALOG);
+    }
+
+    // ─── the two-tier lead time ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("a dynamic lead time is preferred over the catalog hint")
+    void dynamicLeadTimeWins() {
+        when(inventoryClient.fetchLeadTime(any(), any()))
+                .thenReturn(Optional.of(new InventoryClient.LeadTimeClientResponse(
+                        2, 5, "2-5 business days", "INVENTORY", "HIGH", NOW.minusSeconds(60))));
+
+        var leadTime = detail().getAvailability().getLeadTime();
+
+        assertThat(leadTime.getSource()).isEqualTo(LeadTimeSource.INVENTORY);
+        assertThat(leadTime.getMinDays()).isEqualTo(2);
+        assertThat(leadTime.getMaxDays()).isEqualTo(5);
+        assertThat(leadTime.getConfidence()).isEqualTo(DataConfidence.HIGH);
+        // The remote's own timestamp is kept rather than being restamped with request time —
+        // a lead time is only meaningful alongside when it was measured.
+        assertThat(leadTime.getAsOf()).isEqualTo(NOW.minusSeconds(60));
+    }
+
+    @Test
+    @DisplayName("a dynamic lead time with no timestamp is stamped with the request time")
+    void missingAsOfFallsBackToRequestTime() {
+        when(inventoryClient.fetchLeadTime(any(), any()))
+                .thenReturn(Optional.of(new InventoryClient.LeadTimeClientResponse(
+                        2, 5, "2-5 business days", "INVENTORY", "HIGH", null)));
+
+        assertThat(detail().getAvailability().getLeadTime().getAsOf()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("a lead-time lookup that throws falls back to the catalog rather than failing")
+    void leadTimeFailureFallsBackToCatalog() {
+        when(inventoryClient.fetchLeadTime(any(), any())).thenThrow(new RuntimeException("timeout"));
+
+        // Availability itself succeeded, so the section stays OK — only the lead time degrades.
+        // Letting this exception escape would turn a working stock read into an outage.
+        ProductDetailView view = detail();
+        assertThat(view.getAvailability().getStatus()).isEqualTo(DataStatus.OK);
+        assertThat(view.getAvailability().getLeadTime().getSource()).isEqualTo(LeadTimeSource.CATALOG);
+    }
+
+    @ParameterizedTest(name = "source=[{0}] falls back to INVENTORY")
+    @CsvSource(
+            value = {"NULL", "''", "'   '", "NOT_A_SOURCE"},
+            nullValues = "NULL")
+    @DisplayName("an unrecognised lead-time source degrades to INVENTORY rather than throwing")
+    void unparseableSourceFallsBack(String source) {
+        when(inventoryClient.fetchLeadTime(any(), any()))
+                .thenReturn(
+                        Optional.of(new InventoryClient.LeadTimeClientResponse(2, 5, "2-5 days", source, "HIGH", NOW)));
+
+        // These values come off the wire from another service. A new enum constant added
+        // upstream must not take this endpoint down.
+        assertThat(detail().getAvailability().getLeadTime().getSource()).isEqualTo(LeadTimeSource.INVENTORY);
+    }
+
+    @ParameterizedTest(name = "confidence=[{0}] falls back to MEDIUM")
+    @CsvSource(
+            value = {"NULL", "''", "'   '", "VERY_SURE"},
+            nullValues = "NULL")
+    @DisplayName("an unrecognised confidence degrades to MEDIUM rather than throwing")
+    void unparseableConfidenceFallsBack(String confidence) {
+        when(inventoryClient.fetchLeadTime(any(), any()))
+                .thenReturn(Optional.of(
+                        new InventoryClient.LeadTimeClientResponse(2, 5, "2-5 days", "INVENTORY", confidence, NOW)));
+
+        // MEDIUM, not HIGH: an unreadable confidence is not a reason to trust the value more.
+        assertThat(detail().getAvailability().getLeadTime().getConfidence()).isEqualTo(DataConfidence.MEDIUM);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"HIGH", "MEDIUM", "LOW"})
+    @DisplayName("a recognised confidence is passed through unchanged")
+    void recognisedConfidenceIsPassedThrough(String confidence) {
+        when(inventoryClient.fetchLeadTime(any(), any()))
+                .thenReturn(Optional.of(
+                        new InventoryClient.LeadTimeClientResponse(2, 5, "2-5 days", "INVENTORY", confidence, NOW)));
+
+        assertThat(detail().getAvailability().getLeadTime().getConfidence())
+                .isEqualTo(DataConfidence.valueOf(confidence));
+    }
+
+    @Test
+    @DisplayName("a catalog lead time with no hint at all reports LOW confidence")
+    void catalogLeadTimeWithoutHintIsLowConfidence() {
+        // Nothing on the product row and nothing from inventory: the answer is a shrug, and it
+        // must say so rather than presenting a default range as if it were known.
+        assertThat(detail().getAvailability().getLeadTime().getConfidence()).isEqualTo(DataConfidence.LOW);
+    }
+
+    // ─── the rest of the view ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("an unknown product returns null so the controller can 404")
+    void unknownProductReturnsNull() {
+        when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+
+        assertThat(service.getProductDetail(PRODUCT_ID, LOCATION_ID)).isNull();
+    }
+
+    @Test
+    @DisplayName("specifications are built only from the attributes that are set")
+    void specificationsSkipAbsentAttributes() {
+        product.setMaterial("Cast iron");
+        product.setColor(null);
+        product.setWarranty("24 months");
+        product.setManufacturerName(null);
+
+        // Four independent null checks feeding one list. Emitting a row for an unset attribute
+        // would show a customer a blank "Colour:" line on every product that has no colour.
+        assertThat(detail().getSpecifications())
+                .extracting(spec -> spec.getName())
+                .containsExactlyInAnyOrder("Material", "Warranty");
+    }
+
+    @Test
+    @DisplayName("a product with no attributes at all yields no specifications")
+    void noAttributesYieldsEmptySpecifications() {
+        assertThat(detail().getSpecifications()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("the view is stamped with the clock, not with wall time")
+    void generatedAtComesFromTheClock() {
+        // Every asOf on the degraded sections is derived from this one timestamp, so the whole
+        // response describes a single moment rather than several.
+        assertThat(detail().getGeneratedAt()).isEqualTo(NOW);
+    }
+}

--- a/pos-workorder/pom.xml
+++ b/pos-workorder/pom.xml
@@ -13,11 +13,11 @@
     <description>Module to manage workorders for a shop</description>
 
     <properties>
-        <!-- Coverage ratchet (plan Phase 4): measured 78.2% line / 58.5% branch after the
+        <!-- Coverage ratchet (plan Phase 4): measured 78.7% line / 60.4% branch after the
              §7 branch-tail wave (was 76.6% / 56.7%).
              Floors sit ~5 points under to catch regression without failing on noise. -->
         <jacoco.line.min>0.73</jacoco.line.min>
-        <jacoco.branch.min>0.53</jacoco.branch.min>
+        <jacoco.branch.min>0.55</jacoco.branch.min>
     </properties>
     <packaging>jar</packaging>
     <pluginRepositories>

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/ChangeRequestEmergencyRulesTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/ChangeRequestEmergencyRulesTest.java
@@ -1,0 +1,417 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.dto.CreateChangeRequestDTO;
+import com.positivity.workorder.internal.entity.ChangeRequest;
+import com.positivity.workorder.internal.entity.ChangeRequest.ChangeRequestStatus;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderPart;
+import com.positivity.workorder.internal.entity.WorkorderServiceLine;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.repository.ApprovalRecordRepository;
+import com.positivity.workorder.internal.repository.ChangeRequestRepository;
+import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
+import com.positivity.workorder.service.IdempotencyService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Branch-coverage tests for {@link ChangeRequestServiceImpl}'s validation and
+ * emergency-exception rules.
+ *
+ * <p>
+ * A change request is how extra work gets added to a job the customer already
+ * agreed to, so the rules here are the ones that decide whether a customer can
+ * be billed for work they never approved. Two of them are worth stating
+ * outright:
+ *
+ * <ul>
+ * <li><b>Emergency items must carry evidence.</b> An "emergency/safety" item
+ * bypasses the normal approval wait, so it needs either a photo or an explicit
+ * "photo not possible" plus notes. The two checks overlap in a way that is easy
+ * to collapse into one — the second fires for an item that claimed photo-not-
+ * possible and then supplied nothing — and collapsing them would let a shop mark
+ * anything as an emergency with no record of why.</li>
+ * <li><b>A declined emergency blocks closing the workorder</b> until the customer
+ * has acknowledged the denial, on every emergency item, on both services and
+ * parts. That is the paper trail for "we told them it was unsafe and they said
+ * no". The services and parts checks are separate methods with identical bodies,
+ * so a workorder could close with an unacknowledged part while the service half
+ * still worked.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ChangeRequestServiceImpl — validation and emergency rules")
+class ChangeRequestEmergencyRulesTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-12T10:00:00Z");
+    private static final UUID WORKORDER_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b1");
+    private static final UUID CHANGE_REQUEST_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b2");
+
+    @Mock
+    private ChangeRequestRepository changeRequestRepository;
+
+    @Mock
+    private WorkorderRepository workOrderRepository;
+
+    @Mock
+    private WorkorderServiceRepository workOrderServiceRepository;
+
+    @Mock
+    private WorkorderPartRepository workOrderPartRepository;
+
+    @Mock
+    private ApprovalRecordRepository approvalRecordRepository;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    @Mock
+    private RestClient documentServiceRestClient;
+
+    private ChangeRequestServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ChangeRequestServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                changeRequestRepository,
+                workOrderRepository,
+                workOrderServiceRepository,
+                workOrderPartRepository,
+                approvalRecordRepository,
+                idempotencyService,
+                documentServiceRestClient,
+                new ObjectMapper());
+
+        Workorder workorder = new Workorder();
+        workorder.setId(WORKORDER_ID);
+        workorder.setStatus(WorkorderStatus.WORK_IN_PROGRESS);
+        when(workOrderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(workorder));
+    }
+
+    private static CreateChangeRequestDTO.WorkorderItemDTO item() {
+        CreateChangeRequestDTO.WorkorderItemDTO item = new CreateChangeRequestDTO.WorkorderItemDTO();
+        item.setQuantity(1);
+        return item;
+    }
+
+    private static CreateChangeRequestDTO dto(CreateChangeRequestDTO.WorkorderItemDTO... services) {
+        CreateChangeRequestDTO dto = new CreateChangeRequestDTO();
+        dto.setWorkorderId(WORKORDER_ID);
+        dto.setDescription("Corroded brake line found during inspection");
+        dto.setServices(List.of(services));
+        return dto;
+    }
+
+    // ─── request-level validation ────────────────────────────────────────────
+
+    @ParameterizedTest(name = "description=[{0}] is rejected")
+    @CsvSource(
+            value = {"NULL", "''", "'   '"},
+            nullValues = "NULL")
+    @DisplayName("a change request with no meaningful description is rejected")
+    void descriptionIsRequired(String description) {
+        CreateChangeRequestDTO dto = dto(item());
+        dto.setDescription(description);
+
+        // Whitespace is included deliberately: the description is what the customer is shown
+        // when asked to approve extra work, so a blank one is the same as none.
+        assertThatThrownBy(() -> service.createChangeRequest(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Description is required");
+
+        verify(changeRequestRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("a change request with neither services nor parts is rejected")
+    void atLeastOneItemIsRequired() {
+        CreateChangeRequestDTO dto = dto();
+        dto.setServices(List.of());
+        dto.setParts(List.of());
+
+        assertThatThrownBy(() -> service.createChangeRequest(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("At least one service or part");
+    }
+
+    @Test
+    @DisplayName("null lists count as empty rather than throwing")
+    void nullItemListsAreTreatedAsEmpty() {
+        CreateChangeRequestDTO dto = dto();
+        dto.setServices(null);
+        dto.setParts(null);
+
+        // The two collections are checked with a null guard before isEmpty; dropping it turns a
+        // malformed request into a NullPointerException instead of a clear rejection.
+        assertThatThrownBy(() -> service.createChangeRequest(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("At least one service or part");
+    }
+
+    @Test
+    @DisplayName("a request naming an unknown workorder is rejected")
+    void unknownWorkorderIsRejected() {
+        when(workOrderRepository.findById(WORKORDER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.createChangeRequest(dto(item())))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Work order not found");
+    }
+
+    @ParameterizedTest(name = "workorder in {0} cannot take a change request")
+    @EnumSource(
+            value = WorkorderStatus.class,
+            names = {"WORK_IN_PROGRESS"},
+            mode = EnumSource.Mode.EXCLUDE)
+    @DisplayName("only a workorder actually in progress can take a change request")
+    void onlyWorkInProgressAcceptsChangeRequests(WorkorderStatus status) {
+        Workorder workorder = new Workorder();
+        workorder.setId(WORKORDER_ID);
+        workorder.setStatus(status);
+        when(workOrderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(workorder));
+
+        // Every other status is checked rather than one sample: adding extra work to a job that
+        // is finished, invoiced or cancelled is precisely the case that produces a bill the
+        // customer never agreed to.
+        assertThatThrownBy(() -> service.createChangeRequest(dto(item())))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("WORK_IN_PROGRESS");
+
+        verify(changeRequestRepository, never()).save(any());
+    }
+
+    // ─── emergency documentation ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("claiming an emergency exception with no emergency item is rejected")
+    void emergencyExceptionNeedsAnEmergencyItem() {
+        CreateChangeRequestDTO dto = dto(item());
+        dto.setIsEmergencyException(true);
+
+        // The flag and the items must agree. A request that claims the exception but marks
+        // nothing as emergency would take the fast path with no item to justify it.
+        assertThatThrownBy(() -> service.createChangeRequest(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no items are marked as emergency");
+    }
+
+    @Test
+    @DisplayName("an emergency item with no photo and no photo-not-possible flag is rejected")
+    void emergencyItemNeedsPhotoOrAnExplicitReasonItCannotBeTaken() {
+        CreateChangeRequestDTO.WorkorderItemDTO emergency = item();
+        emergency.setIsEmergencySafety(true);
+        CreateChangeRequestDTO dto = dto(emergency);
+        dto.setIsEmergencyException(true);
+
+        assertThatThrownBy(() -> service.createChangeRequest(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("photo evidence");
+    }
+
+    @Test
+    @DisplayName("an emergency item claiming photo-not-possible but supplying no notes is rejected")
+    void photoNotPossibleStillNeedsNotes() {
+        CreateChangeRequestDTO.WorkorderItemDTO emergency = item();
+        emergency.setIsEmergencySafety(true);
+        emergency.setPhotoNotPossible(true);
+        CreateChangeRequestDTO dto = dto(emergency);
+        dto.setIsEmergencyException(true);
+
+        // This is the case that the two overlapping checks exist for. Collapsing them into one
+        // would let an item pass with the flag set and nothing written down, which is the same
+        // as no evidence at all.
+        assertThatThrownBy(() -> service.createChangeRequest(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("notes");
+    }
+
+    @ParameterizedTest(name = "photo={0} photoNotPossible={1} notes={2} accepted={3}")
+    @CsvSource({
+        "https://img/1.jpg, false, ,                    true",
+        "https://img/1.jpg, false, 'seized fitting',    true",
+        "'',                true,  'seized fitting',    true",
+        "'   ',             true,  'seized fitting',    true",
+        "'',                true,  '   ',               false",
+        "'',                false, 'seized fitting',    false",
+    })
+    @DisplayName("the evidence rule is photo, or photo-not-possible with notes")
+    void evidenceTruthTable(String photoUrl, boolean photoNotPossible, String notes, boolean accepted) {
+        CreateChangeRequestDTO.WorkorderItemDTO emergency = item();
+        emergency.setIsEmergencySafety(true);
+        emergency.setPhotoEvidenceUrl(photoUrl);
+        emergency.setPhotoNotPossible(photoNotPossible);
+        emergency.setEmergencyNotes(notes);
+        CreateChangeRequestDTO dto = dto(emergency);
+        dto.setIsEmergencyException(true);
+        when(changeRequestRepository.save(any())).thenAnswer(invocation -> {
+            ChangeRequest saved = invocation.getArgument(0);
+            saved.setId(CHANGE_REQUEST_ID);
+            return saved;
+        });
+
+        // Whitespace-only values appear on both sides of the table: a photo url of spaces is
+        // not a photo, and notes of spaces are not notes.
+        if (accepted) {
+            assertThat(service.createChangeRequest(dto)).isNotNull();
+        } else {
+            assertThatThrownBy(() -> service.createChangeRequest(dto)).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    @DisplayName("an emergency part is validated on the same terms as an emergency service")
+    void emergencyPartsAreValidatedToo() {
+        CreateChangeRequestDTO.WorkorderItemDTO part = item();
+        part.setIsEmergencySafety(true);
+        CreateChangeRequestDTO dto = new CreateChangeRequestDTO();
+        dto.setWorkorderId(WORKORDER_ID);
+        dto.setDescription("Corroded brake line found during inspection");
+        dto.setParts(List.of(part));
+        dto.setIsEmergencyException(true);
+
+        // Services and parts are validated by two separate loops over the same helper. A part
+        // that skipped the check would be the cheaper half of the bill going undocumented.
+        assertThatThrownBy(() -> service.createChangeRequest(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("photo evidence");
+    }
+
+    @Test
+    @DisplayName("a non-emergency request skips the evidence rules entirely")
+    void nonEmergencyRequestSkipsEvidenceRules() {
+        when(changeRequestRepository.save(any())).thenAnswer(invocation -> {
+            ChangeRequest saved = invocation.getArgument(0);
+            saved.setId(CHANGE_REQUEST_ID);
+            return saved;
+        });
+
+        // The ordinary path must not demand photos — this is the branch that keeps the
+        // emergency rules from applying to every change request in the shop.
+        assertThat(service.createChangeRequest(dto(item()))).isNotNull();
+    }
+
+    // ─── closing the workorder ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("a workorder with no declined emergency requests can close")
+    void noDeclinedEmergencyMeansCloseable() {
+        when(changeRequestRepository.findByWorkorder_IdAndStatus(WORKORDER_ID, ChangeRequestStatus.DECLINED))
+                .thenReturn(List.of());
+
+        assertThat(service.canCloseWorkorder(WORKORDER_ID)).isTrue();
+    }
+
+    @Test
+    @DisplayName("a declined request that was never an emergency does not block closing")
+    void declinedNonEmergencyDoesNotBlockClosing() {
+        ChangeRequest declined = new ChangeRequest();
+        declined.setId(CHANGE_REQUEST_ID);
+        declined.setIsEmergencyException(false);
+        when(changeRequestRepository.findByWorkorder_IdAndStatus(WORKORDER_ID, ChangeRequestStatus.DECLINED))
+                .thenReturn(List.of(declined));
+
+        // Only emergency denials need an acknowledgment. Blocking on ordinary declines would
+        // stop every workorder where the customer simply said no to an upsell.
+        assertThat(service.canCloseWorkorder(WORKORDER_ID)).isTrue();
+        verify(workOrderServiceRepository, never()).findByChangeRequest_Id(any());
+    }
+
+    @ParameterizedTest(name = "unacknowledged emergency {0} blocks closing")
+    @CsvSource({"service", "part"})
+    @DisplayName("an unacknowledged emergency item blocks closing, on services and on parts alike")
+    void unacknowledgedEmergencyItemBlocksClosing(String kind) {
+        declinedEmergencyExists();
+
+        if ("service".equals(kind)) {
+            WorkorderServiceLine line = new WorkorderServiceLine();
+            line.setIsEmergencySafety(true);
+            line.setCustomerDenialAcknowledged(false);
+            when(workOrderServiceRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID))
+                    .thenReturn(List.of(line));
+            when(workOrderPartRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID))
+                    .thenReturn(List.of());
+        } else {
+            WorkorderPart part = new WorkorderPart();
+            part.setIsEmergencySafety(true);
+            part.setCustomerDenialAcknowledged(false);
+            when(workOrderServiceRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID))
+                    .thenReturn(List.of());
+            when(workOrderPartRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID))
+                    .thenReturn(List.of(part));
+        }
+
+        // Both halves are asserted because they are separate methods with identical bodies:
+        // the parts check could be dropped and the services one would keep the test green.
+        assertThat(service.canCloseWorkorder(WORKORDER_ID)).isFalse();
+    }
+
+    @Test
+    @DisplayName("once every emergency item is acknowledged, the workorder can close")
+    void acknowledgedEmergencyItemsUnblockClosing() {
+        declinedEmergencyExists();
+        WorkorderServiceLine line = new WorkorderServiceLine();
+        line.setIsEmergencySafety(true);
+        line.setCustomerDenialAcknowledged(true);
+        WorkorderPart part = new WorkorderPart();
+        part.setIsEmergencySafety(true);
+        part.setCustomerDenialAcknowledged(true);
+        when(workOrderServiceRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID))
+                .thenReturn(List.of(line));
+        when(workOrderPartRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID)).thenReturn(List.of(part));
+
+        assertThat(service.canCloseWorkorder(WORKORDER_ID)).isTrue();
+    }
+
+    @Test
+    @DisplayName("a non-emergency item on a declined emergency request needs no acknowledgment")
+    void nonEmergencyItemsNeedNoAcknowledgment() {
+        declinedEmergencyExists();
+        WorkorderServiceLine ordinary = new WorkorderServiceLine();
+        ordinary.setIsEmergencySafety(false);
+        ordinary.setCustomerDenialAcknowledged(false);
+        when(workOrderServiceRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID))
+                .thenReturn(List.of(ordinary));
+        when(workOrderPartRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID)).thenReturn(List.of());
+
+        // The acknowledgment requirement is per item, not per request: an ordinary line riding
+        // along on an emergency request must not hold the workorder open forever.
+        assertThat(service.canCloseWorkorder(WORKORDER_ID)).isTrue();
+    }
+
+    private void declinedEmergencyExists() {
+        ChangeRequest declined = new ChangeRequest();
+        declined.setId(CHANGE_REQUEST_ID);
+        declined.setIsEmergencyException(true);
+        declined.setStatus(ChangeRequestStatus.DECLINED);
+        when(changeRequestRepository.findByWorkorder_IdAndStatus(WORKORDER_ID, ChangeRequestStatus.DECLINED))
+                .thenReturn(List.of(declined));
+    }
+}


### PR DESCRIPTION
## What this does

Closes item 4 of `docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` §7 with a second branch-tail pass.

| Module | Branch at start of §7 | After pass 1 (#1275) | After this PR | Line | Floor |
|---|---|---|---|---|---|
| `pos-catalog` | 53.5% | 57.6% | **59.7%** | 80.3% | 0.75 / 0.54 |
| `pos-workorder` | 56.7% | 58.5% | **60.4%** | 78.7% | 0.73 / 0.55 |

60 new tests. Tests only — no production code changed.

Same approach as pass 1: the next-worst class in each module, picked for **what its branches decide** rather than for how many of them there are.

## `ChangeRequestServiceImpl` — 29.5% → 62.1% branch (93 → 50 missed)

A change request is how extra work gets added to a job the customer already agreed to, so these branches decide whether someone can be billed for work they never approved.

**Emergency items must carry evidence.** An emergency/safety item skips the normal approval wait, so it needs a photo, *or* an explicit "photo not possible" plus notes. The two checks overlap — the second catches an item that claimed photo-not-possible and then supplied nothing — and collapsing them into one would let a shop mark anything as an emergency with no record of why. Full evidence truth table asserted, with whitespace-only values on both sides: a photo url of spaces is not a photo, and notes of spaces are not notes.

**A declined emergency blocks closing the workorder** until the customer has acknowledged the denial, on every emergency item, across services **and** parts. That is the paper trail for "we told them it was unsafe and they said no". The services and parts checks are separate methods with identical bodies, so each is asserted independently — dropping the parts one leaves the services test green.

Also pinned: only a workorder actually in `WORK_IN_PROGRESS` accepts a change request, checked against *every* other status via `@EnumSource` exclusion rather than one sample, because adding work to a job that is finished, invoiced or cancelled is exactly the case that produces an unagreed bill. And the acknowledgment requirement is per *item*, not per request, so an ordinary line riding along on an emergency request does not hold the workorder open forever.

## `ProductDetailServiceImpl` — 37.7% → 54.4% branch (71 → 52 missed)

This view stitches the catalog row together with live pricing from pos-price and live availability from pos-inventory, and its whole design is **graceful degradation**: when a remote call fails the endpoint still answers, with the parts it could get and a `confidence` saying how much of it is real. That makes the failure branches the *normal* operating mode during any partial outage — and invisible from a happy path, because the response still looks complete.

Full confidence matrix asserted (both up → HIGH, either → MEDIUM, neither → LOW), plus:

- **A remote answering successfully with no data is treated exactly like an outage.** Not a price of zero, not an error to propagate.
- **Null amounts stay null.** The BigDecimal→double conversions are null-guarded on both fields; without the guards this is an NPE, and with a naive default it is a free product.
- **Unparseable enum values off the wire** (`source`, `confidence`) degrade to a default rather than throwing, so a new constant added upstream cannot take this endpoint down. An unreadable confidence degrades to MEDIUM, never HIGH.
- **A lead-time lookup that throws falls back to the catalog hint** while leaving availability itself reported OK — letting that exception escape would turn a working stock read into an outage.
- Specifications come from four independent null checks, so a product with no colour does not show a customer a blank "Colour:" row.

## What is left, honestly

Both modules still have tails below their new floors. Next candidates are `SupplierItemCostServiceImpl` (44 missed) and `EstimateServiceImpl` (82). Item 4's stated goal — moving the named modules off their branch floors with parameterized tests over real decisions — is met, and §7.5 records where this stopped rather than implying the tails are gone.

`pos-document-helper` stays deliberately untouched: its entire tail is a duplicated copy of the library that no module consumes (#1274). Testing it would cement a deletion candidate.

## Contract impact — none

Every file here is a test or a `pom.xml` coverage floor. No controller, DTO, schema, event or OpenAPI document changed — see `BACKEND_CONTRACT_GUIDE.md` for the process if one had.

## Verification

`./mvnw -o -pl pos-catalog,pos-workorder -DskipTests=false verify -DskipITs` → BUILD SUCCESS with the new floors active. 31 new tests on change requests, 29 on product detail.

## Review round

One Copilot finding, correct and fixed: `emptyAvailabilityIsAlsoUnavailable` called `detail()` twice, running the whole service — both remote-client mocks included — once per assertion. Captured into a local, as the rest of the class already does. Beyond robustness, the two calls meant a failure in the second assertion pointed at a different invocation than the first. Swept the class for the same shape; that was the only occurrence.

## Note on CI history

This PR was opened against `test-coverage/branch-tails` (the base for #1275) and the workflows only trigger for PRs targeting `main`/`master`/`cap/**`, so it initially showed no checks. #1275 has since merged and this is now rebased onto `main` and retargeted, so CI runs against the real base.