### PR TITLE
docs(openapi): ADR-0042 wave A — 7 modules to depth-STRICT (#1263)

### DIFF
--- a/pos-bulk-loader/openapi.yaml
+++ b/pos-bulk-loader/openapi.yaml
@@ -59,19 +59,15 @@ paths:
         '403':
           description: Job does not belong to the authenticated operator
           content:
-            application/json:
+            application/problem+json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ColumnMappingResponse'
+                $ref: '#/components/schemas/ProblemDetail'
         '404':
           description: Job not found
           content:
-            application/json:
+            application/problem+json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ColumnMappingResponse'
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - bulkImport:upload:execute
@@ -131,19 +127,15 @@ paths:
         '403':
           description: Job does not belong to the authenticated operator
           content:
-            application/json:
+            application/problem+json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ColumnMappingResponse'
+                $ref: '#/components/schemas/ProblemDetail'
         '404':
           description: Job not found
           content:
-            application/json:
+            application/problem+json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ColumnMappingResponse'
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - bulkImport:upload:execute
@@ -290,15 +282,15 @@ paths:
         '404':
           description: Job not found
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/FileUploadResponse'
+                $ref: '#/components/schemas/ProblemDetail'
         '409':
           description: Job is in a terminal state and cannot accept uploads
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/FileUploadResponse'
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - bulkImport:upload:execute
@@ -453,21 +445,21 @@ paths:
         '403':
           description: Job does not belong to the authenticated operator
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/BulkLoadJobResponse'
+                $ref: '#/components/schemas/ProblemDetail'
         '404':
           description: Job not found
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/BulkLoadJobResponse'
+                $ref: '#/components/schemas/ProblemDetail'
         '409':
           description: Invalid state transition
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/BulkLoadJobResponse'
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - bulkImport:upload:execute
@@ -527,27 +519,27 @@ paths:
         '400':
           description: Invalid correction request
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/BulkCorrectionResponse'
+                $ref: '#/components/schemas/ProblemDetail'
         '403':
           description: Job does not belong to the authenticated operator
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/BulkCorrectionResponse'
+                $ref: '#/components/schemas/ProblemDetail'
         '404':
           description: Job not found
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/BulkCorrectionResponse'
+                $ref: '#/components/schemas/ProblemDetail'
         '409':
           description: Job is not in a state that accepts corrections
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/BulkCorrectionResponse'
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - bulkImport:upload:execute
@@ -606,27 +598,27 @@ paths:
         '400':
           description: Invalid correction request
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/CorrectionResultDto'
+                $ref: '#/components/schemas/ProblemDetail'
         '403':
           description: Job does not belong to the authenticated operator
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/CorrectionResultDto'
+                $ref: '#/components/schemas/ProblemDetail'
         '404':
           description: Job not found
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/CorrectionResultDto'
+                $ref: '#/components/schemas/ProblemDetail'
         '409':
           description: Job is not in a state that accepts corrections
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/CorrectionResultDto'
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - bulkImport:upload:execute
@@ -955,17 +947,15 @@ paths:
         '403':
           description: Job does not belong to the authenticated operator
           content:
-            application/json:
+            application/problem+json:
               schema:
-                type: string
-                format: binary
+                $ref: '#/components/schemas/ProblemDetail'
         '404':
           description: Job not found
           content:
-            application/json:
+            application/problem+json:
               schema:
-                type: string
-                format: binary
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - bulkImport:upload:execute
@@ -1010,19 +1000,15 @@ paths:
         '403':
           description: Job does not belong to the authenticated operator
           content:
-            application/json:
+            application/problem+json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AuditRecordResponse'
+                $ref: '#/components/schemas/ProblemDetail'
         '404':
           description: Job not found
           content:
-            application/json:
+            application/problem+json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AuditRecordResponse'
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - bulkImport:upload:execute
@@ -1065,6 +1051,24 @@ components:
       required:
       - sourceColumn
       - targetField
+    ProblemDetail:
+      type: object
+      properties:
+        type:
+          type: string
+          format: uri
+        title:
+          type: string
+        status:
+          type: integer
+          format: int32
+        detail:
+          type: string
+        instance:
+          type: string
+          format: uri
+        properties:
+          type: object
     ColumnMappingResponse:
       type: object
       description: Inferred or user-overridden mapping from a source column to a target field

--- a/pos-bulk-loader/openapi.yaml
+++ b/pos-bulk-loader/openapi.yaml
@@ -25,9 +25,21 @@ paths:
     get:
       tags:
       - Column Mapping API
-      summary: Get proposed column mappings for a job
-      description: Retrieves the proposed column mappings for the specified bulk load job. The operator can only access mappings for their own jobs. This endpoint is typically used to review the detected column mappings before approving them for processing.
-      operationId: getMappings
+      summary: Get Proposed Column Mappings for Job
+      description: 'Returns the column mappings currently stored for a bulk load job, covering both auto-suggested mappings from content detection and operator-approved overrides.
+
+        Use this tool to review detected source-column to target-field mappings, their confidence and origin; use approveColumnMappings instead to finalize the set.
+
+        Preconditions: the job must exist and belong to the authenticated operator; mappings are typically present only after a file upload has triggered content detection.
+
+        Required inputs: jobId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the job does not exist, and 403 when the job belongs to another operator.
+
+        '
+      operationId: getColumnMappings
       parameters:
       - name: jobId
         in: path
@@ -52,6 +64,14 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ColumnMappingResponse'
+        '404':
+          description: Job not found
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ColumnMappingResponse'
       security:
       - bearerAuth:
         - bulkImport:upload:execute
@@ -61,9 +81,21 @@ paths:
     put:
       tags:
       - Column Mapping API
-      summary: Approve and finalize column mappings for a job
-      description: Approves and finalizes the proposed column mappings for the specified bulk load job. The operator can only approve mappings for their own jobs. Once approved, the mappings are locked and used for processing the bulk load job.
-      operationId: approveMappings
+      summary: Approve and Finalize Column Mappings
+      description: 'Replaces all stored column mappings for a bulk load job with the submitted set, marking every mapping operator-approved with confidence 1.0.
+
+        Use this tool after reviewing the suggestions from getColumnMappings; do not use getColumnMappings, which only reads mappings, and note that the submitted list fully replaces prior mappings rather than merging with them.
+
+        Preconditions: the job must exist and belong to the authenticated operator; the job state is not checked, but approved mappings only affect processing started afterwards.
+
+        Required inputs: mappings, a non-empty list where each entry names a sourceColumn from the uploaded file and the targetField it maps to; mappingId is accepted but ignored because the set is replaced wholesale.
+
+        Emits a BULK_LOADER_MAPPING_APPROVE event and deletes previously stored mappings, including auto-suggested ones, before saving the new set.
+
+        Returns 404 when the job does not exist, and 403 when the job belongs to another operator.
+
+        '
+      operationId: approveColumnMappings
       parameters:
       - name: jobId
         in: path
@@ -72,10 +104,20 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Full replacement set of column mappings, one entry per source column to import.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ColumnMappingApproveRequest'
+            examples:
+              Two approved mappings:
+                description: Two approved mappings
+                value:
+                  mappings:
+                  - sourceColumn: Product SKU
+                    targetField: sku
+                  - sourceColumn: Retail Price
+                    targetField: price
         required: true
       responses:
         '200':
@@ -94,6 +136,14 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ColumnMappingResponse'
+        '404':
+          description: Job not found
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ColumnMappingResponse'
       security:
       - bearerAuth:
         - bulkImport:upload:execute
@@ -104,9 +154,21 @@ paths:
     get:
       tags:
       - Bulk Load Jobs API
-      summary: List bulk load jobs for the authenticated operator
-      description: Retrieves a paginated list of bulk load jobs for the authenticated operator. The operator can only access their own jobs.
-      operationId: listJobs
+      summary: List Bulk Load Jobs for Operator
+      description: 'Returns a paginated list of the authenticated operator''s bulk load jobs with their statuses and progress counters.
+
+        Use this tool to find a job id or review import history; use getBulkLoadJob instead when a specific job id is already known.
+
+        Preconditions: none beyond authentication; the listing is always scoped to the caller''s own jobs and other operators'' jobs are never included.
+
+        Required inputs: standard page, size and sort query parameters, all optional with Spring defaults (page 0, size 20).
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty page when the operator has no jobs; there are no operation-specific error responses.
+
+        '
+      operationId: listBulkLoadJobs
       parameters:
       - name: pageable
         in: query
@@ -129,14 +191,34 @@ paths:
     post:
       tags:
       - Bulk Load Jobs API
-      summary: Create a new bulk load job
-      description: Creates a new bulk load job for the authenticated operator. Each operator can only have one active job at a time. The job starts in CREATED state and must be populated with a file upload before processing can begin.
-      operationId: createJob
+      summary: Create a New Bulk Load Job
+      description: 'Creates a bulk load import job owned by the authenticated operator, starting in CREATED state with the target domain and expected file name recorded.
+
+        Use this tool when starting a new bulk import from a file; do not use uploadJobFile, which attaches the file to a job that already exists, and do not use retryBulkLoadJob, which re-queues a FAILED job.
+
+        Preconditions: the operator must have no other job in an active state (CREATED, UPLOADING, DETECTING, MAPPING_REVIEW, DEDUP or PROCESSING); only one active job per operator is allowed.
+
+        Required inputs: fileName (name of the source file that will be uploaded later) and domainType (one of CATALOG_PRODUCT, INVENTORY_STOCK_COUNT, LOCATION, CUSTOMER, PERSON, BASE_PRICE, VEHICLE or VEHICLE_FITMENT); locationId (UUID) is optional at creation but must be set before processing can start.
+
+        Emits a BULK_LOADER_JOB_CREATE event; no file content is stored by this call.
+
+        Returns 201 with the new job, and 409 when the operator already has an active bulk load job in progress.
+
+        '
+      operationId: createBulkLoadJob
       requestBody:
+        description: Bulk load job to create, naming the source file and the target import domain.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BulkLoadJobCreateRequest'
+            examples:
+              Catalog product import:
+                description: Catalog product import
+                value:
+                  fileName: products-2026-01.csv
+                  domainType: CATALOG_PRODUCT
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
         required: true
       responses:
         '201':
@@ -161,9 +243,21 @@ paths:
     post:
       tags:
       - Bulk Load File Upload API
-      summary: Upload a file for a bulk load job
-      description: Uploads a file for the specified bulk load job. The file is stored and associated with the job for later processing. The job must be in CREATED or UPLOADING state. Multiple files can be uploaded, but only the latest file will be processed.
-      operationId: uploadFile
+      summary: Upload a File for Bulk Load Job
+      description: 'Uploads the source data file for a bulk load job as a single multipart request, stores it, and runs content detection to propose column mappings.
+
+        Use this tool for files small enough to send in one request; use createTusUpload instead for large files that need resumable, chunked upload.
+
+        Preconditions: the job must exist, belong to the authenticated operator, and not be in a terminal state (COMPLETED, CANCELLED or FAILED); a CREATED job moves to UPLOADING.
+
+        Required inputs: a multipart form part named file; formats understood by content detection are csv, tsv, txt, psv, xlsx, xlsm, xls, json, xml, yaml and yml, with the first row or record treated as the column headers.
+
+        Emits a BULK_LOADER_FILE_UPLOAD event and persists suggested column mappings from detection; when detection fails the upload still succeeds with a null detection field in the response, and re-uploading replaces the file to be processed because only the latest upload is used.
+
+        Returns 404 when the job does not exist for the authenticated operator, and 409 when the job is already in a terminal state.
+
+        '
+      operationId: uploadJobFile
       parameters:
       - name: jobId
         in: path
@@ -172,16 +266,20 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Multipart form with a single part named file carrying the source data file to import.
         content:
-          application/json:
+          multipart/form-data:
             schema:
               type: object
               properties:
                 file:
                   type: string
                   format: binary
-              required:
-              - file
+            examples:
+              CSV upload:
+                description: CSV upload
+                value: file=@products-2026-01.csv (binary content; first row is the header row)
+        required: true
       responses:
         '200':
           description: File uploaded and content detected
@@ -195,6 +293,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FileUploadResponse'
+        '409':
+          description: Job is in a terminal state and cannot accept uploads
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FileUploadResponse'
       security:
       - bearerAuth:
         - bulkImport:upload:execute
@@ -204,9 +308,21 @@ paths:
     post:
       tags:
       - TUS Resumable Upload API
-      summary: Create a resumable upload
-      description: Creates a new TUS upload scoped to a bulk load job. Returns a Location header with the absolute upload URL for subsequent HEAD and PATCH requests. The URL is reconstructed from the X-Forwarded-Proto/Host/Port/Prefix headers supplied by the API gateway / reverse-proxy chain, so it reflects the public address (including any proxy path prefix) rather than this service's internal one.
-      operationId: createUpload
+      summary: Create a Resumable Upload
+      description: 'Creates a resumable TUS upload session scoped to a bulk load job and returns its absolute upload URL in the Location header, rebuilt from the gateway''s X-Forwarded headers so it reflects the public address.
+
+        Use this tool to start uploading a large file in chunks; use uploadJobFile instead when the file is small enough for a single multipart request, and do not send file bytes here because chunks go to appendTusUploadChunk.
+
+        Preconditions: the caller must send a Tus-Resumable header of 1.0.0; the job id is recorded but not validated here, so a wrong job id only fails later when the finished file is attached to the job.
+
+        Required inputs: Upload-Length header with the total file size in bytes (server maximum 536870912 by default), and optionally Upload-Metadata with a base64-encoded filename field, without which the file is stored as upload.bin.
+
+        Emits a BULK_LOADER_TUS_UPLOAD_CREATE event and creates an empty temp file; the session expires after 24 hours by default (see the Upload-Expires header) and expired incomplete uploads are cleaned up automatically.
+
+        Returns 201 with Location, Upload-Offset and Upload-Expires headers, 412 when the Tus-Resumable header is missing or not 1.0.0, and 413 when Upload-Length exceeds the server maximum.
+
+        '
+      operationId: createTusUpload
       parameters:
       - name: jobId
         in: path
@@ -247,9 +363,21 @@ paths:
     post:
       tags:
       - Bulk Load Jobs API
-      summary: Retry a failed bulk load job
-      description: Retries a bulk load job that has reached the FAILED state, resetting it to CREATED and re-queuing it for processing. The operator can only retry their own jobs. Returns 409 if the job is not in FAILED state.
-      operationId: retryJob
+      summary: Retry a Failed Bulk Load Job
+      description: 'Resets a FAILED bulk load job back to CREATED and clears its progress counters so it can be processed again.
+
+        Use this tool after fixing the cause of a failure, typically via submitCorrections; do not use cancelBulkLoadJob, which terminates a job instead of re-queuing it.
+
+        Preconditions: the job must belong to the authenticated operator, must be in FAILED state, and the operator must have no other active job.
+
+        Required inputs: jobId (UUID) as a path parameter; there is no request body.
+
+        Emits a BULK_LOADER_JOB_RETRY event and resets startedAt, completedAt, totalRows and all row counters; processing does not start until startJobProcessing is called again.
+
+        Returns 404 when the job does not exist, 403 when it belongs to another operator, and 409 when the job is not in FAILED state or the operator already has an active job.
+
+        '
+      operationId: retryBulkLoadJob
       parameters:
       - name: jobId
         in: path
@@ -257,6 +385,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       responses:
         '200':
           description: Job reset and re-queued for retry
@@ -292,9 +421,21 @@ paths:
     post:
       tags:
       - Bulk Load File Upload API
-      summary: Launch a bulk load job for processing
-      description: Starts Spring Batch execution for the specified bulk load job and transitions it to PROCESSING. The job must be in CREATED, UPLOADING, or MAPPING_REVIEW state and must already have a persisted upload and locationId.
-      operationId: startProcessing
+      summary: Launch a Bulk Load Job
+      description: 'Starts asynchronous Spring Batch processing for a bulk load job and transitions it to PROCESSING.
+
+        Use this tool once the uploaded file is persisted and the mappings are acceptable; do not treat the 200 response as import completion, and poll getBulkLoadJob instead because the batch run continues in the background.
+
+        Preconditions: the job must belong to the authenticated operator, be in CREATED, UPLOADING or MAPPING_REVIEW state, and already have both a persisted uploaded file and a locationId assigned.
+
+        Required inputs: jobId (UUID) as a path parameter; there is no request body, and the caller''s Authorization bearer token is forwarded to downstream domain services for the row-level writes.
+
+        Emits a BULK_LOADER_JOB_START event, launches the Spring Batch job, and stamps startedAt; row counters on the job update as chunks are processed.
+
+        Returns 404 when the job does not exist, 403 when it belongs to another operator, and 409 when the state is not launchable or the uploaded file or locationId is missing.
+
+        '
+      operationId: startJobProcessing
       parameters:
       - name: jobId
         in: path
@@ -305,6 +446,12 @@ paths:
       responses:
         '200':
           description: Job transitioned to PROCESSING
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkLoadJobResponse'
+        '403':
+          description: Job does not belong to the authenticated operator
           content:
             application/json:
               schema:
@@ -330,8 +477,22 @@ paths:
     post:
       tags:
       - Review Queue API
-      summary: Submit corrected records for a bulk load job
-      description: Submits corrected data for one or more error records from a bulk import audit. The job must be in FAILED state to accept corrections. Returns 409 if the job is not in a correctable state.
+      summary: Submit Corrected Records for Job
+      description: 'Submits corrected field values for one or more audit records of a FAILED bulk load job, marking each accepted record CORRECTED.
+
+        Use this tool to fix several failed rows in one call; use submitSingleCorrection instead when correcting exactly one record and a per-record accept or reject status is wanted.
+
+        Preconditions: the job must belong to the authenticated operator and be in FAILED state; each auditRecordId must belong to that job.
+
+        Required inputs: corrections, a non-empty list where each item carries auditRecordId (UUID) and correctedData, a map of field names to corrected string values.
+
+        Emits a BULK_LOADER_CORRECTION_SUBMIT event and stores the corrected values on each audit record; items whose audit record is missing or belongs to another job are rejected individually and reported in the response''s rejections list without failing the call.
+
+        Correcting records does not re-run the import; call retryBulkLoadJob and then startJobProcessing to process the job again.
+
+        Returns 201 with accepted and rejected counts, 409 when the job is not in FAILED state, 404 when the job does not exist, and 403 when it belongs to another operator.
+
+        '
       operationId: submitCorrections
       parameters:
       - name: jobId
@@ -341,10 +502,20 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Batch of corrected values, one item per failed audit record to be marked CORRECTED.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BulkCorrectionRequest'
+            examples:
+              Correct one failed row:
+                description: Correct one failed row
+                value:
+                  corrections:
+                  - auditRecordId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                    correctedData:
+                      sku: PROD-001
+                      price: '19.99'
         required: true
       responses:
         '201':
@@ -387,8 +558,20 @@ paths:
     post:
       tags:
       - Review Queue API
-      summary: Submit a single correction record
-      description: Submits a corrected data record for a single failed audit entry from a bulk import job. The job must be in FAILED state. Returns the acceptance or rejection status for the submitted record.
+      summary: Submit a Single Correction Record
+      description: 'Submits corrected field values for exactly one audit record of a FAILED bulk load job and reports whether the correction was accepted.
+
+        Use this tool for interactive row-by-row fixing; use submitCorrections instead to correct a batch of records in one call.
+
+        Preconditions: the job must belong to the authenticated operator and be in FAILED state; the auditRecordId must belong to that job.
+
+        Required inputs: auditRecordId (UUID) and correctedData, a map of field names to corrected string values.
+
+        Emits a BULK_LOADER_CORRECTION_SUBMIT_SINGLE event and stores the corrected values on the audit record, setting its review status to CORRECTED when accepted; correcting a record does not re-run the import.
+
+        Returns 201 with status ACCEPTED or REJECTED plus a rejectionReason when rejected, 409 when the job is not in FAILED state, 404 when the job does not exist, and 403 when it belongs to another operator.
+
+        '
       operationId: submitSingleCorrection
       parameters:
       - name: jobId
@@ -397,11 +580,21 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       requestBody:
+        description: Single corrected record naming the audit record and the field values that replace the failed ones.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BulkCorrectionItem'
+            examples:
+              Corrected row:
+                description: Corrected row
+                value:
+                  auditRecordId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  correctedData:
+                    sku: PROD-001
+                    price: '19.99'
         required: true
       responses:
         '201':
@@ -444,9 +637,21 @@ paths:
     post:
       tags:
       - Bulk Load Jobs API
-      summary: Cancel a running bulk load job
-      description: Cancels a bulk load job that is currently in progress. The operator can only cancel their own jobs.
-      operationId: cancelJob
+      summary: Cancel a Running Bulk Load Job
+      description: 'Cancels an in-flight bulk load job by moving it to the terminal CANCELLED state.
+
+        Use this tool to abandon a job that is no longer wanted; do not use retryBulkLoadJob, which re-queues a FAILED job rather than stopping one.
+
+        Preconditions: the job must belong to the authenticated operator and must not already be in a terminal state (COMPLETED, CANCELLED or FAILED).
+
+        Required inputs: jobId (UUID) as a path parameter; there is no request body.
+
+        Emits a BULK_LOADER_JOB_CANCEL event and sets the job status to CANCELLED; rows already imported are not rolled back.
+
+        Returns 404 when the job does not exist, 403 when it belongs to another operator, and 409 when the job is already COMPLETED, CANCELLED or FAILED.
+
+        '
+      operationId: cancelBulkLoadJob
       parameters:
       - name: jobId
         in: path
@@ -457,6 +662,18 @@ paths:
       responses:
         '200':
           description: Job cancelled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkLoadJobResponse'
+        '403':
+          description: Job does not belong to the authenticated operator
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkLoadJobResponse'
+        '404':
+          description: Job not found
           content:
             application/json:
               schema:
@@ -477,9 +694,21 @@ paths:
     delete:
       tags:
       - TUS Resumable Upload API
-      summary: Cancel an upload
-      description: Permanently deletes a TUS upload and its temporary file.
-      operationId: deleteUpload
+      summary: Cancel a Resumable Upload
+      description: 'Cancels a TUS upload session, permanently deleting both the session record and its temporary chunk file.
+
+        Use this tool to abandon a partially transferred upload; do not use cancelBulkLoadJob, which cancels the bulk load job itself rather than an upload session.
+
+        Preconditions: the upload session must exist and the caller must send a Tus-Resumable header of 1.0.0; a completed upload whose file has already been attached to the job is not detached by this call.
+
+        Required inputs: uploadId (UUID) as a path parameter; there is no request body.
+
+        Emits a BULK_LOADER_TUS_UPLOAD_CANCEL event and removes the temporary file; the deletion cannot be undone and the upload URL becomes invalid.
+
+        Returns 204 on success, 404 when the upload does not exist, and 412 when the Tus-Resumable header is missing or not 1.0.0.
+
+        '
+      operationId: cancelTusUpload
       parameters:
       - name: uploadId
         in: path
@@ -508,9 +737,21 @@ paths:
     head:
       tags:
       - TUS Resumable Upload API
-      summary: Get upload offset
-      description: Returns the current byte offset of a TUS upload for resumption.
-      operationId: getOffset
+      summary: Get Current Upload Offset
+      description: 'Returns the current byte offset of a TUS upload in the Upload-Offset response header so a client can resume where the last transfer stopped.
+
+        Use this tool after an interrupted transfer to learn where to resume; do not use getTusCapabilities, which reports server-wide limits rather than per-upload progress.
+
+        Preconditions: the upload session must exist and the caller must send a Tus-Resumable header of 1.0.0.
+
+        Required inputs: uploadId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; the response carries Upload-Offset, Upload-Length and Upload-Expires headers with an empty body.
+
+        Returns 404 when the upload does not exist, and 412 when the Tus-Resumable header is missing or not 1.0.0.
+
+        '
+      operationId: getTusUploadOffset
       parameters:
       - name: uploadId
         in: path
@@ -539,9 +780,21 @@ paths:
     patch:
       tags:
       - TUS Resumable Upload API
-      summary: Upload a chunk
-      description: Appends a byte range to an in-progress TUS upload. Content-Type must be application/offset+octet-stream. Upload-Offset must equal the current server-side offset.
-      operationId: uploadChunk
+      summary: Upload a Chunk
+      description: 'Appends a contiguous byte range to an in-progress TUS upload and, when the final byte arrives, moves the finished file into job storage.
+
+        Use this tool repeatedly to stream the file in chunks after createTusUpload; do not guess the offset after a failure, and call getTusUploadOffset instead to learn the server-side offset.
+
+        Preconditions: the upload must exist, not be complete, and not be expired; the Upload-Offset header must exactly equal the server''s current offset.
+
+        Required inputs: uploadId (UUID) as a path parameter, a Content-Type of application/offset+octet-stream, Tus-Resumable, Upload-Offset and Content-Length headers, and the raw chunk bytes as the request body.
+
+        Emits a BULK_LOADER_TUS_UPLOAD_CHUNK_APPEND event; when the new offset reaches Upload-Length the file is finalized into the job''s storage and the job records the upload, moving a CREATED job to UPLOADING (finalization fails with 404 when the job is gone or 409 when it is terminal).
+
+        Returns 204 with the new Upload-Offset header on success, 409 when the offset does not match or the upload is already complete, 410 when the upload has expired, 415 when the Content-Type is wrong, 412 when the TUS version is unsupported, and 404 when the upload does not exist.
+
+        '
+      operationId: appendTusUploadChunk
       parameters:
       - name: uploadId
         in: path
@@ -592,9 +845,21 @@ paths:
     options:
       tags:
       - TUS Resumable Upload API
-      summary: TUS server capabilities
-      description: Returns supported TUS version, extensions, and max upload size. No authentication required.
-      operationId: options
+      summary: Get TUS Server Capabilities
+      description: 'Advertises the TUS resumable-upload capabilities of this server, namely protocol version 1.0.0, the creation, termination and expiration extensions, and the maximum upload size.
+
+        Use this tool during the tus client handshake to discover limits before creating an upload; do not use it to check the progress of an existing upload, which is getTusUploadOffset.
+
+        Preconditions: none; this endpoint requires no authentication.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        No events are emitted and no state changes; the capabilities are returned in the Tus-Version, Tus-Max-Size and Tus-Extension response headers.
+
+        Returns 204 in all cases, with the capability data carried in headers rather than a body.
+
+        '
+      operationId: getTusCapabilities
       responses:
         '204':
           description: Server capabilities
@@ -606,9 +871,21 @@ paths:
     get:
       tags:
       - Bulk Load Jobs API
-      summary: Get a bulk load job by ID
-      description: Retrieves the details of a bulk load job for the authenticated operator. The operator can only access their own jobs.
-      operationId: getJob
+      summary: Get a Bulk Load Job by ID
+      description: 'Returns the current state of a single bulk load job, including status, row counts and success and failure totals.
+
+        Use this tool to poll job progress after startJobProcessing, or whenever the job id is already known; use listBulkLoadJobs instead when the id is unknown.
+
+        Preconditions: the job must exist and belong to the authenticated operator; jobs owned by other operators are reported as not found rather than forbidden.
+
+        Required inputs: jobId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no job exists with the supplied id for the authenticated operator.
+
+        '
+      operationId: getBulkLoadJob
       parameters:
       - name: jobId
         in: path
@@ -645,8 +922,20 @@ paths:
     get:
       tags:
       - Review Queue API
-      summary: Download error report as CSV for a bulk load job
-      description: Generates and downloads a CSV file containing all error records for the specified bulk load job.
+      summary: Download Error Report as CSV
+      description: 'Generates a CSV export of the audit records for a bulk load job and returns it as a text/csv attachment.
+
+        Use this tool to hand failed rows to a spreadsheet for offline correction; use listAuditRecords instead when the records are needed as JSON for programmatic handling.
+
+        Preconditions: the job must exist and belong to the authenticated operator.
+
+        Required inputs: jobId (UUID) as a path parameter; the response is a CSV with header columns row_number, entity_type, review_status, reason_codes and original_values, covering every audit record for the job rather than only errored rows.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no job exists with the supplied id for the authenticated operator.
+
+        '
       operationId: downloadErrorReport
       parameters:
       - name: jobId
@@ -670,6 +959,13 @@ paths:
               schema:
                 type: string
                 format: binary
+        '404':
+          description: Job not found
+          content:
+            application/json:
+              schema:
+                type: string
+                format: binary
       security:
       - bearerAuth:
         - bulkImport:upload:execute
@@ -680,9 +976,21 @@ paths:
     get:
       tags:
       - Review Queue API
-      summary: Get audit records for a bulk load job
-      description: Returns a list of audit records for the specified bulk load job, including review status and details for each record.
-      operationId: getAuditRecords
+      summary: Get Audit Records for Job
+      description: 'Returns every row-level audit record captured for a bulk load job, including review status, reason codes and the original source values.
+
+        Use this tool to inspect which rows failed and why after processing; use downloadErrorReport instead when a CSV export of the same records is needed.
+
+        Preconditions: the job must exist and belong to the authenticated operator; audit records exist only after processing has run.
+
+        Required inputs: jobId (UUID) as a path parameter; there is no request body and no pagination, so the full list is returned in one response.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no job exists with the supplied id for the authenticated operator.
+
+        '
+      operationId: listAuditRecords
       parameters:
       - name: jobId
         in: path
@@ -701,6 +1009,14 @@ paths:
                   $ref: '#/components/schemas/AuditRecordResponse'
         '403':
           description: Job does not belong to the authenticated operator
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuditRecordResponse'
+        '404':
+          description: Job not found
           content:
             application/json:
               schema:
@@ -778,7 +1094,6 @@ components:
           example: 0.95
         overriddenByUser:
           type: boolean
-          default: false
           description: Whether the mapping was overridden by a user
           example: false
         createdAt:
@@ -949,7 +1264,6 @@ components:
             Price: basePrice
         llmFallbackUsed:
           type: boolean
-          default: false
           description: Whether an LLM fallback was used to perform the detection
           example: false
       required:
@@ -1096,12 +1410,12 @@ components:
     PageBulkLoadJobResponse:
       type: object
       properties:
-        totalElements:
-          type: integer
-          format: int64
         totalPages:
           type: integer
           format: int32
+        totalElements:
+          type: integer
+          format: int64
         size:
           type: integer
           format: int32
@@ -1112,17 +1426,17 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
     PageableObject:

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/BulkLoadJobController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/BulkLoadJobController.java
@@ -5,6 +5,8 @@ import com.positivity.bulkloader.internal.dto.BulkLoadJobResponse;
 import com.positivity.bulkloader.service.BulkLoadJobService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -41,14 +43,41 @@ public class BulkLoadJobController {
     @PostMapping
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
     @EmitEvent(id = "BULK_LOADER_JOB_CREATE", apiVersion = "1")
-    @Operation(
-            summary = "Create a new bulk load job",
-            description =
-                    "Creates a new bulk load job for the authenticated operator. Each operator can only have one active job at a time. The job starts in CREATED state and must be populated with a file upload before processing can begin.")
+    @Operation(operationId = "createBulkLoadJob", summary = "Create a New Bulk Load Job", description = """
+                    Creates a bulk load import job owned by the authenticated operator, starting in CREATED state \
+                    with the target domain and expected file name recorded.
+                    Use this tool when starting a new bulk import from a file; do not use uploadJobFile, which \
+                    attaches the file to a job that already exists, and do not use retryBulkLoadJob, which re-queues \
+                    a FAILED job.
+                    Preconditions: the operator must have no other job in an active state (CREATED, UPLOADING, \
+                    DETECTING, MAPPING_REVIEW, DEDUP or PROCESSING); only one active job per operator is allowed.
+                    Required inputs: fileName (name of the source file that will be uploaded later) and domainType \
+                    (one of CATALOG_PRODUCT, INVENTORY_STOCK_COUNT, LOCATION, CUSTOMER, PERSON, BASE_PRICE, VEHICLE \
+                    or VEHICLE_FITMENT); locationId (UUID) is optional at creation but must be set before processing \
+                    can start.
+                    Emits a BULK_LOADER_JOB_CREATE event; no file content is stored by this call.
+                    Returns 201 with the new job, and 409 when the operator already has an active bulk load job \
+                    in progress.
+                    """)
     @ApiResponse(responseCode = "201", description = "Job created")
     @ApiResponse(responseCode = "409", description = "Operator already has an active job")
     public ResponseEntity<BulkLoadJobResponse> createJob(
-            @Valid @RequestBody @NonNull BulkLoadJobCreateRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Bulk load job to create, naming the source file and the target import domain.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Catalog product import", value = """
+                                                                    {"fileName":"products-2026-01.csv",
+                                                                     "domainType":"CATALOG_PRODUCT",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BulkLoadJobCreateRequest request) {
         String operatorId = currentOperatorId();
         BulkLoadJobResponse response = bulkLoadJobService.createJob(request, operatorId);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -56,10 +85,17 @@ public class BulkLoadJobController {
 
     @GetMapping("/{jobId}")
     @PreAuthorize("hasAuthority('bulkImport:status:read')")
-    @Operation(
-            summary = "Get a bulk load job by ID",
-            description =
-                    "Retrieves the details of a bulk load job for the authenticated operator. The operator can only access their own jobs.")
+    @Operation(operationId = "getBulkLoadJob", summary = "Get a Bulk Load Job by ID", description = """
+                    Returns the current state of a single bulk load job, including status, row counts and success \
+                    and failure totals.
+                    Use this tool to poll job progress after startJobProcessing, or whenever the job id is already \
+                    known; use listBulkLoadJobs instead when the id is unknown.
+                    Preconditions: the job must exist and belong to the authenticated operator; jobs owned by other \
+                    operators are reported as not found rather than forbidden.
+                    Required inputs: jobId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no job exists with the supplied id for the authenticated operator.
+                    """)
     @ApiResponse(responseCode = "200", description = "Job found")
     @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
     @ApiResponse(responseCode = "404", description = "Job not found")
@@ -70,10 +106,19 @@ public class BulkLoadJobController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('bulkImport:status:read')")
-    @Operation(
-            summary = "List bulk load jobs for the authenticated operator",
-            description =
-                    "Retrieves a paginated list of bulk load jobs for the authenticated operator. The operator can only access their own jobs.")
+    @Operation(operationId = "listBulkLoadJobs", summary = "List Bulk Load Jobs for Operator", description = """
+                    Returns a paginated list of the authenticated operator's bulk load jobs with their statuses and \
+                    progress counters.
+                    Use this tool to find a job id or review import history; use getBulkLoadJob instead when a \
+                    specific job id is already known.
+                    Preconditions: none beyond authentication; the listing is always scoped to the caller's own jobs \
+                    and other operators' jobs are never included.
+                    Required inputs: standard page, size and sort query parameters, all optional with Spring \
+                    defaults (page 0, size 20).
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty page when the operator has no jobs; there are no operation-specific \
+                    error responses.
+                    """)
     @ApiResponse(responseCode = "200", description = "Jobs listed")
     public ResponseEntity<Page<BulkLoadJobResponse>> listJobs(@NonNull Pageable pageable) {
         String operatorId = currentOperatorId();
@@ -83,11 +128,21 @@ public class BulkLoadJobController {
     @PostMapping("/{jobId}/cancel")
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
     @EmitEvent(id = "BULK_LOADER_JOB_CANCEL", apiVersion = "1")
-    @Operation(
-            summary = "Cancel a running bulk load job",
-            description =
-                    "Cancels a bulk load job that is currently in progress. The operator can only cancel their own jobs.")
+    @Operation(operationId = "cancelBulkLoadJob", summary = "Cancel a Running Bulk Load Job", description = """
+                    Cancels an in-flight bulk load job by moving it to the terminal CANCELLED state.
+                    Use this tool to abandon a job that is no longer wanted; do not use retryBulkLoadJob, which \
+                    re-queues a FAILED job rather than stopping one.
+                    Preconditions: the job must belong to the authenticated operator and must not already be in a \
+                    terminal state (COMPLETED, CANCELLED or FAILED).
+                    Required inputs: jobId (UUID) as a path parameter; there is no request body.
+                    Emits a BULK_LOADER_JOB_CANCEL event and sets the job status to CANCELLED; rows already imported \
+                    are not rolled back.
+                    Returns 404 when the job does not exist, 403 when it belongs to another operator, and 409 when \
+                    the job is already COMPLETED, CANCELLED or FAILED.
+                    """)
     @ApiResponse(responseCode = "200", description = "Job cancelled")
+    @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
+    @ApiResponse(responseCode = "404", description = "Job not found")
     @ApiResponse(responseCode = "409", description = "Job is already in terminal state")
     public ResponseEntity<BulkLoadJobResponse> cancelJob(@PathVariable @NonNull UUID jobId) {
         String operatorId = currentOperatorId();
@@ -97,10 +152,19 @@ public class BulkLoadJobController {
     @PostMapping("/{jobId}/retry")
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
     @EmitEvent(id = "BULK_LOADER_JOB_RETRY", apiVersion = "1")
-    @Operation(
-            summary = "Retry a failed bulk load job",
-            description =
-                    "Retries a bulk load job that has reached the FAILED state, resetting it to CREATED and re-queuing it for processing. The operator can only retry their own jobs. Returns 409 if the job is not in FAILED state.")
+    @Operation(operationId = "retryBulkLoadJob", summary = "Retry a Failed Bulk Load Job", description = """
+                    Resets a FAILED bulk load job back to CREATED and clears its progress counters so it can be \
+                    processed again.
+                    Use this tool after fixing the cause of a failure, typically via submitCorrections; do not use \
+                    cancelBulkLoadJob, which terminates a job instead of re-queuing it.
+                    Preconditions: the job must belong to the authenticated operator, must be in FAILED state, and \
+                    the operator must have no other active job.
+                    Required inputs: jobId (UUID) as a path parameter; there is no request body.
+                    Emits a BULK_LOADER_JOB_RETRY event and resets startedAt, completedAt, totalRows and all row \
+                    counters; processing does not start until startJobProcessing is called again.
+                    Returns 404 when the job does not exist, 403 when it belongs to another operator, and 409 when \
+                    the job is not in FAILED state or the operator already has an active job.
+                    """)
     @ApiResponse(responseCode = "200", description = "Job reset and re-queued for retry")
     @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
     @ApiResponse(responseCode = "404", description = "Job not found")

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/ColumnMappingController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/ColumnMappingController.java
@@ -7,6 +7,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -15,6 +16,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -52,8 +54,20 @@ public class ColumnMappingController {
                     Returns 404 when the job does not exist, and 403 when the job belongs to another operator.
                     """)
     @ApiResponse(responseCode = "200", description = "Mappings returned")
-    @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
-    @ApiResponse(responseCode = "404", description = "Job not found")
+    @ApiResponse(
+            responseCode = "403",
+            description = "Job does not belong to the authenticated operator",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Job not found",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
     public ResponseEntity<List<ColumnMappingResponse>> getMappings(@PathVariable @NonNull UUID jobId) {
         String operatorId = currentOperatorId();
         return ResponseEntity.ok(columnMappingService.getMappingsForJob(jobId, operatorId));
@@ -81,8 +95,20 @@ public class ColumnMappingController {
                     Returns 404 when the job does not exist, and 403 when the job belongs to another operator.
                     """)
     @ApiResponse(responseCode = "200", description = "Mappings approved")
-    @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
-    @ApiResponse(responseCode = "404", description = "Job not found")
+    @ApiResponse(
+            responseCode = "403",
+            description = "Job does not belong to the authenticated operator",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Job not found",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
     public ResponseEntity<List<ColumnMappingResponse>> approveMappings(
             @PathVariable @NonNull UUID jobId,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/ColumnMappingController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/ColumnMappingController.java
@@ -5,6 +5,8 @@ import com.positivity.bulkloader.internal.dto.ColumnMappingResponse;
 import com.positivity.bulkloader.service.ColumnMappingService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -38,12 +40,20 @@ public class ColumnMappingController {
 
     @GetMapping("/{jobId}/mappings")
     @PreAuthorize("hasAuthority('bulkImport:status:read')")
-    @Operation(
-            summary = "Get proposed column mappings for a job",
-            description =
-                    "Retrieves the proposed column mappings for the specified bulk load job. The operator can only access mappings for their own jobs. This endpoint is typically used to review the detected column mappings before approving them for processing.")
+    @Operation(operationId = "getColumnMappings", summary = "Get Proposed Column Mappings for Job", description = """
+                    Returns the column mappings currently stored for a bulk load job, covering both auto-suggested \
+                    mappings from content detection and operator-approved overrides.
+                    Use this tool to review detected source-column to target-field mappings, their confidence and \
+                    origin; use approveColumnMappings instead to finalize the set.
+                    Preconditions: the job must exist and belong to the authenticated operator; mappings are \
+                    typically present only after a file upload has triggered content detection.
+                    Required inputs: jobId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when the job does not exist, and 403 when the job belongs to another operator.
+                    """)
     @ApiResponse(responseCode = "200", description = "Mappings returned")
     @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
+    @ApiResponse(responseCode = "404", description = "Job not found")
     public ResponseEntity<List<ColumnMappingResponse>> getMappings(@PathVariable @NonNull UUID jobId) {
         String operatorId = currentOperatorId();
         return ResponseEntity.ok(columnMappingService.getMappingsForJob(jobId, operatorId));
@@ -53,13 +63,44 @@ public class ColumnMappingController {
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
     @EmitEvent(id = "BULK_LOADER_MAPPING_APPROVE", apiVersion = "1")
     @Operation(
-            summary = "Approve and finalize column mappings for a job",
-            description =
-                    "Approves and finalizes the proposed column mappings for the specified bulk load job. The operator can only approve mappings for their own jobs. Once approved, the mappings are locked and used for processing the bulk load job.")
+            operationId = "approveColumnMappings",
+            summary = "Approve and Finalize Column Mappings",
+            description = """
+                    Replaces all stored column mappings for a bulk load job with the submitted set, marking every \
+                    mapping operator-approved with confidence 1.0.
+                    Use this tool after reviewing the suggestions from getColumnMappings; do not use \
+                    getColumnMappings, which only reads mappings, and note that the submitted list fully replaces \
+                    prior mappings rather than merging with them.
+                    Preconditions: the job must exist and belong to the authenticated operator; the job state is not \
+                    checked, but approved mappings only affect processing started afterwards.
+                    Required inputs: mappings, a non-empty list where each entry names a sourceColumn from the \
+                    uploaded file and the targetField it maps to; mappingId is accepted but ignored because the set \
+                    is replaced wholesale.
+                    Emits a BULK_LOADER_MAPPING_APPROVE event and deletes previously stored mappings, including \
+                    auto-suggested ones, before saving the new set.
+                    Returns 404 when the job does not exist, and 403 when the job belongs to another operator.
+                    """)
     @ApiResponse(responseCode = "200", description = "Mappings approved")
     @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
+    @ApiResponse(responseCode = "404", description = "Job not found")
     public ResponseEntity<List<ColumnMappingResponse>> approveMappings(
-            @PathVariable @NonNull UUID jobId, @Valid @RequestBody @NonNull ColumnMappingApproveRequest request) {
+            @PathVariable @NonNull UUID jobId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Full replacement set of column mappings, one entry per source column to import.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Two approved mappings", value = """
+                                                                    {"mappings":[
+                                                                      {"sourceColumn":"Product SKU","targetField":"sku"},
+                                                                      {"sourceColumn":"Retail Price","targetField":"price"}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    ColumnMappingApproveRequest request) {
         String operatorId = currentOperatorId();
         return ResponseEntity.ok(columnMappingService.approveMappings(jobId, operatorId, request));
     }

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/FileUploadController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/FileUploadController.java
@@ -9,6 +9,10 @@ import com.positivity.bulkloader.service.FileStorageService;
 import com.positivity.events.EmitEvent;
 import com.positivity.security.common.GatewaySecurityConstants;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
@@ -50,12 +54,44 @@ public class FileUploadController {
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
     @EmitEvent(id = "BULK_LOADER_FILE_UPLOAD", apiVersion = "1")
     @Operation(
-            summary = "Upload a file for a bulk load job",
-            description =
-                    "Uploads a file for the specified bulk load job. The file is stored and associated with the job for later processing. "
-                            + "The job must be in CREATED or UPLOADING state. Multiple files can be uploaded, but only the latest file will be processed.")
+            operationId = "uploadJobFile",
+            summary = "Upload a File for Bulk Load Job",
+            description = """
+                    Uploads the source data file for a bulk load job as a single multipart request, stores it, and \
+                    runs content detection to propose column mappings.
+                    Use this tool for files small enough to send in one request; use createTusUpload instead for \
+                    large files that need resumable, chunked upload.
+                    Preconditions: the job must exist, belong to the authenticated operator, and not be in a \
+                    terminal state (COMPLETED, CANCELLED or FAILED); a CREATED job moves to UPLOADING.
+                    Required inputs: a multipart form part named file; formats understood by content detection are \
+                    csv, tsv, txt, psv, xlsx, xlsm, xls, json, xml, yaml and yml, with the first row or record \
+                    treated as the column headers.
+                    Emits a BULK_LOADER_FILE_UPLOAD event and persists suggested column mappings from detection; \
+                    when detection fails the upload still succeeds with a null detection field in the response, and \
+                    re-uploading replaces the file to be processed because only the latest upload is used.
+                    Returns 404 when the job does not exist for the authenticated operator, and 409 when the job is \
+                    already in a terminal state.
+                    """,
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Multipart form with a single part named file carrying the source data file to import.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "multipart/form-data",
+                                            schemaProperties =
+                                                    @SchemaProperty(
+                                                            name = "file",
+                                                            schema = @Schema(type = "string", format = "binary")),
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "CSV upload",
+                                                            value =
+                                                                    "file=@products-2026-01.csv (binary content; first row is the header row)"))))
     @ApiResponse(responseCode = "200", description = "File uploaded and content detected")
     @ApiResponse(responseCode = "404", description = "Job not found")
+    @ApiResponse(responseCode = "409", description = "Job is in a terminal state and cannot accept uploads")
     public ResponseEntity<FileUploadResponse> uploadFile(
             @PathVariable @NonNull UUID jobId, @RequestParam("file") @NonNull MultipartFile file) throws IOException {
         String operatorId = currentOperatorId();
@@ -92,12 +128,22 @@ public class FileUploadController {
     @PostMapping("/{jobId}/process")
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
     @EmitEvent(id = "BULK_LOADER_JOB_START", apiVersion = "1")
-    @Operation(
-            summary = "Launch a bulk load job for processing",
-            description =
-                    "Starts Spring Batch execution for the specified bulk load job and transitions it to PROCESSING. "
-                            + "The job must be in CREATED, UPLOADING, or MAPPING_REVIEW state and must already have a persisted upload and locationId.")
+    @Operation(operationId = "startJobProcessing", summary = "Launch a Bulk Load Job", description = """
+                    Starts asynchronous Spring Batch processing for a bulk load job and transitions it to PROCESSING.
+                    Use this tool once the uploaded file is persisted and the mappings are acceptable; do not treat \
+                    the 200 response as import completion, and poll getBulkLoadJob instead because the batch run \
+                    continues in the background.
+                    Preconditions: the job must belong to the authenticated operator, be in CREATED, UPLOADING or \
+                    MAPPING_REVIEW state, and already have both a persisted uploaded file and a locationId assigned.
+                    Required inputs: jobId (UUID) as a path parameter; there is no request body, and the caller's \
+                    Authorization bearer token is forwarded to downstream domain services for the row-level writes.
+                    Emits a BULK_LOADER_JOB_START event, launches the Spring Batch job, and stamps startedAt; row \
+                    counters on the job update as chunks are processed.
+                    Returns 404 when the job does not exist, 403 when it belongs to another operator, and 409 when \
+                    the state is not launchable or the uploaded file or locationId is missing.
+                    """)
     @ApiResponse(responseCode = "200", description = "Job transitioned to PROCESSING")
+    @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
     @ApiResponse(responseCode = "404", description = "Job not found")
     @ApiResponse(responseCode = "409", description = "Invalid state transition")
     public ResponseEntity<BulkLoadJobResponse> startProcessing(@PathVariable @NonNull UUID jobId) {

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/FileUploadController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/FileUploadController.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -90,8 +91,20 @@ public class FileUploadController {
                                                             value =
                                                                     "file=@products-2026-01.csv (binary content; first row is the header row)"))))
     @ApiResponse(responseCode = "200", description = "File uploaded and content detected")
-    @ApiResponse(responseCode = "404", description = "Job not found")
-    @ApiResponse(responseCode = "409", description = "Job is in a terminal state and cannot accept uploads")
+    @ApiResponse(
+            responseCode = "404",
+            description = "Job not found",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Job is in a terminal state and cannot accept uploads",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
     public ResponseEntity<FileUploadResponse> uploadFile(
             @PathVariable @NonNull UUID jobId, @RequestParam("file") @NonNull MultipartFile file) throws IOException {
         String operatorId = currentOperatorId();
@@ -143,9 +156,27 @@ public class FileUploadController {
                     the state is not launchable or the uploaded file or locationId is missing.
                     """)
     @ApiResponse(responseCode = "200", description = "Job transitioned to PROCESSING")
-    @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
-    @ApiResponse(responseCode = "404", description = "Job not found")
-    @ApiResponse(responseCode = "409", description = "Invalid state transition")
+    @ApiResponse(
+            responseCode = "403",
+            description = "Job does not belong to the authenticated operator",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Job not found",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Invalid state transition",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
     public ResponseEntity<BulkLoadJobResponse> startProcessing(@PathVariable @NonNull UUID jobId) {
         String operatorId = currentOperatorId();
         bulkLoadJobService.startProcessing(jobId, operatorId, currentAuthorizationHeader());

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/ReviewQueueController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/ReviewQueueController.java
@@ -11,6 +11,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -23,6 +24,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -62,8 +64,20 @@ public class ReviewQueueController {
                     Returns 404 when no job exists with the supplied id for the authenticated operator.
                     """)
     @ApiResponse(responseCode = "200", description = "Audit records returned")
-    @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
-    @ApiResponse(responseCode = "404", description = "Job not found")
+    @ApiResponse(
+            responseCode = "403",
+            description = "Job does not belong to the authenticated operator",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Job not found",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
     public ResponseEntity<List<AuditRecordResponse>> getAuditRecords(@PathVariable @NonNull UUID jobId) {
         bulkLoadJobService.getJob(jobId, currentOperatorId());
         return ResponseEntity.ok(reviewQueueService.getAuditRecords(jobId));
@@ -84,8 +98,20 @@ public class ReviewQueueController {
                     Returns 404 when no job exists with the supplied id for the authenticated operator.
                     """)
     @ApiResponse(responseCode = "200", description = "CSV error report downloaded")
-    @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
-    @ApiResponse(responseCode = "404", description = "Job not found")
+    @ApiResponse(
+            responseCode = "403",
+            description = "Job does not belong to the authenticated operator",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Job not found",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
     public ResponseEntity<Resource> downloadErrorReport(@PathVariable @NonNull UUID jobId) {
         bulkLoadJobService.getJob(jobId, currentOperatorId());
         Resource report = reviewQueueService.generateErrorReport(jobId);
@@ -116,10 +142,34 @@ public class ReviewQueueController {
                     when the job does not exist, and 403 when it belongs to another operator.
                     """)
     @ApiResponse(responseCode = "201", description = "Corrections submitted successfully")
-    @ApiResponse(responseCode = "400", description = "Invalid correction request")
-    @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
-    @ApiResponse(responseCode = "404", description = "Job not found")
-    @ApiResponse(responseCode = "409", description = "Job is not in a state that accepts corrections")
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid correction request",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Job does not belong to the authenticated operator",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Job not found",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Job is not in a state that accepts corrections",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
     public ResponseEntity<BulkCorrectionResponse> submitCorrections(
             @PathVariable @NonNull UUID jobId,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -169,10 +219,34 @@ public class ReviewQueueController {
                             schema =
                                     @io.swagger.v3.oas.annotations.media.Schema(
                                             implementation = CorrectionResultDto.class)))
-    @ApiResponse(responseCode = "400", description = "Invalid correction request")
-    @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
-    @ApiResponse(responseCode = "404", description = "Job not found")
-    @ApiResponse(responseCode = "409", description = "Job is not in a state that accepts corrections")
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid correction request",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Job does not belong to the authenticated operator",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Job not found",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Job is not in a state that accepts corrections",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
     public ResponseEntity<CorrectionResultDto> submitSingleCorrection(
             @io.swagger.v3.oas.annotations.Parameter(description = "ID of the bulk load job", required = true)
                     @PathVariable

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/ReviewQueueController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/ReviewQueueController.java
@@ -9,6 +9,8 @@ import com.positivity.bulkloader.service.BulkLoadJobService;
 import com.positivity.bulkloader.service.ReviewQueueService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -47,12 +49,21 @@ public class ReviewQueueController {
 
     @GetMapping("/{jobId}/audit")
     @PreAuthorize("hasAuthority('bulkImport:status:read')")
-    @Operation(
-            summary = "Get audit records for a bulk load job",
-            description =
-                    "Returns a list of audit records for the specified bulk load job, including review status and details for each record.")
+    @Operation(operationId = "listAuditRecords", summary = "Get Audit Records for Job", description = """
+                    Returns every row-level audit record captured for a bulk load job, including review status, \
+                    reason codes and the original source values.
+                    Use this tool to inspect which rows failed and why after processing; use downloadErrorReport \
+                    instead when a CSV export of the same records is needed.
+                    Preconditions: the job must exist and belong to the authenticated operator; audit records exist \
+                    only after processing has run.
+                    Required inputs: jobId (UUID) as a path parameter; there is no request body and no pagination, \
+                    so the full list is returned in one response.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no job exists with the supplied id for the authenticated operator.
+                    """)
     @ApiResponse(responseCode = "200", description = "Audit records returned")
     @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
+    @ApiResponse(responseCode = "404", description = "Job not found")
     public ResponseEntity<List<AuditRecordResponse>> getAuditRecords(@PathVariable @NonNull UUID jobId) {
         bulkLoadJobService.getJob(jobId, currentOperatorId());
         return ResponseEntity.ok(reviewQueueService.getAuditRecords(jobId));
@@ -60,12 +71,21 @@ public class ReviewQueueController {
 
     @GetMapping("/{jobId}/error-report")
     @PreAuthorize("hasAuthority('bulkImport:status:read')")
-    @Operation(
-            summary = "Download error report as CSV for a bulk load job",
-            description =
-                    "Generates and downloads a CSV file containing all error records for the specified bulk load job.")
+    @Operation(operationId = "downloadErrorReport", summary = "Download Error Report as CSV", description = """
+                    Generates a CSV export of the audit records for a bulk load job and returns it as a text/csv \
+                    attachment.
+                    Use this tool to hand failed rows to a spreadsheet for offline correction; use listAuditRecords \
+                    instead when the records are needed as JSON for programmatic handling.
+                    Preconditions: the job must exist and belong to the authenticated operator.
+                    Required inputs: jobId (UUID) as a path parameter; the response is a CSV with header columns \
+                    row_number, entity_type, review_status, reason_codes and original_values, covering every audit \
+                    record for the job rather than only errored rows.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no job exists with the supplied id for the authenticated operator.
+                    """)
     @ApiResponse(responseCode = "200", description = "CSV error report downloaded")
     @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
+    @ApiResponse(responseCode = "404", description = "Job not found")
     public ResponseEntity<Resource> downloadErrorReport(@PathVariable @NonNull UUID jobId) {
         bulkLoadJobService.getJob(jobId, currentOperatorId());
         Resource report = reviewQueueService.generateErrorReport(jobId);
@@ -78,17 +98,46 @@ public class ReviewQueueController {
     @PostMapping("/{jobId}/corrections")
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
     @EmitEvent(id = "BULK_LOADER_CORRECTION_SUBMIT", apiVersion = "1")
-    @Operation(
-            summary = "Submit corrected records for a bulk load job",
-            description =
-                    "Submits corrected data for one or more error records from a bulk import audit. The job must be in FAILED state to accept corrections. Returns 409 if the job is not in a correctable state.")
+    @Operation(operationId = "submitCorrections", summary = "Submit Corrected Records for Job", description = """
+                    Submits corrected field values for one or more audit records of a FAILED bulk load job, marking \
+                    each accepted record CORRECTED.
+                    Use this tool to fix several failed rows in one call; use submitSingleCorrection instead when \
+                    correcting exactly one record and a per-record accept or reject status is wanted.
+                    Preconditions: the job must belong to the authenticated operator and be in FAILED state; each \
+                    auditRecordId must belong to that job.
+                    Required inputs: corrections, a non-empty list where each item carries auditRecordId (UUID) and \
+                    correctedData, a map of field names to corrected string values.
+                    Emits a BULK_LOADER_CORRECTION_SUBMIT event and stores the corrected values on each audit \
+                    record; items whose audit record is missing or belongs to another job are rejected individually \
+                    and reported in the response's rejections list without failing the call.
+                    Correcting records does not re-run the import; call retryBulkLoadJob and then startJobProcessing \
+                    to process the job again.
+                    Returns 201 with accepted and rejected counts, 409 when the job is not in FAILED state, 404 \
+                    when the job does not exist, and 403 when it belongs to another operator.
+                    """)
     @ApiResponse(responseCode = "201", description = "Corrections submitted successfully")
     @ApiResponse(responseCode = "400", description = "Invalid correction request")
     @ApiResponse(responseCode = "403", description = "Job does not belong to the authenticated operator")
     @ApiResponse(responseCode = "404", description = "Job not found")
     @ApiResponse(responseCode = "409", description = "Job is not in a state that accepts corrections")
     public ResponseEntity<BulkCorrectionResponse> submitCorrections(
-            @PathVariable @NonNull UUID jobId, @Valid @RequestBody @NonNull BulkCorrectionRequest request) {
+            @PathVariable @NonNull UUID jobId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Batch of corrected values, one item per failed audit record to be marked CORRECTED.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Correct one failed row", value = """
+                                                                    {"corrections":[
+                                                                      {"auditRecordId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                       "correctedData":{"sku":"PROD-001","price":"19.99"}}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BulkCorrectionRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(reviewQueueService.submitCorrections(jobId, request, currentOperatorId()));
     }
@@ -96,11 +145,22 @@ public class ReviewQueueController {
     @PostMapping("/{jobId}/corrections/single")
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
     @EmitEvent(id = "BULK_LOADER_CORRECTION_SUBMIT_SINGLE", apiVersion = "1")
-    @Operation(
-            operationId = "submitSingleCorrection",
-            summary = "Submit a single correction record",
-            description =
-                    "Submits a corrected data record for a single failed audit entry from a bulk import job. The job must be in FAILED state. Returns the acceptance or rejection status for the submitted record.")
+    @Operation(operationId = "submitSingleCorrection", summary = "Submit a Single Correction Record", description = """
+                    Submits corrected field values for exactly one audit record of a FAILED bulk load job and \
+                    reports whether the correction was accepted.
+                    Use this tool for interactive row-by-row fixing; use submitCorrections instead to correct a \
+                    batch of records in one call.
+                    Preconditions: the job must belong to the authenticated operator and be in FAILED state; the \
+                    auditRecordId must belong to that job.
+                    Required inputs: auditRecordId (UUID) and correctedData, a map of field names to corrected \
+                    string values.
+                    Emits a BULK_LOADER_CORRECTION_SUBMIT_SINGLE event and stores the corrected values on the audit \
+                    record, setting its review status to CORRECTED when accepted; correcting a record does not \
+                    re-run the import.
+                    Returns 201 with status ACCEPTED or REJECTED plus a rejectionReason when rejected, 409 when the \
+                    job is not in FAILED state, 404 when the job does not exist, and 403 when it belongs to another \
+                    operator.
+                    """)
     @ApiResponse(
             responseCode = "201",
             description = "Correction processed",
@@ -118,7 +178,21 @@ public class ReviewQueueController {
                     @PathVariable
                     @NonNull
                     UUID jobId,
-            @Valid @RequestBody @NonNull BulkCorrectionItem item) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Single corrected record naming the audit record and the field values that replace the failed ones.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Corrected row", value = """
+                                                                    {"auditRecordId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "correctedData":{"sku":"PROD-001","price":"19.99"}}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BulkCorrectionItem item) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(reviewQueueService.submitSingleCorrection(jobId, item, currentOperatorId()));
     }

--- a/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/TusUploadController.java
+++ b/pos-bulk-loader/src/main/java/com/positivity/bulkloader/internal/controller/TusUploadController.java
@@ -59,9 +59,17 @@ public class TusUploadController {
 
     @RequestMapping(value = "/tus", method = RequestMethod.OPTIONS)
     @PreAuthorize("permitAll()")
-    @Operation(
-            summary = "TUS server capabilities",
-            description = "Returns supported TUS version, extensions, and max upload size. No authentication required.")
+    @Operation(operationId = "getTusCapabilities", summary = "Get TUS Server Capabilities", description = """
+                    Advertises the TUS resumable-upload capabilities of this server, namely protocol version 1.0.0, \
+                    the creation, termination and expiration extensions, and the maximum upload size.
+                    Use this tool during the tus client handshake to discover limits before creating an upload; do \
+                    not use it to check the progress of an existing upload, which is getTusUploadOffset.
+                    Preconditions: none; this endpoint requires no authentication.
+                    Required inputs: none; there are no parameters and no request body.
+                    No events are emitted and no state changes; the capabilities are returned in the Tus-Version, \
+                    Tus-Max-Size and Tus-Extension response headers.
+                    Returns 204 in all cases, with the capability data carried in headers rather than a body.
+                    """)
     @ApiResponse(responseCode = "204", description = "Server capabilities")
     public ResponseEntity<Void> options() {
         return ResponseEntity.noContent()
@@ -75,13 +83,25 @@ public class TusUploadController {
     @PostMapping("/bulk-jobs/{jobId}/tus")
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
     @EmitEvent(id = "BULK_LOADER_TUS_UPLOAD_CREATE", apiVersion = "1")
-    @Operation(
-            summary = "Create a resumable upload",
-            description = "Creates a new TUS upload scoped to a bulk load job. "
-                    + "Returns a Location header with the absolute upload URL for subsequent HEAD and PATCH "
-                    + "requests. The URL is reconstructed from the X-Forwarded-Proto/Host/Port/Prefix headers "
-                    + "supplied by the API gateway / reverse-proxy chain, so it reflects the public address "
-                    + "(including any proxy path prefix) rather than this service's internal one.")
+    @Operation(operationId = "createTusUpload", summary = "Create a Resumable Upload", description = """
+                    Creates a resumable TUS upload session scoped to a bulk load job and returns its absolute upload \
+                    URL in the Location header, rebuilt from the gateway's X-Forwarded headers so it reflects the \
+                    public address.
+                    Use this tool to start uploading a large file in chunks; use uploadJobFile instead when the \
+                    file is small enough for a single multipart request, and do not send file bytes here because \
+                    chunks go to appendTusUploadChunk.
+                    Preconditions: the caller must send a Tus-Resumable header of 1.0.0; the job id is recorded but \
+                    not validated here, so a wrong job id only fails later when the finished file is attached to \
+                    the job.
+                    Required inputs: Upload-Length header with the total file size in bytes (server maximum \
+                    536870912 by default), and optionally Upload-Metadata with a base64-encoded filename field, \
+                    without which the file is stored as upload.bin.
+                    Emits a BULK_LOADER_TUS_UPLOAD_CREATE event and creates an empty temp file; the session expires \
+                    after 24 hours by default (see the Upload-Expires header) and expired incomplete uploads are \
+                    cleaned up automatically.
+                    Returns 201 with Location, Upload-Offset and Upload-Expires headers, 412 when the Tus-Resumable \
+                    header is missing or not 1.0.0, and 413 when Upload-Length exceeds the server maximum.
+                    """)
     @ApiResponse(responseCode = "201", description = "Upload created")
     @ApiResponse(responseCode = "412", description = "Unsupported TUS version")
     @ApiResponse(responseCode = "413", description = "Upload-Length exceeds server maximum")
@@ -123,9 +143,19 @@ public class TusUploadController {
 
     @RequestMapping(value = "/tus/{uploadId}", method = RequestMethod.HEAD)
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
-    @Operation(
-            summary = "Get upload offset",
-            description = "Returns the current byte offset of a TUS upload for resumption.")
+    @Operation(operationId = "getTusUploadOffset", summary = "Get Current Upload Offset", description = """
+                    Returns the current byte offset of a TUS upload in the Upload-Offset response header so a client \
+                    can resume where the last transfer stopped.
+                    Use this tool after an interrupted transfer to learn where to resume; do not use \
+                    getTusCapabilities, which reports server-wide limits rather than per-upload progress.
+                    Preconditions: the upload session must exist and the caller must send a Tus-Resumable header \
+                    of 1.0.0.
+                    Required inputs: uploadId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; the response carries Upload-Offset, Upload-Length \
+                    and Upload-Expires headers with an empty body.
+                    Returns 404 when the upload does not exist, and 412 when the Tus-Resumable header is missing \
+                    or not 1.0.0.
+                    """)
     @ApiResponse(responseCode = "200", description = "Current upload offset")
     @ApiResponse(responseCode = "404", description = "Upload not found")
     @ApiResponse(responseCode = "412", description = "Unsupported TUS version")
@@ -149,11 +179,23 @@ public class TusUploadController {
     @PatchMapping("/tus/{uploadId}")
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
     @EmitEvent(id = "BULK_LOADER_TUS_UPLOAD_CHUNK_APPEND", apiVersion = "1")
-    @Operation(
-            summary = "Upload a chunk",
-            description = "Appends a byte range to an in-progress TUS upload. "
-                    + "Content-Type must be application/offset+octet-stream. "
-                    + "Upload-Offset must equal the current server-side offset.")
+    @Operation(operationId = "appendTusUploadChunk", summary = "Upload a Chunk", description = """
+                    Appends a contiguous byte range to an in-progress TUS upload and, when the final byte arrives, \
+                    moves the finished file into job storage.
+                    Use this tool repeatedly to stream the file in chunks after createTusUpload; do not guess the \
+                    offset after a failure, and call getTusUploadOffset instead to learn the server-side offset.
+                    Preconditions: the upload must exist, not be complete, and not be expired; the Upload-Offset \
+                    header must exactly equal the server's current offset.
+                    Required inputs: uploadId (UUID) as a path parameter, a Content-Type of \
+                    application/offset+octet-stream, Tus-Resumable, Upload-Offset and Content-Length headers, and \
+                    the raw chunk bytes as the request body.
+                    Emits a BULK_LOADER_TUS_UPLOAD_CHUNK_APPEND event; when the new offset reaches Upload-Length \
+                    the file is finalized into the job's storage and the job records the upload, moving a CREATED \
+                    job to UPLOADING (finalization fails with 404 when the job is gone or 409 when it is terminal).
+                    Returns 204 with the new Upload-Offset header on success, 409 when the offset does not match or \
+                    the upload is already complete, 410 when the upload has expired, 415 when the Content-Type is \
+                    wrong, 412 when the TUS version is unsupported, and 404 when the upload does not exist.
+                    """)
     @ApiResponse(responseCode = "204", description = "Chunk accepted, new offset returned")
     @ApiResponse(responseCode = "409", description = "Upload-Offset conflict")
     @ApiResponse(responseCode = "410", description = "Upload has expired")
@@ -187,7 +229,20 @@ public class TusUploadController {
     @DeleteMapping("/tus/{uploadId}")
     @PreAuthorize("hasAuthority('bulkImport:upload:execute')")
     @EmitEvent(id = "BULK_LOADER_TUS_UPLOAD_CANCEL", apiVersion = "1")
-    @Operation(summary = "Cancel an upload", description = "Permanently deletes a TUS upload and its temporary file.")
+    @Operation(operationId = "cancelTusUpload", summary = "Cancel a Resumable Upload", description = """
+                    Cancels a TUS upload session, permanently deleting both the session record and its temporary \
+                    chunk file.
+                    Use this tool to abandon a partially transferred upload; do not use cancelBulkLoadJob, which \
+                    cancels the bulk load job itself rather than an upload session.
+                    Preconditions: the upload session must exist and the caller must send a Tus-Resumable header of \
+                    1.0.0; a completed upload whose file has already been attached to the job is not detached by \
+                    this call.
+                    Required inputs: uploadId (UUID) as a path parameter; there is no request body.
+                    Emits a BULK_LOADER_TUS_UPLOAD_CANCEL event and removes the temporary file; the deletion cannot \
+                    be undone and the upload URL becomes invalid.
+                    Returns 204 on success, 404 when the upload does not exist, and 412 when the Tus-Resumable \
+                    header is missing or not 1.0.0.
+                    """)
     @ApiResponse(responseCode = "204", description = "Upload deleted")
     @ApiResponse(responseCode = "404", description = "Upload not found")
     @ApiResponse(responseCode = "412", description = "Unsupported TUS version")

--- a/pos-documents/openapi.yaml
+++ b/pos-documents/openapi.yaml
@@ -18,13 +18,47 @@ paths:
       tags:
       - Document Render API
       summary: Render document to PDF
-      description: Renders input content and template context into a PDF document.
+      description: 'Renders the supplied source content into a PDF document and returns the PDF bytes inline.
+
+        Use this tool when a printable document is needed from structured content; do not use it to
+
+        store or retrieve documents, because nothing is persisted and every call re-renders from the
+
+        request alone.
+
+        Preconditions: none beyond an authenticated caller with documents:render; when templateId is
+
+        supplied the named template must exist.
+
+        Required inputs: format (JSON, XML, MARKDOWN, TEXT or CSV, describing the source content) and
+
+        content, the raw text to render; templateId is optional and applies the named layout.
+
+        Emits a DOCUMENT_RENDER event; no document record is created and the output exists only in the
+
+        response body.
+
+        Returns 400 when the format is missing or unsupported, 404 when the named template does not
+
+        exist, 422 when the content is blank or exceeds the maximum input size, and 500 when PDF
+
+        rendering itself fails.
+
+        '
       operationId: renderDocument
       requestBody:
+        description: Source content and target format to render into a PDF.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RenderRequest'
+            examples:
+              Invoice content with a template:
+                description: Invoice content with a template
+                value:
+                  format: JSON
+                  templateId: invoice-default
+                  content: '{"title":"Invoice","total":125.00}'
         required: true
       responses:
         '200':

--- a/pos-documents/src/main/java/com/positivity/documents/internal/controller/DocumentRenderController.java
+++ b/pos-documents/src/main/java/com/positivity/documents/internal/controller/DocumentRenderController.java
@@ -37,8 +37,23 @@ public class DocumentRenderController {
     @EmitEvent(id = "DOCUMENT_RENDER", apiVersion = "1")
     @PreAuthorize("hasAuthority('documents:render')")
     @Operation(
+            operationId = "renderDocument",
             summary = "Render document to PDF",
-            description = "Renders input content and template context into a PDF document.",
+            description = """
+                    Renders the supplied source content into a PDF document and returns the PDF bytes inline.
+                    Use this tool when a printable document is needed from structured content; do not use it to
+                    store or retrieve documents, because nothing is persisted and every call re-renders from the
+                    request alone.
+                    Preconditions: none beyond an authenticated caller with documents:render; when templateId is
+                    supplied the named template must exist.
+                    Required inputs: format (JSON, XML, MARKDOWN, TEXT or CSV, describing the source content) and
+                    content, the raw text to render; templateId is optional and applies the named layout.
+                    Emits a DOCUMENT_RENDER event; no document record is created and the output exists only in the
+                    response body.
+                    Returns 400 when the format is missing or unsupported, 404 when the named template does not
+                    exist, 422 when the content is blank or exceeds the maximum input size, and 500 when PDF
+                    rendering itself fails.
+                    """,
             tags = {"Document Render API"})
     @ApiResponse(
             responseCode = "200",
@@ -49,7 +64,22 @@ public class DocumentRenderController {
                             schema = @Schema(type = "string", format = "binary", implementation = String.class)))
     @ApiResponse(responseCode = "400", description = "Invalid render request")
     @ApiResponse(responseCode = "403", description = "Forbidden")
-    public ResponseEntity<byte[]> renderDocument(@RequestBody @Valid RenderRequest request) {
+    public ResponseEntity<byte[]> renderDocument(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Source content and target format to render into a PDF.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            examples =
+                                                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                                            name = "Invoice content with a template",
+                                                            value =
+                                                                    "{\"format\":\"JSON\",\"templateId\":\"invoice-default\","
+                                                                            + "\"content\":\"{\\\"title\\\":\\\"Invoice\\\",\\\"total\\\":125.00}\"}")))
+                    @RequestBody
+                    @Valid
+                    RenderRequest request) {
         byte[] pdfContent = pdfRenderingService.renderPdf(request);
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=document.pdf")

--- a/pos-event-receiver/openapi.yaml
+++ b/pos-event-receiver/openapi.yaml
@@ -17,8 +17,20 @@ paths:
     get:
       tags:
       - Event Types
-      summary: Get event type by ID
-      description: Retrieve a specific event type by its unique ID
+      summary: Get an event type by id
+      description: 'Returns a single event type, resolved by its UUID primary key, including its typeCode, description, active flag, apiVersion and latency thresholds.
+
+        Use this tool when the event-type id is already known from a prior create or list call; use getEventTypeByCode instead when only the typeCode string such as ORDER_ORDER_CREATE is known.
+
+        Preconditions: an event type row with the supplied id must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body and no filtering.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no event type exists for the supplied id.
+
+        '
       operationId: getEventTypeById
       parameters:
       - name: id
@@ -45,8 +57,20 @@ paths:
     put:
       tags:
       - Event Types
-      summary: Update event type
-      description: Update an existing event type
+      summary: Update an existing event type
+      description: 'Updates an existing event type identified by its UUID, replacing the description and active flag and selectively overriding apiVersion and the latency thresholds; the stored typeCode itself is never changed by this operation.
+
+        Use this tool when the registration id is known and the type must already exist; use upsertEventType instead to create-or-update by typeCode without knowing the id.
+
+        Preconditions: an event type row with the supplied id must exist, and the caller must present a valid X-Events-Api-Secret shared-secret header when pos.events.api-secret is configured.
+
+        Required inputs: id (UUID) as a path parameter and a body with typeCode and description; active defaults to false when omitted, and a null apiVersion or null p50Micros/p95Micros/p99Micros keeps the currently stored values.
+
+        Emits an EVENT_RECEIVER_EVENT_TYPE_UPDATE event and updates one event_type row.
+
+        Returns 404 when no event type exists for the id, 400 when a field fails validation such as thresholds violating p50 <= p95 <= p99, and 401 when the shared secret is missing or invalid.
+
+        '
       operationId: updateEventType
       parameters:
       - name: id
@@ -58,11 +82,21 @@ paths:
           format: uuid
         example: 018e1c9f-6b5a-7890-abcd-1234567890ab
       requestBody:
-        description: Updated event type details
+        description: Replacement event type details; omitted optional fields fall back to stored or default values.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/EventTypeRequest'
+            examples:
+              Tighten thresholds:
+                description: Tighten thresholds
+                value:
+                  typeCode: ORDER_ORDER_CREATE
+                  description: Emitted when an order is created
+                  active: true
+                  p50Micros: 250000
+                  p95Micros: 750000
+                  p99Micros: 1500000
         required: true
       responses:
         '200':
@@ -80,8 +114,20 @@ paths:
     delete:
       tags:
       - Event Types
-      summary: Delete event type
-      description: Delete an event type by ID
+      summary: Delete an event type by id
+      description: 'Deletes an event type registration by its UUID, removing the typeCode, metadata and latency thresholds from the registry.
+
+        Use this tool when a registration was created in error or is being retired permanently; do not use it for a temporary pause — updateEventType with active set to false deactivates the type reversibly instead.
+
+        Preconditions: an event type row with the supplied id must exist, and the caller must present a valid X-Events-Api-Secret shared-secret header when pos.events.api-secret is configured.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits an EVENT_RECEIVER_EVENT_TYPE_DELETE event and removes one event_type row; already recorded emitted_event history is not touched.
+
+        Returns 204 on successful deletion, 404 when no event type exists for the id, and 401 when the shared secret is missing or invalid.
+
+        '
       operationId: deleteEventType
       parameters:
       - name: id
@@ -101,8 +147,20 @@ paths:
     get:
       tags:
       - Event Types
-      summary: Get event type by code
-      description: Retrieve a specific event type by its unique type code
+      summary: Get an event type by code
+      description: 'Returns a single event type resolved by its unique typeCode, the same code services reference in @EmitEvent annotations.
+
+        Use this tool when only the typeCode string is known; use getEventTypeById instead when the UUID of the registration row is already at hand.
+
+        Preconditions: an event type with the given code must exist; the code is trimmed and upper-cased before lookup, so matching is case-insensitive on input.
+
+        Required inputs: typeCode as a path parameter, containing only letters, digits and underscores after normalization.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no event type matches the normalized code, and 400 when the code contains characters other than letters, digits and underscores.
+
+        '
       operationId: getEventTypeByCode
       parameters:
       - name: typeCode
@@ -129,8 +187,20 @@ paths:
     put:
       tags:
       - Event Types
-      summary: Upsert event type
-      description: Create or update an event type by type code
+      summary: Create or update event type by code
+      description: 'Creates the event type when the typeCode is not yet registered, or updates it in place when it is, keyed by the typeCode path segment; this is the idempotent registration path that module EventTypeInitializers call at startup.
+
+        Use this tool when the caller does not care whether the type exists yet; use updateEventType instead when a missing type must fail with 404, and createEventType when a duplicate must be rejected.
+
+        Preconditions: the body typeCode, when supplied, must match the path typeCode after normalization, and the caller must present a valid X-Events-Api-Secret shared-secret header when pos.events.api-secret is configured.
+
+        Required inputs: typeCode as a path parameter plus a body with typeCode and description; active defaults to false when omitted, while a null apiVersion or null p50Micros/p95Micros/p99Micros keeps the stored values on update and falls back to 1 and 10000000 microseconds on create.
+
+        Emits an EVENT_RECEIVER_EVENT_TYPE_UPSERT event and inserts or updates one event_type row.
+
+        Returns 200 for both the create and update outcome, 400 when the path and body typeCode disagree or a field fails validation, and 401 when the shared secret is missing or invalid.
+
+        '
       operationId: upsertEventType
       parameters:
       - name: typeCode
@@ -142,11 +212,22 @@ paths:
           minLength: 1
         example: ORDER_ORDER_CREATE
       requestBody:
-        description: Event type details
+        description: Event type registration to create or overwrite; its typeCode must match the path code when provided.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/EventTypeRequest'
+            examples:
+              Startup registration:
+                description: Startup registration
+                value:
+                  typeCode: ORDER_ORDER_CREATE
+                  description: Emitted when an order is created
+                  active: true
+                  apiVersion: '1'
+                  p50Micros: 500000
+                  p95Micros: 1000000
+                  p99Micros: 2000000
         required: true
       responses:
         '200':
@@ -165,15 +246,36 @@ paths:
     post:
       tags:
       - Event Emission
-      summary: Receive emitted event
-      description: Stores a preregistered emitted event payload
+      summary: Receive and store an emitted event
+      description: 'Receives one event occurrence emitted by another pos service and queues it for storage in the emitted_event time-series table.
+
+        Use this tool when a service needs to record that a registered event happened; do not use upsertEventType, which registers or edits event-type metadata rather than recording occurrences.
+
+        Preconditions: the event id must already exist in the preregistered_event allowlist, and the call must carry a valid X-Events-Api-Secret shared-secret header when pos.events.api-secret is configured; this service is internal-network only and is not exposed through the API gateway.
+
+        Required inputs: id (uppercase letters, digits and underscores), numeric apiVersion, timestamp as positive epoch milliseconds, elapsedMs of zero or more, and publishedAt as a UTC instant.
+
+        No events are emitted by this operation itself, by design, to prevent infinite recursion; the submitted event is queued in memory and a batch flush persists the queue every 5 seconds, so a 200 response means accepted, not yet durably stored.
+
+        Returns 400 when the id is not preregistered or a field fails validation, and 401 when the shared secret is missing or invalid.
+
+        '
       operationId: receiveEvent
       requestBody:
-        description: Event payload to persist
+        description: Single event occurrence to record, identifying the preregistered event id and its timing measurements.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/EmitEventRequest'
+            examples:
+              Order creation event:
+                description: Order creation event
+                value:
+                  id: ORDER_ORDER_CREATE
+                  apiVersion: '1'
+                  timestamp: 1730809200000
+                  elapsedMs: 42
+                  publishedAt: 2026-03-05 21:15:00+00:00
         required: true
       responses:
         '200':
@@ -192,9 +294,21 @@ paths:
     get:
       tags:
       - Event Types
-      summary: Get all event types
-      description: Retrieve all available event types
-      operationId: getAllEventTypes
+      summary: List all registered event types
+      description: 'Lists every registered event type, active and inactive, with its typeCode, description, apiVersion and p50/p95/p99 latency thresholds in microseconds.
+
+        Use this tool when auditing the full event-type registry including deactivated types; use listActiveEventTypes instead when only the types currently accepted for monitoring matter.
+
+        Preconditions: none beyond service availability; GET requests pass the shared-secret filter without authentication.
+
+        Required inputs: none; there are no parameters, no paging and no filtering.
+
+        No events are emitted and no state changes; this is a read-only projection of the event_type table.
+
+        Returns 200 with the full list, which is empty when no event types have been registered.
+
+        '
+      operationId: listEventTypes
       responses:
         '200':
           description: List of event types returned successfully
@@ -205,15 +319,38 @@ paths:
     post:
       tags:
       - Event Types
-      summary: Create event type
-      description: Create a new event type for preregistered events
+      summary: Create a new event type
+      description: 'Creates a new event type registration whose typeCode other services reference from @EmitEvent annotations, with latency thresholds used to monitor event performance.
+
+        Use this tool when registering a brand-new typeCode that must not already exist; use upsertEventType instead for idempotent create-or-update registration, because a duplicate typeCode is rejected here.
+
+        Preconditions: no event type with the same normalized typeCode may exist, and the caller must present a valid X-Events-Api-Secret shared-secret header when pos.events.api-secret is configured.
+
+        Required inputs: typeCode (letters, digits and underscores; trimmed and upper-cased) and description; active defaults to false when omitted from the JSON body, apiVersion defaults to 1, and p50Micros/p95Micros/p99Micros default to 10000000 microseconds (10 seconds) and must satisfy p50 <= p95 <= p99 when supplied.
+
+        Emits an EVENT_RECEIVER_EVENT_TYPE_CREATE event and inserts one event_type row.
+
+        Returns 201 with the created type, 400 when the typeCode already exists or a field fails validation, and 401 when the shared secret is missing or invalid.
+
+        '
       operationId: createEventType
       requestBody:
-        description: Event type details
+        description: Event type registration to create, naming the code, description and optional latency thresholds.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/EventTypeRequest'
+            examples:
+              New event type:
+                description: New event type
+                value:
+                  typeCode: ORDER_ORDER_CREATE
+                  description: Emitted when an order is created
+                  active: true
+                  apiVersion: '1'
+                  p50Micros: 500000
+                  p95Micros: 1000000
+                  p99Micros: 2000000
         required: true
       responses:
         '201':
@@ -233,8 +370,20 @@ paths:
       tags:
       - Event Summary
       summary: Get event summary for the last week
-      description: Returns event counts grouped by event type for the last 7 days
-      operationId: getLastWeekSummary
+      description: 'Returns emitted-event counts grouped by event type code for the trailing 7 days, read from the emitted_event_hourly TimescaleDB continuous aggregate.
+
+        Use this tool for a weekly trend of platform event traffic; use getEventSummaryLastHour or getEventSummaryLastDay instead when a shorter window is wanted.
+
+        Preconditions: none beyond service availability; GET requests bypass the shared-secret filter, and the aggregate refreshes hourly with a one-hour end offset, so the newest counts can lag by up to an hour.
+
+        Required inputs: none; the window is fixed at 7 days and cannot be parameterized.
+
+        Emits an EVENT_RECEIVER_SUMMARY_LAST_WEEK event recording the query itself; the read changes no stored state.
+
+        Returns 200 with a list of event-type and count pairs, which is empty when no events fall inside the window.
+
+        '
+      operationId: getEventSummaryLastWeek
       responses:
         '200':
           description: Summary returned successfully
@@ -247,8 +396,20 @@ paths:
       tags:
       - Event Summary
       summary: Get event summary for the last hour
-      description: Returns event counts grouped by event type for the last 60 minutes
-      operationId: getLastHourSummary
+      description: 'Returns emitted-event counts grouped by event type code for the trailing 60 minutes, read from the emitted_event_hourly TimescaleDB continuous aggregate.
+
+        Use this tool for a near-real-time pulse of platform event traffic; use getEventSummaryLastDay or getEventSummaryLastWeek instead for longer trend windows.
+
+        Preconditions: none beyond service availability; GET requests bypass the shared-secret filter, and the aggregate refreshes hourly with a one-hour end offset, so the newest counts can lag by up to an hour.
+
+        Required inputs: none; the window is fixed at one hour and cannot be parameterized.
+
+        Emits an EVENT_RECEIVER_SUMMARY_LAST_HOUR event recording the query itself; the read changes no stored state.
+
+        Returns 200 with a list of event-type and count pairs, which is empty when no events fall inside the window.
+
+        '
+      operationId: getEventSummaryLastHour
       responses:
         '200':
           description: Summary returned successfully
@@ -261,8 +422,20 @@ paths:
       tags:
       - Event Summary
       summary: Get event summary for the last day
-      description: Returns event counts grouped by event type for the last 24 hours
-      operationId: getLastDaySummary
+      description: 'Returns emitted-event counts grouped by event type code for the trailing 24 hours, read from the emitted_event_hourly TimescaleDB continuous aggregate.
+
+        Use this tool for a daily view of platform event traffic; use getEventSummaryLastHour instead for a near-real-time pulse, or getEventSummaryLastWeek for the weekly trend.
+
+        Preconditions: none beyond service availability; GET requests bypass the shared-secret filter, and the aggregate refreshes hourly with a one-hour end offset, so the newest counts can lag by up to an hour.
+
+        Required inputs: none; the window is fixed at 24 hours and cannot be parameterized.
+
+        Emits an EVENT_RECEIVER_SUMMARY_LAST_DAY event recording the query itself; the read changes no stored state.
+
+        Returns 200 with a list of event-type and count pairs, which is empty when no events fall inside the window.
+
+        '
+      operationId: getEventSummaryLastDay
       responses:
         '200':
           description: Summary returned successfully
@@ -274,9 +447,21 @@ paths:
     get:
       tags:
       - Event Types
-      summary: Get active event types
-      description: Retrieve only active event types
-      operationId: getActiveEventTypes
+      summary: List only active event types
+      description: 'Lists the event types whose active flag is true, which are the types currently expected to appear in event traffic and latency monitoring.
+
+        Use this tool when only live, monitorable event types matter; use listEventTypes instead to audit the whole registry including deactivated types.
+
+        Preconditions: none beyond service availability; GET requests pass the shared-secret filter without authentication.
+
+        Required inputs: none; there are no parameters, no paging and no filtering.
+
+        No events are emitted and no state changes; this is a read-only projection of the event_type table filtered on active = true.
+
+        Returns 200 with the active list, which is empty when every registered type is inactive.
+
+        '
+      operationId: listActiveEventTypes
       responses:
         '200':
           description: List of active event types returned successfully
@@ -315,16 +500,19 @@ components:
           format: int64
           description: '50th percentile latency threshold in microseconds (default: 10,000,000 = 10s)'
           example: 500000
+          minimum: 0
         p95Micros:
           type: integer
           format: int64
           description: '95th percentile latency threshold in microseconds (default: 10,000,000 = 10s)'
           example: 1000000
+          minimum: 0
         p99Micros:
           type: integer
           format: int64
           description: '99th percentile latency threshold in microseconds (default: 10,000,000 = 10s)'
           example: 2000000
+          minimum: 0
       required:
       - description
       - typeCode
@@ -398,11 +586,13 @@ components:
           format: int64
           description: Event timestamp in epoch milliseconds
           example: 1730809200000
+          minimum: 0
         elapsedMs:
           type: integer
           format: int64
           description: Elapsed operation time in milliseconds
           example: 42
+          minimum: 0
         publishedAt:
           type: string
           format: date-time

--- a/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/controller/EmitEventController.java
+++ b/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/controller/EmitEventController.java
@@ -4,6 +4,7 @@ import com.positivity.poseventreceiver.internal.dto.EmitEventRequest;
 import com.positivity.poseventreceiver.service.EmitEventService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -67,17 +68,45 @@ public class EmitEventController {
      */
     @PostMapping
     @Operation(
-            summary = "Receive emitted event",
-            description = "Stores a preregistered emitted event payload",
+            operationId = "receiveEvent",
+            summary = "Receive and store an emitted event",
+            description = """
+                    Receives one event occurrence emitted by another pos service and queues it for storage in the \
+                    emitted_event time-series table.
+                    Use this tool when a service needs to record that a registered event happened; do not use \
+                    upsertEventType, which registers or edits event-type metadata rather than recording occurrences.
+                    Preconditions: the event id must already exist in the preregistered_event allowlist, and the call \
+                    must carry a valid X-Events-Api-Secret shared-secret header when pos.events.api-secret is \
+                    configured; this service is internal-network only and is not exposed through the API gateway.
+                    Required inputs: id (uppercase letters, digits and underscores), numeric apiVersion, timestamp as \
+                    positive epoch milliseconds, elapsedMs of zero or more, and publishedAt as a UTC instant.
+                    No events are emitted by this operation itself, by design, to prevent infinite recursion; the \
+                    submitted event is queued in memory and a batch flush persists the queue every 5 seconds, so a 200 \
+                    response means accepted, not yet durably stored.
+                    Returns 400 when the id is not preregistered or a field fails validation, and 401 when the shared \
+                    secret is missing or invalid.
+                    """,
             tags = {"Event Emission"})
     @ApiResponse(responseCode = "200", description = "Event stored successfully")
     @ApiResponse(responseCode = "400", description = "Event type ID is not preregistered")
     // @EmitEvent - FORBIDDEN: See warning above. Would cause infinite recursion.
     public ResponseEntity<String> receiveEvent(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            description = "Event payload to persist",
+                            description =
+                                    "Single event occurrence to record, identifying the preregistered event id and its"
+                                            + " timing measurements.",
                             required = true,
-                            content = @Content(schema = @Schema(implementation = EmitEventRequest.class)))
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = EmitEventRequest.class),
+                                            examples = @ExampleObject(name = "Order creation event", value = """
+                                                                    {"id":"ORDER_ORDER_CREATE",
+                                                                     "apiVersion":"1",
+                                                                     "timestamp":1730809200000,
+                                                                     "elapsedMs":42,
+                                                                     "publishedAt":"2026-03-05T21:15:00Z"}
+                                                                    """)))
                     @Valid
                     @NotNull
                     @RequestBody

--- a/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/controller/EventSummaryController.java
+++ b/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/controller/EventSummaryController.java
@@ -39,8 +39,22 @@ public class EventSummaryController {
     @GetMapping("/lastHour")
     @EmitEvent(id = "EVENT_RECEIVER_SUMMARY_LAST_HOUR", apiVersion = "1")
     @Operation(
+            operationId = "getEventSummaryLastHour",
             summary = "Get event summary for the last hour",
-            description = "Returns event counts grouped by event type for the last 60 minutes",
+            description = """
+                    Returns emitted-event counts grouped by event type code for the trailing 60 minutes, read from \
+                    the emitted_event_hourly TimescaleDB continuous aggregate.
+                    Use this tool for a near-real-time pulse of platform event traffic; use getEventSummaryLastDay or \
+                    getEventSummaryLastWeek instead for longer trend windows.
+                    Preconditions: none beyond service availability; GET requests bypass the shared-secret filter, \
+                    and the aggregate refreshes hourly with a one-hour end offset, so the newest counts can lag by up \
+                    to an hour.
+                    Required inputs: none; the window is fixed at one hour and cannot be parameterized.
+                    Emits an EVENT_RECEIVER_SUMMARY_LAST_HOUR event recording the query itself; the read changes no \
+                    stored state.
+                    Returns 200 with a list of event-type and count pairs, which is empty when no events fall inside \
+                    the window.
+                    """,
             tags = {"Event Summary"})
     @ApiResponse(
             responseCode = "200",
@@ -54,8 +68,22 @@ public class EventSummaryController {
     @GetMapping("/lastDay")
     @EmitEvent(id = "EVENT_RECEIVER_SUMMARY_LAST_DAY", apiVersion = "1")
     @Operation(
+            operationId = "getEventSummaryLastDay",
             summary = "Get event summary for the last day",
-            description = "Returns event counts grouped by event type for the last 24 hours",
+            description = """
+                    Returns emitted-event counts grouped by event type code for the trailing 24 hours, read from the \
+                    emitted_event_hourly TimescaleDB continuous aggregate.
+                    Use this tool for a daily view of platform event traffic; use getEventSummaryLastHour instead for \
+                    a near-real-time pulse, or getEventSummaryLastWeek for the weekly trend.
+                    Preconditions: none beyond service availability; GET requests bypass the shared-secret filter, \
+                    and the aggregate refreshes hourly with a one-hour end offset, so the newest counts can lag by up \
+                    to an hour.
+                    Required inputs: none; the window is fixed at 24 hours and cannot be parameterized.
+                    Emits an EVENT_RECEIVER_SUMMARY_LAST_DAY event recording the query itself; the read changes no \
+                    stored state.
+                    Returns 200 with a list of event-type and count pairs, which is empty when no events fall inside \
+                    the window.
+                    """,
             tags = {"Event Summary"})
     @ApiResponse(
             responseCode = "200",
@@ -69,8 +97,22 @@ public class EventSummaryController {
     @GetMapping("/lastWeek")
     @EmitEvent(id = "EVENT_RECEIVER_SUMMARY_LAST_WEEK", apiVersion = "1")
     @Operation(
+            operationId = "getEventSummaryLastWeek",
             summary = "Get event summary for the last week",
-            description = "Returns event counts grouped by event type for the last 7 days",
+            description = """
+                    Returns emitted-event counts grouped by event type code for the trailing 7 days, read from the \
+                    emitted_event_hourly TimescaleDB continuous aggregate.
+                    Use this tool for a weekly trend of platform event traffic; use getEventSummaryLastHour or \
+                    getEventSummaryLastDay instead when a shorter window is wanted.
+                    Preconditions: none beyond service availability; GET requests bypass the shared-secret filter, \
+                    and the aggregate refreshes hourly with a one-hour end offset, so the newest counts can lag by up \
+                    to an hour.
+                    Required inputs: none; the window is fixed at 7 days and cannot be parameterized.
+                    Emits an EVENT_RECEIVER_SUMMARY_LAST_WEEK event recording the query itself; the read changes no \
+                    stored state.
+                    Returns 200 with a list of event-type and count pairs, which is empty when no events fall inside \
+                    the window.
+                    """,
             tags = {"Event Summary"})
     @ApiResponse(
             responseCode = "200",

--- a/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/controller/EventTypeController.java
+++ b/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/controller/EventTypeController.java
@@ -7,6 +7,7 @@ import com.positivity.poseventreceiver.service.EventTypeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,8 +45,19 @@ public class EventTypeController {
 
     @GetMapping
     @Operation(
-            summary = "Get all event types",
-            description = "Retrieve all available event types",
+            operationId = "listEventTypes",
+            summary = "List all registered event types",
+            description = """
+                    Lists every registered event type, active and inactive, with its typeCode, description, apiVersion \
+                    and p50/p95/p99 latency thresholds in microseconds.
+                    Use this tool when auditing the full event-type registry including deactivated types; use \
+                    listActiveEventTypes instead when only the types currently accepted for monitoring matter.
+                    Preconditions: none beyond service availability; GET requests pass the shared-secret filter \
+                    without authentication.
+                    Required inputs: none; there are no parameters, no paging and no filtering.
+                    No events are emitted and no state changes; this is a read-only projection of the event_type table.
+                    Returns 200 with the full list, which is empty when no event types have been registered.
+                    """,
             tags = {"Event Types"})
     @ApiResponse(
             responseCode = "200",
@@ -58,8 +70,20 @@ public class EventTypeController {
 
     @GetMapping("/active")
     @Operation(
-            summary = "Get active event types",
-            description = "Retrieve only active event types",
+            operationId = "listActiveEventTypes",
+            summary = "List only active event types",
+            description = """
+                    Lists the event types whose active flag is true, which are the types currently expected to appear \
+                    in event traffic and latency monitoring.
+                    Use this tool when only live, monitorable event types matter; use listEventTypes instead to audit \
+                    the whole registry including deactivated types.
+                    Preconditions: none beyond service availability; GET requests pass the shared-secret filter \
+                    without authentication.
+                    Required inputs: none; there are no parameters, no paging and no filtering.
+                    No events are emitted and no state changes; this is a read-only projection of the event_type table \
+                    filtered on active = true.
+                    Returns 200 with the active list, which is empty when every registered type is inactive.
+                    """,
             tags = {"Event Types"})
     @ApiResponse(
             responseCode = "200",
@@ -72,8 +96,18 @@ public class EventTypeController {
 
     @GetMapping("/{id}")
     @Operation(
-            summary = "Get event type by ID",
-            description = "Retrieve a specific event type by its unique ID",
+            operationId = "getEventTypeById",
+            summary = "Get an event type by id",
+            description = """
+                    Returns a single event type, resolved by its UUID primary key, including its typeCode, \
+                    description, active flag, apiVersion and latency thresholds.
+                    Use this tool when the event-type id is already known from a prior create or list call; use \
+                    getEventTypeByCode instead when only the typeCode string such as ORDER_ORDER_CREATE is known.
+                    Preconditions: an event type row with the supplied id must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body and no filtering.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no event type exists for the supplied id.
+                    """,
             tags = {"Event Types"})
     @ApiResponse(
             responseCode = "200",
@@ -94,8 +128,21 @@ public class EventTypeController {
 
     @GetMapping("/code/{typeCode}")
     @Operation(
-            summary = "Get event type by code",
-            description = "Retrieve a specific event type by its unique type code",
+            operationId = "getEventTypeByCode",
+            summary = "Get an event type by code",
+            description = """
+                    Returns a single event type resolved by its unique typeCode, the same code services reference in \
+                    @EmitEvent annotations.
+                    Use this tool when only the typeCode string is known; use getEventTypeById instead when the UUID \
+                    of the registration row is already at hand.
+                    Preconditions: an event type with the given code must exist; the code is trimmed and upper-cased \
+                    before lookup, so matching is case-insensitive on input.
+                    Required inputs: typeCode as a path parameter, containing only letters, digits and underscores \
+                    after normalization.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no event type matches the normalized code, and 400 when the code contains \
+                    characters other than letters, digits and underscores.
+                    """,
             tags = {"Event Types"})
     @ApiResponse(
             responseCode = "200",
@@ -120,8 +167,24 @@ public class EventTypeController {
     @PostMapping
     @EmitEvent(id = "EVENT_RECEIVER_EVENT_TYPE_CREATE", apiVersion = "1")
     @Operation(
-            summary = "Create event type",
-            description = "Create a new event type for preregistered events",
+            operationId = "createEventType",
+            summary = "Create a new event type",
+            description = """
+                    Creates a new event type registration whose typeCode other services reference from @EmitEvent \
+                    annotations, with latency thresholds used to monitor event performance.
+                    Use this tool when registering a brand-new typeCode that must not already exist; use \
+                    upsertEventType instead for idempotent create-or-update registration, because a duplicate \
+                    typeCode is rejected here.
+                    Preconditions: no event type with the same normalized typeCode may exist, and the caller must \
+                    present a valid X-Events-Api-Secret shared-secret header when pos.events.api-secret is configured.
+                    Required inputs: typeCode (letters, digits and underscores; trimmed and upper-cased) and \
+                    description; active defaults to false when omitted from the JSON body, apiVersion defaults to 1, \
+                    and p50Micros/p95Micros/p99Micros default to 10000000 microseconds (10 seconds) and must satisfy \
+                    p50 <= p95 <= p99 when supplied.
+                    Emits an EVENT_RECEIVER_EVENT_TYPE_CREATE event and inserts one event_type row.
+                    Returns 201 with the created type, 400 when the typeCode already exists or a field fails \
+                    validation, and 401 when the shared secret is missing or invalid.
+                    """,
             tags = {"Event Types"})
     @ApiResponse(
             responseCode = "201",
@@ -130,9 +193,22 @@ public class EventTypeController {
     @ApiResponse(responseCode = "400", description = "Invalid request parameters")
     public ResponseEntity<EventTypeResponse> createEventType(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            description = "Event type details",
+                            description = "Event type registration to create, naming the code, description and optional"
+                                    + " latency thresholds.",
                             required = true,
-                            content = @Content(schema = @Schema(implementation = EventTypeRequest.class)))
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = EventTypeRequest.class),
+                                            examples = @ExampleObject(name = "New event type", value = """
+                                                                    {"typeCode":"ORDER_ORDER_CREATE",
+                                                                     "description":"Emitted when an order is created",
+                                                                     "active":true,
+                                                                     "apiVersion":"1",
+                                                                     "p50Micros":500000,
+                                                                     "p95Micros":1000000,
+                                                                     "p99Micros":2000000}
+                                                                    """)))
                     @Valid
                     @NotNull
                     @RequestBody
@@ -162,8 +238,25 @@ public class EventTypeController {
     @PutMapping("/code/{typeCode}")
     @EmitEvent(id = "EVENT_RECEIVER_EVENT_TYPE_UPSERT", apiVersion = "1")
     @Operation(
-            summary = "Upsert event type",
-            description = "Create or update an event type by type code",
+            operationId = "upsertEventType",
+            summary = "Create or update event type by code",
+            description = """
+                    Creates the event type when the typeCode is not yet registered, or updates it in place when it \
+                    is, keyed by the typeCode path segment; this is the idempotent registration path that module \
+                    EventTypeInitializers call at startup.
+                    Use this tool when the caller does not care whether the type exists yet; use updateEventType \
+                    instead when a missing type must fail with 404, and createEventType when a duplicate must be \
+                    rejected.
+                    Preconditions: the body typeCode, when supplied, must match the path typeCode after \
+                    normalization, and the caller must present a valid X-Events-Api-Secret shared-secret header when \
+                    pos.events.api-secret is configured.
+                    Required inputs: typeCode as a path parameter plus a body with typeCode and description; active \
+                    defaults to false when omitted, while a null apiVersion or null p50Micros/p95Micros/p99Micros \
+                    keeps the stored values on update and falls back to 1 and 10000000 microseconds on create.
+                    Emits an EVENT_RECEIVER_EVENT_TYPE_UPSERT event and inserts or updates one event_type row.
+                    Returns 200 for both the create and update outcome, 400 when the path and body typeCode disagree \
+                    or a field fails validation, and 401 when the shared secret is missing or invalid.
+                    """,
             tags = {"Event Types"})
     @ApiResponse(
             responseCode = "200",
@@ -176,9 +269,23 @@ public class EventTypeController {
                     @NotBlank
                     String typeCode,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            description = "Event type details",
+                            description =
+                                    "Event type registration to create or overwrite; its typeCode must match the path"
+                                            + " code when provided.",
                             required = true,
-                            content = @Content(schema = @Schema(implementation = EventTypeRequest.class)))
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = EventTypeRequest.class),
+                                            examples = @ExampleObject(name = "Startup registration", value = """
+                                                                    {"typeCode":"ORDER_ORDER_CREATE",
+                                                                     "description":"Emitted when an order is created",
+                                                                     "active":true,
+                                                                     "apiVersion":"1",
+                                                                     "p50Micros":500000,
+                                                                     "p95Micros":1000000,
+                                                                     "p99Micros":2000000}
+                                                                    """)))
                     @Valid
                     @NotNull
                     @RequestBody
@@ -203,8 +310,23 @@ public class EventTypeController {
     @PutMapping("/{id}")
     @EmitEvent(id = "EVENT_RECEIVER_EVENT_TYPE_UPDATE", apiVersion = "1")
     @Operation(
-            summary = "Update event type",
-            description = "Update an existing event type",
+            operationId = "updateEventType",
+            summary = "Update an existing event type",
+            description = """
+                    Updates an existing event type identified by its UUID, replacing the description and active flag \
+                    and selectively overriding apiVersion and the latency thresholds; the stored typeCode itself is \
+                    never changed by this operation.
+                    Use this tool when the registration id is known and the type must already exist; use \
+                    upsertEventType instead to create-or-update by typeCode without knowing the id.
+                    Preconditions: an event type row with the supplied id must exist, and the caller must present a \
+                    valid X-Events-Api-Secret shared-secret header when pos.events.api-secret is configured.
+                    Required inputs: id (UUID) as a path parameter and a body with typeCode and description; active \
+                    defaults to false when omitted, and a null apiVersion or null p50Micros/p95Micros/p99Micros keeps \
+                    the currently stored values.
+                    Emits an EVENT_RECEIVER_EVENT_TYPE_UPDATE event and updates one event_type row.
+                    Returns 404 when no event type exists for the id, 400 when a field fails validation such as \
+                    thresholds violating p50 <= p95 <= p99, and 401 when the shared secret is missing or invalid.
+                    """,
             tags = {"Event Types"})
     @ApiResponse(
             responseCode = "200",
@@ -217,9 +339,22 @@ public class EventTypeController {
                     @NotNull
                     UUID id,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            description = "Updated event type details",
+                            description =
+                                    "Replacement event type details; omitted optional fields fall back to stored or"
+                                            + " default values.",
                             required = true,
-                            content = @Content(schema = @Schema(implementation = EventTypeRequest.class)))
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = EventTypeRequest.class),
+                                            examples = @ExampleObject(name = "Tighten thresholds", value = """
+                                                                    {"typeCode":"ORDER_ORDER_CREATE",
+                                                                     "description":"Emitted when an order is created",
+                                                                     "active":true,
+                                                                     "p50Micros":250000,
+                                                                     "p95Micros":750000,
+                                                                     "p99Micros":1500000}
+                                                                    """)))
                     @Valid
                     @NotNull
                     @RequestBody
@@ -248,8 +383,22 @@ public class EventTypeController {
     @DeleteMapping("/{id}")
     @EmitEvent(id = "EVENT_RECEIVER_EVENT_TYPE_DELETE", apiVersion = "1")
     @Operation(
-            summary = "Delete event type",
-            description = "Delete an event type by ID",
+            operationId = "deleteEventType",
+            summary = "Delete an event type by id",
+            description = """
+                    Deletes an event type registration by its UUID, removing the typeCode, metadata and latency \
+                    thresholds from the registry.
+                    Use this tool when a registration was created in error or is being retired permanently; do not \
+                    use it for a temporary pause — updateEventType with active set to false deactivates the type \
+                    reversibly instead.
+                    Preconditions: an event type row with the supplied id must exist, and the caller must present a \
+                    valid X-Events-Api-Secret shared-secret header when pos.events.api-secret is configured.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits an EVENT_RECEIVER_EVENT_TYPE_DELETE event and removes one event_type row; already recorded \
+                    emitted_event history is not touched.
+                    Returns 204 on successful deletion, 404 when no event type exists for the id, and 401 when the \
+                    shared secret is missing or invalid.
+                    """,
             tags = {"Event Types"})
     @ApiResponse(responseCode = "204", description = "Event type deleted successfully")
     @ApiResponse(responseCode = "404", description = "Event type not found")

--- a/pos-image/openapi.yaml
+++ b/pos-image/openapi.yaml
@@ -15,7 +15,23 @@ paths:
       tags:
       - Image API
       summary: Get image by ID
-      description: Retrieve an image file by its unique database ID.
+      description: 'Returns the stored image file for a numeric image id as a binary attachment.
+
+        Use this tool when the image''s database id is already known; use getImageByFilename instead when
+
+        only the filename is known.
+
+        Preconditions: the image record must exist and its backing file must still be present on disk.
+
+        Required inputs: id (numeric database id) path parameter; there is no request body and no
+
+        resizing or format options.
+
+        No events are emitted and no state changes; this is a read-only file retrieval.
+
+        Returns 404 when no image record has that id or the backing file is missing from storage.
+
+        '
       operationId: getImageById
       parameters:
       - name: id
@@ -46,7 +62,29 @@ paths:
       tags:
       - Image API
       summary: Get image by filename
-      description: Retrieve an image file by its filename.
+      description: 'Returns the stored image file matching a filename as a binary attachment.
+
+        Use this tool when only the filename is known, such as a reference embedded in catalog data; use
+
+        getImageById instead when the numeric id is available, because filenames are not guaranteed
+
+        unique over time.
+
+        Preconditions: an image record with that exact filename must exist and its backing file must
+
+        still be present on disk.
+
+        Required inputs: filename path parameter, matched exactly including extension; there is no
+
+        request body and no resizing or format options.
+
+        No events are emitted and no state changes; this is a read-only file retrieval.
+
+        Returns 404 when no image record matches the filename or the backing file is missing from
+
+        storage.
+
+        '
       operationId: getImageByFilename
       parameters:
       - name: filename

--- a/pos-image/src/main/java/com/positivity/image/internal/controller/ImageController.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/controller/ImageController.java
@@ -28,8 +28,18 @@ public class ImageController {
     private final ImageService imageService;
 
     @Operation(
+            operationId = "getImageById",
             summary = "Get image by ID",
-            description = "Retrieve an image file by its unique database ID.",
+            description = """
+                    Returns the stored image file for a numeric image id as a binary attachment.
+                    Use this tool when the image's database id is already known; use getImageByFilename instead when
+                    only the filename is known.
+                    Preconditions: the image record must exist and its backing file must still be present on disk.
+                    Required inputs: id (numeric database id) path parameter; there is no request body and no
+                    resizing or format options.
+                    No events are emitted and no state changes; this is a read-only file retrieval.
+                    Returns 404 when no image record has that id or the backing file is missing from storage.
+                    """,
             tags = {"Image API"})
     @ApiResponse(responseCode = "200", description = "Image file returned successfully.")
     @ApiResponse(responseCode = "404", description = "Image not found.")
@@ -45,8 +55,21 @@ public class ImageController {
     }
 
     @Operation(
+            operationId = "getImageByFilename",
             summary = "Get image by filename",
-            description = "Retrieve an image file by its filename.",
+            description = """
+                    Returns the stored image file matching a filename as a binary attachment.
+                    Use this tool when only the filename is known, such as a reference embedded in catalog data; use
+                    getImageById instead when the numeric id is available, because filenames are not guaranteed
+                    unique over time.
+                    Preconditions: an image record with that exact filename must exist and its backing file must
+                    still be present on disk.
+                    Required inputs: filename path parameter, matched exactly including extension; there is no
+                    request body and no resizing or format options.
+                    No events are emitted and no state changes; this is a read-only file retrieval.
+                    Returns 404 when no image record matches the filename or the backing file is missing from
+                    storage.
+                    """,
             tags = {"Image API"})
     @ApiResponse(responseCode = "200", description = "Image file returned successfully.")
     @ApiResponse(responseCode = "404", description = "Image not found.")

--- a/pos-marketing/openapi.yaml
+++ b/pos-marketing/openapi.yaml
@@ -21,9 +21,21 @@ paths:
     get:
       tags:
       - Marketing Templates
-      summary: Get template
-      description: Retrieve a template and its available tokens
-      operationId: get
+      summary: Get Message Template By Id
+      description: 'Returns one message template with its name, channel, audience type, subject, body, and the substitution tokens available to its audience.
+
+        Use this tool when the template id is already known; use listMessageTemplates instead when searching by channel or audience.
+
+        Preconditions: the template must exist.
+
+        Required inputs: templateId (UUID) as a path parameter; there is no request body.
+
+        Emits a MARKETING_TEMPLATE_GET audit event; no marketing state is changed and this is a read-only projection.
+
+        Returns 404 when no template exists for the supplied id.
+
+        '
+      operationId: getMessageTemplateById
       parameters:
       - name: templateId
         in: path
@@ -50,9 +62,21 @@ paths:
     put:
       tags:
       - Marketing Templates
-      summary: Update template
-      description: Update a template's name, subject, or body
-      operationId: update
+      summary: Update Message Template
+      description: 'Updates a template''s name, subject and body, re-validating every {{token}} against the audience''s vocabulary.
+
+        Use this tool to revise wording; do not use createMessageTemplate for a different channel or audience, because channel and audienceType are immutable and changing either requires a new template.
+
+        Preconditions: the template must exist, the channel and audienceType in the body must equal the stored values, and no other template may hold the new name.
+
+        Required inputs: templateId (UUID) path parameter plus the full body (name, channel, audienceType, body); subject is required for EMAIL and discarded for SMS.
+
+        Emits a MARKETING_TEMPLATE_UPDATE event; campaigns already bound to the template pick up the new wording at their next dispatch.
+
+        Returns 404 when the template does not exist, 409 when the name belongs to another template, and 422 when channel or audienceType is changed or the token, subject or SMS length rules fail.
+
+        '
+      operationId: updateMessageTemplate
       parameters:
       - name: templateId
         in: path
@@ -61,10 +85,20 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Full replacement template; channel and audienceType must match the stored values because both are immutable.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpsertMessageTemplateRequest'
+            examples:
+              Commercial email template:
+                description: Commercial email template
+                value:
+                  name: Spring fleet email
+                  channel: EMAIL
+                  audienceType: COMMERCIAL
+                  subject: '{{accountName}}, your spring fleet alignment offer'
+                  body: 'Hi {{contactFirstName}}, {{accountName}} qualifies for our spring alignment offer. Use code {{offerCode}} at {{shopName}}. Unsubscribe: {{unsubscribeUrl}}'
         required: true
       responses:
         '200':
@@ -89,9 +123,21 @@ paths:
     delete:
       tags:
       - Marketing Templates
-      summary: Delete template
-      description: Delete a template that no campaign is using
-      operationId: delete
+      summary: Delete Unused Message Template
+      description: 'Permanently deletes a message template that no campaign references.
+
+        Use this tool to retire an unused template; detach it from every campaign first via updateCampaign rather than expecting the delete to cascade.
+
+        Preconditions: the template must exist and must not be referenced as the email or SMS template of any campaign, because a campaign whose template vanished would fail at dispatch across its whole audience.
+
+        Required inputs: templateId (UUID) as a path parameter; there is no request body and no confirmation flag.
+
+        Emits a MARKETING_TEMPLATE_DELETE event; the deletion is irreversible.
+
+        Returns 404 when the template does not exist, and 422 when it is still attached to at least one campaign.
+
+        '
+      operationId: deleteMessageTemplate
       parameters:
       - name: templateId
         in: path
@@ -117,9 +163,21 @@ paths:
     get:
       tags:
       - Marketing Campaigns
-      summary: Get campaign
-      description: Retrieve a campaign by id
-      operationId: get_1
+      summary: Get Campaign By Id
+      description: 'Returns one campaign''s full definition, including status, channels, bound segment, templates, schedule and delivery window.
+
+        Use this tool when the campaign id is already known; use listCampaigns instead when searching by status or program.
+
+        Preconditions: the campaign must exist.
+
+        Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+
+        Emits a MARKETING_CAMPAIGN_GET audit event; no marketing state is changed and this is a read-only projection.
+
+        Returns 404 when no campaign exists for the supplied id.
+
+        '
+      operationId: getCampaignById
       parameters:
       - name: campaignId
         in: path
@@ -146,9 +204,21 @@ paths:
     put:
       tags:
       - Marketing Campaigns
-      summary: Update campaign
-      description: Update a DRAFT campaign. Editing is refused once dispatch has begun.
-      operationId: update_1
+      summary: Update Draft Campaign
+      description: 'Replaces the definition of a DRAFT campaign, including its code, channels, segment, templates, schedule and delivery window.
+
+        Use this tool to revise a campaign before it is scheduled; do not use createCampaign, which makes a new campaign, and use the lifecycle tools (scheduleCampaign, pauseCampaign, cancelCampaign) rather than this one to change status.
+
+        Preconditions: the campaign must exist and still be in DRAFT, since once dispatch may have begun the definition is frozen; audienceType must equal the stored value because it is immutable.
+
+        Required inputs: campaignId (UUID) path parameter plus the full replacement body (code, name, audienceType, channels); scheduleType defaults to IMMEDIATE when omitted, and omitted optional fields are cleared rather than preserved.
+
+        Emits a MARKETING_CAMPAIGN_UPDATE event; no recipients are contacted.
+
+        Returns 404 when the campaign does not exist, 409 when the code belongs to another campaign, and 422 when the campaign is no longer editable, audienceType is changed, or the schedule and window fields are inconsistent.
+
+        '
+      operationId: updateCampaign
       parameters:
       - name: campaignId
         in: path
@@ -157,10 +227,32 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Full replacement campaign definition; audienceType must match the stored value, and omitted optional fields are cleared.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpsertCampaignRequest'
+            examples:
+              Scheduled commercial campaign:
+                description: Scheduled commercial campaign
+                value:
+                  code: SPRING-FLEET-2026
+                  name: Spring fleet alignment push
+                  description: Alignment offer for commercial fleet accounts
+                  audienceType: COMMERCIAL
+                  campaignProgramId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                  channels:
+                  - EMAIL
+                  - SMS
+                  segmentId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
+                  promotionOfferId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03
+                  catalogFocusRef: service:alignment
+                  windowStart: 2026-03-01 00:00:00+00:00
+                  windowEnd: 2026-03-31 23:59:59+00:00
+                  scheduleType: SCHEDULED
+                  scheduledAt: 2026-03-02 14:00:00+00:00
+                  emailTemplateId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04
+                  smsTemplateId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a05
         required: true
       responses:
         '200':
@@ -186,9 +278,21 @@ paths:
     get:
       tags:
       - Marketing Templates
-      summary: List templates
-      description: List templates, optionally filtered by channel and audience
-      operationId: list
+      summary: List Message Templates
+      description: 'Lists message templates ordered by name, optionally filtered by delivery channel and audience type.
+
+        Use this tool when browsing templates or finding one to attach to a campaign; do not use getMessageTemplateById, which requires a known template id and returns exactly one template.
+
+        Preconditions: none; an empty result simply means no template matches the filters.
+
+        Required inputs: none; channel (EMAIL or SMS) and audienceType (COMMERCIAL or INDIVIDUAL) are optional query filters that combine when both are supplied.
+
+        Emits a MARKETING_TEMPLATE_LIST audit event; no marketing state is changed.
+
+        Returns 200 with an empty array when nothing matches, so an empty result is not an error condition.
+
+        '
+      operationId: listMessageTemplates
       parameters:
       - name: channel
         in: query
@@ -225,14 +329,36 @@ paths:
     post:
       tags:
       - Marketing Templates
-      summary: Create template
-      description: Create a template. Unknown tokens and tokens outside the audience's vocabulary are rejected.
-      operationId: create
+      summary: Create Message Template
+      description: 'Creates a channel-specific message template whose {{token}} placeholders are validated against the closed vocabulary for its audience at save time, so a typo costs a validation error rather than a batch of broken messages.
+
+        Use this tool when authoring a new template; do not use updateMessageTemplate, which revises an existing template and cannot change its channel or audienceType.
+
+        Preconditions: no template may already use the same name (compared case-insensitively); commercial-only tokens such as accountName are rejected for INDIVIDUAL audiences and vehicle tokens for COMMERCIAL ones.
+
+        Required inputs: name, channel (EMAIL or SMS), audienceType (COMMERCIAL or INDIVIDUAL) and body; subject is required for EMAIL, and for SMS it must be absent and any supplied value is discarded.
+
+        Emits a MARKETING_TEMPLATE_CREATE event; no campaign is affected until the template is attached to one.
+
+        Returns 409 when the name is already in use, and 422 when a token is unknown or outside the audience''s vocabulary, an email template lacks a subject, an SMS template has one, or an SMS body exceeds 320 characters.
+
+        '
+      operationId: createMessageTemplate
       requestBody:
+        description: 'Template to create: name, channel, audience, subject (EMAIL only) and a body whose {{token}} placeholders must belong to the audience''s vocabulary.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpsertMessageTemplateRequest'
+            examples:
+              Commercial email template:
+                description: Commercial email template
+                value:
+                  name: Spring fleet email
+                  channel: EMAIL
+                  audienceType: COMMERCIAL
+                  subject: '{{accountName}}, your spring fleet alignment offer'
+                  body: 'Hi {{contactFirstName}}, {{accountName}} qualifies for our spring alignment offer. Use code {{offerCode}} at {{shopName}}. Unsubscribe: {{unsubscribeUrl}}'
         required: true
       responses:
         '201':
@@ -256,9 +382,21 @@ paths:
     get:
       tags:
       - Marketing Campaigns
-      summary: List campaigns
-      description: List campaigns, optionally filtered by status or program
-      operationId: list_1
+      summary: List Campaigns
+      description: 'Lists marketing campaigns ordered by newest first, optionally filtered by lifecycle status and campaign program.
+
+        Use this tool when browsing or searching campaigns; do not use getCampaignById, which requires a known campaign id and returns exactly one campaign.
+
+        Preconditions: none; an empty result simply means no campaign matches the filters.
+
+        Required inputs: none; status (DRAFT, SCHEDULED, SENDING, SENT, PAUSED, CANCELLED or CLOSED) and campaignProgramId (UUID) are optional query filters that combine when both are supplied.
+
+        Emits a MARKETING_CAMPAIGN_LIST audit event; no marketing state is changed.
+
+        Returns 200 with an empty array when nothing matches, so an empty result is not an error condition.
+
+        '
+      operationId: listCampaigns
       parameters:
       - name: status
         in: query
@@ -298,14 +436,48 @@ paths:
     post:
       tags:
       - Marketing Campaigns
-      summary: Create campaign
-      description: Create a campaign in DRAFT status
-      operationId: create_1
+      summary: Create Campaign
+      description: 'Creates a marketing campaign in DRAFT status; nothing is targeted or sent until it is scheduled and dispatched.
+
+        Use this tool when defining a new campaign; do not use updateCampaign, which edits an existing DRAFT campaign.
+
+        Preconditions: no campaign may already use the same code (compared case-insensitively); segment and templates may be attached later, since readiness is only enforced by scheduleCampaign.
+
+        Required inputs: code, name, audienceType (COMMERCIAL or INDIVIDUAL, immutable after creation) and a non-empty channels set (EMAIL, SMS); scheduleType defaults to IMMEDIATE, and scheduledAt is required only when scheduleType is SCHEDULED.
+
+        Emits a MARKETING_CAMPAIGN_CREATE event; no recipients are contacted.
+
+        Returns 409 when the code is already in use, and 422 when scheduleType is SCHEDULED without scheduledAt or windowEnd precedes windowStart.
+
+        '
+      operationId: createCampaign
       requestBody:
+        description: 'Campaign definition: code, name, audience, channels, and the optional segment, templates, offer and schedule to attach.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpsertCampaignRequest'
+            examples:
+              Scheduled commercial campaign:
+                description: Scheduled commercial campaign
+                value:
+                  code: SPRING-FLEET-2026
+                  name: Spring fleet alignment push
+                  description: Alignment offer for commercial fleet accounts
+                  audienceType: COMMERCIAL
+                  campaignProgramId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                  channels:
+                  - EMAIL
+                  - SMS
+                  segmentId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
+                  promotionOfferId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03
+                  catalogFocusRef: service:alignment
+                  windowStart: 2026-03-01 00:00:00+00:00
+                  windowEnd: 2026-03-31 23:59:59+00:00
+                  scheduleType: SCHEDULED
+                  scheduledAt: 2026-03-02 14:00:00+00:00
+                  emailTemplateId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04
+                  smsTemplateId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a05
         required: true
       responses:
         '201':
@@ -329,9 +501,21 @@ paths:
     post:
       tags:
       - Marketing Campaigns
-      summary: Dispatch campaign
-      description: 'Queue the campaign''s audience for delivery. Asynchronous and idempotent: re-invoking never double-sends.'
-      operationId: send
+      summary: Dispatch Campaign To Audience
+      description: 'Materializes the campaign''s resolved audience into one PENDING send row per recipient and channel, moves a SCHEDULED campaign to SENDING, and returns 202 with the queued count while the send worker delivers asynchronously.
+
+        Use this tool to start or retry delivery; do not use scheduleCampaign, which only validates readiness, and do not use previewCampaignAudience, which reports reach without queueing anything.
+
+        Preconditions: the campaign must exist, be SCHEDULED or SENDING, and have a segment bound; the audience is the last snapshot replicated from pos-customer.
+
+        Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+
+        Emits a MARKETING_CAMPAIGN_SEND event; the call is idempotent because each recipient-channel pair is unique per campaign, so re-invoking never double-sends, and when no audience snapshot has arrived yet it queues nothing, asynchronously requests resolution from pos-customer, and reports queued 0 for a later retry.
+
+        Returns 404 when the campaign does not exist, and 422 when it is not SCHEDULED or SENDING or has no segment bound.
+
+        '
+      operationId: dispatchCampaign
       parameters:
       - name: campaignId
         in: path
@@ -363,9 +547,21 @@ paths:
     post:
       tags:
       - Marketing Campaigns
-      summary: Schedule campaign
-      description: Validate the segment, templates, and offer, then move the campaign to SCHEDULED
-      operationId: schedule
+      summary: Schedule Campaign For Dispatch
+      description: 'Validates a campaign''s readiness and moves it to SCHEDULED, the state from which dispatch is allowed.
+
+        Use this tool when a DRAFT campaign is complete; do not use dispatchCampaign, which queues the actual sends and only accepts a campaign that is already SCHEDULED or SENDING.
+
+        Preconditions: the campaign must exist and be in DRAFT or PAUSED; it must have at least one channel, a bound segment that is known to this module, active, and matching the campaign''s audienceType, and an existing template attached for every selected channel.
+
+        Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+
+        Emits a MARKETING_CAMPAIGN_SCHEDULE event and publishes a campaign-scheduled fact through the transactional outbox.
+
+        Returns 404 when the campaign does not exist, and 422 listing every readiness problem at once when the campaign is not ready or the transition is not legal from its current status.
+
+        '
+      operationId: scheduleCampaign
       parameters:
       - name: campaignId
         in: path
@@ -395,9 +591,21 @@ paths:
     post:
       tags:
       - Marketing Campaigns
-      summary: Resume campaign
-      description: Return a paused campaign to the dispatch queue
-      operationId: resume
+      summary: Resume Paused Campaign
+      description: 'Returns a PAUSED campaign to SCHEDULED so it re-enters the dispatch queue; the send worker decides when delivery actually restarts rather than jumping straight back into SENDING.
+
+        Use this tool to continue a campaign that pauseCampaign halted; do not use scheduleCampaign, which re-runs readiness validation on a DRAFT or PAUSED campaign.
+
+        Preconditions: the campaign must exist and be PAUSED.
+
+        Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+
+        Emits a MARKETING_CAMPAIGN_RESUME event; recipients already recorded as sent are never re-queued, because each recipient-channel pair is unique per campaign.
+
+        Returns 404 when the campaign does not exist, and 422 when its current status does not allow resuming.
+
+        '
+      operationId: resumeCampaign
       parameters:
       - name: campaignId
         in: path
@@ -412,6 +620,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CampaignResponse'
+        '404':
+          description: Campaign not found
         '422':
           description: Illegal lifecycle transition
         '403':
@@ -425,9 +635,21 @@ paths:
     post:
       tags:
       - Marketing Campaigns
-      summary: Pause campaign
-      description: Halt dispatch; queued recipients stop being drained
-      operationId: pause
+      summary: Pause Campaign Dispatch
+      description: 'Moves a campaign to PAUSED so the send worker stops draining its queued recipients.
+
+        Use this tool to halt an in-flight or scheduled campaign without losing it; do not use cancelCampaign, which is terminal and cannot be undone.
+
+        Preconditions: the campaign must exist and be in SCHEDULED or SENDING, the only statuses that permit the PAUSED transition.
+
+        Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+
+        Emits a MARKETING_CAMPAIGN_PAUSE event; already-delivered messages are unaffected and queued send rows remain PENDING for a later resume.
+
+        Returns 404 when the campaign does not exist, and 422 when its current status does not allow pausing.
+
+        '
+      operationId: pauseCampaign
       parameters:
       - name: campaignId
         in: path
@@ -442,6 +664,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CampaignResponse'
+        '404':
+          description: Campaign not found
         '422':
           description: Illegal lifecycle transition
         '403':
@@ -455,9 +679,21 @@ paths:
     post:
       tags:
       - Marketing Campaigns
-      summary: Cancel campaign
-      description: Cancel a campaign; the state is terminal
-      operationId: cancel
+      summary: Cancel Campaign Permanently
+      description: 'Moves a campaign to CANCELLED, a terminal state from which no further transition exists.
+
+        Use this tool to abandon a campaign for good; do not use pauseCampaign, which halts dispatch reversibly and keeps the queue intact.
+
+        Preconditions: the campaign must exist and be in DRAFT, SCHEDULED, SENDING or PAUSED; a SENT campaign can only be CLOSED, and CANCELLED and CLOSED campaigns cannot transition at all.
+
+        Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+
+        Emits a MARKETING_CAMPAIGN_CANCEL event; messages already delivered are not recalled.
+
+        Returns 404 when the campaign does not exist, and 422 when its current status does not allow cancellation.
+
+        '
+      operationId: cancelCampaign
       parameters:
       - name: campaignId
         in: path
@@ -472,6 +708,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CampaignResponse'
+        '404':
+          description: Campaign not found
         '422':
           description: Illegal lifecycle transition
         '403':
@@ -485,9 +723,21 @@ paths:
     post:
       tags:
       - Marketing Campaigns
-      summary: Preview audience
-      description: Per-channel reach after consent, account gate, and suppression, plus any issues that would block scheduling
-      operationId: previewAudience
+      summary: Preview Campaign Audience
+      description: 'Reports the campaign''s last resolved audience snapshot: total segment members, per-channel eligible counts after consent, staleness and suppression checks, whether each channel has a template, and the readiness problems that would block scheduling.
+
+        Use this tool to gauge reach before scheduling or dispatch; do not use dispatchCampaign, which actually queues messages for delivery.
+
+        Preconditions: the campaign must exist and have a segmentId bound; membership is replicated asynchronously from pos-customer, so the counts reflect the snapshot taken at resolvedAt rather than live CRM data.
+
+        Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+
+        Emits a MARKETING_AUDIENCE_PREVIEW audit event and, while the campaign is still DRAFT, SCHEDULED or PAUSED, asynchronously requests a fresher membership snapshot from pos-customer; the campaign itself is not modified.
+
+        Returns 404 when the campaign does not exist, and 422 when no segment is bound so there is nothing to preview.
+
+        '
+      operationId: previewCampaignAudience
       parameters:
       - name: campaignId
         in: path
@@ -502,6 +752,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AudiencePreviewResponse'
+        '404':
+          description: Campaign not found
         '422':
           description: Campaign has no segment bound
         '503':
@@ -517,9 +769,21 @@ paths:
     get:
       tags:
       - Marketing Analytics
-      summary: Program stats
-      description: Compare the commercial and individual arms of one campaign program side by side
-      operationId: programStats
+      summary: Get Campaign Program Stats
+      description: 'Returns the full stats block for every campaign sharing one campaignProgramId, so the commercial and individual arms of an initiative can be compared side by side.
+
+        Use this tool when comparing the arms of a program; use getCampaignStats instead for a single campaign.
+
+        Preconditions: at least one campaign must reference the campaignProgramId, since the program has no record of its own in this module.
+
+        Required inputs: campaignProgramId (UUID) as a path parameter; there is no request body.
+
+        Emits a MARKETING_PROGRAM_STATS_GET audit event; no marketing state is changed and this is a read-only projection.
+
+        Returns 404 when no campaign references the supplied campaignProgramId.
+
+        '
+      operationId: getProgramStats
       parameters:
       - name: campaignProgramId
         in: path
@@ -547,9 +811,21 @@ paths:
     get:
       tags:
       - Marketing Analytics
-      summary: Campaign stats
-      description: Per-channel reach funnel plus redemptions and discount value credited to the campaign
-      operationId: campaignStats
+      summary: Get Campaign Stats
+      description: 'Returns one campaign''s per-channel delivery funnel (targeted, suppressed, sent, delivered, bounced, complained, failed) plus the redemption count and discount value attributed to its campaign code; the sent figure is cumulative, counting delivered, bounced and complained messages as sent.
+
+        Use this tool for aggregate campaign performance; use listCampaignSends instead to inspect individual recipient send rows, and use getProgramStats to compare the arms of a program.
+
+        Preconditions: the campaign must exist; a campaign that has never dispatched reports zeroed funnels rather than an error.
+
+        Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+
+        Emits a MARKETING_CAMPAIGN_STATS_GET audit event; no marketing state is changed and this is a read-only projection.
+
+        Returns 404 when no campaign exists for the supplied id.
+
+        '
+      operationId: getCampaignStats
       parameters:
       - name: campaignId
         in: path
@@ -577,9 +853,21 @@ paths:
     get:
       tags:
       - Marketing Campaigns
-      summary: List sends
-      description: Per-recipient send records for a campaign
-      operationId: listSends
+      summary: List Campaign Send Records
+      description: 'Lists the per-recipient, per-channel send rows a campaign dispatch queued, including status, failure reason, provider message id, attempts and timestamps.
+
+        Use this tool to inspect individual delivery outcomes; use getCampaignStats instead for aggregate funnel and attribution numbers.
+
+        Preconditions: none; an unknown campaignId yields an empty page rather than an error.
+
+        Required inputs: campaignId (UUID) as a path parameter; page defaults to 0 and size defaults to 50, clamped between 1 and 200, ordered by queuedAt ascending.
+
+        Emits a MARKETING_CAMPAIGN_SENDS_LIST audit event; no marketing state is changed and this is a read-only projection.
+
+        Returns 200 with an empty page when the campaign has no send rows, so an empty result is not an error condition.
+
+        '
+      operationId: listCampaignSends
       parameters:
       - name: campaignId
         in: path

--- a/pos-marketing/openapi.yaml
+++ b/pos-marketing/openapi.yaml
@@ -52,8 +52,16 @@ paths:
                 $ref: '#/components/schemas/MessageTemplateResponse'
         '404':
           description: Template not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:template:view
@@ -109,12 +117,28 @@ paths:
                 $ref: '#/components/schemas/MessageTemplateResponse'
         '404':
           description: Template not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '409':
           description: Template name already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '422':
           description: Invalid token, or an immutable field was changed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:template:manage
@@ -150,10 +174,22 @@ paths:
           description: Template deleted
         '404':
           description: Template not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '422':
           description: Template is attached to a campaign
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:template:manage
@@ -194,8 +230,16 @@ paths:
                 $ref: '#/components/schemas/CampaignResponse'
         '404':
           description: Campaign not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:campaign:view
@@ -263,12 +307,28 @@ paths:
                 $ref: '#/components/schemas/CampaignResponse'
         '404':
           description: Campaign not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '409':
           description: Campaign code already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '422':
           description: Campaign is no longer editable, or an immutable field was changed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:campaign:edit
@@ -321,6 +381,10 @@ paths:
                   $ref: '#/components/schemas/MessageTemplateResponse'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:template:view
@@ -369,10 +433,22 @@ paths:
                 $ref: '#/components/schemas/MessageTemplateResponse'
         '409':
           description: Template name already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '422':
           description: Invalid token, missing subject, or SMS body over the segment limit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:template:manage
@@ -428,6 +504,10 @@ paths:
                   $ref: '#/components/schemas/CampaignResponse'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:campaign:view
@@ -488,10 +568,22 @@ paths:
                 $ref: '#/components/schemas/CampaignResponse'
         '409':
           description: Campaign code already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '422':
           description: Campaign definition is inconsistent
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:campaign:create
@@ -532,12 +624,24 @@ paths:
                 type: object
         '404':
           description: Campaign not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '422':
           description: Campaign is not in a dispatchable state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '503':
           description: pos-customer unavailable
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:campaign:send
@@ -578,10 +682,22 @@ paths:
                 $ref: '#/components/schemas/CampaignResponse'
         '404':
           description: Campaign not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '422':
           description: Campaign is not ready to schedule
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:campaign:schedule
@@ -622,10 +738,22 @@ paths:
                 $ref: '#/components/schemas/CampaignResponse'
         '404':
           description: Campaign not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '422':
           description: Illegal lifecycle transition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:campaign:manage
@@ -666,10 +794,22 @@ paths:
                 $ref: '#/components/schemas/CampaignResponse'
         '404':
           description: Campaign not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '422':
           description: Illegal lifecycle transition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:campaign:manage
@@ -710,10 +850,22 @@ paths:
                 $ref: '#/components/schemas/CampaignResponse'
         '404':
           description: Campaign not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '422':
           description: Illegal lifecycle transition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:campaign:manage
@@ -754,12 +906,24 @@ paths:
                 $ref: '#/components/schemas/AudiencePreviewResponse'
         '404':
           description: Campaign not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '422':
           description: Campaign has no segment bound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '503':
           description: pos-customer unavailable
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:campaign:view
@@ -800,8 +964,16 @@ paths:
                 $ref: '#/components/schemas/ProgramStatsResponse'
         '404':
           description: Campaign program not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:stats:view
@@ -842,8 +1014,16 @@ paths:
                 $ref: '#/components/schemas/CampaignStatsResponse'
         '404':
           description: Campaign not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:stats:view
@@ -898,6 +1078,10 @@ paths:
                 $ref: '#/components/schemas/PagedResponse'
         '403':
           description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - marketing:campaign:view
@@ -993,6 +1177,69 @@ components:
       - channel
       - name
       - templateId
+    ApiError:
+      type: object
+      description: Standard error response envelope returned by all Durion backend APIs
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+          example: ORDER_NOT_FOUND
+        message:
+          type: string
+          description: Human-readable error message
+          example: Order '550e8400-e29b-41d4-a716-446655440000' was not found
+        status:
+          type: integer
+          format: int32
+          description: HTTP status code
+          example: 404
+        timestamp:
+          type: string
+          description: ISO 8601 UTC timestamp of the error
+          example: 2026-03-17 14:30:00+00:00
+        correlationId:
+          type: string
+          description: Unique correlation ID for distributed request tracing
+          example: 550e8400-e29b-41d4-a716-446655440000
+        fieldErrors:
+          type: array
+          description: Field-level validation errors; present (non-null) for validation-related errors such as VALIDATION_ERROR or VALIDATION_FAILED; omitted for all other error types
+          items:
+            $ref: '#/components/schemas/FieldError'
+        referenceId:
+          type: string
+          description: Workflow or review-case reference identifier, when applicable
+          example: REVIEW-2026-000123
+        nextAction:
+          type: string
+          description: Recommended next step for the caller, when applicable
+          example: Retry the request with a valid quantity
+        supportAction:
+          type: string
+          description: Support or admin investigation guidance, when applicable
+          example: Contact support with the correlation ID for assistance
+      required:
+      - code
+      - correlationId
+      - message
+      - status
+      - timestamp
+    FieldError:
+      type: object
+      description: Validation error for a specific request field
+      properties:
+        field:
+          type: string
+          description: Field name
+          example: quantity
+        message:
+          type: string
+          description: Validation failure message
+          example: must be greater than 0
+      required:
+      - field
+      - message
     UpsertCampaignRequest:
       type: object
       description: Request to create or update a marketing campaign

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/CampaignController.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/CampaignController.java
@@ -10,6 +10,7 @@ import com.positivity.marketing.internal.enums.CampaignStatus;
 import com.positivity.marketing.internal.security.MarketingPermissionRegistry;
 import com.positivity.marketing.service.CampaignSendService;
 import com.positivity.marketing.service.CampaignService;
+import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -88,7 +89,10 @@ public class CampaignController {
                         @Content(
                                 mediaType = "application/json",
                                 array = @ArraySchema(schema = @Schema(implementation = CampaignResponse.class)))),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping
     @SecurityRequirement(
@@ -118,8 +122,14 @@ public class CampaignController {
                 responseCode = "200",
                 description = "Campaign returned",
                 content = @Content(schema = @Schema(implementation = CampaignResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "404",
+                description = "Campaign not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping("/{campaignId}")
     @SecurityRequirement(
@@ -151,9 +161,18 @@ public class CampaignController {
                 responseCode = "201",
                 description = "Campaign created",
                 content = @Content(schema = @Schema(implementation = CampaignResponse.class))),
-        @ApiResponse(responseCode = "409", description = "Campaign code already exists", content = @Content),
-        @ApiResponse(responseCode = "422", description = "Campaign definition is inconsistent", content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "409",
+                description = "Campaign code already exists",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "422",
+                description = "Campaign definition is inconsistent",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PostMapping
     @SecurityRequirement(
@@ -202,13 +221,22 @@ public class CampaignController {
                 responseCode = "200",
                 description = "Campaign updated",
                 content = @Content(schema = @Schema(implementation = CampaignResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
-        @ApiResponse(responseCode = "409", description = "Campaign code already exists", content = @Content),
+        @ApiResponse(
+                responseCode = "404",
+                description = "Campaign not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "409",
+                description = "Campaign code already exists",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
         @ApiResponse(
                 responseCode = "422",
                 description = "Campaign is no longer editable, or an immutable field was changed",
-                content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PutMapping("/{campaignId}")
     @SecurityRequirement(
@@ -256,10 +284,19 @@ public class CampaignController {
                 responseCode = "200",
                 description = "Preview returned",
                 content = @Content(schema = @Schema(implementation = AudiencePreviewResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
-        @ApiResponse(responseCode = "422", description = "Campaign has no segment bound", content = @Content),
+        @ApiResponse(
+                responseCode = "404",
+                description = "Campaign not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "422",
+                description = "Campaign has no segment bound",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
         @ApiResponse(responseCode = "503", description = "pos-customer unavailable", content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PostMapping("/{campaignId}/audience-preview")
     @SecurityRequirement(
@@ -291,9 +328,18 @@ public class CampaignController {
                 responseCode = "200",
                 description = "Campaign scheduled",
                 content = @Content(schema = @Schema(implementation = CampaignResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
-        @ApiResponse(responseCode = "422", description = "Campaign is not ready to schedule", content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "404",
+                description = "Campaign not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "422",
+                description = "Campaign is not ready to schedule",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PostMapping("/{campaignId}/schedule")
     @SecurityRequirement(
@@ -322,9 +368,18 @@ public class CampaignController {
                 responseCode = "200",
                 description = "Campaign paused",
                 content = @Content(schema = @Schema(implementation = CampaignResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
-        @ApiResponse(responseCode = "422", description = "Illegal lifecycle transition", content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "404",
+                description = "Campaign not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "422",
+                description = "Illegal lifecycle transition",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PostMapping("/{campaignId}/pause")
     @SecurityRequirement(
@@ -353,9 +408,18 @@ public class CampaignController {
                 responseCode = "200",
                 description = "Campaign resumed",
                 content = @Content(schema = @Schema(implementation = CampaignResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
-        @ApiResponse(responseCode = "422", description = "Illegal lifecycle transition", content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "404",
+                description = "Campaign not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "422",
+                description = "Illegal lifecycle transition",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PostMapping("/{campaignId}/resume")
     @SecurityRequirement(
@@ -384,9 +448,18 @@ public class CampaignController {
                 responseCode = "200",
                 description = "Campaign cancelled",
                 content = @Content(schema = @Schema(implementation = CampaignResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
-        @ApiResponse(responseCode = "422", description = "Illegal lifecycle transition", content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "404",
+                description = "Campaign not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "422",
+                description = "Illegal lifecycle transition",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PostMapping("/{campaignId}/cancel")
     @SecurityRequirement(
@@ -417,10 +490,19 @@ public class CampaignController {
                     """)
     @ApiResponses({
         @ApiResponse(responseCode = "202", description = "Dispatch accepted"),
-        @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
-        @ApiResponse(responseCode = "422", description = "Campaign is not in a dispatchable state", content = @Content),
+        @ApiResponse(
+                responseCode = "404",
+                description = "Campaign not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "422",
+                description = "Campaign is not in a dispatchable state",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
         @ApiResponse(responseCode = "503", description = "pos-customer unavailable", content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PostMapping("/{campaignId}/send")
     @SecurityRequirement(
@@ -451,7 +533,10 @@ public class CampaignController {
                 responseCode = "200",
                 description = "Send records returned",
                 content = @Content(schema = @Schema(implementation = PagedResponse.class))),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping("/{campaignId}/sends")
     @SecurityRequirement(

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/CampaignController.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/CampaignController.java
@@ -13,6 +13,7 @@ import com.positivity.marketing.service.CampaignService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -40,6 +41,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/marketing/campaigns")
 public class CampaignController {
 
+    static final String CAMPAIGN_EXAMPLE = """
+            {"code":"SPRING-FLEET-2026",
+             "name":"Spring fleet alignment push",
+             "description":"Alignment offer for commercial fleet accounts",
+             "audienceType":"COMMERCIAL",
+             "campaignProgramId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01",
+             "channels":["EMAIL","SMS"],
+             "segmentId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02",
+             "promotionOfferId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03",
+             "catalogFocusRef":"service:alignment",
+             "windowStart":"2026-03-01T00:00:00Z",
+             "windowEnd":"2026-03-31T23:59:59Z",
+             "scheduleType":"SCHEDULED",
+             "scheduledAt":"2026-03-02T14:00:00Z",
+             "emailTemplateId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04",
+             "smsTemplateId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a05"}
+            """;
+
     private final CampaignService campaignService;
     private final CampaignSendService campaignSendService;
 
@@ -48,7 +67,19 @@ public class CampaignController {
         this.campaignSendService = campaignSendService;
     }
 
-    @Operation(summary = "List campaigns", description = "List campaigns, optionally filtered by status or program")
+    @Operation(operationId = "listCampaigns", summary = "List Campaigns", description = """
+                    Lists marketing campaigns ordered by newest first, optionally filtered by lifecycle status \
+                    and campaign program.
+                    Use this tool when browsing or searching campaigns; do not use getCampaignById, which \
+                    requires a known campaign id and returns exactly one campaign.
+                    Preconditions: none; an empty result simply means no campaign matches the filters.
+                    Required inputs: none; status (DRAFT, SCHEDULED, SENDING, SENT, PAUSED, CANCELLED or \
+                    CLOSED) and campaignProgramId (UUID) are optional query filters that combine when both \
+                    are supplied.
+                    Emits a MARKETING_CAMPAIGN_LIST audit event; no marketing state is changed.
+                    Returns 200 with an empty array when nothing matches, so an empty result is not an error \
+                    condition.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -71,7 +102,17 @@ public class CampaignController {
         return ResponseEntity.ok(campaignService.list(status, campaignProgramId));
     }
 
-    @Operation(summary = "Get campaign", description = "Retrieve a campaign by id")
+    @Operation(operationId = "getCampaignById", summary = "Get Campaign By Id", description = """
+                    Returns one campaign's full definition, including status, channels, bound segment, \
+                    templates, schedule and delivery window.
+                    Use this tool when the campaign id is already known; use listCampaigns instead when \
+                    searching by status or program.
+                    Preconditions: the campaign must exist.
+                    Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+                    Emits a MARKETING_CAMPAIGN_GET audit event; no marketing state is changed and this is a \
+                    read-only projection.
+                    Returns 404 when no campaign exists for the supplied id.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -90,7 +131,21 @@ public class CampaignController {
         return ResponseEntity.ok(campaignService.get(campaignId));
     }
 
-    @Operation(summary = "Create campaign", description = "Create a campaign in DRAFT status")
+    @Operation(operationId = "createCampaign", summary = "Create Campaign", description = """
+                    Creates a marketing campaign in DRAFT status; nothing is targeted or sent until it is \
+                    scheduled and dispatched.
+                    Use this tool when defining a new campaign; do not use updateCampaign, which edits an \
+                    existing DRAFT campaign.
+                    Preconditions: no campaign may already use the same code (compared case-insensitively); \
+                    segment and templates may be attached later, since readiness is only enforced by \
+                    scheduleCampaign.
+                    Required inputs: code, name, audienceType (COMMERCIAL or INDIVIDUAL, immutable after \
+                    creation) and a non-empty channels set (EMAIL, SMS); scheduleType defaults to IMMEDIATE, \
+                    and scheduledAt is required only when scheduleType is SCHEDULED.
+                    Emits a MARKETING_CAMPAIGN_CREATE event; no recipients are contacted.
+                    Returns 409 when the code is already in use, and 422 when scheduleType is SCHEDULED \
+                    without scheduledAt or windowEnd precedes windowStart.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "201",
@@ -106,13 +161,42 @@ public class CampaignController {
             scopes = {MarketingPermissionRegistry.CAMPAIGN_CREATE})
     @PreAuthorize("hasAuthority('marketing:campaign:create')")
     @EmitEvent(id = "MARKETING_CAMPAIGN_CREATE", apiVersion = "1")
-    public ResponseEntity<CampaignResponse> create(@Valid @RequestBody UpsertCampaignRequest request) {
+    public ResponseEntity<CampaignResponse> create(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Campaign definition: code, name, audience, channels, and the optional segment,"
+                                            + " templates, offer and schedule to attach.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Scheduled commercial campaign",
+                                                            value = CAMPAIGN_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    UpsertCampaignRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(campaignService.create(request));
     }
 
-    @Operation(
-            summary = "Update campaign",
-            description = "Update a DRAFT campaign. Editing is refused once dispatch has begun.")
+    @Operation(operationId = "updateCampaign", summary = "Update Draft Campaign", description = """
+                    Replaces the definition of a DRAFT campaign, including its code, channels, segment, \
+                    templates, schedule and delivery window.
+                    Use this tool to revise a campaign before it is scheduled; do not use createCampaign, \
+                    which makes a new campaign, and use the lifecycle tools (scheduleCampaign, pauseCampaign, \
+                    cancelCampaign) rather than this one to change status.
+                    Preconditions: the campaign must exist and still be in DRAFT, since once dispatch may \
+                    have begun the definition is frozen; audienceType must equal the stored value because it \
+                    is immutable.
+                    Required inputs: campaignId (UUID) path parameter plus the full replacement body (code, \
+                    name, audienceType, channels); scheduleType defaults to IMMEDIATE when omitted, and \
+                    omitted optional fields are cleared rather than preserved.
+                    Emits a MARKETING_CAMPAIGN_UPDATE event; no recipients are contacted.
+                    Returns 404 when the campaign does not exist, 409 when the code belongs to another \
+                    campaign, and 422 when the campaign is no longer editable, audienceType is changed, or \
+                    the schedule and window fields are inconsistent.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -133,19 +217,46 @@ public class CampaignController {
     @PreAuthorize("hasAuthority('marketing:campaign:edit')")
     @EmitEvent(id = "MARKETING_CAMPAIGN_UPDATE", apiVersion = "1")
     public ResponseEntity<CampaignResponse> update(
-            @PathVariable UUID campaignId, @Valid @RequestBody UpsertCampaignRequest request) {
+            @PathVariable UUID campaignId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement campaign definition; audienceType must match the stored"
+                                    + " value, and omitted optional fields are cleared.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Scheduled commercial campaign",
+                                                            value = CAMPAIGN_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    UpsertCampaignRequest request) {
         return ResponseEntity.ok(campaignService.update(campaignId, request));
     }
 
-    @Operation(
-            summary = "Preview audience",
-            description =
-                    "Per-channel reach after consent, account gate, and suppression, plus any issues that would block scheduling")
+    @Operation(operationId = "previewCampaignAudience", summary = "Preview Campaign Audience", description = """
+                    Reports the campaign's last resolved audience snapshot: total segment members, per-channel \
+                    eligible counts after consent, staleness and suppression checks, whether each channel has a \
+                    template, and the readiness problems that would block scheduling.
+                    Use this tool to gauge reach before scheduling or dispatch; do not use dispatchCampaign, \
+                    which actually queues messages for delivery.
+                    Preconditions: the campaign must exist and have a segmentId bound; membership is \
+                    replicated asynchronously from pos-customer, so the counts reflect the snapshot taken at \
+                    resolvedAt rather than live CRM data.
+                    Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+                    Emits a MARKETING_AUDIENCE_PREVIEW audit event and, while the campaign is still DRAFT, \
+                    SCHEDULED or PAUSED, asynchronously requests a fresher membership snapshot from \
+                    pos-customer; the campaign itself is not modified.
+                    Returns 404 when the campaign does not exist, and 422 when no segment is bound so there \
+                    is nothing to preview.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
                 description = "Preview returned",
                 content = @Content(schema = @Schema(implementation = AudiencePreviewResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
         @ApiResponse(responseCode = "422", description = "Campaign has no segment bound", content = @Content),
         @ApiResponse(responseCode = "503", description = "pos-customer unavailable", content = @Content),
         @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
@@ -160,9 +271,21 @@ public class CampaignController {
         return ResponseEntity.ok(campaignService.previewAudience(campaignId));
     }
 
-    @Operation(
-            summary = "Schedule campaign",
-            description = "Validate the segment, templates, and offer, then move the campaign to SCHEDULED")
+    @Operation(operationId = "scheduleCampaign", summary = "Schedule Campaign For Dispatch", description = """
+                    Validates a campaign's readiness and moves it to SCHEDULED, the state from which dispatch \
+                    is allowed.
+                    Use this tool when a DRAFT campaign is complete; do not use dispatchCampaign, which queues \
+                    the actual sends and only accepts a campaign that is already SCHEDULED or SENDING.
+                    Preconditions: the campaign must exist and be in DRAFT or PAUSED; it must have at least \
+                    one channel, a bound segment that is known to this module, active, and matching the \
+                    campaign's audienceType, and an existing template attached for every selected channel.
+                    Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+                    Emits a MARKETING_CAMPAIGN_SCHEDULE event and publishes a campaign-scheduled fact through \
+                    the transactional outbox.
+                    Returns 404 when the campaign does not exist, and 422 listing every readiness problem at \
+                    once when the campaign is not ready or the transition is not legal from its current \
+                    status.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -182,12 +305,24 @@ public class CampaignController {
         return ResponseEntity.ok(campaignService.schedule(campaignId));
     }
 
-    @Operation(summary = "Pause campaign", description = "Halt dispatch; queued recipients stop being drained")
+    @Operation(operationId = "pauseCampaign", summary = "Pause Campaign Dispatch", description = """
+                    Moves a campaign to PAUSED so the send worker stops draining its queued recipients.
+                    Use this tool to halt an in-flight or scheduled campaign without losing it; do not use \
+                    cancelCampaign, which is terminal and cannot be undone.
+                    Preconditions: the campaign must exist and be in SCHEDULED or SENDING, the only statuses \
+                    that permit the PAUSED transition.
+                    Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+                    Emits a MARKETING_CAMPAIGN_PAUSE event; already-delivered messages are unaffected and \
+                    queued send rows remain PENDING for a later resume.
+                    Returns 404 when the campaign does not exist, and 422 when its current status does not \
+                    allow pausing.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
                 description = "Campaign paused",
                 content = @Content(schema = @Schema(implementation = CampaignResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
         @ApiResponse(responseCode = "422", description = "Illegal lifecycle transition", content = @Content),
         @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
     })
@@ -201,12 +336,24 @@ public class CampaignController {
         return ResponseEntity.ok(campaignService.pause(campaignId));
     }
 
-    @Operation(summary = "Resume campaign", description = "Return a paused campaign to the dispatch queue")
+    @Operation(operationId = "resumeCampaign", summary = "Resume Paused Campaign", description = """
+                    Returns a PAUSED campaign to SCHEDULED so it re-enters the dispatch queue; the send worker \
+                    decides when delivery actually restarts rather than jumping straight back into SENDING.
+                    Use this tool to continue a campaign that pauseCampaign halted; do not use \
+                    scheduleCampaign, which re-runs readiness validation on a DRAFT or PAUSED campaign.
+                    Preconditions: the campaign must exist and be PAUSED.
+                    Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+                    Emits a MARKETING_CAMPAIGN_RESUME event; recipients already recorded as sent are never \
+                    re-queued, because each recipient-channel pair is unique per campaign.
+                    Returns 404 when the campaign does not exist, and 422 when its current status does not \
+                    allow resuming.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
                 description = "Campaign resumed",
                 content = @Content(schema = @Schema(implementation = CampaignResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
         @ApiResponse(responseCode = "422", description = "Illegal lifecycle transition", content = @Content),
         @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
     })
@@ -220,12 +367,24 @@ public class CampaignController {
         return ResponseEntity.ok(campaignService.resume(campaignId));
     }
 
-    @Operation(summary = "Cancel campaign", description = "Cancel a campaign; the state is terminal")
+    @Operation(operationId = "cancelCampaign", summary = "Cancel Campaign Permanently", description = """
+                    Moves a campaign to CANCELLED, a terminal state from which no further transition exists.
+                    Use this tool to abandon a campaign for good; do not use pauseCampaign, which halts \
+                    dispatch reversibly and keeps the queue intact.
+                    Preconditions: the campaign must exist and be in DRAFT, SCHEDULED, SENDING or PAUSED; a \
+                    SENT campaign can only be CLOSED, and CANCELLED and CLOSED campaigns cannot transition at \
+                    all.
+                    Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+                    Emits a MARKETING_CAMPAIGN_CANCEL event; messages already delivered are not recalled.
+                    Returns 404 when the campaign does not exist, and 422 when its current status does not \
+                    allow cancellation.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
                 description = "Campaign cancelled",
                 content = @Content(schema = @Schema(implementation = CampaignResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
         @ApiResponse(responseCode = "422", description = "Illegal lifecycle transition", content = @Content),
         @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
     })
@@ -239,10 +398,23 @@ public class CampaignController {
         return ResponseEntity.ok(campaignService.cancel(campaignId));
     }
 
-    @Operation(
-            summary = "Dispatch campaign",
-            description =
-                    "Queue the campaign's audience for delivery. Asynchronous and idempotent: re-invoking never double-sends.")
+    @Operation(operationId = "dispatchCampaign", summary = "Dispatch Campaign To Audience", description = """
+                    Materializes the campaign's resolved audience into one PENDING send row per recipient and \
+                    channel, moves a SCHEDULED campaign to SENDING, and returns 202 with the queued count \
+                    while the send worker delivers asynchronously.
+                    Use this tool to start or retry delivery; do not use scheduleCampaign, which only \
+                    validates readiness, and do not use previewCampaignAudience, which reports reach without \
+                    queueing anything.
+                    Preconditions: the campaign must exist, be SCHEDULED or SENDING, and have a segment \
+                    bound; the audience is the last snapshot replicated from pos-customer.
+                    Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+                    Emits a MARKETING_CAMPAIGN_SEND event; the call is idempotent because each \
+                    recipient-channel pair is unique per campaign, so re-invoking never double-sends, and \
+                    when no audience snapshot has arrived yet it queues nothing, asynchronously requests \
+                    resolution from pos-customer, and reports queued 0 for a later retry.
+                    Returns 404 when the campaign does not exist, and 422 when it is not SCHEDULED or \
+                    SENDING or has no segment bound.
+                    """)
     @ApiResponses({
         @ApiResponse(responseCode = "202", description = "Dispatch accepted"),
         @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
@@ -261,7 +433,19 @@ public class CampaignController {
         return ResponseEntity.accepted().body(Map.of("campaignId", campaignId, "queued", queued));
     }
 
-    @Operation(summary = "List sends", description = "Per-recipient send records for a campaign")
+    @Operation(operationId = "listCampaignSends", summary = "List Campaign Send Records", description = """
+                    Lists the per-recipient, per-channel send rows a campaign dispatch queued, including \
+                    status, failure reason, provider message id, attempts and timestamps.
+                    Use this tool to inspect individual delivery outcomes; use getCampaignStats instead for \
+                    aggregate funnel and attribution numbers.
+                    Preconditions: none; an unknown campaignId yields an empty page rather than an error.
+                    Required inputs: campaignId (UUID) as a path parameter; page defaults to 0 and size \
+                    defaults to 50, clamped between 1 and 200, ordered by queuedAt ascending.
+                    Emits a MARKETING_CAMPAIGN_SENDS_LIST audit event; no marketing state is changed and \
+                    this is a read-only projection.
+                    Returns 200 with an empty page when the campaign has no send rows, so an empty result is \
+                    not an error condition.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/CampaignStatsController.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/CampaignStatsController.java
@@ -32,9 +32,21 @@ public class CampaignStatsController {
         this.statsService = statsService;
     }
 
-    @Operation(
-            summary = "Campaign stats",
-            description = "Per-channel reach funnel plus redemptions and discount value credited to the campaign")
+    @Operation(operationId = "getCampaignStats", summary = "Get Campaign Stats", description = """
+                    Returns one campaign's per-channel delivery funnel (targeted, suppressed, sent, \
+                    delivered, bounced, complained, failed) plus the redemption count and discount value \
+                    attributed to its campaign code; the sent figure is cumulative, counting delivered, \
+                    bounced and complained messages as sent.
+                    Use this tool for aggregate campaign performance; use listCampaignSends instead to \
+                    inspect individual recipient send rows, and use getProgramStats to compare the arms of a \
+                    program.
+                    Preconditions: the campaign must exist; a campaign that has never dispatched reports \
+                    zeroed funnels rather than an error.
+                    Required inputs: campaignId (UUID) as a path parameter; there is no request body.
+                    Emits a MARKETING_CAMPAIGN_STATS_GET audit event; no marketing state is changed and this \
+                    is a read-only projection.
+                    Returns 404 when no campaign exists for the supplied id.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -53,9 +65,18 @@ public class CampaignStatsController {
         return ResponseEntity.ok(statsService.campaignStats(campaignId));
     }
 
-    @Operation(
-            summary = "Program stats",
-            description = "Compare the commercial and individual arms of one campaign program side by side")
+    @Operation(operationId = "getProgramStats", summary = "Get Campaign Program Stats", description = """
+                    Returns the full stats block for every campaign sharing one campaignProgramId, so the \
+                    commercial and individual arms of an initiative can be compared side by side.
+                    Use this tool when comparing the arms of a program; use getCampaignStats instead for a \
+                    single campaign.
+                    Preconditions: at least one campaign must reference the campaignProgramId, since the \
+                    program has no record of its own in this module.
+                    Required inputs: campaignProgramId (UUID) as a path parameter; there is no request body.
+                    Emits a MARKETING_PROGRAM_STATS_GET audit event; no marketing state is changed and this \
+                    is a read-only projection.
+                    Returns 404 when no campaign references the supplied campaignProgramId.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/CampaignStatsController.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/CampaignStatsController.java
@@ -5,6 +5,7 @@ import com.positivity.marketing.internal.dto.CampaignStatsResponse;
 import com.positivity.marketing.internal.dto.ProgramStatsResponse;
 import com.positivity.marketing.internal.security.MarketingPermissionRegistry;
 import com.positivity.marketing.service.CampaignStatsService;
+import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -52,8 +53,14 @@ public class CampaignStatsController {
                 responseCode = "200",
                 description = "Stats returned",
                 content = @Content(schema = @Schema(implementation = CampaignStatsResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Campaign not found", content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "404",
+                description = "Campaign not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping("/campaigns/{campaignId}/stats")
     @SecurityRequirement(
@@ -82,8 +89,14 @@ public class CampaignStatsController {
                 responseCode = "200",
                 description = "Program stats returned",
                 content = @Content(schema = @Schema(implementation = ProgramStatsResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Campaign program not found", content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "404",
+                description = "Campaign program not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping("/programs/{campaignProgramId}/stats")
     @SecurityRequirement(

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/MessageTemplateController.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/MessageTemplateController.java
@@ -10,6 +10,7 @@ import com.positivity.marketing.service.MessageTemplateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -37,13 +38,34 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/marketing/templates")
 public class MessageTemplateController {
 
+    static final String TEMPLATE_EXAMPLE = """
+            {"name":"Spring fleet email",
+             "channel":"EMAIL",
+             "audienceType":"COMMERCIAL",
+             "subject":"{{accountName}}, your spring fleet alignment offer",
+             "body":"Hi {{contactFirstName}}, {{accountName}} qualifies for our spring alignment offer. \
+            Use code {{offerCode}} at {{shopName}}. Unsubscribe: {{unsubscribeUrl}}"}
+            """;
+
     private final MessageTemplateService templateService;
 
     public MessageTemplateController(MessageTemplateService templateService) {
         this.templateService = templateService;
     }
 
-    @Operation(summary = "List templates", description = "List templates, optionally filtered by channel and audience")
+    @Operation(operationId = "listMessageTemplates", summary = "List Message Templates", description = """
+                    Lists message templates ordered by name, optionally filtered by delivery channel and \
+                    audience type.
+                    Use this tool when browsing templates or finding one to attach to a campaign; do not use \
+                    getMessageTemplateById, which requires a known template id and returns exactly one \
+                    template.
+                    Preconditions: none; an empty result simply means no template matches the filters.
+                    Required inputs: none; channel (EMAIL or SMS) and audienceType (COMMERCIAL or \
+                    INDIVIDUAL) are optional query filters that combine when both are supplied.
+                    Emits a MARKETING_TEMPLATE_LIST audit event; no marketing state is changed.
+                    Returns 200 with an empty array when nothing matches, so an empty result is not an error \
+                    condition.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -68,7 +90,17 @@ public class MessageTemplateController {
         return ResponseEntity.ok(templateService.list(channel, audienceType));
     }
 
-    @Operation(summary = "Get template", description = "Retrieve a template and its available tokens")
+    @Operation(operationId = "getMessageTemplateById", summary = "Get Message Template By Id", description = """
+                    Returns one message template with its name, channel, audience type, subject, body, and \
+                    the substitution tokens available to its audience.
+                    Use this tool when the template id is already known; use listMessageTemplates instead \
+                    when searching by channel or audience.
+                    Preconditions: the template must exist.
+                    Required inputs: templateId (UUID) as a path parameter; there is no request body.
+                    Emits a MARKETING_TEMPLATE_GET audit event; no marketing state is changed and this is a \
+                    read-only projection.
+                    Returns 404 when no template exists for the supplied id.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -87,10 +119,24 @@ public class MessageTemplateController {
         return ResponseEntity.ok(templateService.get(templateId));
     }
 
-    @Operation(
-            summary = "Create template",
-            description =
-                    "Create a template. Unknown tokens and tokens outside the audience's vocabulary are rejected.")
+    @Operation(operationId = "createMessageTemplate", summary = "Create Message Template", description = """
+                    Creates a channel-specific message template whose {{token}} placeholders are validated \
+                    against the closed vocabulary for its audience at save time, so a typo costs a \
+                    validation error rather than a batch of broken messages.
+                    Use this tool when authoring a new template; do not use updateMessageTemplate, which \
+                    revises an existing template and cannot change its channel or audienceType.
+                    Preconditions: no template may already use the same name (compared case-insensitively); \
+                    commercial-only tokens such as accountName are rejected for INDIVIDUAL audiences and \
+                    vehicle tokens for COMMERCIAL ones.
+                    Required inputs: name, channel (EMAIL or SMS), audienceType (COMMERCIAL or INDIVIDUAL) \
+                    and body; subject is required for EMAIL, and for SMS it must be absent and any supplied \
+                    value is discarded.
+                    Emits a MARKETING_TEMPLATE_CREATE event; no campaign is affected until the template is \
+                    attached to one.
+                    Returns 409 when the name is already in use, and 422 when a token is unknown or outside \
+                    the audience's vocabulary, an email template lacks a subject, an SMS template has one, \
+                    or an SMS body exceeds 320 characters.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "201",
@@ -109,11 +155,40 @@ public class MessageTemplateController {
             scopes = {MarketingPermissionRegistry.TEMPLATE_MANAGE})
     @PreAuthorize("hasAuthority('marketing:template:manage')")
     @EmitEvent(id = "MARKETING_TEMPLATE_CREATE", apiVersion = "1")
-    public ResponseEntity<MessageTemplateResponse> create(@Valid @RequestBody UpsertMessageTemplateRequest request) {
+    public ResponseEntity<MessageTemplateResponse> create(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Template to create: name, channel, audience, subject (EMAIL only) and a"
+                                    + " body whose {{token}} placeholders must belong to the audience's vocabulary.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Commercial email template",
+                                                            value = TEMPLATE_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    UpsertMessageTemplateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(templateService.create(request));
     }
 
-    @Operation(summary = "Update template", description = "Update a template's name, subject, or body")
+    @Operation(operationId = "updateMessageTemplate", summary = "Update Message Template", description = """
+                    Updates a template's name, subject and body, re-validating every {{token}} against the \
+                    audience's vocabulary.
+                    Use this tool to revise wording; do not use createMessageTemplate for a different \
+                    channel or audience, because channel and audienceType are immutable and changing either \
+                    requires a new template.
+                    Preconditions: the template must exist, the channel and audienceType in the body must \
+                    equal the stored values, and no other template may hold the new name.
+                    Required inputs: templateId (UUID) path parameter plus the full body (name, channel, \
+                    audienceType, body); subject is required for EMAIL and discarded for SMS.
+                    Emits a MARKETING_TEMPLATE_UPDATE event; campaigns already bound to the template pick up \
+                    the new wording at their next dispatch.
+                    Returns 404 when the template does not exist, 409 when the name belongs to another \
+                    template, and 422 when channel or audienceType is changed or the token, subject or SMS \
+                    length rules fail.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -134,11 +209,37 @@ public class MessageTemplateController {
     @PreAuthorize("hasAuthority('marketing:template:manage')")
     @EmitEvent(id = "MARKETING_TEMPLATE_UPDATE", apiVersion = "1")
     public ResponseEntity<MessageTemplateResponse> update(
-            @PathVariable UUID templateId, @Valid @RequestBody UpsertMessageTemplateRequest request) {
+            @PathVariable UUID templateId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement template; channel and audienceType must match the stored"
+                                    + " values because both are immutable.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Commercial email template",
+                                                            value = TEMPLATE_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    UpsertMessageTemplateRequest request) {
         return ResponseEntity.ok(templateService.update(templateId, request));
     }
 
-    @Operation(summary = "Delete template", description = "Delete a template that no campaign is using")
+    @Operation(operationId = "deleteMessageTemplate", summary = "Delete Unused Message Template", description = """
+                    Permanently deletes a message template that no campaign references.
+                    Use this tool to retire an unused template; detach it from every campaign first via \
+                    updateCampaign rather than expecting the delete to cascade.
+                    Preconditions: the template must exist and must not be referenced as the email or SMS \
+                    template of any campaign, because a campaign whose template vanished would fail at \
+                    dispatch across its whole audience.
+                    Required inputs: templateId (UUID) as a path parameter; there is no request body and no \
+                    confirmation flag.
+                    Emits a MARKETING_TEMPLATE_DELETE event; the deletion is irreversible.
+                    Returns 404 when the template does not exist, and 422 when it is still attached to at \
+                    least one campaign.
+                    """)
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "Template deleted", content = @Content),
         @ApiResponse(responseCode = "404", description = "Template not found", content = @Content),

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/MessageTemplateController.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/MessageTemplateController.java
@@ -7,6 +7,7 @@ import com.positivity.marketing.internal.enums.AudienceType;
 import com.positivity.marketing.internal.enums.CampaignChannel;
 import com.positivity.marketing.internal.security.MarketingPermissionRegistry;
 import com.positivity.marketing.service.MessageTemplateService;
+import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -76,7 +77,10 @@ public class MessageTemplateController {
                                 array =
                                         @ArraySchema(
                                                 schema = @Schema(implementation = MessageTemplateResponse.class)))),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping
     @SecurityRequirement(
@@ -106,8 +110,14 @@ public class MessageTemplateController {
                 responseCode = "200",
                 description = "Template returned",
                 content = @Content(schema = @Schema(implementation = MessageTemplateResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Template not found", content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "404",
+                description = "Template not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @GetMapping("/{templateId}")
     @SecurityRequirement(
@@ -142,12 +152,18 @@ public class MessageTemplateController {
                 responseCode = "201",
                 description = "Template created",
                 content = @Content(schema = @Schema(implementation = MessageTemplateResponse.class))),
-        @ApiResponse(responseCode = "409", description = "Template name already exists", content = @Content),
+        @ApiResponse(
+                responseCode = "409",
+                description = "Template name already exists",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
         @ApiResponse(
                 responseCode = "422",
                 description = "Invalid token, missing subject, or SMS body over the segment limit",
-                content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PostMapping
     @SecurityRequirement(
@@ -194,13 +210,22 @@ public class MessageTemplateController {
                 responseCode = "200",
                 description = "Template updated",
                 content = @Content(schema = @Schema(implementation = MessageTemplateResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Template not found", content = @Content),
-        @ApiResponse(responseCode = "409", description = "Template name already exists", content = @Content),
+        @ApiResponse(
+                responseCode = "404",
+                description = "Template not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "409",
+                description = "Template name already exists",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
         @ApiResponse(
                 responseCode = "422",
                 description = "Invalid token, or an immutable field was changed",
-                content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @PutMapping("/{templateId}")
     @SecurityRequirement(
@@ -242,9 +267,18 @@ public class MessageTemplateController {
                     """)
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "Template deleted", content = @Content),
-        @ApiResponse(responseCode = "404", description = "Template not found", content = @Content),
-        @ApiResponse(responseCode = "422", description = "Template is attached to a campaign", content = @Content),
-        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+        @ApiResponse(
+                responseCode = "404",
+                description = "Template not found",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "422",
+                description = "Template is attached to a campaign",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class))),
+        @ApiResponse(
+                responseCode = "403",
+                description = "Forbidden - insufficient permissions",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     })
     @DeleteMapping("/{templateId}")
     @SecurityRequirement(

--- a/pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml
+++ b/pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml
@@ -19,10 +19,12 @@ modules:
     mode: STRICT
   pos-shop-manager:
     mode: STRICT
+    annotationDepth: STRICT
   pos-invoice:
     mode: STRICT
   pos-bulk-loader:
     mode: STRICT
+    annotationDepth: STRICT
   pos-vehicle-inventory:
     mode: STRICT
   pos-warranty:
@@ -32,12 +34,16 @@ modules:
     annotationDepth: STRICT
   pos-event-receiver:
     mode: STRICT
+    annotationDepth: STRICT
   pos-vehicle-fitment:
     mode: STRICT
+    annotationDepth: STRICT
   pos-image:
     mode: STRICT
+    annotationDepth: STRICT
   pos-documents:
     mode: STRICT
+    annotationDepth: STRICT
   pos-security-service:
     mode: STRICT
   pos-api-gateway:
@@ -47,6 +53,7 @@ modules:
     mode: STRICT
   pos-marketing:
     mode: STRICT
+    annotationDepth: STRICT
   pos-people-contact:
     mode: STRICT
   pos-tax:

--- a/pos-shop-manager/openapi.yaml
+++ b/pos-shop-manager/openapi.yaml
@@ -27,8 +27,20 @@ paths:
     put:
       tags:
       - Appointments API
-      summary: Reschedule appointment
-      description: Reschedule an existing appointment
+      summary: Move an Appointment to a New Time Window
+      description: 'Moves an existing appointment to a new time window while preserving its resource, customer and service requests, recording the change in reschedule history and the appointment audit trail.
+
+        Use this tool when a booked appointment must change times; do not use cancelAppointment, which terminates the appointment instead of moving it, and do not use createAppointment for a visit that is not yet booked.
+
+        Preconditions: the appointment must exist and be in SCHEDULED, CHECKED_IN or WAITING_FOR_PARTS status; completed, cancelled and other statuses cannot be rescheduled.
+
+        Required inputs: newStartAt and newEndAt (UTC instants, newStartAt before newEndAt) and a reason code; rescheduleReasonNotes (max 1000 characters) is mandatory when reason is OTHER, and notifyCustomer defaults to true.
+
+        Emits a SHOPMGR_APPOINTMENT_RESCHEDULE event; a downstream workorder reschedule notification is additionally published only when the appointment carries a workorderLinkRef.
+
+        Returns 400 when the time window is invalid or notes are missing for reason OTHER, 404 when the appointment does not exist, and 409 when the appointment status does not permit rescheduling.
+
+        '
       operationId: rescheduleAppointment
       parameters:
       - name: appointmentId
@@ -38,10 +50,20 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: New time window with a mandatory reason code and optional notes recorded in the reschedule history.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RescheduleAppointmentRequest'
+            examples:
+              Customer-requested reschedule:
+                description: Customer-requested reschedule
+                value:
+                  newStartAt: 2026-06-19 08:00:00+00:00
+                  newEndAt: 2026-06-19 10:00:00+00:00
+                  reason: CUSTOMER_REQUEST
+                  rescheduleReasonNotes: Customer asked to move to Friday morning
+                  notifyCustomer: true
         required: true
       responses:
         '200':
@@ -77,8 +99,20 @@ paths:
     post:
       tags:
       - Appointments API
-      summary: Create appointment
-      description: Create a new appointment
+      summary: Create a New Shop Appointment
+      description: 'Creates a shop appointment that reserves a time window for a customer''s vehicle at a location, optionally against a specific bay or mobile-unit resource and optionally linked to an originating estimate or work order.
+
+        Use this tool when booking new shop work; do not use rescheduleAppointment, which moves the time window of an appointment that already exists.
+
+        Preconditions: the customer and vehicle must exist in the local CRM replicas and the vehicle must belong to the customer; the requested window must not overlap another SCHEDULED appointment on the same resource at the location; when sourceType (ESTIMATE or WORK_ORDER) is set, sourceId is required, the source must be eligible for scheduling, and no appointment may already exist for that source.
+
+        Required inputs: crmCustomerId, crmVehicleId and locationId (UUIDs), startAt and endAt (UTC instants, startAt before endAt) and at least one serviceRequestIds entry; an optional Idempotency-Key header (non-blank, max 128 characters) makes retries safe and replays the original response only when the retried request matches the stored appointment''s scheduling fields.
+
+        Emits a SHOPMGR_APPOINTMENT_CREATE event and persists customer and vehicle snapshots on the appointment, which is created in SCHEDULED status.
+
+        Returns 400 when the slot is already booked, the idempotency key was reused with a different request, or sourceId is missing for a supplied sourceType; 404 when the customer or vehicle is unknown; 409 when the vehicle does not belong to the customer; and 422 when the source estimate or work order is not eligible for scheduling.
+
+        '
       operationId: createAppointment
       parameters:
       - name: Idempotency-Key
@@ -95,10 +129,25 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: 'Booking details for the appointment: customer, vehicle, location, time window, service requests and optional originating source document.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AppointmentCreateRequest'
+            examples:
+              Appointment from an estimate:
+                description: Appointment from an estimate
+                value:
+                  crmCustomerId: 01960003-0000-7000-8000-000000000001
+                  crmVehicleId: 01960003-0000-7000-8000-000000000002
+                  locationId: 01960003-0000-7000-8000-000000000003
+                  resourceId: BAY-04
+                  startAt: 2026-06-18 08:00:00+00:00
+                  endAt: 2026-06-18 10:00:00+00:00
+                  serviceRequestIds:
+                  - 01960003-0000-7000-8000-000000000004
+                  sourceType: ESTIMATE
+                  sourceId: EST-2026-000045
         required: true
       responses:
         '201':
@@ -109,6 +158,18 @@ paths:
                 $ref: '#/components/schemas/AppointmentResponse'
         '400':
           description: Validation or conflict error — requested slot is unavailable, duplicate source appointment, or request fields are invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppointmentResponse'
+        '404':
+          description: Customer or vehicle not found in the local CRM replicas.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppointmentResponse'
+        '409':
+          description: Vehicle does not belong to the supplied customer.
           content:
             application/json:
               schema:
@@ -136,9 +197,21 @@ paths:
     post:
       tags:
       - Conflict Override API
-      summary: Execute appointment conflict override
-      description: Executes a conflict override for the specified appointment when authorized.
-      operationId: executeOverride
+      summary: Override a Scheduling Conflict on an Appointment
+      description: 'Records a manager-authorized bypass of a detected scheduling conflict, flagging the appointment as conflict-overridden and persisting an immutable override record with the acting user and timestamp.
+
+        Use this tool when a blocking conflict on an appointment must be deliberately accepted; do not use createAssignment with override=true, which overrides assignment constraints while staffing, and do not use rescheduleAppointment, which resolves the conflict by moving the appointment instead.
+
+        Preconditions: the appointment must exist, and the caller must hold the shop:schedule:edit or appointments:reschedule authority.
+
+        Required inputs: appointmentId in the body matching the path parameter, and a non-blank overrideReason; conflictDetails is an optional JSON string describing the conflict being bypassed.
+
+        Emits a SHOPMGR_APPOINTMENT_CONFLICT_OVERRIDE_CREATE event, sets the appointment''s conflict-override flag and stores the override record with the actor resolved from the security context.
+
+        Returns 400 when the path and body appointmentId differ, the overrideReason is blank, or the appointment cannot be resolved, and 403 when the caller lacks the required authority.
+
+        '
+      operationId: executeConflictOverride
       parameters:
       - name: appointmentId
         in: path
@@ -148,10 +221,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Override decision naming the appointment, the justification, and an optional description of the conflict being bypassed.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ConflictOverrideRequest'
+            examples:
+              Override for a waiting customer:
+                description: Override for a waiting customer
+                value:
+                  appointmentId: 01960003-0000-7000-8000-000000000001
+                  overrideReason: Customer waiting on-site
+                  conflictDetails: '{"type":"TECHNICIAN_DOUBLE_BOOKED","resourceId":"01960003-0000-7000-8000-000000000010"}'
         required: true
       responses:
         '201':
@@ -189,8 +270,20 @@ paths:
     get:
       tags:
       - Appointment Assignments
-      summary: List appointment assignments
-      description: Returns the current assignments associated with the specified appointment.
+      summary: List Assignments for an Appointment
+      description: 'Returns all assignments recorded for an appointment, including each mechanic''s role, the reserved resource, status and override flag.
+
+        Use this tool when reading the staffing of a known appointment; do not use createAssignment, which creates a new assignment, and use searchShopAudit for the historical change trail.
+
+        Preconditions: none beyond authorization; an unknown appointmentId is not rejected.
+
+        Required inputs: appointmentId (UUID) as a path parameter; there is no request body and no filtering.
+
+        Emits a SHOPMGR_ASSIGNMENT_LIST_FETCHED audit event; no state changes occur, this is a read-only projection.
+
+        Returns 200 with an empty list when the appointment has no assignments or does not exist; no 404 is raised for an unknown appointmentId.
+
+        '
       operationId: listAssignments
       parameters:
       - name: appointmentId
@@ -227,8 +320,20 @@ paths:
     post:
       tags:
       - Appointment Assignments
-      summary: Create appointment assignments
-      description: Creates assignments for the specified appointment using the requested mechanics or shop resources.
+      summary: Create Mechanic Assignments for an Appointment
+      description: 'Creates the mechanic assignment for a scheduled appointment in CONFIRMED status, linking one LEAD mechanic and optional ASSIST mechanics and optionally reserving a bay or mobile-unit resource.
+
+        Use this tool when staffing a booked appointment; do not use executeConflictOverride, which records a schedule-conflict bypass without assigning anyone, and use listAssignments to read what is already assigned.
+
+        Preconditions: the appointment must exist and be in SCHEDULED status, no CONFIRMED or IN_PROGRESS assignment may already exist for it, and every mechanicPersonId must resolve to a known mechanic.
+
+        Required inputs: mechanics with exactly one LEAD role (a single mechanic with a null role defaults to LEAD); resourceId and resourceType are optional, and override=true requires the shop:schedule:edit authority plus a non-blank overrideReason.
+
+        Emits a SHOPMGR_ASSIGNMENT_CREATED event and persists the assignment and its mechanic links.
+
+        Returns 400 when the appointment or a mechanic cannot be resolved, the LEAD constraint is violated, or overrideReason is blank with override=true, and 403 when override is requested without the shop:schedule:edit authority.
+
+        '
       operationId: createAssignment
       parameters:
       - name: appointmentId
@@ -239,10 +344,22 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Mechanics to assign with their roles plus an optional bay or mobile-unit resource; the appointmentId in the path takes precedence over the body.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateAssignmentRequest'
+            examples:
+              Single lead mechanic with a bay:
+                description: Single lead mechanic with a bay
+                value:
+                  appointmentId: 01960003-0000-7000-8000-000000000001
+                  mechanics:
+                  - mechanicPersonId: 01960003-0000-7000-8000-000000000010
+                    role: LEAD
+                  resourceId: 01960003-0000-7000-8000-000000000005
+                  resourceType: BAY
+                  override: false
         required: true
       responses:
         '201':
@@ -266,8 +383,20 @@ paths:
     get:
       tags:
       - Shop Audit
-      summary: Search shop audit trail
-      description: Searches the shop audit trail using filter criteria. At least one filter criterion is required.
+      summary: Search the Shop Audit Trail
+      description: 'Searches the immutable shop audit trail of schedule and assignment changes, returning matching entries in reverse-chronological order with actor, event type, change summary and reason.
+
+        Use this tool when investigating who changed a schedule or assignment and why; use getShopAuditEntry instead when the audit entry id is already known.
+
+        Preconditions: at least one filter criterion (workorderId, appointmentId, mechanicId, actorUserId, eventType or locationId) must be supplied; unbounded scans are rejected.
+
+        Required inputs: any combination of the filter fields plus optional fromDateTime and toDateTime, which default to the last 90 days ending now; eventType is one of SCHEDULE_CREATED, SCHEDULE_UPDATED, SCHEDULE_CANCELLED, ASSIGNMENT_CREATED or ASSIGNMENT_REMOVED.
+
+        No events are emitted and no state changes; this is a read-only projection of records retained for seven years.
+
+        Returns 400 when no filter criterion is provided.
+
+        '
       operationId: searchShopAudit
       parameters:
       - name: filter
@@ -305,8 +434,20 @@ paths:
     get:
       tags:
       - Shop Audit
-      summary: Get shop audit entry by ID
-      description: Returns a single shop audit entry by its UUID.
+      summary: Get a Shop Audit Entry by ID
+      description: 'Returns a single immutable shop audit entry, including actor, event type, change summary, change patch and reason fields.
+
+        Use this tool when the audit entry id is already known; use searchShopAudit instead to find entries by workorder, appointment, mechanic, actor, event type or location.
+
+        Preconditions: the audit entry must exist; entries are never updated or deleted once written.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no audit entry exists for the supplied id.
+
+        '
       operationId: getShopAuditEntry
       parameters:
       - name: id
@@ -343,8 +484,20 @@ paths:
     get:
       tags:
       - Technician API
-      summary: Get technician person details
-      description: Resolves the person identity (names, contact details) of a technician working at the given shop location from the local people-contact replica. Identity fields can trail the people-contact authority by the event-propagation delay.
+      summary: Get Person Details for a Technician
+      description: 'Resolves the person identity (names, emails, phone numbers) of a technician working at a shop location from the local people-contact replica.
+
+        Use this tool when displaying or contacting an assigned technician; use viewSchedule instead for the technician''s scheduled work.
+
+        Preconditions: a technician record must link the personId to the locationId; replica identity fields can trail the people-contact authority by the event-propagation delay.
+
+        Required inputs: locationId and personId (UUIDs) as path parameters; there is no request body.
+
+        Emits a SHOPMGR_TECHNICIAN_PERSON_GET audit event; no state changes occur, and when the replica row has not yet arrived the response carries only the person id with name and contact fields null.
+
+        Returns 404 when no technician links the person to the location.
+
+        '
       operationId: getTechnicianPerson
       parameters:
       - name: locationId
@@ -385,8 +538,20 @@ paths:
     get:
       tags:
       - Schedule API
-      summary: View schedule
-      description: Read-only schedule view for a location and date.
+      summary: View the Daily Schedule for a Location
+      description: 'Builds the read-only schedule board for one location and date, grouping appointments into resource lanes (bay, mobile unit, technician or UNASSIGNED) and marking overlaps of one minute or more within the same lane as BLOCKING conflicts.
+
+        Use this tool when rendering or inspecting a day''s shop schedule; use getAppointmentById instead when a single appointment id is already known.
+
+        Preconditions: the location must exist as a shop; the day window is computed in the shop''s configured timezone, falling back to UTC when none is configured.
+
+        Required inputs: locationId (UUID) and date (YYYY-MM-DD); resourceType and resourceId are optional filters, includeAvailabilityOverlay defaults to false, and range defaults to LOCATION_HOURS (06:00-18:00 local) with FULL_DAY covering midnight to midnight.
+
+        Emits a SHOPMGR_SCHEDULE_VIEW audit event; no state changes occur, and when the overlay is requested availabilityOverlayStatus reports AVAILABLE or UNAVAILABLE with an HR_SYSTEM_UNAVAILABLE warning when the staffing replica has no data for the location.
+
+        Returns 404 when the location is unknown or the resourceId filter matches no lane on that date.
+
+        '
       operationId: viewSchedule
       parameters:
       - name: locationId
@@ -470,17 +635,29 @@ paths:
     get:
       tags:
       - Appointments API
-      summary: Load appointment
-      description: Retrieve an appointment by ID
-      operationId: getAppointment
+      summary: Get an Appointment by Its ID
+      description: 'Returns the full appointment record, including status, time window, service request ids and the customer and vehicle snapshots captured at booking.
+
+        Use this tool when the appointment id is already known; use viewSchedule instead to browse appointments by location and date.
+
+        Preconditions: the appointment must exist; appointmentId must be a UUID in canonical text form.
+
+        Required inputs: appointmentId as a path parameter; there is no request body and no filtering.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 400 when appointmentId is not a valid UUID, and 404 when no appointment exists for the supplied id.
+
+        '
+      operationId: getAppointmentById
       parameters:
       - name: appointmentId
         in: path
-        description: Appointment ID
+        description: Appointment ID (UUID)
         required: true
         schema:
           type: string
-        example: appt-123
+        example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
       - name: X-Correlation-Id
         in: header
         description: Correlation ID for request tracing
@@ -491,6 +668,12 @@ paths:
       responses:
         '200':
           description: Appointment retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppointmentResponse'
+        '400':
+          description: appointmentId is not a valid UUID.
           content:
             application/json:
               schema:
@@ -518,8 +701,20 @@ paths:
     delete:
       tags:
       - Appointments API
-      summary: Cancel appointment
-      description: Cancel a scheduled appointment
+      summary: Cancel a Scheduled Appointment With Reason
+      description: 'Cancels a scheduled appointment, setting its status to CANCELLED with the supplied reason code and recording the cancellation in the appointment audit trail.
+
+        Use this tool when a booked visit will not happen; do not use rescheduleAppointment, which keeps the appointment alive at a new time.
+
+        Preconditions: the appointment must exist and be in SCHEDULED status; appointments that are already checked in, in progress, completed or cancelled are rejected.
+
+        Required inputs: cancellationReason (CUSTOMER_REQUEST, TECHNICIAN_UNAVAILABLE, WEATHER, VEHICLE_NOT_READY or OTHER); notes is optional free text up to 1000 characters.
+
+        Emits a SHOPMGR_APPOINTMENT_CANCEL event; a downstream workorder cancellation notification is additionally published only when the appointment carries a workorderLinkRef.
+
+        Returns 404 when the appointment does not exist, and 409 when the appointment is not in SCHEDULED status.
+
+        '
       operationId: cancelAppointment
       parameters:
       - name: appointmentId
@@ -529,14 +724,27 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Cancellation reason code and optional free-text notes stored on the appointment.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CancelAppointmentRequest'
+            examples:
+              Customer-requested cancellation:
+                description: Customer-requested cancellation
+                value:
+                  cancellationReason: CUSTOMER_REQUEST
+                  notes: Customer rescheduled to next week
         required: true
       responses:
         '200':
           description: Appointment cancelled successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppointmentResponse'
+        '404':
+          description: Appointment not found.
           content:
             application/json:
               schema:
@@ -676,7 +884,7 @@ components:
       - status
     AppointmentCreateRequest:
       type: object
-      description: Appointment creation request body
+      description: Request to create an appointment from an estimate or workorder source document
       properties:
         crmCustomerId:
           type: string
@@ -740,7 +948,7 @@ components:
       - startAt
     ConflictOverrideRequest:
       type: object
-      description: Conflict override request payload
+      description: Request to bypass a scheduling conflict with manager permission
       properties:
         appointmentId:
           type: string

--- a/pos-shop-manager/openapi.yaml
+++ b/pos-shop-manager/openapi.yaml
@@ -77,19 +77,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppointmentResponse'
+                $ref: '#/components/schemas/ApiError'
         '404':
           description: Appointment not found.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppointmentResponse'
+                $ref: '#/components/schemas/ApiError'
         '409':
           description: Appointment state conflict — appointment is not in a reschedulable status.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppointmentResponse'
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - appointments:reschedule
@@ -161,25 +161,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppointmentResponse'
+                $ref: '#/components/schemas/ApiError'
         '404':
           description: Customer or vehicle not found in the local CRM replicas.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppointmentResponse'
+                $ref: '#/components/schemas/ApiError'
         '409':
           description: Vehicle does not belong to the supplied customer.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppointmentResponse'
+                $ref: '#/components/schemas/ApiError'
         '422':
           description: Source not eligible — estimate or work order cannot be scheduled (ineligible status).
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppointmentResponse'
+                $ref: '#/components/schemas/ApiError'
         '501':
           description: Not implemented.
           content:
@@ -677,13 +677,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppointmentResponse'
+                $ref: '#/components/schemas/ApiError'
         '404':
           description: Appointment not found.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppointmentResponse'
+                $ref: '#/components/schemas/ApiError'
         '501':
           description: Not implemented.
           content:
@@ -748,13 +748,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppointmentResponse'
+                $ref: '#/components/schemas/ApiError'
         '409':
           description: Appointment state conflict.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppointmentResponse'
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - appointments:cancel
@@ -804,6 +804,69 @@ components:
       - newEndAt
       - newStartAt
       - reason
+    ApiError:
+      type: object
+      description: Standard error response envelope returned by all Durion backend APIs
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+          example: ORDER_NOT_FOUND
+        message:
+          type: string
+          description: Human-readable error message
+          example: Order '550e8400-e29b-41d4-a716-446655440000' was not found
+        status:
+          type: integer
+          format: int32
+          description: HTTP status code
+          example: 404
+        timestamp:
+          type: string
+          description: ISO 8601 UTC timestamp of the error
+          example: 2026-03-17 14:30:00+00:00
+        correlationId:
+          type: string
+          description: Unique correlation ID for distributed request tracing
+          example: 550e8400-e29b-41d4-a716-446655440000
+        fieldErrors:
+          type: array
+          description: Field-level validation errors; present (non-null) for validation-related errors such as VALIDATION_ERROR or VALIDATION_FAILED; omitted for all other error types
+          items:
+            $ref: '#/components/schemas/FieldError'
+        referenceId:
+          type: string
+          description: Workflow or review-case reference identifier, when applicable
+          example: REVIEW-2026-000123
+        nextAction:
+          type: string
+          description: Recommended next step for the caller, when applicable
+          example: Retry the request with a valid quantity
+        supportAction:
+          type: string
+          description: Support or admin investigation guidance, when applicable
+          example: Contact support with the correlation ID for assistance
+      required:
+      - code
+      - correlationId
+      - message
+      - status
+      - timestamp
+    FieldError:
+      type: object
+      description: Validation error for a specific request field
+      properties:
+        field:
+          type: string
+          description: Field name
+          example: quantity
+        message:
+          type: string
+          description: Validation failure message
+          example: must be greater than 0
+      required:
+      - field
+      - message
     AppointmentResponse:
       type: object
       description: Response describing a created or retrieved appointment
@@ -1180,69 +1243,6 @@ components:
           format: date-time
           description: Inclusive end timestamp for date-time range filter
           example: 2026-12-31 23:59:59+00:00
-    ApiError:
-      type: object
-      description: Standard error response envelope returned by all Durion backend APIs
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-          example: ORDER_NOT_FOUND
-        message:
-          type: string
-          description: Human-readable error message
-          example: Order '550e8400-e29b-41d4-a716-446655440000' was not found
-        status:
-          type: integer
-          format: int32
-          description: HTTP status code
-          example: 404
-        timestamp:
-          type: string
-          description: ISO 8601 UTC timestamp of the error
-          example: 2026-03-17 14:30:00+00:00
-        correlationId:
-          type: string
-          description: Unique correlation ID for distributed request tracing
-          example: 550e8400-e29b-41d4-a716-446655440000
-        fieldErrors:
-          type: array
-          description: Field-level validation errors; present (non-null) for validation-related errors such as VALIDATION_ERROR or VALIDATION_FAILED; omitted for all other error types
-          items:
-            $ref: '#/components/schemas/FieldError'
-        referenceId:
-          type: string
-          description: Workflow or review-case reference identifier, when applicable
-          example: REVIEW-2026-000123
-        nextAction:
-          type: string
-          description: Recommended next step for the caller, when applicable
-          example: Retry the request with a valid quantity
-        supportAction:
-          type: string
-          description: Support or admin investigation guidance, when applicable
-          example: Contact support with the correlation ID for assistance
-      required:
-      - code
-      - correlationId
-      - message
-      - status
-      - timestamp
-    FieldError:
-      type: object
-      description: Validation error for a specific request field
-      properties:
-        field:
-          type: string
-          description: Field name
-          example: quantity
-        message:
-          type: string
-          description: Validation failure message
-          example: must be greater than 0
-      required:
-      - field
-      - message
     ShopAuditEntryResponse:
       type: object
       description: Read-only shop audit trail entry recording a schedule or assignment change

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/AppointmentsController.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/AppointmentsController.java
@@ -8,6 +8,8 @@ import com.positivity.shopmanager.internal.dto.RescheduleAppointmentRequest;
 import com.positivity.shopmanager.service.AppointmentsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -35,12 +37,36 @@ public class AppointmentsController {
 
     private final AppointmentsService appointmentsService;
 
-    @Operation(summary = "Create appointment", description = "Create a new appointment")
+    @Operation(operationId = "createAppointment", summary = "Create a New Shop Appointment", description = """
+                    Creates a shop appointment that reserves a time window for a customer's vehicle at a location, \
+                    optionally against a specific bay or mobile-unit resource and optionally linked to an originating \
+                    estimate or work order.
+                    Use this tool when booking new shop work; do not use rescheduleAppointment, which moves the time \
+                    window of an appointment that already exists.
+                    Preconditions: the customer and vehicle must exist in the local CRM replicas and the vehicle must \
+                    belong to the customer; the requested window must not overlap another SCHEDULED appointment on \
+                    the same resource at the location; when sourceType (ESTIMATE or WORK_ORDER) is set, sourceId is \
+                    required, the source must be eligible for scheduling, and no appointment may already exist for \
+                    that source.
+                    Required inputs: crmCustomerId, crmVehicleId and locationId (UUIDs), startAt and endAt (UTC \
+                    instants, startAt before endAt) and at least one serviceRequestIds entry; an optional \
+                    Idempotency-Key header (non-blank, max 128 characters) makes retries safe and replays the \
+                    original response only when the retried request matches the stored appointment's scheduling \
+                    fields.
+                    Emits a SHOPMGR_APPOINTMENT_CREATE event and persists customer and vehicle snapshots on the \
+                    appointment, which is created in SCHEDULED status.
+                    Returns 400 when the slot is already booked, the idempotency key was reused with a different \
+                    request, or sourceId is missing for a supplied sourceType; 404 when the customer or vehicle is \
+                    unknown; 409 when the vehicle does not belong to the customer; and 422 when the source estimate \
+                    or work order is not eligible for scheduling.
+                    """)
     @ApiResponse(responseCode = "201", description = "Appointment created successfully.")
     @ApiResponse(
             responseCode = "400",
             description =
                     "Validation or conflict error — requested slot is unavailable, duplicate source appointment, or request fields are invalid.")
+    @ApiResponse(responseCode = "404", description = "Customer or vehicle not found in the local CRM replicas.")
+    @ApiResponse(responseCode = "409", description = "Vehicle does not belong to the supplied customer.")
     @ApiResponse(
             responseCode = "422",
             description = "Source not eligible — estimate or work order cannot be scheduled (ineligible status).")
@@ -52,7 +78,28 @@ public class AppointmentsController {
             scopes = {"appointments:create", "shop:schedule:edit"})
     @PreAuthorize("hasAnyAuthority('appointments:create','shop:schedule:edit')")
     public ResponseEntity<AppointmentResponse> createAppointment(
-            @Parameter(description = "Appointment creation request body") @Valid @RequestBody
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Booking details for the appointment: customer, vehicle, location, time window,"
+                                            + " service requests and optional originating source document.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "Appointment from an estimate", value = """
+                                                                    {"crmCustomerId":"01960003-0000-7000-8000-000000000001",
+                                                                     "crmVehicleId":"01960003-0000-7000-8000-000000000002",
+                                                                     "locationId":"01960003-0000-7000-8000-000000000003",
+                                                                     "resourceId":"BAY-04",
+                                                                     "startAt":"2026-06-18T08:00:00Z",
+                                                                     "endAt":"2026-06-18T10:00:00Z",
+                                                                     "serviceRequestIds":["01960003-0000-7000-8000-000000000004"],
+                                                                     "sourceType":"ESTIMATE",
+                                                                     "sourceId":"EST-2026-000045"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
                     AppointmentCreateRequest request,
             @Parameter(description = "Idempotency key for safe retries")
                     @org.springframework.web.bind.annotation.RequestHeader(value = "Idempotency-Key", required = false)
@@ -72,8 +119,19 @@ public class AppointmentsController {
                 .body(response);
     }
 
-    @Operation(summary = "Load appointment", description = "Retrieve an appointment by ID")
+    @Operation(operationId = "getAppointmentById", summary = "Get an Appointment by Its ID", description = """
+                    Returns the full appointment record, including status, time window, service request ids and the \
+                    customer and vehicle snapshots captured at booking.
+                    Use this tool when the appointment id is already known; use viewSchedule instead to browse \
+                    appointments by location and date.
+                    Preconditions: the appointment must exist; appointmentId must be a UUID in canonical text form.
+                    Required inputs: appointmentId as a path parameter; there is no request body and no filtering.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 400 when appointmentId is not a valid UUID, and 404 when no appointment exists for the \
+                    supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Appointment retrieved successfully.")
+    @ApiResponse(responseCode = "400", description = "appointmentId is not a valid UUID.")
     @ApiResponse(responseCode = "404", description = "Appointment not found.")
     @ApiResponse(responseCode = "501", description = "Not implemented.")
     @GetMapping("/appointments/{appointmentId}")
@@ -82,7 +140,9 @@ public class AppointmentsController {
             scopes = {"appointments:view", "shop:schedule:view"})
     @PreAuthorize("hasAnyAuthority('appointments:view','shop:schedule:view')")
     public ResponseEntity<AppointmentResponse> getAppointment(
-            @Parameter(description = "Appointment ID", example = "appt-123") @PathVariable String appointmentId,
+            @Parameter(description = "Appointment ID (UUID)", example = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b")
+                    @PathVariable
+                    String appointmentId,
             @Parameter(description = "Correlation ID for request tracing")
                     @org.springframework.web.bind.annotation.RequestHeader(value = "X-Correlation-Id", required = false)
                     UUID correlationId) {
@@ -94,7 +154,25 @@ public class AppointmentsController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "Reschedule appointment", description = "Reschedule an existing appointment")
+    @Operation(
+            operationId = "rescheduleAppointment",
+            summary = "Move an Appointment to a New Time Window",
+            description = """
+                    Moves an existing appointment to a new time window while preserving its resource, customer and \
+                    service requests, recording the change in reschedule history and the appointment audit trail.
+                    Use this tool when a booked appointment must change times; do not use cancelAppointment, which \
+                    terminates the appointment instead of moving it, and do not use createAppointment for a visit \
+                    that is not yet booked.
+                    Preconditions: the appointment must exist and be in SCHEDULED, CHECKED_IN or WAITING_FOR_PARTS \
+                    status; completed, cancelled and other statuses cannot be rescheduled.
+                    Required inputs: newStartAt and newEndAt (UTC instants, newStartAt before newEndAt) and a reason \
+                    code; rescheduleReasonNotes (max 1000 characters) is mandatory when reason is OTHER, and \
+                    notifyCustomer defaults to true.
+                    Emits a SHOPMGR_APPOINTMENT_RESCHEDULE event; a downstream workorder reschedule notification is \
+                    additionally published only when the appointment carries a workorderLinkRef.
+                    Returns 400 when the time window is invalid or notes are missing for reason OTHER, 404 when the \
+                    appointment does not exist, and 409 when the appointment status does not permit rescheduling.
+                    """)
     @ApiResponse(responseCode = "200", description = "Appointment rescheduled successfully.")
     @ApiResponse(
             responseCode = "400",
@@ -111,12 +189,49 @@ public class AppointmentsController {
     @PreAuthorize("hasAuthority('appointments:reschedule')")
     @EmitEvent(id = "SHOPMGR_APPOINTMENT_RESCHEDULE", apiVersion = "1")
     public ResponseEntity<AppointmentResponse> rescheduleAppointment(
-            @PathVariable UUID appointmentId, @Valid @RequestBody RescheduleAppointmentRequest request) {
+            @PathVariable UUID appointmentId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "New time window with a mandatory reason code and optional notes recorded"
+                                    + " in the reschedule history.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Customer-requested reschedule",
+                                                            value = """
+                                                                    {"newStartAt":"2026-06-19T08:00:00Z",
+                                                                     "newEndAt":"2026-06-19T10:00:00Z",
+                                                                     "reason":"CUSTOMER_REQUEST",
+                                                                     "rescheduleReasonNotes":"Customer asked to move to Friday morning",
+                                                                     "notifyCustomer":true}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    RescheduleAppointmentRequest request) {
         return ResponseEntity.ok(appointmentsService.rescheduleAppointment(appointmentId, request));
     }
 
-    @Operation(summary = "Cancel appointment", description = "Cancel a scheduled appointment")
+    @Operation(
+            operationId = "cancelAppointment",
+            summary = "Cancel a Scheduled Appointment With Reason",
+            description = """
+                    Cancels a scheduled appointment, setting its status to CANCELLED with the supplied reason code \
+                    and recording the cancellation in the appointment audit trail.
+                    Use this tool when a booked visit will not happen; do not use rescheduleAppointment, which keeps \
+                    the appointment alive at a new time.
+                    Preconditions: the appointment must exist and be in SCHEDULED status; appointments that are \
+                    already checked in, in progress, completed or cancelled are rejected.
+                    Required inputs: cancellationReason (CUSTOMER_REQUEST, TECHNICIAN_UNAVAILABLE, WEATHER, \
+                    VEHICLE_NOT_READY or OTHER); notes is optional free text up to 1000 characters.
+                    Emits a SHOPMGR_APPOINTMENT_CANCEL event; a downstream workorder cancellation notification is \
+                    additionally published only when the appointment carries a workorderLinkRef.
+                    Returns 404 when the appointment does not exist, and 409 when the appointment is not in \
+                    SCHEDULED status.
+                    """)
     @ApiResponse(responseCode = "200", description = "Appointment cancelled successfully.")
+    @ApiResponse(responseCode = "404", description = "Appointment not found.")
     @ApiResponse(responseCode = "409", description = "Appointment state conflict.")
     @DeleteMapping("/appointments/{appointmentId}/cancel")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -125,7 +240,24 @@ public class AppointmentsController {
     @PreAuthorize("hasAuthority('appointments:cancel')")
     @EmitEvent(id = "SHOPMGR_APPOINTMENT_CANCEL", apiVersion = "1")
     public ResponseEntity<AppointmentResponse> cancelAppointment(
-            @PathVariable UUID appointmentId, @Valid @RequestBody CancelAppointmentRequest request) {
+            @PathVariable UUID appointmentId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Cancellation reason code and optional free-text notes stored on the"
+                                    + " appointment.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Customer-requested cancellation",
+                                                            value = """
+                                                                    {"cancellationReason":"CUSTOMER_REQUEST",
+                                                                     "notes":"Customer rescheduled to next week"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CancelAppointmentRequest request) {
         return ResponseEntity.ok(appointmentsService.cancelAppointment(appointmentId, request));
     }
 

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/AppointmentsController.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/AppointmentsController.java
@@ -1,6 +1,7 @@
 package com.positivity.shopmanager.internal.controller;
 
 import com.positivity.events.EmitEvent;
+import com.positivity.shared.error.ApiError;
 import com.positivity.shopmanager.internal.dto.AppointmentCreateRequest;
 import com.positivity.shopmanager.internal.dto.AppointmentResponse;
 import com.positivity.shopmanager.internal.dto.CancelAppointmentRequest;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -64,12 +66,20 @@ public class AppointmentsController {
     @ApiResponse(
             responseCode = "400",
             description =
-                    "Validation or conflict error — requested slot is unavailable, duplicate source appointment, or request fields are invalid.")
-    @ApiResponse(responseCode = "404", description = "Customer or vehicle not found in the local CRM replicas.")
-    @ApiResponse(responseCode = "409", description = "Vehicle does not belong to the supplied customer.")
+                    "Validation or conflict error — requested slot is unavailable, duplicate source appointment, or request fields are invalid.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Customer or vehicle not found in the local CRM replicas.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Vehicle does not belong to the supplied customer.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     @ApiResponse(
             responseCode = "422",
-            description = "Source not eligible — estimate or work order cannot be scheduled (ineligible status).")
+            description = "Source not eligible — estimate or work order cannot be scheduled (ineligible status).",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     @ApiResponse(responseCode = "501", description = "Not implemented.")
     @EmitEvent(id = "SHOPMGR_APPOINTMENT_CREATE", apiVersion = "1")
     @PostMapping("/appointments")
@@ -131,8 +141,14 @@ public class AppointmentsController {
                     supplied id.
                     """)
     @ApiResponse(responseCode = "200", description = "Appointment retrieved successfully.")
-    @ApiResponse(responseCode = "400", description = "appointmentId is not a valid UUID.")
-    @ApiResponse(responseCode = "404", description = "Appointment not found.")
+    @ApiResponse(
+            responseCode = "400",
+            description = "appointmentId is not a valid UUID.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Appointment not found.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     @ApiResponse(responseCode = "501", description = "Not implemented.")
     @GetMapping("/appointments/{appointmentId}")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -177,11 +193,16 @@ public class AppointmentsController {
     @ApiResponse(
             responseCode = "400",
             description =
-                    "Validation error — invalid times, missing mandatory fields, or blank notes required for OTHER reason.")
-    @ApiResponse(responseCode = "404", description = "Appointment not found.")
+                    "Validation error — invalid times, missing mandatory fields, or blank notes required for OTHER reason.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Appointment not found.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     @ApiResponse(
             responseCode = "409",
-            description = "Appointment state conflict — appointment is not in a reschedulable status.")
+            description = "Appointment state conflict — appointment is not in a reschedulable status.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     @PutMapping("/appointments/{appointmentId}/reschedule")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -231,8 +252,14 @@ public class AppointmentsController {
                     SCHEDULED status.
                     """)
     @ApiResponse(responseCode = "200", description = "Appointment cancelled successfully.")
-    @ApiResponse(responseCode = "404", description = "Appointment not found.")
-    @ApiResponse(responseCode = "409", description = "Appointment state conflict.")
+    @ApiResponse(
+            responseCode = "404",
+            description = "Appointment not found.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Appointment state conflict.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     @DeleteMapping("/appointments/{appointmentId}/cancel")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/AssignmentController.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/AssignmentController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,9 +44,26 @@ public class AssignmentController {
     @PreAuthorize("hasAuthority('shop:bay:assign')")
     @EmitEvent(id = "SHOPMGR_ASSIGNMENT_CREATED", apiVersion = "1")
     @Operation(
-            summary = "Create appointment assignments",
-            description =
-                    "Creates assignments for the specified appointment using the requested mechanics or shop resources.")
+            operationId = "createAssignment",
+            summary = "Create Mechanic Assignments for an Appointment",
+            description = """
+                    Creates the mechanic assignment for a scheduled appointment in CONFIRMED status, linking one \
+                    LEAD mechanic and optional ASSIST mechanics and optionally reserving a bay or mobile-unit \
+                    resource.
+                    Use this tool when staffing a booked appointment; do not use executeConflictOverride, which \
+                    records a schedule-conflict bypass without assigning anyone, and use listAssignments to read \
+                    what is already assigned.
+                    Preconditions: the appointment must exist and be in SCHEDULED status, no CONFIRMED or \
+                    IN_PROGRESS assignment may already exist for it, and every mechanicPersonId must resolve to a \
+                    known mechanic.
+                    Required inputs: mechanics with exactly one LEAD role (a single mechanic with a null role \
+                    defaults to LEAD); resourceId and resourceType are optional, and override=true requires the \
+                    shop:schedule:edit authority plus a non-blank overrideReason.
+                    Emits a SHOPMGR_ASSIGNMENT_CREATED event and persists the assignment and its mechanic links.
+                    Returns 400 when the appointment or a mechanic cannot be resolved, the LEAD constraint is \
+                    violated, or overrideReason is blank with override=true, and 403 when override is requested \
+                    without the shop:schedule:edit authority.
+                    """)
     @ApiResponse(
             responseCode = "201",
             description = "Assignments created",
@@ -53,7 +71,27 @@ public class AssignmentController {
     @ApiResponse(responseCode = "403", description = "Forbidden")
     public @NonNull AssignmentResponse createAssignment(
             @Parameter(description = "Appointment identifier", required = true) @PathVariable UUID appointmentId,
-            @RequestBody @NonNull CreateAssignmentRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Mechanics to assign with their roles plus an optional bay or mobile-unit"
+                                    + " resource; the appointmentId in the path takes precedence over the body.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Single lead mechanic with a bay",
+                                                            value = """
+                                                                    {"appointmentId":"01960003-0000-7000-8000-000000000001",
+                                                                     "mechanics":[{"mechanicPersonId":"01960003-0000-7000-8000-000000000010",
+                                                                                   "role":"LEAD"}],
+                                                                     "resourceId":"01960003-0000-7000-8000-000000000005",
+                                                                     "resourceType":"BAY",
+                                                                     "override":false}
+                                                                    """)))
+                    @RequestBody
+                    @NonNull
+                    CreateAssignmentRequest request) {
         var augmented = CreateAssignmentRequest.builder()
                 .appointmentId(appointmentId)
                 .mechanics(request.getMechanics())
@@ -71,9 +109,19 @@ public class AssignmentController {
             scopes = {"appointments:view", "shop:schedule:view"})
     @PreAuthorize("hasAnyAuthority('appointments:view', 'shop:schedule:view')")
     @EmitEvent(id = "SHOPMGR_ASSIGNMENT_LIST_FETCHED", apiVersion = "1")
-    @Operation(
-            summary = "List appointment assignments",
-            description = "Returns the current assignments associated with the specified appointment.")
+    @Operation(operationId = "listAssignments", summary = "List Assignments for an Appointment", description = """
+                    Returns all assignments recorded for an appointment, including each mechanic's role, the \
+                    reserved resource, status and override flag.
+                    Use this tool when reading the staffing of a known appointment; do not use createAssignment, \
+                    which creates a new assignment, and use searchShopAudit for the historical change trail.
+                    Preconditions: none beyond authorization; an unknown appointmentId is not rejected.
+                    Required inputs: appointmentId (UUID) as a path parameter; there is no request body and no \
+                    filtering.
+                    Emits a SHOPMGR_ASSIGNMENT_LIST_FETCHED audit event; no state changes occur, this is a \
+                    read-only projection.
+                    Returns 200 with an empty list when the appointment has no assignments or does not exist; no \
+                    404 is raised for an unknown appointmentId.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Assignments returned",

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/ConflictOverrideController.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/ConflictOverrideController.java
@@ -6,6 +6,8 @@ import com.positivity.shopmanager.service.dto.ConflictOverrideRequest;
 import com.positivity.shopmanager.service.dto.ConflictOverrideResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
@@ -47,15 +49,50 @@ public class ConflictOverrideController {
     @PreAuthorize("hasAnyAuthority('shop:schedule:edit', 'appointments:reschedule')")
     @EmitEvent(id = "SHOPMGR_APPOINTMENT_CONFLICT_OVERRIDE_CREATE", apiVersion = "1")
     @Operation(
-            summary = "Execute appointment conflict override",
-            description = "Executes a conflict override for the specified appointment when authorized.")
+            operationId = "executeConflictOverride",
+            summary = "Override a Scheduling Conflict on an Appointment",
+            description = """
+                    Records a manager-authorized bypass of a detected scheduling conflict, flagging the appointment \
+                    as conflict-overridden and persisting an immutable override record with the acting user and \
+                    timestamp.
+                    Use this tool when a blocking conflict on an appointment must be deliberately accepted; do not \
+                    use createAssignment with override=true, which overrides assignment constraints while staffing, \
+                    and do not use rescheduleAppointment, which resolves the conflict by moving the appointment \
+                    instead.
+                    Preconditions: the appointment must exist, and the caller must hold the shop:schedule:edit or \
+                    appointments:reschedule authority.
+                    Required inputs: appointmentId in the body matching the path parameter, and a non-blank \
+                    overrideReason; conflictDetails is an optional JSON string describing the conflict being \
+                    bypassed.
+                    Emits a SHOPMGR_APPOINTMENT_CONFLICT_OVERRIDE_CREATE event, sets the appointment's \
+                    conflict-override flag and stores the override record with the actor resolved from the security \
+                    context.
+                    Returns 400 when the path and body appointmentId differ, the overrideReason is blank, or the \
+                    appointment cannot be resolved, and 403 when the caller lacks the required authority.
+                    """)
     @ApiResponse(responseCode = "201", description = "Conflict override executed.")
     @ApiResponse(responseCode = "400", description = "Invalid request or appointment ID mismatch.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
     @ApiResponse(responseCode = "404", description = "Appointment not found.")
     public @NonNull ConflictOverrideResponse executeOverride(
             @Parameter(description = "Appointment ID", required = true) @PathVariable @NonNull UUID appointmentId,
-            @Parameter(description = "Conflict override request payload", required = true) @RequestBody @NonNull
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Override decision naming the appointment, the justification, and an"
+                                    + " optional description of the conflict being bypassed.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Override for a waiting customer",
+                                                            value = """
+                                                                    {"appointmentId":"01960003-0000-7000-8000-000000000001",
+                                                                     "overrideReason":"Customer waiting on-site",
+                                                                     "conflictDetails":"{\\"type\\":\\"TECHNICIAN_DOUBLE_BOOKED\\",\\"resourceId\\":\\"01960003-0000-7000-8000-000000000010\\"}"}
+                                                                    """)))
+                    @RequestBody
+                    @NonNull
                     ConflictOverrideRequest request) {
         // Validate that path appointmentId is consistent with request body
         // appointmentId

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/ScheduleController.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/ScheduleController.java
@@ -32,7 +32,22 @@ public class ScheduleController {
 
     private final AppointmentsService appointmentsService;
 
-    @Operation(summary = "View schedule", description = "Read-only schedule view for a location and date.")
+    @Operation(operationId = "viewSchedule", summary = "View the Daily Schedule for a Location", description = """
+                    Builds the read-only schedule board for one location and date, grouping appointments into \
+                    resource lanes (bay, mobile unit, technician or UNASSIGNED) and marking overlaps of one minute \
+                    or more within the same lane as BLOCKING conflicts.
+                    Use this tool when rendering or inspecting a day's shop schedule; use getAppointmentById \
+                    instead when a single appointment id is already known.
+                    Preconditions: the location must exist as a shop; the day window is computed in the shop's \
+                    configured timezone, falling back to UTC when none is configured.
+                    Required inputs: locationId (UUID) and date (YYYY-MM-DD); resourceType and resourceId are \
+                    optional filters, includeAvailabilityOverlay defaults to false, and range defaults to \
+                    LOCATION_HOURS (06:00-18:00 local) with FULL_DAY covering midnight to midnight.
+                    Emits a SHOPMGR_SCHEDULE_VIEW audit event; no state changes occur, and when the overlay is \
+                    requested availabilityOverlayStatus reports AVAILABLE or UNAVAILABLE with an \
+                    HR_SYSTEM_UNAVAILABLE warning when the staffing replica has no data for the location.
+                    Returns 404 when the location is unknown or the resourceId filter matches no lane on that date.
+                    """)
     @ApiResponse(responseCode = "200", description = "Schedule retrieved successfully.")
     @ApiResponse(responseCode = "400", description = "Invalid input parameters")
     @ApiResponse(responseCode = "403", description = "Not authorized for this location")

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/ShopAuditController.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/ShopAuditController.java
@@ -47,11 +47,21 @@ public class ShopAuditController {
      */
     @GetMapping
     @PreAuthorize("hasAnyAuthority('shop:schedule:view', 'appointments:view')")
-    @Operation(
-            operationId = "searchShopAudit",
-            summary = "Search shop audit trail",
-            description =
-                    "Searches the shop audit trail using filter criteria. At least one filter criterion is required.")
+    @Operation(operationId = "searchShopAudit", summary = "Search the Shop Audit Trail", description = """
+                    Searches the immutable shop audit trail of schedule and assignment changes, returning matching \
+                    entries in reverse-chronological order with actor, event type, change summary and reason.
+                    Use this tool when investigating who changed a schedule or assignment and why; use \
+                    getShopAuditEntry instead when the audit entry id is already known.
+                    Preconditions: at least one filter criterion (workorderId, appointmentId, mechanicId, \
+                    actorUserId, eventType or locationId) must be supplied; unbounded scans are rejected.
+                    Required inputs: any combination of the filter fields plus optional fromDateTime and \
+                    toDateTime, which default to the last 90 days ending now; eventType is one of \
+                    SCHEDULE_CREATED, SCHEDULE_UPDATED, SCHEDULE_CANCELLED, ASSIGNMENT_CREATED or \
+                    ASSIGNMENT_REMOVED.
+                    No events are emitted and no state changes; this is a read-only projection of records retained \
+                    for seven years.
+                    Returns 400 when no filter criterion is provided.
+                    """)
     @ApiResponse(responseCode = "200", description = "Audit entries returned")
     @ApiResponse(
             responseCode = "400",
@@ -73,10 +83,16 @@ public class ShopAuditController {
      */
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyAuthority('shop:schedule:view', 'appointments:view')")
-    @Operation(
-            operationId = "getShopAuditEntry",
-            summary = "Get shop audit entry by ID",
-            description = "Returns a single shop audit entry by its UUID.")
+    @Operation(operationId = "getShopAuditEntry", summary = "Get a Shop Audit Entry by ID", description = """
+                    Returns a single immutable shop audit entry, including actor, event type, change summary, \
+                    change patch and reason fields.
+                    Use this tool when the audit entry id is already known; use searchShopAudit instead to find \
+                    entries by workorder, appointment, mechanic, actor, event type or location.
+                    Preconditions: the audit entry must exist; entries are never updated or deleted once written.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no audit entry exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Audit entry returned")
     @ApiResponse(
             responseCode = "403",

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/TechnicianController.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/controller/TechnicianController.java
@@ -24,11 +24,19 @@ public class TechnicianController {
 
     private final TechnicianPersonService technicianPersonService;
 
-    @Operation(
-            summary = "Get technician person details",
-            description = "Resolves the person identity (names, contact details) of a technician working at the"
-                    + " given shop location from the local people-contact replica. Identity fields can trail the"
-                    + " people-contact authority by the event-propagation delay.")
+    @Operation(operationId = "getTechnicianPerson", summary = "Get Person Details for a Technician", description = """
+                    Resolves the person identity (names, emails, phone numbers) of a technician working at a shop \
+                    location from the local people-contact replica.
+                    Use this tool when displaying or contacting an assigned technician; use viewSchedule instead \
+                    for the technician's scheduled work.
+                    Preconditions: a technician record must link the personId to the locationId; replica identity \
+                    fields can trail the people-contact authority by the event-propagation delay.
+                    Required inputs: locationId and personId (UUIDs) as path parameters; there is no request body.
+                    Emits a SHOPMGR_TECHNICIAN_PERSON_GET audit event; no state changes occur, and when the \
+                    replica row has not yet arrived the response carries only the person id with name and contact \
+                    fields null.
+                    Returns 404 when no technician links the person to the location.
+                    """)
     @ApiResponse(responseCode = "200", description = "Technician person details returned.")
     @ApiResponse(responseCode = "404", description = "No technician links this person to this location.")
     @EmitEvent(id = "SHOPMGR_TECHNICIAN_PERSON_GET", apiVersion = "1")

--- a/pos-vehicle-fitment/openapi.yaml
+++ b/pos-vehicle-fitment/openapi.yaml
@@ -21,9 +21,21 @@ paths:
     get:
       tags:
       - Vehicle Applicability Hints
-      summary: Get a vehicle applicability hint
-      description: Retrieve a hint by its ID
-      operationId: getHint
+      summary: Get Vehicle Applicability Hint
+      description: 'Returns one vehicle applicability hint, including its productId, fitment tags and audit fields.
+
+        Use this tool when the hintId is already known; use listVehicleHintsByProduct instead to find all hints attached to a product.
+
+        Preconditions: the hint must exist under the supplied hintId.
+
+        Required inputs: hintId (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the hint, and 404 when no hint exists for the supplied id.
+
+        '
+      operationId: getVehicleHint
       parameters:
       - name: hintId
         in: path
@@ -52,9 +64,21 @@ paths:
     put:
       tags:
       - Vehicle Applicability Hints
-      summary: Update a vehicle applicability hint
-      description: Update the fitment tags for an existing hint
-      operationId: updateHint
+      summary: Update Vehicle Applicability Hint
+      description: 'Replaces the full set of fitment tags on an existing vehicle applicability hint; the previous tags are deleted and the submitted list becomes the hint''s only tags.
+
+        Use this tool to correct or extend the vehicles a product fits; do not use createVehicleHint, which adds a second hint to the product instead of changing this one.
+
+        Preconditions: the hint must already exist under the supplied hintId; the owning productId cannot be changed here.
+
+        Required inputs: hintId (UUID) as a path parameter and fitmentTags, a non-empty list of tagType/tagValue pairs; the list is a full replacement, so tags to keep must be resubmitted.
+
+        Emits a VEHICLE_HINT_UPDATED event and records the caller as updatedBy.
+
+        Returns 200 with the updated hint, and 404 when no hint exists for the supplied id.
+
+        '
+      operationId: updateVehicleHint
       parameters:
       - name: hintId
         in: path
@@ -64,10 +88,22 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Replacement fitment tag list for the hint; it fully supersedes the tags currently stored.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateHintRequest'
+            examples:
+              Replace tags with a wider year range:
+                description: Replace tags with a wider year range
+                value:
+                  fitmentTags:
+                  - tagType: MAKE
+                    tagValue: Toyota
+                  - tagType: MODEL
+                    tagValue: Camry
+                  - tagType: YEAR_RANGE
+                    tagValue: 2016-2024
         required: true
       responses:
         '200':
@@ -95,9 +131,21 @@ paths:
     delete:
       tags:
       - Vehicle Applicability Hints
-      summary: Delete a vehicle applicability hint
-      description: Remove a hint and all its associated tags
-      operationId: deleteHint
+      summary: Delete Vehicle Applicability Hint
+      description: 'Deletes a vehicle applicability hint together with all fitment tags attached to it, removing those match criteria from product filtering.
+
+        Use this tool when a hint''s vehicle coverage should no longer apply to the product at all; do not use updateVehicleHint, which keeps the hint and replaces its tags instead.
+
+        Preconditions: the hint must exist under the supplied hintId.
+
+        Required inputs: hintId (UUID) as a path parameter; there is no request body.
+
+        Emits a VEHICLE_HINT_DELETED event; the delete is permanent, with no soft-delete or restore.
+
+        Returns 204 on successful deletion, and 404 when no hint exists for the supplied id.
+
+        '
+      operationId: deleteVehicleHint
       parameters:
       - name: hintId
         in: path
@@ -119,14 +167,39 @@ paths:
     post:
       tags:
       - Vehicle Applicability Hints
-      summary: Create a vehicle applicability hint
-      description: Create a new hint with fitment tags for a product
-      operationId: createHint
+      summary: Create Vehicle Applicability Hint
+      description: 'Creates a vehicle applicability hint that attaches a set of fitment tags to one product, making the product discoverable through filterProductsByVehicleAttributes.
+
+        Use this tool when declaring which vehicles a product fits for the first time; do not use updateVehicleHint, which replaces the tags on a hint that already exists.
+
+        Preconditions: none are checked against other services; productId is stored as given and is not verified against the catalog, so callers must supply a valid product id themselves.
+
+        Required inputs: productId (UUID) and fitmentTags, a non-empty list of tagType/tagValue pairs; tagType is one of MAKE, MODEL, YEAR_RANGE, TIRE_SIZE, AXLE_POSITION, ENGINE_SIZE or TRIM_LEVEL, tagValue is at most 120 characters, and YEAR_RANGE values use "2018-2022" or a single year like "2020".
+
+        Emits a VEHICLE_HINT_CREATED event and persists the hint with its tags in one transaction.
+
+        Returns 201 with the stored hint on success; because productId is not validated, an unknown product id still returns 201 rather than 404.
+
+        '
+      operationId: createVehicleHint
       requestBody:
+        description: 'Hint to create: the product identifier and the fitment tags that describe which vehicles the product applies to.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateHintRequest'
+            examples:
+              Make, model and year-range hint:
+                description: Make, model and year-range hint
+                value:
+                  productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  fitmentTags:
+                  - tagType: MAKE
+                    tagValue: Toyota
+                  - tagType: MODEL
+                    tagValue: Camry
+                  - tagType: YEAR_RANGE
+                    tagValue: 2018-2022
         required: true
       responses:
         '201':
@@ -155,14 +228,35 @@ paths:
     post:
       tags:
       - Vehicle Applicability Hints
-      summary: Filter products by vehicle attributes
-      description: Find products that match the provided vehicle attributes
-      operationId: filterProducts
+      summary: Filter Products by Vehicle Attributes
+      description: 'Finds product ids whose applicability hints are compatible with a supplied set of vehicle attributes such as make, model and year.
+
+        Use this tool to answer which products fit a given vehicle; use listVehicleHintsByProduct instead to go the other direction, from a product to its vehicle coverage.
+
+        Preconditions: hints must already exist, and attribute keys must match tag types case-insensitively (make, model, year_range, tire_size, axle_position, engine_size, trim_level); unknown keys are ignored rather than rejected.
+
+        Required inputs: vehicleAttributes, a non-empty map of attribute name to value; value matching is case-insensitive, a hint that lacks a given tag type is treated as compatible with that attribute, and a year value like "2020" matches YEAR_RANGE tags stored as "2018-2022" or as a single year.
+
+        Emits a FITMENT_PRODUCTS_FILTER event; no hint or product records are modified.
+
+        Returns 200 with the matching productIds and their count, which may be empty, and 400 when vehicleAttributes is missing, empty, or contains blank keys or values.
+
+        '
+      operationId: filterProductsByVehicleAttributes
       requestBody:
+        description: Vehicle attributes to match against stored fitment tags; keys name a tag type and values describe the vehicle being fitted.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/FilterProductsRequest'
+            examples:
+              Match a 2020 Toyota Camry:
+                description: Match a 2020 Toyota Camry
+                value:
+                  vehicleAttributes:
+                    make: Toyota
+                    model: Camry
+                    year_range: '2020'
         required: true
       responses:
         '200':
@@ -185,14 +279,44 @@ paths:
     post:
       tags:
       - Vehicle Fitment Bulk Ingest API
-      summary: Bulk ingest records
-      description: Accepts a batch of domain records for bulk import. Returns per-record results.
-      operationId: bulkIngest
+      summary: Bulk Ingest Part Fitment Records
+      description: 'Bulk-imports part fitment records, creating one part-to-vehicle fitment row per record and resolving manufacturer, make, model and vehicle-type names to reference rows.
+
+        Use this tool for catalog-scale fitment loads from a prepared batch; do not use createVehicleHint, which manages per-product applicability hint tags rather than part fitment rows.
+
+        Preconditions: the caller must hold vehicle-fitment:hint:create; referenced manufacturer, make, model and vehicle-type names need not pre-exist, because each is matched case-insensitively and created on the fly when missing.
+
+        Required inputs: jobId (UUID), locationId (UUID) and records, a non-empty list where each record requires partNumberId (numeric); manufacturerName, makeName, modelName, vehicleTypeName, vehicleYear, engineType, submodel and notes are optional, and jobId, locationId and operatorId are accepted for the envelope but not persisted by this module.
+
+        Emits a VEHICLE_FITMENT_BULK_INGEST event covering the whole batch; rows are processed independently, so one failed row does not roll back the others.
+
+        Returns 200 even when every row fails, so callers must inspect each result''s success flag and FITMENT_INGEST_FAILED errorCode rather than trusting the status alone.
+
+        '
+      operationId: bulkIngestVehicleFitments
       requestBody:
+        description: Batch envelope of part fitment records to import, each naming the vehicle the part applies to.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BulkIngestRequestFitmentBulkIngestRecord'
+            examples:
+              Single fitment record:
+                description: Single fitment record
+                value:
+                  jobId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  operatorId: user-jdoe
+                  records:
+                  - partNumberId: 100245
+                    manufacturerName: Toyota Motor Corporation
+                    makeName: Toyota
+                    modelName: Camry
+                    vehicleTypeName: Passenger Car
+                    vehicleYear: 2018-2022
+                    engineType: 2.5L I4
+                    submodel: SE
+                    notes: Verified against OEM catalog
         required: true
       responses:
         '200':
@@ -216,9 +340,21 @@ paths:
     get:
       tags:
       - Vehicle Fitment API
-      summary: Get vehicle types for make
-      description: Retrieve all vehicle types for a given make.
-      operationId: getVehicleTypesForMake
+      summary: List Vehicle Types for a Make
+      description: 'Returns the vehicle types, meaning body classes such as Passenger Car or Truck, recorded for one make, served from a local cache of the NHTSA vPIC registry.
+
+        Use this tool when a make''s body classes are needed; do not use listModelsByMake, which returns the make''s named models instead.
+
+        Preconditions: the make must already exist in the local cache under the supplied id.
+
+        Required inputs: makeId (UUID) as a path parameter.
+
+        No events are emitted; a cache refresh may rewrite the local vehicle-type rows for the make, but nothing else changes.
+
+        Returns 200 with the vehicle-type list, and 500 when the make id cannot be resolved or the NHTSA refresh fails, because the not-found case is not currently mapped to 404.
+
+        '
+      operationId: listVehicleTypesByMake
       parameters:
       - name: makeId
         in: path
@@ -245,9 +381,21 @@ paths:
     get:
       tags:
       - Vehicle Fitment API
-      summary: Get models by make
-      description: Retrieve all models for a given make.
-      operationId: getModelsByMake
+      summary: List Models for a Make
+      description: 'Returns all vehicle models recorded for one make, served from a local cache of the NHTSA vPIC registry.
+
+        Use this tool after picking a make from listMakesByManufacturer; do not use listVehicleTypesByMake, which returns body classes such as Passenger Car rather than named models.
+
+        Preconditions: the make must already exist in the local cache under the supplied id.
+
+        Required inputs: makeId (UUID) as a path parameter.
+
+        No events are emitted; a cache refresh may rewrite the local model rows for the make, but nothing else changes.
+
+        Returns 200 with the model list, and 500 when the make id cannot be resolved or the NHTSA refresh fails, because the not-found case is not currently mapped to 404.
+
+        '
+      operationId: listModelsByMake
       parameters:
       - name: makeId
         in: path
@@ -274,9 +422,21 @@ paths:
     get:
       tags:
       - Vehicle Fitment API
-      summary: Get all manufacturers
-      description: Retrieve a list of all vehicle manufacturers.
-      operationId: getManufacturers
+      summary: List Vehicle Manufacturers
+      description: 'Returns the list of vehicle manufacturers known to the fitment service, served from a local cache of the NHTSA vPIC registry.
+
+        Use this tool to start the manufacturer-make-model selection chain; do not use listMakesByManufacturer, which requires a manufacturerId taken from this response.
+
+        Preconditions: none beyond authentication; when the local cache is empty or stale the list is re-fetched from the public NHTSA vPIC service, so outbound connectivity is required for a refresh.
+
+        Required inputs: none; there are no parameters, no paging and no filtering.
+
+        No events are emitted; a refresh rewrites the local manufacturer cache rows, but the response is otherwise a read-only projection.
+
+        Returns 200 with the manufacturer list, which may be empty, and 500 when the NHTSA refresh cannot be fetched or parsed.
+
+        '
+      operationId: listManufacturers
       responses:
         '200':
           description: List of manufacturers returned successfully.
@@ -294,9 +454,21 @@ paths:
     get:
       tags:
       - Vehicle Fitment API
-      summary: Get makes by manufacturer
-      description: Retrieve all makes for a given manufacturer.
-      operationId: getMakesByManufacturer
+      summary: List Makes for a Manufacturer
+      description: 'Returns all vehicle makes recorded for one manufacturer, served from a local cache of the NHTSA vPIC registry.
+
+        Use this tool after picking a manufacturer from listManufacturers; do not use listModelsByMake, which descends one level further and needs a makeId taken from this response.
+
+        Preconditions: the manufacturer must already exist in the local cache under the supplied id; ids are the UUIDs returned by listManufacturers, not raw NHTSA numeric ids.
+
+        Required inputs: manufacturerId (UUID) as a path parameter.
+
+        No events are emitted; a cache refresh may rewrite the local make rows for the manufacturer, but nothing else changes.
+
+        Returns 200 with the make list, and 500 when the manufacturer id cannot be resolved or the NHTSA refresh fails, because the not-found case is not currently mapped to 404.
+
+        '
+      operationId: listMakesByManufacturer
       parameters:
       - name: manufacturerId
         in: path
@@ -323,9 +495,21 @@ paths:
     get:
       tags:
       - Vehicle Applicability Hints
-      summary: Get hints by product ID
-      description: Retrieve all hints associated with a specific product
-      operationId: getHintsByProductId
+      summary: List Hints for a Product
+      description: 'Returns every vehicle applicability hint recorded for one product, each with its full fitment tag list.
+
+        Use this tool to review a product''s declared vehicle coverage; use getVehicleHint instead when a specific hintId is already known.
+
+        Preconditions: none; an unknown productId or one without hints simply yields an empty list rather than an error.
+
+        Required inputs: productId (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the hint list, which is empty when the product has no hints.
+
+        '
+      operationId: listVehicleHintsByProduct
       parameters:
       - name: productId
         in: path

--- a/pos-vehicle-fitment/src/main/java/com/positivity/vehiclefitment/internal/controller/VehicleApplicabilityHintController.java
+++ b/pos-vehicle-fitment/src/main/java/com/positivity/vehiclefitment/internal/controller/VehicleApplicabilityHintController.java
@@ -9,6 +9,8 @@ import com.positivity.vehiclefitment.internal.dto.UpdateHintRequest;
 import com.positivity.vehiclefitment.service.VehicleApplicabilityHintService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -44,15 +46,47 @@ public class VehicleApplicabilityHintController {
 
     private final VehicleApplicabilityHintService hintService;
 
-    @Operation(
-            summary = "Create a vehicle applicability hint",
-            description = "Create a new hint with fitment tags for a product")
+    @Operation(operationId = "createVehicleHint", summary = "Create Vehicle Applicability Hint", description = """
+                    Creates a vehicle applicability hint that attaches a set of fitment tags to one product, making \
+                    the product discoverable through filterProductsByVehicleAttributes.
+                    Use this tool when declaring which vehicles a product fits for the first time; do not use \
+                    updateVehicleHint, which replaces the tags on a hint that already exists.
+                    Preconditions: none are checked against other services; productId is stored as given and is not \
+                    verified against the catalog, so callers must supply a valid product id themselves.
+                    Required inputs: productId (UUID) and fitmentTags, a non-empty list of tagType/tagValue pairs; \
+                    tagType is one of MAKE, MODEL, YEAR_RANGE, TIRE_SIZE, AXLE_POSITION, ENGINE_SIZE or TRIM_LEVEL, \
+                    tagValue is at most 120 characters, and YEAR_RANGE values use "2018-2022" or a single year like \
+                    "2020".
+                    Emits a VEHICLE_HINT_CREATED event and persists the hint with its tags in one transaction.
+                    Returns 201 with the stored hint on success; because productId is not validated, an unknown \
+                    product id still returns 201 rather than 404.
+                    """)
     @ApiResponse(responseCode = "201", description = "Hint created successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request data")
     @ApiResponse(responseCode = "404", description = "Product not found")
     @EmitEvent(id = "VEHICLE_HINT_CREATED", apiVersion = "1")
     @PostMapping
-    public ResponseEntity<HintResponse> createHint(@Valid @RequestBody CreateHintRequest request) {
+    public ResponseEntity<HintResponse> createHint(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Hint to create: the product identifier and the fitment tags that describe which vehicles the product applies to.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Make, model and year-range hint",
+                                                            value = """
+                                                                    {"productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "fitmentTags":[
+                                                                       {"tagType":"MAKE","tagValue":"Toyota"},
+                                                                       {"tagType":"MODEL","tagValue":"Camry"},
+                                                                       {"tagType":"YEAR_RANGE","tagValue":"2018-2022"}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CreateHintRequest request) {
         try {
             HintResponse response = hintService.createHint(request);
             return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -62,9 +96,18 @@ public class VehicleApplicabilityHintController {
         }
     }
 
-    @Operation(
-            summary = "Update a vehicle applicability hint",
-            description = "Update the fitment tags for an existing hint")
+    @Operation(operationId = "updateVehicleHint", summary = "Update Vehicle Applicability Hint", description = """
+                    Replaces the full set of fitment tags on an existing vehicle applicability hint; the previous \
+                    tags are deleted and the submitted list becomes the hint's only tags.
+                    Use this tool to correct or extend the vehicles a product fits; do not use createVehicleHint, \
+                    which adds a second hint to the product instead of changing this one.
+                    Preconditions: the hint must already exist under the supplied hintId; the owning productId \
+                    cannot be changed here.
+                    Required inputs: hintId (UUID) as a path parameter and fitmentTags, a non-empty list of \
+                    tagType/tagValue pairs; the list is a full replacement, so tags to keep must be resubmitted.
+                    Emits a VEHICLE_HINT_UPDATED event and records the caller as updatedBy.
+                    Returns 200 with the updated hint, and 404 when no hint exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Hint updated successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request data")
     @ApiResponse(responseCode = "404", description = "Hint not found")
@@ -72,7 +115,25 @@ public class VehicleApplicabilityHintController {
     @PutMapping("/{hintId}")
     public ResponseEntity<HintResponse> updateHint(
             @Parameter(description = "ID of the hint to update") @PathVariable UUID hintId,
-            @Valid @RequestBody UpdateHintRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Replacement fitment tag list for the hint; it fully supersedes the tags currently stored.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Replace tags with a wider year range",
+                                                            value = """
+                                                                    {"fitmentTags":[
+                                                                       {"tagType":"MAKE","tagValue":"Toyota"},
+                                                                       {"tagType":"MODEL","tagValue":"Camry"},
+                                                                       {"tagType":"YEAR_RANGE","tagValue":"2016-2024"}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    UpdateHintRequest request) {
         try {
             HintResponse response = hintService.updateHint(hintId, request);
             return ResponseEntity.ok(response);
@@ -82,9 +143,16 @@ public class VehicleApplicabilityHintController {
         }
     }
 
-    @Operation(
-            summary = "Delete a vehicle applicability hint",
-            description = "Remove a hint and all its associated tags")
+    @Operation(operationId = "deleteVehicleHint", summary = "Delete Vehicle Applicability Hint", description = """
+                    Deletes a vehicle applicability hint together with all fitment tags attached to it, removing \
+                    those match criteria from product filtering.
+                    Use this tool when a hint's vehicle coverage should no longer apply to the product at all; do \
+                    not use updateVehicleHint, which keeps the hint and replaces its tags instead.
+                    Preconditions: the hint must exist under the supplied hintId.
+                    Required inputs: hintId (UUID) as a path parameter; there is no request body.
+                    Emits a VEHICLE_HINT_DELETED event; the delete is permanent, with no soft-delete or restore.
+                    Returns 204 on successful deletion, and 404 when no hint exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "204", description = "Hint deleted successfully")
     @ApiResponse(responseCode = "404", description = "Hint not found")
     @EmitEvent(id = "VEHICLE_HINT_DELETED", apiVersion = "1")
@@ -100,7 +168,15 @@ public class VehicleApplicabilityHintController {
         }
     }
 
-    @Operation(summary = "Get a vehicle applicability hint", description = "Retrieve a hint by its ID")
+    @Operation(operationId = "getVehicleHint", summary = "Get Vehicle Applicability Hint", description = """
+                    Returns one vehicle applicability hint, including its productId, fitment tags and audit fields.
+                    Use this tool when the hintId is already known; use listVehicleHintsByProduct instead to find \
+                    all hints attached to a product.
+                    Preconditions: the hint must exist under the supplied hintId.
+                    Required inputs: hintId (UUID) as a path parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the hint, and 404 when no hint exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Hint retrieved successfully")
     @ApiResponse(responseCode = "404", description = "Hint not found")
     @GetMapping("/{hintId}")
@@ -115,9 +191,17 @@ public class VehicleApplicabilityHintController {
         }
     }
 
-    @Operation(
-            summary = "Get hints by product ID",
-            description = "Retrieve all hints associated with a specific product")
+    @Operation(operationId = "listVehicleHintsByProduct", summary = "List Hints for a Product", description = """
+                    Returns every vehicle applicability hint recorded for one product, each with its full fitment \
+                    tag list.
+                    Use this tool to review a product's declared vehicle coverage; use getVehicleHint instead when \
+                    a specific hintId is already known.
+                    Preconditions: none; an unknown productId or one without hints simply yields an empty list \
+                    rather than an error.
+                    Required inputs: productId (UUID) as a path parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the hint list, which is empty when the product has no hints.
+                    """)
     @ApiResponse(responseCode = "200", description = "Hints retrieved successfully")
     @GetMapping("/product/{productId}")
     public ResponseEntity<List<HintResponse>> getHintsByProductId(
@@ -127,13 +211,44 @@ public class VehicleApplicabilityHintController {
     }
 
     @Operation(
-            summary = "Filter products by vehicle attributes",
-            description = "Find products that match the provided vehicle attributes")
+            operationId = "filterProductsByVehicleAttributes",
+            summary = "Filter Products by Vehicle Attributes",
+            description = """
+                    Finds product ids whose applicability hints are compatible with a supplied set of vehicle \
+                    attributes such as make, model and year.
+                    Use this tool to answer which products fit a given vehicle; use listVehicleHintsByProduct \
+                    instead to go the other direction, from a product to its vehicle coverage.
+                    Preconditions: hints must already exist, and attribute keys must match tag types \
+                    case-insensitively (make, model, year_range, tire_size, axle_position, engine_size, \
+                    trim_level); unknown keys are ignored rather than rejected.
+                    Required inputs: vehicleAttributes, a non-empty map of attribute name to value; value matching \
+                    is case-insensitive, a hint that lacks a given tag type is treated as compatible with that \
+                    attribute, and a year value like "2020" matches YEAR_RANGE tags stored as "2018-2022" or as a \
+                    single year.
+                    Emits a FITMENT_PRODUCTS_FILTER event; no hint or product records are modified.
+                    Returns 200 with the matching productIds and their count, which may be empty, and 400 when \
+                    vehicleAttributes is missing, empty, or contains blank keys or values.
+                    """)
     @ApiResponse(responseCode = "200", description = "Products filtered successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request data")
     @EmitEvent(id = "FITMENT_PRODUCTS_FILTER", apiVersion = "1")
     @PostMapping("/filter-products")
-    public ResponseEntity<FilterProductsResponse> filterProducts(@Valid @RequestBody FilterProductsRequest request) {
+    public ResponseEntity<FilterProductsResponse> filterProducts(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Vehicle attributes to match against stored fitment tags; keys name a tag type and values describe the vehicle being fitted.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Match a 2020 Toyota Camry", value = """
+                                                                    {"vehicleAttributes":{"make":"Toyota",
+                                                                                          "model":"Camry",
+                                                                                          "year_range":"2020"}}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    FilterProductsRequest request) {
         FilterProductsResponse response = hintService.filterProductsByVehicleAttributes(request.getVehicleAttributes());
         return ResponseEntity.ok(response);
     }

--- a/pos-vehicle-fitment/src/main/java/com/positivity/vehiclefitment/internal/controller/VehicleFitmentBulkIngestController.java
+++ b/pos-vehicle-fitment/src/main/java/com/positivity/vehiclefitment/internal/controller/VehicleFitmentBulkIngestController.java
@@ -9,6 +9,9 @@ import com.positivity.vehiclefitment.internal.dto.FitmentBulkIngestRecord;
 import com.positivity.vehiclefitment.service.VehicleFitmentService;
 import com.positivity.vehiclefitment.service.dto.CreatePartFitmentRequest;
 import com.positivity.vehiclefitment.service.dto.PartFitmentResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
@@ -36,12 +39,62 @@ public class VehicleFitmentBulkIngestController extends AbstractBulkIngestContro
 
     private final VehicleFitmentService vehicleFitmentService;
 
+    private static final String BULK_INGEST_EXAMPLE = """
+            {"jobId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+             "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+             "operatorId":"user-jdoe",
+             "records":[{"partNumberId":100245,
+                         "manufacturerName":"Toyota Motor Corporation",
+                         "makeName":"Toyota",
+                         "modelName":"Camry",
+                         "vehicleTypeName":"Passenger Car",
+                         "vehicleYear":"2018-2022",
+                         "engineType":"2.5L I4",
+                         "submodel":"SE",
+                         "notes":"Verified against OEM catalog"}]}
+            """;
+
     @Override
+    @Operation(
+            operationId = "bulkIngestVehicleFitments",
+            summary = "Bulk Ingest Part Fitment Records",
+            description = """
+                    Bulk-imports part fitment records, creating one part-to-vehicle fitment row per record and \
+                    resolving manufacturer, make, model and vehicle-type names to reference rows.
+                    Use this tool for catalog-scale fitment loads from a prepared batch; do not use \
+                    createVehicleHint, which manages per-product applicability hint tags rather than part fitment \
+                    rows.
+                    Preconditions: the caller must hold vehicle-fitment:hint:create; referenced manufacturer, make, \
+                    model and vehicle-type names need not pre-exist, because each is matched case-insensitively and \
+                    created on the fly when missing.
+                    Required inputs: jobId (UUID), locationId (UUID) and records, a non-empty list where each record \
+                    requires partNumberId (numeric); manufacturerName, makeName, modelName, vehicleTypeName, \
+                    vehicleYear, engineType, submodel and notes are optional, and jobId, locationId and operatorId \
+                    are accepted for the envelope but not persisted by this module.
+                    Emits a VEHICLE_FITMENT_BULK_INGEST event covering the whole batch; rows are processed \
+                    independently, so one failed row does not roll back the others.
+                    Returns 200 even when every row fails, so callers must inspect each result's success flag and \
+                    FITMENT_INGEST_FAILED errorCode rather than trusting the status alone.
+                    """)
     @PostMapping("/bulk-ingest")
     @PreAuthorize("hasAuthority('vehicle-fitment:hint:create')")
     @EmitEvent(id = "VEHICLE_FITMENT_BULK_INGEST", apiVersion = "1")
     public ResponseEntity<BulkIngestResponse> bulkIngest(
-            @Valid @RequestBody @NonNull BulkIngestRequest<FitmentBulkIngestRecord> request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Batch envelope of part fitment records to import, each naming the vehicle the part applies to.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Single fitment record",
+                                                            value = BULK_INGEST_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BulkIngestRequest<FitmentBulkIngestRecord> request) {
         return super.bulkIngest(request);
     }
 

--- a/pos-vehicle-fitment/src/main/java/com/positivity/vehiclefitment/internal/controller/VehicleFitmentController.java
+++ b/pos-vehicle-fitment/src/main/java/com/positivity/vehiclefitment/internal/controller/VehicleFitmentController.java
@@ -31,7 +31,19 @@ public class VehicleFitmentController {
 
     private final VehicleFitmentService vehicleFitmentService;
 
-    @Operation(summary = "Get all manufacturers", description = "Retrieve a list of all vehicle manufacturers.")
+    @Operation(operationId = "listManufacturers", summary = "List Vehicle Manufacturers", description = """
+                    Returns the list of vehicle manufacturers known to the fitment service, served from a local \
+                    cache of the NHTSA vPIC registry.
+                    Use this tool to start the manufacturer-make-model selection chain; do not use \
+                    listMakesByManufacturer, which requires a manufacturerId taken from this response.
+                    Preconditions: none beyond authentication; when the local cache is empty or stale the list is \
+                    re-fetched from the public NHTSA vPIC service, so outbound connectivity is required for a refresh.
+                    Required inputs: none; there are no parameters, no paging and no filtering.
+                    No events are emitted; a refresh rewrites the local manufacturer cache rows, but the response is \
+                    otherwise a read-only projection.
+                    Returns 200 with the manufacturer list, which may be empty, and 500 when the NHTSA refresh \
+                    cannot be fetched or parsed.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of manufacturers returned successfully.")
     @GetMapping("/manufacturers")
     public List<ManufacturerResponse> getManufacturers() {
@@ -40,7 +52,19 @@ public class VehicleFitmentController {
                 .toList();
     }
 
-    @Operation(summary = "Get makes by manufacturer", description = "Retrieve all makes for a given manufacturer.")
+    @Operation(operationId = "listMakesByManufacturer", summary = "List Makes for a Manufacturer", description = """
+                    Returns all vehicle makes recorded for one manufacturer, served from a local cache of the NHTSA \
+                    vPIC registry.
+                    Use this tool after picking a manufacturer from listManufacturers; do not use listModelsByMake, \
+                    which descends one level further and needs a makeId taken from this response.
+                    Preconditions: the manufacturer must already exist in the local cache under the supplied id; ids \
+                    are the UUIDs returned by listManufacturers, not raw NHTSA numeric ids.
+                    Required inputs: manufacturerId (UUID) as a path parameter.
+                    No events are emitted; a cache refresh may rewrite the local make rows for the manufacturer, but \
+                    nothing else changes.
+                    Returns 200 with the make list, and 500 when the manufacturer id cannot be resolved or the NHTSA \
+                    refresh fails, because the not-found case is not currently mapped to 404.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of makes returned successfully.")
     @GetMapping("/makes/{manufacturerId}")
     public List<MakeResponse> getMakesByManufacturer(
@@ -52,7 +76,18 @@ public class VehicleFitmentController {
                 .toList();
     }
 
-    @Operation(summary = "Get models by make", description = "Retrieve all models for a given make.")
+    @Operation(operationId = "listModelsByMake", summary = "List Models for a Make", description = """
+                    Returns all vehicle models recorded for one make, served from a local cache of the NHTSA vPIC \
+                    registry.
+                    Use this tool after picking a make from listMakesByManufacturer; do not use \
+                    listVehicleTypesByMake, which returns body classes such as Passenger Car rather than named models.
+                    Preconditions: the make must already exist in the local cache under the supplied id.
+                    Required inputs: makeId (UUID) as a path parameter.
+                    No events are emitted; a cache refresh may rewrite the local model rows for the make, but nothing \
+                    else changes.
+                    Returns 200 with the model list, and 500 when the make id cannot be resolved or the NHTSA \
+                    refresh fails, because the not-found case is not currently mapped to 404.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of models returned successfully.")
     @GetMapping("/models/{makeId}")
     public List<ModelResponse> getModelsByMake(
@@ -63,7 +98,18 @@ public class VehicleFitmentController {
                 .toList();
     }
 
-    @Operation(summary = "Get vehicle types for make", description = "Retrieve all vehicle types for a given make.")
+    @Operation(operationId = "listVehicleTypesByMake", summary = "List Vehicle Types for a Make", description = """
+                    Returns the vehicle types, meaning body classes such as Passenger Car or Truck, recorded for one \
+                    make, served from a local cache of the NHTSA vPIC registry.
+                    Use this tool when a make's body classes are needed; do not use listModelsByMake, which returns \
+                    the make's named models instead.
+                    Preconditions: the make must already exist in the local cache under the supplied id.
+                    Required inputs: makeId (UUID) as a path parameter.
+                    No events are emitted; a cache refresh may rewrite the local vehicle-type rows for the make, but \
+                    nothing else changes.
+                    Returns 200 with the vehicle-type list, and 500 when the make id cannot be resolved or the NHTSA \
+                    refresh fails, because the not-found case is not currently mapped to 404.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of vehicle types returned successfully.")
     @GetMapping("/vehicle-types/{makeId}")
     public List<VehicleTypeResponse> getVehicleTypesForMake(


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (platform-wide API documentation standard, #1263 rollout wave A of E)
- Parent STORY (durion): ADR-0042 (`durion/docs/adr/0042-openapi-annotation-standards.adr.md`)
- Child issue: louisburroughs/durion-positivity-backend#1263
- Domain: `domain:platform` (touches shopmgr, fitment, events, bulk-load, marketing, documents, image)

## Contract References
- Contract guide entry (durion): `domains/platform/.business-rules/BACKEND_CONTRACT_GUIDE.md` — no contract semantics change. Spec deltas are `description`, `operationId`, `requestBody` metadata and `@ApiResponse` additions matching real handler output; no path, schema field, or behavior changed.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controllers
- [x] `openapi.yaml` regenerated for all seven modules; aggregate unchanged (no paths added/removed)
- [ ] Angular SDK regenerated — deferred to a single regen after the full wave stack lands (doc-only deltas)

## Scope

**Wave A of the #1263 rollout** — converts seven modules to the ADR-0042 seven-part description standard (`docs/OPENAPI_DESCRIPTION_STANDARD.md`) and flips them to `annotationDepth: STRICT`:

| module | ops | request bodies annotated |
| --- | --- | --- |
| pos-shop-manager | 11 | 5 |
| pos-vehicle-fitment | 11 | 4 |
| pos-event-receiver | 12 | 4 |
| pos-bulk-loader | 16 | 5 (incl. multipart upload) |
| pos-marketing | 18 | 4 |
| pos-documents | 1 | 1 |
| pos-image | 2 | 0 |

Descriptions were written by domain agents from the service implementations, not the annotations. Code-derived corrections now in the contract text (details in the commit message): the real event-receiver auth header (`X-Events-Api-Secret`), batched-flush durability semantics, bulk-loader retry/cancel semantics and the error-report actually exporting all rows, shop-manager's appointment state machine, fitment's tag-type compatibility rules.

**Known annotation/code mismatches surfaced (annotations kept, descriptions state real behavior — candidates for follow-up fixes):**
- pos-shop-manager `executeConflictOverride`: documented 404 unreachable, maps to 400 today.
- pos-vehicle-fitment: unknown manufacturer/make ids surface as 500 (no module advice; same gap class fixed for vehicle-inventory in #1278); `createVehicleHint` 404 unreachable (productId never validated).
- pos-event-receiver: nothing populates the `preregistered_event` allowlist that `receiveEvent` checks.

## Tests
- [x] Unit — module validator suite green; wave A modules pass depth-STRICT (`OpenApiRepositoryValidationTest`)
- [ ] Integration — n/a (no behavior changes)
- [ ] Provider behavioral contract tests — n/a
- How to run:
```bash
./mvnw -pl pos-openapi-validation -DskipTests=false -Dtest=OpenApiRepositoryValidationTest test
```

## Risk & Rollback
- Risk level: Low — annotation/documentation only; no logic, routes, or security changes.
- Rollback plan: revert the commit, or set the seven `annotationDepth` entries back to `REPORT_ONLY`.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, rollout branch `docs/1263-wave-a`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a
- [x] Links to parent + child issues are present
