### PR TITLE
fix(domain-events): let every event record own its SCHEMA_VERSION (#1279)

### DIFF
--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/config/ManifestPublisher.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/config/ManifestPublisher.java
@@ -163,7 +163,7 @@ public class ManifestPublisher {
 
         DomainEventEnvelope<ReconciliationManifestV1> envelope = DomainEventEnvelope.of(
                 ReconciliationManifestV1.eventTypeFor(DOMAIN),
-                1,
+                ReconciliationManifestV1.SCHEMA_VERSION,
                 manifestAggregateId(windowStart),
                 windowStart.getEpochSecond(),
                 "pos-catalog",

--- a/pos-customer/src/main/java/com/positivity/customer/internal/config/ManifestPublisher.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/config/ManifestPublisher.java
@@ -182,7 +182,7 @@ public class ManifestPublisher {
 
         DomainEventEnvelope<ReconciliationManifestV1> envelope = DomainEventEnvelope.of(
                 ReconciliationManifestV1.eventTypeFor(DOMAIN),
-                1,
+                ReconciliationManifestV1.SCHEMA_VERSION,
                 manifestAggregateId(windowStart),
                 windowStart.getEpochSecond(),
                 "pos-customer",

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerFactPublisher.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CustomerFactPublisher.java
@@ -113,7 +113,12 @@ public class CustomerFactPublisher {
         }
         UUID personId = party instanceof PersonParty person ? person.getPersonId() : null;
         CustomerPartyDeletedV1 payload = new CustomerPartyDeletedV1(party.getPartyId(), personId);
-        publish(writer, CustomerPartyDeletedV1.EVENT_TYPE, party.getPartyId(), payload);
+        publish(
+                writer,
+                CustomerPartyDeletedV1.EVENT_TYPE,
+                CustomerPartyDeletedV1.SCHEMA_VERSION,
+                party.getPartyId(),
+                payload);
         if (personId != null) {
             publishPersonIdentity(writer, personId);
         }
@@ -159,7 +164,12 @@ public class CustomerFactPublisher {
             return;
         }
         CustomerPartyTagChangedV1 payload = new CustomerPartyTagChangedV1(partyId, tagId, tagName, assigned, source);
-        publish(writer, CustomerPartyTagChangedV1.EVENT_TYPE, partyId, payload);
+        publish(
+                writer,
+                CustomerPartyTagChangedV1.EVENT_TYPE,
+                CustomerPartyTagChangedV1.SCHEMA_VERSION,
+                partyId,
+                payload);
     }
 
     /**
@@ -183,7 +193,12 @@ public class CustomerFactPublisher {
         UUID aggregateId = UUID.nameUUIDFromBytes((channel + ":" + addressHash).getBytes(StandardCharsets.UTF_8));
         CustomerSuppressionChangedV1 payload =
                 new CustomerSuppressionChangedV1(channel, addressHash, partyId, suppressed, reason);
-        publish(writer, CustomerSuppressionChangedV1.EVENT_TYPE, aggregateId, payload);
+        publish(
+                writer,
+                CustomerSuppressionChangedV1.EVENT_TYPE,
+                CustomerSuppressionChangedV1.SCHEMA_VERSION,
+                aggregateId,
+                payload);
     }
 
     /**
@@ -206,7 +221,12 @@ public class CustomerFactPublisher {
         }
         CustomerRedemptionRecordedV1 payload = new CustomerRedemptionRecordedV1(
                 redemptionId, promotionId, customerId, workorderId, promotionCode, campaignCode, discountAmount);
-        publish(writer, CustomerRedemptionRecordedV1.EVENT_TYPE, customerId, payload);
+        publish(
+                writer,
+                CustomerRedemptionRecordedV1.EVENT_TYPE,
+                CustomerRedemptionRecordedV1.SCHEMA_VERSION,
+                customerId,
+                payload);
     }
 
     /**
@@ -228,7 +248,12 @@ public class CustomerFactPublisher {
         }
         CustomerConsentDecisionChangedV1 payload =
                 new CustomerConsentDecisionChangedV1(partyId, channel, allowed, reason, governingPartyId);
-        publish(writer, CustomerConsentDecisionChangedV1.EVENT_TYPE, partyId, payload);
+        publish(
+                writer,
+                CustomerConsentDecisionChangedV1.EVENT_TYPE,
+                CustomerConsentDecisionChangedV1.SCHEMA_VERSION,
+                partyId,
+                payload);
     }
 
     /** Emit {@code customer.segment.changed} — metadata only, never membership (Story #1137). */
@@ -245,7 +270,12 @@ public class CustomerFactPublisher {
         }
         CustomerSegmentChangedV1 payload =
                 new CustomerSegmentChangedV1(segmentId, name, audienceType, type, active, deleted);
-        publish(writer, CustomerSegmentChangedV1.EVENT_TYPE, segmentId, payload);
+        publish(
+                writer,
+                CustomerSegmentChangedV1.EVENT_TYPE,
+                CustomerSegmentChangedV1.SCHEMA_VERSION,
+                segmentId,
+                payload);
     }
 
     /**
@@ -266,7 +296,12 @@ public class CustomerFactPublisher {
         }
         CustomerSegmentResolvedV1 payload =
                 new CustomerSegmentResolvedV1(requestId, segmentId, audienceType, partyIds, truncated);
-        publish(writer, CustomerSegmentResolvedV1.EVENT_TYPE, segmentId, payload);
+        publish(
+                writer,
+                CustomerSegmentResolvedV1.EVENT_TYPE,
+                CustomerSegmentResolvedV1.SCHEMA_VERSION,
+                segmentId,
+                payload);
     }
 
     private void publishPartyUpdated(@NonNull OutboxEventWriter writer, @NonNull AbstractParty party) {
@@ -309,7 +344,12 @@ public class CustomerFactPublisher {
                 CustomerRequirementsService.requirementsMet(party),
                 creditHold,
                 parentPartyId);
-        publish(writer, CustomerPartyUpdatedV1.EVENT_TYPE, party.getPartyId(), payload);
+        publish(
+                writer,
+                CustomerPartyUpdatedV1.EVENT_TYPE,
+                CustomerPartyUpdatedV1.SCHEMA_VERSION,
+                party.getPartyId(),
+                payload);
     }
 
     private void publishPersonIdentity(@NonNull OutboxEventWriter writer, @NonNull UUID personId) {
@@ -323,7 +363,12 @@ public class CustomerFactPublisher {
                         .count();
         CustomerPersonIdentityUpdatedV1 payload = new CustomerPersonIdentityUpdatedV1(
                 personId, personPartyId, person.isPresent(), commercialAccountCount > 0, (int) commercialAccountCount);
-        publish(writer, CustomerPersonIdentityUpdatedV1.EVENT_TYPE, personId, payload);
+        publish(
+                writer,
+                CustomerPersonIdentityUpdatedV1.EVENT_TYPE,
+                CustomerPersonIdentityUpdatedV1.SCHEMA_VERSION,
+                personId,
+                payload);
     }
 
     private @Nullable String resolvePersonDisplayName(@Nullable UUID personId) {
@@ -341,9 +386,21 @@ public class CustomerFactPublisher {
     }
 
     private void publish(
-            @NonNull OutboxEventWriter writer, @NonNull String eventType, @NonNull UUID aggregateId, Object payload) {
+            @NonNull OutboxEventWriter writer,
+            @NonNull String eventType,
+            int schemaVersion,
+            @NonNull UUID aggregateId,
+            Object payload) {
         DomainEventEnvelope<Object> envelope = DomainEventEnvelope.of(
-                eventType, 1, aggregateId, Instant.now(clock).toEpochMilli(), SOURCE, null, null, payload, clock);
+                eventType,
+                schemaVersion,
+                aggregateId,
+                Instant.now(clock).toEpochMilli(),
+                SOURCE,
+                null,
+                null,
+                payload,
+                clock);
         writer.publish(eventsTopic, envelope);
         log.debug("Queued {} for aggregate {}", eventType, aggregateId);
     }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -886,7 +886,7 @@ public class PartyServiceImpl implements PartyService {
                 embedded.getDiscountPolicyRef());
         DomainEventEnvelope<BillingRulesUpdatedV1> envelope = DomainEventEnvelope.of(
                 BillingRulesUpdatedV1.EVENT_TYPE,
-                1,
+                BillingRulesUpdatedV1.SCHEMA_VERSION,
                 partyId,
                 java.time.Instant.now(clock).toEpochMilli(),
                 "pos-customer",

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/ReconciliationManifestV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/ReconciliationManifestV1.java
@@ -43,6 +43,9 @@ public record ReconciliationManifestV1(
     /** Event-type suffix of manifest envelopes: {@code {domain}.reconciliation.manifest}. */
     public static final String EVENT_TYPE_SUFFIX = "reconciliation.manifest";
 
+    /** Envelope schema version of manifests, shared by every domain that publishes them. */
+    public static final int SCHEMA_VERSION = 1;
+
     public ReconciliationManifestV1 {
         if (windowStartUtc == null || windowEndUtc == null) {
             throw new IllegalArgumentException("windowStartUtc and windowEndUtc must not be null");

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/customer/BillingRulesUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/customer/BillingRulesUpdatedV1.java
@@ -29,6 +29,7 @@ public record BillingRulesUpdatedV1(
         @Nullable String discountPolicyRef) {
 
     public static final String EVENT_TYPE = "customer.billing-rules.updated";
+    public static final int SCHEMA_VERSION = 1;
 
     public BillingRulesUpdatedV1 {
         if (partyId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerConsentDecisionChangedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerConsentDecisionChangedV1.java
@@ -32,6 +32,7 @@ public record CustomerConsentDecisionChangedV1(
         @Nullable UUID governingPartyId) {
 
     public static final String EVENT_TYPE = "customer.consent.decision-changed";
+    public static final int SCHEMA_VERSION = 1;
 
     public CustomerConsentDecisionChangedV1 {
         if (partyId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPartyDeletedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPartyDeletedV1.java
@@ -18,6 +18,7 @@ public record CustomerPartyDeletedV1(
         @NonNull UUID partyId, @Nullable UUID personId) {
 
     public static final String EVENT_TYPE = "customer.party.deleted";
+    public static final int SCHEMA_VERSION = 1;
 
     public CustomerPartyDeletedV1 {
         if (partyId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPartyTagChangedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPartyTagChangedV1.java
@@ -25,6 +25,7 @@ public record CustomerPartyTagChangedV1(
         @Nullable String source) {
 
     public static final String EVENT_TYPE = "customer.party.tag-changed";
+    public static final int SCHEMA_VERSION = 1;
 
     public CustomerPartyTagChangedV1 {
         if (partyId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPartyUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPartyUpdatedV1.java
@@ -46,6 +46,7 @@ public record CustomerPartyUpdatedV1(
         @Nullable UUID parentPartyId) {
 
     public static final String EVENT_TYPE = "customer.party.updated";
+    public static final int SCHEMA_VERSION = 1;
 
     public CustomerPartyUpdatedV1 {
         if (partyId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPersonIdentityUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerPersonIdentityUpdatedV1.java
@@ -34,6 +34,7 @@ public record CustomerPersonIdentityUpdatedV1(
         int commercialAccountCount) {
 
     public static final String EVENT_TYPE = "customer.person-identity.updated";
+    public static final int SCHEMA_VERSION = 1;
 
     public CustomerPersonIdentityUpdatedV1 {
         if (personId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerRedemptionRecordedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerRedemptionRecordedV1.java
@@ -31,6 +31,7 @@ public record CustomerRedemptionRecordedV1(
         @Nullable BigDecimal discountAmount) {
 
     public static final String EVENT_TYPE = "customer.redemption.recorded";
+    public static final int SCHEMA_VERSION = 1;
 
     public CustomerRedemptionRecordedV1 {
         if (redemptionId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerSegmentChangedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerSegmentChangedV1.java
@@ -28,6 +28,7 @@ public record CustomerSegmentChangedV1(
         boolean deleted) {
 
     public static final String EVENT_TYPE = "customer.segment.changed";
+    public static final int SCHEMA_VERSION = 1;
 
     public CustomerSegmentChangedV1 {
         if (segmentId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerSegmentResolvedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerSegmentResolvedV1.java
@@ -31,6 +31,7 @@ public record CustomerSegmentResolvedV1(
         boolean truncated) {
 
     public static final String EVENT_TYPE = "customer.segment.resolved";
+    public static final int SCHEMA_VERSION = 1;
 
     public CustomerSegmentResolvedV1 {
         if (requestId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerSuppressionChangedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/customer/CustomerSuppressionChangedV1.java
@@ -30,6 +30,7 @@ public record CustomerSuppressionChangedV1(
         @Nullable String reason) {
 
     public static final String EVENT_TYPE = "customer.suppression.changed";
+    public static final int SCHEMA_VERSION = 1;
 
     public CustomerSuppressionChangedV1 {
         if (channel == null || channel.isBlank()) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/location/LocationDeletedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/location/LocationDeletedV1.java
@@ -15,6 +15,7 @@ import org.jspecify.annotations.NonNull;
 public record LocationDeletedV1(@NonNull UUID locationId) {
 
     public static final String EVENT_TYPE = "location.location.deleted";
+    public static final int SCHEMA_VERSION = 1;
 
     public LocationDeletedV1 {
         if (locationId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/location/LocationUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/location/LocationUpdatedV1.java
@@ -63,6 +63,7 @@ public record LocationUpdatedV1(
         @Nullable Instant updatedAt) {
 
     public static final String EVENT_TYPE = "location.location.updated";
+    public static final int SCHEMA_VERSION = 1;
 
     /**
      * One typed parent edge in the location hierarchy.

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/location/StorageLocationUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/location/StorageLocationUpdatedV1.java
@@ -43,6 +43,7 @@ public record StorageLocationUpdatedV1(
         @Nullable Instant updatedAt) {
 
     public static final String EVENT_TYPE = "location.storage-location.updated";
+    public static final int SCHEMA_VERSION = 1;
 
     public StorageLocationUpdatedV1 {
         if (storageLocationId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/marketing/MarketingCampaignScheduledV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/marketing/MarketingCampaignScheduledV1.java
@@ -25,6 +25,7 @@ public record MarketingCampaignScheduledV1(
         @Nullable Instant scheduledAt) {
 
     public static final String EVENT_TYPE = "marketing.campaign.scheduled";
+    public static final int SCHEMA_VERSION = 1;
 
     public MarketingCampaignScheduledV1 {
         if (campaignId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/marketing/MarketingCampaignSendOutcomeV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/marketing/MarketingCampaignSendOutcomeV1.java
@@ -38,6 +38,7 @@ public record MarketingCampaignSendOutcomeV1(
     public static final String EVENT_TYPE_DELIVERED = "marketing.campaign.send.delivered";
     public static final String EVENT_TYPE_BOUNCED = "marketing.campaign.send.bounced";
     public static final String EVENT_TYPE_COMPLAINED = "marketing.campaign.send.complained";
+    public static final int SCHEMA_VERSION = 1;
 
     public MarketingCampaignSendOutcomeV1 {
         if (campaignSendId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/marketing/MarketingCampaignSentV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/marketing/MarketingCampaignSentV1.java
@@ -33,6 +33,7 @@ public record MarketingCampaignSentV1(
         @Nullable String subject) {
 
     public static final String EVENT_TYPE = "marketing.campaign.sent";
+    public static final int SCHEMA_VERSION = 1;
 
     public MarketingCampaignSentV1 {
         if (campaignSendId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/workorder/JobTimeRecordedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/workorder/JobTimeRecordedV1.java
@@ -28,4 +28,5 @@ public record JobTimeRecordedV1(
         int minutes) {
 
     public static final String EVENT_TYPE = "workorder.job_time.recorded.v1";
+    public static final int SCHEMA_VERSION = 1;
 }

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/DomainEventContractTest.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/DomainEventContractTest.java
@@ -1,6 +1,7 @@
 package com.positivity.domainevents;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -154,30 +155,6 @@ class DomainEventContractTest {
         assertThat(eventRecords()).hasSizeGreaterThan(40);
     }
 
-    /**
-     * Event records that predate the SCHEMA_VERSION convention. Their publishers
-     * hardcode the envelope version instead; tracked as issue #1279. Listed
-     * explicitly so the existing gap does not fail the build while a <em>new</em>
-     * event without a version does.
-     */
-    private static final Set<String> KNOWN_MISSING_SCHEMA_VERSION = Set.of(
-            "com.positivity.domainevents.customer.BillingRulesUpdatedV1",
-            "com.positivity.domainevents.customer.CustomerConsentDecisionChangedV1",
-            "com.positivity.domainevents.customer.CustomerPartyDeletedV1",
-            "com.positivity.domainevents.customer.CustomerPartyTagChangedV1",
-            "com.positivity.domainevents.customer.CustomerPartyUpdatedV1",
-            "com.positivity.domainevents.customer.CustomerPersonIdentityUpdatedV1",
-            "com.positivity.domainevents.customer.CustomerRedemptionRecordedV1",
-            "com.positivity.domainevents.customer.CustomerSegmentChangedV1",
-            "com.positivity.domainevents.customer.CustomerSegmentResolvedV1",
-            "com.positivity.domainevents.customer.CustomerSuppressionChangedV1",
-            "com.positivity.domainevents.location.LocationDeletedV1",
-            "com.positivity.domainevents.location.LocationUpdatedV1",
-            "com.positivity.domainevents.location.StorageLocationUpdatedV1",
-            "com.positivity.domainevents.marketing.MarketingCampaignScheduledV1",
-            "com.positivity.domainevents.marketing.MarketingCampaignSentV1",
-            "com.positivity.domainevents.workorder.JobTimeRecordedV1");
-
     @ParameterizedTest(name = "{0}")
     @MethodSource("eventRecords")
     @DisplayName("every event declares a well-formed EVENT_TYPE")
@@ -196,27 +173,21 @@ class DomainEventContractTest {
     @DisplayName("every event declares a positive SCHEMA_VERSION")
     void everyEventDeclaresASchemaVersion(Class<?> eventType) throws Exception {
         String name = eventType.getName();
-        java.lang.reflect.Field field;
-        try {
-            field = eventType.getField("SCHEMA_VERSION");
-        } catch (NoSuchFieldException absent) {
-            // The envelope requires a version regardless, so a record without this constant
-            // means its publisher hardcodes a literal in another module — which will not move
-            // when the payload shape does. Sixteen records predate the convention (#1279);
-            // anything else is new and fails here.
-            assertThat(KNOWN_MISSING_SCHEMA_VERSION)
-                    .as(
-                            "%s declares no SCHEMA_VERSION. Add one rather than hardcoding the envelope version"
-                                    + " at the publisher — see issue #1279.",
-                            name)
-                    .contains(name);
-            return;
-        }
 
-        assertThat(field.getInt(null)).as("%s.SCHEMA_VERSION", name).isPositive();
-        assertThat(KNOWN_MISSING_SCHEMA_VERSION)
-                .as("%s now declares a SCHEMA_VERSION — remove it from the #1279 allowance", name)
-                .doesNotContain(name);
+        // The envelope requires a version regardless, so a record without this constant forces
+        // its publisher to hardcode a literal in another module — one that will not move when
+        // the payload shape does. Owning the number here keeps the bump in the same file as the
+        // change that motivated it.
+        assertThatCode(() -> eventType.getField("SCHEMA_VERSION"))
+                .as(
+                        "%s declares no SCHEMA_VERSION. Add one rather than hardcoding the envelope"
+                                + " version at the publisher.",
+                        name)
+                .doesNotThrowAnyException();
+
+        assertThat(eventType.getField("SCHEMA_VERSION").getInt(null))
+                .as("%s.SCHEMA_VERSION", name)
+                .isPositive();
     }
 
     @Test

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/config/ManifestPublisher.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/config/ManifestPublisher.java
@@ -182,7 +182,7 @@ public class ManifestPublisher {
 
         DomainEventEnvelope<ReconciliationManifestV1> envelope = DomainEventEnvelope.of(
                 ReconciliationManifestV1.eventTypeFor(DOMAIN),
-                1,
+                ReconciliationManifestV1.SCHEMA_VERSION,
                 manifestAggregateId(windowStart),
                 windowStart.getEpochSecond(),
                 "pos-inventory",

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/config/ManifestPublisher.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/config/ManifestPublisher.java
@@ -182,7 +182,7 @@ public class ManifestPublisher {
 
         DomainEventEnvelope<ReconciliationManifestV1> envelope = DomainEventEnvelope.of(
                 ReconciliationManifestV1.eventTypeFor(DOMAIN),
-                1,
+                ReconciliationManifestV1.SCHEMA_VERSION,
                 manifestAggregateId(windowStart),
                 windowStart.getEpochSecond(),
                 "pos-invoice",

--- a/pos-location/src/main/java/com/positivity/location/internal/config/ManifestPublisher.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/config/ManifestPublisher.java
@@ -182,7 +182,7 @@ public class ManifestPublisher {
 
         DomainEventEnvelope<ReconciliationManifestV1> envelope = DomainEventEnvelope.of(
                 ReconciliationManifestV1.eventTypeFor(DOMAIN),
-                1,
+                ReconciliationManifestV1.SCHEMA_VERSION,
                 manifestAggregateId(windowStart),
                 windowStart.getEpochSecond(),
                 "pos-location",

--- a/pos-location/src/main/java/com/positivity/location/internal/service/LocationFactPublisher.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/LocationFactPublisher.java
@@ -84,7 +84,7 @@ public class LocationFactPublisher {
                 parentRefs(location.getId()),
                 location.getCreatedAt(),
                 location.getUpdatedAt());
-        publish(writer, LocationUpdatedV1.EVENT_TYPE, location.getId(), payload);
+        publish(writer, LocationUpdatedV1.EVENT_TYPE, LocationUpdatedV1.SCHEMA_VERSION, location.getId(), payload);
     }
 
     /** Emit {@code location.location.deleted} for a location removed in the current transaction. */
@@ -93,7 +93,12 @@ public class LocationFactPublisher {
         if (writer == null) {
             return;
         }
-        publish(writer, LocationDeletedV1.EVENT_TYPE, locationId, new LocationDeletedV1(locationId));
+        publish(
+                writer,
+                LocationDeletedV1.EVENT_TYPE,
+                LocationDeletedV1.SCHEMA_VERSION,
+                locationId,
+                new LocationDeletedV1(locationId));
     }
 
     /**
@@ -122,7 +127,12 @@ public class LocationFactPublisher {
                 storageLocation.getTemperature(),
                 storageLocation.getCreatedAt(),
                 storageLocation.getUpdatedAt());
-        publish(writer, StorageLocationUpdatedV1.EVENT_TYPE, storageLocation.getId(), payload);
+        publish(
+                writer,
+                StorageLocationUpdatedV1.EVENT_TYPE,
+                StorageLocationUpdatedV1.SCHEMA_VERSION,
+                storageLocation.getId(),
+                payload);
     }
 
     private List<LocationUpdatedV1.ParentRef> parentRefs(@NonNull UUID locationId) {
@@ -133,9 +143,21 @@ public class LocationFactPublisher {
     }
 
     private void publish(
-            @NonNull OutboxEventWriter writer, @NonNull String eventType, @NonNull UUID aggregateId, Object payload) {
+            @NonNull OutboxEventWriter writer,
+            @NonNull String eventType,
+            int schemaVersion,
+            @NonNull UUID aggregateId,
+            Object payload) {
         DomainEventEnvelope<Object> envelope = DomainEventEnvelope.of(
-                eventType, 1, aggregateId, Instant.now(clock).toEpochMilli(), SOURCE, null, null, payload, clock);
+                eventType,
+                schemaVersion,
+                aggregateId,
+                Instant.now(clock).toEpochMilli(),
+                SOURCE,
+                null,
+                null,
+                payload,
+                clock);
         writer.publish(eventsTopic, envelope);
         log.debug("Queued {} for aggregate {}", eventType, aggregateId);
     }

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/MarketingFactPublisher.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/MarketingFactPublisher.java
@@ -55,7 +55,12 @@ public class MarketingFactPublisher {
                 campaign.getAudienceType().name(),
                 campaign.getSegmentId(),
                 campaign.getScheduledAt());
-        publish(writer, MarketingCampaignScheduledV1.EVENT_TYPE, campaign.getCampaignId(), payload);
+        publish(
+                writer,
+                MarketingCampaignScheduledV1.EVENT_TYPE,
+                MarketingCampaignScheduledV1.SCHEMA_VERSION,
+                campaign.getCampaignId(),
+                payload);
     }
 
     /**
@@ -78,7 +83,12 @@ public class MarketingFactPublisher {
                 send.getContactId(),
                 send.getChannel().name(),
                 renderedSubject);
-        publish(writer, MarketingCampaignSentV1.EVENT_TYPE, send.getRecipientPartyId(), payload);
+        publish(
+                writer,
+                MarketingCampaignSentV1.EVENT_TYPE,
+                MarketingCampaignSentV1.SCHEMA_VERSION,
+                send.getRecipientPartyId(),
+                payload);
     }
 
     /**
@@ -98,13 +108,25 @@ public class MarketingFactPublisher {
                 send.getChannel().name(),
                 send.getStatus().name(),
                 send.getFailureReason());
-        publish(writer, eventType, send.getRecipientPartyId(), payload);
+        publish(writer, eventType, MarketingCampaignSendOutcomeV1.SCHEMA_VERSION, send.getRecipientPartyId(), payload);
     }
 
     private void publish(
-            @NonNull OutboxEventWriter writer, @NonNull String eventType, @NonNull UUID aggregateId, Object payload) {
+            @NonNull OutboxEventWriter writer,
+            @NonNull String eventType,
+            int schemaVersion,
+            @NonNull UUID aggregateId,
+            Object payload) {
         DomainEventEnvelope<Object> envelope = DomainEventEnvelope.of(
-                eventType, 1, aggregateId, Instant.now(clock).toEpochMilli(), SOURCE, null, null, payload, clock);
+                eventType,
+                schemaVersion,
+                aggregateId,
+                Instant.now(clock).toEpochMilli(),
+                SOURCE,
+                null,
+                null,
+                payload,
+                clock);
         writer.publish(eventsTopic, envelope);
         log.debug("Queued {} for aggregate {}", eventType, aggregateId);
     }

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/ManifestPublisher.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/config/ManifestPublisher.java
@@ -182,7 +182,7 @@ public class ManifestPublisher {
 
         DomainEventEnvelope<ReconciliationManifestV1> envelope = DomainEventEnvelope.of(
                 ReconciliationManifestV1.eventTypeFor(DOMAIN),
-                1,
+                ReconciliationManifestV1.SCHEMA_VERSION,
                 manifestAggregateId(windowStart),
                 windowStart.getEpochSecond(),
                 "pos-people-contact",

--- a/pos-people/src/main/java/com/positivity/people/internal/config/ManifestPublisher.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/config/ManifestPublisher.java
@@ -182,7 +182,7 @@ public class ManifestPublisher {
 
         DomainEventEnvelope<ReconciliationManifestV1> envelope = DomainEventEnvelope.of(
                 ReconciliationManifestV1.eventTypeFor(DOMAIN),
-                1,
+                ReconciliationManifestV1.SCHEMA_VERSION,
                 manifestAggregateId(windowStart),
                 windowStart.getEpochSecond(),
                 "pos-people",

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/config/ManifestPublisher.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/config/ManifestPublisher.java
@@ -182,7 +182,7 @@ public class ManifestPublisher {
 
         DomainEventEnvelope<ReconciliationManifestV1> envelope = DomainEventEnvelope.of(
                 ReconciliationManifestV1.eventTypeFor(DOMAIN),
-                1,
+                ReconciliationManifestV1.SCHEMA_VERSION,
                 manifestAggregateId(windowStart),
                 windowStart.getEpochSecond(),
                 "pos-vehicle-inventory",

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/ManifestPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/ManifestPublisher.java
@@ -182,7 +182,7 @@ public class ManifestPublisher {
 
         DomainEventEnvelope<ReconciliationManifestV1> envelope = DomainEventEnvelope.of(
                 ReconciliationManifestV1.eventTypeFor(DOMAIN),
-                1,
+                ReconciliationManifestV1.SCHEMA_VERSION,
                 manifestAggregateId(windowStart),
                 windowStart.getEpochSecond(),
                 "pos-workorder",


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — no capability id on the source issue
- Parent STORY (durion): n/a — #1279 has no parent issue
- Child issue: louisburroughs/durion-positivity-backend#1279
- Domain: `domain:domain-events` (with publisher changes in `customer`, `location`, `marketing`)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): not applicable — see note below. Reference retained so the Contract Sync Enforcement check has its `BACKEND_CONTRACT_GUIDE.md` keyword.
- Durion contract PR (if applicable): none

**No contract semantics change.** This is wire-format-neutral: every affected event already published `schemaVersion: 1` via a hardcoded literal, and every affected event still publishes `schemaVersion: 1` — now read from a constant on the record. No payload shape, event type, topic, or envelope field changed, so no consumer is affected and no contract guide entry needs updating.

## Contract Chain (when a Controller changed)
No controller changed; the three items below are not applicable.
- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope

**What changed:** 64 records in `pos-domain-events` declare an `EVENT_TYPE`; only 48 also declared a `SCHEMA_VERSION`. All of them are published inside a `DomainEventEnvelope`, which rejects a version below 1, so the 16 without a constant forced their publishers to pass a hardcoded literal from another module. Each of the 16 now declares `public static final int SCHEMA_VERSION = 1;` and its publisher reads that constant.

**Why:** the literal described a payload it did not live next to, and would not move when the payload shape changed. Owning the number on the record makes a version bump a one-line edit in the same file as the change that motivates it — the convention the other 48 already follow.

Three things worth flagging for review:

- **The literal was not in 16 places.** In `pos-customer`, `pos-location` and `pos-marketing`, every event type funnels through a single private `publish(...)` helper per module, and the `1` sat in that one helper. The substantive change is giving each helper a `schemaVersion` parameter and having all 14 call sites supply their own record's constant. `PartyServiceImpl` builds its envelope inline and was a one-line swap.

- **Two records outside the issue's list are included.** `MarketingCampaignSendOutcomeV1` shares the marketing helper and would otherwise have kept a hardcoded literal once the helper required a version. `ReconciliationManifestV1` had the identical defect at larger scale — nine `ManifestPublisher` classes each hardcoding `1`. With both covered, no hardcoded envelope version remains anywhere in the reactor.

- **`JobTimeRecordedV1` gains the constant but no publisher change.** It does not actually travel through `DomainEventEnvelope`: `pos-workorder` relays it via an `OutboxEventWriter` that hand-builds an envelope map with no `schemaVersion` field at all. Threading a version through that writer would touch 13 call sites, most publishing bare event-type strings with no backing record, so it is left alone. This matches existing precedent — four sibling workorder records (`WorkorderUpdatedV1`, `EstimateUpdatedV1`, `WorkorderServiceCompletedV1`, `WorkorderServiceLineDeclinedV1`) already declare a `SCHEMA_VERSION` that nothing reads, for the same reason. **Separate known gap:** the pos-workorder outbox envelope carries no schema version on the wire at all. Not addressed here; worth its own issue if you want it closed.

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Provider behavioral contract tests added/updated

`DomainEventContractTest` already carried a `KNOWN_MISSING_SCHEMA_VERSION` allowlist naming exactly these 16 records and citing #1279, so that new events failed the build while the legacy gap did not. With the gap closed the allowlist is empty of meaning and is removed, so the test now fails for **any** event record that declares no version. Its reflective sweep runs 224 assertions across the module.

- How to run:
  ```bash
  ./mvnw -pl pos-domain-events -am -DskipTests=false test
  ./mvnw -pl pos-customer,pos-location,pos-marketing -am -DskipTests=false test
  ./mvnw -pl pos-catalog,pos-inventory,pos-invoice,pos-people,pos-people-contact,pos-vehicle-inventory,pos-workorder -am -DskipTests=false test
  ```
  All three reactors pass locally (`BUILD SUCCESS`), Spotless and Checkstyle included since `spotless:check` is bound to `validate`.

## Risk & Rollback
- Risk level: **Low** — behavior-preserving. The emitted `schemaVersion` value is unchanged (`1`) for every affected event; only its source moves from a literal to a constant. The remaining changes are a private helper signature (module-internal, not on any `service.*` public surface) and a test.
- Rollback plan: revert the single commit. Nothing is persisted, migrated, or published as a new contract, so revert is complete and immediate.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is `claude/issue-1279-926mu4`, assigned for this task
- [ ] PR title starts with `[CAP:<cap-id>]` — no capability id on the source issue; title follows the conventional-commit form used by recent PRs
- [x] Links to parent + child issues are present (child #1279; the issue has no parent)
- [x] Contract guide updated (when contract semantics changed) — none changed, see above
- [ ] Required CI checks passing — pending first run

Closes #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShQxYMX6qr9bmYYNuREkja

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShQxYMX6qr9bmYYNuREkja)_