### PR TITLE
fix(events): make every event type legal in DomainEventEnvelope — restores a silently dropped inventory fact (#1289, #1286)

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderEventsListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderEventsListener.java
@@ -34,7 +34,7 @@ import tools.jackson.databind.ObjectMapper;
  * <ul>
  *   <li>{@code workorder.service.completed.v1} → a {@link ServiceHistory} row, powering
  *       last-service-age and service-due segment predicates.
- *   <li>{@code workorder.service_line.declined.v1} → exactly one {@code DECLINED_SERVICE_FOLLOWUP}
+ *   <li>{@code workorder.service-line.declined.v1} → exactly one {@code DECLINED_SERVICE_FOLLOWUP}
  *       {@link FollowUpTask}, and the declined-service segment predicate.
  * </ul>
  *

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/WorkorderEventsListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/WorkorderEventsListenerTest.java
@@ -63,7 +63,7 @@ class WorkorderEventsListenerTest {
 
     private String declinedEvent(String eventId) {
         return """
-                {"eventId":"%s","eventType":"workorder.service_line.declined.v1","sourceService":"pos-workorder",
+                {"eventId":"%s","eventType":"workorder.service-line.declined.v1","sourceService":"pos-workorder",
                  "payload":{"workorderId":"%s","workorderNumber":"WO-2026-1001","workorderLineId":"%s",
                             "partyId":"%s","vehicleId":"%s","description":"Brake pads",
                             "declineReason":"Defer to next visit","declinedAt":"2026-07-20T10:00:00Z"}}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/ProductValueChangedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/ProductValueChangedV1.java
@@ -11,7 +11,7 @@ import org.jspecify.annotations.Nullable;
  * {@code product.value} / manual {@code stock.valuation.layer} analog).
  *
  * <p>Published by pos-inventory on {@code inventory.events.v1} with
- * {@code eventType = "inventory.product_value.changed"} — one fact per applied revaluation (this is
+ * {@code eventType = "inventory.product-value.changed"} — one fact per applied revaluation (this is
  * an occurrence, not a snapshot: it is never re-emitted). pos-accounting consumes it to post the
  * revaluation journal entry for the value delta.
  *
@@ -48,7 +48,7 @@ public record ProductValueChangedV1(
         @NonNull String actor,
         @NonNull Instant occurredAt) {
 
-    public static final String EVENT_TYPE = "inventory.product_value.changed";
+    public static final String EVENT_TYPE = "inventory.product-value.changed";
     public static final int SCHEMA_VERSION = 1;
 
     public ProductValueChangedV1 {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/workorder/JobTimeRecordedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/workorder/JobTimeRecordedV1.java
@@ -6,7 +6,7 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Payload for {@code workorder.job_time.recorded.v1} on {@code workorder.events.v1}
+ * Payload for {@code workorder.job-time.recorded.v1} on {@code workorder.events.v1}
  * (ADR-0044 §6, #875).
  *
  * <p>Published by pos-workorder when a workorder completes: one fact per finalized labor entry,
@@ -27,6 +27,6 @@ public record JobTimeRecordedV1(
         @NonNull Instant endAtUtc,
         int minutes) {
 
-    public static final String EVENT_TYPE = "workorder.job_time.recorded.v1";
+    public static final String EVENT_TYPE = "workorder.job-time.recorded.v1";
     public static final int SCHEMA_VERSION = 1;
 }

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/workorder/WorkorderServiceLineDeclinedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/workorder/WorkorderServiceLineDeclinedV1.java
@@ -10,7 +10,7 @@ import org.jspecify.annotations.Nullable;
  * open question O-7).
  *
  * <p>Published by pos-workorder on {@code workorder.events.v1} with
- * {@code eventType = "workorder.service_line.declined.v1"} — one fact per declined service line,
+ * {@code eventType = "workorder.service-line.declined.v1"} — one fact per declined service line,
  * emitted at workorder completion (a declined recommendation, promoted onto the workorder from
  * the estimate, carries its rejection reason). pos-customer raises exactly one
  * {@code DECLINED_SERVICE_FOLLOWUP} task per fact and exposes a "declined service in last N days"
@@ -39,7 +39,7 @@ public record WorkorderServiceLineDeclinedV1(
         @Nullable String declineReason,
         @NonNull Instant declinedAt) {
 
-    public static final String EVENT_TYPE = "workorder.service_line.declined.v1";
+    public static final String EVENT_TYPE = "workorder.service-line.declined.v1";
     public static final int SCHEMA_VERSION = 1;
 
     public WorkorderServiceLineDeclinedV1 {

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/DomainEventContractTest.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/DomainEventContractTest.java
@@ -162,10 +162,20 @@ class DomainEventContractTest {
         String type = (String) eventType.getField("EVENT_TYPE").get(null);
 
         assertThat(type).as("%s.EVENT_TYPE", eventType.getSimpleName()).isNotBlank();
-        // Dotted lowercase, hyphens allowed inside any segment (e.g. people-contact.user-person-link.updated). These
-        // strings are matched by
-        // consumers as literals, so a stray capital or space is a fact nobody receives.
-        assertThat(type).as("%s.EVENT_TYPE shape", eventType.getSimpleName()).matches("[a-z0-9_-]+(\\.[a-z0-9_-]+)+");
+
+        // Checked against the envelope itself rather than a regex copied from it. The two drifted
+        // once: this test allowed underscores, DomainEventEnvelope did not, and
+        // inventory.product_value.changed sat in the gap — every ProductValueChangedV1 threw at
+        // construction and was swallowed by its publisher's catch-all, so the fact was silently
+        // dropped in production and no consumer ever saw one (#1289). A regex cannot catch that;
+        // only the real constructor can.
+        assertThatCode(() -> new DomainEventEnvelope<>(
+                        SAMPLE_UUID, type, 1, SAMPLE_UUID, 0L, SAMPLE_INSTANT, "pos-sample", null, null, "payload"))
+                .as(
+                        "%s.EVENT_TYPE (%s) is rejected by DomainEventEnvelope, so publishing it throws."
+                                + " Event types are dotted lowercase with hyphens, never underscores.",
+                        eventType.getSimpleName(), type)
+                .doesNotThrowAnyException();
     }
 
     @ParameterizedTest(name = "{0}")

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/ProductValueChangedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/ProductValueChangedV1Test.java
@@ -15,7 +15,7 @@ class ProductValueChangedV1Test {
 
     @Test
     void carriesSchemaIdentity() {
-        assertThat(ProductValueChangedV1.EVENT_TYPE).isEqualTo("inventory.product_value.changed");
+        assertThat(ProductValueChangedV1.EVENT_TYPE).isEqualTo("inventory.product-value.changed");
         assertThat(ProductValueChangedV1.SCHEMA_VERSION).isEqualTo(1);
     }
 

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/workorder/WorkorderServiceLineDeclinedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/workorder/WorkorderServiceLineDeclinedV1Test.java
@@ -42,7 +42,7 @@ class WorkorderServiceLineDeclinedV1Test {
 
         assertThat(back).isEqualTo(evt);
         assertThat(back.declineReason()).isEqualTo("Customer will defer to next visit");
-        assertThat(WorkorderServiceLineDeclinedV1.EVENT_TYPE).isEqualTo("workorder.service_line.declined.v1");
+        assertThat(WorkorderServiceLineDeclinedV1.EVENT_TYPE).isEqualTo("workorder.service-line.declined.v1");
     }
 
     @Test

--- a/pos-people/src/main/java/com/positivity/people/internal/entity/ExtJobTimeReplica.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/entity/ExtJobTimeReplica.java
@@ -17,7 +17,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
- * Read-only job-time replica fed by {@code workorder.job_time.recorded.v1} facts
+ * Read-only job-time replica fed by {@code workorder.job-time.recorded.v1} facts
  * (ADR-0044 §6, #875). One row per finalized labor entry of a completed workorder; the
  * attendance-discrepancy report aggregates minutes per technician/location/local-date from
  * {@code endAtUtc} using the caller's timezone.

--- a/pos-people/src/main/java/com/positivity/people/internal/service/WorkorderEventsListener.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/WorkorderEventsListener.java
@@ -22,7 +22,7 @@ import tools.jackson.databind.ObjectMapper;
  * Consumes {@code workorder.events.v1} into the {@code ext_workorder_job_time} replica
  * (ADR-0044 §6, #875), replacing the retired synchronous {@code WorkexecJobTimeClient}.
  *
- * <p>Only {@code workorder.job_time.recorded.v1} is handled; other workorder facts are ignored.
+ * <p>Only {@code workorder.job-time.recorded.v1} is handled; other workorder facts are ignored.
  * Idempotent via {@code processed_events} in the upsert transaction; re-completions of a
  * reopened workorder re-emit entries and the upsert (keyed by laborEntryId) is last-write-wins.
  */

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/KafkaEventRelay.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/KafkaEventRelay.java
@@ -34,45 +34,73 @@ public class KafkaEventRelay {
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onWorkSessionStarted(WorkSessionStartedEvent event) {
         producer.publish(
-                "workorder.work_session.started.v1", event.workSessionId().toString(), event);
+                "workorder.work_session.started.v1",
+                WorkSessionStartedEvent.SCHEMA_VERSION,
+                event.workSessionId().toString(),
+                event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onWorkSessionStopped(WorkSessionStoppedEvent event) {
         producer.publish(
-                "workorder.work_session.stopped.v1", event.workSessionId().toString(), event);
+                "workorder.work_session.stopped.v1",
+                WorkSessionStoppedEvent.SCHEMA_VERSION,
+                event.workSessionId().toString(),
+                event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTravelSegmentStarted(TravelSegmentStartedEvent event) {
         producer.publish(
-                "workorder.travel_segment.started.v1", event.travelSegmentId().toString(), event);
+                "workorder.travel_segment.started.v1",
+                TravelSegmentStartedEvent.SCHEMA_VERSION,
+                event.travelSegmentId().toString(),
+                event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTravelSegmentStopped(TravelSegmentStoppedEvent event) {
         producer.publish(
-                "workorder.travel_segment.stopped.v1", event.travelSegmentId().toString(), event);
+                "workorder.travel_segment.stopped.v1",
+                TravelSegmentStoppedEvent.SCHEMA_VERSION,
+                event.travelSegmentId().toString(),
+                event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onJobTimeRecorded(JobTimeRecordedV1 event) {
-        producer.publish(JobTimeRecordedV1.EVENT_TYPE, event.laborEntryId().toString(), event);
+        producer.publish(
+                JobTimeRecordedV1.EVENT_TYPE,
+                JobTimeRecordedV1.SCHEMA_VERSION,
+                event.laborEntryId().toString(),
+                event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTimeEntryApproved(TimeEntryApprovedEvent event) {
-        producer.publish("workorder.time_entry.approved.v1", event.timeEntryId().toString(), event);
+        producer.publish(
+                "workorder.time_entry.approved.v1",
+                TimeEntryApprovedEvent.SCHEMA_VERSION,
+                event.timeEntryId().toString(),
+                event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTimeEntryRejected(TimeEntryRejectedEvent event) {
-        producer.publish("workorder.time_entry.rejected.v1", event.timeEntryId().toString(), event);
+        producer.publish(
+                "workorder.time_entry.rejected.v1",
+                TimeEntryRejectedEvent.SCHEMA_VERSION,
+                event.timeEntryId().toString(),
+                event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onEstimateCreated(EstimateCreatedEvent event) {
-        producer.publish("workorder.estimate.created.v1", event.getEstimateId().toString(), event);
+        producer.publish(
+                "workorder.estimate.created.v1",
+                EstimateCreatedEvent.SCHEMA_VERSION,
+                event.getEstimateId().toString(),
+                event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
@@ -83,6 +111,10 @@ public class KafkaEventRelay {
                     event.getEstimateId());
             return;
         }
-        producer.publish("workorder.estimate.revised.v1", event.getWorkorderId().toString(), event);
+        producer.publish(
+                "workorder.estimate.revised.v1",
+                EstimateRevisedEvent.SCHEMA_VERSION,
+                event.getWorkorderId().toString(),
+                event);
     }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/KafkaEventRelay.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/KafkaEventRelay.java
@@ -34,73 +34,60 @@ public class KafkaEventRelay {
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onWorkSessionStarted(WorkSessionStartedEvent event) {
         producer.publish(
-                "workorder.work_session.started.v1",
+                "workorder.work-session.started.v1",
                 WorkSessionStartedEvent.SCHEMA_VERSION,
-                event.workSessionId().toString(),
+                event.workSessionId(),
                 event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onWorkSessionStopped(WorkSessionStoppedEvent event) {
         producer.publish(
-                "workorder.work_session.stopped.v1",
+                "workorder.work-session.stopped.v1",
                 WorkSessionStoppedEvent.SCHEMA_VERSION,
-                event.workSessionId().toString(),
+                event.workSessionId(),
                 event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTravelSegmentStarted(TravelSegmentStartedEvent event) {
         producer.publish(
-                "workorder.travel_segment.started.v1",
+                "workorder.travel-segment.started.v1",
                 TravelSegmentStartedEvent.SCHEMA_VERSION,
-                event.travelSegmentId().toString(),
+                event.travelSegmentId(),
                 event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTravelSegmentStopped(TravelSegmentStoppedEvent event) {
         producer.publish(
-                "workorder.travel_segment.stopped.v1",
+                "workorder.travel-segment.stopped.v1",
                 TravelSegmentStoppedEvent.SCHEMA_VERSION,
-                event.travelSegmentId().toString(),
+                event.travelSegmentId(),
                 event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onJobTimeRecorded(JobTimeRecordedV1 event) {
-        producer.publish(
-                JobTimeRecordedV1.EVENT_TYPE,
-                JobTimeRecordedV1.SCHEMA_VERSION,
-                event.laborEntryId().toString(),
-                event);
+        producer.publish(JobTimeRecordedV1.EVENT_TYPE, JobTimeRecordedV1.SCHEMA_VERSION, event.laborEntryId(), event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTimeEntryApproved(TimeEntryApprovedEvent event) {
         producer.publish(
-                "workorder.time_entry.approved.v1",
-                TimeEntryApprovedEvent.SCHEMA_VERSION,
-                event.timeEntryId().toString(),
-                event);
+                "workorder.time-entry.approved.v1", TimeEntryApprovedEvent.SCHEMA_VERSION, event.timeEntryId(), event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onTimeEntryRejected(TimeEntryRejectedEvent event) {
         producer.publish(
-                "workorder.time_entry.rejected.v1",
-                TimeEntryRejectedEvent.SCHEMA_VERSION,
-                event.timeEntryId().toString(),
-                event);
+                "workorder.time-entry.rejected.v1", TimeEntryRejectedEvent.SCHEMA_VERSION, event.timeEntryId(), event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void onEstimateCreated(EstimateCreatedEvent event) {
         producer.publish(
-                "workorder.estimate.created.v1",
-                EstimateCreatedEvent.SCHEMA_VERSION,
-                event.getEstimateId().toString(),
-                event);
+                "workorder.estimate.created.v1", EstimateCreatedEvent.SCHEMA_VERSION, event.getEstimateId(), event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
@@ -112,9 +99,6 @@ public class KafkaEventRelay {
             return;
         }
         producer.publish(
-                "workorder.estimate.revised.v1",
-                EstimateRevisedEvent.SCHEMA_VERSION,
-                event.getWorkorderId().toString(),
-                event);
+                "workorder.estimate.revised.v1", EstimateRevisedEvent.SCHEMA_VERSION, event.getWorkorderId(), event);
     }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxEventWriter.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxEventWriter.java
@@ -1,12 +1,11 @@
 package com.positivity.workorder.internal.config;
 
-import com.positivity.shared.id.UUIDv7Generator;
+import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.workorder.internal.entity.OutboxEvent;
 import com.positivity.workorder.internal.repository.OutboxEventRepository;
 import java.time.Clock;
 import java.time.Instant;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
@@ -20,22 +19,19 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Transactional-outbox writer for workorder domain events (ADR-0044 §4).
  *
- * <p>Replaces the previous direct {@code KafkaTemplate} producer: the serialized event is stored
- * in {@code event_outbox} within the caller's transaction, so an event exists if and only if the
- * business state change committed. {@link OutboxPublisher} drains the table to Kafka with
- * at-least-once delivery.
+ * <p>Serializes a full {@link DomainEventEnvelope} into {@code event_outbox} within the caller's
+ * transaction, so an event exists if and only if the business state change committed.
+ * {@link OutboxPublisher} drains the table to Kafka with at-least-once delivery.
  *
- * <p>The JSON envelope shape is (eventId, eventType, schemaVersion, occurredAtUtc,
- * aggregateVersion, sourceService, payload). Every field the original producer emitted is still
- * emitted under the same name, so existing consumers (pos-customer's workorder event handler)
- * keep working; {@code schemaVersion} was added by #1286 and is additive.
+ * <p>This module used to hand-build the envelope as a map, because {@link DomainEventEnvelope}
+ * rejects underscores in the event type and several of this module's types contained them. Those
+ * types were renamed to the hyphenated form (#1286), so the envelope is now the shared one and the
+ * schema version it requires is supplied by the payload type rather than a literal (#1279).
  *
- * <p>This module hand-builds the envelope instead of using {@link
- * com.positivity.domainevents.DomainEventEnvelope} like the other thirteen modules, because that
- * type rejects underscores in the event type and several of this module's live types contain them
- * ({@code workorder.job_time.recorded.v1}, {@code workorder.work_session.started.v1}, …).
- * Reconciling the two means renaming those types, which is a breaking change for every consumer
- * that matches them as literals — see #1286.
+ * <p>Unlike its peers this writer keeps a convenience signature rather than taking a ready-made
+ * envelope: the callers are transactional relays that know their payload and aggregate id but not
+ * the topic, and building the nine-argument envelope at each of them would duplicate the same
+ * source-service and clock wiring thirteen times.
  */
 @Slf4j
 @Component
@@ -61,41 +57,34 @@ public class OutboxEventWriter {
      * module-internal payload types declare their own.
      */
     @Transactional(propagation = Propagation.MANDATORY)
-    public void publish(@NonNull String eventType, int schemaVersion, @NonNull String key, @NonNull Object payload) {
-        if (schemaVersion < 1) {
-            throw new IllegalArgumentException("schemaVersion must be >= 1 but was: " + schemaVersion);
-        }
+    public void publish(
+            @NonNull String eventType, int schemaVersion, @NonNull UUID aggregateId, @NonNull Object payload) {
+        DomainEventEnvelope<Object> envelope = DomainEventEnvelope.of(
+                eventType,
+                schemaVersion,
+                aggregateId,
+                // Emission-timestamp LWW hint for replica stale guards (ADR-0044 §6, #897).
+                Instant.now(clock).toEpochMilli(),
+                SOURCE_SERVICE,
+                null,
+                null,
+                payload,
+                clock);
         OutboxEvent event = OutboxEvent.builder()
                 .topic(eventsTopic)
-                .recordKey(key)
-                .payload(serializeEnvelope(eventType, schemaVersion, payload))
+                .recordKey(envelope.recordKey())
+                .payload(serialize(envelope))
                 .createdAt(Instant.now(clock))
                 .build();
         outboxEventRepository.save(event);
-        log.debug("Queued outbox event type={} topic={} key={}", eventType, eventsTopic, key);
+        log.debug("Queued outbox event type={} topic={} key={}", eventType, eventsTopic, envelope.recordKey());
     }
 
-    private String serializeEnvelope(String eventType, int schemaVersion, Object payload) {
-        Instant occurredAt = Instant.now(clock);
-        Map<String, Object> envelope = new LinkedHashMap<>();
-        envelope.put("eventId", UUIDv7Generator.generate().toString());
-        envelope.put("eventType", eventType);
-        // Which payload shape this is. Additive: the existing consumers read this envelope as a
-        // JsonNode tree and pull fields by name, so a key they do not know is ignored. Kept as a
-        // plain map rather than DomainEventEnvelope because that type rejects the underscores in
-        // several of this module's event types (see #1286).
-        envelope.put("schemaVersion", schemaVersion);
-        envelope.put("occurredAtUtc", occurredAt);
-        // Emission-timestamp LWW hint for replica stale guards (ADR-0044 §6, #897) — additive,
-        // legacy consumers of this envelope ignore it.
-        envelope.put("aggregateVersion", occurredAt.toEpochMilli());
-        envelope.put("sourceService", SOURCE_SERVICE);
-        envelope.put("payload", payload);
-
+    private String serialize(DomainEventEnvelope<?> envelope) {
         try {
             return objectMapper.writeValueAsString(envelope);
         } catch (Exception e) {
-            throw new IllegalStateException("Unable to serialize Kafka event envelope for type: " + eventType, e);
+            throw new IllegalStateException("Unable to serialize event envelope for type: " + envelope.eventType(), e);
         }
     }
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxEventWriter.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/OutboxEventWriter.java
@@ -25,9 +25,17 @@ import tools.jackson.databind.ObjectMapper;
  * business state change committed. {@link OutboxPublisher} drains the table to Kafka with
  * at-least-once delivery.
  *
- * <p>The JSON envelope shape (eventId, eventType, occurredAtUtc, sourceService, payload) is
- * unchanged from the previous producer, so existing consumers (pos-customer's workorder event
- * handler) keep working.
+ * <p>The JSON envelope shape is (eventId, eventType, schemaVersion, occurredAtUtc,
+ * aggregateVersion, sourceService, payload). Every field the original producer emitted is still
+ * emitted under the same name, so existing consumers (pos-customer's workorder event handler)
+ * keep working; {@code schemaVersion} was added by #1286 and is additive.
+ *
+ * <p>This module hand-builds the envelope instead of using {@link
+ * com.positivity.domainevents.DomainEventEnvelope} like the other thirteen modules, because that
+ * type rejects underscores in the event type and several of this module's live types contain them
+ * ({@code workorder.job_time.recorded.v1}, {@code workorder.work_session.started.v1}, …).
+ * Reconciling the two means renaming those types, which is a breaking change for every consumer
+ * that matches them as literals — see #1286.
  */
 @Slf4j
 @Component
@@ -46,24 +54,37 @@ public class OutboxEventWriter {
     /**
      * Queue a domain event for publication as part of the current transaction. Must be called
      * inside the business transaction ({@code MANDATORY}) — that is the whole point of the outbox.
+     *
+     * <p>{@code schemaVersion} must come from a constant on the payload type rather than a literal
+     * at the call site, so the number moves with the payload it describes (#1279). Payloads that
+     * have a {@code pos-domain-events} record pass that record's {@code SCHEMA_VERSION}; the
+     * module-internal payload types declare their own.
      */
     @Transactional(propagation = Propagation.MANDATORY)
-    public void publish(@NonNull String eventType, @NonNull String key, @NonNull Object payload) {
+    public void publish(@NonNull String eventType, int schemaVersion, @NonNull String key, @NonNull Object payload) {
+        if (schemaVersion < 1) {
+            throw new IllegalArgumentException("schemaVersion must be >= 1 but was: " + schemaVersion);
+        }
         OutboxEvent event = OutboxEvent.builder()
                 .topic(eventsTopic)
                 .recordKey(key)
-                .payload(serializeEnvelope(eventType, payload))
+                .payload(serializeEnvelope(eventType, schemaVersion, payload))
                 .createdAt(Instant.now(clock))
                 .build();
         outboxEventRepository.save(event);
         log.debug("Queued outbox event type={} topic={} key={}", eventType, eventsTopic, key);
     }
 
-    private String serializeEnvelope(String eventType, Object payload) {
+    private String serializeEnvelope(String eventType, int schemaVersion, Object payload) {
         Instant occurredAt = Instant.now(clock);
         Map<String, Object> envelope = new LinkedHashMap<>();
         envelope.put("eventId", UUIDv7Generator.generate().toString());
         envelope.put("eventType", eventType);
+        // Which payload shape this is. Additive: the existing consumers read this envelope as a
+        // JsonNode tree and pull fields by name, so a key they do not know is ignored. Kept as a
+        // plain map rather than DomainEventEnvelope because that type rejects the underscores in
+        // several of this module's event types (see #1286).
+        envelope.put("schemaVersion", schemaVersion);
         envelope.put("occurredAtUtc", occurredAt);
         // Emission-timestamp LWW hint for replica stale guards (ADR-0044 §6, #897) — additive,
         // legacy consumers of this envelope ignore it.

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/domain/TimeEntryApprovedEvent.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/domain/TimeEntryApprovedEvent.java
@@ -5,4 +5,8 @@ import java.util.UUID;
 
 /** Domain event published when a time entry is approved. */
 public record TimeEntryApprovedEvent(
-        UUID timeEntryId, UUID workOrderId, String approvedByUserId, Instant decisionAtUtc) {}
+        UUID timeEntryId, UUID workOrderId, String approvedByUserId, Instant decisionAtUtc) {
+
+    /** Payload schema version carried on the outbox envelope; bump with the payload shape. */
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/domain/TimeEntryRejectedEvent.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/domain/TimeEntryRejectedEvent.java
@@ -5,4 +5,8 @@ import java.util.UUID;
 
 /** Domain event published when a time entry is rejected. */
 public record TimeEntryRejectedEvent(
-        UUID timeEntryId, UUID workOrderId, String rejectedByUserId, Instant decisionAtUtc, String rejectionReason) {}
+        UUID timeEntryId, UUID workOrderId, String rejectedByUserId, Instant decisionAtUtc, String rejectionReason) {
+
+    /** Payload schema version carried on the outbox envelope; bump with the payload shape. */
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/domain/TravelSegmentStartedEvent.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/domain/TravelSegmentStartedEvent.java
@@ -4,4 +4,8 @@ import java.time.Instant;
 import java.util.UUID;
 
 /** Domain event published when a travel segment is started. */
-public record TravelSegmentStartedEvent(UUID travelSegmentId, UUID technicianId, Instant startAt) {}
+public record TravelSegmentStartedEvent(UUID travelSegmentId, UUID technicianId, Instant startAt) {
+
+    /** Payload schema version carried on the outbox envelope; bump with the payload shape. */
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/domain/TravelSegmentStoppedEvent.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/domain/TravelSegmentStoppedEvent.java
@@ -4,4 +4,8 @@ import java.time.Instant;
 import java.util.UUID;
 
 /** Domain event published when a travel segment is stopped. */
-public record TravelSegmentStoppedEvent(UUID travelSegmentId, UUID technicianId, Instant endAt, int durationMinutes) {}
+public record TravelSegmentStoppedEvent(UUID travelSegmentId, UUID technicianId, Instant endAt, int durationMinutes) {
+
+    /** Payload schema version carried on the outbox envelope; bump with the payload shape. */
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/domain/WorkSessionStartedEvent.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/domain/WorkSessionStartedEvent.java
@@ -6,4 +6,8 @@ import java.util.UUID;
 /**
  * Domain event published when a work session is started.
  */
-public record WorkSessionStartedEvent(UUID workSessionId, UUID mechanicId, Instant startAt) {}
+public record WorkSessionStartedEvent(UUID workSessionId, UUID mechanicId, Instant startAt) {
+
+    /** Payload schema version carried on the outbox envelope; bump with the payload shape. */
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/domain/WorkSessionStoppedEvent.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/domain/WorkSessionStoppedEvent.java
@@ -6,4 +6,8 @@ import java.util.UUID;
 /**
  * Domain event published when a work session is stopped.
  */
-public record WorkSessionStoppedEvent(UUID workSessionId, UUID mechanicId, Instant endAt, int totalDurationSeconds) {}
+public record WorkSessionStoppedEvent(UUID workSessionId, UUID mechanicId, Instant endAt, int totalDurationSeconds) {
+
+    /** Payload schema version carried on the outbox envelope; bump with the payload shape. */
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/event/EstimateCreatedEvent.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/event/EstimateCreatedEvent.java
@@ -19,6 +19,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class EstimateCreatedEvent {
 
+    /** Payload schema version carried on the outbox envelope; bump with the payload shape. */
+    public static final int SCHEMA_VERSION = 1;
+
     /**
      * ID of the newly created Estimate
      */

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/event/EstimateRevisedEvent.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/event/EstimateRevisedEvent.java
@@ -20,6 +20,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class EstimateRevisedEvent {
+
+    /** Payload schema version carried on the outbox envelope; bump with the payload shape. */
+    public static final int SCHEMA_VERSION = 1;
     /**
      * ID of the Estimate that was revised
      */

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateFactPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateFactPublisher.java
@@ -95,8 +95,7 @@ public class EstimateFactPublisher {
                     items,
                     estimate.getCreatedAt(),
                     estimate.getUpdatedAt());
-            writer.publish(
-                    EstimateUpdatedV1.EVENT_TYPE, EstimateUpdatedV1.SCHEMA_VERSION, estimateId.toString(), payload);
+            writer.publish(EstimateUpdatedV1.EVENT_TYPE, EstimateUpdatedV1.SCHEMA_VERSION, estimateId, payload);
         }
     }
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateFactPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateFactPublisher.java
@@ -95,7 +95,8 @@ public class EstimateFactPublisher {
                     items,
                     estimate.getCreatedAt(),
                     estimate.getUpdatedAt());
-            writer.publish(EstimateUpdatedV1.EVENT_TYPE, estimateId.toString(), payload);
+            writer.publish(
+                    EstimateUpdatedV1.EVENT_TYPE, EstimateUpdatedV1.SCHEMA_VERSION, estimateId.toString(), payload);
         }
     }
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/ServiceCompletionFactPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/ServiceCompletionFactPublisher.java
@@ -142,7 +142,7 @@ public class ServiceCompletionFactPublisher {
         writer.publish(
                 WorkorderServiceCompletedV1.EVENT_TYPE,
                 WorkorderServiceCompletedV1.SCHEMA_VERSION,
-                workorder.getId().toString(),
+                workorder.getId(),
                 payload);
     }
 
@@ -166,7 +166,7 @@ public class ServiceCompletionFactPublisher {
             writer.publish(
                     WorkorderServiceLineDeclinedV1.EVENT_TYPE,
                     WorkorderServiceLineDeclinedV1.SCHEMA_VERSION,
-                    workorder.getId().toString(),
+                    workorder.getId(),
                     payload);
         }
     }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/ServiceCompletionFactPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/ServiceCompletionFactPublisher.java
@@ -139,7 +139,11 @@ public class ServiceCompletionFactPublisher {
                 completedAt,
                 serviceTotal.add(partTotal),
                 performed);
-        writer.publish(WorkorderServiceCompletedV1.EVENT_TYPE, workorder.getId().toString(), payload);
+        writer.publish(
+                WorkorderServiceCompletedV1.EVENT_TYPE,
+                WorkorderServiceCompletedV1.SCHEMA_VERSION,
+                workorder.getId().toString(),
+                payload);
     }
 
     private void publishDeclines(
@@ -160,7 +164,10 @@ public class ServiceCompletionFactPublisher {
                     completedAt);
             // Keyed by the workorder id so a workorder's facts stay ordered on one partition.
             writer.publish(
-                    WorkorderServiceLineDeclinedV1.EVENT_TYPE, workorder.getId().toString(), payload);
+                    WorkorderServiceLineDeclinedV1.EVENT_TYPE,
+                    WorkorderServiceLineDeclinedV1.SCHEMA_VERSION,
+                    workorder.getId().toString(),
+                    payload);
         }
     }
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderFactPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderFactPublisher.java
@@ -102,7 +102,8 @@ public class WorkorderFactPublisher {
                     services,
                     workorder.getCreatedAt(),
                     workorder.getUpdatedAt());
-            writer.publish(WorkorderUpdatedV1.EVENT_TYPE, workorderId.toString(), payload);
+            writer.publish(
+                    WorkorderUpdatedV1.EVENT_TYPE, WorkorderUpdatedV1.SCHEMA_VERSION, workorderId.toString(), payload);
         }
     }
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderFactPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderFactPublisher.java
@@ -102,8 +102,7 @@ public class WorkorderFactPublisher {
                     services,
                     workorder.getCreatedAt(),
                     workorder.getUpdatedAt());
-            writer.publish(
-                    WorkorderUpdatedV1.EVENT_TYPE, WorkorderUpdatedV1.SCHEMA_VERSION, workorderId.toString(), payload);
+            writer.publish(WorkorderUpdatedV1.EVENT_TYPE, WorkorderUpdatedV1.SCHEMA_VERSION, workorderId, payload);
         }
     }
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
@@ -674,7 +674,7 @@ public class WorkorderServiceImpl implements WorkorderService {
     }
 
     /**
-     * One {@code workorder.job_time.recorded.v1} fact per finalized labor entry (ADR-0044 §6,
+     * One {@code workorder.job-time.recorded.v1} fact per finalized labor entry (ADR-0044 §6,
      * #875): pos-people replaces its synchronous job-time-totals lookup with a replica fed by
      * these facts. Published inside the completion transaction; the Kafka relay writes them to
      * the outbox BEFORE_COMMIT, so facts exist iff the completion committed. Re-completions

--- a/pos-workorder/src/test/java/com/positivity/workorder/config/WorkorderKafkaEventRelayTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/config/WorkorderKafkaEventRelayTest.java
@@ -33,6 +33,7 @@ class WorkorderKafkaEventRelayTest {
         verify(producer)
                 .publish(
                         "workorder.work_session.started.v1",
+                        WorkSessionStartedEvent.SCHEMA_VERSION,
                         event.workSessionId().toString(),
                         event);
     }

--- a/pos-workorder/src/test/java/com/positivity/workorder/config/WorkorderKafkaEventRelayTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/config/WorkorderKafkaEventRelayTest.java
@@ -32,9 +32,9 @@ class WorkorderKafkaEventRelayTest {
 
         verify(producer)
                 .publish(
-                        "workorder.work_session.started.v1",
+                        "workorder.work-session.started.v1",
                         WorkSessionStartedEvent.SCHEMA_VERSION,
-                        event.workSessionId().toString(),
+                        event.workSessionId(),
                         event);
     }
 

--- a/pos-workorder/src/test/java/com/positivity/workorder/event/ManifestPublisherTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/event/ManifestPublisherTest.java
@@ -226,7 +226,7 @@ class ManifestPublisherTest {
     void skipsMalformedRows() {
         OutboxEvent good = row(
                 eventIdAt(WINDOW_START.plusSeconds(60), 1),
-                "workorder.work_session.started.v1",
+                "workorder.work-session.started.v1",
                 WINDOW_START.plusSeconds(60));
         OutboxEvent badJson = OutboxEvent.builder()
                 .id(UUID.randomUUID())

--- a/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxEventWriterIntegrationTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxEventWriterIntegrationTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.positivity.workorder.internal.config.OutboxEventWriter;
+import com.positivity.workorder.internal.domain.TimeEntryApprovedEvent;
+import com.positivity.workorder.internal.domain.WorkSessionStartedEvent;
+import com.positivity.workorder.internal.domain.WorkSessionStoppedEvent;
 import com.positivity.workorder.internal.entity.OutboxEvent;
 import com.positivity.workorder.internal.repository.OutboxEventRepository;
 import java.time.Clock;
@@ -53,7 +56,11 @@ class OutboxEventWriterIntegrationTest {
     @Test
     @DisplayName("Outbox row is persisted when the business transaction commits")
     void persistsRowOnCommit() {
-        writer.publish("workorder.work_session.started.v1", "wo-key-1", Map.of("workorderId", "wo-1"));
+        writer.publish(
+                "workorder.work_session.started.v1",
+                WorkSessionStartedEvent.SCHEMA_VERSION,
+                "wo-key-1",
+                Map.of("workorderId", "wo-1"));
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
@@ -68,6 +75,7 @@ class OutboxEventWriterIntegrationTest {
         assertThat(row.getPayload())
                 .contains("\"eventId\"")
                 .contains("\"eventType\":\"workorder.work_session.started.v1\"")
+                .contains("\"schemaVersion\":1")
                 .contains("\"occurredAtUtc\"")
                 .contains("\"sourceService\":\"pos-workorder\"")
                 .contains("\"payload\"");
@@ -78,11 +86,25 @@ class OutboxEventWriterIntegrationTest {
     @Test
     @DisplayName("No outbox row survives when the business transaction rolls back")
     void discardsRowOnRollback() {
-        writer.publish("workorder.work_session.stopped.v1", "wo-key-2", Map.of("workorderId", "wo-2"));
+        writer.publish(
+                "workorder.work_session.stopped.v1",
+                WorkSessionStoppedEvent.SCHEMA_VERSION,
+                "wo-key-2",
+                Map.of("workorderId", "wo-2"));
         TestTransaction.flagForRollback();
         TestTransaction.end();
 
         assertThat(repository.findTop100ByPublishedAtIsNullOrderByIdAsc()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("A schemaVersion below 1 is rejected rather than published")
+    void rejectsNonPositiveSchemaVersion() {
+        // Mirrors the DomainEventEnvelope guard. This envelope is hand-built (#1286), so nothing
+        // else would stop a 0 from reaching consumers as a legitimate-looking version.
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> writer.publish("workorder.work_session.started.v1", 0, "wo-key-4", Map.of()))
+                .withMessageContaining("schemaVersion must be >= 1");
     }
 
     @Test
@@ -91,6 +113,10 @@ class OutboxEventWriterIntegrationTest {
         TestTransaction.end();
 
         assertThatExceptionOfType(IllegalTransactionStateException.class)
-                .isThrownBy(() -> writer.publish("workorder.time_entry.approved.v1", "wo-key-3", Map.of()));
+                .isThrownBy(() -> writer.publish(
+                        "workorder.time_entry.approved.v1",
+                        TimeEntryApprovedEvent.SCHEMA_VERSION,
+                        "wo-key-3",
+                        Map.of()));
     }
 }

--- a/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxEventWriterIntegrationTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxEventWriterIntegrationTest.java
@@ -13,7 +13,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
-import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +33,11 @@ import tools.jackson.databind.json.JsonMapper;
 @DataJpaTest(properties = {"workorder.kafka.enabled=true", "spring.flyway.enabled=false"})
 @Import(OutboxEventWriter.class)
 class OutboxEventWriterIntegrationTest {
+
+    private static final Instant EVENT_TIME = Instant.parse("2026-07-08T12:00:00Z");
+    private static final UUID SAMPLE_ID = UUID.fromString("01980001-0000-7000-8000-000000000001");
+    private static final UUID MECHANIC_ID = UUID.fromString("01980001-0000-7000-8000-000000000002");
+    private static final UUID WORKORDER_ID = UUID.fromString("01980001-0000-7000-8000-000000000003");
 
     @TestConfiguration
     static class Config {
@@ -57,10 +62,10 @@ class OutboxEventWriterIntegrationTest {
     @DisplayName("Outbox row is persisted when the business transaction commits")
     void persistsRowOnCommit() {
         writer.publish(
-                "workorder.work_session.started.v1",
+                "workorder.work-session.started.v1",
                 WorkSessionStartedEvent.SCHEMA_VERSION,
-                "wo-key-1",
-                Map.of("workorderId", "wo-1"));
+                SAMPLE_ID,
+                workSessionStarted());
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
@@ -68,13 +73,14 @@ class OutboxEventWriterIntegrationTest {
         assertThat(rows).hasSize(1);
         OutboxEvent row = rows.getFirst();
         assertThat(row.getTopic()).isEqualTo("workorder.events.v1");
-        assertThat(row.getRecordKey()).isEqualTo("wo-key-1");
+        assertThat(row.getRecordKey()).isEqualTo(SAMPLE_ID.toString());
         assertThat(row.getPublishedAt()).isNull();
         assertThat(row.getCreatedAt()).isEqualTo(Instant.parse("2026-07-08T12:00:00Z"));
-        // Wire format unchanged from the previous direct producer (pos-customer consumer contract).
+        // Every field the previous direct producer emitted, under the same name (pos-customer
+        // consumer contract), plus schemaVersion — the envelope change in #1286 is additive.
         assertThat(row.getPayload())
                 .contains("\"eventId\"")
-                .contains("\"eventType\":\"workorder.work_session.started.v1\"")
+                .contains("\"eventType\":\"workorder.work-session.started.v1\"")
                 .contains("\"schemaVersion\":1")
                 .contains("\"occurredAtUtc\"")
                 .contains("\"sourceService\":\"pos-workorder\"")
@@ -87,10 +93,10 @@ class OutboxEventWriterIntegrationTest {
     @DisplayName("No outbox row survives when the business transaction rolls back")
     void discardsRowOnRollback() {
         writer.publish(
-                "workorder.work_session.stopped.v1",
+                "workorder.work-session.stopped.v1",
                 WorkSessionStoppedEvent.SCHEMA_VERSION,
-                "wo-key-2",
-                Map.of("workorderId", "wo-2"));
+                SAMPLE_ID,
+                new WorkSessionStoppedEvent(SAMPLE_ID, MECHANIC_ID, EVENT_TIME, 3600));
         TestTransaction.flagForRollback();
         TestTransaction.end();
 
@@ -103,7 +109,8 @@ class OutboxEventWriterIntegrationTest {
         // Mirrors the DomainEventEnvelope guard. This envelope is hand-built (#1286), so nothing
         // else would stop a 0 from reaching consumers as a legitimate-looking version.
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> writer.publish("workorder.work_session.started.v1", 0, "wo-key-4", Map.of()))
+                .isThrownBy(
+                        () -> writer.publish("workorder.work-session.started.v1", 0, SAMPLE_ID, workSessionStarted()))
                 .withMessageContaining("schemaVersion must be >= 1");
     }
 
@@ -114,9 +121,14 @@ class OutboxEventWriterIntegrationTest {
 
         assertThatExceptionOfType(IllegalTransactionStateException.class)
                 .isThrownBy(() -> writer.publish(
-                        "workorder.time_entry.approved.v1",
+                        "workorder.time-entry.approved.v1",
                         TimeEntryApprovedEvent.SCHEMA_VERSION,
-                        "wo-key-3",
-                        Map.of()));
+                        SAMPLE_ID,
+                        new TimeEntryApprovedEvent(SAMPLE_ID, WORKORDER_ID, "user-1", EVENT_TIME)));
+    }
+
+    /** The payload type whose SCHEMA_VERSION the publish calls above pass — kept in step. */
+    private static WorkSessionStartedEvent workSessionStarted() {
+        return new WorkSessionStartedEvent(SAMPLE_ID, MECHANIC_ID, EVENT_TIME);
     }
 }

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/ServiceCompletionFactPublisherTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/ServiceCompletionFactPublisherTest.java
@@ -144,7 +144,7 @@ class ServiceCompletionFactPublisherTest {
                 .publish(
                         eq(WorkorderServiceCompletedV1.EVENT_TYPE),
                         eq(WorkorderServiceCompletedV1.SCHEMA_VERSION),
-                        eq(workorderId.toString()),
+                        eq(workorderId),
                         completed.capture());
         WorkorderServiceCompletedV1 completionFact = (WorkorderServiceCompletedV1) completed.getValue();
         assertThat(completionFact.partyId()).isEqualTo(partyId);
@@ -159,7 +159,7 @@ class ServiceCompletionFactPublisherTest {
                 .publish(
                         eq(WorkorderServiceLineDeclinedV1.EVENT_TYPE),
                         eq(WorkorderServiceLineDeclinedV1.SCHEMA_VERSION),
-                        eq(workorderId.toString()),
+                        eq(workorderId),
                         declinedFact.capture());
         WorkorderServiceLineDeclinedV1 fact = (WorkorderServiceLineDeclinedV1) declinedFact.getValue();
         assertThat(fact.description()).isEqualTo("Brake pads");

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/ServiceCompletionFactPublisherTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/ServiceCompletionFactPublisherTest.java
@@ -2,6 +2,7 @@ package com.positivity.workorder.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -140,7 +141,11 @@ class ServiceCompletionFactPublisherTest {
 
         ArgumentCaptor<Object> completed = ArgumentCaptor.forClass(Object.class);
         verify(writer, times(1))
-                .publish(eq(WorkorderServiceCompletedV1.EVENT_TYPE), eq(workorderId.toString()), completed.capture());
+                .publish(
+                        eq(WorkorderServiceCompletedV1.EVENT_TYPE),
+                        eq(WorkorderServiceCompletedV1.SCHEMA_VERSION),
+                        eq(workorderId.toString()),
+                        completed.capture());
         WorkorderServiceCompletedV1 completionFact = (WorkorderServiceCompletedV1) completed.getValue();
         assertThat(completionFact.partyId()).isEqualTo(partyId);
         assertThat(completionFact.vehicleId()).isEqualTo(vehicleId);
@@ -153,6 +158,7 @@ class ServiceCompletionFactPublisherTest {
         verify(writer, times(1))
                 .publish(
                         eq(WorkorderServiceLineDeclinedV1.EVENT_TYPE),
+                        eq(WorkorderServiceLineDeclinedV1.SCHEMA_VERSION),
                         eq(workorderId.toString()),
                         declinedFact.capture());
         WorkorderServiceLineDeclinedV1 fact = (WorkorderServiceLineDeclinedV1) declinedFact.getValue();
@@ -180,8 +186,8 @@ class ServiceCompletionFactPublisherTest {
         publisher.markCompleted(workorderId);
         fireBeforeCommit();
 
-        verify(writer, times(1)).publish(eq(WorkorderServiceCompletedV1.EVENT_TYPE), any(), any());
-        verify(writer, never()).publish(eq(WorkorderServiceLineDeclinedV1.EVENT_TYPE), any(), any());
+        verify(writer, times(1)).publish(eq(WorkorderServiceCompletedV1.EVENT_TYPE), anyInt(), any(), any());
+        verify(writer, never()).publish(eq(WorkorderServiceLineDeclinedV1.EVENT_TYPE), anyInt(), any(), any());
     }
 
     @Test
@@ -192,6 +198,6 @@ class ServiceCompletionFactPublisherTest {
         publisher.markCompleted(UUID.randomUUID());
         fireBeforeCommit();
 
-        verify(writer, never()).publish(any(), any(), any());
+        verify(writer, never()).publish(any(), anyInt(), any(), any());
     }
 }

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderFactPublisherTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderFactPublisherTest.java
@@ -96,7 +96,7 @@ class WorkorderFactPublisherTest {
                 .publish(
                         eq(WorkorderUpdatedV1.EVENT_TYPE),
                         eq(WorkorderUpdatedV1.SCHEMA_VERSION),
-                        eq(workorderId.toString()),
+                        eq(workorderId),
                         payloadCaptor.capture());
         WorkorderUpdatedV1 fact = (WorkorderUpdatedV1) payloadCaptor.getValue();
         assertThat(fact.workorderNumber()).isEqualTo("WO-2026-1001");

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderFactPublisherTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderFactPublisherTest.java
@@ -2,6 +2,7 @@ package com.positivity.workorder.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -92,7 +93,11 @@ class WorkorderFactPublisherTest {
 
         ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
         verify(writer, times(1))
-                .publish(eq(WorkorderUpdatedV1.EVENT_TYPE), eq(workorderId.toString()), payloadCaptor.capture());
+                .publish(
+                        eq(WorkorderUpdatedV1.EVENT_TYPE),
+                        eq(WorkorderUpdatedV1.SCHEMA_VERSION),
+                        eq(workorderId.toString()),
+                        payloadCaptor.capture());
         WorkorderUpdatedV1 fact = (WorkorderUpdatedV1) payloadCaptor.getValue();
         assertThat(fact.workorderNumber()).isEqualTo("WO-2026-1001");
         assertThat(fact.status()).isEqualTo("WORK_IN_PROGRESS");
@@ -108,6 +113,6 @@ class WorkorderFactPublisherTest {
         publisher.markChanged(UUID.randomUUID());
         fireBeforeCommit();
 
-        verify(writer, never()).publish(any(), any(), any());
+        verify(writer, never()).publish(any(), anyInt(), any(), any());
     }
 }


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — no capability id on the source issues
- Parent STORY (durion): n/a — neither issue has a parent
- Child issues: louisburroughs/durion-positivity-backend#1289, louisburroughs/durion-positivity-backend#1286
- Domain: `domain:domain-events`, `domain:inventory`, `domain:workorder`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `BACKEND_CONTRACT_GUIDE.md` — see the breaking-change note below.
- Durion contract PR (if applicable): none

> **⚠️ This PR renames live event types. Read the rollout note before merging.**

## Scope

Three `EVENT_TYPE` constants contained underscores, which `DomainEventEnvelope` rejects — `isValidEventType` accepts only `a-z`, `0-9` and `-` after the first character of each segment. The consequences differed by module, and one of them was **silent data loss**.

### 1. pos-inventory: a fact that has never once been published (#1289)

`ProductValueChangedV1.EVENT_TYPE` was `inventory.product_value.changed`. It is published through the envelope inside a catch-all (`InventoryFactPublisher.java:394-404`):

```java
try {
    publish(writer, ProductValueChangedV1.EVENT_TYPE, ...);
} catch (Exception e) {
    log.warn("Skipping product-value-changed fact for {}: {}", valueChange.revaluationId(), e.getMessage());
}
```

The envelope threw `IllegalArgumentException`, the catch swallowed it, and the fact was dropped. This happened on **every** revaluation — not an edge case, because the failure was in the constant, not the data. `RevaluationService`'s javadoc says the fact "is emitted"; it was not. Corroborating evidence: there is **no consumer of this event anywhere in the repo**, which is what you would expect for an event nobody could ever receive.

Renamed to `inventory.product-value.changed`, matching the module's existing hyphenated style. **This rename carries no compatibility risk** — nothing was ever published under the old name, so there are no in-flight messages, no unpublished outbox rows, and no subscriber.

### 2. pos-workorder: the reason for the hand-rolled envelope (#1286)

The same constraint is why this module built its envelope as a `LinkedHashMap` instead of using the shared type — and that map carried no `schemaVersion` at all, so consumers of its thirteen event types had no way to tell which payload shape they held.

With the underscore types renamed, the module now uses `DomainEventEnvelope` like the other thirteen. The writer takes the aggregate id as a `UUID` and builds the shared envelope; the schema version it requires comes from a constant on the payload type, per the convention in #1279 — which is what finally *reads* `JobTimeRecordedV1.SCHEMA_VERSION`, where #1279 could only declare it. The eight module-internal payload types (`WorkSessionStartedEvent`, `EstimateCreatedEvent`, …) have no `pos-domain-events` record, so each declares its own `SCHEMA_VERSION`.

### 3. The guard that should have caught this

`DomainEventContractTest` asserted `EVENT_TYPE` against `[a-z0-9_-]+(\.[a-z0-9_-]+)+` — a regex that **permits underscores**, looser than the envelope it was meant to describe. The test and the runtime disagreed, and `ProductValueChangedV1` sat exactly in the gap. The test now constructs a real `DomainEventEnvelope` per record instead of pattern-matching, so the two cannot drift again.

Verified by reverting the constant and re-running, rather than assuming:

```
[ERROR] DomainEventContractTest.eventTypeIsWellFormed:178
  [ProductValueChangedV1.EVENT_TYPE (inventory.product_value.changed) is rejected by
   DomainEventEnvelope, so publishing it throws. Event types are dotted lowercase with
   hyphens, never underscores.]
```

## ⚠️ Rollout: this is a hard rename, by decision

Per direction on the issue, producer and consumers switch together with **no compatibility window**. The workorder renames are:

| Old | New |
|---|---|
| `workorder.job_time.recorded.v1` | `workorder.job-time.recorded.v1` |
| `workorder.service_line.declined.v1` | `workorder.service-line.declined.v1` |
| `workorder.work_session.started.v1` / `.stopped.v1` | `workorder.work-session.*` |
| `workorder.travel_segment.started.v1` / `.stopped.v1` | `workorder.travel-segment.*` |
| `workorder.time_entry.approved.v1` / `.rejected.v1` | `workorder.time-entry.*` |

Consumers match these as literals, so **any workorder event in flight at deploy time — or written to the outbox before the deploy and drained after — will be ignored rather than processed.** If that matters for the target environment, drain `workorder.events.v1` and the workorder outbox before rolling out. The pos-inventory rename has no such concern (nothing was ever emitted).

Record-backed types propagate automatically through their `EVENT_TYPE` constants; the eight bare-string types in `KafkaEventRelay` were renamed at the literal. Flyway migration files were left untouched — one carries the old name in a comment, and editing an applied migration would break its checksum.

The workorder wire envelope also gains `aggregateId`, `correlationId` and `actor`, and keeps every field it already emitted under the same name. Listeners read a `JsonNode` tree by field name, so they are unaffected beyond the type strings.

## Tests
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Provider behavioral contract tests added/updated

- How to run:
  ```bash
  ./mvnw -pl pos-domain-events,pos-workorder,pos-inventory,pos-customer,pos-people,pos-invoice,pos-order,pos-warranty -am -DskipTests=false test
  ```
  `BUILD SUCCESS` locally across all 14 reactor modules that command covers — every module that produces or consumes the renamed events.

## Risk & Rollback
- Risk level: **Medium** — the code change is compile-checked end to end and well covered, but renaming a live event type is an operational change, not just a code one. See the rollout note.
- Rollback plan: reverting restores the old type strings, and re-introduces the pos-inventory silent drop. If a rollback happens after deploy, events published under the new names in the interim will not be matched by the reverted consumers — the same drain consideration applies in reverse.

## Checklist
- [ ] Branch name matches `cap/&lt;cap-id&gt;` — branch is `claude/issue-1279-926mu4`, assigned for this task
- [ ] PR title starts with `[CAP:&lt;cap-id&gt;]` — no capability id on the source issues
- [x] Links to parent + child issues are present (children #1289, #1286; neither has a parent)
- [x] Contract guide updated (when contract semantics changed) — breaking rename documented above
- [ ] Required CI checks passing — pending re-run

Closes #1289
Closes #1286

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShQxYMX6qr9bmYYNuREkja