### PR TITLE
Fix the inverted 24h cache check in both vehicle-reference modules

### DIFF
--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -834,7 +834,7 @@ stale cache refetches and replaces — and, for NHTSA, the derivation
 instead of duplicating them.
 
 Writing them surfaced a live defect, filed as
-louisburroughs/durion-positivity-backend#1265 and listed below.
+louisburroughs/durion-positivity-backend#1265 and since fixed — see below.
 
 ### 7.3 Controller web slices closed (2026-08-12)
 
@@ -1063,13 +1063,14 @@ One defect filed: #1279.
   rejects every real Canadian province.
 - louisburroughs/durion-positivity-backend#1255 — replica listeners silently drop
   events whose payload omits a primitive field (Jackson 3).
-- louisburroughs/durion-positivity-backend#1265 — `pos-vehicle-reference-nhtsa`
-  inverts its own 24h cache: `isCacheExpired` computes "is still fresh", and
-  three of six call sites negate it, so those methods call vPIC on every request
-  while the cache is warm and then serve permanently frozen rows once it is not.
-  The same helper is copied into `pos-vehicle-reference-carapi`, where both call
-  sites happen to cancel out — correct by accident, and a trap for anyone who
-  fixes the name alone.
+- ~~louisburroughs/durion-positivity-backend#1265~~ — closed 2026-08-13.
+  `pos-vehicle-reference-nhtsa` inverted its own 24h cache: `isCacheExpired`
+  computed "is still fresh", and three of six call sites negated it, so those
+  methods called vPIC on every request while the cache was warm and then served
+  permanently frozen rows once it was not. The helper is now `isCacheFresh` in
+  both vehicle-reference modules, with every call site unnegated — including
+  `pos-vehicle-reference-carapi`, where the two inversions had cancelled out and
+  the behaviour was correct only by accident.
 - ~~louisburroughs/durion-positivity-backend#1269~~ — closed 2026-08-13.
   `pos-vehicle-inventory` had no `@ControllerAdvice` at all, so a wrong-length VIN
   on `@Validated` `GET /vin/{vin}` raised `ConstraintViolationException` and

--- a/pos-vehicle-reference-carapi/src/main/java/com/positivity/vehiclereferencecarapi/internal/service/VehicleReferenceService.java
+++ b/pos-vehicle-reference-carapi/src/main/java/com/positivity/vehiclereferencecarapi/internal/service/VehicleReferenceService.java
@@ -36,7 +36,7 @@ public class VehicleReferenceService {
 
     public List<CarApiMake> getMakes() {
         List<CarApiMake> cached = makeRepository.findAll();
-        if (!cached.isEmpty() && isCacheExpired(cached.getFirst().getCacheTimestamp())) {
+        if (!cached.isEmpty() && isCacheFresh(cached.getFirst().getCacheTimestamp())) {
             return cached;
         }
         String url = carApiBaseUrl + "/makes";
@@ -61,7 +61,7 @@ public class VehicleReferenceService {
 
     public List<CarApiModel> getModelsByMakeId(UUID makeId) {
         List<CarApiModel> cached = modelRepository.findByMakeId(makeId);
-        if (!cached.isEmpty() && isCacheExpired(cached.getFirst().getCacheTimestamp())) {
+        if (!cached.isEmpty() && isCacheFresh(cached.getFirst().getCacheTimestamp())) {
             return cached;
         }
         String url = carApiBaseUrl + "/models?make_id=" + makeId;
@@ -85,7 +85,12 @@ public class VehicleReferenceService {
         }
     }
 
-    private boolean isCacheExpired(LocalDateTime cacheTimestamp) {
+    /**
+     * Returns {@code true} while the cached rows are still inside the 24-hour
+     * window, i.e. while they may be served without calling CarAPI. A {@code null}
+     * timestamp cannot be shown to be fresh, so it is treated as needing a refetch.
+     */
+    private boolean isCacheFresh(LocalDateTime cacheTimestamp) {
         return cacheTimestamp != null && !cacheTimestamp.plus(CACHE_EXPIRY).isBefore(LocalDateTime.now(clock));
     }
 }

--- a/pos-vehicle-reference-carapi/src/test/java/com/positivity/vehiclereferencecarapi/internal/service/VehicleReferenceServiceTest.java
+++ b/pos-vehicle-reference-carapi/src/test/java/com/positivity/vehiclereferencecarapi/internal/service/VehicleReferenceServiceTest.java
@@ -40,11 +40,11 @@ import org.springframework.web.client.RestClient;
  * slow and a way to get throttled.
  *
  * <p>
- * <b>Read {@link #cacheIsServedWhileFresh()} before changing
- * {@code isCacheExpired}.</b> That method computes the opposite of its name, and
- * its one call site is inverted to match, so the net behaviour is correct. The
- * two mistakes cancel; fixing either alone breaks the cache. See the comment on
- * that test.
+ * Both methods gate on {@code isCacheFresh}, unnegated. That helper was formerly
+ * named {@code isCacheExpired} while computing the opposite — correct here only
+ * because both call sites happened to be inverted to match, and outright broken
+ * in the pos-vehicle-reference-nhtsa copy (issue #1265). Keep the name and the
+ * call sites agreeing.
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -101,14 +101,6 @@ class VehicleReferenceServiceTest {
         // that is the assertion: a fresh cache must not hit the rate-limited third party.
         server.verify();
         verify(makeRepository, never()).deleteAll();
-
-        // NOTE for anyone "fixing" isCacheExpired: it returns true when the cache is FRESH
-        // (it negates isBefore, so it really answers "is still valid"), and the call site
-        // reads `if (!cached.isEmpty() && isCacheExpired(...)) return cached;`. Inverted name,
-        // inverted usage, correct net behaviour — which this test pins. Correcting the method
-        // alone flips the call site's meaning and the service would refetch every request
-        // while the cache is good, and serve stale rows once it is not. The nhtsa copy of this
-        // helper does not cancel out at three of its six call sites — see issue #1265.
     }
 
     @Test

--- a/pos-vehicle-reference-nhtsa/src/main/java/com/positivity/nhtsa/internal/service/VehicleReferenceService.java
+++ b/pos-vehicle-reference-nhtsa/src/main/java/com/positivity/nhtsa/internal/service/VehicleReferenceService.java
@@ -35,7 +35,7 @@ public class VehicleReferenceService {
 
     public List<VehicleVariable> getVehicleVariables() {
         List<VehicleVariable> cached = vehicleVariableRepository.findAll();
-        if (!cached.isEmpty() && !isCacheExpired(cached.getFirst().getCacheTimestamp())) {
+        if (!cached.isEmpty() && isCacheFresh(cached.getFirst().getCacheTimestamp())) {
             return cached;
         }
         String url = NHTSA_API_BASE + "/GetVehicleVariableList?format=json";
@@ -59,7 +59,7 @@ public class VehicleReferenceService {
 
     public List<VehicleVariableValue> getVehicleVariableValues(UUID variableId) {
         List<VehicleVariableValue> cached = vehicleVariableValueRepository.findByVariable_Id(variableId);
-        if (!cached.isEmpty() && !isCacheExpired(cached.getFirst().getCacheTimestamp())) {
+        if (!cached.isEmpty() && isCacheFresh(cached.getFirst().getCacheTimestamp())) {
             return cached;
         }
         String url = NHTSA_API_BASE + "/GetVehicleVariableValuesList/" + variableId + "?format=json";
@@ -84,7 +84,7 @@ public class VehicleReferenceService {
 
     public List<Manufacturer> getManufacturers() {
         List<Manufacturer> cached = manufacturerRepository.findAll();
-        if (!cached.isEmpty() && isCacheExpired(cached.getFirst().getCacheTimestamp())) {
+        if (!cached.isEmpty() && isCacheFresh(cached.getFirst().getCacheTimestamp())) {
             return cached;
         }
         String url = NHTSA_API_BASE + "/getallmanufacturers?format=json";
@@ -113,7 +113,7 @@ public class VehicleReferenceService {
                 .findById(manufacturerId)
                 .orElseThrow(() -> new IllegalArgumentException("Manufacturer not found with ID: " + manufacturerId));
         List<Make> cached = makeRepository.findByManufacturerId(manufacturerId);
-        if (!cached.isEmpty() && isCacheExpired(cached.getFirst().getCacheTimestamp())) {
+        if (!cached.isEmpty() && isCacheFresh(cached.getFirst().getCacheTimestamp())) {
             return cached;
         }
         String url = NHTSA_API_BASE + "/GetMakeForManufacturer/" + manufacturerId + "?format=json";
@@ -143,7 +143,7 @@ public class VehicleReferenceService {
                 .findById(makeId)
                 .orElseThrow(() -> new IllegalArgumentException("Make not found with ID: " + makeId));
         List<Model> cached = modelRepository.findByMakeId(makeId);
-        if (!cached.isEmpty() && isCacheExpired(cached.getFirst().getCacheTimestamp())) {
+        if (!cached.isEmpty() && isCacheFresh(cached.getFirst().getCacheTimestamp())) {
             return cached;
         }
         String url = NHTSA_API_BASE + "/GetModelsForMakeId/" + makeId + "?format=json";
@@ -173,7 +173,7 @@ public class VehicleReferenceService {
                 .findById(makeId)
                 .orElseThrow(() -> new IllegalArgumentException("Make not found with ID: " + makeId));
         List<VehicleType> cached = vehicleTypeRepository.findByMakeId(makeId);
-        if (!cached.isEmpty() && !isCacheExpired(cached.getFirst().getCacheTimestamp())) {
+        if (!cached.isEmpty() && isCacheFresh(cached.getFirst().getCacheTimestamp())) {
             return cached;
         }
         String url = NHTSA_API_BASE + "/GetVehicleTypesForMakeId/" + makeId + "?format=json";
@@ -196,7 +196,12 @@ public class VehicleReferenceService {
         return vehicleTypeRepository.findByMakeId(makeId);
     }
 
-    private boolean isCacheExpired(LocalDateTime cacheTimestamp) {
+    /**
+     * Returns {@code true} while the cached rows are still inside the 24-hour
+     * window, i.e. while they may be served without calling vPIC. A {@code null}
+     * timestamp cannot be shown to be fresh, so it is treated as needing a refetch.
+     */
+    private boolean isCacheFresh(LocalDateTime cacheTimestamp) {
         return cacheTimestamp != null && !cacheTimestamp.plus(CACHE_EXPIRY).isBefore(LocalDateTime.now(clock));
     }
 }

--- a/pos-vehicle-reference-nhtsa/src/test/java/com/positivity/nhtsa/internal/service/VehicleReferenceServiceTest.java
+++ b/pos-vehicle-reference-nhtsa/src/test/java/com/positivity/nhtsa/internal/service/VehicleReferenceServiceTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import com.positivity.nhtsa.internal.entity.Make;
 import com.positivity.nhtsa.internal.entity.Manufacturer;
 import com.positivity.nhtsa.internal.entity.Model;
+import com.positivity.nhtsa.internal.entity.VehicleType;
 import com.positivity.nhtsa.internal.entity.VehicleVariable;
 import com.positivity.nhtsa.internal.repository.MakeRepository;
 import com.positivity.nhtsa.internal.repository.ManufacturerRepository;
@@ -51,14 +52,14 @@ import org.springframework.web.client.RestClient;
  * Two behaviours are worth knowing before editing this service:
  *
  * <ul>
- * <li><b>{@code isCacheExpired} computes the opposite of its name</b> — it really
- * answers "is still fresh". Three of the six call sites account for that and
- * behave correctly; the other three negate it and therefore serve the cache only
- * once it is stale, hitting vPIC on every request while it is warm. That is a
- * live bug, pinned by {@link #vehicleVariableCacheIsInverted()} and filed as
- * issue #1265. Fixing it means correcting the method name and all six call sites
- * together — and the same inverted helper was copied into
- * pos-vehicle-reference-carapi, where both call sites happen to be consistent.</li>
+ * <li><b>All six methods gate on {@code isCacheFresh}, unnegated</b> — the helper
+ * answers "are these rows still inside the 24-hour window", so every call site
+ * reads {@code if (!cached.isEmpty() && isCacheFresh(...)) return cached;}. It
+ * used to be named {@code isCacheExpired} while computing the opposite, and three
+ * of the six call sites negated it on top of that: those three called vPIC on
+ * every request while the cache was warm and then froze once it went stale
+ * (issue #1265). Keep the name and the call sites agreeing — a helper whose name
+ * inverts its body is what made half this service silently uncached.</li>
  * <li><b>NHTSA ids are hashed into UUIDs</b> via
  * {@code UUID.nameUUIDFromBytes("make-" + id)}, so the same vPIC record always
  * maps to the same primary key and a refetch updates rather than duplicates.
@@ -242,41 +243,82 @@ class VehicleReferenceServiceTest {
     }
 
     @Test
-    @DisplayName("BUG: the vehicle-variable cache is inverted — a fresh cache refetches from vPIC")
-    void vehicleVariableCacheIsInverted() {
+    @DisplayName("serves cached vehicle variables without calling vPIC while fresh")
+    void vehicleVariableCacheIsServedWhileFresh() {
         VehicleVariable cachedVar = new VehicleVariable();
         cachedVar.setId(UUID.randomUUID());
         cachedVar.setName("Body Class");
         cachedVar.setCacheTimestamp(fresh());
         when(vehicleVariableRepository.findAll()).thenReturn(List.of(cachedVar));
+
+        assertThat(service.getVehicleVariables())
+                .singleElement()
+                .extracting(VehicleVariable::getName)
+                .isEqualTo("Body Class");
+
+        // Regression guard for issue #1265: this call site used to negate a helper that was
+        // itself inverted, so an hour-old cache still went out to vPIC — and rewrote every
+        // row, making a read a database write too. No HTTP expectation is registered, so any
+        // outbound call fails this test.
+        server.verify();
+        verify(vehicleVariableRepository, never()).deleteAll();
+    }
+
+    @Test
+    @DisplayName("refetches vehicle variables once the cache falls outside the 24h window")
+    void staleVehicleVariablesRefetched() {
+        VehicleVariable cachedVar = new VehicleVariable();
+        cachedVar.setId(UUID.randomUUID());
+        cachedVar.setName("Body Class");
+        cachedVar.setCacheTimestamp(stale());
+        when(vehicleVariableRepository.findAll()).thenReturn(List.of(cachedVar));
         server.expect(requestTo(BASE + "/GetVehicleVariableList?format=json"))
                 .andRespond(withSuccess("""
-                        {"Results":[{"ID":5,"Name":"Body Class"}]}""", MediaType.APPLICATION_JSON));
+                        {"Results":[{"ID":5,"Name":"Body Class","Description":"Sedan, SUV, ..."}]}""", MediaType.APPLICATION_JSON));
 
         service.getVehicleVariables();
 
-        // Documents current behaviour, not desired behaviour. isCacheExpired() actually
-        // answers "is still fresh"; three of this service's six methods
-        // (getVehicleVariables, getVehicleVariableValues, getVehicleTypesForMake) then negate
-        // it, so they return the cache only once it is STALE and hit vPIC on every request
-        // while it is warm — the exact opposite of the intent, against a public API with no
-        // SLA. The other three call sites omit the negation and behave correctly. Tracked as
-        // issue #1265. The registered expectation above is the assertion: an outbound call happened
-        // despite an hour-old cache. Fixing it means correcting the method name and
-        // all six call sites together.
+        // The other half of #1265: with the double inversion this branch was unreachable once
+        // the cache aged past 24h, so the rows froze at whatever vPIC last returned.
+        org.mockito.ArgumentCaptor<VehicleVariable> captor = org.mockito.ArgumentCaptor.forClass(VehicleVariable.class);
+        verify(vehicleVariableRepository).save(captor.capture());
+        assertThat(captor.getValue().getName()).isEqualTo("Body Class");
+        assertThat(captor.getValue().getCacheTimestamp()).isEqualTo(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC));
         server.verify();
     }
 
     @Test
-    @DisplayName("the three non-negated methods do serve a fresh cache without calling vPIC")
-    void nonNegatedMethodsCacheCorrectly() {
-        when(manufacturerRepository.findAll()).thenReturn(List.of(manufacturer(fresh())));
+    @DisplayName("serves cached vehicle types per make without calling vPIC while fresh")
+    void vehicleTypeCacheIsServedWhileFresh() {
+        VehicleType cachedType = new VehicleType();
+        cachedType.setId(UUID.randomUUID());
+        cachedType.setVehicleTypeName("Passenger Car");
+        cachedType.setCacheTimestamp(fresh());
+        when(makeRepository.findById(MAKE_ID)).thenReturn(Optional.of(make(fresh())));
+        when(vehicleTypeRepository.findByMakeId(MAKE_ID)).thenReturn(List.of(cachedType));
 
+        assertThat(service.getVehicleTypesForMake(MAKE_ID))
+                .singleElement()
+                .extracting(VehicleType::getVehicleTypeName)
+                .isEqualTo("Passenger Car");
+
+        // Third of the three call sites corrected by #1265.
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("treats a row with no cache timestamp as needing a refetch")
+    void nullTimestampRefetches() {
+        when(manufacturerRepository.findAll()).thenReturn(List.of(manufacturer(null)));
+        server.expect(requestTo(BASE + "/getallmanufacturers?format=json"))
+                .andRespond(withSuccess("""
+                        {"Results":[{"Mfr_ID":988,"Mfr_CommonName":"HONDA"}]}""", MediaType.APPLICATION_JSON));
+
+        // An unstamped row cannot be shown to be fresh, so it must not be trusted — the
+        // freshness check has to fail closed, not open.
         service.getManufacturers();
 
-        // Same helper, no negation at the call site: no HTTP expectation is registered, so
-        // any outbound call would fail this test. This is the contrast that shows the bug
-        // above is a call-site inconsistency rather than a broken helper.
+        verify(manufacturerRepository).save(any());
         server.verify();
     }
 }


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — defect fix, no capability id
- Parent STORY (durion): n/a
- Child issue: Fixes louisburroughs/durion-positivity-backend#1265
- Domain: `domain:vehicle-reference`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Not applicable — no contract-relevant files changed. The diff touches one
`internal/service` class per module (a private helper and its call sites) plus
tests and a doc; no controller, DTO, `*Request`/`*Response`, event, `openapi.yaml`,
or validation/error model is modified, so no `BACKEND_CONTRACT_GUIDE.md` entry
needs updating. Endpoint request/response shapes are unchanged — only how often
the service goes out to vPIC behind them.

- Contract guide entry (durion): n/a
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
No controller changed.

- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope

**What changed**

`VehicleReferenceService.isCacheExpired(LocalDateTime)` computed the opposite of
its name — `!cacheTimestamp.plus(CACHE_EXPIRY).isBefore(now)` answers *"is still
fresh"* — and in `pos-vehicle-reference-nhtsa` three of the six call sites negated
it on top of that.

- Renamed the helper to `isCacheFresh` in both vehicle-reference modules and
  documented what it returns. The body is unchanged.
- Dropped the negation at the three inverted nhtsa call sites
  (`getVehicleVariables`, `getVehicleVariableValues`, `getVehicleTypesForMake`).
  All six call sites now read
  `if (!cached.isEmpty() && isCacheFresh(...)) return cached;`.
- The other three nhtsa call sites and both `pos-vehicle-reference-carapi` call
  sites are rename-only: the double inversion cancelled there, so their behaviour
  is unchanged.
- Marked #1265 closed in `docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md`.

**Why**

The three inverted methods had no working cache at all. While the cache was warm
they called the NHTSA vPIC API on *every* request — and each of those calls
rewrites the cache rows, so a read was also a database write. vPIC is a public
government API with no SLA and no contractual rate limit; the cache exists
precisely so these endpoints do not depend on it per-request.

Once the rows aged past 24 hours the inversion flipped the other way: the cache
was served unconditionally and the refetch branch became unreachable, so the rows
froze at whatever vPIC last returned. That is the failure mode that returns wrong
data silently rather than merely being slow.

The helper was copied into `pos-vehicle-reference-carapi`, where both call sites
omit the negation and net behaviour was already correct — correct by accident.
Renaming there in the same change removes the trap: fixing the name alone in
either module would have silently flipped the currently-correct call sites into
the broken behaviour.

## Tests

`vehicleVariableCacheIsInverted()` had pinned the defect by asserting an outbound
vPIC call happened despite an hour-old cache. It is now
`vehicleVariableCacheIsServedWhileFresh()` and asserts the opposite: no outbound
call, and no cache rewrite.

Added:
- `staleVehicleVariablesRefetched()` — covers the refetch branch that was
  unreachable before this fix.
- `vehicleTypeCacheIsServedWhileFresh()` — the third corrected call site.
- `nullTimestampRefetches()` — pins that an unstamped row fails closed rather
  than being treated as fresh.

Removed `nonNegatedMethodsCacheCorrectly()`: it existed as the contrast case for
the call-site inconsistency, which no longer exists, and
`manufacturersServedFromCache()` already covers that path. The class-level notes
in both test classes described the cancelling inversion as something to preserve;
they now describe the invariant instead.

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated

**How to run**

```bash
./mvnw -pl pos-vehicle-reference-nhtsa,pos-vehicle-reference-carapi -am -DskipTests=false verify
```

Green locally: 10 service tests in nhtsa, 6 in carapi, ArchUnit passing in both.

## Risk & Rollback

- Risk level: Low. The change is confined to a private freshness check and its
  call sites; no schema, endpoint, or serialized shape moves. Behaviour changes
  only for the three previously-inverted nhtsa methods, and only toward the
  documented intent: warm cache is served without an outbound call, stale cache
  refetches. The first request to each of those endpoints after deploy may
  refetch (rows cached over 24h ago now correctly fall outside the window), after
  which they settle into the normal 24h cycle.
- Rollback plan: revert the commit. No data migration and no persisted state
  depends on this, so a revert restores the prior behaviour immediately.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is `claude/issue-1265-712ycm`, the issue-scoped branch this work was assigned to
- [ ] PR title starts with `[CAP:<cap-id>]` — no capability id for this defect fix
- [x] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed) — no contract semantics changed
- [ ] Required CI checks passing — pending first run

---
_Generated by [Claude Code](https://claude.ai/code/session_016BpAfrphqAZg3SMDKrQpWV)_