### PR TITLE
feat(openapi): ADR-0042 description-depth standard + validator gate, pos-tax and pos-supplier converted (#1263)

### DIFF
--- a/docs/OPENAPI_DESCRIPTION_STANDARD.md
+++ b/docs/OPENAPI_DESCRIPTION_STANDARD.md
@@ -1,0 +1,230 @@
+# OpenAPI Operation Description Standard
+
+This document is the fleet-wide template for the two ADR-0042 requirements that no module
+satisfied before it existed (see [#1263](https://github.com/louisburroughs/durion-positivity-backend/issues/1263)):
+
+- **§1 `description`** — a structured tool invocation guide of 4–8 sentences covering seven required elements.
+- **§3 request body** — swagger `@RequestBody` with `description`, explicit `required`, and at least one example.
+
+ADR-0042 (`durion/docs/adr/0042-openapi-annotation-standards.adr.md`) states *what* must be
+present. This document fixes *how* it is written, so that 964 operations across 26 modules read
+as one voice rather than 26 interpretations, and so that the depth can be machine-checked by
+`pos-openapi-validation` instead of remaining aspirational.
+
+## Why the wording is prescriptive
+
+These descriptions are consumed by the MCP server to choose tools. Their value is comparative: an
+agent picking between `createInvoice` and `createCreditMemo` benefits only if both descriptions
+answer the same questions in the same order. A description that is merely *long* is worth nothing
+if the agent has to guess where the preconditions are. So the template fixes sentence order and
+lead-in phrases; the validator checks for those lead-ins, which is also what makes the rule
+enforceable without natural-language understanding.
+
+## The template
+
+Write the description as 4–8 sentences, in this order, using these lead-ins:
+
+```text
+<Primary action.>
+Use this tool when <trigger>; do not use <alternative tool> for <that other purpose>.
+Preconditions: <state or data that must already exist>.
+Required inputs: <mandatory fields, formats, constraints, non-obvious defaults>.
+<Side effects — "Emits <EVENT_ID> ..." or "No events are emitted; ...">
+Returns <code> when <business condition>, <code> when <business condition>.
+```
+
+Mapping to the seven ADR-0042 elements:
+
+| # | ADR-0042 element | Where it lives in the template |
+| --- | --- | --- |
+| 1 | Primary action | First sentence |
+| 2 | When to use | `Use this tool when ...` |
+| 3 | Required preconditions | `Preconditions: ...` |
+| 4 | Key input expectations | `Required inputs: ...` |
+| 5 | Side effects | `Emits ...` / `No events are emitted ...` |
+| 6 | Error conditions | `Returns 409 when ...` |
+| 7 | What NOT to do | `do not use ... ` clause, or `... instead` |
+
+### Writing rules
+
+- **Third person, present tense, declarative.** "Creates a supplier account", not "Create" or
+  "This endpoint will create".
+- **Name the alternative tool by `operationId`.** "do not use `updateSupplierAccount` for this" is
+  actionable; "do not use this for updates" is not.
+- **Preconditions are checkable state**, not restatements of validation: "the supplier profile must
+  be ACTIVE", not "the request must be valid".
+- **Required inputs name fields and formats**, and state defaults that a caller cannot infer:
+  "`supplierId` (UUID) and `code`; `enabled` defaults to true".
+- **Side effects are concrete**: the event id emitted, records touched, asynchrony the caller must
+  poll for. When there are none, say so — `No events are emitted; the change takes effect
+  immediately.` Silence is indistinguishable from an omission.
+- **Error sentence lists business failures**, not the framework's generic set. 400 for malformed
+  payloads and 401/403 for auth are documented in `@ApiResponses` and need not be narrated;
+  409/404/422 conditions do, because the caller can self-correct from them.
+- **No markdown, no line-leading bullets.** The MCP server flattens the text.
+- **4–8 sentences.** Under four means an element is missing; over eight means the description is
+  being used as a manual.
+
+### Read-only operations
+
+GETs still take all seven elements. The elements do not disappear, they get shorter:
+
+- Preconditions are usually about existence and visibility: "the caller's tenant must own the record".
+- Side effects: "No events are emitted; this is a read-only projection."
+- Errors: "Returns 404 when no supplier profile exists for the supplied id."
+
+### Text blocks
+
+Use a Java text block and let the lines wrap naturally. The generated YAML folds them into one
+string; sentence boundaries, not line boundaries, are what the validator counts.
+
+## Worked exemplars
+
+### Create (state-changing, emits an event)
+
+```java
+@Operation(
+        operationId = "createSupplierAccount",
+        summary = "Create a supplier account",
+        description =
+                """
+                Creates a purchasing account that binds one supplier profile to one location for ordering and invoicing.
+                Use this tool when a location is authorised to buy from a supplier for the first time; do not use \
+                updateSupplierAccount, which changes an account that already exists.
+                Preconditions: the supplier profile must exist and be ACTIVE, the location must exist, and no account \
+                may already exist for that supplier and location pair.
+                Required inputs: supplierId (UUID), locationId (UUID) and accountNumber; creditLimit is optional and \
+                defaults to null, meaning no enforced limit.
+                Emits a SUPPLIER_ACCOUNT_CREATE event; no order or invoice records are touched.
+                Returns 409 when an account already exists for the supplier and location pair, and 404 when the \
+                supplier profile or location cannot be resolved.
+                """)
+```
+
+### Read (single resource)
+
+```java
+@Operation(
+        operationId = "getSupplierProfileById",
+        summary = "Get a supplier profile",
+        description =
+                """
+                Returns the full supplier profile, including its integration status and contact metadata.
+                Use this tool when a supplier id is already known; use listSupplierProfiles instead when searching \
+                by name, code or status.
+                Preconditions: the supplier profile must exist and be visible to the caller's tenant.
+                Required inputs: supplierId (UUID) as a path parameter; there is no request body and no filtering.
+                No events are emitted and no state changes; this is a read-only projection.
+                Returns 404 when no supplier profile exists for the supplied id.
+                """)
+```
+
+### State transition (idempotent, tolerant of an outage)
+
+```java
+@Operation(
+        operationId = "commitTaxDocument",
+        summary = "Commit tax document",
+        description =
+                """
+                Commits the provider tax document for an invoice that has been finalised, making the recorded tax \
+                filing-visible at the provider.
+                Use this tool when an invoice reaches a finalised state; do not use it to recalculate tax, which is \
+                calculateTax, and do not use it to reverse a commit, which is voidTaxDocument.
+                Preconditions: tax must already have been calculated for this referenceId, and the source invoice \
+                must be finalised rather than DRAFT.
+                Required inputs: referenceId (UUID) as a path parameter, which is the source invoice id; \
+                referenceType is optional and defaults to INVOICE.
+                Emits a TAX_COMMIT event and records a provider transaction; the call is idempotent on referenceId, \
+                and a provider outage records PENDING_COMMIT rather than failing, leaving the re-commit job to \
+                true it up.
+                Returns 200 with a PENDING_COMMIT status when the provider is unreachable, so callers must read the \
+                returned status rather than treating 200 as a completed commit.
+                """)
+```
+
+## Request bodies (§3)
+
+Every operation that takes a body must annotate it. `@RequestBody` here is
+`io.swagger.v3.oas.annotations.parameters.RequestBody`, which coexists with Spring's
+`@org.springframework.web.bind.annotation.RequestBody` on the same parameter:
+
+```java
+public ResponseEntity<SupplierAccount> createSupplierAccount(
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                        description = "Supplier account to create, binding one supplier profile to one location.",
+                        required = true,
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        name = "Minimal account",
+                                                        value =
+                                                                """
+                                                                {"supplierId":"018f8c1e-0000-7000-8000-000000000001",
+                                                                 "locationId":"018f8c1e-0000-7000-8000-000000000002",
+                                                                 "accountNumber":"ACCT-1001"}
+                                                                """)))
+                @Valid
+                @org.springframework.web.bind.annotation.RequestBody
+                SupplierAccountRequest request) {
+```
+
+Required:
+
+- `description` — what the body represents, one sentence. Not a repeat of the summary.
+- `required` — stated explicitly, even when true.
+- at least one `@ExampleObject` with a realistic, schema-valid value. Use UUID v7 shaped ids.
+
+The DTO's own `@Schema` field annotations are covered by ADR-0042 §5 and are not part of this
+document; the example exists so an agent can construct a body without resolving the `$ref`.
+
+## Enforcement
+
+`pos-openapi-validation` checks these rules per module. The dimension is `annotationDepth` in
+`pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml`:
+
+| `annotationDepth` | Effect |
+| --- | --- |
+| `STRICT` | Depth findings fail the build in every mode. |
+| `REPORT_ONLY` | Depth findings are reported, and fail only under `-Dopenapi.validation.mode=STRICT`. Default when the key is absent. |
+| `EXEMPT` | Depth is not checked. Requires a `annotationDepthReason`. |
+
+The checks, and the message each emits:
+
+| Check | Message fragment |
+| --- | --- |
+| 4–8 sentences | `description has N sentences (ADR-0042 §1 requires 4-8)` |
+| Primary action opens the text | `description does not open with a primary-action sentence` |
+| When-to-use lead-in | `description missing when-to-use guidance ("Use this tool ...")` |
+| Preconditions lead-in | `description missing preconditions ("Preconditions: ...")` |
+| Input expectations lead-in | `description missing input expectations ("Required inputs: ...")` |
+| Side effects lead-in | `description missing side effects ("Emits ..." or "No events are emitted")` |
+| Error conditions | `description missing error conditions ("Returns <code> when ...")` |
+| Negative guidance | `description missing negative guidance ("do not use ..." / "... instead")` |
+| Request body description | `request body missing description (ADR-0042 §3)` |
+| Request body `required` | `request body missing explicit required flag (ADR-0042 §3)` |
+| Request body example | `request body missing example (ADR-0042 §3)` |
+
+Run the checks:
+
+```bash
+# Blocking findings only (annotationDepth: STRICT modules)
+./mvnw -pl pos-openapi-validation -DskipTests=false -Dtest=OpenApiRepositoryValidationTest test
+
+# Full fleet gap, including REPORT_ONLY modules
+./mvnw -pl pos-openapi-validation -DskipTests=false \
+  -Dopenapi.validation.mode=STRICT -Dtest=OpenApiRepositoryValidationTest test
+```
+
+## Rollout
+
+Modules move to `annotationDepth: STRICT` one at a time, each with its spec regenerated in the same
+change (`scripts/generate-openapi.sh <module>`). `pos-tax` and `pos-supplier` are the reference
+conversions; read their controllers before converting a new module.
+
+Rewriting descriptions is a domain exercise, not a mechanical one — a generic seven-part
+description that passes the validator and tells an agent nothing is worse than the one-line
+description it replaced, because it costs tokens on every tool-selection prompt. If the
+preconditions or side effects of an operation are not known, find out before writing the sentence.

--- a/pos-openapi-validation/README.md
+++ b/pos-openapi-validation/README.md
@@ -23,6 +23,12 @@ The repository validation flow is:
 - operations missing `summary`
 - operations missing `description`
 
+`OpenApiAnnotationDepthValidator` additionally checks, for modules whose `annotationDepth` is not `EXEMPT`, that each operation meets the ADR-0042 §1 and §3 depth rules fixed in `docs/OPENAPI_DESCRIPTION_STANDARD.md`:
+
+- descriptions of 4–8 sentences opening with a primary-action sentence
+- the six remaining §1 elements, detected by their canonical lead-ins (`Use this tool ...`, `Preconditions: ...`, `Required inputs: ...`, `Emits ...` / `No events are emitted`, `Returns <code> when ...`, and negative guidance such as `do not use ...`)
+- request bodies carrying a `description`, an explicit `required`, and at least one example
+
 `OpenApiAggregateValidator` checks the aggregate spec for:
 
 - duplicate YAML keys in the aggregate file
@@ -40,6 +46,16 @@ The repository validation flow is:
 | `EXCLUDED` | The module is outside the current rollout scope and is skipped entirely. |
 
 A module that is absent from the inventory is not validated at all — the validator never looks at a spec it was not told about, so an unregistered module can ship an `openapi.yaml` that does not parse and CI stays green. `scripts/check-openapi-inventory-drift.sh` guards against that: it fails when a module with a committed `openapi.yaml` has no inventory entry, and when an inventory entry names something that is no longer a reactor module. CI runs it on every build.
+
+Description depth is a second, independent dimension on the same entry:
+
+| `annotationDepth` | Meaning |
+| --- | --- |
+| `STRICT` | Depth findings are blocking now. |
+| `REPORT_ONLY` | Depth findings are reported and become blocking under `-Dopenapi.validation.mode=STRICT`. This is the default when the key is absent. |
+| `EXEMPT` | Depth is not checked; requires an `annotationDepthReason`. |
+
+`mode` and `annotationDepth` are deliberately separate: every module is already `STRICT` on summary/description *presence*, while ADR-0042's depth requirement was met by no module in the fleet when it was introduced (#1263). `pos-tax` and `pos-supplier` are the reference conversions at `annotationDepth: STRICT`; every other module stays `REPORT_ONLY` until its descriptions are rewritten, so a default-mode run stays green while `-Dopenapi.validation.mode=STRICT` reports the full fleet gap.
 
 When adding a new spec-producing module, register it at `STRICT`. That may surface real defects in the spec; the fix belongs in the controller annotations the spec is generated from, not in the inventory entry. If the module cannot be made `STRICT`-clean immediately, `REPORT_ONLY` is still better than absence.
 

--- a/pos-openapi-validation/src/main/java/com/positivity/openapivalidation/internal/policy/OpenApiModulePolicy.java
+++ b/pos-openapi-validation/src/main/java/com/positivity/openapivalidation/internal/policy/OpenApiModulePolicy.java
@@ -4,12 +4,34 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 public record OpenApiModulePolicy(
-        @NonNull Mode mode, @Nullable String reason) {
+        @NonNull Mode mode,
+        @Nullable String reason,
+        @NonNull DepthMode annotationDepth,
+        @Nullable String annotationDepthReason) {
+
+    /** Spec-shape checks only: presence of summary and description, no ADR-0042 depth checks. */
+    public OpenApiModulePolicy(@NonNull Mode mode, @Nullable String reason) {
+        this(mode, reason, DepthMode.EXEMPT, null);
+    }
 
     public enum Mode {
         STRICT,
         REPORT_ONLY,
         EXCEPTION,
         EXCLUDED
+    }
+
+    /**
+     * Enforcement level for the ADR-0042 §1 description depth and §3 request body rules described in
+     * {@code docs/OPENAPI_DESCRIPTION_STANDARD.md}.
+     */
+    public enum DepthMode {
+        STRICT,
+        REPORT_ONLY,
+        EXEMPT
+    }
+
+    public @NonNull Mode depthIssueMode() {
+        return annotationDepth == DepthMode.STRICT ? Mode.STRICT : Mode.REPORT_ONLY;
     }
 }

--- a/pos-openapi-validation/src/main/java/com/positivity/openapivalidation/internal/policy/OpenApiValidationInventoryLoader.java
+++ b/pos-openapi-validation/src/main/java/com/positivity/openapivalidation/internal/policy/OpenApiValidationInventoryLoader.java
@@ -44,17 +44,38 @@ public final class OpenApiValidationInventoryLoader {
             throw new IllegalArgumentException("Expected non-blank mode for module: " + moduleName);
         }
         OpenApiModulePolicy.Mode mode = OpenApiModulePolicy.Mode.valueOf(modeString);
-        Object reasonValue = policyMap.get("reason");
-        String reason;
-        if (reasonValue == null) {
-            reason = null;
-        } else if (reasonValue instanceof String s) {
-            reason = s;
+        String reason = optionalString(policyMap.get("reason"), "reason", moduleName);
+
+        Object depthValue = policyMap.get("annotationDepth");
+        OpenApiModulePolicy.DepthMode annotationDepth;
+        if (depthValue == null) {
+            annotationDepth = OpenApiModulePolicy.DepthMode.REPORT_ONLY;
+        } else if (depthValue instanceof String depthString && !depthString.isBlank()) {
+            annotationDepth = OpenApiModulePolicy.DepthMode.valueOf(depthString);
         } else {
-            throw new IllegalArgumentException("Expected string reason for module: " + moduleName + ", got: "
-                    + reasonValue.getClass().getSimpleName());
+            throw new IllegalArgumentException("Expected non-blank annotationDepth for module: " + moduleName);
         }
-        return new OpenApiModulePolicy(mode, reason);
+
+        String annotationDepthReason =
+                optionalString(policyMap.get("annotationDepthReason"), "annotationDepthReason", moduleName);
+        if (annotationDepth == OpenApiModulePolicy.DepthMode.EXEMPT
+                && (annotationDepthReason == null || annotationDepthReason.isBlank())) {
+            throw new IllegalArgumentException(
+                    "annotationDepth: EXEMPT requires an annotationDepthReason for module: " + moduleName);
+        }
+
+        return new OpenApiModulePolicy(mode, reason, annotationDepth, annotationDepthReason);
+    }
+
+    private static String optionalString(Object value, @NonNull String key, @NonNull String moduleName) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String string) {
+            return string;
+        }
+        throw new IllegalArgumentException("Expected string " + key + " for module: " + moduleName + ", got: "
+                + value.getClass().getSimpleName());
     }
 
     private static @NonNull Map<?, ?> requireMap(Object value, @NonNull String description) {

--- a/pos-openapi-validation/src/main/java/com/positivity/openapivalidation/internal/validator/OpenApiAnnotationDepthValidator.java
+++ b/pos-openapi-validation/src/main/java/com/positivity/openapivalidation/internal/validator/OpenApiAnnotationDepthValidator.java
@@ -1,0 +1,123 @@
+package com.positivity.openapivalidation.internal.validator;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Checks the ADR-0042 §1 description depth and §3 request body rules for a single operation.
+ *
+ * <p>The seven §1 elements are detected by the canonical lead-in phrases fixed in
+ * {@code docs/OPENAPI_DESCRIPTION_STANDARD.md}. Detecting lead-ins rather than meaning is what makes the
+ * rule enforceable; it is also what makes the fleet read in one voice, which is the point of the
+ * standard — these descriptions are compared against each other by an agent choosing a tool.
+ */
+public class OpenApiAnnotationDepthValidator {
+
+    static final int MIN_SENTENCES = 4;
+    static final int MAX_SENTENCES = 8;
+    private static final int MIN_PRIMARY_ACTION_LENGTH = 30;
+
+    /** Splits on sentence punctuation only when the next sentence starts, so "e.g." does not count. */
+    private static final Pattern SENTENCE_BOUNDARY = Pattern.compile("(?<=[.!?])\\s+(?=[A-Z(\"])");
+
+    private static final Pattern WHEN_TO_USE = Pattern.compile("(?i)\\buse this (tool|operation|endpoint)\\b");
+    private static final Pattern PRECONDITIONS = Pattern.compile("(?i)\\bpreconditions?\\b\\s*:");
+    private static final Pattern INPUT_EXPECTATIONS = Pattern.compile("(?i)\\b(required )?inputs?\\b\\s*:");
+    private static final Pattern SIDE_EFFECTS =
+            Pattern.compile("(?i)\\bemits\\b|\\bno events are emitted\\b|\\bside[ -]effects?\\b\\s*:");
+    private static final Pattern ERROR_CONDITIONS = Pattern.compile("(?i)\\breturns\\s+\\d{3}\\b");
+    private static final Pattern NEGATIVE_GUIDANCE =
+            Pattern.compile("(?i)\\bdo not\\b|\\bdon't\\b|\\binstead\\b|\\brather than\\b");
+
+    public @NonNull List<String> check(@NonNull Operation operation) {
+        List<String> findings = new ArrayList<>();
+        checkDescription(operation.getDescription(), findings);
+        checkRequestBody(operation.getRequestBody(), findings);
+        return List.copyOf(findings);
+    }
+
+    private void checkDescription(String description, List<String> findings) {
+        if (description == null || description.isBlank()) {
+            // Absence is already reported by OpenApiModuleValidator; depth adds nothing here.
+            return;
+        }
+        // Text blocks wrap mid-phrase, so "do not" can arrive split across a newline. Match on
+        // single-spaced text or every multi-word lead-in becomes line-break sensitive.
+        String normalized = description.replaceAll("\\s+", " ").strip();
+        List<String> sentences = splitSentences(normalized);
+        if (sentences.size() < MIN_SENTENCES || sentences.size() > MAX_SENTENCES) {
+            findings.add("description has " + sentences.size() + " sentence"
+                    + (sentences.size() == 1 ? "" : "s") + " (ADR-0042 §1 requires " + MIN_SENTENCES + "-"
+                    + MAX_SENTENCES + ")");
+        }
+        String first = sentences.isEmpty() ? "" : sentences.get(0);
+        if (first.length() < MIN_PRIMARY_ACTION_LENGTH
+                || WHEN_TO_USE.matcher(first).find()) {
+            findings.add("description does not open with a primary-action sentence");
+        }
+        require(WHEN_TO_USE, normalized, findings, "when-to-use guidance (\"Use this tool ...\")");
+        require(PRECONDITIONS, normalized, findings, "preconditions (\"Preconditions: ...\")");
+        require(INPUT_EXPECTATIONS, normalized, findings, "input expectations (\"Required inputs: ...\")");
+        require(SIDE_EFFECTS, normalized, findings, "side effects (\"Emits ...\" or \"No events are emitted\")");
+        require(ERROR_CONDITIONS, normalized, findings, "error conditions (\"Returns <code> when ...\")");
+        require(NEGATIVE_GUIDANCE, normalized, findings, "negative guidance (\"do not use ...\" / \"... instead\")");
+    }
+
+    private void checkRequestBody(RequestBody requestBody, List<String> findings) {
+        if (requestBody == null) {
+            return;
+        }
+        if (requestBody.getDescription() == null || requestBody.getDescription().isBlank()) {
+            findings.add("request body missing description (ADR-0042 §3)");
+        }
+        if (requestBody.getRequired() == null) {
+            findings.add("request body missing explicit required flag (ADR-0042 §3)");
+        }
+        if (!hasExample(requestBody.getContent())) {
+            findings.add("request body missing example (ADR-0042 §3)");
+        }
+    }
+
+    private static boolean hasExample(Content content) {
+        if (content == null) {
+            return false;
+        }
+        for (MediaType mediaType : content.values()) {
+            if (mediaType == null) {
+                continue;
+            }
+            if (mediaType.getExample() != null
+                    || (mediaType.getExamples() != null
+                            && !mediaType.getExamples().isEmpty())) {
+                return true;
+            }
+            if (mediaType.getSchema() != null && mediaType.getSchema().getExample() != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void require(Pattern pattern, String description, List<String> findings, String element) {
+        if (!pattern.matcher(description).find()) {
+            findings.add("description missing " + element);
+        }
+    }
+
+    static @NonNull List<String> splitSentences(@NonNull String description) {
+        List<String> sentences = new ArrayList<>();
+        for (String candidate : SENTENCE_BOUNDARY.split(description.replaceAll("\\s+", " "))) {
+            String trimmed = candidate.strip();
+            if (!trimmed.isEmpty()) {
+                sentences.add(trimmed);
+            }
+        }
+        return List.copyOf(sentences);
+    }
+}

--- a/pos-openapi-validation/src/main/java/com/positivity/openapivalidation/internal/validator/OpenApiModuleValidator.java
+++ b/pos-openapi-validation/src/main/java/com/positivity/openapivalidation/internal/validator/OpenApiModuleValidator.java
@@ -14,6 +14,16 @@ import org.jspecify.annotations.NonNull;
 
 public class OpenApiModuleValidator {
 
+    private final OpenApiAnnotationDepthValidator depthValidator;
+
+    public OpenApiModuleValidator() {
+        this(new OpenApiAnnotationDepthValidator());
+    }
+
+    public OpenApiModuleValidator(@NonNull OpenApiAnnotationDepthValidator depthValidator) {
+        this.depthValidator = depthValidator;
+    }
+
     public @NonNull List<OpenApiValidationIssue> validate(
             @NonNull String module, @NonNull Path specPath, @NonNull OpenApiModulePolicy policy) {
         if (!Files.exists(specPath)) {
@@ -42,6 +52,11 @@ public class OpenApiModuleValidator {
                 }
                 if (isBlank(operation.getDescription())) {
                     issues.add(new OpenApiValidationIssue(module, policy.mode(), prefix + " missing description"));
+                }
+                if (policy.annotationDepth() != OpenApiModulePolicy.DepthMode.EXEMPT) {
+                    for (String finding : depthValidator.check(operation)) {
+                        issues.add(new OpenApiValidationIssue(module, policy.depthIssueMode(), prefix + " " + finding));
+                    }
                 }
             }
         }

--- a/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/policy/OpenApiValidationInventoryLoaderTest.java
+++ b/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/policy/OpenApiValidationInventoryLoaderTest.java
@@ -21,6 +21,27 @@ class OpenApiValidationInventoryLoaderTest {
     }
 
     @Test
+    void defaultsAnnotationDepthToReportOnlyAndReadsExplicitStrict() {
+        OpenApiValidationInventory inventory =
+                OpenApiValidationInventoryLoader.load(Path.of("src/test/resources/openapi/module-inventory.yaml"));
+
+        assertThat(inventory.policyFor("pos-accounting").annotationDepth())
+                .isEqualTo(OpenApiModulePolicy.DepthMode.REPORT_ONLY);
+        assertThat(inventory.policyFor("pos-tax").annotationDepth()).isEqualTo(OpenApiModulePolicy.DepthMode.STRICT);
+        assertThat(inventory.policyFor("pos-supplier").annotationDepth())
+                .isEqualTo(OpenApiModulePolicy.DepthMode.STRICT);
+    }
+
+    @Test
+    void throwsWhenAnnotationDepthIsExemptWithoutReason() {
+        Path path = Path.of("src/test/resources/openapi/depth-exempt-without-reason.yaml");
+
+        assertThatThrownBy(() -> OpenApiValidationInventoryLoader.load(path))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("annotationDepthReason");
+    }
+
+    @Test
     void throwsWhenReasonIsNotString() {
         Path path = Path.of("src/test/resources/openapi/invalid-reason-type.yaml");
 

--- a/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/validator/OpenApiAnnotationDepthValidatorTest.java
+++ b/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/validator/OpenApiAnnotationDepthValidatorTest.java
@@ -1,0 +1,125 @@
+package com.positivity.openapivalidation.internal.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import org.junit.jupiter.api.Test;
+
+class OpenApiAnnotationDepthValidatorTest {
+
+    private static final String COMPLIANT_DESCRIPTION = """
+            Creates a purchasing account that binds one supplier profile to one location.
+            Use this tool when a location is authorised to buy from a supplier for the first time; do not use \
+            updateSupplierAccount, which changes an account that already exists.
+            Preconditions: the supplier profile must exist and be ACTIVE.
+            Required inputs: supplierId (UUID) and accountNumber; creditLimit defaults to null.
+            Emits a SUPPLIER_ACCOUNT_CREATE event.
+            Returns 409 when an account already exists for the supplier and location pair.
+            """;
+
+    private final OpenApiAnnotationDepthValidator validator = new OpenApiAnnotationDepthValidator();
+
+    @Test
+    void acceptsADescriptionCoveringAllSevenElements() {
+        assertThat(validator.check(new Operation().description(COMPLIANT_DESCRIPTION)))
+                .isEmpty();
+    }
+
+    @Test
+    void countsSentencesRatherThanLines() {
+        assertThat(OpenApiAnnotationDepthValidator.splitSentences(COMPLIANT_DESCRIPTION))
+                .hasSize(6);
+    }
+
+    @Test
+    void doesNotTreatAbbreviationsAsSentenceBoundaries() {
+        assertThat(OpenApiAnnotationDepthValidator.splitSentences(
+                        "Creates a record, e.g. an invoice line. Returns 404 when absent."))
+                .hasSize(2);
+    }
+
+    @Test
+    void rejectsADescriptionThatOpensWithWhenToUse() {
+        String description = COMPLIANT_DESCRIPTION.substring(COMPLIANT_DESCRIPTION.indexOf("Use this tool"));
+
+        assertThat(validator.check(new Operation().description(description)))
+                .contains("description does not open with a primary-action sentence");
+    }
+
+    @Test
+    void rejectsADescriptionLongerThanEightSentences() {
+        String description = COMPLIANT_DESCRIPTION + "Also note this. And this. And this more.";
+
+        assertThat(validator.check(new Operation().description(description)))
+                .contains("description has 9 sentences (ADR-0042 §1 requires 4-8)");
+    }
+
+    @Test
+    void skipsDepthChecksWhenDescriptionIsAbsentBecausePresenceIsReportedElsewhere() {
+        assertThat(validator.check(new Operation())).isEmpty();
+    }
+
+    @Test
+    void matchesLeadInsSplitAcrossLineBreaks() {
+        String description = """
+                Replaces the stored details of an auth config on a vendor profile.
+                Use this tool to rotate credential references; do
+                not use it to rename a config that bindings reference.
+                Preconditions: the auth config must exist.
+                Required inputs: authConfigId (UUID) and the full body.
+                Emits a SUPPLIER_AUTHCONFIG_UPDATE event.
+                Returns 404 when the config does not exist.
+                """;
+
+        assertThat(validator.check(new Operation().description(description))).isEmpty();
+    }
+
+    @Test
+    void acceptsARequestBodyWithDescriptionRequiredFlagAndExample() {
+        Operation operation = new Operation()
+                .description(COMPLIANT_DESCRIPTION)
+                .requestBody(new RequestBody()
+                        .description("Supplier account to create.")
+                        .required(true)
+                        .content(new Content()
+                                .addMediaType(
+                                        "application/json",
+                                        new MediaType().addExamples("minimal", new Example().value("{}")))));
+
+        assertThat(validator.check(operation)).isEmpty();
+    }
+
+    @Test
+    void acceptsASchemaLevelExample() {
+        Operation operation = new Operation()
+                .description(COMPLIANT_DESCRIPTION)
+                .requestBody(new RequestBody()
+                        .description("Supplier account to create.")
+                        .required(true)
+                        .content(new Content()
+                                .addMediaType(
+                                        "application/json",
+                                        new MediaType()
+                                                .schema(new io.swagger.v3.oas.models.media.Schema<>().example("{}")))));
+
+        assertThat(validator.check(operation)).isEmpty();
+    }
+
+    @Test
+    void reportsRequestBodyGapsIndependentlyOfTheDescription() {
+        Operation operation = new Operation()
+                .description(COMPLIANT_DESCRIPTION)
+                .requestBody(
+                        new RequestBody().content(new Content().addMediaType("application/json", new MediaType())));
+
+        assertThat(validator.check(operation))
+                .containsExactly(
+                        "request body missing description (ADR-0042 §3)",
+                        "request body missing explicit required flag (ADR-0042 §3)",
+                        "request body missing example (ADR-0042 §3)");
+    }
+}

--- a/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/validator/OpenApiModuleValidatorTest.java
+++ b/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/validator/OpenApiModuleValidatorTest.java
@@ -73,6 +73,73 @@ class OpenApiModuleValidatorTest {
     }
 
     @Test
+    void reportsDepthAndRequestBodyGapsWhenAnnotationDepthIsStrict() {
+        var issues = validator.validate(
+                "pos-documents",
+                Path.of("src/test/resources/openapi/fixtures/module/shallow-module.yaml"),
+                new OpenApiModulePolicy(
+                        OpenApiModulePolicy.Mode.STRICT, null, OpenApiModulePolicy.DepthMode.STRICT, null));
+
+        assertThat(issues)
+                .extracting(OpenApiValidationIssue::message)
+                .contains(
+                        "pos-documents POST /v1/documents: description has 1 sentence (ADR-0042 §1 requires 4-8)",
+                        "pos-documents POST /v1/documents: description does not open with a primary-action sentence",
+                        "pos-documents POST /v1/documents: description missing when-to-use guidance"
+                                + " (\"Use this tool ...\")",
+                        "pos-documents POST /v1/documents: description missing preconditions"
+                                + " (\"Preconditions: ...\")",
+                        "pos-documents POST /v1/documents: description missing input expectations"
+                                + " (\"Required inputs: ...\")",
+                        "pos-documents POST /v1/documents: description missing side effects"
+                                + " (\"Emits ...\" or \"No events are emitted\")",
+                        "pos-documents POST /v1/documents: description missing error conditions"
+                                + " (\"Returns <code> when ...\")",
+                        "pos-documents POST /v1/documents: description missing negative guidance"
+                                + " (\"do not use ...\" / \"... instead\")",
+                        "pos-documents POST /v1/documents: request body missing description (ADR-0042 §3)",
+                        "pos-documents POST /v1/documents: request body missing explicit required flag"
+                                + " (ADR-0042 §3)",
+                        "pos-documents POST /v1/documents: request body missing example (ADR-0042 §3)");
+        assertThat(issues).allSatisfy(issue -> assertThat(issue.mode()).isEqualTo(OpenApiModulePolicy.Mode.STRICT));
+    }
+
+    @Test
+    void tagsDepthIssuesAsReportOnlyWhenAnnotationDepthIsReportOnly() {
+        var issues = validator.validate(
+                "pos-documents",
+                Path.of("src/test/resources/openapi/fixtures/module/shallow-module.yaml"),
+                new OpenApiModulePolicy(
+                        OpenApiModulePolicy.Mode.STRICT, null, OpenApiModulePolicy.DepthMode.REPORT_ONLY, null));
+
+        assertThat(issues).isNotEmpty();
+        assertThat(issues)
+                .allSatisfy(issue -> assertThat(issue.mode()).isEqualTo(OpenApiModulePolicy.Mode.REPORT_ONLY));
+    }
+
+    @Test
+    void skipsDepthChecksWhenAnnotationDepthIsExempt() {
+        var issues = validator.validate(
+                "pos-documents",
+                Path.of("src/test/resources/openapi/fixtures/module/shallow-module.yaml"),
+                new OpenApiModulePolicy(
+                        OpenApiModulePolicy.Mode.STRICT, null, OpenApiModulePolicy.DepthMode.EXEMPT, "fixture"));
+
+        assertThat(issues).isEmpty();
+    }
+
+    @Test
+    void returnsNoIssuesForModuleMeetingTheDescriptionStandard() {
+        var issues = validator.validate(
+                "pos-documents",
+                Path.of("src/test/resources/openapi/fixtures/module/deep-module.yaml"),
+                new OpenApiModulePolicy(
+                        OpenApiModulePolicy.Mode.STRICT, null, OpenApiModulePolicy.DepthMode.STRICT, null));
+
+        assertThat(issues).isEmpty();
+    }
+
+    @Test
     void throwsForMalformedSpecFile() {
         assertThatThrownBy(() -> validator.validate(
                         "pos-order",

--- a/pos-openapi-validation/src/test/resources/openapi/depth-exempt-without-reason.yaml
+++ b/pos-openapi-validation/src/test/resources/openapi/depth-exempt-without-reason.yaml
@@ -1,0 +1,4 @@
+modules:
+  pos-test:
+    mode: STRICT
+    annotationDepth: EXEMPT

--- a/pos-openapi-validation/src/test/resources/openapi/fixtures/module/deep-module.yaml
+++ b/pos-openapi-validation/src/test/resources/openapi/fixtures/module/deep-module.yaml
@@ -1,0 +1,43 @@
+openapi: "3.0.3"
+info:
+  title: pos-documents
+  version: "1.0"
+paths:
+  /v1/documents:
+    post:
+      summary: Create a document
+      description: |
+        Creates a stored document from the supplied metadata and content reference.
+        Use this tool when a caller already holds an uploaded content reference; do not use
+        uploadDocumentContent, which stores the bytes themselves.
+        Preconditions: the referenced content must already be uploaded and the owning entity must exist.
+        Required inputs: contentRef (string) and ownerId (UUID); retentionDays is optional and defaults
+        to the tenant retention policy.
+        Emits a DOCUMENT_CREATE event; the content reference is marked as claimed.
+        Returns 404 when the owning entity cannot be resolved, and 409 when the content reference has
+        already been claimed by another document.
+      requestBody:
+        description: Document metadata and the content reference to claim.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateDocumentRequest"
+            examples:
+              minimal:
+                value:
+                  contentRef: "content/018f8c1e-0000-7000-8000-000000000001"
+                  ownerId: "018f8c1e-0000-7000-8000-000000000002"
+      responses:
+        "201":
+          description: Document created
+components:
+  schemas:
+    CreateDocumentRequest:
+      type: object
+      properties:
+        contentRef:
+          type: string
+        ownerId:
+          type: string
+          format: uuid

--- a/pos-openapi-validation/src/test/resources/openapi/fixtures/module/shallow-module.yaml
+++ b/pos-openapi-validation/src/test/resources/openapi/fixtures/module/shallow-module.yaml
@@ -1,0 +1,24 @@
+openapi: "3.0.3"
+info:
+  title: pos-documents
+  version: "1.0"
+paths:
+  /v1/documents:
+    post:
+      summary: Create a document
+      description: Creates a document.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateDocumentRequest"
+      responses:
+        "201":
+          description: Document created
+components:
+  schemas:
+    CreateDocumentRequest:
+      type: object
+      properties:
+        contentRef:
+          type: string

--- a/pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml
+++ b/pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml
@@ -29,6 +29,7 @@ modules:
     mode: STRICT
   pos-supplier:
     mode: STRICT
+    annotationDepth: STRICT
   pos-event-receiver:
     mode: STRICT
   pos-vehicle-fitment:
@@ -50,6 +51,7 @@ modules:
     mode: STRICT
   pos-tax:
     mode: STRICT
+    annotationDepth: STRICT
   pos-inquiry:
     mode: EXCEPTION
     reason: stub module with no REST producer surface

--- a/pos-supplier/openapi.yaml
+++ b/pos-supplier/openapi.yaml
@@ -26,8 +26,24 @@ paths:
       tags:
       - Supplier Vendor Profiles
       summary: Get vendor profile
-      description: Retrieve one vendor profile by id
-      operationId: getProfile
+      description: 'Returns one vendor profile with its timeouts, retry settings, sandbox overlay and whether it is
+
+        ADMIN-managed or YAML-managed.
+
+        Use this tool when the vendorProfileId is already known; use listVendorProfiles instead to search
+
+        by supplierRef.
+
+        Preconditions: the profile must exist.
+
+        Required inputs: vendorProfileId (UUIDv7) path parameter; there is no request body.
+
+        Emits a SUPPLIER_PROFILE_GET audit event; no configuration is changed.
+
+        Returns 404 when no profile exists for the supplied id.
+
+        '
+      operationId: getVendorProfile
       parameters:
       - name: vendorProfileId
         in: path
@@ -66,8 +82,36 @@ paths:
       tags:
       - Supplier Vendor Profiles
       summary: Update vendor profile
-      description: Full update of a vendor profile; rejected for YAML-managed profiles (ADR-0050 §6)
-      operationId: updateProfile
+      description: 'Replaces every settable field of a vendor profile, including its alias, display name, enabled and
+
+        sandbox flags and default timeouts.
+
+        Use this tool to change connection defaults or take a supplier out of service by clearing
+
+        enabled; do not use it on YAML-managed profiles, whose source of truth is the deployment
+
+        configuration instead.
+
+        Preconditions: the profile must exist, must be ADMIN-managed, and the supplierRef in the body
+
+        must not belong to a different profile.
+
+        Required inputs: vendorProfileId (UUIDv7) path parameter plus the full body, because every field
+
+        is replaced; omitting an optional field resets it to the deployment default rather than leaving
+
+        the stored value.
+
+        Emits a SUPPLIER_PROFILE_UPDATE audit event; disabling a profile immediately makes its bindings
+
+        resolve to a typed not-configured outcome.
+
+        Returns 404 when the profile does not exist, 409 when it is YAML-managed or the supplierRef is
+
+        taken, and 400 when a required field is blank or a timeout is not greater than zero.
+
+        '
+      operationId: updateVendorProfile
       parameters:
       - name: vendorProfileId
         in: path
@@ -78,10 +122,23 @@ paths:
           format: uuid
           example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
       requestBody:
+        description: Replacement values for every settable field of the vendor profile.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/VendorProfileRequest'
+            examples:
+              Enabled production profile:
+                description: Enabled production profile
+                value:
+                  supplierRef: michelin-eu
+                  displayName: Michelin Europe
+                  enabled: true
+                  sandbox: false
+                  connectTimeoutMillis: 5000
+                  readTimeoutMillis: 30000
+                  maxRetries: 2
+                  retryBackoff: EXPONENTIAL
         required: true
       responses:
         '200':
@@ -124,8 +181,28 @@ paths:
       tags:
       - Supplier Vendor Profiles
       summary: Delete vendor profile
-      description: Delete a vendor profile and its child configuration; rejected for YAML-managed profiles
-      operationId: deleteProfile
+      description: 'Deletes a vendor profile together with its accounts, auth config and endpoint bindings.
+
+        Use this tool only when a supplier connection is being retired permanently; to stop traffic while
+
+        keeping the configuration, call updateVendorProfile with enabled cleared instead.
+
+        Preconditions: the profile must exist and must be ADMIN-managed, because YAML-managed profiles
+
+        are owned by the deployment configuration.
+
+        Required inputs: vendorProfileId (UUIDv7) path parameter; there is no request body and no
+
+        confirmation flag.
+
+        Emits a SUPPLIER_PROFILE_DELETE audit event and cascades to the profile''s child configuration;
+
+        exchange audit records already written are retained.
+
+        Returns 404 when the profile does not exist and 409 when it is YAML-managed.
+
+        '
+      operationId: deleteVendorProfile
       parameters:
       - name: vendorProfileId
         in: path
@@ -167,8 +244,36 @@ paths:
       tags:
       - Supplier Endpoint Bindings
       summary: Update endpoint binding
-      description: Replace an endpoint binding
-      operationId: updateBinding
+      description: 'Replaces every settable field of an endpoint binding, including its capability, adapter version,
+
+        URL, auth config, schedule, enabled flag and audit capture level.
+
+        Use this tool to repoint a capability or take it out of service by clearing enabled; do not use
+
+        it to bind a second capability, which is createEndpointBinding.
+
+        Preconditions: the profile must exist and be ADMIN-managed, the binding must belong to it, and a
+
+        changed capability must not already be bound elsewhere on the profile.
+
+        Required inputs: vendorProfileId and bindingId (UUIDv7) path parameters plus the full body,
+
+        because every field is replaced; omitting captureLevel resets it to the deployment default rather
+
+        than leaving the stored value.
+
+        Emits a SUPPLIER_BINDING_UPDATE audit event; a disabled binding immediately reports the typed
+
+        CAPABILITY_NOT_CONFIGURED outcome with HTTP 200 rather than failing.
+
+        Returns 404 when the profile or binding does not exist, 409 when the profile is YAML-managed or
+
+        the capability is already bound, and 400 when the capability, protocol family or auth config name
+
+        is unknown.
+
+        '
+      operationId: updateEndpointBinding
       parameters:
       - name: vendorProfileId
         in: path
@@ -187,10 +292,23 @@ paths:
           format: uuid
           example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a60
       requestBody:
+        description: Endpoint binding to store in place of the existing one, mapping one capability to a vendor endpoint.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/EndpointBindingRequest'
+            examples:
+              Stock inquiry over EDIWHEEL A2.5:
+                description: Stock inquiry over EDIWHEEL A2.5
+                value:
+                  capability: STOCK_INQUIRY
+                  protocolFamily: EDIWHEEL_A25
+                  version: A2_5
+                  baseUrl: https://edi.michelin.example/a25
+                  path: /stock/inquiry
+                  authConfigName: ediwheel-basic
+                  enabled: true
+                  captureLevel: REDACTED
         required: true
       responses:
         '200':
@@ -233,8 +351,28 @@ paths:
       tags:
       - Supplier Endpoint Bindings
       summary: Delete endpoint binding
-      description: Remove a binding, disabling its capability for the profile
-      operationId: deleteBinding
+      description: 'Removes an endpoint binding, which disables that one capability for the vendor profile.
+
+        Use this tool when a capability is retired for a supplier; to pause it while keeping the
+
+        configuration, call updateEndpointBinding with enabled cleared instead, since a disabled binding
+
+        behaves exactly as an absent one.
+
+        Preconditions: the profile must exist and be ADMIN-managed, and the binding must belong to it.
+
+        Required inputs: vendorProfileId and bindingId (UUIDv7) path parameters; there is no request
+
+        body.
+
+        Emits a SUPPLIER_BINDING_DELETE audit event; the capability then resolves to the typed
+
+        CAPABILITY_NOT_CONFIGURED outcome, and exchange audit rows already written are retained.
+
+        Returns 404 when the profile or binding does not exist, and 409 when the profile is YAML-managed.
+
+        '
+      operationId: deleteEndpointBinding
       parameters:
       - name: vendorProfileId
         in: path
@@ -284,7 +422,35 @@ paths:
       tags:
       - Supplier Auth Configs
       summary: Update auth config
-      description: Replace an auth config; renaming while endpoint bindings reference it is rejected
+      description: 'Replaces the name, credential scheme and secret references of an existing auth config.
+
+        Use this tool to rotate which references a connection resolves or to switch credential scheme; do
+
+        not use it to rename a config that endpoint bindings still reference, because bindings resolve it
+
+        by name and the rename is rejected.
+
+        Preconditions: the profile must exist and be ADMIN-managed, the auth config must belong to it,
+
+        and a new name must be free and unreferenced.
+
+        Required inputs: vendorProfileId and authConfigId (UUIDv7) path parameters plus the full body,
+
+        because every field is replaced; omitting a reference field clears it, which fails validation
+
+        when the declared type requires it.
+
+        Emits a SUPPLIER_AUTHCONFIG_UPDATE audit event; the new references take effect on the next
+
+        outbound call, and the response omits every reference value.
+
+        Returns 404 when the profile or config does not exist, 409 when the profile is YAML-managed or
+
+        the name is in use or still referenced, and 400 when the reference set does not match the
+
+        declared type.
+
+        '
       operationId: updateAuthConfig
       parameters:
       - name: vendorProfileId
@@ -304,10 +470,21 @@ paths:
           format: uuid
           example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a61
       requestBody:
+        description: Auth config to store in place of the existing one. Every secret field is a reference, never a plaintext credential.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AuthConfigRequest'
+            examples:
+              Basic auth plus API key:
+                description: Basic auth plus API key
+                value:
+                  name: ediwheel-basic
+                  type: BASIC_PLUS_APIKEY
+                  usernameRef: env:MICHELIN_EDI_USER
+                  passwordRef: env:MICHELIN_EDI_PASSWORD
+                  apiKeyRef: env:MICHELIN_EDI_APIKEY
+                  apiKeyHeader: apikey
         required: true
       responses:
         '200':
@@ -350,7 +527,31 @@ paths:
       tags:
       - Supplier Auth Configs
       summary: Delete auth config
-      description: Remove an auth config; rejected while endpoint bindings still reference it
+      description: 'Removes an auth config from a vendor profile.
+
+        Use this tool when a credential scheme is retired; do not call it to rotate credentials, where
+
+        updateAuthConfig repoints the references instead, and repoint or delete the endpoint bindings
+
+        that name it first, because deletion is rejected while any binding still references it.
+
+        Preconditions: the profile must exist and be ADMIN-managed, the config must belong to it, and no
+
+        endpoint binding may reference it.
+
+        Required inputs: vendorProfileId and authConfigId (UUIDv7) path parameters; there is no request
+
+        body.
+
+        Emits a SUPPLIER_AUTHCONFIG_DELETE audit event; the referenced secrets themselves are untouched,
+
+        since only the reference is stored here.
+
+        Returns 404 when the profile or config does not exist, and 409 when the profile is YAML-managed
+
+        or a binding still references the config.
+
+        '
       operationId: deleteAuthConfig
       parameters:
       - name: vendorProfileId
@@ -401,8 +602,34 @@ paths:
       tags:
       - Supplier Commercial Accounts
       summary: Update commercial account
-      description: Replace a commercial account
-      operationId: updateAccount
+      description: 'Replaces the role, account number, agency code and location mapping of an existing commercial
+
+        account.
+
+        Use this tool to correct a vendor-assigned account number or move a DELIVERY account to another
+
+        location; do not use it to add a second account, which is createCommercialAccount.
+
+        Preconditions: the profile must exist and be ADMIN-managed, the account must belong to that
+
+        profile, and the target slot must not already be occupied by another account.
+
+        Required inputs: vendorProfileId and accountId (UUIDv7) path parameters plus the full body,
+
+        because every field is replaced; omitting agencyCode clears it.
+
+        Emits a SUPPLIER_ACCOUNT_UPDATE audit event; orders already transmitted under the previous
+
+        account number are unaffected.
+
+        Returns 404 when the profile or account does not exist, 409 when the profile is YAML-managed or
+
+        the account slot is taken, and 400 when accountNumber is blank or deliveryLocationId does not
+
+        match the role.
+
+        '
+      operationId: updateCommercialAccount
       parameters:
       - name: vendorProfileId
         in: path
@@ -421,10 +648,19 @@ paths:
           format: uuid
           example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a62
       requestBody:
+        description: Commercial account to store in place of the existing one on the vendor profile.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CommercialAccountRequest'
+            examples:
+              Delivery account for one location:
+                description: Delivery account for one location
+                value:
+                  role: DELIVERY
+                  accountNumber: FR-0042871
+                  agencyCode: PAR01
+                  deliveryLocationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a70
         required: true
       responses:
         '200':
@@ -467,8 +703,28 @@ paths:
       tags:
       - Supplier Commercial Accounts
       summary: Delete commercial account
-      description: Remove a commercial account
-      operationId: deleteAccount
+      description: 'Removes a commercial account from a vendor profile, freeing its BILLING or per-location DELIVERY
+
+        slot.
+
+        Use this tool when a location stops ordering from the supplier; to change the account number
+
+        instead, call updateCommercialAccount, which preserves the slot.
+
+        Preconditions: the profile must exist and be ADMIN-managed, and the account must belong to that
+
+        profile.
+
+        Required inputs: vendorProfileId and accountId (UUIDv7) path parameters; there is no request body.
+
+        Emits a SUPPLIER_ACCOUNT_DELETE audit event; ordering for the mapped location resolves to a
+
+        not-configured outcome from that point on.
+
+        Returns 404 when the profile or account does not exist, and 409 when the profile is YAML-managed.
+
+        '
+      operationId: deleteCommercialAccount
       parameters:
       - name: vendorProfileId
         in: path
@@ -518,8 +774,28 @@ paths:
       tags:
       - Supplier Vendor Profiles
       summary: List vendor profiles
-      description: All vendor profiles, ordered by supplierRef
-      operationId: listProfiles
+      description: 'Returns every configured vendor profile, ordered by supplierRef, with its enabled, sandbox and
+
+        source-of-truth state.
+
+        Use this tool to discover a vendorProfileId before working with accounts, auth config or
+
+        bindings; use getVendorProfile instead when the id is already known.
+
+        Preconditions: none; the list is unfiltered and includes both ADMIN-managed and YAML-managed
+
+        profiles.
+
+        Required inputs: none, and there is no request body, paging or filtering.
+
+        Emits a SUPPLIER_PROFILE_LIST audit event; no configuration is changed.
+
+        Returns 200 with an empty array when nothing is configured, so an empty result is not an error
+
+        condition.
+
+        '
+      operationId: listVendorProfiles
       responses:
         '200':
           description: Profiles returned.
@@ -545,13 +821,52 @@ paths:
       tags:
       - Supplier Vendor Profiles
       summary: Create vendor profile
-      description: Create an ADMIN-managed vendor profile; supplierRef must be unique
-      operationId: createProfile
+      description: 'Creates an ADMIN-managed vendor profile, the row that carries one supplier connection and owns
+
+        its accounts, auth config and endpoint bindings.
+
+        Use this tool when onboarding a new supplier connection; do not use it to change an existing
+
+        profile, which is updateVendorProfile, and note that YAML-managed profiles cannot be created
+
+        here at all.
+
+        Preconditions: supplierRef must not already be in use by another profile.
+
+        Required inputs: supplierRef and displayName, both non-blank, plus the enabled and sandbox flags;
+
+        timeouts, maxRetries, retryBackoff and sandboxBaseUrlOverride are optional and fall back to the
+
+        deployment defaults when omitted.
+
+        Emits a SUPPLIER_PROFILE_CREATE audit event; the profile is created with no bindings, so it
+
+        resolves every capability to a not-configured outcome until bindings are added.
+
+        Returns 409 when supplierRef is already in use, and 400 when supplierRef or displayName are blank
+
+        or a timeout value is not greater than zero.
+
+        '
+      operationId: createVendorProfile
       requestBody:
+        description: Vendor profile to create; the configuration source is always ADMIN.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/VendorProfileRequest'
+            examples:
+              Enabled production profile:
+                description: Enabled production profile
+                value:
+                  supplierRef: michelin-eu
+                  displayName: Michelin Europe
+                  enabled: true
+                  sandbox: false
+                  connectTimeoutMillis: 5000
+                  readTimeoutMillis: 30000
+                  maxRetries: 2
+                  retryBackoff: EXPONENTIAL
         required: true
       responses:
         '201':
@@ -589,8 +904,26 @@ paths:
       tags:
       - Supplier Endpoint Bindings
       summary: List endpoint bindings
-      description: Bindings of a vendor profile, ordered by capability
-      operationId: listBindings
+      description: 'Returns the capability endpoint bindings of a vendor profile, ordered by capability, each with
+
+        its protocol family, version, URL, auth config name and enabled flag.
+
+        Use this tool to see which capabilities a supplier actually resolves; do not infer availability
+
+        from the profile itself, because an absent or disabled binding disables just that capability.
+
+        Preconditions: the vendor profile must exist.
+
+        Required inputs: vendorProfileId (UUIDv7) path parameter; there is no request body or filtering.
+
+        Emits a SUPPLIER_BINDING_LIST audit event; no configuration is changed.
+
+        Returns 404 when the vendor profile does not exist, and 200 with an empty array when the profile
+
+        has no bindings, which means every capability is unconfigured.
+
+        '
+      operationId: listEndpointBindings
       parameters:
       - name: vendorProfileId
         in: path
@@ -631,8 +964,36 @@ paths:
       tags:
       - Supplier Endpoint Bindings
       summary: Create endpoint binding
-      description: Bind a capability to (protocolFamily, version, baseUrl, path, authConfigName)
-      operationId: createBinding
+      description: 'Binds one supplier capability on a vendor profile to a protocol family, adapter version, URL and
+
+        auth config, which is what makes that capability resolve at call time.
+
+        Use this tool when enabling a capability for a supplier; do not use it to change an existing
+
+        binding, which is updateEndpointBinding, since at most one binding per capability may exist.
+
+        Preconditions: the profile must exist and be ADMIN-managed, the capability must not already be
+
+        bound on it, and authConfigName must name an auth config on the same profile.
+
+        Required inputs: vendorProfileId (UUIDv7) path parameter plus capability, protocolFamily,
+
+        version, baseUrl, path and authConfigName; version is not validated on write, so a key with no
+
+        registered codec is accepted and then resolves to CAPABILITY_NOT_CONFIGURED on every call.
+
+        Emits a SUPPLIER_BINDING_CREATE audit event; captureLevel and the redaction classifications
+
+        decide what the exchange-audit trail retains for this binding from now on.
+
+        Returns 404 when the profile does not exist, 409 when the profile is YAML-managed or the
+
+        capability is already bound, and 400 when the capability, protocol family or auth config name is
+
+        unknown.
+
+        '
+      operationId: createEndpointBinding
       parameters:
       - name: vendorProfileId
         in: path
@@ -643,10 +1004,23 @@ paths:
           format: uuid
           example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
       requestBody:
+        description: Endpoint binding to add to the vendor profile, mapping one capability to a vendor endpoint.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/EndpointBindingRequest'
+            examples:
+              Stock inquiry over EDIWHEEL A2.5:
+                description: Stock inquiry over EDIWHEEL A2.5
+                value:
+                  capability: STOCK_INQUIRY
+                  protocolFamily: EDIWHEEL_A25
+                  version: A2_5
+                  baseUrl: https://edi.michelin.example/a25
+                  path: /stock/inquiry
+                  authConfigName: ediwheel-basic
+                  enabled: true
+                  captureLevel: REDACTED
         required: true
       responses:
         '201':
@@ -690,7 +1064,25 @@ paths:
       tags:
       - Supplier Auth Configs
       summary: List auth configs
-      description: Auth configs of a vendor profile, ordered by name
+      description: 'Returns the auth configs of a vendor profile, ordered by name, showing the credential scheme and
+
+        which reference fields are populated.
+
+        Use this tool to find the auth config name an endpoint binding should reference; do not use it to
+
+        read credentials, because secret references are write-only and never appear in a response.
+
+        Preconditions: the vendor profile must exist.
+
+        Required inputs: vendorProfileId (UUIDv7) path parameter; there is no request body or filtering.
+
+        Emits a SUPPLIER_AUTHCONFIG_LIST audit event; no configuration is changed.
+
+        Returns 404 when the vendor profile does not exist, and 200 with an empty array when the profile
+
+        has no auth configs.
+
+        '
       operationId: listAuthConfigs
       parameters:
       - name: vendorProfileId
@@ -732,7 +1124,37 @@ paths:
       tags:
       - Supplier Auth Configs
       summary: Create auth config
-      description: Add an auth config to a vendor profile; secret fields are references, never plaintext
+      description: 'Adds a named auth config to a vendor profile, describing one credential scheme as a set of secret
+
+        references resolved at call time.
+
+        Use this tool when a supplier connection needs credentials; do not put plaintext credentials in
+
+        any field, because every secret field takes a scheme-prefixed reference such as env:VAR_NAME and
+
+        plaintext is rejected.
+
+        Preconditions: the profile must exist and be ADMIN-managed, and the name must not already be used
+
+        by another auth config on the same profile.
+
+        Required inputs: vendorProfileId (UUIDv7) path parameter plus name and type in the body; the type
+
+        fixes which reference fields are required and which must be absent, so BASIC_PLUS_APIKEY needs
+
+        usernameRef, passwordRef and apiKeyRef while OAUTH2_CLIENT_CREDENTIALS needs tokenUrlRef,
+
+        clientIdRef and clientSecretRef.
+
+        Emits a SUPPLIER_AUTHCONFIG_CREATE audit event; the response omits every reference value.
+
+        Returns 404 when the profile does not exist, 409 when the profile is YAML-managed or the name is
+
+        taken, and 400 when the reference set does not match the declared type or a reference is
+
+        malformed.
+
+        '
       operationId: createAuthConfig
       parameters:
       - name: vendorProfileId
@@ -744,10 +1166,21 @@ paths:
           format: uuid
           example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
       requestBody:
+        description: Auth config to add to the vendor profile. Every secret field is a reference, never a plaintext credential.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AuthConfigRequest'
+            examples:
+              Basic auth plus API key:
+                description: Basic auth plus API key
+                value:
+                  name: ediwheel-basic
+                  type: BASIC_PLUS_APIKEY
+                  usernameRef: env:MICHELIN_EDI_USER
+                  passwordRef: env:MICHELIN_EDI_PASSWORD
+                  apiKeyRef: env:MICHELIN_EDI_APIKEY
+                  apiKeyHeader: apikey
         required: true
       responses:
         '201':
@@ -791,8 +1224,28 @@ paths:
       tags:
       - Supplier Commercial Accounts
       summary: List commercial accounts
-      description: Accounts of a vendor profile, billing first
-      operationId: listAccounts
+      description: 'Returns the commercial accounts configured on a vendor profile, the BILLING account first and
+
+        then the per-location DELIVERY accounts.
+
+        Use this tool to find the accountId or the vendor account number for a location; do not use it to
+
+        read credentials, which are never returned here because account numbers are ordinary
+
+        configuration data.
+
+        Preconditions: the vendor profile must exist.
+
+        Required inputs: vendorProfileId (UUIDv7) path parameter; there is no request body or filtering.
+
+        Emits a SUPPLIER_ACCOUNT_LIST audit event; no configuration is changed.
+
+        Returns 404 when the vendor profile does not exist, and 200 with an empty array when the profile
+
+        exists but has no accounts.
+
+        '
+      operationId: listCommercialAccounts
       parameters:
       - name: vendorProfileId
         in: path
@@ -833,8 +1286,34 @@ paths:
       tags:
       - Supplier Commercial Accounts
       summary: Create commercial account
-      description: Add a billing or delivery account; delivery accounts carry the pos-location mapping
-      operationId: createAccount
+      description: 'Adds a commercial account to a vendor profile, either the profile''s single BILLING account or a
+
+        DELIVERY account mapping one pos-location to its vendor account number.
+
+        Use this tool when a location is first authorised to order from a supplier; do not use it to
+
+        correct an account number, which is updateCommercialAccount.
+
+        Preconditions: the vendor profile must exist and be ADMIN-managed, and the slot must be free —
+
+        one BILLING account per profile and one DELIVERY account per profile and location pair.
+
+        Required inputs: vendorProfileId (UUIDv7) path parameter plus role and accountNumber in the body;
+
+        deliveryLocationId is required for DELIVERY and must be absent for BILLING, and agencyCode is
+
+        optional.
+
+        Emits a SUPPLIER_ACCOUNT_CREATE audit event; no order or invoice records are touched.
+
+        Returns 404 when the profile does not exist, 409 when the profile is YAML-managed or the account
+
+        slot is already taken, and 400 when accountNumber is blank or deliveryLocationId does not match
+
+        the role.
+
+        '
+      operationId: createCommercialAccount
       parameters:
       - name: vendorProfileId
         in: path
@@ -845,10 +1324,19 @@ paths:
           format: uuid
           example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
       requestBody:
+        description: Commercial account to create on the vendor profile.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CommercialAccountRequest'
+            examples:
+              Delivery account for one location:
+                description: Delivery account for one location
+                value:
+                  role: DELIVERY
+                  accountNumber: FR-0042871
+                  agencyCode: PAR01
+                  deliveryLocationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a70
         required: true
       responses:
         '201':
@@ -892,8 +1380,32 @@ paths:
       tags:
       - Supplier Exchange Audit
       summary: List supplier exchanges in a window
-      description: 'Exchange metadata for one vendor profile within a half-open time window (from inclusive, to exclusive), newest first. Payload content is NOT included and nothing is recorded: browsing the trail discloses no commercial content. Rows whose stored content cannot be decrypted still list normally, because this query never touches the encrypted columns.'
-      operationId: listExchanges
+      description: 'Returns a page of exchange-audit metadata for one vendor profile within a half-open time window,
+
+        newest first.
+
+        Use this tool to find the exchangeAuditId of a supplier call; use traceSupplierCorrelation instead
+
+        when every attempt of one logical call is wanted, and do not expect payload content here.
+
+        Preconditions: the caller must hold supplier:audit:read, which supplier:profile:read does not
+
+        imply; the vendor profile need not still exist, because audit history outlives configuration.
+
+        Required inputs: vendorProfileId, from (inclusive) and to (exclusive) as ISO-8601 instants;
+
+        capability is optional, page defaults to 0 and size defaults to 50 with a maximum of 200.
+
+        Emits a SUPPLIER_AUDIT_EXCHANGE_LIST event; no payload content is served, so no access row is
+
+        written against the exchanges listed.
+
+        Returns 400 when the window end is not after its start, the capability key is unrecognised, or the
+
+        page size is out of range.
+
+        '
+      operationId: listSupplierExchanges
       parameters:
       - name: vendorProfileId
         in: query
@@ -973,8 +1485,22 @@ paths:
       tags:
       - Supplier Exchange Audit
       summary: Get one exchange's audit metadata
-      description: Metadata of a single attempt, without payload content. Use this to decide whether content exists (requestPayloadPresent / responsePayloadPresent) before making the recorded payload call.
-      operationId: getExchange
+      description: 'Returns the metadata of a single supplier exchange attempt, without any payload content.
+
+        Use this tool to check requestPayloadPresent and responsePayloadPresent before calling
+
+        readSupplierExchangePayload, which is recorded; do not use it to read the documents themselves.
+
+        Preconditions: the caller must hold supplier:audit:read and the exchange-audit record must exist.
+
+        Required inputs: exchangeAuditId (UUIDv7) path parameter; there is no request body.
+
+        Emits a SUPPLIER_AUDIT_EXCHANGE_GET event; because no content is served, no access row is written.
+
+        Returns 404 when no exchange-audit record has that id.
+
+        '
+      operationId: getSupplierExchange
       parameters:
       - name: exchangeAuditId
         in: path
@@ -1014,8 +1540,36 @@ paths:
       tags:
       - Supplier Exchange Audit
       summary: Read one exchange's stored payload content
-      description: 'Returns the stored request and response documents. THIS CALL IS ITSELF RECORDED (ADR-0050 §7): an access row naming the caller is written in the same transaction, and the content is withheld if that row cannot be written. Null payload fields are a normal state, not an error — a METADATA_ONLY binding captured none, the exchange carried no body, or retention has already purged the content after 400 days. When ''redacted'' is true the documents are not the wire bytes: sensitive fields were replaced at capture time and the originals were never stored.'
-      operationId: readPayload
+      description: 'Returns the stored request and response documents of one supplier exchange.
+
+        Use this tool only when the documents themselves are needed; use getSupplierExchange instead for
+
+        routine inspection, because this call is itself recorded and each read adds an access row naming the
+
+        caller.
+
+        Preconditions: the caller must hold supplier:audit:read, the record must exist, and the access row
+
+        must be writable, since content is withheld when it cannot be written.
+
+        Required inputs: exchangeAuditId (UUIDv7) path parameter; there is no request body and no way to
+
+        request the unredacted originals.
+
+        Emits a SUPPLIER_AUDIT_PAYLOAD_READ event and writes an access row in the same transaction; null
+
+        payload fields are normal, meaning a METADATA_ONLY binding, a bodiless exchange, or content already
+
+        purged after 400 days, and a redacted flag means sensitive fields were replaced at capture time so
+
+        the originals were never stored.
+
+        Returns 404 when no record has that id, and 500 when stored content exists but cannot be decrypted,
+
+        in which case the read is still recorded with an UNREADABLE outcome.
+
+        '
+      operationId: readSupplierExchangePayload
       parameters:
       - name: exchangeAuditId
         in: path
@@ -1061,8 +1615,30 @@ paths:
       tags:
       - Supplier Exchange Audit
       summary: List who read one exchange's payload content
-      description: 'The ADR-0050 §7 access trail for one exchange, newest first: who read it, when, and what the read yielded. Only payload reads appear here. Metadata browsing does not, and neither do denied attempts — a 403 disclosed nothing. Reading this trail is not itself recorded, or every inspection would generate the noise the next one has to sift.'
-      operationId: listAccesses
+      description: 'Returns the access trail for one exchange, newest first: who read its payload, when, and what the
+
+        read yielded.
+
+        Use this tool to audit who has seen a trading partner''s documents; do not expect metadata browsing
+
+        or denied attempts here, because a 403 disclosed nothing and is deliberately not recorded.
+
+        Preconditions: the caller must hold supplier:audit:read; an unknown exchangeAuditId returns an
+
+        empty page rather than 404, because access rows carry no foreign key to the exchange.
+
+        Required inputs: exchangeAuditId (UUIDv7) path parameter; page defaults to 0 and size defaults to
+
+        50 with a maximum of 200.
+
+        Emits a SUPPLIER_AUDIT_ACCESS_LIST event; reading this trail is not itself recorded, or every
+
+        inspection would generate the noise the next one has to sift.
+
+        Returns 400 when the page size is outside the permitted range.
+
+        '
+      operationId: listSupplierExchangeAccesses
       parameters:
       - name: exchangeAuditId
         in: path
@@ -1119,8 +1695,28 @@ paths:
       tags:
       - Supplier Exchange Audit
       summary: Trace one logical call by correlation id
-      description: Every attempt sharing a correlation id, OLDEST FIRST — the order in which a retry sequence actually happened. Metadata only; nothing is recorded.
-      operationId: traceCorrelation
+      description: 'Returns every exchange attempt sharing one correlation id, oldest first, which is the order in
+
+        which a retry sequence actually happened.
+
+        Use this tool when a single logical supplier call needs to be reconstructed across its retries; use
+
+        listSupplierExchanges instead to search a time window.
+
+        Preconditions: the caller must hold supplier:audit:read; an unknown correlation id is not an error
+
+        and yields an empty page.
+
+        Required inputs: correlationId path parameter; page defaults to 0 and size defaults to 50 with a
+
+        maximum of 200.
+
+        Emits a SUPPLIER_AUDIT_EXCHANGE_TRACE event; metadata only, so no payload access is recorded.
+
+        Returns 400 when the page size is outside the permitted range.
+
+        '
+      operationId: traceSupplierCorrelation
       parameters:
       - name: correlationId
         in: path

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierAccountAdminController.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierAccountAdminController.java
@@ -9,6 +9,7 @@ import com.positivity.supplier.service.model.CommercialAccountView;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -46,9 +47,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/supplier/admin/profiles/{vendorProfileId}/accounts")
 public class SupplierAccountAdminController {
 
+    private static final String ACCOUNT_EXAMPLE = """
+            {"role":"DELIVERY","accountNumber":"FR-0042871","agencyCode":"PAR01",
+             "deliveryLocationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a70"}
+            """;
+
     private final SupplierProfileAdminService adminService;
 
-    @Operation(summary = "List commercial accounts", description = "Accounts of a vendor profile, billing first")
+    @Operation(operationId = "listCommercialAccounts", summary = "List commercial accounts", description = """
+                    Returns the commercial accounts configured on a vendor profile, the BILLING account first and
+                    then the per-location DELIVERY accounts.
+                    Use this tool to find the accountId or the vendor account number for a location; do not use it to
+                    read credentials, which are never returned here because account numbers are ordinary
+                    configuration data.
+                    Preconditions: the vendor profile must exist.
+                    Required inputs: vendorProfileId (UUIDv7) path parameter; there is no request body or filtering.
+                    Emits a SUPPLIER_ACCOUNT_LIST audit event; no configuration is changed.
+                    Returns 404 when the vendor profile does not exist, and 200 with an empty array when the profile
+                    exists but has no accounts.
+                    """)
     @ApiResponse(responseCode = "200", description = "Accounts returned.")
     @ApiResponse(
             responseCode = "404",
@@ -83,9 +100,21 @@ public class SupplierAccountAdminController {
         return ResponseEntity.ok(adminService.listAccounts(vendorProfileId));
     }
 
-    @Operation(
-            summary = "Create commercial account",
-            description = "Add a billing or delivery account; delivery accounts carry the pos-location mapping")
+    @Operation(operationId = "createCommercialAccount", summary = "Create commercial account", description = """
+                    Adds a commercial account to a vendor profile, either the profile's single BILLING account or a
+                    DELIVERY account mapping one pos-location to its vendor account number.
+                    Use this tool when a location is first authorised to order from a supplier; do not use it to
+                    correct an account number, which is updateCommercialAccount.
+                    Preconditions: the vendor profile must exist and be ADMIN-managed, and the slot must be free —
+                    one BILLING account per profile and one DELIVERY account per profile and location pair.
+                    Required inputs: vendorProfileId (UUIDv7) path parameter plus role and accountNumber in the body;
+                    deliveryLocationId is required for DELIVERY and must be absent for BILLING, and agencyCode is
+                    optional.
+                    Emits a SUPPLIER_ACCOUNT_CREATE audit event; no order or invoice records are touched.
+                    Returns 404 when the profile does not exist, 409 when the profile is YAML-managed or the account
+                    slot is already taken, and 400 when accountNumber is blank or deliveryLocationId does not match
+                    the role.
+                    """)
     @ApiResponse(responseCode = "201", description = "Account created.")
     @ApiResponse(
             responseCode = "400",
@@ -125,11 +154,38 @@ public class SupplierAccountAdminController {
                     @PathVariable
                     @NotNull
                     UUID vendorProfileId,
-            @Valid @NotNull @RequestBody CommercialAccountRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Commercial account to create on the vendor profile.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Delivery account for one location",
+                                                            value = ACCOUNT_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    CommercialAccountRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(adminService.createAccount(vendorProfileId, request));
     }
 
-    @Operation(summary = "Update commercial account", description = "Replace a commercial account")
+    @Operation(operationId = "updateCommercialAccount", summary = "Update commercial account", description = """
+                    Replaces the role, account number, agency code and location mapping of an existing commercial
+                    account.
+                    Use this tool to correct a vendor-assigned account number or move a DELIVERY account to another
+                    location; do not use it to add a second account, which is createCommercialAccount.
+                    Preconditions: the profile must exist and be ADMIN-managed, the account must belong to that
+                    profile, and the target slot must not already be occupied by another account.
+                    Required inputs: vendorProfileId and accountId (UUIDv7) path parameters plus the full body,
+                    because every field is replaced; omitting agencyCode clears it.
+                    Emits a SUPPLIER_ACCOUNT_UPDATE audit event; orders already transmitted under the previous
+                    account number are unaffected.
+                    Returns 404 when the profile or account does not exist, 409 when the profile is YAML-managed or
+                    the account slot is taken, and 400 when accountNumber is blank or deliveryLocationId does not
+                    match the role.
+                    """)
     @ApiResponse(responseCode = "200", description = "Account updated.")
     @ApiResponse(
             responseCode = "400",
@@ -181,11 +237,36 @@ public class SupplierAccountAdminController {
                     @PathVariable
                     @NotNull
                     UUID accountId,
-            @Valid @NotNull @RequestBody CommercialAccountRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Commercial account to store in place of the existing one on the vendor profile.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Delivery account for one location",
+                                                            value = ACCOUNT_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    CommercialAccountRequest request) {
         return ResponseEntity.ok(adminService.updateAccount(vendorProfileId, accountId, request));
     }
 
-    @Operation(summary = "Delete commercial account", description = "Remove a commercial account")
+    @Operation(operationId = "deleteCommercialAccount", summary = "Delete commercial account", description = """
+                    Removes a commercial account from a vendor profile, freeing its BILLING or per-location DELIVERY
+                    slot.
+                    Use this tool when a location stops ordering from the supplier; to change the account number
+                    instead, call updateCommercialAccount, which preserves the slot.
+                    Preconditions: the profile must exist and be ADMIN-managed, and the account must belong to that
+                    profile.
+                    Required inputs: vendorProfileId and accountId (UUIDv7) path parameters; there is no request body.
+                    Emits a SUPPLIER_ACCOUNT_DELETE audit event; ordering for the mapped location resolves to a
+                    not-configured outcome from that point on.
+                    Returns 404 when the profile or account does not exist, and 409 when the profile is YAML-managed.
+                    """)
     @ApiResponse(responseCode = "204", description = "Account deleted.")
     @ApiResponse(
             responseCode = "404",

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierAuthConfigAdminController.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierAuthConfigAdminController.java
@@ -9,6 +9,7 @@ import com.positivity.supplier.service.model.AuthConfigView;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -47,9 +48,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/supplier/admin/profiles/{vendorProfileId}/auth-configs")
 public class SupplierAuthConfigAdminController {
 
+    private static final String AUTH_CONFIG_EXAMPLE = """
+            {"name":"ediwheel-basic","type":"BASIC_PLUS_APIKEY","usernameRef":"env:MICHELIN_EDI_USER",
+             "passwordRef":"env:MICHELIN_EDI_PASSWORD","apiKeyRef":"env:MICHELIN_EDI_APIKEY","apiKeyHeader":"apikey"}
+            """;
+
     private final SupplierProfileAdminService adminService;
 
-    @Operation(summary = "List auth configs", description = "Auth configs of a vendor profile, ordered by name")
+    @Operation(operationId = "listAuthConfigs", summary = "List auth configs", description = """
+                    Returns the auth configs of a vendor profile, ordered by name, showing the credential scheme and
+                    which reference fields are populated.
+                    Use this tool to find the auth config name an endpoint binding should reference; do not use it to
+                    read credentials, because secret references are write-only and never appear in a response.
+                    Preconditions: the vendor profile must exist.
+                    Required inputs: vendorProfileId (UUIDv7) path parameter; there is no request body or filtering.
+                    Emits a SUPPLIER_AUTHCONFIG_LIST audit event; no configuration is changed.
+                    Returns 404 when the vendor profile does not exist, and 200 with an empty array when the profile
+                    has no auth configs.
+                    """)
     @ApiResponse(responseCode = "200", description = "Auth configs returned.")
     @ApiResponse(
             responseCode = "404",
@@ -84,9 +100,23 @@ public class SupplierAuthConfigAdminController {
         return ResponseEntity.ok(adminService.listAuthConfigs(vendorProfileId));
     }
 
-    @Operation(
-            summary = "Create auth config",
-            description = "Add an auth config to a vendor profile; secret fields are references, never plaintext")
+    @Operation(operationId = "createAuthConfig", summary = "Create auth config", description = """
+                    Adds a named auth config to a vendor profile, describing one credential scheme as a set of secret
+                    references resolved at call time.
+                    Use this tool when a supplier connection needs credentials; do not put plaintext credentials in
+                    any field, because every secret field takes a scheme-prefixed reference such as env:VAR_NAME and
+                    plaintext is rejected.
+                    Preconditions: the profile must exist and be ADMIN-managed, and the name must not already be used
+                    by another auth config on the same profile.
+                    Required inputs: vendorProfileId (UUIDv7) path parameter plus name and type in the body; the type
+                    fixes which reference fields are required and which must be absent, so BASIC_PLUS_APIKEY needs
+                    usernameRef, passwordRef and apiKeyRef while OAUTH2_CLIENT_CREDENTIALS needs tokenUrlRef,
+                    clientIdRef and clientSecretRef.
+                    Emits a SUPPLIER_AUTHCONFIG_CREATE audit event; the response omits every reference value.
+                    Returns 404 when the profile does not exist, 409 when the profile is YAML-managed or the name is
+                    taken, and 400 when the reference set does not match the declared type or a reference is
+                    malformed.
+                    """)
     @ApiResponse(responseCode = "201", description = "Auth config created (without credential reference values).")
     @ApiResponse(
             responseCode = "400",
@@ -126,13 +156,41 @@ public class SupplierAuthConfigAdminController {
                     @PathVariable
                     @NotNull
                     UUID vendorProfileId,
-            @Valid @NotNull @RequestBody AuthConfigRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Auth config to add to the vendor profile. Every secret field is a reference, never a plaintext"
+                                            + " credential.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Basic auth plus API key",
+                                                            value = AUTH_CONFIG_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    AuthConfigRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(adminService.createAuthConfig(vendorProfileId, request));
     }
 
-    @Operation(
-            summary = "Update auth config",
-            description = "Replace an auth config; renaming while endpoint bindings reference it is rejected")
+    @Operation(operationId = "updateAuthConfig", summary = "Update auth config", description = """
+                    Replaces the name, credential scheme and secret references of an existing auth config.
+                    Use this tool to rotate which references a connection resolves or to switch credential scheme; do
+                    not use it to rename a config that endpoint bindings still reference, because bindings resolve it
+                    by name and the rename is rejected.
+                    Preconditions: the profile must exist and be ADMIN-managed, the auth config must belong to it,
+                    and a new name must be free and unreferenced.
+                    Required inputs: vendorProfileId and authConfigId (UUIDv7) path parameters plus the full body,
+                    because every field is replaced; omitting a reference field clears it, which fails validation
+                    when the declared type requires it.
+                    Emits a SUPPLIER_AUTHCONFIG_UPDATE audit event; the new references take effect on the next
+                    outbound call, and the response omits every reference value.
+                    Returns 404 when the profile or config does not exist, 409 when the profile is YAML-managed or
+                    the name is in use or still referenced, and 400 when the reference set does not match the
+                    declared type.
+                    """)
     @ApiResponse(responseCode = "200", description = "Auth config updated (without credential reference values).")
     @ApiResponse(
             responseCode = "400",
@@ -184,13 +242,39 @@ public class SupplierAuthConfigAdminController {
                     @PathVariable
                     @NotNull
                     UUID authConfigId,
-            @Valid @NotNull @RequestBody AuthConfigRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Auth config to store in place of the existing one. Every secret field is a reference, never a plaintext"
+                                            + " credential.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Basic auth plus API key",
+                                                            value = AUTH_CONFIG_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    AuthConfigRequest request) {
         return ResponseEntity.ok(adminService.updateAuthConfig(vendorProfileId, authConfigId, request));
     }
 
-    @Operation(
-            summary = "Delete auth config",
-            description = "Remove an auth config; rejected while endpoint bindings still reference it")
+    @Operation(operationId = "deleteAuthConfig", summary = "Delete auth config", description = """
+                    Removes an auth config from a vendor profile.
+                    Use this tool when a credential scheme is retired; do not call it to rotate credentials, where
+                    updateAuthConfig repoints the references instead, and repoint or delete the endpoint bindings
+                    that name it first, because deletion is rejected while any binding still references it.
+                    Preconditions: the profile must exist and be ADMIN-managed, the config must belong to it, and no
+                    endpoint binding may reference it.
+                    Required inputs: vendorProfileId and authConfigId (UUIDv7) path parameters; there is no request
+                    body.
+                    Emits a SUPPLIER_AUTHCONFIG_DELETE audit event; the referenced secrets themselves are untouched,
+                    since only the reference is stored here.
+                    Returns 404 when the profile or config does not exist, and 409 when the profile is YAML-managed
+                    or a binding still references the config.
+                    """)
     @ApiResponse(responseCode = "204", description = "Auth config deleted.")
     @ApiResponse(
             responseCode = "404",

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierEndpointBindingAdminController.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierEndpointBindingAdminController.java
@@ -9,6 +9,7 @@ import com.positivity.supplier.service.model.EndpointBindingView;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -48,9 +49,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/supplier/admin/profiles/{vendorProfileId}/bindings")
 public class SupplierEndpointBindingAdminController {
 
+    private static final String BINDING_EXAMPLE = """
+            {"capability":"STOCK_INQUIRY","protocolFamily":"EDIWHEEL_A25","version":"A2_5",
+             "baseUrl":"https://edi.michelin.example/a25","path":"/stock/inquiry",
+             "authConfigName":"ediwheel-basic","enabled":true,"captureLevel":"REDACTED"}
+            """;
+
     private final SupplierProfileAdminService adminService;
 
-    @Operation(summary = "List endpoint bindings", description = "Bindings of a vendor profile, ordered by capability")
+    @Operation(operationId = "listEndpointBindings", summary = "List endpoint bindings", description = """
+                    Returns the capability endpoint bindings of a vendor profile, ordered by capability, each with
+                    its protocol family, version, URL, auth config name and enabled flag.
+                    Use this tool to see which capabilities a supplier actually resolves; do not infer availability
+                    from the profile itself, because an absent or disabled binding disables just that capability.
+                    Preconditions: the vendor profile must exist.
+                    Required inputs: vendorProfileId (UUIDv7) path parameter; there is no request body or filtering.
+                    Emits a SUPPLIER_BINDING_LIST audit event; no configuration is changed.
+                    Returns 404 when the vendor profile does not exist, and 200 with an empty array when the profile
+                    has no bindings, which means every capability is unconfigured.
+                    """)
     @ApiResponse(responseCode = "200", description = "Bindings returned.")
     @ApiResponse(
             responseCode = "404",
@@ -85,9 +102,22 @@ public class SupplierEndpointBindingAdminController {
         return ResponseEntity.ok(adminService.listBindings(vendorProfileId));
     }
 
-    @Operation(
-            summary = "Create endpoint binding",
-            description = "Bind a capability to (protocolFamily, version, baseUrl, path, authConfigName)")
+    @Operation(operationId = "createEndpointBinding", summary = "Create endpoint binding", description = """
+                    Binds one supplier capability on a vendor profile to a protocol family, adapter version, URL and
+                    auth config, which is what makes that capability resolve at call time.
+                    Use this tool when enabling a capability for a supplier; do not use it to change an existing
+                    binding, which is updateEndpointBinding, since at most one binding per capability may exist.
+                    Preconditions: the profile must exist and be ADMIN-managed, the capability must not already be
+                    bound on it, and authConfigName must name an auth config on the same profile.
+                    Required inputs: vendorProfileId (UUIDv7) path parameter plus capability, protocolFamily,
+                    version, baseUrl, path and authConfigName; version is not validated on write, so a key with no
+                    registered codec is accepted and then resolves to CAPABILITY_NOT_CONFIGURED on every call.
+                    Emits a SUPPLIER_BINDING_CREATE audit event; captureLevel and the redaction classifications
+                    decide what the exchange-audit trail retains for this binding from now on.
+                    Returns 404 when the profile does not exist, 409 when the profile is YAML-managed or the
+                    capability is already bound, and 400 when the capability, protocol family or auth config name is
+                    unknown.
+                    """)
     @ApiResponse(responseCode = "201", description = "Binding created.")
     @ApiResponse(
             responseCode = "400",
@@ -128,11 +158,40 @@ public class SupplierEndpointBindingAdminController {
                     @PathVariable
                     @NotNull
                     UUID vendorProfileId,
-            @Valid @NotNull @RequestBody EndpointBindingRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Endpoint binding to add to the vendor profile, mapping one capability to a vendor endpoint.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Stock inquiry over EDIWHEEL A2.5",
+                                                            value = BINDING_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    EndpointBindingRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(adminService.createBinding(vendorProfileId, request));
     }
 
-    @Operation(summary = "Update endpoint binding", description = "Replace an endpoint binding")
+    @Operation(operationId = "updateEndpointBinding", summary = "Update endpoint binding", description = """
+                    Replaces every settable field of an endpoint binding, including its capability, adapter version,
+                    URL, auth config, schedule, enabled flag and audit capture level.
+                    Use this tool to repoint a capability or take it out of service by clearing enabled; do not use
+                    it to bind a second capability, which is createEndpointBinding.
+                    Preconditions: the profile must exist and be ADMIN-managed, the binding must belong to it, and a
+                    changed capability must not already be bound elsewhere on the profile.
+                    Required inputs: vendorProfileId and bindingId (UUIDv7) path parameters plus the full body,
+                    because every field is replaced; omitting captureLevel resets it to the deployment default rather
+                    than leaving the stored value.
+                    Emits a SUPPLIER_BINDING_UPDATE audit event; a disabled binding immediately reports the typed
+                    CAPABILITY_NOT_CONFIGURED outcome with HTTP 200 rather than failing.
+                    Returns 404 when the profile or binding does not exist, 409 when the profile is YAML-managed or
+                    the capability is already bound, and 400 when the capability, protocol family or auth config name
+                    is unknown.
+                    """)
     @ApiResponse(responseCode = "200", description = "Binding updated.")
     @ApiResponse(
             responseCode = "400",
@@ -185,13 +244,36 @@ public class SupplierEndpointBindingAdminController {
                     @PathVariable
                     @NotNull
                     UUID bindingId,
-            @Valid @NotNull @RequestBody EndpointBindingRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Endpoint binding to store in place of the existing one, mapping one capability to a vendor endpoint.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Stock inquiry over EDIWHEEL A2.5",
+                                                            value = BINDING_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    EndpointBindingRequest request) {
         return ResponseEntity.ok(adminService.updateBinding(vendorProfileId, bindingId, request));
     }
 
-    @Operation(
-            summary = "Delete endpoint binding",
-            description = "Remove a binding, disabling its capability for the profile")
+    @Operation(operationId = "deleteEndpointBinding", summary = "Delete endpoint binding", description = """
+                    Removes an endpoint binding, which disables that one capability for the vendor profile.
+                    Use this tool when a capability is retired for a supplier; to pause it while keeping the
+                    configuration, call updateEndpointBinding with enabled cleared instead, since a disabled binding
+                    behaves exactly as an absent one.
+                    Preconditions: the profile must exist and be ADMIN-managed, and the binding must belong to it.
+                    Required inputs: vendorProfileId and bindingId (UUIDv7) path parameters; there is no request
+                    body.
+                    Emits a SUPPLIER_BINDING_DELETE audit event; the capability then resolves to the typed
+                    CAPABILITY_NOT_CONFIGURED outcome, and exchange audit rows already written are retained.
+                    Returns 404 when the profile or binding does not exist, and 409 when the profile is YAML-managed.
+                    """)
     @ApiResponse(responseCode = "204", description = "Binding deleted.")
     @ApiResponse(
             responseCode = "404",

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierExchangeAuditController.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierExchangeAuditController.java
@@ -75,12 +75,22 @@ public class SupplierExchangeAuditController {
     private final SupplierExchangeAuditService auditService;
 
     @Operation(
+            operationId = "listSupplierExchanges",
             summary = "List supplier exchanges in a window",
-            description = "Exchange metadata for one vendor profile within a half-open time window"
-                    + " (from inclusive, to exclusive), newest first. Payload content is NOT included and"
-                    + " nothing is recorded: browsing the trail discloses no commercial content. Rows whose"
-                    + " stored content cannot be decrypted still list normally, because this query never"
-                    + " touches the encrypted columns.")
+            description = """
+                    Returns a page of exchange-audit metadata for one vendor profile within a half-open time window,
+                    newest first.
+                    Use this tool to find the exchangeAuditId of a supplier call; use traceSupplierCorrelation instead
+                    when every attempt of one logical call is wanted, and do not expect payload content here.
+                    Preconditions: the caller must hold supplier:audit:read, which supplier:profile:read does not
+                    imply; the vendor profile need not still exist, because audit history outlives configuration.
+                    Required inputs: vendorProfileId, from (inclusive) and to (exclusive) as ISO-8601 instants;
+                    capability is optional, page defaults to 0 and size defaults to 50 with a maximum of 200.
+                    Emits a SUPPLIER_AUDIT_EXCHANGE_LIST event; no payload content is served, so no access row is
+                    written against the exchanges listed.
+                    Returns 400 when the window end is not after its start, the capability key is unrecognised, or the
+                    page size is out of range.
+                    """)
     @ApiResponse(responseCode = "200", description = "A page of exchange metadata, newest first.")
     @ApiResponse(
             responseCode = "400",
@@ -151,9 +161,20 @@ public class SupplierExchangeAuditController {
     }
 
     @Operation(
+            operationId = "traceSupplierCorrelation",
             summary = "Trace one logical call by correlation id",
-            description = "Every attempt sharing a correlation id, OLDEST FIRST — the order in which a retry"
-                    + " sequence actually happened. Metadata only; nothing is recorded.")
+            description = """
+                    Returns every exchange attempt sharing one correlation id, oldest first, which is the order in
+                    which a retry sequence actually happened.
+                    Use this tool when a single logical supplier call needs to be reconstructed across its retries; use
+                    listSupplierExchanges instead to search a time window.
+                    Preconditions: the caller must hold supplier:audit:read; an unknown correlation id is not an error
+                    and yields an empty page.
+                    Required inputs: correlationId path parameter; page defaults to 0 and size defaults to 50 with a
+                    maximum of 200.
+                    Emits a SUPPLIER_AUDIT_EXCHANGE_TRACE event; metadata only, so no payload access is recorded.
+                    Returns 400 when the page size is outside the permitted range.
+                    """)
     @ApiResponse(responseCode = "200", description = "A page of exchange metadata, oldest first.")
     @ApiResponse(
             responseCode = "400",
@@ -194,11 +215,15 @@ public class SupplierExchangeAuditController {
         return ResponseEntity.ok(auditService.traceCorrelation(correlationId, page, size));
     }
 
-    @Operation(
-            summary = "Get one exchange's audit metadata",
-            description = "Metadata of a single attempt, without payload content. Use this to decide whether"
-                    + " content exists (requestPayloadPresent / responsePayloadPresent) before making the"
-                    + " recorded payload call.")
+    @Operation(operationId = "getSupplierExchange", summary = "Get one exchange's audit metadata", description = """
+                    Returns the metadata of a single supplier exchange attempt, without any payload content.
+                    Use this tool to check requestPayloadPresent and responsePayloadPresent before calling
+                    readSupplierExchangePayload, which is recorded; do not use it to read the documents themselves.
+                    Preconditions: the caller must hold supplier:audit:read and the exchange-audit record must exist.
+                    Required inputs: exchangeAuditId (UUIDv7) path parameter; there is no request body.
+                    Emits a SUPPLIER_AUDIT_EXCHANGE_GET event; because no content is served, no access row is written.
+                    Returns 404 when no exchange-audit record has that id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Exchange metadata returned.")
     @ApiResponse(
             responseCode = "404",
@@ -233,14 +258,24 @@ public class SupplierExchangeAuditController {
     }
 
     @Operation(
+            operationId = "readSupplierExchangePayload",
             summary = "Read one exchange's stored payload content",
-            description = "Returns the stored request and response documents. THIS CALL IS ITSELF RECORDED"
-                    + " (ADR-0050 §7): an access row naming the caller is written in the same transaction, and"
-                    + " the content is withheld if that row cannot be written. Null payload fields are a normal"
-                    + " state, not an error — a METADATA_ONLY binding captured none, the exchange carried no"
-                    + " body, or retention has already purged the content after 400 days. When 'redacted' is"
-                    + " true the documents are not the wire bytes: sensitive fields were replaced at capture"
-                    + " time and the originals were never stored.")
+            description = """
+                    Returns the stored request and response documents of one supplier exchange.
+                    Use this tool only when the documents themselves are needed; use getSupplierExchange instead for
+                    routine inspection, because this call is itself recorded and each read adds an access row naming the
+                    caller.
+                    Preconditions: the caller must hold supplier:audit:read, the record must exist, and the access row
+                    must be writable, since content is withheld when it cannot be written.
+                    Required inputs: exchangeAuditId (UUIDv7) path parameter; there is no request body and no way to
+                    request the unredacted originals.
+                    Emits a SUPPLIER_AUDIT_PAYLOAD_READ event and writes an access row in the same transaction; null
+                    payload fields are normal, meaning a METADATA_ONLY binding, a bodiless exchange, or content already
+                    purged after 400 days, and a redacted flag means sensitive fields were replaced at capture time so
+                    the originals were never stored.
+                    Returns 404 when no record has that id, and 500 when stored content exists but cannot be decrypted,
+                    in which case the read is still recorded with an UNREADABLE outcome.
+                    """)
     @ApiResponse(responseCode = "200", description = "Stored content returned, and the read has been recorded.")
     @ApiResponse(
             responseCode = "404",
@@ -284,11 +319,21 @@ public class SupplierExchangeAuditController {
     }
 
     @Operation(
+            operationId = "listSupplierExchangeAccesses",
             summary = "List who read one exchange's payload content",
-            description = "The ADR-0050 §7 access trail for one exchange, newest first: who read it, when, and"
-                    + " what the read yielded. Only payload reads appear here. Metadata browsing does not, and"
-                    + " neither do denied attempts — a 403 disclosed nothing. Reading this trail is not itself"
-                    + " recorded, or every inspection would generate the noise the next one has to sift.")
+            description = """
+                    Returns the access trail for one exchange, newest first: who read its payload, when, and what the
+                    read yielded.
+                    Use this tool to audit who has seen a trading partner's documents; do not expect metadata browsing
+                    or denied attempts here, because a 403 disclosed nothing and is deliberately not recorded.
+                    Preconditions: the caller must hold supplier:audit:read; an unknown exchangeAuditId returns an
+                    empty page rather than 404, because access rows carry no foreign key to the exchange.
+                    Required inputs: exchangeAuditId (UUIDv7) path parameter; page defaults to 0 and size defaults to
+                    50 with a maximum of 200.
+                    Emits a SUPPLIER_AUDIT_ACCESS_LIST event; reading this trail is not itself recorded, or every
+                    inspection would generate the noise the next one has to sift.
+                    Returns 400 when the page size is outside the permitted range.
+                    """)
     @ApiResponse(responseCode = "200", description = "A page of access records, newest first.")
     @ApiResponse(
             responseCode = "400",

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierProfileAdminController.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierProfileAdminController.java
@@ -9,6 +9,7 @@ import com.positivity.supplier.service.model.VendorProfileView;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -46,9 +47,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/supplier/admin/profiles")
 public class SupplierProfileAdminController {
 
+    private static final String PROFILE_EXAMPLE = """
+            {"supplierRef":"michelin-eu","displayName":"Michelin Europe","enabled":true,"sandbox":false,
+             "connectTimeoutMillis":5000,"readTimeoutMillis":30000,"maxRetries":2,"retryBackoff":"EXPONENTIAL"}
+            """;
+
     private final SupplierProfileAdminService adminService;
 
-    @Operation(summary = "List vendor profiles", description = "All vendor profiles, ordered by supplierRef")
+    @Operation(operationId = "listVendorProfiles", summary = "List vendor profiles", description = """
+                    Returns every configured vendor profile, ordered by supplierRef, with its enabled, sandbox and
+                    source-of-truth state.
+                    Use this tool to discover a vendorProfileId before working with accounts, auth config or
+                    bindings; use getVendorProfile instead when the id is already known.
+                    Preconditions: none; the list is unfiltered and includes both ADMIN-managed and YAML-managed
+                    profiles.
+                    Required inputs: none, and there is no request body, paging or filtering.
+                    Emits a SUPPLIER_PROFILE_LIST audit event; no configuration is changed.
+                    Returns 200 with an empty array when nothing is configured, so an empty result is not an error
+                    condition.
+                    """)
     @ApiResponse(responseCode = "200", description = "Profiles returned.")
     @ApiResponse(
             responseCode = "401",
@@ -67,7 +84,16 @@ public class SupplierProfileAdminController {
         return ResponseEntity.ok(adminService.listProfiles());
     }
 
-    @Operation(summary = "Get vendor profile", description = "Retrieve one vendor profile by id")
+    @Operation(operationId = "getVendorProfile", summary = "Get vendor profile", description = """
+                    Returns one vendor profile with its timeouts, retry settings, sandbox overlay and whether it is
+                    ADMIN-managed or YAML-managed.
+                    Use this tool when the vendorProfileId is already known; use listVendorProfiles instead to search
+                    by supplierRef.
+                    Preconditions: the profile must exist.
+                    Required inputs: vendorProfileId (UUIDv7) path parameter; there is no request body.
+                    Emits a SUPPLIER_PROFILE_GET audit event; no configuration is changed.
+                    Returns 404 when no profile exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Profile returned.")
     @ApiResponse(
             responseCode = "404",
@@ -102,9 +128,21 @@ public class SupplierProfileAdminController {
         return ResponseEntity.ok(adminService.getProfile(vendorProfileId));
     }
 
-    @Operation(
-            summary = "Create vendor profile",
-            description = "Create an ADMIN-managed vendor profile; supplierRef must be unique")
+    @Operation(operationId = "createVendorProfile", summary = "Create vendor profile", description = """
+                    Creates an ADMIN-managed vendor profile, the row that carries one supplier connection and owns
+                    its accounts, auth config and endpoint bindings.
+                    Use this tool when onboarding a new supplier connection; do not use it to change an existing
+                    profile, which is updateVendorProfile, and note that YAML-managed profiles cannot be created
+                    here at all.
+                    Preconditions: supplierRef must not already be in use by another profile.
+                    Required inputs: supplierRef and displayName, both non-blank, plus the enabled and sandbox flags;
+                    timeouts, maxRetries, retryBackoff and sandboxBaseUrlOverride are optional and fall back to the
+                    deployment defaults when omitted.
+                    Emits a SUPPLIER_PROFILE_CREATE audit event; the profile is created with no bindings, so it
+                    resolves every capability to a not-configured outcome until bindings are added.
+                    Returns 409 when supplierRef is already in use, and 400 when supplierRef or displayName are blank
+                    or a timeout value is not greater than zero.
+                    """)
     @ApiResponse(responseCode = "201", description = "Profile created.")
     @ApiResponse(
             responseCode = "400",
@@ -127,13 +165,40 @@ public class SupplierProfileAdminController {
     @PreAuthorize("hasAuthority('" + SupplierPermissions.PROFILE_WRITE + "')")
     @EmitEvent(id = "SUPPLIER_PROFILE_CREATE", apiVersion = "1")
     @PostMapping
-    public ResponseEntity<VendorProfileView> createProfile(@Valid @NotNull @RequestBody VendorProfileRequest request) {
+    public ResponseEntity<VendorProfileView> createProfile(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Vendor profile to create; the configuration source is always ADMIN.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Enabled production profile",
+                                                            value = PROFILE_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    VendorProfileRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(adminService.createProfile(request));
     }
 
-    @Operation(
-            summary = "Update vendor profile",
-            description = "Full update of a vendor profile; rejected for YAML-managed profiles (ADR-0050 §6)")
+    @Operation(operationId = "updateVendorProfile", summary = "Update vendor profile", description = """
+                    Replaces every settable field of a vendor profile, including its alias, display name, enabled and
+                    sandbox flags and default timeouts.
+                    Use this tool to change connection defaults or take a supplier out of service by clearing
+                    enabled; do not use it on YAML-managed profiles, whose source of truth is the deployment
+                    configuration instead.
+                    Preconditions: the profile must exist, must be ADMIN-managed, and the supplierRef in the body
+                    must not belong to a different profile.
+                    Required inputs: vendorProfileId (UUIDv7) path parameter plus the full body, because every field
+                    is replaced; omitting an optional field resets it to the deployment default rather than leaving
+                    the stored value.
+                    Emits a SUPPLIER_PROFILE_UPDATE audit event; disabling a profile immediately makes its bindings
+                    resolve to a typed not-configured outcome.
+                    Returns 404 when the profile does not exist, 409 when it is YAML-managed or the supplierRef is
+                    taken, and 400 when a required field is blank or a timeout is not greater than zero.
+                    """)
     @ApiResponse(responseCode = "200", description = "Profile updated.")
     @ApiResponse(
             responseCode = "400",
@@ -173,13 +238,35 @@ public class SupplierProfileAdminController {
                     @PathVariable
                     @NotNull
                     UUID vendorProfileId,
-            @Valid @NotNull @RequestBody VendorProfileRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Replacement values for every settable field of the vendor profile.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Enabled production profile",
+                                                            value = PROFILE_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    VendorProfileRequest request) {
         return ResponseEntity.ok(adminService.updateProfile(vendorProfileId, request));
     }
 
-    @Operation(
-            summary = "Delete vendor profile",
-            description = "Delete a vendor profile and its child configuration; rejected for YAML-managed profiles")
+    @Operation(operationId = "deleteVendorProfile", summary = "Delete vendor profile", description = """
+                    Deletes a vendor profile together with its accounts, auth config and endpoint bindings.
+                    Use this tool only when a supplier connection is being retired permanently; to stop traffic while
+                    keeping the configuration, call updateVendorProfile with enabled cleared instead.
+                    Preconditions: the profile must exist and must be ADMIN-managed, because YAML-managed profiles
+                    are owned by the deployment configuration.
+                    Required inputs: vendorProfileId (UUIDv7) path parameter; there is no request body and no
+                    confirmation flag.
+                    Emits a SUPPLIER_PROFILE_DELETE audit event and cascades to the profile's child configuration;
+                    exchange audit records already written are retained.
+                    Returns 404 when the profile does not exist and 409 when it is YAML-managed.
+                    """)
     @ApiResponse(responseCode = "204", description = "Profile deleted.")
     @ApiResponse(
             responseCode = "404",

--- a/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxLineItem.java
+++ b/pos-tax-common/src/main/java/com/positivity/tax/common/dto/TaxLineItem.java
@@ -54,7 +54,12 @@ public class TaxLineItem {
      */
     @NotNull(message = "Quantity is required")
     @Positive(message = "Quantity must be positive")
-    @Schema(description = "Quantity of the item", example = "1", requiredMode = REQUIRED)
+    @Schema(
+            description = "Quantity of the item. Must be greater than zero; zero is rejected.",
+            example = "1",
+            requiredMode = REQUIRED,
+            minimum = "0",
+            exclusiveMinimum = true)
     private BigDecimal quantity;
 
     /**
@@ -62,7 +67,12 @@ public class TaxLineItem {
      */
     @NotNull(message = "Unit price is required")
     @Positive(message = "Unit price must be positive")
-    @Schema(description = "Unit price of the item before tax", example = "89.99", requiredMode = REQUIRED)
+    @Schema(
+            description = "Unit price of the item before tax. Must be greater than zero; zero is rejected.",
+            example = "89.99",
+            requiredMode = REQUIRED,
+            minimum = "0",
+            exclusiveMinimum = true)
     private BigDecimal unitPrice;
 
     /**

--- a/pos-tax/openapi.yaml
+++ b/pos-tax/openapi.yaml
@@ -20,8 +20,22 @@ paths:
       tags:
       - Tax Exemption Certificates
       summary: Get an exemption certificate
-      description: Fetch a single certificate by id
-      operationId: get
+      description: 'Returns a single tax exemption certificate, including its scope, reason code and validity window.
+
+        Use this tool when the certificate id is already known; use listExemptionCertificates instead when
+
+        searching by customer.
+
+        Preconditions: the certificate must exist in the registry.
+
+        Required inputs: id (UUID) path parameter; there is no request body and no filtering.
+
+        No events are emitted and no state changes; this is a read-only registry projection.
+
+        Returns 404 when no certificate exists for the supplied id.
+
+        '
+      operationId: getExemptionCertificateById
       parameters:
       - name: id
         in: path
@@ -51,8 +65,32 @@ paths:
       tags:
       - Tax Exemption Certificates
       summary: Update an exemption certificate
-      description: Update an existing certificate
-      operationId: update
+      description: 'Replaces the stored details of an exemption certificate, including its customer, scope, reason
+
+        code and validity window.
+
+        Use this tool to correct or expire an existing registration; do not use it to register a further
+
+        certificate for the same customer, which is createExemptionCertificate.
+
+        Preconditions: the certificate must exist; expiring a certificate is done by setting expiresAt or
+
+        moving status to INACTIVE or REVOKED rather than by deleting it, because there is no delete endpoint.
+
+        Required inputs: id (UUID) path parameter plus the full body, since every supplied field replaces
+
+        the stored value; an omitted status leaves the current status unchanged.
+
+        Emits a TAX_EXEMPTION_CERT_UPDATE approval-preset audit event; tax already calculated against the
+
+        old values is not recalculated.
+
+        Returns 404 when no certificate exists for the supplied id, and 400 when customerId, reasonCode or
+
+        effectiveFrom are missing from the body.
+
+        '
+      operationId: updateExemptionCertificate
       parameters:
       - name: id
         in: path
@@ -61,10 +99,22 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Replacement details for the exemption certificate.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ExemptionCertificateRequest'
+            examples:
+              Expire a resale certificate:
+                description: Expire a resale certificate
+                value:
+                  customerId: CUST-100234
+                  stateScope: CA
+                  reasonCode: RESALE
+                  certificateNumber: RESALE-2026-0001
+                  effectiveFrom: 2026-01-01
+                  expiresAt: 2026-06-30
+                  status: INACTIVE
         required: true
       responses:
         '200':
@@ -89,8 +139,32 @@ paths:
       tags:
       - Tax
       summary: Void tax document
-      description: Void the provider tax document when its invoice reverts to DRAFT (InvoiceStatus has no CANCELLED/VOIDED; void hooks the revert transition).
-      operationId: voidTransaction
+      description: 'Voids the provider tax document for an invoice that has been reverted to DRAFT, withdrawing the
+
+        committed tax from the provider.
+
+        Use this tool when a finalized invoice reverts to DRAFT; do not use it for ordinary corrections,
+
+        where calculateTax followed by commitTaxDocument replaces the figures instead.
+
+        Preconditions: a provider transaction must already exist for this referenceId, which means tax was
+
+        calculated and committed earlier.
+
+        Required inputs: referenceId (UUID) path parameter, which is the source invoice id; there is no
+
+        request body and no referenceType, because the existing transaction supplies it.
+
+        Emits a TAX_VOID event and moves the stored provider transaction to VOIDED, or to FAILED when the
+
+        provider rejects the void.
+
+        Returns 200 with status FAILED when the provider call fails, so callers must read the returned
+
+        status rather than treating 200 as a completed void.
+
+        '
+      operationId: voidTaxDocument
       parameters:
       - name: referenceId
         in: path
@@ -115,8 +189,34 @@ paths:
       tags:
       - Tax
       summary: Commit tax document
-      description: Commit the provider tax document for a finalized invoice. Idempotent; never blocks on provider outage (records PENDING_COMMIT for the re-commit job).
-      operationId: commit
+      description: 'Commits the provider tax document for a finalized invoice so the recorded tax becomes
+
+        filing-visible at the provider.
+
+        Use this tool when an invoice is finalized; do not use it to recalculate amounts, which is
+
+        calculateTax, and do not use it to reverse a commit, which is voidTaxDocument.
+
+        Preconditions: tax must already have been calculated for this referenceId with a committable
+
+        request, so that a provider document exists to commit.
+
+        Required inputs: referenceId (UUID) path parameter, which is the source invoice id; referenceType
+
+        is an optional query parameter defaulting to INVOICE.
+
+        Emits a TAX_COMMIT event and updates the stored provider transaction; the call is idempotent, so
+
+        an already-COMMITTED document is returned unchanged.
+
+        Returns 200 with status PENDING_COMMIT rather than an error when the provider call fails, because
+
+        a sale is never blocked on the provider, so callers must read the returned status instead of
+
+        treating 200 as a completed commit and leave the re-commit job to true it up.
+
+        '
+      operationId: commitTaxDocument
       parameters:
       - name: referenceId
         in: path
@@ -147,8 +247,28 @@ paths:
       tags:
       - Tax Exemption Certificates
       summary: List exemption certificates
-      description: List certificates, optionally by customer
-      operationId: list
+      description: 'Returns the registered tax exemption certificates, newest effective date first, optionally
+
+        narrowed to a single customer.
+
+        Use this tool to discover a certificate id before calculating tax with an exemption; do not use
+
+        it to test whether an exemption applies on a given date, which calculateTax resolves itself.
+
+        Preconditions: none; an unknown or unmatched customerId yields an empty list rather than an error.
+
+        Required inputs: none, and customerId is an optional query parameter matched exactly, not as a
+
+        substring.
+
+        No events are emitted and no state changes; this is a read-only registry projection.
+
+        Returns 200 with an empty array when no certificate matches, so an empty result is not an error
+
+        condition.
+
+        '
+      operationId: listExemptionCertificates
       parameters:
       - name: customerId
         in: query
@@ -173,13 +293,51 @@ paths:
       tags:
       - Tax Exemption Certificates
       summary: Create an exemption certificate
-      description: Register a new certificate
-      operationId: create
+      description: 'Registers a tax exemption certificate for a customer so that later calculations can treat their
+
+        line items as exempt.
+
+        Use this tool when a customer supplies a new certificate; do not use it to correct an existing
+
+        registration, which is updateExemptionCertificate.
+
+        Preconditions: none are enforced against other services, so the customerId is accepted as an
+
+        opaque identifier and is not verified against the customer registry.
+
+        Required inputs: customerId, reasonCode (RESALE, GOVERNMENT, NONPROFIT, AGRICULTURAL or OTHER)
+
+        and effectiveFrom; stateScope null means every state, expiresAt null means no expiry, and status
+
+        defaults to ACTIVE.
+
+        Emits a TAX_EXEMPTION_CERT_CREATE approval-preset audit event; no existing certificate is
+
+        superseded, so overlapping certificates for the same customer can coexist.
+
+        Returns 400 when customerId, reasonCode or effectiveFrom are missing or the reason code is not a
+
+        recognised value.
+
+        '
+      operationId: createExemptionCertificate
       requestBody:
+        description: Exemption certificate to register for a customer.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ExemptionCertificateRequest'
+            examples:
+              Resale certificate for California:
+                description: Resale certificate for California
+                value:
+                  customerId: CUST-100234
+                  stateScope: CA
+                  reasonCode: RESALE
+                  certificateNumber: RESALE-2026-0001
+                  effectiveFrom: 2026-01-01
+                  expiresAt: 2027-12-31
+                  status: ACTIVE
         required: true
       responses:
         '201':
@@ -204,7 +362,35 @@ paths:
       tags:
       - Tax
       summary: Calculate tax
-      description: Calculate tax for line items based on location. Routes to external service in production or test calculator in test mode.
+      description: 'Calculates tax for the supplied line items against the destination address and returns the
+
+        per-line and total tax amounts.
+
+        Use this tool whenever a quote, estimate or invoice needs tax figures; do not use it to make a
+
+        calculation permanent, which is commitTaxDocument.
+
+        Preconditions: none beyond an authenticated caller; when an exemption is claimed the referenced
+
+        certificate must already exist in the registry and be ACTIVE for the destination state on the
+
+        transaction date, otherwise tax is calculated as taxable.
+
+        Required inputs: lineItems (at least one) and destinationAddress with countryCode and postalCode;
+
+        currencyCode defaults to USD, calculationType defaults to SALE, and referenceId should carry the
+
+        source document id so the result can later be committed.
+
+        Emits a TAX_CALCULATE event and, in production mode, calls the configured external tax provider;
+
+        no provider document is created until commitTaxDocument is called.
+
+        Returns 400 when line items or the destination address are missing or malformed, and 500 when the
+
+        provider is unreachable in production mode.
+
+        '
       operationId: calculateTax
       requestBody:
         description: International tax calculation request
@@ -262,8 +448,26 @@ paths:
       tags:
       - Tax
       summary: Get tax service mode
-      description: Check if the tax service is currently in test mode or production mode
-      operationId: getMode
+      description: 'Returns whether the tax service is running against the external provider or against the built-in
+
+        test calculator.
+
+        Use this tool to interpret a calculation result before relying on it; do not use it as a health
+
+        check, which is the actuator health endpoint instead.
+
+        Preconditions: none; the mode is service configuration and is readable at any time.
+
+        Required inputs: none, and there is no request body or query parameter.
+
+        No events are emitted and no state changes; this is a read-only configuration projection.
+
+        Returns 200 in all cases, so an absent or unexpected mode value indicates a misconfigured
+
+        deployment rather than a request error.
+
+        '
+      operationId: getTaxServiceMode
       responses:
         '200':
           description: Tax service mode retrieved successfully
@@ -545,11 +749,11 @@ components:
           type: string
         countryCode:
           type: string
-        postalCode:
-          type: string
         city:
           type: string
         stateCode:
+          type: string
+        postalCode:
           type: string
       required:
       - destinationAddress
@@ -572,10 +776,12 @@ components:
           type: number
           description: Quantity of the item
           example: 1
+          minimum: 0
         unitPrice:
           type: number
           description: Unit price of the item before tax
           example: 89.99
+          minimum: 0
         subtotal:
           type: number
           description: Total amount before tax (quantity x unitPrice); calculated when omitted
@@ -633,10 +839,12 @@ components:
           type: number
           description: Tax rate applied for this jurisdiction, expressed as a decimal fraction (e.g. 0.0725 for 7.25%)
           example: 0.0725
+          minimum: 0
         amount:
           type: number
           description: Tax amount calculated for this jurisdiction on this line item
           example: 6.53
+          minimum: 0
         exempt:
           type: boolean
           description: Whether this is a zero-rate exempt row (rate is the would-be jurisdiction rate, amount is zero)
@@ -669,14 +877,17 @@ components:
           type: number
           description: Line subtotal before tax
           example: 100.0
+          minimum: 0
         taxAmount:
           type: number
           description: Line tax amount
           example: 10.0
+          minimum: 0
         total:
           type: number
           description: Line total including tax
           example: 110.0
+          minimum: 0
         taxExempt:
           type: boolean
           description: Whether this line item is tax exempt (resolved exemption produced zero-rate rows)
@@ -714,18 +925,22 @@ components:
           type: number
           description: Total amount before tax
           example: 150.0
+          minimum: 0
         totalTax:
           type: number
           description: Total tax amount
           example: 15.0
+          minimum: 0
         total:
           type: number
           description: Total amount including tax
           example: 165.0
+          minimum: 0
         effectiveTaxRate:
           type: number
           description: 'Effective tax rate: total tax divided by the exempt-filtered taxable base (the taxable amount remaining after tax-exempt lines are excluded), expressed as percentage points. This is NOT total tax divided by the raw subtotal (ADR-0042).'
           example: 10.0
+          minimum: 0
         jurisdictions:
           type: array
           description: Applied tax jurisdictions with per-jurisdiction tax amounts
@@ -818,6 +1033,7 @@ components:
           type: number
           description: Tax rate as percentage points
           example: 7.25
+          minimum: 0
         jurisdictionType:
           type: string
           description: Jurisdiction type
@@ -834,6 +1050,7 @@ components:
           type: number
           description: Calculated tax amount for this jurisdiction
           example: 6.53
+          minimum: 0
         jurisdictionTypeI18nKey:
           type: string
           description: I18n key for localized jurisdiction type labels

--- a/pos-tax/openapi.yaml
+++ b/pos-tax/openapi.yaml
@@ -774,12 +774,12 @@ components:
           minLength: 1
         quantity:
           type: number
-          description: Quantity of the item
+          description: Quantity of the item. Must be greater than zero; zero is rejected.
           example: 1
           minimum: 0
         unitPrice:
           type: number
-          description: Unit price of the item before tax
+          description: Unit price of the item before tax. Must be greater than zero; zero is rejected.
           example: 89.99
           minimum: 0
         subtotal:

--- a/pos-tax/src/main/java/com/positivity/tax/internal/controller/ExemptionCertificateController.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/controller/ExemptionCertificateController.java
@@ -5,6 +5,8 @@ import com.positivity.tax.internal.dto.ExemptionCertificateRequest;
 import com.positivity.tax.internal.dto.ExemptionCertificateResponse;
 import com.positivity.tax.service.ExemptionCertificateService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -51,7 +53,18 @@ public class ExemptionCertificateController {
      */
     @GetMapping
     @PreAuthorize("hasAuthority('tax:exemption:view')")
-    @Operation(summary = "List exemption certificates", description = "List certificates, optionally by customer")
+    @Operation(operationId = "listExemptionCertificates", summary = "List exemption certificates", description = """
+                    Returns the registered tax exemption certificates, newest effective date first, optionally
+                    narrowed to a single customer.
+                    Use this tool to discover a certificate id before calculating tax with an exemption; do not use
+                    it to test whether an exemption applies on a given date, which calculateTax resolves itself.
+                    Preconditions: none; an unknown or unmatched customerId yields an empty list rather than an error.
+                    Required inputs: none, and customerId is an optional query parameter matched exactly, not as a
+                    substring.
+                    No events are emitted and no state changes; this is a read-only registry projection.
+                    Returns 200 with an empty array when no certificate matches, so an empty result is not an error
+                    condition.
+                    """)
     @ApiResponse(responseCode = "200", description = "Certificates listed")
     @SecurityRequirement(
             name = "bearerAuth",
@@ -68,7 +81,15 @@ public class ExemptionCertificateController {
      */
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('tax:exemption:view')")
-    @Operation(summary = "Get an exemption certificate", description = "Fetch a single certificate by id")
+    @Operation(operationId = "getExemptionCertificateById", summary = "Get an exemption certificate", description = """
+                    Returns a single tax exemption certificate, including its scope, reason code and validity window.
+                    Use this tool when the certificate id is already known; use listExemptionCertificates instead when
+                    searching by customer.
+                    Preconditions: the certificate must exist in the registry.
+                    Required inputs: id (UUID) path parameter; there is no request body and no filtering.
+                    No events are emitted and no state changes; this is a read-only registry projection.
+                    Returns 404 when no certificate exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Certificate found")
     @ApiResponse(responseCode = "404", description = "Certificate not found")
     @SecurityRequirement(
@@ -87,14 +108,46 @@ public class ExemptionCertificateController {
     @PostMapping
     @PreAuthorize("hasAuthority('tax:exemption:manage')")
     @EmitEvent(id = "TAX_EXEMPTION_CERT_CREATE", apiVersion = "1")
-    @Operation(summary = "Create an exemption certificate", description = "Register a new certificate")
+    @Operation(
+            operationId = "createExemptionCertificate",
+            summary = "Create an exemption certificate",
+            description = """
+                    Registers a tax exemption certificate for a customer so that later calculations can treat their
+                    line items as exempt.
+                    Use this tool when a customer supplies a new certificate; do not use it to correct an existing
+                    registration, which is updateExemptionCertificate.
+                    Preconditions: none are enforced against other services, so the customerId is accepted as an
+                    opaque identifier and is not verified against the customer registry.
+                    Required inputs: customerId, reasonCode (RESALE, GOVERNMENT, NONPROFIT, AGRICULTURAL or OTHER)
+                    and effectiveFrom; stateScope null means every state, expiresAt null means no expiry, and status
+                    defaults to ACTIVE.
+                    Emits a TAX_EXEMPTION_CERT_CREATE approval-preset audit event; no existing certificate is
+                    superseded, so overlapping certificates for the same customer can coexist.
+                    Returns 400 when customerId, reasonCode or effectiveFrom are missing or the reason code is not a
+                    recognised value.
+                    """)
     @ApiResponse(responseCode = "201", description = "Certificate created")
     @ApiResponse(responseCode = "400", description = "Invalid certificate payload")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"tax:exemption:manage"})
     public ResponseEntity<ExemptionCertificateResponse> create(
-            @Valid @RequestBody ExemptionCertificateRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Exemption certificate to register for a customer.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Resale certificate for California",
+                                                            value =
+                                                                    "{\"customerId\":\"CUST-100234\",\"stateScope\":\"CA\",\"reasonCode\":\"RESALE\","
+                                                                            + "\"certificateNumber\":\"RESALE-2026-0001\",\"effectiveFrom\":\"2026-01-01\","
+                                                                            + "\"expiresAt\":\"2027-12-31\",\"status\":\"ACTIVE\"}")))
+                    @Valid
+                    @RequestBody
+                    ExemptionCertificateRequest request) {
         ExemptionCertificateResponse created = service.create(request);
         return ResponseEntity.created(URI.create("/v1/tax/exemption-certificates/" + created.id()))
                 .body(created);
@@ -110,14 +163,46 @@ public class ExemptionCertificateController {
     @PutMapping("/{id}")
     @PreAuthorize("hasAuthority('tax:exemption:manage')")
     @EmitEvent(id = "TAX_EXEMPTION_CERT_UPDATE", apiVersion = "1")
-    @Operation(summary = "Update an exemption certificate", description = "Update an existing certificate")
+    @Operation(
+            operationId = "updateExemptionCertificate",
+            summary = "Update an exemption certificate",
+            description = """
+                    Replaces the stored details of an exemption certificate, including its customer, scope, reason
+                    code and validity window.
+                    Use this tool to correct or expire an existing registration; do not use it to register a further
+                    certificate for the same customer, which is createExemptionCertificate.
+                    Preconditions: the certificate must exist; expiring a certificate is done by setting expiresAt or
+                    moving status to INACTIVE or REVOKED rather than by deleting it, because there is no delete endpoint.
+                    Required inputs: id (UUID) path parameter plus the full body, since every supplied field replaces
+                    the stored value; an omitted status leaves the current status unchanged.
+                    Emits a TAX_EXEMPTION_CERT_UPDATE approval-preset audit event; tax already calculated against the
+                    old values is not recalculated.
+                    Returns 404 when no certificate exists for the supplied id, and 400 when customerId, reasonCode or
+                    effectiveFrom are missing from the body.
+                    """)
     @ApiResponse(responseCode = "200", description = "Certificate updated")
     @ApiResponse(responseCode = "404", description = "Certificate not found")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"tax:exemption:manage"})
     public ResponseEntity<ExemptionCertificateResponse> update(
-            @PathVariable UUID id, @Valid @RequestBody ExemptionCertificateRequest request) {
+            @PathVariable UUID id,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Replacement details for the exemption certificate.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Expire a resale certificate",
+                                                            value =
+                                                                    "{\"customerId\":\"CUST-100234\",\"stateScope\":\"CA\",\"reasonCode\":\"RESALE\","
+                                                                            + "\"certificateNumber\":\"RESALE-2026-0001\",\"effectiveFrom\":\"2026-01-01\","
+                                                                            + "\"expiresAt\":\"2026-06-30\",\"status\":\"INACTIVE\"}")))
+                    @Valid
+                    @RequestBody
+                    ExemptionCertificateRequest request) {
         return ResponseEntity.ok(service.update(id, request));
     }
 }

--- a/pos-tax/src/main/java/com/positivity/tax/internal/controller/TaxController.java
+++ b/pos-tax/src/main/java/com/positivity/tax/internal/controller/TaxController.java
@@ -48,10 +48,22 @@ public class TaxController {
     @PostMapping("/calculate")
     @PreAuthorize("hasAuthority('tax:calculate')")
     @EmitEvent(id = "TAX_CALCULATE", apiVersion = "1")
-    @Operation(
-            summary = "Calculate tax",
-            description =
-                    "Calculate tax for line items based on location. Routes to external service in production or test calculator in test mode.")
+    @Operation(operationId = "calculateTax", summary = "Calculate tax", description = """
+                    Calculates tax for the supplied line items against the destination address and returns the
+                    per-line and total tax amounts.
+                    Use this tool whenever a quote, estimate or invoice needs tax figures; do not use it to make a
+                    calculation permanent, which is commitTaxDocument.
+                    Preconditions: none beyond an authenticated caller; when an exemption is claimed the referenced
+                    certificate must already exist in the registry and be ACTIVE for the destination state on the
+                    transaction date, otherwise tax is calculated as taxable.
+                    Required inputs: lineItems (at least one) and destinationAddress with countryCode and postalCode;
+                    currencyCode defaults to USD, calculationType defaults to SALE, and referenceId should carry the
+                    source document id so the result can later be committed.
+                    Emits a TAX_CALCULATE event and, in production mode, calls the configured external tax provider;
+                    no provider document is created until commitTaxDocument is called.
+                    Returns 400 when line items or the destination address are missing or malformed, and 500 when the
+                    provider is unreachable in production mode.
+                    """)
     @ApiResponse(responseCode = "200", description = "Tax calculated successfully")
     @ApiResponse(responseCode = "400", description = "Invalid tax calculation request")
     @ApiResponse(responseCode = "500", description = "Tax calculation failed")
@@ -102,10 +114,21 @@ public class TaxController {
     @PostMapping("/transactions/{referenceId}/commit")
     @PreAuthorize("hasAuthority('tax:commit')")
     @EmitEvent(id = "TAX_COMMIT", apiVersion = "1")
-    @Operation(
-            summary = "Commit tax document",
-            description = "Commit the provider tax document for a finalized invoice. Idempotent; never blocks on"
-                    + " provider outage (records PENDING_COMMIT for the re-commit job).")
+    @Operation(operationId = "commitTaxDocument", summary = "Commit tax document", description = """
+                    Commits the provider tax document for a finalized invoice so the recorded tax becomes
+                    filing-visible at the provider.
+                    Use this tool when an invoice is finalized; do not use it to recalculate amounts, which is
+                    calculateTax, and do not use it to reverse a commit, which is voidTaxDocument.
+                    Preconditions: tax must already have been calculated for this referenceId with a committable
+                    request, so that a provider document exists to commit.
+                    Required inputs: referenceId (UUID) path parameter, which is the source invoice id; referenceType
+                    is an optional query parameter defaulting to INVOICE.
+                    Emits a TAX_COMMIT event and updates the stored provider transaction; the call is idempotent, so
+                    an already-COMMITTED document is returned unchanged.
+                    Returns 200 with status PENDING_COMMIT rather than an error when the provider call fails, because
+                    a sale is never blocked on the provider, so callers must read the returned status instead of
+                    treating 200 as a completed commit and leave the re-commit job to true it up.
+                    """)
     @ApiResponse(responseCode = "200", description = "Commit recorded (COMMITTED or PENDING_COMMIT)")
     @SecurityRequirement(
             name = "bearerAuth",
@@ -125,10 +148,20 @@ public class TaxController {
     @PostMapping("/transactions/{referenceId}/void")
     @PreAuthorize("hasAuthority('tax:commit')")
     @EmitEvent(id = "TAX_VOID", apiVersion = "1")
-    @Operation(
-            summary = "Void tax document",
-            description = "Void the provider tax document when its invoice reverts to DRAFT (InvoiceStatus has no"
-                    + " CANCELLED/VOIDED; void hooks the revert transition).")
+    @Operation(operationId = "voidTaxDocument", summary = "Void tax document", description = """
+                    Voids the provider tax document for an invoice that has been reverted to DRAFT, withdrawing the
+                    committed tax from the provider.
+                    Use this tool when a finalized invoice reverts to DRAFT; do not use it for ordinary corrections,
+                    where calculateTax followed by commitTaxDocument replaces the figures instead.
+                    Preconditions: a provider transaction must already exist for this referenceId, which means tax was
+                    calculated and committed earlier.
+                    Required inputs: referenceId (UUID) path parameter, which is the source invoice id; there is no
+                    request body and no referenceType, because the existing transaction supplies it.
+                    Emits a TAX_VOID event and moves the stored provider transaction to VOIDED, or to FAILED when the
+                    provider rejects the void.
+                    Returns 200 with status FAILED when the provider call fails, so callers must read the returned
+                    status rather than treating 200 as a completed void.
+                    """)
     @ApiResponse(responseCode = "200", description = "Void recorded")
     @SecurityRequirement(
             name = "bearerAuth",
@@ -158,9 +191,17 @@ public class TaxController {
      */
     @GetMapping("/mode")
     @PreAuthorize("hasAuthority('tax:mode:view')")
-    @Operation(
-            summary = "Get tax service mode",
-            description = "Check if the tax service is currently in test mode or production mode")
+    @Operation(operationId = "getTaxServiceMode", summary = "Get tax service mode", description = """
+                    Returns whether the tax service is running against the external provider or against the built-in
+                    test calculator.
+                    Use this tool to interpret a calculation result before relying on it; do not use it as a health
+                    check, which is the actuator health endpoint instead.
+                    Preconditions: none; the mode is service configuration and is readable at any time.
+                    Required inputs: none, and there is no request body or query parameter.
+                    No events are emitted and no state changes; this is a read-only configuration projection.
+                    Returns 200 in all cases, so an absent or unexpected mode value indicates a misconfigured
+                    deployment rather than a request error.
+                    """)
     @ApiResponse(responseCode = "200", description = "Tax service mode retrieved successfully")
     @SecurityRequirement(
             name = "bearerAuth",


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (platform-wide API documentation standard)
- Parent STORY (durion): n/a — the decision this implements is ADR-0042 (`durion/docs/adr/0042-openapi-annotation-standards.adr.md`)
- Child issue: louisburroughs/durion-positivity-backend#1263
- Domain: `domain:platform`

## Contract References
- Contract guide entry (durion): `domains/platform/.business-rules/BACKEND_CONTRACT_GUIDE.md` — no contract semantics change here. The only spec deltas are `description`, `operationId` and `requestBody` metadata on existing `pos-tax` and `pos-supplier` operations; no path, schema, status code or field changed.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller
- [x] `openapi.yaml` regenerated for both converted modules (`scripts/generate-openapi.sh pos-tax pos-supplier`); `pos-api-gateway/docs/openapi-aggregate.yaml` is unchanged because it indexes module specs by `$ref` and no path was added or removed
- [ ] Angular SDK regenerated — **not done in this PR.** The deltas are documentation-only (descriptions/operationIds/examples), so no generated client signature changes; regenerating would still refresh doc comments and is worth folding into the next SDK cut.

## Scope

**What changed:** two ADR-0042 requirements were satisfied by zero of the 26 modules, and this makes them defined, enforceable and true for two of them.

- `docs/OPENAPI_DESCRIPTION_STANDARD.md` — the fleet template: seven-part sentence order, the canonical lead-in phrases, writing rules (including read-only operations), three worked exemplars, and the enforcement contract.
- `OpenApiAnnotationDepthValidator` — checks 4–8 sentences, an opening primary-action sentence, each of the six remaining §1 elements by its lead-in, and the §3 request-body rules (`description`, explicit `required`, at least one example).
- `module-inventory.yaml` — new `annotationDepth` dimension (`STRICT` / `REPORT_ONLY` / `EXEMPT`, `EXEMPT` requiring a reason), independent of the existing `mode`. Absent means `REPORT_ONLY`.
- `pos-tax` (8 operations) and `pos-supplier` (22) converted and moved to `annotationDepth: STRICT`, specs regenerated.

**Why:** ADR-0042 §1 asks for a "structured tool invocation guide (4-8 sentences)" covering seven elements; the measured fleet baseline before this PR was:

| | fleet |
| --- | --- |
| operations | 964 |
| descriptions with ≥4 sentences | 30 (3.1%) |
| request bodies | 394 |
| request bodies with a `description` | 45 (11%) |

`OpenApiModuleValidator` only asserted that a description was *present*, so even `-Dopenapi.validation.mode=STRICT` reported nothing. Doing this per-module would have produced 26 interpretations of the same rule; these descriptions are read by the MCP server to choose between tools, so their value comes from the whole surface answering the same questions in the same order.

**Deliberate limits, stated plainly:**

- Detection is by lead-in phrase, not by meaning. That is what makes the rule enforceable without natural-language understanding, and it keeps the voice consistent — but it cannot distinguish a real description from a padded one. The standard says so explicitly: a generic seven-part description that passes the validator and tells an agent nothing is worse than the one-liner it replaced, because it costs tokens on every tool-selection prompt.
- The remaining 934 operations stay `REPORT_ONLY`. A default-mode run is green; `-Dopenapi.validation.mode=STRICT` now reports the full fleet gap, which it previously could not.

## Tests
- [x] Unit tests added/updated — `OpenApiAnnotationDepthValidatorTest` (10 cases: element coverage, sentence counting incl. abbreviations and lead-ins split across line breaks, request-body variants), plus depth cases in `OpenApiModuleValidatorTest` and `annotationDepth` parsing/validation in `OpenApiValidationInventoryLoaderTest`.
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a
- How to run:

```bash
./mvnw -pl pos-openapi-validation -DskipTests=false test
./mvnw -pl pos-openapi-validation -DskipTests=false -Dtest=OpenApiRepositoryValidationTest test
./mvnw -pl pos-tax,pos-supplier -DskipTests=false test
```

All green locally, including `scripts/check-openapi-inventory-drift.sh`.

## Risk & Rollback
- Risk level: Low. No runtime behavior changes; the validator addition is test-scope, and every unconverted module defaults to `REPORT_ONLY`.
- Rollback plan: revert the commit. If only the gate is unwanted, set `annotationDepth: REPORT_ONLY` on `pos-tax` and `pos-supplier` — the descriptions themselves are an improvement independent of enforcement.

## Follow-up

#1263 stays open for step 3 of its own sequencing: rolling the remaining 22 spec-producing modules (934 operations) behind the check, largest last. A per-module checklist is posted as a comment on #1263.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — no capability id; branch is `docs/1263-openapi-description-standard`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a for the same reason
- [x] Links to parent + child issues are present
