### PR TITLE
ci: report every module below its coverage floor, not just the first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -806,20 +806,29 @@ jobs:
             exit 0
           fi
 
-          COUNT=$(wc -l < "$RUNNER_TEMP/coverage-violations.txt")
+          # One module can breach both counters, so violations and modules are different
+          # counts. Report both: the module count is what says how much work this is, the
+          # violation count is what you tick off.
+          VIOLATIONS=$(wc -l < "$RUNNER_TEMP/coverage-violations.txt")
+          sed 's/^Rule violated for bundle \([^:]*\):.*/\1/' "$RUNNER_TEMP/coverage-violations.txt" \
+            | sort -u > "$RUNNER_TEMP/coverage-modules.txt"
+          MODULES=$(wc -l < "$RUNNER_TEMP/coverage-modules.txt")
+
           {
-            echo "## Coverage ratchet: $COUNT module(s) below floor"
+            echo "## Coverage ratchet: $MODULES module(s) below floor, $VIOLATIONS violation(s)"
             echo
             echo '```'
             cat "$RUNNER_TEMP/coverage-violations.txt"
             echo '```'
+            echo
+            echo "Modules: $(paste -sd, "$RUNNER_TEMP/coverage-modules.txt" | sed 's/,/, /g')"
             echo
             echo "Floors live in each module's pom.xml (jacoco.line.min / jacoco.branch.min)."
             echo "See docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6 for how they are set."
           } >> "$GITHUB_STEP_SUMMARY"
 
           while IFS= read -r line; do echo "::error::$line"; done < "$RUNNER_TEMP/coverage-violations.txt"
-          echo "Coverage ratchet failed for $COUNT module(s); see the job summary for the full list."
+          echo "Coverage ratchet failed for $MODULES module(s) ($VIOLATIONS violation(s)); see the job summary."
           exit 1
 
       - name: Upload aggregate JaCoCo coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,13 +768,59 @@ jobs:
         # and fell back to its own `target/site/jacoco/jacoco.xml` — losing exactly the
         # cross-module coverage the aggregate report exists to capture. The path is absolute
         # (github.workspace) so it resolves identically from every module.
+        #
+        # The coverage ratchet runs here with -Djacoco.check.haltOnFailure=false. With the
+        # default (true) the reactor stops at the first module under its floor, so a single
+        # regression hid every other module's result *and* skipped the SonarCloud upload, because
+        # the sonar goal is bound to the aggregate module that depends on all of them. Reporting
+        # one offender per nightly run turns a ten-minute fix into a ten-day queue. The gate is
+        # not weakened: JaCoCo still evaluates every rule and logs each violation, and the step
+        # below fails the job with the complete list.
         run: |
+          set -o pipefail
           ./mvnw -pl ${{ env.COVERAGE_AGGREGATE_MODULE }} -am -DskipITs -Darchunit.skipTests=true verify -T 1C -B \
+            -Djacoco.check.haltOnFailure=false \
             org.sonarsource.scanner.maven:sonar-maven-plugin:${{ env.SONAR_MAVEN_PLUGIN_VERSION }}:sonar \
             -Dsonar.projectKey=louisburroughs_durion-positivity-backend \
             -Dsonar.organization=louisburroughs \
             -Dsonar.host.url=https://sonarcloud.io \
-            -Dsonar.coverage.jacoco.aggregateXmlReportPaths=${{ github.workspace }}/${{ env.COVERAGE_AGGREGATE_XML_PATH }}
+            -Dsonar.coverage.jacoco.aggregateXmlReportPaths=${{ github.workspace }}/${{ env.COVERAGE_AGGREGATE_XML_PATH }} \
+            2>&1 | tee "$RUNNER_TEMP/full-coverage.log"
+
+      - name: Enforce the coverage ratchet across every module
+        if: always()
+        run: |
+          LOG="$RUNNER_TEMP/full-coverage.log"
+          if [ ! -f "$LOG" ]; then
+            echo "::error::Coverage log missing — the build step did not run to completion."
+            exit 1
+          fi
+
+          # JaCoCo emits one "Rule violated for bundle <module>: <counter> covered ratio is X,
+          # but expected minimum is Y" per breach. Collect them all rather than the first.
+          grep -F 'Rule violated for bundle' "$LOG" | sed 's/^\[WARNING\] *//; s/^\[ERROR\] *//' \
+            | sort -u > "$RUNNER_TEMP/coverage-violations.txt" || true
+
+          if [ ! -s "$RUNNER_TEMP/coverage-violations.txt" ]; then
+            echo "Coverage ratchet: every module met its floor."
+            exit 0
+          fi
+
+          COUNT=$(wc -l < "$RUNNER_TEMP/coverage-violations.txt")
+          {
+            echo "## Coverage ratchet: $COUNT module(s) below floor"
+            echo
+            echo '```'
+            cat "$RUNNER_TEMP/coverage-violations.txt"
+            echo '```'
+            echo
+            echo "Floors live in each module's pom.xml (jacoco.line.min / jacoco.branch.min)."
+            echo "See docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6 for how they are set."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          while IFS= read -r line; do echo "::error::$line"; done < "$RUNNER_TEMP/coverage-violations.txt"
+          echo "Coverage ratchet failed for $COUNT module(s); see the job summary for the full list."
+          exit 1
 
       - name: Upload aggregate JaCoCo coverage report
         if: always()

--- a/pom.xml
+++ b/pom.xml
@@ -368,6 +368,10 @@
 		<sonar.organization>louisburroughs</sonar.organization>
 		<!-- Coverage ratchet defaults (plan Phase 4). Overridden per module in each
 		     module pom; 0.00 here means "unguarded" for modules that set nothing. -->
+		<!-- Fail the build on the first module that misses its floor. Set false to let the
+		     reactor finish and report every offender at once — see the overnight coverage
+		     job in .github/workflows/ci.yml. -->
+		<jacoco.check.haltOnFailure>true</jacoco.check.haltOnFailure>
 		<jacoco.line.min>0.00</jacoco.line.min>
 		<jacoco.branch.min>0.00</jacoco.branch.min>
 		<!-- Test runtime tuning -->
@@ -547,7 +551,7 @@
 							<goal>check</goal>
 						</goals>
 						<configuration>
-							<haltOnFailure>true</haltOnFailure>
+							<haltOnFailure>${jacoco.check.haltOnFailure}</haltOnFailure>
 							<rules>
 								<rule>
 									<element>BUNDLE</element>


### PR DESCRIPTION
## Short answer

Yes. The gate now evaluates **every** module and fails the job once, with the full list.

## The problem

`Full Coverage SonarCloud Analysis` runs the whole reactor in one Maven invocation, and `check-ratchet` had `haltOnFailure=true`. Maven's default fail-fast stops at the first module under its floor, which costs two things:

1. **Every later module goes unchecked.** One nightly run reports one offender; fixing it reveals the next. A backlog of ten is ten nights.
2. **SonarCloud never runs.** The `sonar` goal is bound to `pos-coverage-aggregate`, which depends on all the modules — so a single coverage regression blinds the entire analysis, which is the job's main purpose.

`--fail-at-end` alone does not solve (2): the aggregate module depends on the failed one and would still be skipped.

## The change

`haltOnFailure` is now driven by `jacoco.check.haltOnFailure`, defaulting to `true`:

```xml
<haltOnFailure>${jacoco.check.haltOnFailure}</haltOnFailure>
```

- **Per-module and PR builds: unchanged.** They still fail fast, which is right when you are the person who just moved the number.
- **The overnight job passes `false`**, lets the reactor and Sonar finish, and a new step fails the job with the complete list — written to the step summary and emitted as `::error::` annotations so each violation is visible without opening the log.

**The gate is not weakened.** JaCoCo still evaluates every rule and logs every breach; only the point at which the failure is raised moves.

## Verified both directions

Against `pos-catalog` with a deliberately impossible floor:

```
-Djacoco.check.haltOnFailure=false -Djacoco.line.min=0.99 -Djacoco.branch.min=0.99
  [WARNING] Rule violated ... lines covered ratio is 0.80, but expected minimum is 0.99
  [WARNING] Rule violated ... branches covered ratio is 0.59, but expected minimum is 0.99
  BUILD SUCCESS          <- step below turns this into the job failure

default (-Djacoco.line.min=0.99)
  [WARNING] Rule violated ... lines covered ratio is 0.80, but expected minimum is 0.99
  BUILD FAILURE ... check-ratchet ... Coverage checks have not been met
```

Note the non-halting form reports **both** counters — fail-fast stops after the line check and never mentions branches, so even for a single module you were seeing half the picture.

## On the reported `pos-documents` failure — I could not reproduce it

- Standalone `verify`: **75.20% line / 52.88% branch** against floors of **0.70 / 0.47**. Passes.
- Re-run under the overnight flags (`-pl pos-documents -am -DskipITs -Darchunit.skipTests=true -T 1C`): passes.
- The Actions log for that run has expired, so the ratio it actually measured is not recoverable.

So I have **not** diagnosed the underlying cause, and this PR does not claim to fix it. What it does is make the next nightly run print the measured ratio for `pos-documents` *and* every other module in a single pass. If you still have `/tmp/full-coverage-sonarcloud.log`, lines 1139 and 1152 would settle it immediately — the `Rule violated` line carries the actual ratio.

Plausible causes worth keeping in mind once we see the number: coverage genuinely below floor only in the full-reactor run (a test that behaves differently there), or a partial/empty `jacoco.exec` for that module under `-T 1C`. The reported ratio distinguishes the two — a near-zero ratio means the exec file, a close-to-floor ratio means real coverage.

## Files

- `pom.xml` — `haltOnFailure` becomes a property, default `true`, documented next to the floors.
- `.github/workflows/ci.yml` — overnight job passes `false`, tees its log, and gains the enforcement step.
