### PR TITLE
test(workorder): correct two now-false envelope comments and pin the added fields

### DIFF
--- a/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxEventWriterIntegrationTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/event/OutboxEventWriterIntegrationTest.java
@@ -76,12 +76,16 @@ class OutboxEventWriterIntegrationTest {
         assertThat(row.getRecordKey()).isEqualTo(SAMPLE_ID.toString());
         assertThat(row.getPublishedAt()).isNull();
         assertThat(row.getCreatedAt()).isEqualTo(Instant.parse("2026-07-08T12:00:00Z"));
-        // Every field the previous direct producer emitted, under the same name (pos-customer
-        // consumer contract), plus schemaVersion — the envelope change in #1286 is additive.
+        // Now a serialized DomainEventEnvelope rather than the hand-built map (#1286). Every field
+        // the map emitted is still emitted under the same name — that is the pos-customer consumer
+        // contract, and those listeners read the envelope as a JsonNode tree by field name — and
+        // the envelope adds schemaVersion, aggregateId, correlationId and actor on top.
         assertThat(row.getPayload())
                 .contains("\"eventId\"")
                 .contains("\"eventType\":\"workorder.work-session.started.v1\"")
                 .contains("\"schemaVersion\":1")
+                .contains("\"aggregateId\":\"" + SAMPLE_ID + "\"")
+                .contains("\"aggregateVersion\"")
                 .contains("\"occurredAtUtc\"")
                 .contains("\"sourceService\":\"pos-workorder\"")
                 .contains("\"payload\"");
@@ -106,8 +110,10 @@ class OutboxEventWriterIntegrationTest {
     @Test
     @DisplayName("A schemaVersion below 1 is rejected rather than published")
     void rejectsNonPositiveSchemaVersion() {
-        // Mirrors the DomainEventEnvelope guard. This envelope is hand-built (#1286), so nothing
-        // else would stop a 0 from reaching consumers as a legitimate-looking version.
+        // The guard is DomainEventEnvelope's own, reached through the writer. Pinning it here is
+        // what proves the writer actually routes through the shared envelope: while this module
+        // hand-built its map (#1286) nothing validated the version at all, and a 0 would have
+        // reached consumers looking legitimate.
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(
                         () -> writer.publish("workorder.work-session.started.v1", 0, SAMPLE_ID, workSessionStarted()))


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — no capability id; this is review follow-up, not new scope
- Parent STORY (durion): n/a
- Child issue: n/a — follow-up to review comments on #1287, which merged before these corrections were pushed
- Domain: `domain:workorder`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `BACKEND_CONTRACT_GUIDE.md` — no entry needs changing; nothing here touches contract behavior.
- Durion contract PR (if applicable): none

**No behavior change of any kind.** This PR edits two comments and adds two assertions in a single test class. No production file is touched, so no API, event, payload, envelope or topic changes. (The contract-sync check fires only because the test lives under a path with an `event` directory segment.)

## Contract Chain (when a Controller changed)
No controller changed; the three items below are not applicable.
- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope

Follow-up to two Copilot review comments on #1287. Both were fair; #1287 merged while the corrections were being written, so they land here instead.

**What changed:**

1. **A comment that asserted the opposite of the truth.** `rejectsNonPositiveSchemaVersion` said *"this envelope is hand-built (#1286), so nothing else would stop a 0 from reaching consumers"*. After #1287 converted the module to `DomainEventEnvelope`, the shared envelope is exactly what stops it — and the writer's own explicit guard was removed in that conversion, since the envelope now performs the check. The comment now states what the assertion actually proves: that the writer routes through `DomainEventEnvelope` at all. That is a more useful thing to pin than the guard itself, because it fails if someone reintroduces a bespoke envelope.

2. **A comment that was understated.** The serialized-envelope comment described the change as *"plus schemaVersion — additive"*. True when written, but the conversion also added `aggregateId`, `correlationId` and `actor`. It now describes the envelope as it actually is, and keeps the point that matters for consumers: every field the old map emitted is still emitted under the same name, and the listeners read a `JsonNode` tree by field name.

3. **Coverage for the fields the conversion added.** The assertion checked only `schemaVersion` of the new fields, so `aggregateId` and `aggregateVersion` went out on the wire untested. Both are now pinned, `aggregateId` by value against the id passed to `publish`.

**Why bother:** point 1 is a comment that would actively mislead the next reader about why the test passes, and point 3 is real missing coverage on a wire format that changed in the previous PR.

## Tests
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated

- How to run:
  ```bash
  ./mvnw -pl pos-workorder -am -DskipTests=false test
  ```
  `BUILD SUCCESS` locally, including the four cases in `OutboxEventWriterIntegrationTest`.

## Risk & Rollback
- Risk level: **Low** — comments and test assertions only; no production code in the diff.
- Rollback plan: revert the single commit. Nothing downstream depends on it.

## Checklist
- [ ] Branch name matches `cap/&lt;cap-id&gt;` — branch is `claude/issue-1279-926mu4`, assigned for this task
- [ ] PR title starts with `[CAP:&lt;cap-id&gt;]` — no capability id; title follows the conventional-commit form used by recent PRs
- [x] Links to parent + child issues are present — follow-up to review threads on #1287; no issue of its own
- [x] Contract guide updated (when contract semantics changed) — no contract change
- [ ] Required CI checks passing — pending first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShQxYMX6qr9bmYYNuREkja

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShQxYMX6qr9bmYYNuREkja)_