### PR TITLE
docs(openapi): ADR-0042 wave B — 5 modules to depth-STRICT (#1263)

### DIFF
--- a/docs/OPENAPI_DESCRIPTION_STANDARD.md
+++ b/docs/OPENAPI_DESCRIPTION_STANDARD.md
@@ -174,7 +174,9 @@ public ResponseEntity<SupplierAccount> createSupplierAccount(
 Required:
 
 - `description` — what the body represents, one sentence. Not a repeat of the summary.
-- `required` — stated explicitly, even when true.
+- `required` — stated explicitly, even when false for a genuinely optional body. (Annotation-level
+  convention only: springdoc omits `required: false` from the generated spec because it is the
+  OpenAPI default, so the validator cannot check this on the spec.)
 - at least one `@ExampleObject` with a realistic, schema-valid value. Use UUID v7 shaped ids.
 
 The DTO's own `@Schema` field annotations are covered by ADR-0042 §5 and are not part of this
@@ -204,7 +206,6 @@ The checks, and the message each emits:
 | Error conditions | `description missing error conditions ("Returns <code> when ...")` |
 | Negative guidance | `description missing negative guidance ("do not use ..." / "... instead")` |
 | Request body description | `request body missing description (ADR-0042 §3)` |
-| Request body `required` | `request body missing explicit required flag (ADR-0042 §3)` |
 | Request body example | `request body missing example (ADR-0042 §3)` |
 
 Run the checks:

--- a/pos-invoice/openapi.yaml
+++ b/pos-invoice/openapi.yaml
@@ -29,8 +29,20 @@ paths:
     get:
       tags:
       - Billing Rules
-      summary: Get billing rules for a party/customer
-      description: Retrieve the current billing rules configuration for a commercial account
+      summary: Get Billing Rules for a Party
+      description: 'Returns the billing rules configured for a commercial account party: purchase-order requirement, payment terms code, invoice delivery method, and invoice grouping strategy.
+
+        Use this tool when the billing configuration of a known party is needed before invoicing; do not use upsertBillingRules, which creates or replaces the configuration.
+
+        Preconditions: a billing rules record must already exist for the party, created explicitly or defaulted when the commercial account was provisioned.
+
+        Required inputs: partyId (UUID) as a path parameter; there is no request body.
+
+        Emits a BILLING_RULES_GET audit event; no state changes — this is a read-only projection.
+
+        Returns 404 when no billing rules are configured for the party, and 400 with an empty body when partyId is not a well-formed UUID.
+
+        '
       operationId: getBillingRules
       parameters:
       - name: partyId
@@ -59,8 +71,20 @@ paths:
     put:
       tags:
       - Billing Rules
-      summary: Create or update billing rules
-      description: Idempotent upsert of billing rules for a commercial account
+      summary: Create or Update Billing Rules
+      description: 'Creates or replaces the billing rules for a commercial account party in one idempotent upsert keyed on the path partyId, which overrides any partyId carried in the body.
+
+        Use this tool when configuring how a party is invoiced; use getBillingRules instead to read the current configuration without changing it.
+
+        Preconditions: paymentTermsCode must belong to the validated vocabulary (DUE_ON_RECEIPT, NET_10, NET_15, NET_30, NET_45, NET_60); a missing record is created and an existing one is updated in place.
+
+        Required inputs: partyId (UUID path), purchaseOrderRequired (boolean), paymentTermsCode, invoiceDeliveryMethod (EMAIL, PORTAL, MAIL) and invoiceGroupingStrategy (PER_WORKORDER, PER_VEHICLE, SINGLE_INVOICE); updatedBy is taken from the security context, never from the body.
+
+        Emits a BILLING_RULES_UPSERT event and publishes a billing-rules-updated notification; due dates of already-finalized invoices are never recomputed from a terms change.
+
+        Returns 201 when the record is created, 200 when an existing record is updated, and 400 with an empty body when partyId is not a well-formed UUID.
+
+        '
       operationId: upsertBillingRules
       parameters:
       - name: partyId
@@ -69,10 +93,20 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Billing rules configuration to store for the party.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BillingRulesDTO'
+            examples:
+              Net-30 emailed per-workorder invoicing:
+                description: Net-30 emailed per-workorder invoicing
+                value:
+                  partyId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  purchaseOrderRequired: true
+                  paymentTermsCode: NET_30
+                  invoiceDeliveryMethod: EMAIL
+                  invoiceGroupingStrategy: PER_WORKORDER
         required: true
       responses:
         '200':
@@ -102,14 +136,36 @@ paths:
     post:
       tags:
       - StandaloneRefund
-      summary: Record standalone refund for a customer party
-      description: Record a refund anchored to a customer party when no invoice exists in the system; the disbursement itself happens out of band
-      operationId: refundPartyStandalone
+      summary: Record Standalone Party Refund
+      description: 'Records a refund anchored directly to a customer party when no invoice exists in this system, such as a vendor-paid warranty settlement on a predecessor-system sale; the cash disbursement itself happens out of band.
+
+        Use this tool only when there is no invoice to anchor to; use createStandaloneInvoiceRefund instead when an invoice is on file, and refundPayment when the captured payment itself exists.
+
+        Preconditions: the caller needs the finance-only ISSUE_MANUAL_REFUND authority; because there is no invoice, no refundable-amount cap applies.
+
+        Required inputs: partyId (non-blank, max 64 characters), amount (positive) and reason (a RefundReason); notes and externalReference are optional, and a retry replaying the same externalReference among the party''s purely party-anchored records returns the existing record.
+
+        Emits an INVOICE_PARTY_STANDALONE_REFUND event and stores a COMPLETED refund record anchored to the party; no gateway call is made.
+
+        Returns 201 with the refund record, and 400 when partyId is blank.
+
+        '
+      operationId: createStandalonePartyRefund
       requestBody:
+        description: Out-of-band refund to record against a customer party with no invoice on file.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PartyStandaloneRefundRequest'
+            examples:
+              Vendor-paid settlement:
+                description: Vendor-paid settlement
+                value:
+                  partyId: party-000123
+                  amount: 25.0
+                  reason: CUSTOMER_RETURN
+                  notes: Vendor-paid warranty settlement, no invoice on file
+                  externalReference: WC-2026-000042
         required: true
       responses:
         '201':
@@ -132,14 +188,41 @@ paths:
     post:
       tags:
       - Invoice
-      summary: Create invoice
-      description: Create invoice draft from completed workorder data
+      summary: Create Invoice Draft from Workorder
+      description: 'Creates a DRAFT invoice from completed workorder data, pricing the supplied line items, calculating draft tax against the shop location''s jurisdiction, and assigning the permanent invoice number immediately.
+
+        Use this tool for workorder billing; do not use createInvoiceFromOrder, which fronts a sales order at counter-sale checkout with order-authoritative totals.
+
+        Preconditions: the workorder must be complete enough to bill; the call is idempotent on workorderId — a replay returns the workorder''s existing invoice instead of creating a duplicate.
+
+        Required inputs: workorderId (UUID); estimateId, approvalId, locationId, customerId, idempotencyKey and lineItems (description, quantity, unitPrice, amount, optional type) are optional, and a missing lineItems list produces an empty zero-subtotal draft.
+
+        Emits an INVOICE_CREATE event, persists the per-line tax breakdown, and publishes an invoice-updated notification.
+
+        Returns 201 with the invoice (existing or new), and 400 when workorderId is missing.
+
+        '
       operationId: createInvoice
       requestBody:
+        description: Workorder billing data the invoice draft is built from.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/InvoiceCreationRequest'
+            examples:
+              Workorder invoice draft:
+                description: Workorder invoice draft
+                value:
+                  workorderId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a30
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a31
+                  customerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a32
+                  idempotencyKey: inv-create-wo-1234
+                  lineItems:
+                  - description: Brake pad replacement
+                    quantity: 2.0
+                    unitPrice: 45.0
+                    amount: 90.0
+                    type: LABOR
         required: true
       responses:
         '201':
@@ -157,8 +240,20 @@ paths:
     post:
       tags:
       - Invoice
-      summary: Revert finalized invoice
-      description: 'Revert a FINALIZED invoice back to DRAFT within 24h of finalization and before GL posting (Story #13, AC6)'
+      summary: Revert Finalized Invoice to Draft
+      description: 'Reverts a FINALIZED invoice back to DRAFT within 24 hours of finalization, before GL posting has made it immutable, and voids the provider tax document committed at finalization.
+
+        Use this tool to correct a wrongly finalized invoice; do not use cancelInvoice, which terminally cancels a DRAFT invoice on the order-void path.
+
+        Preconditions: the invoice must be FINALIZED (POSTED is immutable), less than 24 hours must have elapsed since finalizedAt, and callers without invoice:finalize:override (or a manager/admin role) must supply a valid elevation token from elevateManagerApproval as managerApprovalCode.
+
+        Required inputs: invoiceId (UUID) as a path parameter plus managerApprovalCode and a reason in the body; the reverting actor and approving manager are captured for audit.
+
+        Emits an INVOICE_DRAFT_REVERT event, publishes an invoice-updated notification, and issues a tax void toward pos-tax for the reverted document.
+
+        Returns 200 with the DRAFT invoice, 404 when the invoice does not exist, 409 when it is POSTED, not FINALIZED, or the 24-hour window has expired, and 400 when the approval code is blank, invalid, or expired.
+
+        '
       operationId: revertInvoice
       parameters:
       - name: invoiceId
@@ -168,10 +263,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Manager approval and business reason authorizing the reversion.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RevertRequest'
+            examples:
+              Revert with approval:
+                description: Revert with approval
+                value:
+                  managerApprovalCode: MGR-ELEV-TOKEN-abc123
+                  reason: Incorrect line item billed
         required: true
       responses:
         '200':
@@ -190,9 +292,21 @@ paths:
     get:
       tags:
       - PaymentReversal
-      summary: List refunds for an invoice
-      description: Return every refund record anchored to the invoice — payment-intent refunds whose intent belongs to the invoice and standalone invoice-anchored refunds alike — for warranty settlement reconciliation
-      operationId: listRefunds
+      summary: List Refunds for an Invoice
+      description: 'Returns every refund record anchored to the invoice — refunds of captured payment intents and standalone invoice-anchored refunds alike — for warranty-settlement reconciliation.
+
+        Use this tool to reconcile what has already been returned before issuing another refund; do not use refundPayment or createStandaloneInvoiceRefund, which create refunds rather than list them.
+
+        Preconditions: the invoice must exist; the caller needs the invoice:manage authority.
+
+        Required inputs: invoiceId (UUID) as a path parameter; there is no request body or filtering.
+
+        Emits an INVOICE_REFUND_LIST audit event; no state changes — this is a read-only projection.
+
+        Returns 404 when no invoice exists for the supplied id.
+
+        '
+      operationId: listInvoiceRefunds
       parameters:
       - name: invoiceId
         in: path
@@ -224,9 +338,21 @@ paths:
     post:
       tags:
       - StandaloneRefund
-      summary: Record standalone refund for an invoice
-      description: Record a refund against an invoice whose original payment is not in the system; the disbursement itself happens out of band
-      operationId: refundInvoiceStandalone
+      summary: Record Standalone Invoice Refund
+      description: 'Records a refund against an invoice whose original payment is not in this system — predecessor-system sales, pre-deploy invoices, vendor-paid warranty work — while the cash disbursement itself happens out of band (till, check, or vendor payment).
+
+        Use this tool only when no captured payment intent exists to refund; do not use refundPayment, which reverses a CAPTURED gateway payment, and use createStandalonePartyRefund instead when no invoice is on file at all.
+
+        Preconditions: the invoice must exist, the caller needs the finance-only ISSUE_MANUAL_REFUND authority, and cumulative refunds across payment-anchored and standalone records may not exceed the invoice total.
+
+        Required inputs: amount (positive) and reason (a RefundReason such as CUSTOMER_RETURN); notes and externalReference are optional, and a retry replaying the same externalReference returns the existing record instead of double-recording.
+
+        Emits an INVOICE_STANDALONE_REFUND event and stores a COMPLETED refund record anchored to the invoice; no gateway call is made.
+
+        Returns 201 with the refund record, 404 when the invoice does not exist, and 422 when the amount exceeds the invoice''s remaining refundable balance.
+
+        '
+      operationId: createStandaloneInvoiceRefund
       parameters:
       - name: invoiceId
         in: path
@@ -235,10 +361,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Out-of-band refund to record against the invoice.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/StandaloneRefundRequest'
+            examples:
+              Walk-in warranty refund:
+                description: Walk-in warranty refund
+                value:
+                  amount: 25.0
+                  reason: CUSTOMER_RETURN
+                  notes: Walk-in warranty claim on a predecessor-system cash sale
+                  externalReference: WC-2026-000042
         required: true
       responses:
         '201':
@@ -267,8 +402,20 @@ paths:
     post:
       tags:
       - Receipt
-      summary: Generate invoice receipt
-      description: Generate a receipt for an invoice payment using the requested terminal and template
+      summary: Generate Receipt for Invoice Payment
+      description: 'Generates a receipt record for an invoice payment, assigning a unique reference built from the invoice number, a UTC timestamp and a per-invoice sequence, with the cashier taken from the security context.
+
+        Use this tool once per payment after tender; do not use reprintReceipt, which duplicates a receipt that already exists.
+
+        Preconditions: the invoice and payment intent must exist, the intent must belong to the invoice, and the caller needs the GENERATE_RECEIPT authority.
+
+        Required inputs: paymentIntentId (UUID), terminalId, templateId and templateVersion.
+
+        Emits an INVOICE_RECEIPT_GENERATE event and stores the receipt in GENERATED status with a zero reprint count; the receipt also becomes a downloadable artifact of the invoice.
+
+        Returns 201 with the receipt reference, 404 when the invoice or payment intent does not exist or the intent belongs to a different invoice, and 403 when the GENERATE_RECEIPT authority is missing.
+
+        '
       operationId: generateReceipt
       parameters:
       - name: invoiceId
@@ -278,10 +425,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Payment, terminal and template identifying what the receipt documents.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GenerateReceiptRequest'
+            examples:
+              Counter receipt:
+                description: Counter receipt
+                value:
+                  paymentIntentId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a60
+                  terminalId: TERM-001
+                  templateId: RECEIPT_DEFAULT
+                  templateVersion: '1'
         required: true
       responses:
         '201':
@@ -304,8 +460,20 @@ paths:
     post:
       tags:
       - Receipt
-      summary: Reprint invoice receipt
-      description: Create a reprint of an existing receipt and record the reason for the reprint
+      summary: Reprint an Existing Receipt
+      description: 'Records a reprint of an existing receipt, incrementing its reprint count and capturing the reason and the reprinting actor for audit.
+
+        Use this tool when a customer needs a duplicate copy; do not use generateReceipt, which creates a new receipt for a payment that has none yet.
+
+        Preconditions: the receipt must exist, and its reprint count must be below 5 unless the caller holds the SUPERVISOR_OVERRIDE authority.
+
+        Required inputs: receiptId (UUID) as a path parameter and a non-blank reason in the body.
+
+        Emits an INVOICE_RECEIPT_REPRINT event and updates the receipt''s reprint count, last reprint reason and last reprinted-by.
+
+        Returns 200 with the receipt, 404 when the receipt does not exist, and 409 when the reprint limit of 5 is exceeded without a supervisor override.
+
+        '
       operationId: reprintReceipt
       parameters:
       - name: invoiceId
@@ -321,10 +489,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Business reason the duplicate copy is being produced.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ReprintReceiptRequest'
+            examples:
+              Duplicate copy:
+                description: Duplicate copy
+                value:
+                  reason: Customer requested a duplicate copy
         required: true
       responses:
         '200':
@@ -353,9 +527,21 @@ paths:
     post:
       tags:
       - Receipt
-      summary: Record printed receipt delivery
-      description: Record the delivery status for a printed receipt associated with an invoice
-      operationId: recordPrintDelivery
+      summary: Record Printed Receipt Delivery Status
+      description: 'Records the outcome of printing a receipt at the terminal, stamping the receipt''s delivery method as PRINT with the reported status; the physical printing itself happens client-side, not here.
+
+        Use this tool after the terminal reports its print result; do not use recordReceiptEmailDelivery, which records an email delivery attempt with its recipient address.
+
+        Preconditions: the receipt must already exist via generateReceipt.
+
+        Required inputs: receiptId (UUID) as a path parameter and status (SUCCESS or FAILED) in the body.
+
+        Emits an INVOICE_RECEIPT_PRINT_DELIVERY event and overwrites the receipt''s delivery method and status.
+
+        Returns 200 with an empty body on success, and 404 when the receipt does not exist.
+
+        '
+      operationId: recordReceiptPrintDelivery
       parameters:
       - name: invoiceId
         in: path
@@ -370,10 +556,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Print outcome reported by the terminal.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PrintDeliveryRequest'
+            examples:
+              Successful print:
+                description: Successful print
+                value:
+                  status: SUCCESS
         required: true
       responses:
         '200':
@@ -388,9 +580,21 @@ paths:
     post:
       tags:
       - Receipt
-      summary: Email invoice receipt
-      description: Send an invoice receipt by email and record the delivery status for the attempt
-      operationId: sendEmailReceipt
+      summary: Record Emailed Receipt Delivery Status
+      description: 'Records the outcome of emailing a receipt to a customer, stamping the receipt''s delivery method as EMAIL with the recipient address and the reported status; this endpoint records the attempt rather than dispatching the email itself.
+
+        Use this tool after an email delivery attempt completes; do not use recordReceiptPrintDelivery, which records a terminal print outcome.
+
+        Preconditions: the receipt must already exist via generateReceipt.
+
+        Required inputs: receiptId (UUID) as a path parameter plus emailAddress and status (SUCCESS or FAILED) in the body.
+
+        Emits an INVOICE_RECEIPT_EMAIL_DELIVERY event and overwrites the receipt''s delivery method, address and status.
+
+        Returns 200 with an empty body on success, and 404 when the receipt does not exist.
+
+        '
+      operationId: recordReceiptEmailDelivery
       parameters:
       - name: invoiceId
         in: path
@@ -405,10 +609,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Recipient address and outcome of the email delivery attempt.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/EmailDeliveryRequest'
+            examples:
+              Successful email:
+                description: Successful email
+                value:
+                  emailAddress: customer@example.com
+                  status: SUCCESS
         required: true
       responses:
         '200':
@@ -423,8 +634,20 @@ paths:
     post:
       tags:
       - Payment
-      summary: Initiate card payment
-      description: Initiate a SALE_CAPTURE or AUTH_ONLY card payment against an invoice
+      summary: Initiate Card Payment on Invoice
+      description: 'Initiates a card payment against an invoice through the payment gateway, creating a payment intent that is CAPTURED immediately (SALE_CAPTURE) or left AUTHORIZED as a hold (AUTH_ONLY).
+
+        Use this tool to take card tender; do not use capturePayment, which settles an existing AUTH_ONLY hold rather than starting a new payment.
+
+        Preconditions: the invoice must exist; the caller needs the PROCESS_PAYMENT authority, plus OVERRIDE_PAYMENT_LIMIT when the amount exceeds 500.00 and SELECT_PAYMENT_FLOW to choose AUTH_ONLY.
+
+        Required inputs: paymentFlow (SALE_CAPTURE or AUTH_ONLY), amount (positive), idempotencyKey and paymentToken (tokenised card reference, never a PAN); a replayed idempotencyKey with an identical payload returns the existing intent instead of charging twice.
+
+        Emits an INVOICE_PAYMENT_INITIATE event and records the gateway result on the intent.
+
+        Returns 201 with the intent, 404 when the invoice does not exist, 409 when the idempotencyKey was already used with a different payload, 422 when the gateway declines, and 403 when a required payment authority is missing.
+
+        '
       operationId: initiatePayment
       parameters:
       - name: invoiceId
@@ -434,10 +657,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: 'Card tender details: flow, amount, idempotency key and tokenised card reference.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/InitiatePaymentRequest'
+            examples:
+              One-step sale capture:
+                description: One-step sale capture
+                value:
+                  paymentFlow: SALE_CAPTURE
+                  amount: 149.99
+                  idempotencyKey: idem-018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a50
+                  paymentToken: tok_1NXyZ2eZvKYlo2Cabc12345
         required: true
       responses:
         '201':
@@ -478,8 +710,20 @@ paths:
     post:
       tags:
       - PaymentReversal
-      summary: Void authorized payment
-      description: Void a previously authorized invoice payment before it is captured
+      summary: Void Authorized Payment Hold
+      description: 'Voids a previously authorized invoice payment hold at the gateway before it is captured, releasing the customer''s funds without any money movement.
+
+        Use this tool on an AUTHORIZED hold; do not use refundPayment, which returns funds from a payment that was already CAPTURED.
+
+        Preconditions: the payment intent must belong to the invoice and be AUTHORIZED, the caller needs the VOID_PAYMENT authority, and less than 24 hours may have elapsed since authorization unless the caller also holds SUPERVISOR_OVERRIDE.
+
+        Required inputs: reason (CUSTOMER_REQUEST, DUPLICATE_AUTHORIZATION, ENTRY_ERROR, FRAUD_PREVENTION, MANAGER_DISCRETION or OTHER); notes are optional free text.
+
+        Emits an INVOICE_PAYMENT_VOID event, moves the intent to VOIDED, and publishes a payment-voided notification.
+
+        Returns 200 with an empty body on success, 404 when the intent does not exist under the invoice, 409 when the intent is not AUTHORIZED, 422 when the 24-hour void window has expired, and 500 when the gateway rejects the void.
+
+        '
       operationId: voidPayment
       parameters:
       - name: invoiceId
@@ -495,10 +739,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Reason and optional notes explaining why the authorization is released.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/VoidPaymentRequest'
+            examples:
+              Customer cancelled:
+                description: Customer cancelled
+                value:
+                  reason: CUSTOMER_REQUEST
+                  notes: Customer cancelled before pickup
         required: true
       responses:
         '200':
@@ -517,8 +768,20 @@ paths:
     post:
       tags:
       - PaymentReversal
-      summary: Refund captured payment
-      description: Create a refund for a captured invoice payment and record the refund details
+      summary: Refund a Captured Payment
+      description: 'Refunds all or part of a CAPTURED invoice payment through the gateway and records the refund against the payment intent.
+
+        Use this tool when the original card payment lives in this system; do not use voidPayment, which releases an uncaptured hold, and use createStandaloneInvoiceRefund instead when the original payment is not on file.
+
+        Preconditions: the payment intent must belong to the invoice and be CAPTURED, the caller needs the REFUND_PAYMENT authority, less than 180 days may have elapsed since capture unless the caller holds SUPERVISOR_OVERRIDE, and cumulative refunds may not exceed the captured amount.
+
+        Required inputs: amount (positive) and reason (a RefundReason such as CUSTOMER_RETURN or SERVICE_ERROR); notes and externalReference are optional, and a retry replaying the same externalReference returns the existing refund instead of paying twice.
+
+        Emits an INVOICE_PAYMENT_REFUND event and publishes a payment-refunded notification on success; a gateway failure is persisted as a FAILED refund record, so callers must read the returned status rather than treating 201 as completed.
+
+        Returns 201 with the refund record, 404 when the intent does not exist under the invoice, 409 when the intent is not CAPTURED, and 422 when the 180-day window has expired or the amount exceeds the remaining refundable balance.
+
+        '
       operationId: refundPayment
       parameters:
       - name: invoiceId
@@ -534,10 +797,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Refund amount, business reason and optional external correlation for the captured payment.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RefundPaymentRequest'
+            examples:
+              Partial return refund:
+                description: Partial return refund
+                value:
+                  amount: 25.0
+                  reason: CUSTOMER_RETURN
+                  notes: Returned damaged part
+                  externalReference: WC-2026-000042
         required: true
       responses:
         '201':
@@ -572,8 +844,20 @@ paths:
     post:
       tags:
       - Payment
-      summary: Capture authorized payment hold
-      description: Capture all or part of a previously authorized invoice payment hold
+      summary: Capture Authorized Payment Hold
+      description: 'Captures all or part of a previously authorized AUTH_ONLY payment hold at the gateway; when the captured amount is below the authorized amount, the remainder of the hold is voided.
+
+        Use this tool to settle an existing AUTHORIZED intent; do not use initiatePayment, which starts a new payment, and use voidPayment instead to release the hold without taking funds.
+
+        Preconditions: the payment intent must belong to the invoice and be in AUTHORIZED status; the caller needs the MANUAL_CAPTURE authority.
+
+        Required inputs: amount (positive, up to the authorized amount) and captureIdempotencyKey, which is forwarded to the gateway so a retried capture settles at most once.
+
+        Emits an INVOICE_PAYMENT_CAPTURE event; the intent moves to CAPTURED on success or CAPTURE_FAILED on decline, and an ambiguous gateway response is resolved by a status inquiry before failing.
+
+        Returns 200 with the captured intent, 404 when the intent does not exist under the invoice, 409 when the intent is not AUTHORIZED, 422 when the gateway declines the capture, and 403 when the MANUAL_CAPTURE authority is missing.
+
+        '
       operationId: capturePayment
       parameters:
       - name: invoiceId
@@ -589,10 +873,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Amount to settle from the authorized hold and the capture idempotency key.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CaptureAmountRequest'
+            examples:
+              Partial capture:
+                description: Partial capture
+                value:
+                  amount: 89.99
+                  captureIdempotencyKey: capture-018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a51
         required: true
       responses:
         '200':
@@ -621,8 +912,20 @@ paths:
     post:
       tags:
       - Invoice
-      summary: Finalize invoice
-      description: 'Transition invoice from DRAFT to FINALIZED; enforces permission matrix and emits InvoiceFinalized event for async GL posting (Story #13)'
+      summary: Finalize a Draft Invoice
+      description: 'Transitions an invoice from DRAFT to FINALIZED: runs the committable tax calculation, freezes tax, totals, payment terms and due date, then commits the provider tax document.
+
+        Use this tool when the sale is ready to issue; do not use revertInvoice, which undoes a finalization, and mint the managerApprovalCode with elevateManagerApproval when one is needed.
+
+        Preconditions: the invoice must be DRAFT with tax already calculated; callers without invoice:finalize:override (or a manager/admin role) need a valid elevation token as managerApprovalCode when the stored total exceeds 500.00.
+
+        Required inputs: invoiceId (UUID) as a path parameter; managerApprovalCode and overrideReason in the body are optional below the cap and for override holders.
+
+        Emits an INVOICE_FINALIZED event and publishes the async accounting event that drives GL posting; the tax commit tolerates a provider outage by recording PENDING_COMMIT in pos-tax for the re-commit job, and is skipped entirely when nothing is taxable.
+
+        Returns 200 with the finalized invoice, 404 when the invoice does not exist, 409 when the invoice is not DRAFT or tax has not been calculated, and 400 when a required managerApprovalCode is missing, invalid, or expired.
+
+        '
       operationId: finalizeInvoice
       parameters:
       - name: invoiceId
@@ -632,10 +935,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Optional manager-approval material for finalizations above the amount cap.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/FinalizationRequest'
+            examples:
+              Finalize with manager approval:
+                description: Finalize with manager approval
+                value:
+                  managerApprovalCode: MGR-ELEV-TOKEN-abc123
+                  overrideReason: Customer pre-approved by branch manager
         required: true
       responses:
         '200':
@@ -654,8 +964,20 @@ paths:
     post:
       tags:
       - Invoice
-      summary: Cancel a draft invoice
-      description: Terminal cancel of a DRAFT invoice before any money moved (order-void path). Rejected with 409 when the invoice has left DRAFT or carries an authorized/captured payment. Idempotent — cancelling a CANCELLED invoice returns 200.
+      summary: Cancel a Draft Invoice
+      description: 'Cancels a DRAFT invoice terminally before any money has moved, the invoice-side effect of an order void.
+
+        Use this tool when an order is voided before tender; do not use revertInvoice, which returns a FINALIZED invoice to DRAFT, and do not use it when payments exist — reverse those first through voidPayment or refundPayment (order cancellation saga).
+
+        Preconditions: the invoice must still be DRAFT and must carry no AUTHORIZED or CAPTURED payment intent; cancelling an already CANCELLED invoice is an idempotent no-op.
+
+        Required inputs: invoiceId (UUID) as a path parameter; there is no request body.
+
+        Emits an INVOICE_CANCEL event and sets the invoice status to CANCELLED.
+
+        Returns 200 when cancelled or already cancelled, 409 when the invoice has left DRAFT or carries an authorized/captured payment, and 404 when the invoice does not exist.
+
+        '
       operationId: cancelInvoice
       parameters:
       - name: invoiceId
@@ -686,9 +1008,21 @@ paths:
     post:
       tags:
       - invoice-artifact-controller
-      summary: Create a short-lived download token for an invoice artifact
-      description: Issues a short-lived signed token bound to the invoice and artifact. The token is presented to the public download endpoint so a browser can fetch the file via a direct link.
-      operationId: createDownloadToken
+      summary: Create Artifact Download Token
+      description: 'Issues a short-lived signed token bound to one invoice artifact, so a browser can fetch the PDF through the public download link without an Authorization header.
+
+        Use this tool after listInvoiceArtifacts has supplied an artifactRefId; do not use downloadInvoiceArtifact without a token — it rejects unsigned requests.
+
+        Preconditions: the invoice must exist and the artifact reference must belong to that invoice (an invoice ref must match the path invoice, a receipt ref must be one of its receipts).
+
+        Required inputs: invoiceId (UUID) and artifactRefId (opaque reference from listInvoiceArtifacts) as path parameters; there is no request body.
+
+        No events are emitted and no record is stored; the token is stateless, signed, and expires after 300 seconds by default (invoice.artifacts.token-ttl-seconds).
+
+        Returns 404 when the invoice does not exist or the artifact does not belong to it.
+
+        '
+      operationId: createArtifactDownloadToken
       parameters:
       - name: invoiceId
         in: path
@@ -722,9 +1056,21 @@ paths:
     post:
       tags:
       - Invoice
-      summary: Apply invoice adjustment
-      description: Apply discount, fee, correction, or warranty credit to a draft invoice
-      operationId: applyAdjustment
+      summary: Apply Adjustment to Draft Invoice
+      description: 'Applies a monetary adjustment (DISCOUNT, FEE, CORRECTION, or WARRANTY credit) to a DRAFT invoice and recalculates its tax and total.
+
+        Use this tool while the invoice is still DRAFT; do not use it after finalization — tax and totals freeze there, so revertInvoice must return the invoice to DRAFT first.
+
+        Preconditions: the invoice must exist and be in DRAFT status; a retry supplying the same type and externalReference replays idempotently, returning the invoice without double-crediting.
+
+        Required inputs: type, amount (greater than zero), reason, and authorizedBy; externalReference is optional and correlates the adjustment to an external record such as a warranty settlement.
+
+        Emits an INVOICE_ADJUSTMENT_APPLY event, replaces the persisted per-line tax breakdown, and publishes an invoice-updated notification.
+
+        Returns 200 with the recalculated invoice, 404 when the invoice does not exist, 409 when the invoice has left DRAFT, and 400 when the type, amount, reason, or authorizedBy is missing or the amount is not positive.
+
+        '
+      operationId: applyInvoiceAdjustment
       parameters:
       - name: invoiceId
         in: path
@@ -733,10 +1079,20 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Adjustment to add to the draft invoice, with its business justification.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AdjustmentRequest'
+            examples:
+              Warranty credit:
+                description: Warranty credit
+                value:
+                  type: WARRANTY
+                  amount: 25.0
+                  reason: Warranty settlement credit
+                  authorizedBy: jdoe
+                  externalReference: WC-2026-000042
         required: true
       responses:
         '200':
@@ -754,14 +1110,45 @@ paths:
     post:
       tags:
       - Invoice
-      summary: Create invoice from a sales order
-      description: Create the invoice fronting a sales order at checkout (counter sale). Idempotent on orderId — a replay returns the existing invoice with 200. When workorderId is present and a workorder invoice already exists, that invoice is returned for tender instead of creating a duplicate.
+      summary: Create Invoice from Sales Order
+      description: 'Creates the DRAFT invoice fronting a sales order at counter-sale checkout, recording the order''s already-priced subtotal, tax and total verbatim — pos-order and pos-tax are authoritative, so nothing is re-priced here.
+
+        Use this tool at order checkout; do not use createInvoice, which builds and prices a draft from workorder data.
+
+        Preconditions: the order must carry final totals and at least one line; the call is idempotent on orderId, and when workorderId is set an existing workorder invoice is returned for tender instead of creating a duplicate.
+
+        Required inputs: orderId (UUID), subtotal, taxAmount, totalAmount (non-negative) and lines; customerId, locationId and the deposit fields are optional, but depositSourceType and depositSourceId become mandatory when depositAmount is set.
+
+        Emits an INVOICE_CREATE_FROM_ORDER event; a deposit take also registers a deposit credit (idempotent on orderId), and a workorder settlement draws down available deposit credits, reported as depositApplied.
+
+        Returns 201 when a new invoice is created, 200 when an existing invoice is returned (orderId replay or workorder dedupe), and 400 when totals are missing or negative, lines are empty, or deposit fields are inconsistent.
+
+        '
       operationId: createInvoiceFromOrder
       requestBody:
+        description: Sales order snapshot — authoritative totals and sold lines — the invoice records.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/OrderInvoiceCreationRequest'
+            examples:
+              Counter sale:
+                description: Counter sale
+                value:
+                  orderId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a40
+                  customerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a41
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a42
+                  subtotal: 120.0
+                  taxAmount: 9.6
+                  totalAmount: 129.6
+                  lines:
+                  - orderLineId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a43
+                    description: Brake pad set
+                    quantity: 2
+                    unitPrice: 45.0
+                    amount: 90.0
+                    taxAmount: 7.2
+                    type: PART
         required: true
       responses:
         '201':
@@ -785,9 +1172,21 @@ paths:
     get:
       tags:
       - Deposit Credits
-      summary: List deposit credits held against a source document
-      description: Lists all deposit credits associated with the given source type and source id.
-      operationId: listBySource
+      summary: List Deposit Credits by Source
+      description: 'Lists every deposit credit held against one source document, identified by its type and id.
+
+        Use this tool when checking what down-payments a settlement can draw on; use getDepositCredit instead when a specific depositCreditId is already known.
+
+        Preconditions: none — an unknown or credit-free source returns an empty list rather than an error.
+
+        Required inputs: sourceType query parameter (ESTIMATE, WORKORDER or ORDER, case-insensitive) and sourceId (UUID) query parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 422 when sourceType is not one of the known values.
+
+        '
+      operationId: listDepositCreditsBySource
       parameters:
       - name: sourceType
         in: query
@@ -816,14 +1215,37 @@ paths:
     post:
       tags:
       - Deposit Credits
-      summary: Register a deposit credit taken by a sales order
-      description: Creates a deposit credit record tied to the provided source transaction.
-      operationId: createDeposit
+      summary: Register a Deposit Credit
+      description: 'Creates an AVAILABLE deposit credit for a down-payment taken at pos-order checkout, holding the amount against its source document until a settlement invoice draws it down.
+
+        Use this tool when a deposit was tendered against an estimate, workorder, or order; do not use refundDepositCredit, which returns a credit''s remaining balance when the source is cancelled.
+
+        Preconditions: none beyond a priced source document — the call is idempotent on orderId, so a replay for an order that already registered a credit returns the existing record unchanged.
+
+        Required inputs: orderId (UUID, idempotency anchor), sourceType (ESTIMATE, WORKORDER or ORDER), sourceId (UUID) and amount (positive); partyId is optional and currencyCode defaults to USD.
+
+        Emits an INVOICE_DEPOSIT_CREATE event; no invoice records are touched until settlement applies the credit.
+
+        Returns 201 with the credit (existing or new), and 422 when the amount is not positive or the sourceType is not a known value.
+
+        '
+      operationId: createDepositCredit
       requestBody:
+        description: Deposit taken at checkout to register as a credit against its source document.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateDepositRequest'
+            examples:
+              Workorder down-payment:
+                description: Workorder down-payment
+                value:
+                  orderId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a10
+                  sourceType: WORKORDER
+                  sourceId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a11
+                  partyId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a12
+                  amount: 200.0
+                  currencyCode: USD
         required: true
       responses:
         '200':
@@ -840,9 +1262,21 @@ paths:
     post:
       tags:
       - Deposit Credits
-      summary: Refund a deposit credit's remaining balance
-      description: Used when the deposit's source is cancelled after the deposit was taken (spec R7.4).
-      operationId: refundDeposit
+      summary: Refund a Deposit Credit Balance
+      description: 'Zeroes the remaining balance of a deposit credit and marks it REFUNDED, recording that the deposit is returned because its source document was cancelled after the deposit was taken.
+
+        Use this tool on source cancellation (spec R7.4); do not use createDepositCredit, which registers a new deposit, and note the cash disbursement itself is not performed here.
+
+        Preconditions: the deposit credit must exist; a credit already REFUNDED is left unchanged, so the call is idempotent.
+
+        Required inputs: depositCreditId (UUID) as a path parameter; the reason query parameter is optional and defaults to "source cancelled"; there is no request body.
+
+        Emits an INVOICE_DEPOSIT_REFUND event and sets the credit''s status to REFUNDED with a zero remaining balance.
+
+        Returns 200 with the refunded credit, and 404 when no deposit credit exists for the supplied id.
+
+        '
+      operationId: refundDepositCredit
       parameters:
       - name: depositCreditId
         in: path
@@ -870,14 +1304,33 @@ paths:
     post:
       tags:
       - Billing Authorization
-      summary: Mint a manager-approval elevation token
-      description: Verifies the named manager (by employee number) holds invoice:finalize:override and mints a short-lived token scoped to the given invoice, returned as the managerApprovalCode for finalize.
-      operationId: elevate
+      summary: Mint Manager-Approval Elevation Token
+      description: 'Mints a short-lived elevation token scoped to one invoice after verifying that the named manager is an ACTIVE employee holding the invoice:finalize:override authority.
+
+        Use this tool when an actor with invoice:finalize but not invoice:finalize:override needs a managerApprovalCode for finalizeInvoice or revertInvoice; do not use finalizeInvoice directly without a token when the invoice total exceeds the 500.00 service-advisor cap.
+
+        Preconditions: the manager''s employee number must resolve to an ACTIVE person in the local employee replica and that person must hold invoice:finalize:override.
+
+        Required inputs: managerEmployeeNumber and invoiceId (UUID); the token is bound to that invoice only and expires after five minutes by default (invoice.elevation.token-ttl-seconds).
+
+        No events are emitted; the token is signed and stateless, and the grant is audit-logged with the approving manager''s person id.
+
+        Returns 200 with the token and its expiry, and 401 with an empty body when the employee number is unknown or inactive or the person lacks the override authority.
+
+        '
+      operationId: elevateManagerApproval
       requestBody:
+        description: Manager identification and the invoice the elevation token will authorize.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ElevateRequest'
+            examples:
+              Elevation for one invoice:
+                description: Elevation for one invoice
+                value:
+                  managerEmployeeNumber: EMP-0001
+                  invoiceId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a20
         required: true
       responses:
         '200':
@@ -907,8 +1360,20 @@ paths:
     get:
       tags:
       - Invoice
-      summary: Get invoice
-      description: Get invoice details
+      summary: Get Invoice Details
+      description: 'Returns the full invoice detail — status, line items, adjustments, totals, tax breakdown, due date and the resolved workorder number.
+
+        Use this tool when the invoiceId is already known; use searchInvoices instead when locating an invoice by number, customer name or workorder number.
+
+        Preconditions: the invoice must exist.
+
+        Required inputs: invoiceId (UUID) as a path parameter; there is no request body.
+
+        Emits an INVOICE_GET audit event; no state changes — this is a read-only projection.
+
+        Returns 404 when no invoice exists for the supplied id.
+
+        '
       operationId: getInvoice
       parameters:
       - name: invoiceId
@@ -933,9 +1398,21 @@ paths:
     get:
       tags:
       - invoice-artifact-controller
-      summary: List the downloadable artifacts (documents) for an invoice
-      description: Returns the documents available for the invoice (the invoice itself and any receipts) as opaque, URL-safe artifact references with suggested file names and MIME types.
-      operationId: listArtifacts
+      summary: List Downloadable Invoice Artifacts
+      description: 'Returns the downloadable documents for an invoice — always the invoice document itself, plus one entry per generated receipt — as opaque URL-safe artifact references with suggested file names and application/pdf MIME types.
+
+        Use this tool to discover artifactRefId values before minting a download token; do not use downloadInvoiceArtifact directly, which requires a signed token from createArtifactDownloadToken.
+
+        Preconditions: the invoice must exist; receipts appear only after generateReceipt has created them.
+
+        Required inputs: invoiceId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no invoice exists for the supplied id.
+
+        '
+      operationId: listInvoiceArtifacts
       parameters:
       - name: invoiceId
         in: path
@@ -968,9 +1445,21 @@ paths:
     get:
       tags:
       - invoice-artifact-download-controller
-      summary: Download an invoice artifact as PDF using a signed download token
-      description: Streams the artifact as application/pdf. Public endpoint authorized solely by the signed download token (query parameter); intended for browser direct-download links.
-      operationId: download
+      summary: Download Invoice Artifact as PDF
+      description: 'Streams an invoice or receipt artifact as an application/pdf attachment, rendering it on demand through the document service.
+
+        Use this tool (or a browser direct link) with a token minted by createArtifactDownloadToken; do not call it with a bearer token alone — the endpoint is public and authorized solely by the signed download token.
+
+        Preconditions: a valid unexpired download token bound to exactly this invoiceId and artifactRefId, and the artifact must still belong to the invoice.
+
+        Required inputs: invoiceId (UUID) and artifactRefId as path parameters plus the token query parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only render of the stored document data.
+
+        Returns 403 when the token is missing, malformed, expired, or bound to a different artifact, and 404 when the invoice or artifact cannot be resolved.
+
+        '
+      operationId: downloadInvoiceArtifact
       parameters:
       - name: invoiceId
         in: path
@@ -1014,8 +1503,20 @@ paths:
     get:
       tags:
       - Invoice Search
-      summary: Search invoices
-      description: Paginated free-text search for invoices matching the invoice number, customer name, or workorder number.
+      summary: Search Invoices by Free Text
+      description: 'Searches invoices by a free-text term matched against the invoice number, the customer name (resolved via the customer service), or the workorder number, returning a page of finder rows.
+
+        Use this tool to locate an invoice when its id is unknown; use getInvoice instead once the invoiceId is known, and searchInvoiceLines for line-level warranty correlation.
+
+        Preconditions: none — but a blank or missing q short-circuits to an empty page rather than listing all invoices.
+
+        Required inputs: q (free-text term) plus optional page, size and sort parameters; size defaults to 25, is hard-capped at 50, and the default sort is createdAt descending.
+
+        Emits an INVOICE_SEARCH audit event; no state changes — this is a read-only projection.
+
+        Returns 400 when pagination parameters are malformed.
+
+        '
       operationId: searchInvoices
       parameters:
       - name: q
@@ -1057,8 +1558,20 @@ paths:
     get:
       tags:
       - Invoice Search
-      summary: Search invoice line items by customer party
-      description: Returns invoice line items belonging to the given customer party, optionally narrowed by a SKU/description term, flattened with the owning invoice's number, status, and creation time. Newest invoice first, bounded to the newest 200 lines. Built for warranty-claim correlation.
+      summary: Search Invoice Lines by Party
+      description: 'Returns invoice line items belonging to one customer party, flattened with the owning invoice''s number, status and creation time, newest invoice first and bounded to the newest 200 lines; built for warranty-claim origin-line correlation.
+
+        Use this tool to find the invoice line a warranty claim originates from; use searchInvoices instead for invoice-level free-text search.
+
+        Preconditions: none — an unknown party simply returns an empty list.
+
+        Required inputs: partyId (UUID) query parameter; q is an optional SKU or description term narrowing the lines.
+
+        Emits an INVOICE_ITEM_SEARCH audit event; no state changes — this is a read-only projection.
+
+        Returns 400 when partyId is missing or malformed.
+
+        '
       operationId: searchInvoiceLines
       parameters:
       - name: partyId
@@ -1067,6 +1580,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       - name: q
         in: query
         description: SKU / description term narrowing the lines (optional)
@@ -1103,9 +1617,21 @@ paths:
     get:
       tags:
       - Deposit Credits
-      summary: Get a deposit credit by id
-      description: Retrieves a single deposit credit by its identifier.
-      operationId: getDeposit
+      summary: Get a Deposit Credit
+      description: 'Returns a single deposit credit with its status (AVAILABLE, PARTIALLY_APPLIED, FULLY_APPLIED or REFUNDED), original amount and remaining balance.
+
+        Use this tool when the depositCreditId is already known; use listDepositCreditsBySource instead to find the credits held against an estimate, workorder or order.
+
+        Preconditions: the deposit credit must exist.
+
+        Required inputs: depositCreditId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no deposit credit exists for the supplied id.
+
+        '
+      operationId: getDepositCredit
       parameters:
       - name: depositCreditId
         in: path
@@ -1141,7 +1667,6 @@ components:
           example: 01960003-0000-7000-8000-000000000002
         purchaseOrderRequired:
           type: boolean
-          default: false
           description: Whether a purchase order is required before invoicing
           example: true
         paymentTermsCode:
@@ -1207,6 +1732,7 @@ components:
           type: number
           description: Amount to refund
           example: 25.0
+          minimum: 0
         reason:
           type: string
           description: Reason the refund is being issued
@@ -1576,7 +2102,6 @@ components:
           example: msmith
         requiresManagerApproval:
           type: boolean
-          default: false
           description: Whether finalizing this invoice requires a manager approval code (DRAFT total exceeds the service-advisor threshold)
           example: false
         items:
@@ -1634,6 +2159,7 @@ components:
           type: number
           description: Amount to refund
           example: 25.0
+          minimum: 0
         reason:
           type: string
           description: Reason the refund is being issued
@@ -1770,6 +2296,7 @@ components:
           type: number
           description: Payment amount (must be positive)
           example: 149.99
+          minimum: 0
         idempotencyKey:
           type: string
           description: Client-provided idempotency key for safe retry
@@ -1859,6 +2386,7 @@ components:
           type: number
           description: Amount to refund from the captured payment
           example: 25.0
+          minimum: 0
         reason:
           type: string
           description: Reason the payment is being refunded
@@ -1894,6 +2422,7 @@ components:
           type: number
           description: Amount to capture from the authorized hold
           example: 89.99
+          minimum: 0
         captureIdempotencyKey:
           type: string
           description: Idempotency key ensuring the capture is processed at most once
@@ -1948,7 +2477,6 @@ components:
           example: 50.0
         existing:
           type: boolean
-          default: false
           description: True when an existing invoice was returned (orderId replay or workorder dedupe).
       required:
       - existing
@@ -2132,6 +2660,7 @@ components:
           type: number
           description: Deposit amount
           example: 200.0
+          minimum: 0
         currencyCode:
           type: string
           description: ISO-4217 currency; defaults to USD
@@ -2419,17 +2948,17 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
     PageableObject:

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/BillingRulesController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/BillingRulesController.java
@@ -4,6 +4,8 @@ import com.positivity.events.EmitEvent;
 import com.positivity.invoice.internal.dto.BillingRulesDTO;
 import com.positivity.invoice.service.BillingRulesService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -49,9 +51,18 @@ public class BillingRulesController {
 
     @GetMapping("/{partyId}")
     @EmitEvent(id = "BILLING_RULES_GET", apiVersion = "1")
-    @Operation(
-            summary = "Get billing rules for a party/customer",
-            description = "Retrieve the current billing rules configuration for a commercial account")
+    @Operation(operationId = "getBillingRules", summary = "Get Billing Rules for a Party", description = """
+                    Returns the billing rules configured for a commercial account party: purchase-order requirement, \
+                    payment terms code, invoice delivery method, and invoice grouping strategy.
+                    Use this tool when the billing configuration of a known party is needed before invoicing; do not \
+                    use upsertBillingRules, which creates or replaces the configuration.
+                    Preconditions: a billing rules record must already exist for the party, created explicitly or \
+                    defaulted when the commercial account was provisioned.
+                    Required inputs: partyId (UUID) as a path parameter; there is no request body.
+                    Emits a BILLING_RULES_GET audit event; no state changes — this is a read-only projection.
+                    Returns 404 when no billing rules are configured for the party, and 400 with an empty body when \
+                    partyId is not a well-formed UUID.
+                    """)
     @ApiResponse(responseCode = "200", description = "Billing rules found")
     @ApiResponse(responseCode = "404", description = "No billing rules configured for this party")
     public ResponseEntity<BillingRulesDTO> getBillingRules(@PathVariable @NonNull String partyId) {
@@ -71,14 +82,47 @@ public class BillingRulesController {
 
     @PutMapping("/{partyId}")
     @EmitEvent(id = "BILLING_RULES_UPSERT", apiVersion = "1")
-    @Operation(
-            summary = "Create or update billing rules",
-            description = "Idempotent upsert of billing rules for a commercial account")
+    @Operation(operationId = "upsertBillingRules", summary = "Create or Update Billing Rules", description = """
+                    Creates or replaces the billing rules for a commercial account party in one idempotent upsert \
+                    keyed on the path partyId, which overrides any partyId carried in the body.
+                    Use this tool when configuring how a party is invoiced; use getBillingRules instead to read the \
+                    current configuration without changing it.
+                    Preconditions: paymentTermsCode must belong to the validated vocabulary (DUE_ON_RECEIPT, NET_10, \
+                    NET_15, NET_30, NET_45, NET_60); a missing record is created and an existing one is updated in \
+                    place.
+                    Required inputs: partyId (UUID path), purchaseOrderRequired (boolean), paymentTermsCode, \
+                    invoiceDeliveryMethod (EMAIL, PORTAL, MAIL) and invoiceGroupingStrategy (PER_WORKORDER, \
+                    PER_VEHICLE, SINGLE_INVOICE); updatedBy is taken from the security context, never from the body.
+                    Emits a BILLING_RULES_UPSERT event and publishes a billing-rules-updated notification; due dates \
+                    of already-finalized invoices are never recomputed from a terms change.
+                    Returns 201 when the record is created, 200 when an existing record is updated, and 400 with an \
+                    empty body when partyId is not a well-formed UUID.
+                    """)
     @ApiResponse(responseCode = "200", description = "Billing rules updated")
     @ApiResponse(responseCode = "201", description = "Billing rules created")
     @ApiResponse(responseCode = "400", description = "Invalid billing rules data")
     public ResponseEntity<BillingRulesDTO> upsertBillingRules(
-            @PathVariable @NonNull String partyId, @Valid @RequestBody @NonNull BillingRulesDTO billingRulesDTO) {
+            @PathVariable @NonNull String partyId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Billing rules configuration to store for the party.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Net-30 emailed per-workorder invoicing",
+                                                            value = """
+                                                                    {"partyId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "purchaseOrderRequired":true,
+                                                                     "paymentTermsCode":"NET_30",
+                                                                     "invoiceDeliveryMethod":"EMAIL",
+                                                                     "invoiceGroupingStrategy":"PER_WORKORDER"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BillingRulesDTO billingRulesDTO) {
 
         // Validate partyId format
         if (!VALID_UUID_PATTERN.matcher(partyId).matches()) {

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/DepositCreditController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/DepositCreditController.java
@@ -7,6 +7,8 @@ import com.positivity.invoice.internal.enums.DepositSourceType;
 import com.positivity.invoice.service.DepositCreditService;
 import com.positivity.invoice.service.model.CreateDepositCommand;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -42,13 +44,45 @@ public class DepositCreditController {
     private final DepositCreditService depositCreditService;
 
     @Operation(
-            summary = "Register a deposit credit taken by a sales order",
-            description = "Creates a deposit credit record tied to the provided source transaction.",
+            operationId = "createDepositCredit",
+            summary = "Register a Deposit Credit",
+            description = """
+                    Creates an AVAILABLE deposit credit for a down-payment taken at pos-order checkout, holding the \
+                    amount against its source document until a settlement invoice draws it down.
+                    Use this tool when a deposit was tendered against an estimate, workorder, or order; do not use \
+                    refundDepositCredit, which returns a credit's remaining balance when the source is cancelled.
+                    Preconditions: none beyond a priced source document — the call is idempotent on orderId, so a \
+                    replay for an order that already registered a credit returns the existing record unchanged.
+                    Required inputs: orderId (UUID, idempotency anchor), sourceType (ESTIMATE, WORKORDER or ORDER), \
+                    sourceId (UUID) and amount (positive); partyId is optional and currencyCode defaults to USD.
+                    Emits an INVOICE_DEPOSIT_CREATE event; no invoice records are touched until settlement applies \
+                    the credit.
+                    Returns 201 with the credit (existing or new), and 422 when the amount is not positive or the \
+                    sourceType is not a known value.
+                    """,
             tags = {"Deposit Credits"})
     @PostMapping
     @EmitEvent(id = "INVOICE_DEPOSIT_CREATE", apiVersion = "1")
     @SecurityRequirement(name = "bearerAuth")
-    public ResponseEntity<DepositCreditResponse> createDeposit(@Valid @RequestBody CreateDepositRequest request) {
+    public ResponseEntity<DepositCreditResponse> createDeposit(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Deposit taken at checkout to register as a credit against its source document.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Workorder down-payment", value = """
+                                                                    {"orderId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a10",
+                                                                     "sourceType":"WORKORDER",
+                                                                     "sourceId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a11",
+                                                                     "partyId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a12",
+                                                                     "amount":200.00,
+                                                                     "currencyCode":"USD"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CreateDepositRequest request) {
         DepositCreditResponse response =
                 DepositCreditResponse.from(depositCreditService.createDeposit(new CreateDepositCommand(
                         request.getOrderId(),
@@ -61,8 +95,18 @@ public class DepositCreditController {
     }
 
     @Operation(
-            summary = "Get a deposit credit by id",
-            description = "Retrieves a single deposit credit by its identifier.",
+            operationId = "getDepositCredit",
+            summary = "Get a Deposit Credit",
+            description = """
+                    Returns a single deposit credit with its status (AVAILABLE, PARTIALLY_APPLIED, FULLY_APPLIED or \
+                    REFUNDED), original amount and remaining balance.
+                    Use this tool when the depositCreditId is already known; use listDepositCreditsBySource instead \
+                    to find the credits held against an estimate, workorder or order.
+                    Preconditions: the deposit credit must exist.
+                    Required inputs: depositCreditId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no deposit credit exists for the supplied id.
+                    """,
             tags = {"Deposit Credits"})
     @GetMapping("/{depositCreditId}")
     @SecurityRequirement(name = "bearerAuth")
@@ -71,8 +115,19 @@ public class DepositCreditController {
     }
 
     @Operation(
-            summary = "List deposit credits held against a source document",
-            description = "Lists all deposit credits associated with the given source type and source id.",
+            operationId = "listDepositCreditsBySource",
+            summary = "List Deposit Credits by Source",
+            description = """
+                    Lists every deposit credit held against one source document, identified by its type and id.
+                    Use this tool when checking what down-payments a settlement can draw on; use getDepositCredit \
+                    instead when a specific depositCreditId is already known.
+                    Preconditions: none — an unknown or credit-free source returns an empty list rather than an \
+                    error.
+                    Required inputs: sourceType query parameter (ESTIMATE, WORKORDER or ORDER, case-insensitive) and \
+                    sourceId (UUID) query parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 422 when sourceType is not one of the known values.
+                    """,
             tags = {"Deposit Credits"})
     @GetMapping
     @SecurityRequirement(name = "bearerAuth")
@@ -85,8 +140,21 @@ public class DepositCreditController {
     }
 
     @Operation(
-            summary = "Refund a deposit credit's remaining balance",
-            description = "Used when the deposit's source is cancelled after the deposit was taken (spec R7.4).",
+            operationId = "refundDepositCredit",
+            summary = "Refund a Deposit Credit Balance",
+            description = """
+                    Zeroes the remaining balance of a deposit credit and marks it REFUNDED, recording that the \
+                    deposit is returned because its source document was cancelled after the deposit was taken.
+                    Use this tool on source cancellation (spec R7.4); do not use createDepositCredit, which \
+                    registers a new deposit, and note the cash disbursement itself is not performed here.
+                    Preconditions: the deposit credit must exist; a credit already REFUNDED is left unchanged, so \
+                    the call is idempotent.
+                    Required inputs: depositCreditId (UUID) as a path parameter; the reason query parameter is \
+                    optional and defaults to "source cancelled"; there is no request body.
+                    Emits an INVOICE_DEPOSIT_REFUND event and sets the credit's status to REFUNDED with a zero \
+                    remaining balance.
+                    Returns 200 with the refunded credit, and 404 when no deposit credit exists for the supplied id.
+                    """,
             tags = {"Deposit Credits"})
     @PostMapping("/{depositCreditId}/refund")
     @EmitEvent(id = "INVOICE_DEPOSIT_REFUND", apiVersion = "1")

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/ElevationController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/ElevationController.java
@@ -5,6 +5,8 @@ import com.positivity.invoice.internal.dto.ElevateResponse;
 import com.positivity.invoice.internal.exception.ElevationDeniedException;
 import com.positivity.invoice.internal.service.ElevationService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -48,14 +50,41 @@ public class ElevationController {
 
     @PostMapping("/elevate")
     @Operation(
-            summary = "Mint a manager-approval elevation token",
-            description =
-                    "Verifies the named manager (by employee number) holds invoice:finalize:override and mints"
-                            + " a short-lived token scoped to the given invoice, returned as the managerApprovalCode for finalize.")
+            operationId = "elevateManagerApproval",
+            summary = "Mint Manager-Approval Elevation Token",
+            description = """
+                    Mints a short-lived elevation token scoped to one invoice after verifying that the named manager \
+                    is an ACTIVE employee holding the invoice:finalize:override authority.
+                    Use this tool when an actor with invoice:finalize but not invoice:finalize:override needs a \
+                    managerApprovalCode for finalizeInvoice or revertInvoice; do not use finalizeInvoice directly \
+                    without a token when the invoice total exceeds the 500.00 service-advisor cap.
+                    Preconditions: the manager's employee number must resolve to an ACTIVE person in the local \
+                    employee replica and that person must hold invoice:finalize:override.
+                    Required inputs: managerEmployeeNumber and invoiceId (UUID); the token is bound to that invoice \
+                    only and expires after five minutes by default (invoice.elevation.token-ttl-seconds).
+                    No events are emitted; the token is signed and stateless, and the grant is audit-logged with the \
+                    approving manager's person id.
+                    Returns 200 with the token and its expiry, and 401 with an empty body when the employee number \
+                    is unknown or inactive or the person lacks the override authority.
+                    """)
     @ApiResponse(responseCode = "200", description = "Elevation token minted")
     @ApiResponse(responseCode = "400", description = "Invalid request")
     @ApiResponse(responseCode = "401", description = "Manager approval denied")
-    public ResponseEntity<ElevateResponse> elevate(@Valid @RequestBody @NonNull ElevateRequest request) {
+    public ResponseEntity<ElevateResponse> elevate(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Manager identification and the invoice the elevation token will authorize.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Elevation for one invoice", value = """
+                                                                    {"managerEmployeeNumber":"EMP-0001",
+                                                                     "invoiceId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a20"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    ElevateRequest request) {
         ElevateResponse response = elevationService.elevate(request.getManagerEmployeeNumber(), request.getInvoiceId());
         return ResponseEntity.ok(response);
     }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactController.java
@@ -35,10 +35,19 @@ public class InvoiceArtifactController {
         this.artifactService = artifactService;
     }
 
-    @Operation(
-            summary = "List the downloadable artifacts (documents) for an invoice",
-            description =
-                    "Returns the documents available for the invoice (the invoice itself and any receipts) as opaque, URL-safe artifact references with suggested file names and MIME types.")
+    @Operation(operationId = "listInvoiceArtifacts", summary = "List Downloadable Invoice Artifacts", description = """
+                    Returns the downloadable documents for an invoice — always the invoice document itself, plus one \
+                    entry per generated receipt — as opaque URL-safe artifact references with suggested file names \
+                    and application/pdf MIME types.
+                    Use this tool to discover artifactRefId values before minting a download token; do not use \
+                    downloadInvoiceArtifact directly, which requires a signed token from \
+                    createArtifactDownloadToken.
+                    Preconditions: the invoice must exist; receipts appear only after generateReceipt has created \
+                    them.
+                    Required inputs: invoiceId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no invoice exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Artifacts listed")
     @ApiResponse(responseCode = "404", description = "Invoice not found")
     @SecurityRequirement(name = "bearerAuth")
@@ -51,9 +60,21 @@ public class InvoiceArtifactController {
     }
 
     @Operation(
-            summary = "Create a short-lived download token for an invoice artifact",
-            description =
-                    "Issues a short-lived signed token bound to the invoice and artifact. The token is presented to the public download endpoint so a browser can fetch the file via a direct link.")
+            operationId = "createArtifactDownloadToken",
+            summary = "Create Artifact Download Token",
+            description = """
+                    Issues a short-lived signed token bound to one invoice artifact, so a browser can fetch the PDF \
+                    through the public download link without an Authorization header.
+                    Use this tool after listInvoiceArtifacts has supplied an artifactRefId; do not use \
+                    downloadInvoiceArtifact without a token — it rejects unsigned requests.
+                    Preconditions: the invoice must exist and the artifact reference must belong to that invoice \
+                    (an invoice ref must match the path invoice, a receipt ref must be one of its receipts).
+                    Required inputs: invoiceId (UUID) and artifactRefId (opaque reference from \
+                    listInvoiceArtifacts) as path parameters; there is no request body.
+                    No events are emitted and no record is stored; the token is stateless, signed, and expires after \
+                    300 seconds by default (invoice.artifacts.token-ttl-seconds).
+                    Returns 404 when the invoice does not exist or the artifact does not belong to it.
+                    """)
     @ApiResponse(responseCode = "200", description = "Token issued")
     @ApiResponse(responseCode = "404", description = "Invoice or artifact not found")
     @SecurityRequirement(name = "bearerAuth")

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactDownloadController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactDownloadController.java
@@ -33,10 +33,21 @@ public class InvoiceArtifactDownloadController {
         this.artifactService = artifactService;
     }
 
-    @Operation(
-            summary = "Download an invoice artifact as PDF using a signed download token",
-            description =
-                    "Streams the artifact as application/pdf. Public endpoint authorized solely by the signed download token (query parameter); intended for browser direct-download links.")
+    @Operation(operationId = "downloadInvoiceArtifact", summary = "Download Invoice Artifact as PDF", description = """
+                    Streams an invoice or receipt artifact as an application/pdf attachment, rendering it on demand \
+                    through the document service.
+                    Use this tool (or a browser direct link) with a token minted by createArtifactDownloadToken; \
+                    do not call it with a bearer token alone — the endpoint is public and authorized solely by the \
+                    signed download token.
+                    Preconditions: a valid unexpired download token bound to exactly this invoiceId and \
+                    artifactRefId, and the artifact must still belong to the invoice.
+                    Required inputs: invoiceId (UUID) and artifactRefId as path parameters plus the token query \
+                    parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only render of the stored document \
+                    data.
+                    Returns 403 when the token is missing, malformed, expired, or bound to a different artifact, and \
+                    404 when the invoice or artifact cannot be resolved.
+                    """)
     @ApiResponse(responseCode = "200", description = "PDF returned")
     @ApiResponse(responseCode = "403", description = "Missing, invalid, or expired token")
     @ApiResponse(responseCode = "404", description = "Invoice or artifact not found")

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceController.java
@@ -13,6 +13,8 @@ import com.positivity.shared.dto.InvoiceGenerationResponse;
 import com.positivity.shared.dto.OrderInvoiceCreationRequest;
 import com.positivity.shared.dto.OrderInvoiceResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -50,32 +52,97 @@ public class InvoiceController {
 
     @PostMapping
     @EmitEvent(id = "INVOICE_CREATE", apiVersion = "1")
-    @Operation(summary = "Create invoice", description = "Create invoice draft from completed workorder data")
+    @Operation(operationId = "createInvoice", summary = "Create Invoice Draft from Workorder", description = """
+                    Creates a DRAFT invoice from completed workorder data, pricing the supplied line items, \
+                    calculating draft tax against the shop location's jurisdiction, and assigning the permanent \
+                    invoice number immediately.
+                    Use this tool for workorder billing; do not use createInvoiceFromOrder, which fronts a sales \
+                    order at counter-sale checkout with order-authoritative totals.
+                    Preconditions: the workorder must be complete enough to bill; the call is idempotent on \
+                    workorderId — a replay returns the workorder's existing invoice instead of creating a duplicate.
+                    Required inputs: workorderId (UUID); estimateId, approvalId, locationId, customerId, \
+                    idempotencyKey and lineItems (description, quantity, unitPrice, amount, optional type) are \
+                    optional, and a missing lineItems list produces an empty zero-subtotal draft.
+                    Emits an INVOICE_CREATE event, persists the per-line tax breakdown, and publishes an \
+                    invoice-updated notification.
+                    Returns 201 with the invoice (existing or new), and 400 when workorderId is missing.
+                    """)
     @ApiResponse(responseCode = "201", description = "Invoice created")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"invoice:manage"})
     public ResponseEntity<InvoiceGenerationResponse> createInvoice(
-            @Valid @RequestBody @NonNull InvoiceCreationRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Workorder billing data the invoice draft is built from.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Workorder invoice draft", value = """
+                                                                    {"workorderId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a30",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a31",
+                                                                     "customerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a32",
+                                                                     "idempotencyKey":"inv-create-wo-1234",
+                                                                     "lineItems":[{"description":"Brake pad replacement",
+                                                                       "quantity":2.0,"unitPrice":45.00,
+                                                                       "amount":90.00,"type":"LABOR"}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    InvoiceCreationRequest request) {
         InvoiceGenerationResponse response = invoiceService.createInvoice(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PostMapping("/from-order")
     @EmitEvent(id = "INVOICE_CREATE_FROM_ORDER", apiVersion = "1")
-    @Operation(
-            summary = "Create invoice from a sales order",
-            description = "Create the invoice fronting a sales order at checkout (counter sale). Idempotent on "
-                    + "orderId — a replay returns the existing invoice with 200. When workorderId is present and a "
-                    + "workorder invoice already exists, that invoice is returned for tender instead of creating a "
-                    + "duplicate.")
+    @Operation(operationId = "createInvoiceFromOrder", summary = "Create Invoice from Sales Order", description = """
+                    Creates the DRAFT invoice fronting a sales order at counter-sale checkout, recording the order's \
+                    already-priced subtotal, tax and total verbatim — pos-order and pos-tax are authoritative, so \
+                    nothing is re-priced here.
+                    Use this tool at order checkout; do not use createInvoice, which builds and prices a draft from \
+                    workorder data.
+                    Preconditions: the order must carry final totals and at least one line; the call is idempotent \
+                    on orderId, and when workorderId is set an existing workorder invoice is returned for tender \
+                    instead of creating a duplicate.
+                    Required inputs: orderId (UUID), subtotal, taxAmount, totalAmount (non-negative) and lines; \
+                    customerId, locationId and the deposit fields are optional, but depositSourceType and \
+                    depositSourceId become mandatory when depositAmount is set.
+                    Emits an INVOICE_CREATE_FROM_ORDER event; a deposit take also registers a deposit credit \
+                    (idempotent on orderId), and a workorder settlement draws down available deposit credits, \
+                    reported as depositApplied.
+                    Returns 201 when a new invoice is created, 200 when an existing invoice is returned (orderId \
+                    replay or workorder dedupe), and 400 when totals are missing or negative, lines are empty, or \
+                    deposit fields are inconsistent.
+                    """)
     @ApiResponse(responseCode = "201", description = "Invoice created")
     @ApiResponse(responseCode = "200", description = "Existing invoice returned (replay or workorder dedupe)")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"invoice:manage"})
     public ResponseEntity<OrderInvoiceResponse> createInvoiceFromOrder(
-            @Valid @RequestBody @NonNull OrderInvoiceCreationRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Sales order snapshot — authoritative totals and sold lines — the invoice records.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Counter sale", value = """
+                                                                    {"orderId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a40",
+                                                                     "customerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a41",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a42",
+                                                                     "subtotal":120.00,"taxAmount":9.60,"totalAmount":129.60,
+                                                                     "lines":[{"orderLineId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a43",
+                                                                       "description":"Brake pad set","quantity":2,
+                                                                       "unitPrice":45.00,"amount":90.00,
+                                                                       "taxAmount":7.20,"type":"PART"}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    OrderInvoiceCreationRequest request) {
         OrderInvoiceResponse response = orderInvoiceService.createInvoiceForOrder(request);
         HttpStatus status = response.isExisting() ? HttpStatus.OK : HttpStatus.CREATED;
         return ResponseEntity.status(status).body(response);
@@ -83,11 +150,19 @@ public class InvoiceController {
 
     @PostMapping("/{invoiceId}/cancel")
     @EmitEvent(id = "INVOICE_CANCEL", apiVersion = "1")
-    @Operation(
-            summary = "Cancel a draft invoice",
-            description = "Terminal cancel of a DRAFT invoice before any money moved (order-void path). Rejected "
-                    + "with 409 when the invoice has left DRAFT or carries an authorized/captured payment. "
-                    + "Idempotent — cancelling a CANCELLED invoice returns 200.")
+    @Operation(operationId = "cancelInvoice", summary = "Cancel a Draft Invoice", description = """
+                    Cancels a DRAFT invoice terminally before any money has moved, the invoice-side effect of an \
+                    order void.
+                    Use this tool when an order is voided before tender; do not use revertInvoice, which returns a \
+                    FINALIZED invoice to DRAFT, and do not use it when payments exist — reverse those first through \
+                    voidPayment or refundPayment (order cancellation saga).
+                    Preconditions: the invoice must still be DRAFT and must carry no AUTHORIZED or CAPTURED payment \
+                    intent; cancelling an already CANCELLED invoice is an idempotent no-op.
+                    Required inputs: invoiceId (UUID) as a path parameter; there is no request body.
+                    Emits an INVOICE_CANCEL event and sets the invoice status to CANCELLED.
+                    Returns 200 when cancelled or already cancelled, 409 when the invoice has left DRAFT or carries \
+                    an authorized/captured payment, and 404 when the invoice does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Invoice cancelled (or already cancelled)")
     @ApiResponse(responseCode = "409", description = "Invoice not cancellable in its current state")
     @SecurityRequirement(
@@ -99,7 +174,16 @@ public class InvoiceController {
 
     @GetMapping("/{invoiceId}")
     @EmitEvent(id = "INVOICE_GET", apiVersion = "1")
-    @Operation(summary = "Get invoice", description = "Get invoice details")
+    @Operation(operationId = "getInvoice", summary = "Get Invoice Details", description = """
+                    Returns the full invoice detail — status, line items, adjustments, totals, tax breakdown, due \
+                    date and the resolved workorder number.
+                    Use this tool when the invoiceId is already known; use searchInvoices instead when locating an \
+                    invoice by number, customer name or workorder number.
+                    Preconditions: the invoice must exist.
+                    Required inputs: invoiceId (UUID) as a path parameter; there is no request body.
+                    Emits an INVOICE_GET audit event; no state changes — this is a read-only projection.
+                    Returns 404 when no invoice exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Invoice found")
     @SecurityRequirement(
             name = "bearerAuth",
@@ -110,47 +194,131 @@ public class InvoiceController {
 
     @PostMapping("/{invoiceId}/adjustments")
     @EmitEvent(id = "INVOICE_ADJUSTMENT_APPLY", apiVersion = "1")
-    @Operation(
-            summary = "Apply invoice adjustment",
-            description = "Apply discount, fee, correction, or warranty credit to a draft invoice")
+    @Operation(operationId = "applyInvoiceAdjustment", summary = "Apply Adjustment to Draft Invoice", description = """
+                    Applies a monetary adjustment (DISCOUNT, FEE, CORRECTION, or WARRANTY credit) to a DRAFT invoice \
+                    and recalculates its tax and total.
+                    Use this tool while the invoice is still DRAFT; do not use it after finalization — tax and \
+                    totals freeze there, so revertInvoice must return the invoice to DRAFT first.
+                    Preconditions: the invoice must exist and be in DRAFT status; a retry supplying the same type \
+                    and externalReference replays idempotently, returning the invoice without double-crediting.
+                    Required inputs: type, amount (greater than zero), reason, and authorizedBy; externalReference \
+                    is optional and correlates the adjustment to an external record such as a warranty settlement.
+                    Emits an INVOICE_ADJUSTMENT_APPLY event, replaces the persisted per-line tax breakdown, and \
+                    publishes an invoice-updated notification.
+                    Returns 200 with the recalculated invoice, 404 when the invoice does not exist, 409 when the \
+                    invoice has left DRAFT, and 400 when the type, amount, reason, or authorizedBy is missing or the \
+                    amount is not positive.
+                    """)
     @ApiResponse(responseCode = "200", description = "Adjustment applied")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"invoice:manage"})
     public ResponseEntity<InvoiceDetailsResponse> applyAdjustment(
-            @PathVariable @NonNull UUID invoiceId, @Valid @RequestBody @NonNull AdjustmentRequest request) {
+            @PathVariable @NonNull UUID invoiceId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Adjustment to add to the draft invoice, with its business justification.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Warranty credit", value = """
+                                                                    {"type":"WARRANTY","amount":25.00,
+                                                                     "reason":"Warranty settlement credit",
+                                                                     "authorizedBy":"jdoe",
+                                                                     "externalReference":"WC-2026-000042"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    AdjustmentRequest request) {
         return ResponseEntity.ok(invoiceService.applyAdjustment(invoiceId, request));
     }
 
     @PostMapping("/{invoiceId}/finalize")
     @EmitEvent(id = "INVOICE_FINALIZED", apiVersion = "1")
-    @Operation(
-            summary = "Finalize invoice",
-            description =
-                    "Transition invoice from DRAFT to FINALIZED; enforces permission matrix and emits InvoiceFinalized event for async GL posting (Story #13)")
+    @Operation(operationId = "finalizeInvoice", summary = "Finalize a Draft Invoice", description = """
+                    Transitions an invoice from DRAFT to FINALIZED: runs the committable tax calculation, freezes \
+                    tax, totals, payment terms and due date, then commits the provider tax document.
+                    Use this tool when the sale is ready to issue; do not use revertInvoice, which undoes a \
+                    finalization, and mint the managerApprovalCode with elevateManagerApproval when one is needed.
+                    Preconditions: the invoice must be DRAFT with tax already calculated; callers without \
+                    invoice:finalize:override (or a manager/admin role) need a valid elevation token as \
+                    managerApprovalCode when the stored total exceeds 500.00.
+                    Required inputs: invoiceId (UUID) as a path parameter; managerApprovalCode and overrideReason in \
+                    the body are optional below the cap and for override holders.
+                    Emits an INVOICE_FINALIZED event and publishes the async accounting event that drives GL \
+                    posting; the tax commit tolerates a provider outage by recording PENDING_COMMIT in pos-tax for \
+                    the re-commit job, and is skipped entirely when nothing is taxable.
+                    Returns 200 with the finalized invoice, 404 when the invoice does not exist, 409 when the \
+                    invoice is not DRAFT or tax has not been calculated, and 400 when a required managerApprovalCode \
+                    is missing, invalid, or expired.
+                    """)
     @ApiResponse(responseCode = "200", description = "Invoice finalized")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"invoice:finalize"})
     @PreAuthorize("hasAuthority('invoice:finalize')")
     public ResponseEntity<InvoiceDetailsResponse> finalizeInvoice(
-            @PathVariable @NonNull UUID invoiceId, @Valid @RequestBody @NonNull FinalizationRequest request) {
+            @PathVariable @NonNull UUID invoiceId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Optional manager-approval material for finalizations above the amount cap.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Finalize with manager approval",
+                                                            value = """
+                                                                    {"managerApprovalCode":"MGR-ELEV-TOKEN-abc123",
+                                                                     "overrideReason":"Customer pre-approved by branch manager"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    FinalizationRequest request) {
         return ResponseEntity.ok(invoiceFinalizationService.completeInvoice(invoiceId, request));
     }
 
     @PostMapping("/{invoiceId}/revert")
     @EmitEvent(id = "INVOICE_DRAFT_REVERT", apiVersion = "1")
-    @Operation(
-            summary = "Revert finalized invoice",
-            description =
-                    "Revert a FINALIZED invoice back to DRAFT within 24h of finalization and before GL posting (Story #13, AC6)")
+    @Operation(operationId = "revertInvoice", summary = "Revert Finalized Invoice to Draft", description = """
+                    Reverts a FINALIZED invoice back to DRAFT within 24 hours of finalization, before GL posting has \
+                    made it immutable, and voids the provider tax document committed at finalization.
+                    Use this tool to correct a wrongly finalized invoice; do not use cancelInvoice, which \
+                    terminally cancels a DRAFT invoice on the order-void path.
+                    Preconditions: the invoice must be FINALIZED (POSTED is immutable), less than 24 hours must have \
+                    elapsed since finalizedAt, and callers without invoice:finalize:override (or a manager/admin \
+                    role) must supply a valid elevation token from elevateManagerApproval as managerApprovalCode.
+                    Required inputs: invoiceId (UUID) as a path parameter plus managerApprovalCode and a reason in \
+                    the body; the reverting actor and approving manager are captured for audit.
+                    Emits an INVOICE_DRAFT_REVERT event, publishes an invoice-updated notification, and issues a tax \
+                    void toward pos-tax for the reverted document.
+                    Returns 200 with the DRAFT invoice, 404 when the invoice does not exist, 409 when it is POSTED, \
+                    not FINALIZED, or the 24-hour window has expired, and 400 when the approval code is blank, \
+                    invalid, or expired.
+                    """)
     @ApiResponse(responseCode = "200", description = "Invoice reverted to DRAFT")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"invoice:finalize"})
     @PreAuthorize("hasAuthority('invoice:finalize')")
     public ResponseEntity<InvoiceDetailsResponse> revertInvoice(
-            @PathVariable @NonNull UUID invoiceId, @Valid @RequestBody @NonNull RevertRequest request) {
+            @PathVariable @NonNull UUID invoiceId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Manager approval and business reason authorizing the reversion.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Revert with approval", value = """
+                                                                    {"managerApprovalCode":"MGR-ELEV-TOKEN-abc123",
+                                                                     "reason":"Incorrect line item billed"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    RevertRequest request) {
         return ResponseEntity.ok(
                 invoiceFinalizationService.revert(invoiceId, request.getManagerApprovalCode(), request.getReason()));
     }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
@@ -46,10 +46,18 @@ public class InvoiceSearchController {
     /** Hard cap on page size so a caller cannot request an unbounded enrichment fan-out. */
     private static final int MAX_PAGE_SIZE = 50;
 
-    @Operation(
-            summary = "Search invoices",
-            description = "Paginated free-text search for invoices matching the invoice number, "
-                    + "customer name, or workorder number.")
+    @Operation(operationId = "searchInvoices", summary = "Search Invoices by Free Text", description = """
+                    Searches invoices by a free-text term matched against the invoice number, the customer name \
+                    (resolved via the customer service), or the workorder number, returning a page of finder rows.
+                    Use this tool to locate an invoice when its id is unknown; use getInvoice instead once the \
+                    invoiceId is known, and searchInvoiceLines for line-level warranty correlation.
+                    Preconditions: none — but a blank or missing q short-circuits to an empty page rather than \
+                    listing all invoices.
+                    Required inputs: q (free-text term) plus optional page, size and sort parameters; size defaults \
+                    to 25, is hard-capped at 50, and the default sort is createdAt descending.
+                    Emits an INVOICE_SEARCH audit event; no state changes — this is a read-only projection.
+                    Returns 400 when pagination parameters are malformed.
+                    """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Page of invoice search results returned."),
         @ApiResponse(
@@ -77,12 +85,18 @@ public class InvoiceSearchController {
         return invoiceSearchService.search(q == null ? "" : q.trim(), capPageSize(pageable));
     }
 
-    @Operation(
-            summary = "Search invoice line items by customer party",
-            description = "Returns invoice line items belonging to the given customer party, "
-                    + "optionally narrowed by a SKU/description term, flattened with the owning "
-                    + "invoice's number, status, and creation time. Newest invoice first, bounded "
-                    + "to the newest 200 lines. Built for warranty-claim correlation.")
+    @Operation(operationId = "searchInvoiceLines", summary = "Search Invoice Lines by Party", description = """
+                    Returns invoice line items belonging to one customer party, flattened with the owning invoice's \
+                    number, status and creation time, newest invoice first and bounded to the newest 200 lines; \
+                    built for warranty-claim origin-line correlation.
+                    Use this tool to find the invoice line a warranty claim originates from; use searchInvoices \
+                    instead for invoice-level free-text search.
+                    Preconditions: none — an unknown party simply returns an empty list.
+                    Required inputs: partyId (UUID) query parameter; q is an optional SKU or description term \
+                    narrowing the lines.
+                    Emits an INVOICE_ITEM_SEARCH audit event; no state changes — this is a read-only projection.
+                    Returns 400 when partyId is missing or malformed.
+                    """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "List of matching invoice line items returned."),
         @ApiResponse(

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/PaymentController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/PaymentController.java
@@ -7,6 +7,8 @@ import com.positivity.invoice.internal.dto.InitiatePaymentRequest;
 import com.positivity.invoice.internal.dto.InitiatePaymentResponse;
 import com.positivity.invoice.service.PaymentService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -59,16 +61,45 @@ public class PaymentController {
     @PostMapping("/{invoiceId}/payments")
     @ResponseStatus(HttpStatus.CREATED)
     @EmitEvent(id = "INVOICE_PAYMENT_INITIATE", apiVersion = "1")
-    @Operation(
-            summary = "Initiate card payment",
-            description = "Initiate a SALE_CAPTURE or AUTH_ONLY card payment against an invoice")
+    @Operation(operationId = "initiatePayment", summary = "Initiate Card Payment on Invoice", description = """
+                    Initiates a card payment against an invoice through the payment gateway, creating a payment \
+                    intent that is CAPTURED immediately (SALE_CAPTURE) or left AUTHORIZED as a hold (AUTH_ONLY).
+                    Use this tool to take card tender; do not use capturePayment, which settles an existing \
+                    AUTH_ONLY hold rather than starting a new payment.
+                    Preconditions: the invoice must exist; the caller needs the PROCESS_PAYMENT authority, plus \
+                    OVERRIDE_PAYMENT_LIMIT when the amount exceeds 500.00 and SELECT_PAYMENT_FLOW to choose \
+                    AUTH_ONLY.
+                    Required inputs: paymentFlow (SALE_CAPTURE or AUTH_ONLY), amount (positive), idempotencyKey and \
+                    paymentToken (tokenised card reference, never a PAN); a replayed idempotencyKey with an \
+                    identical payload returns the existing intent instead of charging twice.
+                    Emits an INVOICE_PAYMENT_INITIATE event and records the gateway result on the intent.
+                    Returns 201 with the intent, 404 when the invoice does not exist, 409 when the idempotencyKey \
+                    was already used with a different payload, 422 when the gateway declines, and 403 when a \
+                    required payment authority is missing.
+                    """)
     @ApiResponse(responseCode = "201", description = "Payment intent created")
     @ApiResponse(responseCode = "400", description = "Invalid or missing required fields")
     @ApiResponse(responseCode = "403", description = "Insufficient permissions")
     @ApiResponse(responseCode = "422", description = "Payment method declined")
     @ApiResponse(responseCode = "503", description = "Payment gateway unavailable")
     public InitiatePaymentResponse initiatePayment(
-            @PathVariable @NonNull UUID invoiceId, @Valid @RequestBody @NonNull InitiatePaymentRequest request) {
+            @PathVariable @NonNull UUID invoiceId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Card tender details: flow, amount, idempotency key and tokenised card reference.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "One-step sale capture", value = """
+                                                                    {"paymentFlow":"SALE_CAPTURE","amount":149.99,
+                                                                     "idempotencyKey":"idem-018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a50",
+                                                                     "paymentToken":"tok_1NXyZ2eZvKYlo2Cabc12345"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    InitiatePaymentRequest request) {
         return paymentService.initiatePayment(invoiceId, request);
     }
 
@@ -82,16 +113,42 @@ public class PaymentController {
      */
     @PostMapping("/{invoiceId}/payments/{paymentId}/capture")
     @EmitEvent(id = "INVOICE_PAYMENT_CAPTURE", apiVersion = "1")
-    @Operation(
-            summary = "Capture authorized payment hold",
-            description = "Capture all or part of a previously authorized invoice payment hold")
+    @Operation(operationId = "capturePayment", summary = "Capture Authorized Payment Hold", description = """
+                    Captures all or part of a previously authorized AUTH_ONLY payment hold at the gateway; when the \
+                    captured amount is below the authorized amount, the remainder of the hold is voided.
+                    Use this tool to settle an existing AUTHORIZED intent; do not use initiatePayment, which starts \
+                    a new payment, and use voidPayment instead to release the hold without taking funds.
+                    Preconditions: the payment intent must belong to the invoice and be in AUTHORIZED status; the \
+                    caller needs the MANUAL_CAPTURE authority.
+                    Required inputs: amount (positive, up to the authorized amount) and captureIdempotencyKey, which \
+                    is forwarded to the gateway so a retried capture settles at most once.
+                    Emits an INVOICE_PAYMENT_CAPTURE event; the intent moves to CAPTURED on success or \
+                    CAPTURE_FAILED on decline, and an ambiguous gateway response is resolved by a status inquiry \
+                    before failing.
+                    Returns 200 with the captured intent, 404 when the intent does not exist under the invoice, 409 \
+                    when the intent is not AUTHORIZED, 422 when the gateway declines the capture, and 403 when the \
+                    MANUAL_CAPTURE authority is missing.
+                    """)
     @ApiResponse(responseCode = "200", description = "Payment captured")
     @ApiResponse(responseCode = "403", description = "Insufficient permissions")
     @ApiResponse(responseCode = "404", description = "Payment intent not found")
     public InitiatePaymentResponse capturePayment(
             @PathVariable @NonNull UUID invoiceId,
             @PathVariable @NonNull UUID paymentId,
-            @Valid @RequestBody @NonNull CaptureAmountRequest body) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Amount to settle from the authorized hold and the capture idempotency key.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Partial capture", value = """
+                                                                    {"amount":89.99,
+                                                                     "captureIdempotencyKey":"capture-018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a51"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    CaptureAmountRequest body) {
         return paymentService.capturePayment(invoiceId, paymentId, body.amount(), body.captureIdempotencyKey());
     }
 

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/PaymentReversalController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/PaymentReversalController.java
@@ -11,6 +11,8 @@ import com.positivity.invoice.internal.enums.VoidReason;
 import com.positivity.invoice.service.PaymentReversalService;
 import com.positivity.invoice.service.RefundPaymentResult;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -47,9 +49,22 @@ public class PaymentReversalController {
 
     @PostMapping("/{invoiceId}/payments/{paymentId}/void")
     @EmitEvent(id = "INVOICE_PAYMENT_VOID", apiVersion = "1")
-    @Operation(
-            summary = "Void authorized payment",
-            description = "Void a previously authorized invoice payment before it is captured")
+    @Operation(operationId = "voidPayment", summary = "Void Authorized Payment Hold", description = """
+                    Voids a previously authorized invoice payment hold at the gateway before it is captured, \
+                    releasing the customer's funds without any money movement.
+                    Use this tool on an AUTHORIZED hold; do not use refundPayment, which returns funds from a \
+                    payment that was already CAPTURED.
+                    Preconditions: the payment intent must belong to the invoice and be AUTHORIZED, the caller needs \
+                    the VOID_PAYMENT authority, and less than 24 hours may have elapsed since authorization unless \
+                    the caller also holds SUPERVISOR_OVERRIDE.
+                    Required inputs: reason (CUSTOMER_REQUEST, DUPLICATE_AUTHORIZATION, ENTRY_ERROR, \
+                    FRAUD_PREVENTION, MANAGER_DISCRETION or OTHER); notes are optional free text.
+                    Emits an INVOICE_PAYMENT_VOID event, moves the intent to VOIDED, and publishes a payment-voided \
+                    notification.
+                    Returns 200 with an empty body on success, 404 when the intent does not exist under the invoice, \
+                    409 when the intent is not AUTHORIZED, 422 when the 24-hour void window has expired, and 500 \
+                    when the gateway rejects the void.
+                    """)
     @ApiResponse(responseCode = "200", description = "Payment voided")
     @ApiResponse(responseCode = "404", description = "Payment intent not found")
     @ApiResponse(responseCode = "409", description = "Invalid payment state")
@@ -57,16 +72,45 @@ public class PaymentReversalController {
     public ResponseEntity<Void> voidPayment(
             @PathVariable @NonNull UUID invoiceId,
             @PathVariable @NonNull UUID paymentId,
-            @Valid @RequestBody @NonNull VoidPaymentRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Reason and optional notes explaining why the authorization is released.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Customer cancelled", value = """
+                                                                    {"reason":"CUSTOMER_REQUEST",
+                                                                     "notes":"Customer cancelled before pickup"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    VoidPaymentRequest request) {
         paymentReversalService.voidPayment(invoiceId, paymentId, request.reason(), request.notes());
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/{invoiceId}/payments/{paymentId}/refunds")
     @EmitEvent(id = "INVOICE_PAYMENT_REFUND", apiVersion = "1")
-    @Operation(
-            summary = "Refund captured payment",
-            description = "Create a refund for a captured invoice payment and record the refund details")
+    @Operation(operationId = "refundPayment", summary = "Refund a Captured Payment", description = """
+                    Refunds all or part of a CAPTURED invoice payment through the gateway and records the refund \
+                    against the payment intent.
+                    Use this tool when the original card payment lives in this system; do not use voidPayment, \
+                    which releases an uncaptured hold, and use createStandaloneInvoiceRefund instead when the \
+                    original payment is not on file.
+                    Preconditions: the payment intent must belong to the invoice and be CAPTURED, the caller needs \
+                    the REFUND_PAYMENT authority, less than 180 days may have elapsed since capture unless the \
+                    caller holds SUPERVISOR_OVERRIDE, and cumulative refunds may not exceed the captured amount.
+                    Required inputs: amount (positive) and reason (a RefundReason such as CUSTOMER_RETURN or \
+                    SERVICE_ERROR); notes and externalReference are optional, and a retry replaying the same \
+                    externalReference returns the existing refund instead of paying twice.
+                    Emits an INVOICE_PAYMENT_REFUND event and publishes a payment-refunded notification on success; \
+                    a gateway failure is persisted as a FAILED refund record, so callers must read the returned \
+                    status rather than treating 201 as completed.
+                    Returns 201 with the refund record, 404 when the intent does not exist under the invoice, 409 \
+                    when the intent is not CAPTURED, and 422 when the 180-day window has expired or the amount \
+                    exceeds the remaining refundable balance.
+                    """)
     @ApiResponse(responseCode = "201", description = "Refund created")
     @ApiResponse(responseCode = "404", description = "Payment intent not found")
     @ApiResponse(responseCode = "409", description = "Invalid payment state")
@@ -74,7 +118,22 @@ public class PaymentReversalController {
     public ResponseEntity<RefundPaymentResponse> refundPayment(
             @PathVariable @NonNull UUID invoiceId,
             @PathVariable @NonNull UUID paymentId,
-            @Valid @RequestBody @NonNull RefundPaymentRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Refund amount, business reason and optional external correlation for the captured payment.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Partial return refund", value = """
+                                                                    {"amount":25.00,"reason":"CUSTOMER_RETURN",
+                                                                     "notes":"Returned damaged part",
+                                                                     "externalReference":"WC-2026-000042"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    RefundPaymentRequest request) {
         var saved = paymentReversalService.refundPayment(
                 invoiceId, paymentId, request.amount(), request.reason(), request.notes(), request.externalReference());
 
@@ -96,11 +155,16 @@ public class PaymentReversalController {
     @GetMapping("/{invoiceId}/refunds")
     @PreAuthorize("hasAuthority('invoice:manage')")
     @EmitEvent(id = "INVOICE_REFUND_LIST", apiVersion = "1")
-    @Operation(
-            summary = "List refunds for an invoice",
-            description = "Return every refund record anchored to the invoice — payment-intent refunds whose"
-                    + " intent belongs to the invoice and standalone invoice-anchored refunds alike —"
-                    + " for warranty settlement reconciliation")
+    @Operation(operationId = "listInvoiceRefunds", summary = "List Refunds for an Invoice", description = """
+                    Returns every refund record anchored to the invoice — refunds of captured payment intents and \
+                    standalone invoice-anchored refunds alike — for warranty-settlement reconciliation.
+                    Use this tool to reconcile what has already been returned before issuing another refund; do not \
+                    use refundPayment or createStandaloneInvoiceRefund, which create refunds rather than list them.
+                    Preconditions: the invoice must exist; the caller needs the invoice:manage authority.
+                    Required inputs: invoiceId (UUID) as a path parameter; there is no request body or filtering.
+                    Emits an INVOICE_REFUND_LIST audit event; no state changes — this is a read-only projection.
+                    Returns 404 when no invoice exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Refund records returned")
     @ApiResponse(responseCode = "404", description = "Invoice not found")
     public List<InvoiceRefundResponse> listRefunds(@PathVariable @NonNull UUID invoiceId) {

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/ReceiptController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/ReceiptController.java
@@ -8,6 +8,8 @@ import com.positivity.invoice.internal.enums.ReceiptDeliveryStatus;
 import com.positivity.invoice.service.Receipt;
 import com.positivity.invoice.service.ReceiptService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,13 +44,41 @@ public class ReceiptController {
     @PostMapping("/{invoiceId}/receipts")
     @ResponseStatus(HttpStatus.CREATED)
     @EmitEvent(id = "INVOICE_RECEIPT_GENERATE", apiVersion = "1")
-    @Operation(
-            summary = "Generate invoice receipt",
-            description = "Generate a receipt for an invoice payment using the requested terminal and template")
+    @Operation(operationId = "generateReceipt", summary = "Generate Receipt for Invoice Payment", description = """
+                    Generates a receipt record for an invoice payment, assigning a unique reference built from the \
+                    invoice number, a UTC timestamp and a per-invoice sequence, with the cashier taken from the \
+                    security context.
+                    Use this tool once per payment after tender; do not use reprintReceipt, which duplicates a \
+                    receipt that already exists.
+                    Preconditions: the invoice and payment intent must exist, the intent must belong to the \
+                    invoice, and the caller needs the GENERATE_RECEIPT authority.
+                    Required inputs: paymentIntentId (UUID), terminalId, templateId and templateVersion.
+                    Emits an INVOICE_RECEIPT_GENERATE event and stores the receipt in GENERATED status with a zero \
+                    reprint count; the receipt also becomes a downloadable artifact of the invoice.
+                    Returns 201 with the receipt reference, 404 when the invoice or payment intent does not exist \
+                    or the intent belongs to a different invoice, and 403 when the GENERATE_RECEIPT authority is \
+                    missing.
+                    """)
     @ApiResponse(responseCode = "201", description = "Receipt generated")
     @ApiResponse(responseCode = "404", description = "Invoice not found")
     public ResponseEntity<ReceiptResponse> generateReceipt(
-            @PathVariable @NonNull UUID invoiceId, @Valid @RequestBody @NonNull GenerateReceiptRequest request) {
+            @PathVariable @NonNull UUID invoiceId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Payment, terminal and template identifying what the receipt documents.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Counter receipt", value = """
+                                                                    {"paymentIntentId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a60",
+                                                                     "terminalId":"TERM-001",
+                                                                     "templateId":"RECEIPT_DEFAULT",
+                                                                     "templateVersion":"1"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    GenerateReceiptRequest request) {
         Receipt receipt = receiptService.generateReceipt(
                 invoiceId,
                 request.paymentIntentId(),
@@ -61,16 +91,38 @@ public class ReceiptController {
     @PostMapping("/{invoiceId}/receipts/{receiptId}/reprint")
     @ResponseStatus(HttpStatus.OK)
     @EmitEvent(id = "INVOICE_RECEIPT_REPRINT", apiVersion = "1")
-    @Operation(
-            summary = "Reprint invoice receipt",
-            description = "Create a reprint of an existing receipt and record the reason for the reprint")
+    @Operation(operationId = "reprintReceipt", summary = "Reprint an Existing Receipt", description = """
+                    Records a reprint of an existing receipt, incrementing its reprint count and capturing the \
+                    reason and the reprinting actor for audit.
+                    Use this tool when a customer needs a duplicate copy; do not use generateReceipt, which creates \
+                    a new receipt for a payment that has none yet.
+                    Preconditions: the receipt must exist, and its reprint count must be below 5 unless the caller \
+                    holds the SUPERVISOR_OVERRIDE authority.
+                    Required inputs: receiptId (UUID) as a path parameter and a non-blank reason in the body.
+                    Emits an INVOICE_RECEIPT_REPRINT event and updates the receipt's reprint count, last reprint \
+                    reason and last reprinted-by.
+                    Returns 200 with the receipt, 404 when the receipt does not exist, and 409 when the reprint \
+                    limit of 5 is exceeded without a supervisor override.
+                    """)
     @ApiResponse(responseCode = "200", description = "Receipt reprinted")
     @ApiResponse(responseCode = "404", description = "Receipt not found")
     @ApiResponse(responseCode = "409", description = "Reprint limit exceeded")
     public ResponseEntity<ReceiptResponse> reprintReceipt(
             @PathVariable @NonNull UUID invoiceId,
             @PathVariable @NonNull UUID receiptId,
-            @Valid @RequestBody @NonNull ReprintReceiptRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Business reason the duplicate copy is being produced.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Duplicate copy", value = """
+                                                                    {"reason":"Customer requested a duplicate copy"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    ReprintReceiptRequest request) {
         Receipt receipt = receiptService.reprintReceipt(receiptId, request.reason());
         return ResponseEntity.ok(toResponse(receipt));
     }
@@ -78,14 +130,39 @@ public class ReceiptController {
     @PostMapping("/{invoiceId}/receipts/{receiptId}/print")
     @EmitEvent(id = "INVOICE_RECEIPT_PRINT_DELIVERY", apiVersion = "1")
     @Operation(
-            summary = "Record printed receipt delivery",
-            description = "Record the delivery status for a printed receipt associated with an invoice")
+            operationId = "recordReceiptPrintDelivery",
+            summary = "Record Printed Receipt Delivery Status",
+            description = """
+                    Records the outcome of printing a receipt at the terminal, stamping the receipt's delivery \
+                    method as PRINT with the reported status; the physical printing itself happens client-side, not \
+                    here.
+                    Use this tool after the terminal reports its print result; do not use recordReceiptEmailDelivery, \
+                    which records an email delivery attempt with its recipient address.
+                    Preconditions: the receipt must already exist via generateReceipt.
+                    Required inputs: receiptId (UUID) as a path parameter and status (SUCCESS or FAILED) in the \
+                    body.
+                    Emits an INVOICE_RECEIPT_PRINT_DELIVERY event and overwrites the receipt's delivery method and \
+                    status.
+                    Returns 200 with an empty body on success, and 404 when the receipt does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Print delivery recorded")
     @ApiResponse(responseCode = "404", description = "Receipt not found")
     public ResponseEntity<Void> recordPrintDelivery(
             @PathVariable @NonNull UUID invoiceId,
             @PathVariable @NonNull UUID receiptId,
-            @RequestBody @Valid @NonNull PrintDeliveryRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Print outcome reported by the terminal.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Successful print", value = """
+                                                                    {"status":"SUCCESS"}
+                                                                    """)))
+                    @RequestBody
+                    @Valid
+                    @NonNull
+                    PrintDeliveryRequest request) {
         receiptService.recordPrintDelivery(receiptId, request.status());
         return ResponseEntity.ok().build();
     }
@@ -93,14 +170,40 @@ public class ReceiptController {
     @PostMapping("/{invoiceId}/receipts/{receiptId}/email")
     @EmitEvent(id = "INVOICE_RECEIPT_EMAIL_DELIVERY", apiVersion = "1")
     @Operation(
-            summary = "Email invoice receipt",
-            description = "Send an invoice receipt by email and record the delivery status for the attempt")
+            operationId = "recordReceiptEmailDelivery",
+            summary = "Record Emailed Receipt Delivery Status",
+            description = """
+                    Records the outcome of emailing a receipt to a customer, stamping the receipt's delivery method \
+                    as EMAIL with the recipient address and the reported status; this endpoint records the attempt \
+                    rather than dispatching the email itself.
+                    Use this tool after an email delivery attempt completes; do not use recordReceiptPrintDelivery, \
+                    which records a terminal print outcome.
+                    Preconditions: the receipt must already exist via generateReceipt.
+                    Required inputs: receiptId (UUID) as a path parameter plus emailAddress and status (SUCCESS or \
+                    FAILED) in the body.
+                    Emits an INVOICE_RECEIPT_EMAIL_DELIVERY event and overwrites the receipt's delivery method, \
+                    address and status.
+                    Returns 200 with an empty body on success, and 404 when the receipt does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Email delivery recorded")
     @ApiResponse(responseCode = "404", description = "Receipt not found")
     public ResponseEntity<Void> sendEmailReceipt(
             @PathVariable @NonNull UUID invoiceId,
             @PathVariable @NonNull UUID receiptId,
-            @RequestBody @Valid @NonNull EmailDeliveryRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Recipient address and outcome of the email delivery attempt.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Successful email", value = """
+                                                                    {"emailAddress":"customer@example.com",
+                                                                     "status":"SUCCESS"}
+                                                                    """)))
+                    @RequestBody
+                    @Valid
+                    @NonNull
+                    EmailDeliveryRequest request) {
         receiptService.sendEmailReceipt(receiptId, request.emailAddress(), request.status());
         return ResponseEntity.ok().build();
     }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/StandaloneRefundController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/StandaloneRefundController.java
@@ -9,6 +9,8 @@ import com.positivity.invoice.internal.enums.RefundReason;
 import com.positivity.invoice.service.PaymentReversalService;
 import com.positivity.invoice.service.RefundPaymentResult;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -54,14 +56,46 @@ public class StandaloneRefundController {
     @PostMapping("/invoices/{invoiceId}/refunds")
     @EmitEvent(id = "INVOICE_STANDALONE_REFUND", apiVersion = "1")
     @Operation(
-            summary = "Record standalone refund for an invoice",
-            description = "Record a refund against an invoice whose original payment is not in the system;"
-                    + " the disbursement itself happens out of band")
+            operationId = "createStandaloneInvoiceRefund",
+            summary = "Record Standalone Invoice Refund",
+            description = """
+                    Records a refund against an invoice whose original payment is not in this system — \
+                    predecessor-system sales, pre-deploy invoices, vendor-paid warranty work — while the cash \
+                    disbursement itself happens out of band (till, check, or vendor payment).
+                    Use this tool only when no captured payment intent exists to refund; do not use refundPayment, \
+                    which reverses a CAPTURED gateway payment, and use createStandalonePartyRefund instead when no \
+                    invoice is on file at all.
+                    Preconditions: the invoice must exist, the caller needs the finance-only ISSUE_MANUAL_REFUND \
+                    authority, and cumulative refunds across payment-anchored and standalone records may not exceed \
+                    the invoice total.
+                    Required inputs: amount (positive) and reason (a RefundReason such as CUSTOMER_RETURN); notes \
+                    and externalReference are optional, and a retry replaying the same externalReference returns \
+                    the existing record instead of double-recording.
+                    Emits an INVOICE_STANDALONE_REFUND event and stores a COMPLETED refund record anchored to the \
+                    invoice; no gateway call is made.
+                    Returns 201 with the refund record, 404 when the invoice does not exist, and 422 when the \
+                    amount exceeds the invoice's remaining refundable balance.
+                    """)
     @ApiResponse(responseCode = "201", description = "Refund recorded")
     @ApiResponse(responseCode = "404", description = "Invoice not found")
     @ApiResponse(responseCode = "422", description = "Insufficient refundable amount")
     public ResponseEntity<RefundPaymentResponse> refundInvoiceStandalone(
-            @PathVariable @NonNull UUID invoiceId, @Valid @RequestBody @NonNull StandaloneRefundRequest request) {
+            @PathVariable @NonNull UUID invoiceId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Out-of-band refund to record against the invoice.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Walk-in warranty refund", value = """
+                                                                    {"amount":25.00,"reason":"CUSTOMER_RETURN",
+                                                                     "notes":"Walk-in warranty claim on a predecessor-system cash sale",
+                                                                     "externalReference":"WC-2026-000042"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    StandaloneRefundRequest request) {
         RefundPaymentResult saved = paymentReversalService.refundInvoiceStandalone(
                 invoiceId, request.amount(), request.reason(), request.notes(), request.externalReference());
         return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(saved));
@@ -70,13 +104,43 @@ public class StandaloneRefundController {
     @PostMapping("/refunds")
     @EmitEvent(id = "INVOICE_PARTY_STANDALONE_REFUND", apiVersion = "1")
     @Operation(
-            summary = "Record standalone refund for a customer party",
-            description = "Record a refund anchored to a customer party when no invoice exists in the system;"
-                    + " the disbursement itself happens out of band")
+            operationId = "createStandalonePartyRefund",
+            summary = "Record Standalone Party Refund",
+            description = """
+                    Records a refund anchored directly to a customer party when no invoice exists in this system, \
+                    such as a vendor-paid warranty settlement on a predecessor-system sale; the cash disbursement \
+                    itself happens out of band.
+                    Use this tool only when there is no invoice to anchor to; use createStandaloneInvoiceRefund \
+                    instead when an invoice is on file, and refundPayment when the captured payment itself exists.
+                    Preconditions: the caller needs the finance-only ISSUE_MANUAL_REFUND authority; because there is \
+                    no invoice, no refundable-amount cap applies.
+                    Required inputs: partyId (non-blank, max 64 characters), amount (positive) and reason (a \
+                    RefundReason); notes and externalReference are optional, and a retry replaying the same \
+                    externalReference among the party's purely party-anchored records returns the existing record.
+                    Emits an INVOICE_PARTY_STANDALONE_REFUND event and stores a COMPLETED refund record anchored to \
+                    the party; no gateway call is made.
+                    Returns 201 with the refund record, and 400 when partyId is blank.
+                    """)
     @ApiResponse(responseCode = "201", description = "Refund recorded")
     @ApiResponse(responseCode = "400", description = "Missing party anchor")
     public ResponseEntity<RefundPaymentResponse> refundPartyStandalone(
-            @Valid @RequestBody @NonNull PartyStandaloneRefundRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Out-of-band refund to record against a customer party with no invoice on file.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Vendor-paid settlement", value = """
+                                                                    {"partyId":"party-000123","amount":25.00,
+                                                                     "reason":"CUSTOMER_RETURN",
+                                                                     "notes":"Vendor-paid warranty settlement, no invoice on file",
+                                                                     "externalReference":"WC-2026-000042"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    PartyStandaloneRefundRequest request) {
         RefundPaymentResult saved = paymentReversalService.refundPartyStandalone(
                 request.partyId(), request.amount(), request.reason(), request.notes(), request.externalReference());
         return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(saved));

--- a/pos-mcp-server/.flattened-pom.xml
+++ b/pos-mcp-server/.flattened-pom.xml
@@ -21,6 +21,8 @@
   </licenses>
   <properties>
     <maven.compiler.target>25</maven.compiler.target>
+    <jacoco.branch.min>0.63</jacoco.branch.min>
+    <jacoco.line.min>0.75</jacoco.line.min>
     <java.version>25</java.version>
     <maven.compiler.source>25</maven.compiler.source>
   </properties>

--- a/pos-mcp-server/openapi.yaml
+++ b/pos-mcp-server/openapi.yaml
@@ -23,9 +23,21 @@ paths:
     get:
       tags:
       - System Prompts
-      summary: Get system prompt
-      description: Retrieve a single MCP system prompt by its identifier
-      operationId: get
+      summary: Get an MCP System Prompt
+      description: 'Returns a single MCP system prompt by its identifier, including its full content.
+
+        Use this tool when the prompt id (UUID) is already known; use listSystemPrompts instead to discover ids or find a prompt by name.
+
+        Preconditions: a system prompt with the given id must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no system prompt exists for the supplied id.
+
+        '
+      operationId: getSystemPrompt
       parameters:
       - name: id
         in: path
@@ -54,9 +66,21 @@ paths:
     put:
       tags:
       - System Prompts
-      summary: Update system prompt
-      description: Update an existing MCP system prompt by replacing its editable fields
-      operationId: update
+      summary: Update an MCP System Prompt
+      description: 'Replaces the name and content of an existing MCP system prompt.
+
+        Use this tool to edit prompt text or rename a prompt; do not use createSystemPrompt, which adds a new prompt alongside the existing ones.
+
+        Preconditions: the prompt must exist, and when the name is being changed no other prompt may already use the new name.
+
+        Required inputs: id (UUID) as a path parameter plus name and content in the body; both body fields are mandatory and fully replace the stored values.
+
+        Emits a MCP_SYSTEM_PROMPT_UPDATE event and invalidates cached agents built from the prompt so subsequent chats use the new content.
+
+        Returns 200 with the updated prompt, 404 when no prompt exists for the id, and 400 when the new name is already used by another prompt.
+
+        '
+      operationId: updateSystemPrompt
       parameters:
       - name: id
         in: path
@@ -65,10 +89,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Full replacement name and content for the stored prompt.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SystemPromptRequest'
+            examples:
+              Revised assistant prompt:
+                description: Revised assistant prompt
+                value:
+                  name: Workorder Assistant
+                  content: You are a concise assistant that creates and updates workorders.
         required: true
       responses:
         '200':
@@ -91,9 +122,21 @@ paths:
     delete:
       tags:
       - System Prompts
-      summary: Delete system prompt
-      description: Delete an MCP system prompt so it can no longer be selected for agent sessions
-      operationId: delete
+      summary: Delete an MCP System Prompt
+      description: 'Deletes an MCP system prompt so it can no longer be assigned to agent sessions.
+
+        Use this tool to retire a prompt; do not use updateSystemPrompt, which keeps the prompt and changes its fields.
+
+        Preconditions: none; deleting an id that does not exist is a no-op.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a MCP_SYSTEM_PROMPT_DELETE event and, when the prompt existed, invalidates cached agents that were built from it.
+
+        Returns 204 whether or not the prompt existed, making the call idempotent.
+
+        '
+      operationId: deleteSystemPrompt
       parameters:
       - name: id
         in: path
@@ -115,9 +158,21 @@ paths:
     get:
       tags:
       - LLM API Configuration
-      summary: Get an LLM API configuration
-      description: Retrieve a single LLM API provider configuration by its identifier.
-      operationId: get_1
+      summary: Get an LLM API Configuration
+      description: 'Returns a single LLM provider API configuration by its identifier.
+
+        Use this tool when the configuration id (UUID) is already known; use listLlmApiConfigs instead to discover ids.
+
+        Preconditions: a configuration with the given id must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 when the configuration exists; an unknown id is not mapped to a 404 by this module and currently surfaces as a 500 error.
+
+        '
+      operationId: getLlmApiConfig
       parameters:
       - name: id
         in: path
@@ -140,9 +195,21 @@ paths:
     put:
       tags:
       - LLM API Configuration
-      summary: Update an LLM API configuration
-      description: Update an existing LLM API provider configuration by its identifier.
-      operationId: update_1
+      summary: Update an LLM API Configuration
+      description: 'Replaces every editable field of an existing LLM provider API configuration identified by id.
+
+        Use this tool to change a provider''s model, base URL, credential or headers; do not use createLlmApiConfig, which registers an additional configuration.
+
+        Preconditions: the configuration must exist, and when apiId is being changed the new apiId must not already be used by another configuration.
+
+        Required inputs: id (UUID) as a path parameter plus a full body with apiId, model, baseUrl and apiKey; headers defaults to empty when omitted, so a partial body is not merged.
+
+        Emits a MCP_LLM_API_UPDATE event.
+
+        Returns 200 with the updated configuration; an unknown id or a duplicate apiId is rejected, though this module surfaces both as a 500 rather than a 404 or 409.
+
+        '
+      operationId: updateLlmApiConfig
       parameters:
       - name: id
         in: path
@@ -151,10 +218,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Full replacement provider endpoint, model and credential values.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LlmApiConfigRequest'
+            examples:
+              Updated OpenAI provider:
+                description: Updated OpenAI provider
+                value:
+                  apiId: openai-gpt4o
+                  model: gpt-4o
+                  baseUrl: https://api.openai.com/v1
+                  apiKey: sk-proj-xxxxxxxxxxxxxxxx
+                  headers:
+                    X-Org-Id: org-01960003
         required: true
       responses:
         '200':
@@ -171,9 +249,21 @@ paths:
     delete:
       tags:
       - LLM API Configuration
-      summary: Delete an LLM API configuration
-      description: Delete an existing LLM API provider configuration by its identifier.
-      operationId: delete_1
+      summary: Delete an LLM API Configuration
+      description: 'Deletes an LLM provider API configuration so the MCP server can no longer use it to invoke that provider.
+
+        Use this tool to retire a provider configuration; do not use updateLlmApiConfig, which keeps the configuration and changes its fields.
+
+        Preconditions: none; deleting an id that does not exist is a no-op.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a MCP_LLM_API_DELETE event.
+
+        Returns 204 whether or not the configuration existed, making the call idempotent.
+
+        '
+      operationId: deleteLlmApiConfig
       parameters:
       - name: id
         in: path
@@ -193,8 +283,20 @@ paths:
     get:
       tags:
       - MCP Tool Permissions
-      summary: List a tool's permission grants
-      description: Return the permission codes currently granted to a discovered OpenAPI tool.
+      summary: List a Tool's Permission Grants
+      description: 'Returns the permission codes currently granted to a discovered OpenAPI tool.
+
+        Use this tool to inspect why a discovered tool is or is not selectable for a caller; use grantToolPermission or revokeToolPermission instead to change the grants.
+
+        Preconditions: the named tool must exist as a discovered (source openapi) tool; discovered tools are fail-closed and unselectable until at least one grant exists.
+
+        Required inputs: toolName as a path parameter, matching the tool''s registered name exactly.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the grant set (possibly empty), and 404 when no discovered OpenAPI tool has the given name.
+
+        '
       operationId: listToolPermissions
       parameters:
       - name: toolName
@@ -217,8 +319,20 @@ paths:
     post:
       tags:
       - MCP Tool Permissions
-      summary: Grant a permission to a tool
-      description: Grant a permission code to a discovered OpenAPI tool so callers holding it can select the tool. Idempotent. Returns the tool's full permission set.
+      summary: Grant a Permission to a Tool
+      description: 'Grants a permission code to a discovered OpenAPI tool so callers holding that code can select the tool during chat.
+
+        Use this tool to open up a fail-closed discovered operation; do not use revokeToolPermission, which removes a grant.
+
+        Preconditions: the named tool must exist as a discovered (source openapi) tool; granting a code that is already present changes nothing.
+
+        Required inputs: toolName as a path parameter and permissionCode in the body, either the literal AUTHENTICATED or a domain:resource:action code such as event-receiver:event_type:view.
+
+        Emits a MCP_TOOL_PERMISSION_GRANT event; when the grant set actually changes, cached role agents are invalidated so the tool becomes selectable on the next chat turn.
+
+        Returns 201 with the tool''s full permission set (idempotently for repeated grants), 404 when no discovered OpenAPI tool has the given name, and 400 when the permission code does not match the required pattern.
+
+        '
       operationId: grantToolPermission
       parameters:
       - name: toolName
@@ -227,10 +341,16 @@ paths:
         schema:
           type: string
       requestBody:
+        description: The permission code the tool should be selectable under.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ToolPermissionRequest'
+            examples:
+              Domain permission grant:
+                description: Domain permission grant
+                value:
+                  permissionCode: event-receiver:event_type:view
         required: true
       responses:
         '200':
@@ -247,8 +367,20 @@ paths:
     delete:
       tags:
       - MCP Tool Permissions
-      summary: Revoke a permission from a tool
-      description: Revoke a permission code from a discovered OpenAPI tool. Idempotent.
+      summary: Revoke a Permission From a Tool
+      description: 'Revokes a permission code from a discovered OpenAPI tool, removing it from the set that makes the tool selectable.
+
+        Use this tool to withdraw chat access to a discovered operation; do not use grantToolPermission, which adds a grant.
+
+        Preconditions: the named tool must exist as a discovered (source openapi) tool; revoking a code that is not granted changes nothing.
+
+        Required inputs: toolName as a path parameter and permissionCode as a query parameter; there is no request body.
+
+        Emits a MCP_TOOL_PERMISSION_REVOKE event; when the grant set actually changes, cached role agents are invalidated so the tool stops being selectable.
+
+        Returns 204 whether or not the code was granted (idempotent), 404 when no discovered OpenAPI tool has the given name, and 400 when the permission code is blank.
+
+        '
       operationId: revokeToolPermission
       parameters:
       - name: toolName
@@ -274,9 +406,21 @@ paths:
     get:
       tags:
       - System Prompts
-      summary: List system prompts
-      description: List all configured MCP system prompts that can be assigned to agents
-      operationId: list
+      summary: List All MCP System Prompts
+      description: 'Returns every reusable MCP system prompt with its name and content.
+
+        Use this tool to browse prompts or to find a prompt id by name; use getSystemPrompt instead when the id is already known.
+
+        Preconditions: none; an empty list simply means no prompts have been created yet.
+
+        Required inputs: none; there are no filters, no paging and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the full list of prompts.
+
+        '
+      operationId: listSystemPrompts
       responses:
         '200':
           description: System prompts returned
@@ -294,14 +438,33 @@ paths:
     post:
       tags:
       - System Prompts
-      summary: Create system prompt
-      description: Create a new MCP system prompt that can be used during agent orchestration
-      operationId: create
+      summary: Create an MCP System Prompt
+      description: 'Creates a reusable MCP system prompt that agent orchestration can assign to assistant agents.
+
+        Use this tool to add a new named prompt; do not use updateSystemPrompt, which edits a prompt that already exists.
+
+        Preconditions: no prompt may already use the requested name, which is unique across prompts.
+
+        Required inputs: name (unique, human-readable) and content (the prompt text); both are mandatory and non-blank.
+
+        Emits a MCP_SYSTEM_PROMPT_CREATE event and invalidates any cached agents built from a prompt of that name so they rebuild with the new content.
+
+        Returns 201 with the stored prompt, and 400 when a prompt with the same name already exists.
+
+        '
+      operationId: createSystemPrompt
       requestBody:
+        description: The named prompt text to store for assignment to assistant agents.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SystemPromptRequest'
+            examples:
+              Workorder assistant prompt:
+                description: Workorder assistant prompt
+                value:
+                  name: Workorder Assistant
+                  content: You are a helpful assistant that creates workorders.
         required: true
       responses:
         '201':
@@ -325,9 +488,21 @@ paths:
     post:
       tags:
       - NLTI
-      summary: Set the session workflow state
-      description: Advances the operational workflow state of the caller's NLTI session so subsequent chat turns receive the workflow-gated tool set.
-      operationId: setWorkflowState
+      summary: Set the Session Workflow State
+      description: 'Advances the operational workflow state persisted on the caller''s NLTI session so subsequent chat turns receive the workflow-gated tool set for that state.
+
+        Use this tool when a conversation enters or leaves an operational flow such as purchase-order creation; do not use submitNltiRequest, which submits a new prompt and never changes the workflow state directly.
+
+        Preconditions: the session must exist and be owned by the authenticated subject; an unknown session and a session owned by someone else are both rejected as ownership violations.
+
+        Required inputs: sessionId (UUID) as a path parameter and workflowState, one of IDLE, CREATING_PO, RECEIVING_ASN, INVENTORY_RECON or PROCESSING_RETURN; new sessions default to IDLE.
+
+        Emits a NLTI_SESSION_WORKFLOW_STATE_SET event and updates only the session''s workflow state.
+
+        Returns 200 with the persisted state, and 403 when the session does not exist or is not owned by the caller.
+
+        '
+      operationId: setSessionWorkflowState
       parameters:
       - name: sessionId
         in: path
@@ -336,10 +511,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The operational workflow state the session should move to.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/WorkflowStateUpdateRequest'
+            examples:
+              Enter purchase-order flow:
+                description: Enter purchase-order flow
+                value:
+                  workflowState: CREATING_PO
         required: true
       responses:
         '200':
@@ -357,9 +538,21 @@ paths:
     post:
       tags:
       - NLTI
-      summary: Submit a natural language task request
-      description: Submit a natural language task request for asynchronous MCP processing and correlation tracking
-      operationId: submitRequest
+      summary: Submit a Natural Language Task Request
+      description: 'Submits a natural-language prompt for asynchronous task interpretation, classifying the intent as QUERY or ACTION; an ACTION prompt yields a persisted write-plan preview that must be explicitly confirmed and is never executed directly.
+
+        Use this tool to start or continue a natural-language task conversation; do not use confirmWritePlan, which executes a plan this operation has already previewed.
+
+        Preconditions: a supplied sessionId must belong to the calling subject, and a session idle for more than 24 hours is silently replaced with a new one.
+
+        Required inputs: prompt (non-blank text); sessionId (UUID) is optional and a new session is created when it is absent; clientContext is an optional key-value map; an optional X-Correlation-Id header is reused and echoed back, otherwise a correlation id is generated.
+
+        Emits a NLTI_REQUEST_SUBMIT event and persists the request with a SHA-256 prompt hash rather than the raw prompt text.
+
+        Returns 202 with status ACCEPTED or an attached write-plan preview, 403 when the supplied sessionId is owned by another subject, and 429 when the per-session rate limit (default 100 requests) is exceeded.
+
+        '
+      operationId: submitNltiRequest
       parameters:
       - name: X-Correlation-Id
         in: header
@@ -367,10 +560,19 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Natural-language prompt to interpret, with optional session continuity and client context.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/NltiRequestDTO'
+            examples:
+              Workorder prompt:
+                description: Workorder prompt
+                value:
+                  prompt: Create a workorder for an oil change at the downtown store
+                  sessionId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  clientContext:
+                    locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '200':
@@ -388,8 +590,20 @@ paths:
     post:
       tags:
       - NLTI
-      summary: Confirm a previewed write plan
-      description: Executes the exact persisted arguments of the write plan attached to the request. Rejects expired plans, re-checks the caller's permission at execution time, and returns the prior outcome for an already-executed idempotency key instead of re-executing.
+      summary: Confirm a Previewed Write Plan
+      description: 'Executes the previewed write plan attached to an NLTI request, invoking the plan''s target tool with the exact persisted arguments rather than a re-parse of the user''s text.
+
+        Use this tool after submitNltiRequest returned a PENDING_CONFIRMATION write-plan preview and the user approved it; do not use cancelWritePlan, which discards the plan without executing it.
+
+        Preconditions: the plan and its request must exist and belong to the authenticated subject; the plan must not be expired, cancelled or already executing; the caller must still hold the target tool''s permission at execution time; and for MEDIUM or higher risk plans the source-entity versions captured at plan time must be unchanged.
+
+        Required inputs: requestId (UUID) as a path parameter; the body is optional and may carry idempotencyKey, which must match the plan''s key when present.
+
+        Emits a NLTI_WRITE_PLAN_CONFIRM event, appends CONFIRMATION and EXECUTION audit-ledger entries, and executes the target tool; re-confirming a COMPLETE plan returns the prior outcome without re-executing.
+
+        Returns 200 on execution or idempotent replay, 404 when no plan or request exists for the id, 403 when the plan is not owned by the caller or the tool permission is missing, 409 when the plan is cancelled, executing, previously failed, stale, or the idempotency key mismatches, 410 when the plan has expired, and 502 when the target tool call itself fails.
+
+        '
       operationId: confirmWritePlan
       parameters:
       - name: requestId
@@ -404,10 +618,16 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Optional confirmation payload carrying the idempotency key from the plan preview.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ConfirmWritePlanRequest'
+            examples:
+              Confirm with idempotency key:
+                description: Confirm with idempotency key
+                value:
+                  idempotencyKey: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d
       responses:
         '200':
           description: OK
@@ -424,8 +644,20 @@ paths:
     post:
       tags:
       - NLTI
-      summary: Cancel a previewed write plan
-      description: Cancels the pending write plan attached to the request without executing it.
+      summary: Cancel a Previewed Write Plan
+      description: 'Cancels the pending write plan attached to an NLTI request so it can never be executed.
+
+        Use this tool when the user declines a previewed plan; do not use confirmWritePlan, which executes the plan instead of discarding it.
+
+        Preconditions: the plan and its request must exist and belong to the authenticated subject; a plan that is already CANCELLED or EXPIRED is returned unchanged, making the call idempotent.
+
+        Required inputs: requestId (UUID) as a path parameter; there is no request body.
+
+        Emits a NLTI_WRITE_PLAN_CANCEL event and appends a CONFIRMATION audit-ledger entry with outcome cancelled.
+
+        Returns 200 with the plan (idempotently for already-inactive plans), 404 when no plan or request exists for the id, 403 when the plan is not owned by the caller, and 409 when the plan is COMPLETE, EXECUTING or ERROR and can no longer be cancelled.
+
+        '
       operationId: cancelWritePlan
       parameters:
       - name: requestId
@@ -450,14 +682,35 @@ paths:
     post:
       tags:
       - Document Ingestion
-      summary: Queue a document for ingestion into the RAG vector store
-      description: Submit a document for asynchronous ingestion into the RAG vector store. The request includes the document content and optional metadata. The response returns a job ID that can be used to track the ingestion status.
+      summary: Queue a Document for RAG Ingestion
+      description: 'Queues a text document for asynchronous ingestion into the RAG vector store and returns a trackable job.
+
+        Use this tool to add reference content that chat agents can retrieve; do not use getDocumentIngestionJob, which only reads the status of a job that was already queued.
+
+        Preconditions: none beyond the mcp:document:ingest authority; the job is accepted and persisted before any embedding work happens.
+
+        Required inputs: content (non-blank raw text); metadata is an optional key-value map whose document_id entry names the document — when absent a random identifier is generated.
+
+        Emits a MCP_DOCUMENT_INGEST event and creates a PENDING job that is processed in the background through RUNNING to SUCCEEDED or FAILED.
+
+        Returns 202 with the job and a Location header pointing at the job-status resource; embedding failures are reported on the job''s errorMessage, not on this call.
+
+        '
       operationId: ingestDocument
       requestBody:
+        description: Raw document text to embed, with optional identifying metadata.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/DocumentIngestionRequest'
+            examples:
+              Policy document:
+                description: Policy document
+                value:
+                  content: 'Refund policy: customers may return items within 30 days.'
+                  metadata:
+                    document_id: policy-refunds
+                    source: manual
         required: true
       responses:
         '200':
@@ -475,14 +728,32 @@ paths:
     post:
       tags:
       - mcp-chat-controller
-      summary: Execute MCP chat message
-      description: Executes a chat message and returns the full response once complete. For streaming responses, use the /chat/stream endpoint which returns tokens as they are generated.
-      operationId: chat
+      summary: Execute a Blocking MCP Chat Turn
+      description: 'Executes a single chat message against the caller''s permission-scoped assistant agent and returns the complete response text in one blocking call.
+
+        Use this tool for a simple request-response chat turn; do not use streamMcpChat, which returns the same answer incrementally as Server-Sent Events.
+
+        Preconditions: the agent''s tool set is selected from the caller''s granted permission codes and active workflow state, so the same message can produce different results for different callers.
+
+        Required inputs: message (non-blank text); the acting user is derived from the authenticated principal, not from the body.
+
+        Emits a MCP_CHAT_EXECUTE event; the agent may invoke permission-gated tools, RAG retrieval and web search while producing the answer.
+
+        Returns 200 with the full response text, and 429 when the caller''s chat rate limit is exceeded.
+
+        '
+      operationId: executeMcpChat
       requestBody:
+        description: Single user chat message for the assistant agent to answer in full.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ChatRequest'
+            examples:
+              Chat message:
+                description: Chat message
+                value:
+                  message: Show me the open workorders for today
         required: true
       responses:
         '200':
@@ -500,14 +771,32 @@ paths:
     post:
       tags:
       - mcp-streaming-chat-controller
-      summary: Execute MCP streaming chat - returns SSE token stream
-      description: Executes a streaming chat message and returns a stream of tokens as Server-Sent Events (SSE). Each token is sent as an individual SSE with event type 'chat'.
-      operationId: streamChat
+      summary: Stream an MCP Chat Turn Over SSE
+      description: 'Executes a chat message against the caller''s permission-scoped assistant agent and streams the response as Server-Sent Events, one token per event with event type chat.
+
+        Use this tool when the client renders tokens incrementally as they are generated; do not use executeMcpChat, which blocks until the full response is complete.
+
+        Preconditions: the agent''s tool set is selected from the caller''s granted permission codes and active workflow state, so the same message can produce different results for different callers.
+
+        Required inputs: message (non-blank text); the client must accept the text/event-stream media type.
+
+        Emits a MCP_CHAT_STREAM_EXECUTE event; the agent may invoke permission-gated tools, RAG retrieval and web search while streaming.
+
+        Returns 200 with an SSE token stream, and 429 when the caller''s chat rate limit is exceeded.
+
+        '
+      operationId: streamMcpChat
       requestBody:
+        description: Single user chat message whose answer is streamed back token by token.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/StreamChatRequest'
+            examples:
+              Streaming chat message:
+                description: Streaming chat message
+                value:
+                  message: Summarize yesterday's sales
         required: true
       responses:
         '200':
@@ -527,9 +816,21 @@ paths:
     get:
       tags:
       - LLM API Configuration
-      summary: List LLM API configurations
-      description: Retrieve all configured LLM API provider definitions that are available to the MCP server.
-      operationId: list_1
+      summary: List All LLM API Configurations
+      description: 'Returns every configured LLM provider API definition available to the MCP server, including provider base URL and model.
+
+        Use this tool to enumerate provider configurations or to find a configuration id; use getLlmApiConfig instead when the id is already known.
+
+        Preconditions: none; an empty list simply means no provider has been configured yet.
+
+        Required inputs: none; there are no filters, no paging and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the full list of configurations.
+
+        '
+      operationId: listLlmApiConfigs
       responses:
         '200':
           description: OK
@@ -547,14 +848,37 @@ paths:
     post:
       tags:
       - LLM API Configuration
-      summary: Create an LLM API configuration
-      description: Create a new LLM API provider configuration for use by the MCP server.
-      operationId: create_1
+      summary: Create an LLM API Configuration
+      description: 'Creates a new LLM provider API configuration that the MCP server can use to invoke an external model.
+
+        Use this tool to register a new provider endpoint and credential; do not use updateLlmApiConfig, which modifies a configuration that already exists.
+
+        Preconditions: no configuration may already use the requested apiId, which is unique across configurations.
+
+        Required inputs: apiId (stable string identifier), model, baseUrl and apiKey; headers is an optional map of extra HTTP headers and defaults to empty.
+
+        Emits a MCP_LLM_API_CREATE event and stores the credential for later provider calls.
+
+        Returns 201 with the stored configuration; a duplicate apiId is rejected, though this module surfaces that failure as a 500 rather than a 409.
+
+        '
+      operationId: createLlmApiConfig
       requestBody:
+        description: LLM provider endpoint, model and credential to register.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LlmApiConfigRequest'
+            examples:
+              OpenAI provider:
+                description: OpenAI provider
+                value:
+                  apiId: openai-gpt4o
+                  model: gpt-4o
+                  baseUrl: https://api.openai.com/v1
+                  apiKey: sk-proj-xxxxxxxxxxxxxxxx
+                  headers:
+                    X-Org-Id: org-01960003
         required: true
       responses:
         '200':
@@ -572,9 +896,21 @@ paths:
     get:
       tags:
       - NLTI Audit
-      summary: Query the NLTI audit ledger
-      description: Query the NLTI audit ledger with optional filters for correlation ID, time range, and event type. Results are paginated.
-      operationId: queryAudit
+      summary: Query the NLTI Audit Ledger
+      description: 'Returns a page of NLTI audit ledger entries recording request, intent, plan, confirmation and execution events.
+
+        Use this tool to trace what the NLTI pipeline did for a conversation or time window; filter by correlationId rather than paging the whole ledger when tracing a single request.
+
+        Preconditions: none; the ledger is append-only and entries exist only for activity that has already happened.
+
+        Required inputs: all filters are optional — correlationId (UUID) takes precedence, then from and to (ISO-8601 instants, applied only when both are present), then eventType (one of REQUEST, INTENT, PLAN, CONFIRMATION, EXECUTION_STEP, EXECUTION_COMPLETE, EXECUTION_FAILED); results default to page size 20 sorted by timestamp.
+
+        Emits a NLTI_AUDIT_QUERY event; the ledger itself is never modified by this call.
+
+        Returns 200 with a page of audit events, and 400 with code INVALID_EVENT_TYPE when eventType is not one of the supported values.
+
+        '
+      operationId: searchNltiAuditEvents
       parameters:
       - name: correlationId
         in: query
@@ -641,9 +977,21 @@ paths:
     get:
       tags:
       - Document Ingestion
-      summary: Get RAG document ingestion job status
-      description: Retrieve the status and details of an asynchronous document ingestion job using its job ID. The response includes the current status, timestamps, and any error messages if applicable.
-      operationId: getIngestionJob
+      summary: Get Document Ingestion Job Status
+      description: 'Returns the current status of an asynchronous RAG document ingestion job, including timestamps, chunk count and any failure message.
+
+        Use this tool to poll a job created by ingestDocument; do not use ingestDocument again to check progress, since that queues a second ingestion instead.
+
+        Preconditions: the job must exist for the supplied jobId returned by ingestDocument.
+
+        Required inputs: jobId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the job in state PENDING, RUNNING, SUCCEEDED or FAILED, and 404 when no job exists for the id.
+
+        '
+      operationId: getDocumentIngestionJob
       parameters:
       - name: jobId
         in: path
@@ -1169,12 +1517,12 @@ components:
     PageAuditEventResponse:
       type: object
       properties:
-        totalElements:
-          type: integer
-          format: int64
         totalPages:
           type: integer
           format: int32
+        totalElements:
+          type: integer
+          format: int64
         size:
           type: integer
           format: int32
@@ -1185,17 +1533,17 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
     PageableObject:

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/AuditController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/AuditController.java
@@ -39,10 +39,21 @@ class AuditController {
     @GetMapping
     @EmitEvent(id = "NLTI_AUDIT_QUERY", apiVersion = "1")
     @PreAuthorize("hasAuthority('" + McpPermissions.NLTI_AUDIT_READ + "')")
-    @Operation(
-            summary = "Query the NLTI audit ledger",
-            description =
-                    "Query the NLTI audit ledger with optional filters for correlation ID, time range, and event type. Results are paginated.")
+    @Operation(operationId = "searchNltiAuditEvents", summary = "Query the NLTI Audit Ledger", description = """
+                    Returns a page of NLTI audit ledger entries recording request, intent, plan, confirmation and \
+                    execution events.
+                    Use this tool to trace what the NLTI pipeline did for a conversation or time window; filter by \
+                    correlationId rather than paging the whole ledger when tracing a single request.
+                    Preconditions: none; the ledger is append-only and entries exist only for activity that has \
+                    already happened.
+                    Required inputs: all filters are optional — correlationId (UUID) takes precedence, then from \
+                    and to (ISO-8601 instants, applied only when both are present), then eventType (one of \
+                    REQUEST, INTENT, PLAN, CONFIRMATION, EXECUTION_STEP, EXECUTION_COMPLETE, EXECUTION_FAILED); \
+                    results default to page size 20 sorted by timestamp.
+                    Emits a NLTI_AUDIT_QUERY event; the ledger itself is never modified by this call.
+                    Returns 200 with a page of audit events, and 400 with code INVALID_EVENT_TYPE when eventType \
+                    is not one of the supported values.
+                    """)
     ResponseEntity<Page<AuditEventResponse>> queryAudit(
             @RequestParam(required = false) UUID correlationId,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/DocumentIngestionController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/DocumentIngestionController.java
@@ -6,6 +6,8 @@ import com.positivity.mcp.service.DocumentIngestionJob;
 import com.positivity.mcp.service.DocumentIngestionJobStatus;
 import com.positivity.mcp.service.DocumentIngestionService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -42,12 +44,38 @@ public class DocumentIngestionController {
     @PreAuthorize("hasAuthority('" + McpPermissions.MCP_DOCUMENT_INGEST + "')")
     @EmitEvent(id = "MCP_DOCUMENT_INGEST", apiVersion = "1")
     @Operation(
-            summary = "Queue a document for ingestion into the RAG vector store",
-            description =
-                    "Submit a document for asynchronous ingestion into the RAG vector store. The request includes the document content and optional metadata. The response returns a job ID that can be used to track the ingestion status.",
+            operationId = "ingestDocument",
+            summary = "Queue a Document for RAG Ingestion",
+            description = """
+                    Queues a text document for asynchronous ingestion into the RAG vector store and returns a \
+                    trackable job.
+                    Use this tool to add reference content that chat agents can retrieve; do not use \
+                    getDocumentIngestionJob, which only reads the status of a job that was already queued.
+                    Preconditions: none beyond the mcp:document:ingest authority; the job is accepted and \
+                    persisted before any embedding work happens.
+                    Required inputs: content (non-blank raw text); metadata is an optional key-value map whose \
+                    document_id entry names the document — when absent a random identifier is generated.
+                    Emits a MCP_DOCUMENT_INGEST event and creates a PENDING job that is processed in the \
+                    background through RUNNING to SUCCEEDED or FAILED.
+                    Returns 202 with the job and a Location header pointing at the job-status resource; embedding \
+                    failures are reported on the job's errorMessage, not on this call.
+                    """,
             tags = {"Document Ingestion"})
     public ResponseEntity<DocumentIngestionJobResponse> ingestDocument(
-            @RequestBody @Valid @NonNull DocumentIngestionRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Raw document text to embed, with optional identifying metadata.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Policy document", value = """
+                                                                    {"content":"Refund policy: customers may return items within 30 days.",
+                                                                     "metadata":{"document_id":"policy-refunds","source":"manual"}}
+                                                                    """)))
+                    @RequestBody
+                    @Valid
+                    @NonNull
+                    DocumentIngestionRequest request) {
         DocumentIngestionJob job = documentIngestionService.submitDocument(request.content(), request.metadata());
         URI location = URI.create("/v1/mcp/documents/jobs/" + job.jobId());
         return ResponseEntity.accepted().location(location).body(DocumentIngestionJobResponse.from(job));
@@ -56,9 +84,19 @@ public class DocumentIngestionController {
     @GetMapping("/documents/jobs/{jobId}")
     @PreAuthorize("hasAuthority('" + McpPermissions.MCP_DOCUMENT_INGEST + "')")
     @Operation(
-            summary = "Get RAG document ingestion job status",
-            description =
-                    "Retrieve the status and details of an asynchronous document ingestion job using its job ID. The response includes the current status, timestamps, and any error messages if applicable.",
+            operationId = "getDocumentIngestionJob",
+            summary = "Get Document Ingestion Job Status",
+            description = """
+                    Returns the current status of an asynchronous RAG document ingestion job, including \
+                    timestamps, chunk count and any failure message.
+                    Use this tool to poll a job created by ingestDocument; do not use ingestDocument again to \
+                    check progress, since that queues a second ingestion instead.
+                    Preconditions: the job must exist for the supplied jobId returned by ingestDocument.
+                    Required inputs: jobId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the job in state PENDING, RUNNING, SUCCEEDED or FAILED, and 404 when no job \
+                    exists for the id.
+                    """,
             tags = {"Document Ingestion"})
     public ResponseEntity<DocumentIngestionJobResponse> getIngestionJob(@PathVariable @NonNull UUID jobId) {
         return documentIngestionService

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/LlmApiConfigController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/LlmApiConfigController.java
@@ -6,6 +6,8 @@ import com.positivity.mcp.internal.dto.LlmApiConfigResponse;
 import com.positivity.mcp.internal.security.McpPermissions;
 import com.positivity.mcp.service.LlmApiConfigService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
@@ -28,6 +30,14 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "LLM API Configuration", description = "LLM provider API configuration management")
 class LlmApiConfigController {
 
+    private static final String CONFIG_EXAMPLE = """
+            {"apiId":"openai-gpt4o",
+             "model":"gpt-4o",
+             "baseUrl":"https://api.openai.com/v1",
+             "apiKey":"sk-proj-xxxxxxxxxxxxxxxx",
+             "headers":{"X-Org-Id":"org-01960003"}}
+            """;
+
     private final LlmApiConfigService service;
 
     LlmApiConfigController(@NonNull LlmApiConfigService service) {
@@ -40,8 +50,18 @@ class LlmApiConfigController {
             scopes = {"mcp:llm_api:view"})
     @PreAuthorize("hasAuthority('" + McpPermissions.LLM_API_VIEW + "')")
     @Operation(
-            summary = "List LLM API configurations",
-            description = "Retrieve all configured LLM API provider definitions that are available to the MCP server.",
+            operationId = "listLlmApiConfigs",
+            summary = "List All LLM API Configurations",
+            description = """
+                    Returns every configured LLM provider API definition available to the MCP server, including \
+                    provider base URL and model.
+                    Use this tool to enumerate provider configurations or to find a configuration id; use \
+                    getLlmApiConfig instead when the id is already known.
+                    Preconditions: none; an empty list simply means no provider has been configured yet.
+                    Required inputs: none; there are no filters, no paging and no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the full list of configurations.
+                    """,
             tags = {"LLM API Configuration"})
     ResponseEntity<List<LlmApiConfigResponse>> list() {
         return ResponseEntity.ok(service.list());
@@ -53,8 +73,18 @@ class LlmApiConfigController {
             scopes = {"mcp:llm_api:view"})
     @PreAuthorize("hasAuthority('" + McpPermissions.LLM_API_VIEW + "')")
     @Operation(
-            summary = "Get an LLM API configuration",
-            description = "Retrieve a single LLM API provider configuration by its identifier.",
+            operationId = "getLlmApiConfig",
+            summary = "Get an LLM API Configuration",
+            description = """
+                    Returns a single LLM provider API configuration by its identifier.
+                    Use this tool when the configuration id (UUID) is already known; use listLlmApiConfigs instead \
+                    to discover ids.
+                    Preconditions: a configuration with the given id must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 when the configuration exists; an unknown id is not mapped to a 404 by this module \
+                    and currently surfaces as a 500 error.
+                    """,
             tags = {"LLM API Configuration"})
     ResponseEntity<LlmApiConfigResponse> get(@PathVariable @NonNull UUID id) {
         return ResponseEntity.ok(service.get(id));
@@ -67,10 +97,35 @@ class LlmApiConfigController {
     @PreAuthorize("hasAuthority('" + McpPermissions.LLM_API_CREATE + "')")
     @EmitEvent(id = "MCP_LLM_API_CREATE", apiVersion = "1")
     @Operation(
-            summary = "Create an LLM API configuration",
-            description = "Create a new LLM API provider configuration for use by the MCP server.",
+            operationId = "createLlmApiConfig",
+            summary = "Create an LLM API Configuration",
+            description = """
+                    Creates a new LLM provider API configuration that the MCP server can use to invoke an external \
+                    model.
+                    Use this tool to register a new provider endpoint and credential; do not use \
+                    updateLlmApiConfig, which modifies a configuration that already exists.
+                    Preconditions: no configuration may already use the requested apiId, which is unique across \
+                    configurations.
+                    Required inputs: apiId (stable string identifier), model, baseUrl and apiKey; headers is an \
+                    optional map of extra HTTP headers and defaults to empty.
+                    Emits a MCP_LLM_API_CREATE event and stores the credential for later provider calls.
+                    Returns 201 with the stored configuration; a duplicate apiId is rejected, though this module \
+                    surfaces that failure as a 500 rather than a 409.
+                    """,
             tags = {"LLM API Configuration"})
-    ResponseEntity<LlmApiConfigResponse> create(@RequestBody @Validated @NonNull LlmApiConfigRequest request) {
+    ResponseEntity<LlmApiConfigResponse> create(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "LLM provider endpoint, model and credential to register.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "OpenAI provider", value = CONFIG_EXAMPLE)))
+                    @RequestBody
+                    @Validated
+                    @NonNull
+                    LlmApiConfigRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.create(request));
     }
 
@@ -81,11 +136,37 @@ class LlmApiConfigController {
     @PreAuthorize("hasAuthority('" + McpPermissions.LLM_API_UPDATE + "')")
     @EmitEvent(id = "MCP_LLM_API_UPDATE", apiVersion = "1")
     @Operation(
-            summary = "Update an LLM API configuration",
-            description = "Update an existing LLM API provider configuration by its identifier.",
+            operationId = "updateLlmApiConfig",
+            summary = "Update an LLM API Configuration",
+            description = """
+                    Replaces every editable field of an existing LLM provider API configuration identified by id.
+                    Use this tool to change a provider's model, base URL, credential or headers; do not use \
+                    createLlmApiConfig, which registers an additional configuration.
+                    Preconditions: the configuration must exist, and when apiId is being changed the new apiId \
+                    must not already be used by another configuration.
+                    Required inputs: id (UUID) as a path parameter plus a full body with apiId, model, baseUrl and \
+                    apiKey; headers defaults to empty when omitted, so a partial body is not merged.
+                    Emits a MCP_LLM_API_UPDATE event.
+                    Returns 200 with the updated configuration; an unknown id or a duplicate apiId is rejected, \
+                    though this module surfaces both as a 500 rather than a 404 or 409.
+                    """,
             tags = {"LLM API Configuration"})
     ResponseEntity<LlmApiConfigResponse> update(
-            @PathVariable @NonNull UUID id, @RequestBody @Validated @NonNull LlmApiConfigRequest request) {
+            @PathVariable @NonNull UUID id,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement provider endpoint, model and credential values.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Updated OpenAI provider",
+                                                            value = CONFIG_EXAMPLE)))
+                    @RequestBody
+                    @Validated
+                    @NonNull
+                    LlmApiConfigRequest request) {
         return ResponseEntity.ok(service.update(id, request));
     }
 
@@ -96,8 +177,18 @@ class LlmApiConfigController {
     @PreAuthorize("hasAuthority('" + McpPermissions.LLM_API_DELETE + "')")
     @EmitEvent(id = "MCP_LLM_API_DELETE", apiVersion = "1")
     @Operation(
-            summary = "Delete an LLM API configuration",
-            description = "Delete an existing LLM API provider configuration by its identifier.",
+            operationId = "deleteLlmApiConfig",
+            summary = "Delete an LLM API Configuration",
+            description = """
+                    Deletes an LLM provider API configuration so the MCP server can no longer use it to invoke \
+                    that provider.
+                    Use this tool to retire a provider configuration; do not use updateLlmApiConfig, which keeps \
+                    the configuration and changes its fields.
+                    Preconditions: none; deleting an id that does not exist is a no-op.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a MCP_LLM_API_DELETE event.
+                    Returns 204 whether or not the configuration existed, making the call idempotent.
+                    """,
             tags = {"LLM API Configuration"})
     ResponseEntity<Void> delete(@PathVariable @NonNull UUID id) {
         service.delete(id);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpChatController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpChatController.java
@@ -44,24 +44,38 @@ public class McpChatController {
         this.currentUserContextResolver = currentUserContextResolver;
     }
 
-    @Operation(
-            summary = "Execute MCP chat message",
-            description =
-                    "Executes a chat message and returns the full response once complete. For streaming responses, use the /chat/stream endpoint which returns tokens as they are generated.",
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @io.swagger.v3.oas.annotations.media.Content(
-                                            mediaType = org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
-                                            schema =
-                                                    @io.swagger.v3.oas.annotations.media.Schema(
-                                                            implementation = McpChatController.ChatRequest.class))))
+    @Operation(operationId = "executeMcpChat", summary = "Execute a Blocking MCP Chat Turn", description = """
+                    Executes a single chat message against the caller's permission-scoped assistant agent and \
+                    returns the complete response text in one blocking call.
+                    Use this tool for a simple request-response chat turn; do not use streamMcpChat, which returns \
+                    the same answer incrementally as Server-Sent Events.
+                    Preconditions: the agent's tool set is selected from the caller's granted permission codes and \
+                    active workflow state, so the same message can produce different results for different callers.
+                    Required inputs: message (non-blank text); the acting user is derived from the authenticated \
+                    principal, not from the body.
+                    Emits a MCP_CHAT_EXECUTE event; the agent may invoke permission-gated tools, RAG retrieval and \
+                    web search while producing the answer.
+                    Returns 200 with the full response text, and 429 when the caller's chat rate limit is exceeded.
+                    """)
     @PostMapping("/chat")
     @PreAuthorize("hasAuthority('" + McpPermissions.MCP_CHAT_EXECUTE + "')")
     @EmitEvent(id = "MCP_CHAT_EXECUTE", apiVersion = "1")
     public ResponseEntity<ChatResponse> chat(
-            @RequestBody @Valid @NonNull ChatRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Single user chat message for the assistant agent to answer in full.",
+                            required = true,
+                            content =
+                                    @io.swagger.v3.oas.annotations.media.Content(
+                                            mediaType = org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
+                                            examples =
+                                                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                                            name = "Chat message",
+                                                            value =
+                                                                    "{\"message\":\"Show me the open workorders for today\"}")))
+                    @RequestBody
+                    @Valid
+                    @NonNull
+                    ChatRequest request,
             @CurrentSecurityContext(expression = "authentication") @NonNull Authentication authentication) {
 
         CurrentUserContext currentUserContext = currentUserContextResolver.resolve(authentication);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpStreamingChatController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpStreamingChatController.java
@@ -47,9 +47,21 @@ public class McpStreamingChatController {
     }
 
     @Operation(
-            summary = "Execute MCP streaming chat - returns SSE token stream",
-            description =
-                    "Executes a streaming chat message and returns a stream of tokens as Server-Sent Events (SSE). Each token is sent as an individual SSE with event type 'chat'.",
+            operationId = "streamMcpChat",
+            summary = "Stream an MCP Chat Turn Over SSE",
+            description = """
+                    Executes a chat message against the caller's permission-scoped assistant agent and streams the \
+                    response as Server-Sent Events, one token per event with event type chat.
+                    Use this tool when the client renders tokens incrementally as they are generated; do not use \
+                    executeMcpChat, which blocks until the full response is complete.
+                    Preconditions: the agent's tool set is selected from the caller's granted permission codes and \
+                    active workflow state, so the same message can produce different results for different callers.
+                    Required inputs: message (non-blank text); the client must accept the text/event-stream media \
+                    type.
+                    Emits a MCP_CHAT_STREAM_EXECUTE event; the agent may invoke permission-gated tools, RAG \
+                    retrieval and web search while streaming.
+                    Returns 200 with an SSE token stream, and 429 when the caller's chat rate limit is exceeded.
+                    """,
             responses = {
                 @ApiResponse(
                         responseCode = "200",
@@ -66,7 +78,20 @@ public class McpStreamingChatController {
     @PreAuthorize("hasAuthority('" + McpPermissions.MCP_CHAT_STREAM + "')")
     @EmitEvent(id = "MCP_CHAT_STREAM_EXECUTE", apiVersion = "1")
     public Flux<ServerSentEvent<String>> streamChat(
-            @RequestBody @Valid @NonNull StreamChatRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Single user chat message whose answer is streamed back token by token.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            examples =
+                                                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                                            name = "Streaming chat message",
+                                                            value = "{\"message\":\"Summarize yesterday's sales\"}")))
+                    @RequestBody
+                    @Valid
+                    @NonNull
+                    StreamChatRequest request,
             @CurrentSecurityContext(expression = "authentication") @NonNull Authentication authentication) {
 
         CurrentUserContext currentUserContext = currentUserContextResolver.resolve(authentication);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/NltiController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/NltiController.java
@@ -12,6 +12,8 @@ import com.positivity.mcp.internal.service.PermissionCodes;
 import com.positivity.mcp.service.NltiRequestService;
 import com.positivity.security.common.SecurityContextHelper;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -53,12 +55,40 @@ public class NltiController {
     @PostMapping("/requests")
     @EmitEvent(id = "NLTI_REQUEST_SUBMIT", apiVersion = "1")
     @PreAuthorize("hasAuthority('" + McpPermissions.NLTI_REQUEST_SUBMIT + "')")
-    @Operation(
-            summary = "Submit a natural language task request",
-            description =
-                    "Submit a natural language task request for asynchronous MCP processing and correlation tracking")
+    @Operation(operationId = "submitNltiRequest", summary = "Submit a Natural Language Task Request", description = """
+                    Submits a natural-language prompt for asynchronous task interpretation, classifying the intent \
+                    as QUERY or ACTION; an ACTION prompt yields a persisted write-plan preview that must be \
+                    explicitly confirmed and is never executed directly.
+                    Use this tool to start or continue a natural-language task conversation; do not use \
+                    confirmWritePlan, which executes a plan this operation has already previewed.
+                    Preconditions: a supplied sessionId must belong to the calling subject, and a session idle for \
+                    more than 24 hours is silently replaced with a new one.
+                    Required inputs: prompt (non-blank text); sessionId (UUID) is optional and a new session is \
+                    created when it is absent; clientContext is an optional key-value map; an optional \
+                    X-Correlation-Id header is reused and echoed back, otherwise a correlation id is generated.
+                    Emits a NLTI_REQUEST_SUBMIT event and persists the request with a SHA-256 prompt hash rather \
+                    than the raw prompt text.
+                    Returns 202 with status ACCEPTED or an attached write-plan preview, 403 when the supplied \
+                    sessionId is owned by another subject, and 429 when the per-session rate limit (default 100 \
+                    requests) is exceeded.
+                    """)
     ResponseEntity<NltiResponseV1> submitRequest(
-            @Valid @RequestBody @NonNull NltiRequestDTO request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Natural-language prompt to interpret, with optional session continuity and client context.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Workorder prompt", value = """
+                                                                    {"prompt":"Create a workorder for an oil change at the downtown store",
+                                                                     "sessionId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "clientContext":{"locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"}}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    NltiRequestDTO request,
             @RequestHeader(value = NltiCorrelationIdSupport.CORRELATION_ID_HEADER, required = false)
                     String correlationIdHeader,
             @NonNull HttpServletRequest servletRequest) {
@@ -81,12 +111,36 @@ public class NltiController {
     @PostMapping("/sessions/{sessionId}/workflow-state")
     @EmitEvent(id = "NLTI_SESSION_WORKFLOW_STATE_SET", apiVersion = "1")
     @PreAuthorize("hasAuthority('" + McpPermissions.NLTI_REQUEST_SUBMIT + "')")
-    @Operation(
-            summary = "Set the session workflow state",
-            description =
-                    "Advances the operational workflow state of the caller's NLTI session so subsequent chat turns receive the workflow-gated tool set.")
+    @Operation(operationId = "setSessionWorkflowState", summary = "Set the Session Workflow State", description = """
+                    Advances the operational workflow state persisted on the caller's NLTI session so subsequent \
+                    chat turns receive the workflow-gated tool set for that state.
+                    Use this tool when a conversation enters or leaves an operational flow such as purchase-order \
+                    creation; do not use submitNltiRequest, which submits a new prompt and never changes the \
+                    workflow state directly.
+                    Preconditions: the session must exist and be owned by the authenticated subject; an unknown \
+                    session and a session owned by someone else are both rejected as ownership violations.
+                    Required inputs: sessionId (UUID) as a path parameter and workflowState, one of IDLE, \
+                    CREATING_PO, RECEIVING_ASN, INVENTORY_RECON or PROCESSING_RETURN; new sessions default to IDLE.
+                    Emits a NLTI_SESSION_WORKFLOW_STATE_SET event and updates only the session's workflow state.
+                    Returns 200 with the persisted state, and 403 when the session does not exist or is not owned \
+                    by the caller.
+                    """)
     ResponseEntity<WorkflowStateResponse> setWorkflowState(
-            @PathVariable @NonNull UUID sessionId, @Valid @RequestBody @NonNull WorkflowStateUpdateRequest request) {
+            @PathVariable @NonNull UUID sessionId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The operational workflow state the session should move to.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Enter purchase-order flow",
+                                                            value = "{\"workflowState\":\"CREATING_PO\"}")))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    WorkflowStateUpdateRequest request) {
         // Fail fast on a missing authenticated principal rather than defaulting to a sentinel subject:
         // subjectId is the ownership key for this session-mutating call, so an unresolved username must
         // never silently pass through (or mis-attribute the ownership check).
@@ -106,14 +160,41 @@ public class NltiController {
     @PostMapping("/requests/{requestId}/confirm")
     @EmitEvent(id = "NLTI_WRITE_PLAN_CONFIRM", apiVersion = "1")
     @PreAuthorize("hasAuthority('" + McpPermissions.NLTI_REQUEST_SUBMIT + "')")
-    @Operation(
-            summary = "Confirm a previewed write plan",
-            description = "Executes the exact persisted arguments of the write plan attached to the request. "
-                    + "Rejects expired plans, re-checks the caller's permission at execution time, and returns "
-                    + "the prior outcome for an already-executed idempotency key instead of re-executing.")
+    @Operation(operationId = "confirmWritePlan", summary = "Confirm a Previewed Write Plan", description = """
+                    Executes the previewed write plan attached to an NLTI request, invoking the plan's target tool \
+                    with the exact persisted arguments rather than a re-parse of the user's text.
+                    Use this tool after submitNltiRequest returned a PENDING_CONFIRMATION write-plan preview and \
+                    the user approved it; do not use cancelWritePlan, which discards the plan without executing it.
+                    Preconditions: the plan and its request must exist and belong to the authenticated subject; \
+                    the plan must not be expired, cancelled or already executing; the caller must still hold the \
+                    target tool's permission at execution time; and for MEDIUM or higher risk plans the source-entity \
+                    versions captured at plan time must be unchanged.
+                    Required inputs: requestId (UUID) as a path parameter; the body is optional and may carry \
+                    idempotencyKey, which must match the plan's key when present.
+                    Emits a NLTI_WRITE_PLAN_CONFIRM event, appends CONFIRMATION and EXECUTION audit-ledger entries, \
+                    and executes the target tool; re-confirming a COMPLETE plan returns the prior outcome without \
+                    re-executing.
+                    Returns 200 on execution or idempotent replay, 404 when no plan or request exists for the id, \
+                    403 when the plan is not owned by the caller or the tool permission is missing, 409 when the \
+                    plan is cancelled, executing, previously failed, stale, or the idempotency key mismatches, 410 \
+                    when the plan has expired, and 502 when the target tool call itself fails.
+                    """)
     ResponseEntity<WritePlanResponseV1> confirmWritePlan(
             @PathVariable @NonNull UUID requestId,
-            @RequestBody(required = false) ConfirmWritePlanRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Optional confirmation payload carrying the idempotency key from the plan preview.",
+                            required = false,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Confirm with idempotency key",
+                                                            value =
+                                                                    "{\"idempotencyKey\":\"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d\"}")))
+                    @RequestBody(required = false)
+                    ConfirmWritePlanRequest request,
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
         String subjectId = requireSubjectId("write-plan confirmation");
         return ResponseEntity.ok(writePlanService.confirm(
@@ -128,9 +209,19 @@ public class NltiController {
     @PostMapping("/requests/{requestId}/cancel")
     @EmitEvent(id = "NLTI_WRITE_PLAN_CANCEL", apiVersion = "1")
     @PreAuthorize("hasAuthority('" + McpPermissions.NLTI_REQUEST_SUBMIT + "')")
-    @Operation(
-            summary = "Cancel a previewed write plan",
-            description = "Cancels the pending write plan attached to the request without executing it.")
+    @Operation(operationId = "cancelWritePlan", summary = "Cancel a Previewed Write Plan", description = """
+                    Cancels the pending write plan attached to an NLTI request so it can never be executed.
+                    Use this tool when the user declines a previewed plan; do not use confirmWritePlan, which \
+                    executes the plan instead of discarding it.
+                    Preconditions: the plan and its request must exist and belong to the authenticated subject; a \
+                    plan that is already CANCELLED or EXPIRED is returned unchanged, making the call idempotent.
+                    Required inputs: requestId (UUID) as a path parameter; there is no request body.
+                    Emits a NLTI_WRITE_PLAN_CANCEL event and appends a CONFIRMATION audit-ledger entry with \
+                    outcome cancelled.
+                    Returns 200 with the plan (idempotently for already-inactive plans), 404 when no plan or \
+                    request exists for the id, 403 when the plan is not owned by the caller, and 409 when the plan \
+                    is COMPLETE, EXECUTING or ERROR and can no longer be cancelled.
+                    """)
     ResponseEntity<WritePlanResponseV1> cancelWritePlan(@PathVariable @NonNull UUID requestId) {
         String subjectId = requireSubjectId("write-plan cancellation");
         return ResponseEntity.ok(writePlanService.cancel(requestId, subjectId));

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/SystemPromptController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/SystemPromptController.java
@@ -6,6 +6,8 @@ import com.positivity.mcp.internal.dto.SystemPromptResponse;
 import com.positivity.mcp.internal.security.McpPermissions;
 import com.positivity.mcp.service.SystemPromptService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -36,9 +38,15 @@ class SystemPromptController {
     }
 
     @GetMapping
-    @Operation(
-            summary = "List system prompts",
-            description = "List all configured MCP system prompts that can be assigned to agents")
+    @Operation(operationId = "listSystemPrompts", summary = "List All MCP System Prompts", description = """
+                    Returns every reusable MCP system prompt with its name and content.
+                    Use this tool to browse prompts or to find a prompt id by name; use getSystemPrompt instead \
+                    when the id is already known.
+                    Preconditions: none; an empty list simply means no prompts have been created yet.
+                    Required inputs: none; there are no filters, no paging and no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the full list of prompts.
+                    """)
     @ApiResponse(responseCode = "200", description = "System prompts returned")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -49,7 +57,15 @@ class SystemPromptController {
     }
 
     @GetMapping("/{id}")
-    @Operation(summary = "Get system prompt", description = "Retrieve a single MCP system prompt by its identifier")
+    @Operation(operationId = "getSystemPrompt", summary = "Get an MCP System Prompt", description = """
+                    Returns a single MCP system prompt by its identifier, including its full content.
+                    Use this tool when the prompt id (UUID) is already known; use listSystemPrompts instead to \
+                    discover ids or find a prompt by name.
+                    Preconditions: a system prompt with the given id must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no system prompt exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "System prompt returned")
     @ApiResponse(responseCode = "404", description = "System prompt not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -61,9 +77,17 @@ class SystemPromptController {
     }
 
     @PostMapping
-    @Operation(
-            summary = "Create system prompt",
-            description = "Create a new MCP system prompt that can be used during agent orchestration")
+    @Operation(operationId = "createSystemPrompt", summary = "Create an MCP System Prompt", description = """
+                    Creates a reusable MCP system prompt that agent orchestration can assign to assistant agents.
+                    Use this tool to add a new named prompt; do not use updateSystemPrompt, which edits a prompt \
+                    that already exists.
+                    Preconditions: no prompt may already use the requested name, which is unique across prompts.
+                    Required inputs: name (unique, human-readable) and content (the prompt text); both are \
+                    mandatory and non-blank.
+                    Emits a MCP_SYSTEM_PROMPT_CREATE event and invalidates any cached agents built from a prompt \
+                    of that name so they rebuild with the new content.
+                    Returns 201 with the stored prompt, and 400 when a prompt with the same name already exists.
+                    """)
     @ApiResponse(responseCode = "201", description = "System prompt created")
     @ApiResponse(responseCode = "400", description = "System prompt request is invalid")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -71,14 +95,39 @@ class SystemPromptController {
             scopes = {"mcp:system_prompt:create"})
     @PreAuthorize("hasAuthority('" + McpPermissions.SYSTEM_PROMPT_CREATE + "')")
     @EmitEvent(id = "MCP_SYSTEM_PROMPT_CREATE", apiVersion = "1")
-    ResponseEntity<SystemPromptResponse> create(@Validated @RequestBody @NonNull SystemPromptRequest request) {
+    ResponseEntity<SystemPromptResponse> create(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The named prompt text to store for assignment to assistant agents.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "Workorder assistant prompt", value = """
+                                                                    {"name":"Workorder Assistant",
+                                                                     "content":"You are a helpful assistant that creates workorders."}
+                                                                    """)))
+                    @Validated
+                    @RequestBody
+                    @NonNull
+                    SystemPromptRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(systemPromptService.create(request));
     }
 
     @PutMapping("/{id}")
-    @Operation(
-            summary = "Update system prompt",
-            description = "Update an existing MCP system prompt by replacing its editable fields")
+    @Operation(operationId = "updateSystemPrompt", summary = "Update an MCP System Prompt", description = """
+                    Replaces the name and content of an existing MCP system prompt.
+                    Use this tool to edit prompt text or rename a prompt; do not use createSystemPrompt, which \
+                    adds a new prompt alongside the existing ones.
+                    Preconditions: the prompt must exist, and when the name is being changed no other prompt may \
+                    already use the new name.
+                    Required inputs: id (UUID) as a path parameter plus name and content in the body; both body \
+                    fields are mandatory and fully replace the stored values.
+                    Emits a MCP_SYSTEM_PROMPT_UPDATE event and invalidates cached agents built from the prompt so \
+                    subsequent chats use the new content.
+                    Returns 200 with the updated prompt, 404 when no prompt exists for the id, and 400 when the \
+                    new name is already used by another prompt.
+                    """)
     @ApiResponse(responseCode = "200", description = "System prompt updated")
     @ApiResponse(responseCode = "404", description = "System prompt not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -87,14 +136,35 @@ class SystemPromptController {
     @PreAuthorize("hasAuthority('" + McpPermissions.SYSTEM_PROMPT_UPDATE + "')")
     @EmitEvent(id = "MCP_SYSTEM_PROMPT_UPDATE", apiVersion = "1")
     ResponseEntity<SystemPromptResponse> update(
-            @PathVariable @NonNull UUID id, @Validated @RequestBody @NonNull SystemPromptRequest request) {
+            @PathVariable @NonNull UUID id,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement name and content for the stored prompt.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Revised assistant prompt", value = """
+                                                                    {"name":"Workorder Assistant",
+                                                                     "content":"You are a concise assistant that creates and updates workorders."}
+                                                                    """)))
+                    @Validated
+                    @RequestBody
+                    @NonNull
+                    SystemPromptRequest request) {
         return ResponseEntity.ok(systemPromptService.update(id, request));
     }
 
     @DeleteMapping("/{id}")
-    @Operation(
-            summary = "Delete system prompt",
-            description = "Delete an MCP system prompt so it can no longer be selected for agent sessions")
+    @Operation(operationId = "deleteSystemPrompt", summary = "Delete an MCP System Prompt", description = """
+                    Deletes an MCP system prompt so it can no longer be assigned to agent sessions.
+                    Use this tool to retire a prompt; do not use updateSystemPrompt, which keeps the prompt and \
+                    changes its fields.
+                    Preconditions: none; deleting an id that does not exist is a no-op.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a MCP_SYSTEM_PROMPT_DELETE event and, when the prompt existed, invalidates cached agents \
+                    that were built from it.
+                    Returns 204 whether or not the prompt existed, making the call idempotent.
+                    """)
     @ApiResponse(responseCode = "204", description = "System prompt deleted")
     @ApiResponse(responseCode = "404", description = "System prompt not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/ToolPermissionController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/ToolPermissionController.java
@@ -6,6 +6,8 @@ import com.positivity.mcp.internal.dto.ToolPermissionsResponse;
 import com.positivity.mcp.internal.security.McpPermissions;
 import com.positivity.mcp.internal.service.ToolPermissionAdminService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
@@ -47,8 +49,18 @@ class ToolPermissionController {
     @PreAuthorize("hasAuthority('mcp:tool:view')")
     @Operation(
             operationId = "listToolPermissions",
-            summary = "List a tool's permission grants",
-            description = "Return the permission codes currently granted to a discovered OpenAPI tool.",
+            summary = "List a Tool's Permission Grants",
+            description = """
+                    Returns the permission codes currently granted to a discovered OpenAPI tool.
+                    Use this tool to inspect why a discovered tool is or is not selectable for a caller; use \
+                    grantToolPermission or revokeToolPermission instead to change the grants.
+                    Preconditions: the named tool must exist as a discovered (source openapi) tool; discovered \
+                    tools are fail-closed and unselectable until at least one grant exists.
+                    Required inputs: toolName as a path parameter, matching the tool's registered name exactly.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the grant set (possibly empty), and 404 when no discovered OpenAPI tool has \
+                    the given name.
+                    """,
             tags = {"MCP Tool Permissions"})
     ResponseEntity<ToolPermissionsResponse> list(@PathVariable @NonNull String toolName) {
         return ResponseEntity.ok(service.listPermissions(toolName));
@@ -62,12 +74,40 @@ class ToolPermissionController {
     @PreAuthorize("hasAuthority('mcp:tool:manage')")
     @Operation(
             operationId = "grantToolPermission",
-            summary = "Grant a permission to a tool",
-            description = "Grant a permission code to a discovered OpenAPI tool so callers holding it can select "
-                    + "the tool. Idempotent. Returns the tool's full permission set.",
+            summary = "Grant a Permission to a Tool",
+            description = """
+                    Grants a permission code to a discovered OpenAPI tool so callers holding that code can select \
+                    the tool during chat.
+                    Use this tool to open up a fail-closed discovered operation; do not use \
+                    revokeToolPermission, which removes a grant.
+                    Preconditions: the named tool must exist as a discovered (source openapi) tool; granting a \
+                    code that is already present changes nothing.
+                    Required inputs: toolName as a path parameter and permissionCode in the body, either the \
+                    literal AUTHENTICATED or a domain:resource:action code such as event-receiver:event_type:view.
+                    Emits a MCP_TOOL_PERMISSION_GRANT event; when the grant set actually changes, cached role \
+                    agents are invalidated so the tool becomes selectable on the next chat turn.
+                    Returns 201 with the tool's full permission set (idempotently for repeated grants), 404 when \
+                    no discovered OpenAPI tool has the given name, and 400 when the permission code does not match \
+                    the required pattern.
+                    """,
             tags = {"MCP Tool Permissions"})
     ResponseEntity<ToolPermissionsResponse> grant(
-            @PathVariable @NonNull String toolName, @RequestBody @Validated @NonNull ToolPermissionRequest request) {
+            @PathVariable @NonNull String toolName,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The permission code the tool should be selectable under.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Domain permission grant",
+                                                            value =
+                                                                    "{\"permissionCode\":\"event-receiver:event_type:view\"}")))
+                    @RequestBody
+                    @Validated
+                    @NonNull
+                    ToolPermissionRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(service.grantPermission(toolName, request.permissionCode()));
     }
@@ -80,8 +120,21 @@ class ToolPermissionController {
     @PreAuthorize("hasAuthority('mcp:tool:manage')")
     @Operation(
             operationId = "revokeToolPermission",
-            summary = "Revoke a permission from a tool",
-            description = "Revoke a permission code from a discovered OpenAPI tool. Idempotent.",
+            summary = "Revoke a Permission From a Tool",
+            description = """
+                    Revokes a permission code from a discovered OpenAPI tool, removing it from the set that makes \
+                    the tool selectable.
+                    Use this tool to withdraw chat access to a discovered operation; do not use \
+                    grantToolPermission, which adds a grant.
+                    Preconditions: the named tool must exist as a discovered (source openapi) tool; revoking a \
+                    code that is not granted changes nothing.
+                    Required inputs: toolName as a path parameter and permissionCode as a query parameter; there \
+                    is no request body.
+                    Emits a MCP_TOOL_PERMISSION_REVOKE event; when the grant set actually changes, cached role \
+                    agents are invalidated so the tool stops being selectable.
+                    Returns 204 whether or not the code was granted (idempotent), 404 when no discovered OpenAPI \
+                    tool has the given name, and 400 when the permission code is blank.
+                    """,
             tags = {"MCP Tool Permissions"})
     ResponseEntity<Void> revoke(
             @PathVariable @NonNull String toolName, @RequestParam("permissionCode") @NotBlank @NonNull String code) {

--- a/pos-openapi-validation/src/main/java/com/positivity/openapivalidation/internal/validator/OpenApiAnnotationDepthValidator.java
+++ b/pos-openapi-validation/src/main/java/com/positivity/openapivalidation/internal/validator/OpenApiAnnotationDepthValidator.java
@@ -76,9 +76,10 @@ public class OpenApiAnnotationDepthValidator {
         if (requestBody.getDescription() == null || requestBody.getDescription().isBlank()) {
             findings.add("request body missing description (ADR-0042 §3)");
         }
-        if (requestBody.getRequired() == null) {
-            findings.add("request body missing explicit required flag (ADR-0042 §3)");
-        }
+        // ADR-0042 §3 also wants an explicit `required` flag, but springdoc omits `required: false`
+        // (the OpenAPI default) from generated specs, so absence is indistinguishable from an
+        // explicit false. That rule is therefore enforced at the annotation level by convention
+        // (docs/OPENAPI_DESCRIPTION_STANDARD.md), not here.
         if (!hasExample(requestBody.getContent())) {
             findings.add("request body missing example (ADR-0042 §3)");
         }

--- a/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/validator/OpenApiAnnotationDepthValidatorTest.java
+++ b/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/validator/OpenApiAnnotationDepthValidatorTest.java
@@ -119,7 +119,6 @@ class OpenApiAnnotationDepthValidatorTest {
         assertThat(validator.check(operation))
                 .containsExactly(
                         "request body missing description (ADR-0042 §3)",
-                        "request body missing explicit required flag (ADR-0042 §3)",
                         "request body missing example (ADR-0042 §3)");
     }
 }

--- a/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/validator/OpenApiModuleValidatorTest.java
+++ b/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/validator/OpenApiModuleValidatorTest.java
@@ -98,8 +98,6 @@ class OpenApiModuleValidatorTest {
                         "pos-documents POST /v1/documents: description missing negative guidance"
                                 + " (\"do not use ...\" / \"... instead\")",
                         "pos-documents POST /v1/documents: request body missing description (ADR-0042 §3)",
-                        "pos-documents POST /v1/documents: request body missing explicit required flag"
-                                + " (ADR-0042 §3)",
                         "pos-documents POST /v1/documents: request body missing example (ADR-0042 §3)");
         assertThat(issues).allSatisfy(issue -> assertThat(issue.mode()).isEqualTo(OpenApiModulePolicy.Mode.STRICT));
     }

--- a/pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml
+++ b/pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml
@@ -9,6 +9,7 @@ modules:
     mode: STRICT
   pos-price:
     mode: STRICT
+    annotationDepth: STRICT
   pos-customer:
     mode: STRICT
   pos-location:
@@ -22,11 +23,13 @@ modules:
     annotationDepth: STRICT
   pos-invoice:
     mode: STRICT
+    annotationDepth: STRICT
   pos-bulk-loader:
     mode: STRICT
     annotationDepth: STRICT
   pos-vehicle-inventory:
     mode: STRICT
+    annotationDepth: STRICT
   pos-warranty:
     mode: STRICT
   pos-supplier:
@@ -51,11 +54,13 @@ modules:
     reason: aggregate producer without module paths
   pos-mcp-server:
     mode: STRICT
+    annotationDepth: STRICT
   pos-marketing:
     mode: STRICT
     annotationDepth: STRICT
   pos-people-contact:
     mode: STRICT
+    annotationDepth: STRICT
   pos-tax:
     mode: STRICT
     annotationDepth: STRICT

--- a/pos-people-contact/openapi.yaml
+++ b/pos-people-contact/openapi.yaml
@@ -23,8 +23,20 @@ paths:
     get:
       tags:
       - People API
-      summary: Get person by ID
-      description: Retrieve a person by their unique ID.
+      summary: Get a Person by Unique ID
+      description: 'Returns a single person record by its UUID, including emails, work phone numbers and any linked username.
+
+        Use this tool when the person id is already known; use listPeople instead when searching by name or email, and getCurrentPerson when the target is the authenticated caller.
+
+        Preconditions: the person record must exist in the identity directory.
+
+        Required inputs: personId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no person exists for the supplied id.
+
+        '
       operationId: getPersonById
       parameters:
       - name: personId
@@ -56,8 +68,20 @@ paths:
     put:
       tags:
       - People API
-      summary: Update an existing person
-      description: Update the details of an existing person.
+      summary: Update an Existing Person Record
+      description: 'Updates an existing person''s identity fields, fully replacing names, emails and work phone numbers with the submitted values.
+
+        Use this tool to correct or complete a known person''s identity data; do not use replaceContactPoints, which manages the typed contact-point set, and do not use createPerson for records that do not exist yet.
+
+        Preconditions: the person record must already exist for the supplied id.
+
+        Required inputs: personId (UUID) as a path parameter plus a full person body with non-blank firstName and lastName; omitting primaryEmail, secondaryEmail or phoneNumbers erases the stored values, and username is ignored because it is owned by pos-security.
+
+        Emits a PEOPLE_CONTACT_PERSON_UPDATE event and queues a person.updated identity fact on the transactional outbox.
+
+        Returns 200 with the updated person, 404 when no person exists for the id, and 400 when firstName or lastName is blank.
+
+        '
       operationId: updatePerson
       parameters:
       - name: personId
@@ -69,10 +93,21 @@ paths:
           format: uuid
         example: 123e4567-e89b-12d3-a456-426614174000
       requestBody:
+        description: Full replacement identity snapshot for the person.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/Person'
+            examples:
+              Updated person:
+                description: Updated person
+                value:
+                  firstName: Jane
+                  lastName: Smith-Jones
+                  primaryEmail: jane.smith@example.com
+                  secondaryEmail: jane.alt@example.com
+                  phoneNumbers:
+                  - '+15551234567'
         required: true
       responses:
         '200':
@@ -95,8 +130,20 @@ paths:
     delete:
       tags:
       - People API
-      summary: Delete a person
-      description: Delete a person by their unique ID.
+      summary: Delete a Person Identity Record
+      description: 'Deletes a person record and, in the same transaction, its contact points and postal address.
+
+        Use this tool to permanently remove an identity record; do not use unlinkUserFromPerson, which only removes a user link and leaves the person in place.
+
+        Preconditions: the person must exist and must have no user-person links; linked users must be removed first with unlinkUserFromPerson.
+
+        Required inputs: personId (UUID) as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_PERSON_DELETE event and queues a person.deleted fact on the transactional outbox.
+
+        Returns 204 on success, 404 when the person does not exist, and 409 when one or more users are still linked to the person.
+
+        '
       operationId: deletePerson
       parameters:
       - name: personId
@@ -116,6 +163,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
+        '409':
+          description: Person still has linked users; unlink them first.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - people-contact:person:delete
@@ -125,9 +178,21 @@ paths:
     get:
       tags:
       - Postal Address API
-      summary: Get a person's postal address
-      description: Returns the person's structured postal address, or 404 when none is on file.
-      operationId: getPersonAddress
+      summary: Get a Person's Postal Address
+      description: 'Returns the single structured postal address on file for a person; pos-people-contact is the postal-address authority for person parties (FI-4).
+
+        Use this tool when reading a person''s mailing address; use getOrganizationPostalAddress instead for CRM organization parties.
+
+        Preconditions: an address must already have been stored for the person with putPersonPostalAddress.
+
+        Required inputs: personId (UUID) as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_PERSON_ADDRESS_GET audit event; no state changes.
+
+        Returns 404 when no address is on file for the person.
+
+        '
+      operationId: getPersonPostalAddress
       parameters:
       - name: personId
         in: path
@@ -157,9 +222,21 @@ paths:
     put:
       tags:
       - Postal Address API
-      summary: Create or replace a person's postal address
-      description: Stores the structured, validated address. Only line1 and an ISO 3166-1 alpha-2 countryCode are required — the shape is country-agnostic (region is free text, postalCode optional) so it works for any deployment locale.
-      operationId: putPersonAddress
+      summary: Create or Replace Person Postal Address
+      description: 'Creates or replaces the single structured postal address for a person; the shape is country-agnostic, with free-text region and an optional postalCode.
+
+        Use this tool for person mailing addresses; use putOrganizationPostalAddress instead for CRM organization parties, and do not use replaceContactPoints, which manages email and phone channels.
+
+        Preconditions: the person record must exist; any previously stored address is overwritten in place.
+
+        Required inputs: line1 and an ISO 3166-1 alpha-2 countryCode (stored upper-case); line2, city, region and postalCode are optional free text, trimmed, with blanks stored as null.
+
+        Emits a PEOPLE_CONTACT_PERSON_ADDRESS_PUT event and queues a person.updated identity fact carrying the new address.
+
+        Returns 200 with the stored address, 404 when the person does not exist, and 422 when line1 is blank or countryCode is not a valid ISO 3166-1 alpha-2 code.
+
+        '
+      operationId: putPersonPostalAddress
       parameters:
       - name: personId
         in: path
@@ -169,10 +246,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Country-agnostic structured postal address that replaces any address already on file for the person.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PostalAddressDto'
+            examples:
+              Japanese address:
+                description: Japanese address
+                value:
+                  line1: 1-2-3 Ginza
+                  line2: Chuo-ku
+                  city: Tokyo
+                  region: Tokyo
+                  postalCode: 104-0061
+                  countryCode: JP
         required: true
       responses:
         '200':
@@ -187,6 +275,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
+        '422':
+          description: line1 missing or countryCode not a valid ISO 3166-1 alpha-2 code.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - people-contact:person:edit
@@ -195,9 +289,21 @@ paths:
     delete:
       tags:
       - Postal Address API
-      summary: Delete a person's postal address
-      description: Removes the person's postal address; succeeds even when none is on file.
-      operationId: deletePersonAddress
+      summary: Delete a Person's Postal Address
+      description: 'Removes the postal address on file for a person; the operation is idempotent and succeeds when none exists.
+
+        Use this tool to clear a person''s mailing address; do not use deletePerson, which removes the entire identity record.
+
+        Preconditions: none; a missing address is treated as already deleted.
+
+        Required inputs: personId (UUID) as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_PERSON_ADDRESS_DELETE event, and queues a person.updated identity fact only when an address actually existed.
+
+        Returns 204 whether or not an address was on file.
+
+        '
+      operationId: deletePersonPostalAddress
       parameters:
       - name: personId
         in: path
@@ -218,8 +324,20 @@ paths:
     put:
       tags:
       - People API
-      summary: Replace a person's contact points
-      description: Replaces all typed contact points (email/phone) for a person. pos-people-contact is the source of truth for contacts (ADR-0015).
+      summary: Replace a Person's Contact Points
+      description: 'Replaces the full set of typed contact points for one person; pos-people-contact is the source of truth for contact channels (ADR-0015).
+
+        Use this tool to overwrite a person''s contact channels wholesale; do not use updatePerson, which replaces names, primaryEmail, secondaryEmail and phoneNumbers as flat identity fields rather than the typed contact-point set.
+
+        Preconditions: the person should exist; the id is not validated here, so writes for an unknown person are stored without error.
+
+        Required inputs: a JSON array of contact points, each with contactType (EMAIL, PHONE_MOBILE, PHONE_HOME or PHONE_WORK), value, and primary; entries missing contactType or value are silently dropped, and an empty array clears all contact points.
+
+        Emits a people-contact person.updated identity fact through the transactional outbox when the person exists; prior contact points are deleted in the same transaction.
+
+        Returns 204 on success, including when the array is empty or the person id is unknown.
+
+        '
       operationId: replaceContactPoints
       parameters:
       - name: personId
@@ -230,12 +348,23 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Complete replacement set of typed contact points for the person.
         content:
           application/json:
             schema:
               type: array
               items:
                 $ref: '#/components/schemas/ContactPointDto'
+            examples:
+              Email and mobile phone:
+                description: Email and mobile phone
+                value:
+                - contactType: EMAIL
+                  value: jane.smith@example.com
+                  primary: true
+                - contactType: PHONE_MOBILE
+                  value: '+15551234567'
+                  primary: true
         required: true
       responses:
         '204':
@@ -249,9 +378,21 @@ paths:
     get:
       tags:
       - Postal Address API
-      summary: Get an organization's postal address
-      description: Returns the organization party's structured postal address, or 404 when none is on file. The organization id is the party UUID owned by the CRM module.
-      operationId: getOrganizationAddress
+      summary: Get an Organization's Postal Address
+      description: 'Returns the structured postal address on file for a CRM organization party; the organization id is an external pos-customer party reference stored verbatim.
+
+        Use this tool when reading an organization''s mailing address; use getPersonPostalAddress instead for person parties.
+
+        Preconditions: an address must already have been stored for the organization with putOrganizationPostalAddress.
+
+        Required inputs: organizationId (the pos-customer commercial party UUID) as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_ORG_ADDRESS_GET audit event; no state changes.
+
+        Returns 404 when no address is on file for the organization.
+
+        '
+      operationId: getOrganizationPostalAddress
       parameters:
       - name: organizationId
         in: path
@@ -281,9 +422,21 @@ paths:
     put:
       tags:
       - Postal Address API
-      summary: Create or replace an organization's postal address
-      description: Stores the structured, validated address for an organization party. The id is an external party reference (pos-customer commercial party) stored verbatim.
-      operationId: putOrganizationAddress
+      summary: Create or Replace Organization Postal Address
+      description: 'Creates or replaces the single structured postal address for a CRM organization party.
+
+        Use this tool for organization mailing addresses; use putPersonPostalAddress instead for person parties.
+
+        Preconditions: none in this module; the organization id is an external pos-customer party reference stored verbatim without an existence check.
+
+        Required inputs: organizationId (UUID) as a path parameter, plus line1 and an ISO 3166-1 alpha-2 countryCode in the body; line2, city, region and postalCode are optional free text.
+
+        Emits a PEOPLE_CONTACT_ORG_ADDRESS_PUT event and an organization-address-updated fact for downstream consumers.
+
+        Returns 200 with the stored address, and 422 when line1 is blank or countryCode is not a valid ISO 3166-1 alpha-2 code.
+
+        '
+      operationId: putOrganizationPostalAddress
       parameters:
       - name: organizationId
         in: path
@@ -293,10 +446,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Country-agnostic structured postal address that replaces any address already on file for the organization party.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PostalAddressDto'
+            examples:
+              US business address:
+                description: US business address
+                value:
+                  line1: 400 Commerce Way
+                  line2: Suite 210
+                  city: Austin
+                  region: TX
+                  postalCode: '78701'
+                  countryCode: US
         required: true
       responses:
         '200':
@@ -305,6 +469,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PostalAddressDto'
+        '422':
+          description: line1 missing or countryCode not a valid ISO 3166-1 alpha-2 code.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - people-contact:organization:edit
@@ -313,9 +483,21 @@ paths:
     delete:
       tags:
       - Postal Address API
-      summary: Delete an organization's postal address
-      description: Removes the organization party's postal address; succeeds even when none is on file.
-      operationId: deleteOrganizationAddress
+      summary: Delete an Organization's Postal Address
+      description: 'Removes the postal address on file for a CRM organization party; the operation is idempotent and succeeds when none exists.
+
+        Use this tool to clear an organization''s mailing address; use deletePersonPostalAddress instead for person parties.
+
+        Preconditions: none; a missing address is treated as already deleted.
+
+        Required inputs: organizationId (UUID) as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_ORG_ADDRESS_DELETE event, and an organization-address-removed fact is published only when an address actually existed.
+
+        Returns 204 whether or not an address was on file.
+
+        '
+      operationId: deleteOrganizationPostalAddress
       parameters:
       - name: organizationId
         in: path
@@ -336,9 +518,21 @@ paths:
     get:
       tags:
       - People API
-      summary: Get all people
-      description: Retrieve people with an optional text filter. Employment filtering lives in pos-people (ADR-0044 §6) and is not available on the identity directory.
-      operationId: getAllPeople
+      summary: List People in Identity Directory
+      description: 'Lists person records in the identity directory, optionally narrowed by a free-text filter, with each result carrying emails, work phone numbers and any linked username.
+
+        Use this tool when browsing or searching people by name or email; do not use resolvePerson, which performs weighted duplicate matching and may create a new person as a side effect.
+
+        Preconditions: none; an empty directory simply yields an empty list.
+
+        Required inputs: none; q is an optional case-insensitive filter matched against firstName, lastName and primaryEmail, and employment attributes cannot be filtered here because they live in pos-people (ADR-0044 §6).
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the matching people, possibly an empty list when nothing matches the filter.
+
+        '
+      operationId: listPeople
       parameters:
       - name: q
         in: query
@@ -363,14 +557,36 @@ paths:
     post:
       tags:
       - People API
-      summary: Create a new person
-      description: Add a new person to the system.
+      summary: Create a New Person Record
+      description: 'Creates a new person identity record; emails and phone numbers are persisted as contact points owned by this module.
+
+        Use this tool when the person is known to be new; do not use resolvePerson, which should be preferred when a matching person may already exist, and do not use linkUserToPerson, which only associates an existing person with a security user.
+
+        Preconditions: none; duplicate names or emails are not rejected, so deduplication is the caller''s responsibility (or use resolvePerson).
+
+        Required inputs: firstName and lastName (non-blank); primaryEmail, secondaryEmail and phoneNumbers are optional, and username is ignored because usernames are owned by pos-security and linked separately.
+
+        Emits a PEOPLE_CONTACT_PERSON_CREATE event and queues a person.updated identity fact on the transactional outbox.
+
+        Returns 201 with the persisted person, and 400 when firstName or lastName is blank.
+
+        '
       operationId: createPerson
       requestBody:
+        description: Identity fields of the person to create; contact data is stored as contact points.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/Person'
+            examples:
+              New person:
+                description: New person
+                value:
+                  firstName: Jane
+                  lastName: Smith
+                  primaryEmail: jane.smith@example.com
+                  phoneNumbers:
+                  - '+15551234567'
         required: true
       responses:
         '201':
@@ -388,9 +604,21 @@ paths:
     get:
       tags:
       - People - Access Control
-      summary: Get role assignments
-      description: Retrieve role assignments for a person with optional history and date filtering
-      operationId: getAssignments
+      summary: List a Person's Role Assignments
+      description: 'Lists the role assignments a person holds in pos-security, resolved through the person''s active user-person link.
+
+        Use this tool to inspect the access a person already has; do not use listAssignableRoles, which returns the catalog of roles available for assignment.
+
+        Preconditions: the person must have an active user-person link, and the linked username must resolve to a pos-security user.
+
+        Required inputs: personUuid (UUID) as a path parameter; includeHistory defaults to false and adds ended assignments when true, and endDate (ISO date-time) optionally evaluates assignments as of that moment.
+
+        Emits a PEOPLE_CONTACT_ACCESS_ASSIGNMENTS_LIST audit event; no state changes.
+
+        Returns 404 when the person has no user link or the linked username has no security user.
+
+        '
+      operationId: listRoleAssignments
       parameters:
       - name: personUuid
         in: path
@@ -426,9 +654,21 @@ paths:
     post:
       tags:
       - People - Access Control
-      summary: Assign role to person
-      description: Assign a role to a person with optional location scope and date range
-      operationId: createAssignment
+      summary: Assign a Role to a Person
+      description: 'Assigns a role to a person by delegating to pos-security through the person''s linked user account, optionally scoped to one location and bounded by a date window.
+
+        Use this tool to grant access; do not use revokeRoleAssignment, which ends an assignment that already exists.
+
+        Preconditions: the person must have an active user-person link resolving to a pos-security user, and the roleCode must exist in pos-security.
+
+        Required inputs: personUuid (UUID) as a path parameter and roleCode in the body; locationId (UUID) scopes the role to one location when supplied, and optional startDate/endDate bound the assignment, with endDate required to be on or after startDate.
+
+        Emits a PEOPLE_CONTACT_ACCESS_ASSIGNMENT_CREATE event; the assignment record itself is created and owned by pos-security.
+
+        Returns 201 with the created assignment, 400 when roleCode is blank or endDate precedes startDate, and 404 when the person''s user link, the security user, or the role cannot be resolved.
+
+        '
+      operationId: assignRoleToPerson
       parameters:
       - name: personUuid
         in: path
@@ -437,10 +677,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Role code plus optional location scope and effective date window.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PersonRoleAssignmentRequest'
+            examples:
+              Location-scoped technician role:
+                description: Location-scoped technician role
+                value:
+                  roleCode: TECHNICIAN
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  startDate: 2026-09-01 00:00:00
+                  endDate: 2026-12-31 23:59:59
         required: true
       responses:
         '201':
@@ -470,14 +719,35 @@ paths:
     post:
       tags:
       - User-Person Linking API
-      summary: Link user to person
-      description: Create a link between an authentication user and a person record
+      summary: Link User to Person Record
+      description: 'Links a security user account to a person record, optionally recording a linkType and notes; the link is what lets a login act as that person.
+
+        Use this tool when associating a user with a person, for example during onboarding; do not use createUserPersonLink, which is the minimal admin variant without linkType or notes, and do not use createPerson, which creates the identity record itself.
+
+        Preconditions: the person must exist, and the username must not already be linked to a different person; one username maps to at most one person.
+
+        Required inputs: username and personId (UUID); linkType defaults to PRIMARY and notes is optional.
+
+        Emits a PEOPLE_CONTACT_USER_LINK_CREATE event and queues a link-updated fact on the transactional outbox.
+
+        Returns 201 when the link is created, 200 when the identical link already exists (the call is idempotent), 404 when the person does not exist, and 409 when the username is already linked to a different person.
+
+        '
       operationId: linkUserToPerson
       requestBody:
+        description: User-person pair to link, with optional link classification and notes.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LinkUserToPersonRequest'
+            examples:
+              Onboarding link:
+                description: Onboarding link
+                value:
+                  username: marcus.webb
+                  personId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  linkType: PRIMARY
+                  notes: Linked during onboarding
         required: true
       responses:
         '201':
@@ -519,14 +789,33 @@ paths:
     post:
       tags:
       - User-Person Linking API
-      summary: Create user-person link (admin)
-      description: Create a link between an authentication user and a person record
+      summary: Create User Person Link as Admin
+      description: 'Creates a user-person link from the minimal administrative payload of username and personId only; the link is stored with linkType PRIMARY.
+
+        Use this tool for administrative linking when linkType and notes are not needed; do not use linkUserToPerson, which accepts the same pair plus an explicit linkType and notes.
+
+        Preconditions: the person must exist, and the username must not already be linked to a different person; one username maps to at most one person.
+
+        Required inputs: username and personId (UUID); both are mandatory and there are no other fields.
+
+        Emits a PEOPLE_CONTACT_USER_LINK_CREATE event and queues a link-updated fact on the transactional outbox.
+
+        Returns 201 when the link is created, 200 when the identical link already exists (the call is idempotent), 404 when the person does not exist, and 409 when the username is already linked to a different person.
+
+        '
       operationId: createUserPersonLink
       requestBody:
+        description: Minimal user-person pair to link; the link is stored as PRIMARY.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateUserLinkRequest'
+            examples:
+              Admin link:
+                description: Admin link
+                value:
+                  username: marcus.webb
+                  personId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
         required: true
       responses:
         '201':
@@ -568,14 +857,36 @@ paths:
     post:
       tags:
       - People API
-      summary: Resolve person
-      description: Find best matching person by score or create a new person
+      summary: Resolve or Create Matching Person
+      description: 'Finds the best-matching existing person using weighted scoring (email 60, phone 25, lastName 10, firstName 5) and creates a new person when no candidate reaches the threshold.
+
+        Use this tool to deduplicate at intake before creating people; do not use createPerson, which always inserts a new record without any matching.
+
+        Preconditions: none; inputs are normalized before scoring (email lowercased, phone reduced to digits, names trimmed).
+
+        Required inputs: at least one of email, phone, lastName or firstName; threshold is optional and defaults to the configured pos.people-contact.matching.threshold value (30 unless overridden).
+
+        Emits a PEOPLE_CONTACT_PERSON_RESOLVE event; when no match reaches the threshold a new person is created and a person.updated identity fact is queued on the outbox.
+
+        Returns 200 with matchedExisting true, the score and the matchedBy reasons when a candidate wins, 200 with matchedExisting false when a new person was created, and 400 when all four matching inputs are absent or blank.
+
+        '
       operationId: resolvePerson
       requestBody:
+        description: Weighted matching criteria used to find or create the person.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ResolvePersonRequest'
+            examples:
+              Match by email and name:
+                description: Match by email and name
+                value:
+                  email: jane.smith@example.com
+                  phone: '+15551234567'
+                  lastName: Smith
+                  firstName: Jane
+                  threshold: 30
         required: true
       responses:
         '200':
@@ -593,18 +904,36 @@ paths:
     post:
       tags:
       - People API
-      summary: Get people by IDs
-      description: Batch-resolve persons by id in one request. Unknown ids are omitted; the result may be smaller than the request. Used for cross-service identity reads (ADR-0015).
+      summary: Batch Resolve People by IDs
+      description: 'Batch-resolves person records by id in one request, attaching typed contact points and linked usernames to each result.
+
+        Use this tool for cross-service identity reads that need several people at once (ADR-0015); use getPersonById instead for a single known id.
+
+        Preconditions: none; unknown ids are silently omitted, so the result may be smaller than the request.
+
+        Required inputs: a JSON array of person UUIDs as the request body; an empty array yields an empty list.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the resolved people; ids that do not exist are dropped rather than reported as errors.
+
+        '
       operationId: getPeopleByIds
       requestBody:
+        description: JSON array of person UUIDs to resolve in one batch.
         content:
           application/json:
             schema:
               type: array
-              description: Person ids to resolve
               items:
                 type: string
                 format: uuid
+            examples:
+              Two ids:
+                description: Two ids
+                value:
+                - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '200':
@@ -624,9 +953,21 @@ paths:
     get:
       tags:
       - People - Access Control
-      summary: Get available roles
-      description: Retrieve list of roles that can be assigned to people
-      operationId: getRoles
+      summary: List Roles Assignable to Person
+      description: 'Lists the role catalog a person could be assigned, combining LOCATION-scoped and GLOBAL-scoped roles fetched live from pos-security.
+
+        Use this tool to populate a role picker before calling assignRoleToPerson; do not use listRoleAssignments, which returns the roles the person already holds.
+
+        Preconditions: the person record must exist; the roles themselves are owned by pos-security, and no user-person link is needed for this listing.
+
+        Required inputs: personUuid (UUID) as a path parameter; there is no request body and no filtering.
+
+        Emits a PEOPLE_CONTACT_ACCESS_ROLES_LIST audit event; no state changes.
+
+        Returns 404 when the person does not exist, and propagates the pos-security status code when the role listing call fails there.
+
+        '
+      operationId: listAssignableRoles
       parameters:
       - name: personUuid
         in: path
@@ -652,9 +993,21 @@ paths:
     get:
       tags:
       - User-Person Linking API
-      summary: Get users linked to person
-      description: Retrieve all usernames linked to a person record
-      operationId: getUsernamesByPersonId
+      summary: List Usernames Linked to Person
+      description: 'Lists every username linked to a person record as a flat array of strings.
+
+        Use this tool to see which logins can act as a person; use getLinksByPersonId instead when the full link records with linkType, notes and audit fields are needed.
+
+        Preconditions: the person record must exist; a person with no links yields an empty list.
+
+        Required inputs: personId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the person does not exist.
+
+        '
+      operationId: listUsernamesForPerson
       parameters:
       - name: personId
         in: path
@@ -689,8 +1042,20 @@ paths:
     get:
       tags:
       - User-Person Linking API
-      summary: Get person by username
-      description: Retrieve the person record linked to a user
+      summary: Get Person Linked to Username
+      description: 'Returns the person record linked to a username, including emails, work phone numbers and the username itself.
+
+        Use this tool to translate a login identity into its person record; use getCurrentPerson instead when the target is the authenticated caller, and getLinksByPersonId to go from a person to its links.
+
+        Preconditions: a user-person link must exist for the username, and the linked person record must still exist.
+
+        Required inputs: username as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no link exists for the username or the linked person record is missing.
+
+        '
       operationId: getPersonByUsername
       parameters:
       - name: username
@@ -721,8 +1086,20 @@ paths:
     get:
       tags:
       - User-Person Linking API
-      summary: Get links by person ID
-      description: Retrieve user-person links for person
+      summary: Get User Links for Person
+      description: 'Returns the full user-person link records for a person, including linkType, notes, creator and creation time.
+
+        Use this tool when link metadata is needed; use listUsernamesForPerson instead when only the usernames matter, and getPersonByUsername to go from a username to its person.
+
+        Preconditions: the person record must exist; a person with no links yields an empty list.
+
+        Required inputs: personId (UUID) as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_USER_LINK_GET audit event; no state changes.
+
+        Returns 404 when the person does not exist.
+
+        '
       operationId: getLinksByPersonId
       parameters:
       - name: personId
@@ -756,8 +1133,20 @@ paths:
     get:
       tags:
       - People API
-      summary: Get current user's person record
-      description: Resolve the authenticated user to their linked person record. Returns 404 when the user has no person link or the linked person no longer exists.
+      summary: Get Current User's Person Record
+      description: 'Resolves the authenticated caller''s username to its linked person record and returns the identity snapshot with emails, work phone numbers and username.
+
+        Use this tool when the caller needs their own person record without knowing a person id; do not use getPersonById, which requires a known person UUID and can read any person.
+
+        Preconditions: an active user-person link must exist for the authenticated username, and the linked person record must still exist.
+
+        Required inputs: none; identity comes entirely from the authenticated security context.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the caller has no user-person link or the linked person no longer exists, and 401 when the authenticated context carries no username.
+
+        '
       operationId: getCurrentPerson
       responses:
         '200':
@@ -781,9 +1170,21 @@ paths:
     delete:
       tags:
       - People - Access Control
-      summary: Revoke role assignment
-      description: Revoke a role assignment from a person
-      operationId: revokeAssignment
+      summary: Revoke Role Assignment from Person
+      description: 'Revokes one of a person''s role assignments by delegating to pos-security through the person''s linked user account.
+
+        Use this tool to end access granted with assignRoleToPerson; do not use unlinkUserFromPerson, which severs the whole user-person link rather than a single role.
+
+        Preconditions: the person must have an active user-person link resolving to a pos-security user, and an assignment for the roleCode must exist there.
+
+        Required inputs: personUuid (UUID) and roleCode as path parameters; endDate (ISO date-time) optionally ends the assignment at that moment instead of immediately.
+
+        Emits a PEOPLE_CONTACT_ACCESS_ASSIGNMENT_REVOKE event; the assignment state change is recorded in pos-security.
+
+        Returns 204 on success, and 404 when the person has no user link, the security user cannot be resolved, or pos-security has no matching assignment.
+
+        '
+      operationId: revokeRoleAssignment
       parameters:
       - name: personUuid
         in: path
@@ -826,8 +1227,20 @@ paths:
     delete:
       tags:
       - User-Person Linking API
-      summary: Unlink user from person
-      description: Remove the link between a user and person
+      summary: Unlink User from Person Record
+      description: 'Removes the link between a security user and its person record, leaving both the user account and the person untouched.
+
+        Use this tool to sever a login from an identity, including before deletePerson on a person that still has linked users; do not use revokeRoleAssignment, which removes a single role rather than the whole link.
+
+        Preconditions: a user-person link must exist for the username.
+
+        Required inputs: username as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_USER_PERSON_LINK_DELETE event and queues a link-removed fact on the transactional outbox.
+
+        Returns 204 on success, and 404 when no link exists for the username.
+
+        '
       operationId: unlinkUserFromPerson
       parameters:
       - name: username
@@ -875,7 +1288,6 @@ components:
       - value
     Person:
       type: object
-      description: Person object to be created
       properties:
         id:
           type: string
@@ -1118,7 +1530,7 @@ components:
       - username
     ResolvePersonRequest:
       type: object
-      description: Resolve criteria
+      description: Resolve person request with weighted matching inputs
       properties:
         email:
           type: string

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PersonAccessController.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PersonAccessController.java
@@ -7,6 +7,7 @@ import com.positivity.peoplecontact.internal.dto.PersonRoleAssignmentRequest;
 import com.positivity.peoplecontact.service.PeopleAccessControlService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -42,7 +43,19 @@ public class PersonAccessController {
 
     @GetMapping("/{personUuid}/access/roles")
     @EmitEvent(id = "PEOPLE_CONTACT_ACCESS_ROLES_LIST", apiVersion = "1")
-    @Operation(summary = "Get available roles", description = "Retrieve list of roles that can be assigned to people")
+    @Operation(operationId = "listAssignableRoles", summary = "List Roles Assignable to Person", description = """
+                    Lists the role catalog a person could be assigned, combining LOCATION-scoped and \
+                    GLOBAL-scoped roles fetched live from pos-security.
+                    Use this tool to populate a role picker before calling assignRoleToPerson; do not use \
+                    listRoleAssignments, which returns the roles the person already holds.
+                    Preconditions: the person record must exist; the roles themselves are owned by pos-security, \
+                    and no user-person link is needed for this listing.
+                    Required inputs: personUuid (UUID) as a path parameter; there is no request body and no \
+                    filtering.
+                    Emits a PEOPLE_CONTACT_ACCESS_ROLES_LIST audit event; no state changes.
+                    Returns 404 when the person does not exist, and propagates the pos-security status code when \
+                    the role listing call fails there.
+                    """)
     @ApiResponse(responseCode = "200", description = "Roles retrieved successfully")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -54,9 +67,19 @@ public class PersonAccessController {
 
     @GetMapping("/{personUuid}/access/assignments")
     @EmitEvent(id = "PEOPLE_CONTACT_ACCESS_ASSIGNMENTS_LIST", apiVersion = "1")
-    @Operation(
-            summary = "Get role assignments",
-            description = "Retrieve role assignments for a person with optional history and date filtering")
+    @Operation(operationId = "listRoleAssignments", summary = "List a Person's Role Assignments", description = """
+                    Lists the role assignments a person holds in pos-security, resolved through the person's \
+                    active user-person link.
+                    Use this tool to inspect the access a person already has; do not use listAssignableRoles, \
+                    which returns the catalog of roles available for assignment.
+                    Preconditions: the person must have an active user-person link, and the linked username must \
+                    resolve to a pos-security user.
+                    Required inputs: personUuid (UUID) as a path parameter; includeHistory defaults to false and \
+                    adds ended assignments when true, and endDate (ISO date-time) optionally evaluates \
+                    assignments as of that moment.
+                    Emits a PEOPLE_CONTACT_ACCESS_ASSIGNMENTS_LIST audit event; no state changes.
+                    Returns 404 when the person has no user link or the linked username has no security user.
+                    """)
     @ApiResponse(responseCode = "200", description = "Assignments retrieved successfully")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -72,9 +95,22 @@ public class PersonAccessController {
 
     @PostMapping("/{personUuid}/access/assignments")
     @EmitEvent(id = "PEOPLE_CONTACT_ACCESS_ASSIGNMENT_CREATE", apiVersion = "1")
-    @Operation(
-            summary = "Assign role to person",
-            description = "Assign a role to a person with optional location scope and date range")
+    @Operation(operationId = "assignRoleToPerson", summary = "Assign a Role to a Person", description = """
+                    Assigns a role to a person by delegating to pos-security through the person's linked user \
+                    account, optionally scoped to one location and bounded by a date window.
+                    Use this tool to grant access; do not use revokeRoleAssignment, which ends an assignment \
+                    that already exists.
+                    Preconditions: the person must have an active user-person link resolving to a pos-security \
+                    user, and the roleCode must exist in pos-security.
+                    Required inputs: personUuid (UUID) as a path parameter and roleCode in the body; locationId \
+                    (UUID) scopes the role to one location when supplied, and optional startDate/endDate bound \
+                    the assignment, with endDate required to be on or after startDate.
+                    Emits a PEOPLE_CONTACT_ACCESS_ASSIGNMENT_CREATE event; the assignment record itself is \
+                    created and owned by pos-security.
+                    Returns 201 with the created assignment, 400 when roleCode is blank or endDate precedes \
+                    startDate, and 404 when the person's user link, the security user, or the role cannot be \
+                    resolved.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -101,7 +137,25 @@ public class PersonAccessController {
             scopes = {"people-contact:role:assign"})
     @PreAuthorize("hasAuthority('people-contact:role:assign')")
     public ResponseEntity<UserRoleDto> createAssignment(
-            @PathVariable UUID personUuid, @Valid @RequestBody PersonRoleAssignmentRequest request) {
+            @PathVariable UUID personUuid,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Role code plus optional location scope and effective date window.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Location-scoped technician role",
+                                                            value = """
+                                                                    {"roleCode":"TECHNICIAN",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "startDate":"2026-09-01T00:00:00",
+                                                                     "endDate":"2026-12-31T23:59:59"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    PersonRoleAssignmentRequest request) {
         if (request.getRoleCode() == null || request.getRoleCode().isBlank()) {
             throw new IllegalArgumentException("roleCode is required");
         }
@@ -116,7 +170,20 @@ public class PersonAccessController {
 
     @DeleteMapping("/{personUuid}/access/assignments/{roleCode}")
     @EmitEvent(id = "PEOPLE_CONTACT_ACCESS_ASSIGNMENT_REVOKE", apiVersion = "1")
-    @Operation(summary = "Revoke role assignment", description = "Revoke a role assignment from a person")
+    @Operation(operationId = "revokeRoleAssignment", summary = "Revoke Role Assignment from Person", description = """
+                    Revokes one of a person's role assignments by delegating to pos-security through the \
+                    person's linked user account.
+                    Use this tool to end access granted with assignRoleToPerson; do not use \
+                    unlinkUserFromPerson, which severs the whole user-person link rather than a single role.
+                    Preconditions: the person must have an active user-person link resolving to a pos-security \
+                    user, and an assignment for the roleCode must exist there.
+                    Required inputs: personUuid (UUID) and roleCode as path parameters; endDate (ISO date-time) \
+                    optionally ends the assignment at that moment instead of immediately.
+                    Emits a PEOPLE_CONTACT_ACCESS_ASSIGNMENT_REVOKE event; the assignment state change is \
+                    recorded in pos-security.
+                    Returns 204 on success, and 404 when the person has no user link, the security user cannot \
+                    be resolved, or pos-security has no matching assignment.
+                    """)
     @ApiResponse(responseCode = "204", description = "Role assignment revoked successfully")
     @ApiResponse(
             responseCode = "400",

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PersonController.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PersonController.java
@@ -9,6 +9,7 @@ import com.positivity.peoplecontact.service.UserPersonTranslationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,10 +43,18 @@ public class PersonController {
 
     private final UserPersonTranslationService userPersonTranslationService;
 
-    @Operation(
-            summary = "Get current user's person record",
-            description = "Resolve the authenticated user to their linked person record. Returns 404 when the user"
-                    + " has no person link or the linked person no longer exists.")
+    @Operation(operationId = "getCurrentPerson", summary = "Get Current User's Person Record", description = """
+                    Resolves the authenticated caller's username to its linked person record and returns the \
+                    identity snapshot with emails, work phone numbers and username.
+                    Use this tool when the caller needs their own person record without knowing a person id; do \
+                    not use getPersonById, which requires a known person UUID and can read any person.
+                    Preconditions: an active user-person link must exist for the authenticated username, and the \
+                    linked person record must still exist.
+                    Required inputs: none; identity comes entirely from the authenticated security context.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when the caller has no user-person link or the linked person no longer exists, \
+                    and 401 when the authenticated context carries no username.
+                    """)
     @ApiResponse(responseCode = "200", description = "Person found and returned.")
     @ApiResponse(
             responseCode = "404",
@@ -66,10 +75,18 @@ public class PersonController {
                 .orElseThrow(() -> new EntityNotFoundException("No person found for id: " + personId));
     }
 
-    @Operation(
-            summary = "Get all people",
-            description = "Retrieve people with an optional text filter. Employment filtering lives in pos-people"
-                    + " (ADR-0044 §6) and is not available on the identity directory.")
+    @Operation(operationId = "listPeople", summary = "List People in Identity Directory", description = """
+                    Lists person records in the identity directory, optionally narrowed by a free-text filter, \
+                    with each result carrying emails, work phone numbers and any linked username.
+                    Use this tool when browsing or searching people by name or email; do not use resolvePerson, \
+                    which performs weighted duplicate matching and may create a new person as a side effect.
+                    Preconditions: none; an empty directory simply yields an empty list.
+                    Required inputs: none; q is an optional case-insensitive filter matched against firstName, \
+                    lastName and primaryEmail, and employment attributes cannot be filtered here because they \
+                    live in pos-people (ADR-0044 §6).
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the matching people, possibly an empty list when nothing matches the filter.
+                    """)
     @Parameter(name = "q", description = "Case-insensitive text search on firstName, lastName, primaryEmail.")
     @ApiResponse(responseCode = "200", description = "List of people returned successfully.")
     @GetMapping
@@ -81,7 +98,16 @@ public class PersonController {
         return personService.getAllPeople(q);
     }
 
-    @Operation(summary = "Get person by ID", description = "Retrieve a person by their unique ID.")
+    @Operation(operationId = "getPersonById", summary = "Get a Person by Unique ID", description = """
+                    Returns a single person record by its UUID, including emails, work phone numbers and any \
+                    linked username.
+                    Use this tool when the person id is already known; use listPeople instead when searching by \
+                    name or email, and getCurrentPerson when the target is the authenticated caller.
+                    Preconditions: the person record must exist in the identity directory.
+                    Required inputs: personId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no person exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Person found and returned.")
     @ApiResponse(
             responseCode = "404",
@@ -105,25 +131,56 @@ public class PersonController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @Operation(
-            summary = "Get people by IDs",
-            description = "Batch-resolve persons by id in one request. Unknown ids are omitted; the result may be"
-                    + " smaller than the request. Used for cross-service identity reads (ADR-0015).")
+    @Operation(operationId = "getPeopleByIds", summary = "Batch Resolve People by IDs", description = """
+                    Batch-resolves person records by id in one request, attaching typed contact points and linked \
+                    usernames to each result.
+                    Use this tool for cross-service identity reads that need several people at once (ADR-0015); \
+                    use getPersonById instead for a single known id.
+                    Preconditions: none; unknown ids are silently omitted, so the result may be smaller than the \
+                    request.
+                    Required inputs: a JSON array of person UUIDs as the request body; an empty array yields an \
+                    empty list.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the resolved people; ids that do not exist are dropped rather than reported \
+                    as errors.
+                    """)
     @ApiResponse(responseCode = "200", description = "Persons resolved.")
     @PostMapping("/by-ids")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"people-contact:person:view"})
     @PreAuthorize("hasAuthority('people-contact:person:view')")
-    public List<Person> getPeopleByIds(@Parameter(description = "Person ids to resolve") @RequestBody List<UUID> ids) {
+    public List<Person> getPeopleByIds(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "JSON array of person UUIDs to resolve in one batch.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Two ids", value = """
+                                                                    ["018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"]
+                                                                    """)))
+                    @RequestBody
+                    List<UUID> ids) {
         return personService.getPeopleByIds(ids);
     }
 
-    @Operation(
-            summary = "Replace a person's contact points",
-            description =
-                    "Replaces all typed contact points (email/phone) for a person. pos-people-contact is the source of"
-                            + " truth for contacts (ADR-0015).")
+    @Operation(operationId = "replaceContactPoints", summary = "Replace a Person's Contact Points", description = """
+                    Replaces the full set of typed contact points for one person; pos-people-contact is the \
+                    source of truth for contact channels (ADR-0015).
+                    Use this tool to overwrite a person's contact channels wholesale; do not use updatePerson, \
+                    which replaces names, primaryEmail, secondaryEmail and phoneNumbers as flat identity fields \
+                    rather than the typed contact-point set.
+                    Preconditions: the person should exist; the id is not validated here, so writes for an \
+                    unknown person are stored without error.
+                    Required inputs: a JSON array of contact points, each with contactType (EMAIL, PHONE_MOBILE, \
+                    PHONE_HOME or PHONE_WORK), value, and primary; entries missing contactType or value are \
+                    silently dropped, and an empty array clears all contact points.
+                    Emits a people-contact person.updated identity fact through the transactional outbox when \
+                    the person exists; prior contact points are deleted in the same transaction.
+                    Returns 204 on success, including when the array is empty or the person id is unknown.
+                    """)
     @ApiResponse(responseCode = "204", description = "Contact points replaced.")
     @PutMapping("/{personId}/contact-points")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -132,12 +189,41 @@ public class PersonController {
     @PreAuthorize("hasAuthority('people-contact:person:edit')")
     public ResponseEntity<Void> replaceContactPoints(
             @Parameter(description = "Person id") @PathVariable UUID personId,
-            @RequestBody List<Person.ContactPointDto> contactPoints) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Complete replacement set of typed contact points for the person.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Email and mobile phone", value = """
+                                                                    [{"contactType":"EMAIL",
+                                                                      "value":"jane.smith@example.com",
+                                                                      "primary":true},
+                                                                     {"contactType":"PHONE_MOBILE",
+                                                                      "value":"+15551234567",
+                                                                      "primary":true}]
+                                                                    """)))
+                    @RequestBody
+                    List<Person.ContactPointDto> contactPoints) {
         personService.replaceContactPoints(personId, contactPoints);
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Create a new person", description = "Add a new person to the system.")
+    @Operation(operationId = "createPerson", summary = "Create a New Person Record", description = """
+                    Creates a new person identity record; emails and phone numbers are persisted as contact \
+                    points owned by this module.
+                    Use this tool when the person is known to be new; do not use resolvePerson, which should be \
+                    preferred when a matching person may already exist, and do not use linkUserToPerson, which \
+                    only associates an existing person with a security user.
+                    Preconditions: none; duplicate names or emails are not rejected, so deduplication is the \
+                    caller's responsibility (or use resolvePerson).
+                    Required inputs: firstName and lastName (non-blank); primaryEmail, secondaryEmail and \
+                    phoneNumbers are optional, and username is ignored because usernames are owned by \
+                    pos-security and linked separately.
+                    Emits a PEOPLE_CONTACT_PERSON_CREATE event and queues a person.updated identity fact on the \
+                    transactional outbox.
+                    Returns 201 with the persisted person, and 400 when firstName or lastName is blank.
+                    """)
     @ApiResponse(responseCode = "201", description = "Person created successfully.")
     @EmitEvent(id = "PEOPLE_CONTACT_PERSON_CREATE", apiVersion = "1")
     @PostMapping
@@ -146,12 +232,42 @@ public class PersonController {
             scopes = {"people-contact:person:create"})
     @PreAuthorize("hasAuthority('people-contact:person:create')")
     public ResponseEntity<Person> createPerson(
-            @Parameter(description = "Person object to be created") @Valid @RequestBody Person person) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Identity fields of the person to create; contact data is stored as"
+                                    + " contact points.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "New person", value = """
+                                                                    {"firstName":"Jane",
+                                                                     "lastName":"Smith",
+                                                                     "primaryEmail":"jane.smith@example.com",
+                                                                     "phoneNumbers":["+15551234567"]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    Person person) {
         Person saved = personService.savePerson(person);
         return ResponseEntity.status(201).body(saved);
     }
 
-    @Operation(summary = "Resolve person", description = "Find best matching person by score or create a new person")
+    @Operation(operationId = "resolvePerson", summary = "Resolve or Create Matching Person", description = """
+                    Finds the best-matching existing person using weighted scoring (email 60, phone 25, lastName \
+                    10, firstName 5) and creates a new person when no candidate reaches the threshold.
+                    Use this tool to deduplicate at intake before creating people; do not use createPerson, \
+                    which always inserts a new record without any matching.
+                    Preconditions: none; inputs are normalized before scoring (email lowercased, phone reduced \
+                    to digits, names trimmed).
+                    Required inputs: at least one of email, phone, lastName or firstName; threshold is optional \
+                    and defaults to the configured pos.people-contact.matching.threshold value (30 unless \
+                    overridden).
+                    Emits a PEOPLE_CONTACT_PERSON_RESOLVE event; when no match reaches the threshold a new \
+                    person is created and a person.updated identity fact is queued on the outbox.
+                    Returns 200 with matchedExisting true, the score and the matchedBy reasons when a candidate \
+                    wins, 200 with matchedExisting false when a new person was created, and 400 when all four \
+                    matching inputs are absent or blank.
+                    """)
     @ApiResponse(responseCode = "200", description = "Person resolved successfully.")
     @EmitEvent(id = "PEOPLE_CONTACT_PERSON_RESOLVE", apiVersion = "1")
     @PostMapping("/resolve")
@@ -160,12 +276,41 @@ public class PersonController {
             scopes = {"people-contact:person:create"})
     @PreAuthorize("hasAuthority('people-contact:person:create')")
     public ResponseEntity<ResolvePersonResponse> resolvePerson(
-            @Parameter(description = "Resolve criteria") @Valid @RequestBody ResolvePersonRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Weighted matching criteria used to find or create the person.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Match by email and name", value = """
+                                                                    {"email":"jane.smith@example.com",
+                                                                     "phone":"+15551234567",
+                                                                     "lastName":"Smith",
+                                                                     "firstName":"Jane",
+                                                                     "threshold":30}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    ResolvePersonRequest request) {
         ResolvePersonResponse resolved = personService.resolvePerson(request);
         return ResponseEntity.ok(resolved);
     }
 
-    @Operation(summary = "Update an existing person", description = "Update the details of an existing person.")
+    @Operation(operationId = "updatePerson", summary = "Update an Existing Person Record", description = """
+                    Updates an existing person's identity fields, fully replacing names, emails and work phone \
+                    numbers with the submitted values.
+                    Use this tool to correct or complete a known person's identity data; do not use \
+                    replaceContactPoints, which manages the typed contact-point set, and do not use createPerson \
+                    for records that do not exist yet.
+                    Preconditions: the person record must already exist for the supplied id.
+                    Required inputs: personId (UUID) as a path parameter plus a full person body with non-blank \
+                    firstName and lastName; omitting primaryEmail, secondaryEmail or phoneNumbers erases the \
+                    stored values, and username is ignored because it is owned by pos-security.
+                    Emits a PEOPLE_CONTACT_PERSON_UPDATE event and queues a person.updated identity fact on the \
+                    transactional outbox.
+                    Returns 200 with the updated person, 404 when no person exists for the id, and 400 when \
+                    firstName or lastName is blank.
+                    """)
     @ApiResponse(responseCode = "200", description = "Person updated successfully.")
     @ApiResponse(
             responseCode = "404",
@@ -184,7 +329,22 @@ public class PersonController {
             @Parameter(description = "ID of the person to update", example = "123e4567-e89b-12d3-a456-426614174000")
                     @PathVariable
                     UUID personId,
-            @Parameter(description = "Updated person object") @Valid @RequestBody Person person) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement identity snapshot for the person.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Updated person", value = """
+                                                                    {"firstName":"Jane",
+                                                                     "lastName":"Smith-Jones",
+                                                                     "primaryEmail":"jane.smith@example.com",
+                                                                     "secondaryEmail":"jane.alt@example.com",
+                                                                     "phoneNumbers":["+15551234567"]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    Person person) {
         if (personService.getPersonById(personId).isEmpty()) {
             return ResponseEntity.notFound().build();
         }
@@ -193,11 +353,29 @@ public class PersonController {
         return ResponseEntity.ok(updated);
     }
 
-    @Operation(summary = "Delete a person", description = "Delete a person by their unique ID.")
+    @Operation(operationId = "deletePerson", summary = "Delete a Person Identity Record", description = """
+                    Deletes a person record and, in the same transaction, its contact points and postal address.
+                    Use this tool to permanently remove an identity record; do not use unlinkUserFromPerson, \
+                    which only removes a user link and leaves the person in place.
+                    Preconditions: the person must exist and must have no user-person links; linked users must \
+                    be removed first with unlinkUserFromPerson.
+                    Required inputs: personId (UUID) as a path parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_PERSON_DELETE event and queues a person.deleted fact on the \
+                    transactional outbox.
+                    Returns 204 on success, 404 when the person does not exist, and 409 when one or more users \
+                    are still linked to the person.
+                    """)
     @ApiResponse(responseCode = "204", description = "Person deleted successfully.")
     @ApiResponse(
             responseCode = "404",
             description = "Person not found.",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Person still has linked users; unlink them first.",
             content =
                     @Content(
                             mediaType = "application/problem+json",

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PostalAddressController.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PostalAddressController.java
@@ -7,6 +7,7 @@ import com.positivity.peoplecontact.service.PostalAddressService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -35,9 +36,17 @@ public class PostalAddressController {
 
     private final PostalAddressService postalAddressService;
 
-    @Operation(
-            summary = "Get a person's postal address",
-            description = "Returns the person's structured postal address, or 404 when none is on file.")
+    @Operation(operationId = "getPersonPostalAddress", summary = "Get a Person's Postal Address", description = """
+                    Returns the single structured postal address on file for a person; pos-people-contact is the \
+                    postal-address authority for person parties (FI-4).
+                    Use this tool when reading a person's mailing address; use getOrganizationPostalAddress \
+                    instead for CRM organization parties.
+                    Preconditions: an address must already have been stored for the person with \
+                    putPersonPostalAddress.
+                    Required inputs: personId (UUID) as a path parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_PERSON_ADDRESS_GET audit event; no state changes.
+                    Returns 404 when no address is on file for the person.
+                    """)
     @ApiResponse(responseCode = "200", description = "Address found and returned.")
     @ApiResponse(
             responseCode = "404",
@@ -61,14 +70,34 @@ public class PostalAddressController {
     }
 
     @Operation(
-            summary = "Create or replace a person's postal address",
-            description = "Stores the structured, validated address. Only line1 and an ISO 3166-1 alpha-2"
-                    + " countryCode are required — the shape is country-agnostic (region is free text,"
-                    + " postalCode optional) so it works for any deployment locale.")
+            operationId = "putPersonPostalAddress",
+            summary = "Create or Replace Person Postal Address",
+            description = """
+                    Creates or replaces the single structured postal address for a person; the shape is \
+                    country-agnostic, with free-text region and an optional postalCode.
+                    Use this tool for person mailing addresses; use putOrganizationPostalAddress instead for CRM \
+                    organization parties, and do not use replaceContactPoints, which manages email and phone \
+                    channels.
+                    Preconditions: the person record must exist; any previously stored address is overwritten in \
+                    place.
+                    Required inputs: line1 and an ISO 3166-1 alpha-2 countryCode (stored upper-case); line2, \
+                    city, region and postalCode are optional free text, trimmed, with blanks stored as null.
+                    Emits a PEOPLE_CONTACT_PERSON_ADDRESS_PUT event and queues a person.updated identity fact \
+                    carrying the new address.
+                    Returns 200 with the stored address, 404 when the person does not exist, and 422 when line1 \
+                    is blank or countryCode is not a valid ISO 3166-1 alpha-2 code.
+                    """)
     @ApiResponse(responseCode = "200", description = "Address stored.")
     @ApiResponse(
             responseCode = "404",
             description = "Person not found.",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "line1 missing or countryCode not a valid ISO 3166-1 alpha-2 code.",
             content =
                     @Content(
                             mediaType = "application/problem+json",
@@ -81,13 +110,41 @@ public class PostalAddressController {
     @PreAuthorize("hasAuthority('people-contact:person:edit')")
     public ResponseEntity<PostalAddressDto> putPersonAddress(
             @Parameter(description = "Person id") @PathVariable UUID personId,
-            @Valid @RequestBody PostalAddressDto address) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Country-agnostic structured postal address that replaces any address"
+                                    + " already on file for the person.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Japanese address", value = """
+                                                                    {"line1":"1-2-3 Ginza",
+                                                                     "line2":"Chuo-ku",
+                                                                     "city":"Tokyo",
+                                                                     "region":"Tokyo",
+                                                                     "postalCode":"104-0061",
+                                                                     "countryCode":"JP"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    PostalAddressDto address) {
         return ResponseEntity.ok(postalAddressService.putAddress(PartyType.PERSON, personId, address));
     }
 
     @Operation(
-            summary = "Delete a person's postal address",
-            description = "Removes the person's postal address; succeeds even when none is on file.")
+            operationId = "deletePersonPostalAddress",
+            summary = "Delete a Person's Postal Address",
+            description = """
+                    Removes the postal address on file for a person; the operation is idempotent and succeeds \
+                    when none exists.
+                    Use this tool to clear a person's mailing address; do not use deletePerson, which removes \
+                    the entire identity record.
+                    Preconditions: none; a missing address is treated as already deleted.
+                    Required inputs: personId (UUID) as a path parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_PERSON_ADDRESS_DELETE event, and queues a person.updated identity \
+                    fact only when an address actually existed.
+                    Returns 204 whether or not an address was on file.
+                    """)
     @ApiResponse(responseCode = "204", description = "Address removed (or none existed).")
     @EmitEvent(id = "PEOPLE_CONTACT_PERSON_ADDRESS_DELETE", apiVersion = "1")
     @DeleteMapping("/v1/people/{personId}/postal-address")
@@ -101,9 +158,20 @@ public class PostalAddressController {
     }
 
     @Operation(
-            summary = "Get an organization's postal address",
-            description = "Returns the organization party's structured postal address, or 404 when none is on"
-                    + " file. The organization id is the party UUID owned by the CRM module.")
+            operationId = "getOrganizationPostalAddress",
+            summary = "Get an Organization's Postal Address",
+            description = """
+                    Returns the structured postal address on file for a CRM organization party; the organization \
+                    id is an external pos-customer party reference stored verbatim.
+                    Use this tool when reading an organization's mailing address; use getPersonPostalAddress \
+                    instead for person parties.
+                    Preconditions: an address must already have been stored for the organization with \
+                    putOrganizationPostalAddress.
+                    Required inputs: organizationId (the pos-customer commercial party UUID) as a path \
+                    parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_ORG_ADDRESS_GET audit event; no state changes.
+                    Returns 404 when no address is on file for the organization.
+                    """)
     @ApiResponse(responseCode = "200", description = "Address found and returned.")
     @ApiResponse(
             responseCode = "404",
@@ -127,10 +195,29 @@ public class PostalAddressController {
     }
 
     @Operation(
-            summary = "Create or replace an organization's postal address",
-            description = "Stores the structured, validated address for an organization party. The id is an"
-                    + " external party reference (pos-customer commercial party) stored verbatim.")
+            operationId = "putOrganizationPostalAddress",
+            summary = "Create or Replace Organization Postal Address",
+            description = """
+                    Creates or replaces the single structured postal address for a CRM organization party.
+                    Use this tool for organization mailing addresses; use putPersonPostalAddress instead for \
+                    person parties.
+                    Preconditions: none in this module; the organization id is an external pos-customer party \
+                    reference stored verbatim without an existence check.
+                    Required inputs: organizationId (UUID) as a path parameter, plus line1 and an ISO 3166-1 \
+                    alpha-2 countryCode in the body; line2, city, region and postalCode are optional free text.
+                    Emits a PEOPLE_CONTACT_ORG_ADDRESS_PUT event and an organization-address-updated fact for \
+                    downstream consumers.
+                    Returns 200 with the stored address, and 422 when line1 is blank or countryCode is not a \
+                    valid ISO 3166-1 alpha-2 code.
+                    """)
     @ApiResponse(responseCode = "200", description = "Address stored.")
+    @ApiResponse(
+            responseCode = "422",
+            description = "line1 missing or countryCode not a valid ISO 3166-1 alpha-2 code.",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
     @EmitEvent(id = "PEOPLE_CONTACT_ORG_ADDRESS_PUT", apiVersion = "1")
     @PutMapping("/v1/organizations/{organizationId}/postal-address")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -139,13 +226,41 @@ public class PostalAddressController {
     @PreAuthorize("hasAuthority('people-contact:organization:edit')")
     public ResponseEntity<PostalAddressDto> putOrganizationAddress(
             @Parameter(description = "Organization party id") @PathVariable UUID organizationId,
-            @Valid @RequestBody PostalAddressDto address) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Country-agnostic structured postal address that replaces any address"
+                                    + " already on file for the organization party.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "US business address", value = """
+                                                                    {"line1":"400 Commerce Way",
+                                                                     "line2":"Suite 210",
+                                                                     "city":"Austin",
+                                                                     "region":"TX",
+                                                                     "postalCode":"78701",
+                                                                     "countryCode":"US"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    PostalAddressDto address) {
         return ResponseEntity.ok(postalAddressService.putAddress(PartyType.ORGANIZATION, organizationId, address));
     }
 
     @Operation(
-            summary = "Delete an organization's postal address",
-            description = "Removes the organization party's postal address; succeeds even when none is on file.")
+            operationId = "deleteOrganizationPostalAddress",
+            summary = "Delete an Organization's Postal Address",
+            description = """
+                    Removes the postal address on file for a CRM organization party; the operation is idempotent \
+                    and succeeds when none exists.
+                    Use this tool to clear an organization's mailing address; use deletePersonPostalAddress \
+                    instead for person parties.
+                    Preconditions: none; a missing address is treated as already deleted.
+                    Required inputs: organizationId (UUID) as a path parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_ORG_ADDRESS_DELETE event, and an organization-address-removed fact \
+                    is published only when an address actually existed.
+                    Returns 204 whether or not an address was on file.
+                    """)
     @ApiResponse(responseCode = "204", description = "Address removed (or none existed).")
     @EmitEvent(id = "PEOPLE_CONTACT_ORG_ADDRESS_DELETE", apiVersion = "1")
     @DeleteMapping("/v1/organizations/{organizationId}/postal-address")

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/UserPersonLinkController.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/UserPersonLinkController.java
@@ -9,6 +9,7 @@ import com.positivity.peoplecontact.service.UserPersonLinkService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,9 +32,22 @@ public class UserPersonLinkController {
 
     @PostMapping("/users/link")
     @EmitEvent(id = "PEOPLE_CONTACT_USER_LINK_CREATE", apiVersion = "1")
-    @Operation(
-            summary = "Link user to person",
-            description = "Create a link between an authentication user and a person record")
+    @Operation(operationId = "linkUserToPerson", summary = "Link User to Person Record", description = """
+                    Links a security user account to a person record, optionally recording a linkType and notes; \
+                    the link is what lets a login act as that person.
+                    Use this tool when associating a user with a person, for example during onboarding; do not \
+                    use createUserPersonLink, which is the minimal admin variant without linkType or notes, and \
+                    do not use createPerson, which creates the identity record itself.
+                    Preconditions: the person must exist, and the username must not already be linked to a \
+                    different person; one username maps to at most one person.
+                    Required inputs: username and personId (UUID); linkType defaults to PRIMARY and notes is \
+                    optional.
+                    Emits a PEOPLE_CONTACT_USER_LINK_CREATE event and queues a link-updated fact on the \
+                    transactional outbox.
+                    Returns 201 when the link is created, 200 when the identical link already exists (the call \
+                    is idempotent), 404 when the person does not exist, and 409 when the username is already \
+                    linked to a different person.
+                    """)
     @ApiResponse(
             responseCode = "201",
             description = "Link created successfully",
@@ -50,7 +64,21 @@ public class UserPersonLinkController {
             scopes = {"people-contact:userLink:write"})
     @PreAuthorize("hasAuthority('people-contact:userLink:write')")
     public ResponseEntity<UserPersonLinkResponse> linkUserToPerson(
-            @Valid @RequestBody LinkUserToPersonRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "User-person pair to link, with optional link classification and notes.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Onboarding link", value = """
+                                                                    {"username":"marcus.webb",
+                                                                     "personId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "linkType":"PRIMARY",
+                                                                     "notes":"Linked during onboarding"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    LinkUserToPersonRequest request) {
 
         boolean alreadyLinked =
                 linkService.linkExistsByUsernameAndPersonId(request.getUsername(), request.getPersonId());
@@ -63,9 +91,21 @@ public class UserPersonLinkController {
 
     @PostMapping("/user-links")
     @EmitEvent(id = "PEOPLE_CONTACT_USER_LINK_CREATE", apiVersion = "1")
-    @Operation(
-            summary = "Create user-person link (admin)",
-            description = "Create a link between an authentication user and a person record")
+    @Operation(operationId = "createUserPersonLink", summary = "Create User Person Link as Admin", description = """
+                    Creates a user-person link from the minimal administrative payload of username and personId \
+                    only; the link is stored with linkType PRIMARY.
+                    Use this tool for administrative linking when linkType and notes are not needed; do not use \
+                    linkUserToPerson, which accepts the same pair plus an explicit linkType and notes.
+                    Preconditions: the person must exist, and the username must not already be linked to a \
+                    different person; one username maps to at most one person.
+                    Required inputs: username and personId (UUID); both are mandatory and there are no other \
+                    fields.
+                    Emits a PEOPLE_CONTACT_USER_LINK_CREATE event and queues a link-updated fact on the \
+                    transactional outbox.
+                    Returns 201 when the link is created, 200 when the identical link already exists (the call \
+                    is idempotent), 404 when the person does not exist, and 409 when the username is already \
+                    linked to a different person.
+                    """)
     @ApiResponse(
             responseCode = "201",
             description = "Link created successfully",
@@ -82,7 +122,19 @@ public class UserPersonLinkController {
             scopes = {"people-contact:userLink:write"})
     @PreAuthorize("hasAuthority('people-contact:userLink:write')")
     public ResponseEntity<UserPersonLinkResponse> createUserPersonLink(
-            @Valid @RequestBody CreateUserLinkRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Minimal user-person pair to link; the link is stored as PRIMARY.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Admin link", value = """
+                                                                    {"username":"marcus.webb",
+                                                                     "personId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CreateUserLinkRequest request) {
         boolean alreadyLinked =
                 linkService.linkExistsByUsernameAndPersonId(request.getUsername(), request.getPersonId());
         UserPersonLinkResponse response = linkService.createUserLink(request.getUsername(), request.getPersonId());
@@ -93,7 +145,18 @@ public class UserPersonLinkController {
 
     @DeleteMapping("/users/{username}/link")
     @EmitEvent(id = "PEOPLE_CONTACT_USER_PERSON_LINK_DELETE", apiVersion = "1")
-    @Operation(summary = "Unlink user from person", description = "Remove the link between a user and person")
+    @Operation(operationId = "unlinkUserFromPerson", summary = "Unlink User from Person Record", description = """
+                    Removes the link between a security user and its person record, leaving both the user \
+                    account and the person untouched.
+                    Use this tool to sever a login from an identity, including before deletePerson on a person \
+                    that still has linked users; do not use revokeRoleAssignment, which removes a single role \
+                    rather than the whole link.
+                    Preconditions: a user-person link must exist for the username.
+                    Required inputs: username as a path parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_USER_PERSON_LINK_DELETE event and queues a link-removed fact on the \
+                    transactional outbox.
+                    Returns 204 on success, and 404 when no link exists for the username.
+                    """)
     @ApiResponse(responseCode = "204", description = "Link deleted successfully")
     @ApiResponse(responseCode = "404", description = "Link not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -108,7 +171,18 @@ public class UserPersonLinkController {
     }
 
     @GetMapping("/users/{username}/person")
-    @Operation(summary = "Get person by username", description = "Retrieve the person record linked to a user")
+    @Operation(operationId = "getPersonByUsername", summary = "Get Person Linked to Username", description = """
+                    Returns the person record linked to a username, including emails, work phone numbers and the \
+                    username itself.
+                    Use this tool to translate a login identity into its person record; use getCurrentPerson \
+                    instead when the target is the authenticated caller, and getLinksByPersonId to go from a \
+                    person to its links.
+                    Preconditions: a user-person link must exist for the username, and the linked person record \
+                    must still exist.
+                    Required inputs: username as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no link exists for the username or the linked person record is missing.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Person found",
@@ -126,7 +200,15 @@ public class UserPersonLinkController {
     }
 
     @GetMapping("/{personId}/users")
-    @Operation(summary = "Get users linked to person", description = "Retrieve all usernames linked to a person record")
+    @Operation(operationId = "listUsernamesForPerson", summary = "List Usernames Linked to Person", description = """
+                    Lists every username linked to a person record as a flat array of strings.
+                    Use this tool to see which logins can act as a person; use getLinksByPersonId instead when \
+                    the full link records with linkType, notes and audit fields are needed.
+                    Preconditions: the person record must exist; a person with no links yields an empty list.
+                    Required inputs: personId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when the person does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Usernames returned")
     @ApiResponse(responseCode = "404", description = "Person not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -142,7 +224,16 @@ public class UserPersonLinkController {
 
     @GetMapping("/user-links/{personId}")
     @EmitEvent(id = "PEOPLE_CONTACT_USER_LINK_GET", apiVersion = "1")
-    @Operation(summary = "Get links by person ID", description = "Retrieve user-person links for person")
+    @Operation(operationId = "getLinksByPersonId", summary = "Get User Links for Person", description = """
+                    Returns the full user-person link records for a person, including linkType, notes, creator \
+                    and creation time.
+                    Use this tool when link metadata is needed; use listUsernamesForPerson instead when only the \
+                    usernames matter, and getPersonByUsername to go from a username to its person.
+                    Preconditions: the person record must exist; a person with no links yields an empty list.
+                    Required inputs: personId (UUID) as a path parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_USER_LINK_GET audit event; no state changes.
+                    Returns 404 when the person does not exist.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Links found",

--- a/pos-price/openapi.yaml
+++ b/pos-price/openapi.yaml
@@ -31,14 +31,40 @@ paths:
     post:
       tags:
       - Promotion Offers
-      summary: Create promotion offer
-      description: Creates a new promotion offer with code, lifecycle settings, and discount policy.
-      operationId: createOffer
+      summary: Create Promotion Offer
+      description: 'Creates a promotion offer in DRAFT status with a unique promo code, a validity window, and a discount policy.
+
+        Use this tool to define a new promotion; do not use activatePromotionOffer, which only transitions an existing offer to ACTIVE, and note that a DRAFT offer cannot be applied until activated.
+
+        Preconditions: no offer may already exist with the same promoCode, and startDate must not be after endDate.
+
+        Required inputs: promoCode (max 64 characters), name, discountType (PERCENT_LABOR, PERCENT_PARTS, or FIXED_INVOICE), discountValue (minimum 0.01, two decimal places), startDate, and endDate; usageLimit and storeCode are optional and default to unlimited usage and no store scoping.
+
+        Emits a PROMOTION_OFFER_CREATE event and persists the offer with status DRAFT and a zero usage count.
+
+        Returns 409 when the promoCode already exists, and 422 when startDate is after endDate.
+
+        '
+      operationId: createPromotionOffer
       requestBody:
+        description: 'Promotion offer definition: promo code, discount policy, and validity window.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreatePromotionOfferRequest'
+            examples:
+              Percent labor promotion:
+                description: Percent labor promotion
+                value:
+                  promoCode: SUMMER20
+                  name: Summer Labor Discount
+                  description: 20% off labor for seasonal service
+                  discountType: PERCENT_LABOR
+                  discountValue: 20.0
+                  startDate: 2026-06-01
+                  endDate: 2026-08-31
+                  usageLimit: 100
+                  storeCode: NYC-001
         required: true
       responses:
         '201':
@@ -59,6 +85,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PromotionOfferResponse'
+        '422':
+          description: startDate is after endDate.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromotionOfferResponse'
         '403':
           description: Forbidden.
           content:
@@ -74,9 +106,21 @@ paths:
     get:
       tags:
       - Promotion Eligibility Rules
-      summary: List eligibility rules for promotion offer
-      description: Returns all eligibility rules configured for the specified promotion offer.
-      operationId: getRules
+      summary: List Eligibility Rules For Promotion Offer
+      description: 'Lists every eligibility rule currently attached to the promotion offer identified by promotionId.
+
+        Use this tool to inspect a promotion''s audience constraints before editing them; use evaluatePromotionEligibility instead to test whether a concrete account, vehicle, or campaign context passes those rules.
+
+        Preconditions: none beyond the pricing:promotion:view authority; an unknown promotionId is not rejected.
+
+        Required inputs: promotionId (UUID) as a path parameter; there is no request body, filtering, or paging.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty array both when the promotion has no rules and when the promotionId matches no offer, so this operation cannot verify that a promotion exists.
+
+        '
+      operationId: listPromotionEligibilityRules
       parameters:
       - name: promotionId
         in: path
@@ -87,14 +131,6 @@ paths:
       responses:
         '200':
           description: Eligibility rules returned.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/EligibilityRuleResponse'
-        '404':
-          description: Promotion offer not found.
           content:
             application/json:
               schema:
@@ -117,9 +153,21 @@ paths:
     post:
       tags:
       - Promotion Eligibility Rules
-      summary: Add eligibility rule to promotion offer
-      description: Creates and attaches a new eligibility rule to the specified promotion offer.
-      operationId: addRule
+      summary: Add Eligibility Rule To Promotion Offer
+      description: 'Creates an eligibility rule and attaches it to the promotion offer identified by promotionId, constraining who may receive the promotion.
+
+        Use this tool when a promotion must be limited by account list, fleet size, vehicle tag, audience type, or campaign code; do not use evaluatePromotionEligibility, which tests a context against the existing rules without changing them.
+
+        Preconditions: the promotion offer must exist; rules may be added regardless of the offer''s status.
+
+        Required inputs: conditionType (ACCOUNT_ID_LIST, VEHICLE_TAG, ACCOUNT_FLEET_SIZE, AUDIENCE_TYPE, or CAMPAIGN_CODE), an operator supported by that type (IN, NOT_IN, EQUALS, GREATER_THAN_OR_EQUAL_TO), and value (max 255 characters; comma-separated for list types); ruleCombination is optional and defaults to AND, and at evaluation time the first rule''s combination governs all rules.
+
+        Emits a PROMOTION_RULE_CREATE event and the rule takes effect on the next eligibility evaluation.
+
+        Returns 404 when the promotion offer does not exist, and 400 when conditionType, operator, or value is missing or invalid.
+
+        '
+      operationId: createPromotionEligibilityRule
       parameters:
       - name: promotionId
         in: path
@@ -128,10 +176,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: 'Eligibility rule definition: the condition, operator, and comparison value to attach.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AddEligibilityRuleRequest'
+            examples:
+              Fleet size rule:
+                description: Fleet size rule
+                value:
+                  conditionType: ACCOUNT_FLEET_SIZE
+                  operator: GREATER_THAN_OR_EQUAL_TO
+                  value: '25'
+                  ruleCombination: AND
         required: true
       responses:
         '201':
@@ -167,9 +224,21 @@ paths:
     post:
       tags:
       - Promotion Eligibility Rules
-      summary: Evaluate promotion eligibility
-      description: Evaluates whether a promotion offer is eligible for the provided evaluation context.
-      operationId: evaluateEligibility
+      summary: Evaluate Promotion Eligibility
+      description: 'Evaluates whether the supplied account, vehicle, audience, and campaign context passes the eligibility rules attached to a promotion offer, returning an eligible flag and a reason code.
+
+        Use this tool to pre-check eligibility without consuming promotion usage; do not use applyPromotionOffer, which applies the discount and increments the offer''s usage count.
+
+        Preconditions: the first rule''s ruleCombination governs the evaluation (AND requires every rule to pass, OR requires any one); a promotion with no rules, or an unknown promotionId, evaluates to eligible because only the stored rules are consulted.
+
+        Required inputs: a context body whose fields are all optional; accountId and vehicleId (UUIDs), audienceType (compared case-insensitively), and campaignCode, where omitting a field that a rule needs fails that rule with a missing-context reason code such as MISSING_ACCOUNT_CONTEXT.
+
+        Emits a PROMOTION_RULE_EVALUATE event; no promotion state or usage count changes.
+
+        Returns 200 with eligible true or false and a reason code such as ELIGIBLE, ACCOUNT_NOT_IN_LIST, FLEET_SIZE_TOO_SMALL, or VEHICLE_TAG_NOT_PRESENT; 400 occurs only for an unparseable body.
+
+        '
+      operationId: evaluatePromotionEligibility
       parameters:
       - name: promotionId
         in: path
@@ -178,10 +247,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Account, vehicle, audience, and campaign context the promotion's rules are evaluated against.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/EligibilityContext'
+            examples:
+              Fleet account context:
+                description: Fleet account context
+                value:
+                  accountId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  vehicleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  audienceType: COMMERCIAL
+                  campaignCode: SPRING-FLEET-2026
         required: true
       responses:
         '200':
@@ -192,12 +270,6 @@ paths:
                 $ref: '#/components/schemas/EligibilityDecisionResponse'
         '400':
           description: Invalid evaluation request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EligibilityDecisionResponse'
-        '404':
-          description: Promotion offer not found.
           content:
             application/json:
               schema:
@@ -217,14 +289,42 @@ paths:
     post:
       tags:
       - Promotion Offers
-      summary: Apply promotion offer during estimate pricing
-      description: Applies a promotion offer to pricing inputs and returns resulting discount and adjusted totals.
-      operationId: applyPromotion
+      summary: Apply Promotion Offer During Estimate Pricing
+      description: 'Applies a promotion code to an estimate''s pricing context and returns the discount adjustment and the adjusted total.
+
+        Use this tool at estimate time to price in a promotion; use evaluatePromotionEligibility instead for a dry-run check, because this operation consumes one usage against the offer''s usageLimit.
+
+        Preconditions: the offer must be ACTIVE, the current date must fall within startDate and endDate, the context must pass the offer''s eligibility rules, the usage limit must not be exhausted, and no promo code may already be applied because only one promotion is allowed per estimate.
+
+        Required inputs: promotionCode and estimateContext with estimateId, customerId, subtotal, and at least one line item; PERCENT_LABOR and PERCENT_PARTS both currently discount the full subtotal by the percentage, while FIXED_INVOICE subtracts the fixed discountValue.
+
+        Emits a PROMOTION_OFFER_APPLY event and atomically increments the offer''s usage count.
+
+        Returns 400 with code PROMO_NOT_FOUND when the code is unknown, PROMO_NOT_APPLICABLE when the offer is inactive, outside its date range, ineligible for the context, or over its usage limit, and PROMO_MULTIPLE_NOT_ALLOWED when the estimate already carries an applied promo code.
+
+        '
+      operationId: applyPromotionOffer
       requestBody:
+        description: Promotion code plus the estimate context (customer, line items, subtotal) it is applied against.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ApplyPromotionRequest'
+            examples:
+              Apply to estimate:
+                description: Apply to estimate
+                value:
+                  promotionCode: SUMMER20
+                  estimateContext:
+                    estimateId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                    customerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
+                    vehicleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03
+                    lineItems:
+                    - sku: P001
+                      quantity: 1
+                      unitPrice: 500.0
+                    subtotal: 500.0
+                    appliedPromoCodes: []
         required: true
       responses:
         '200':
@@ -234,13 +334,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApplyPromotionResponse'
         '400':
-          description: Invalid promotion application request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApplyPromotionResponse'
-        '404':
-          description: Promotion offer not found or not eligible.
+          description: Invalid request, unknown promo code, promotion not applicable, or promotion already applied.
           content:
             application/json:
               schema:
@@ -260,14 +354,38 @@ paths:
     post:
       tags:
       - Price Restrictions
-      summary: Override price restrictions
-      description: Issues an override for price restrictions. Requires pricing:restriction:override authority.
-      operationId: overrideRestrictions
+      summary: Override Price Restrictions
+      description: 'Issues an audited, time-boxed override of a sale-restriction rule for a specific transaction and product.
+
+        Use this tool after evaluatePriceRestrictions returns ALLOW_WITH_OVERRIDE; do not use deactivateRestrictionRule, which retires the rule for everyone instead of exempting one transaction.
+
+        Preconditions: the referenced restriction rule must exist; the rule''s overrideable flag is not re-checked here, so callers must honour a BLOCK decision from evaluation rather than overriding it.
+
+        Required inputs: ruleId, transactionId, and productId (UUIDs), overrideContext (BROWSE, QUOTE, CHECKOUT, INVOICE_FINALIZE, or COMMIT_SALE), and reasonCode; notes and approvedBy are optional.
+
+        Emits a PRICE_RESTRICTIONS_OVERRIDE event and persists an ISSUED audit record capturing the actor and the rule''s policyVersion; the returned overrideId expires 24 hours after issue.
+
+        Returns 404 when the referenced restriction rule does not exist.
+
+        '
+      operationId: overridePriceRestriction
       requestBody:
+        description: Override justification tying a restriction rule to the transaction and product it is waived for.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RestrictionOverrideRequest'
+            examples:
+              Manager-approved override:
+                description: Manager-approved override
+                value:
+                  ruleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4c01
+                  transactionId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4c02
+                  productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01
+                  overrideContext: CHECKOUT
+                  reasonCode: MANAGER_APPROVAL
+                  notes: Customer is a licensed reseller
+                  approvedBy: user-001
         required: true
       responses:
         '200':
@@ -294,6 +412,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RestrictionOverrideResponse'
+        '404':
+          description: Restriction rule not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RestrictionOverrideResponse'
       security:
       - bearerAuth:
         - pricing:restriction:override
@@ -303,14 +427,36 @@ paths:
     post:
       tags:
       - Price Restrictions
-      summary: Evaluate price restrictions
-      description: Evaluates whether products are subject to restrictions in the given context.
-      operationId: evaluateRestrictions
+      summary: Evaluate Price Restrictions
+      description: 'Evaluates each submitted product and context entry against active sale-restriction rules and returns a per-item decision of ALLOW, BLOCK, ALLOW_WITH_OVERRIDE, or RESTRICTION_UNKNOWN.
+
+        Use this tool before quoting or selling a product to learn whether the sale is blocked or needs an override; do not use overridePriceRestriction, which records the override itself after a decision of ALLOW_WITH_OVERRIDE.
+
+        Preconditions: none; items with no matching active rule resolve to ALLOW.
+
+        Required inputs: items (at least one), each with productId (UUID), locationTag, serviceTag, and context (BROWSE, QUOTE, CHECKOUT, INVOICE_FINALIZE, or COMMIT_SALE); any matching rule with overrideable false forces BLOCK, otherwise matching rules yield ALLOW_WITH_OVERRIDE with the matched ruleIds.
+
+        Emits a PRICE_RESTRICTIONS_EVALUATE event; the evaluation itself is read-only and each item is bounded by an 800 ms timeout.
+
+        Returns 503 when evaluation fails or times out for an item in a commit-path context (CHECKOUT, INVOICE_FINALIZE, COMMIT_SALE), while the same failure on BROWSE or QUOTE degrades that item to a RESTRICTION_UNKNOWN decision instead of an error.
+
+        '
+      operationId: evaluatePriceRestrictions
       requestBody:
+        description: Batch of product/location/service/context entries to test against the active restriction rules.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RestrictionEvaluationRequest'
+            examples:
+              Checkout evaluation:
+                description: Checkout evaluation
+                value:
+                  items:
+                  - productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01
+                    locationTag: RETAIL_STORE
+                    serviceTag: POS_SALE
+                    context: CHECKOUT
         required: true
       responses:
         '200':
@@ -345,9 +491,21 @@ paths:
     get:
       tags:
       - Restriction Rules
-      summary: List all active restriction rules
-      description: Returns all currently active price restriction rules that can affect pricing decisions.
-      operationId: listRules
+      summary: List All Active Restriction Rules
+      description: 'Lists every currently active sale-restriction rule that can affect pricing and sale decisions.
+
+        Use this tool to review the standing restriction policy; use getRestrictionRuleById instead to fetch one rule, including deactivated rules, which this listing omits.
+
+        Preconditions: none beyond an authenticated caller.
+
+        Required inputs: none; there is no request body, filtering, or paging.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty array when no active restriction rules exist.
+
+        '
+      operationId: listRestrictionRules
       responses:
         '200':
           description: List of restriction rules.
@@ -372,14 +530,38 @@ paths:
     post:
       tags:
       - Restriction Rules
-      summary: Create a restriction rule
-      description: Creates a price restriction rule for a product, location tag, and service tag combination.
-      operationId: createRule
+      summary: Create A Restriction Rule
+      description: 'Creates an active sale-restriction rule that blocks or gates a product for a location tag and service tag combination.
+
+        Use this tool to configure a standing restriction policy; do not use overridePriceRestriction, which grants a one-time transaction exemption from an existing rule.
+
+        Preconditions: none are checked beyond authorization; duplicate rules for the same product and tag combination are not rejected, so each call appends a new rule.
+
+        Required inputs: productId (UUID), locationTag (ALL_LOCATIONS, RETAIL_STORE, WAREHOUSE, MOBILE_SERVICE, FRANCHISE, or TEST_LOCATION), serviceTag (POS_SALE, WORKORDER, ESTIMATE, INVOICE, or DELIVERY), effectiveFrom (date), and overrideable; effectiveTo is optional, and policyVersion defaults to 1 when omitted.
+
+        Emits a PRICE_RESTRICTION_RULE_CREATE event and the rule participates in evaluation immediately; a rule with overrideable false forces a BLOCK decision that cannot be overridden.
+
+        Returns 201 with the stored rule, and 400 when a required field is missing or a tag is not a valid enum value.
+
+        '
+      operationId: createRestrictionRule
       requestBody:
+        description: Restriction rule definition scoping a product restriction to location and service tags.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateRestrictionRuleRequest'
+            examples:
+              Overrideable retail restriction:
+                description: Overrideable retail restriction
+                value:
+                  productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01
+                  locationTag: RETAIL_STORE
+                  serviceTag: POS_SALE
+                  effectiveFrom: 2026-03-01
+                  effectiveTo: 2026-12-31
+                  policyVersion: 3
+                  overrideable: true
         required: true
       responses:
         '201':
@@ -415,14 +597,37 @@ paths:
     post:
       tags:
       - Price Quotes
-      summary: Calculate contextual price quote
-      description: Calculates a contextual price quote using request inputs such as product, location, customer tier, and pricing context.
+      summary: Calculate Contextual Price Quote
+      description: 'Calculates a contextual unit and extended price for a product by resolving, in order, the base MSRP effective at the pricing instant, then an active location price override that replaces the running price, then a customer tier discount rate applied to the running price.
+
+        Use this tool to price a line for an estimate or cart; do not use applyPromotionOffer here, because promotions are layered onto the estimate separately, and use getPricingSnapshotById to re-read a previously captured price instead of recalculating.
+
+        Preconditions: a base price for the product and quote currency must be effective at the pricing instant; location overrides and tier rules are optional layers that apply only when active.
+
+        Required inputs: productId, locationId, and customerTierId (UUIDs) plus quantity (minimum 1); effectiveTimestamp defaults to the current time, and currency defaults to the configured pos.price.default-currency (USD unless overridden).
+
+        Emits a PRICE_QUOTE_CALCULATE event but writes no pricing state; the unit price is rounded half-even to two decimals, priceSource is MSRP_FALLBACK when only the base price applied and CALCULATED otherwise, and each resolution step is itemised in pricingBreakdown.
+
+        Returns 404 with code PRICE_BASE_UNAVAILABLE when no base price is effective for the product, currency, and instant.
+
+        '
       operationId: calculatePriceQuote
       requestBody:
+        description: Pricing context identifying the product, quantity, location, customer tier, and optional instant and currency.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PriceQuoteRequest'
+            examples:
+              Tiered quote:
+                description: Tiered quote
+                value:
+                  productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01
+                  quantity: 2
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b02
+                  customerTierId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b03
+                  effectiveTimestamp: 2026-03-05 21:15:00+00:00
+                  currency: USD
         required: true
       responses:
         '200':
@@ -457,14 +662,30 @@ paths:
     post:
       tags:
       - Price Normalization
-      summary: Normalize pricing
-      description: Normalize and standardize pricing data across the system.
+      summary: Normalize Pricing Data
+      description: 'Normalizes and standardizes pricing data across the system; this operation is a declared placeholder that is not yet implemented.
+
+        Use this tool only to probe for the future normalization capability; use calculatePriceQuote instead for any real pricing work, since no normalization logic exists yet.
+
+        Preconditions: none; any authenticated caller is accepted.
+
+        Required inputs: none are read; the optional JSON body is accepted but ignored.
+
+        Emits a PRICE_NORMALIZATION_NORMALIZE event even though no normalization is performed and no state changes.
+
+        Returns 501 unconditionally until the operation is implemented.
+
+        '
       operationId: normalizePricing
       requestBody:
+        description: Optional free-form normalization payload; currently ignored because the endpoint is unimplemented.
         content:
           application/json:
             schema:
               type: object
+            examples:
+              Empty payload:
+                description: Empty payload
       responses:
         '501':
           description: Not yet implemented.
@@ -492,24 +713,55 @@ paths:
     post:
       tags:
       - Price Bulk Ingest API
-      summary: Bulk ingest records
-      description: Accepts a batch of domain records for bulk import. Returns per-record results.
-      operationId: bulkIngest
+      summary: Bulk Import Base Price Records
+      description: 'Bulk-imports base price (MSRP) records, appending an effective-dated price window per product and currency.
+
+        Use this tool for batch price loads from an upstream catalog; use calculatePriceQuote instead to read the price effective at a pricing instant, since quoting resolves these windows.
+
+        Preconditions: each record''s effectiveFrom must start after the product''s current window begins; re-submitting the current open window''s unchanged price is idempotent and returns the existing id.
+
+        Required inputs: jobId and locationId (UUIDs) and records (at least one), each record carrying productId (UUID string), msrp (decimal string), currency (ISO 4217 code), and effectiveFrom as an ISO-8601 instant such as 2026-03-01T00:00:00Z; operatorId is optional.
+
+        Emits a PRICE_BULK_INGEST event; a new window closes the previous open window at its effectiveFrom and rows are processed independently, so one bad row does not abort the batch.
+
+        Returns 200 with per-row results even when rows fail, marking failed rows with errorCode PRICE_INGEST_FAILED (including overlapping-window conflicts and unparseable values), and 400 when the batch envelope itself is invalid.
+
+        '
+      operationId: bulkIngestBasePrices
       requestBody:
+        description: Batch envelope of base-price records to ingest, scoped to a job and location.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BulkIngestRequestBasePriceBulkIngestRecord'
+            examples:
+              Single price window:
+                description: Single price window
+                value:
+                  jobId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d01
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d02
+                  operatorId: user-jdoe
+                  records:
+                  - productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01
+                    msrp: '125.50'
+                    currency: USD
+                    effectiveFrom: 2026-03-01 00:00:00+00:00
         required: true
       responses:
         '200':
-          description: Batch processed (check per-record success/failure in response)
+          description: Batch processed; check per-record success and failure results.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BulkIngestResponse'
         '400':
-          description: Invalid request payload
+          description: Invalid batch envelope.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkIngestResponse'
+        '403':
+          description: Insufficient permissions.
           content:
             application/json:
               schema:
@@ -523,9 +775,21 @@ paths:
     patch:
       tags:
       - Promotion Offers
-      summary: Deactivate promotion offer
-      description: Deactivates a promotion offer so it is no longer eligible for application.
-      operationId: deactivateOffer
+      summary: Deactivate Promotion Offer
+      description: 'Transitions an ACTIVE promotion offer to INACTIVE so its promo code is no longer accepted by applyPromotionOffer.
+
+        Use this tool to withdraw a live offer while keeping its history and rules; do not use deletePromotionEligibilityRule, which removes a single audience rule rather than the offer.
+
+        Preconditions: the offer must exist and currently be ACTIVE; DRAFT, INACTIVE, and EXPIRED offers cannot be deactivated.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a PROMOTION_OFFER_DEACTIVATE event; the offer can later be re-enabled with activatePromotionOffer.
+
+        Returns 404 when the offer does not exist, and 422 when the offer is not currently ACTIVE.
+
+        '
+      operationId: deactivatePromotionOffer
       parameters:
       - name: id
         in: path
@@ -546,6 +810,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PromotionOfferResponse'
+        '422':
+          description: Promotion offer is not currently ACTIVE.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromotionOfferResponse'
         '403':
           description: Forbidden.
           content:
@@ -561,9 +831,21 @@ paths:
     patch:
       tags:
       - Promotion Offers
-      summary: Activate promotion offer
-      description: Activates a promotion offer so it becomes eligible for application.
-      operationId: activateOffer
+      summary: Activate Promotion Offer
+      description: 'Transitions a promotion offer to ACTIVE so applyPromotionOffer will accept its promo code within the validity window.
+
+        Use this tool to publish a DRAFT offer or re-enable an INACTIVE one; do not use createPromotionOffer, which creates a new offer that still starts in DRAFT.
+
+        Preconditions: the offer must exist, must not be EXPIRED, and its endDate must not already be in the past.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a PROMOTION_OFFER_ACTIVATE event and sets the status to ACTIVE immediately.
+
+        Returns 404 when the offer does not exist, and 422 when the offer is EXPIRED or its end date has already passed.
+
+        '
+      operationId: activatePromotionOffer
       parameters:
       - name: id
         in: path
@@ -584,7 +866,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PromotionOfferResponse'
-        '409':
+        '422':
           description: Promotion offer cannot be activated in current state.
           content:
             application/json:
@@ -605,9 +887,21 @@ paths:
     get:
       tags:
       - Promotion Offers
-      summary: Get promotion offer by ID
-      description: Retrieves a promotion offer using its unique identifier.
-      operationId: getOfferById
+      summary: Get Promotion Offer By ID
+      description: 'Returns the full promotion offer, including status, discount policy, validity window, and usage counters.
+
+        Use this tool when the promotion offer''s UUID is already known; use getPromotionOfferByCode instead when only the customer-facing promo code is available.
+
+        Preconditions: the promotion offer must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no promotion offer exists for the supplied id.
+
+        '
+      operationId: getPromotionOfferById
       parameters:
       - name: id
         in: path
@@ -643,9 +937,21 @@ paths:
     get:
       tags:
       - Promotion Offers
-      summary: Get promotion offer by code
-      description: Retrieves a promotion offer using its promotion code.
-      operationId: getOfferByCode
+      summary: Get Promotion Offer By Code
+      description: 'Returns the promotion offer that owns the supplied customer-facing promo code.
+
+        Use this tool when only the promo code from marketing material is known; use getPromotionOfferById instead when the offer''s UUID is available.
+
+        Preconditions: an offer with exactly that promoCode must exist; the lookup is an exact match on the code.
+
+        Required inputs: promoCode (max 64 characters) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no promotion offer exists for the supplied code.
+
+        '
+      operationId: getPromotionOfferByCode
       parameters:
       - name: promoCode
         in: path
@@ -680,9 +986,21 @@ paths:
     get:
       tags:
       - Pricing Snapshots
-      summary: Get pricing snapshot by ID
-      description: Retrieves an immutable pricing snapshot using its snapshot identifier.
-      operationId: getSnapshot
+      summary: Get Pricing Snapshot By ID
+      description: 'Returns an immutable pricing snapshot that captured the prices, applied rules, and policy version of a past pricing decision.
+
+        Use this tool to audit or re-display exactly what was priced at capture time; do not use calculatePriceQuote, which computes a fresh price that may differ from the recorded one.
+
+        Preconditions: a snapshot with the supplied id must have been persisted by an earlier pricing flow.
+
+        Required inputs: snapshotId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; snapshots are immutable and this is a read-only projection.
+
+        Returns 404 with code SNAPSHOT_NOT_FOUND when no snapshot exists for the supplied id.
+
+        '
+      operationId: getPricingSnapshotById
       parameters:
       - name: snapshotId
         in: path
@@ -717,9 +1035,21 @@ paths:
     get:
       tags:
       - Restriction Rules
-      summary: Get a restriction rule by ID
-      description: Returns the active or inactive restriction rule identified by the supplied rule ID.
-      operationId: getRuleById
+      summary: Get A Restriction Rule By ID
+      description: 'Returns a single sale-restriction rule, active or inactive, identified by its rule id.
+
+        Use this tool when the rule id is already known, typically from an evaluation result''s ruleIds; use listRestrictionRules instead to browse the active rule set.
+
+        Preconditions: the rule must exist; inactive rules remain readable through this operation.
+
+        Required inputs: ruleId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no restriction rule exists for the supplied id.
+
+        '
+      operationId: getRestrictionRuleById
       parameters:
       - name: ruleId
         in: path
@@ -753,9 +1083,21 @@ paths:
     delete:
       tags:
       - Restriction Rules
-      summary: Deactivate a restriction rule
-      description: Deactivates the specified restriction rule so it no longer participates in price restriction evaluation.
-      operationId: deactivateRule
+      summary: Deactivate A Restriction Rule
+      description: 'Deactivates a sale-restriction rule so it no longer participates in restriction evaluation.
+
+        Use this tool to retire a standing restriction for everyone; do not use overridePriceRestriction, which leaves the rule active and exempts only a single transaction.
+
+        Preconditions: the rule must exist and still be active; deactivation is not idempotent, so repeating it fails.
+
+        Required inputs: ruleId (UUID) as a path parameter; there is no request body.
+
+        Emits a PRICE_RESTRICTION_RULE_DEACTIVATE event, sets active to false, and stamps effectiveTo with the current date.
+
+        Returns 404 when no restriction rule exists for the supplied id; calling it on an already inactive rule produces a server error rather than a no-op.
+
+        '
+      operationId: deactivateRestrictionRule
       parameters:
       - name: ruleId
         in: path
@@ -797,9 +1139,21 @@ paths:
     delete:
       tags:
       - Promotion Eligibility Rules
-      summary: Delete eligibility rule
-      description: Deletes an eligibility rule from the specified promotion offer.
-      operationId: deleteRule
+      summary: Delete Promotion Eligibility Rule
+      description: 'Deletes a single eligibility rule from a promotion offer, widening the promotion''s audience from the next evaluation onward.
+
+        Use this tool to remove one constraint while keeping the offer and its other rules; do not use deactivatePromotionOffer, which withdraws the entire offer rather than one rule.
+
+        Preconditions: a rule with ruleId must exist and belong to the promotion identified by promotionId.
+
+        Required inputs: promotionId (UUID) and ruleId (UUID) as path parameters; there is no request body.
+
+        Emits a PROMOTION_RULE_DELETE event; the deletion is permanent and cannot be undone.
+
+        Returns 404 when no rule with ruleId exists under that promotion, including when the rule belongs to a different offer.
+
+        '
+      operationId: deletePromotionEligibilityRule
       parameters:
       - name: promotionId
         in: path

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/BasePriceBulkIngestController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/BasePriceBulkIngestController.java
@@ -7,6 +7,10 @@ import com.positivity.bulkingest.BulkIngestResult;
 import com.positivity.events.EmitEvent;
 import com.positivity.price.internal.dto.BasePriceBulkIngestRecord;
 import com.positivity.price.service.BasePriceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.math.BigDecimal;
@@ -37,12 +41,56 @@ public class BasePriceBulkIngestController extends AbstractBulkIngestController<
 
     private final BasePriceService basePriceService;
 
+    private static final String BULK_INGEST_EXAMPLE = """
+            {"jobId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d01",
+             "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d02",
+             "operatorId":"user-jdoe",
+             "records":[
+               {"productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01",
+                "msrp":"125.50",
+                "currency":"USD",
+                "effectiveFrom":"2026-03-01T00:00:00Z"}]}
+            """;
+
     @Override
     @PostMapping("/bulk-ingest")
     @PreAuthorize("hasAuthority('pricing:base_price:create')")
     @EmitEvent(id = "PRICE_BULK_INGEST", apiVersion = "1")
+    @Operation(operationId = "bulkIngestBasePrices", summary = "Bulk Import Base Price Records", description = """
+                    Bulk-imports base price (MSRP) records, appending an effective-dated price window per product and \
+                    currency.
+                    Use this tool for batch price loads from an upstream catalog; use calculatePriceQuote instead to \
+                    read the price effective at a pricing instant, since quoting resolves these windows.
+                    Preconditions: each record's effectiveFrom must start after the product's current window begins; \
+                    re-submitting the current open window's unchanged price is idempotent and returns the existing id.
+                    Required inputs: jobId and locationId (UUIDs) and records (at least one), each record carrying \
+                    productId (UUID string), msrp (decimal string), currency (ISO 4217 code), and effectiveFrom as an \
+                    ISO-8601 instant such as 2026-03-01T00:00:00Z; operatorId is optional.
+                    Emits a PRICE_BULK_INGEST event; a new window closes the previous open window at its effectiveFrom \
+                    and rows are processed independently, so one bad row does not abort the batch.
+                    Returns 200 with per-row results even when rows fail, marking failed rows with errorCode \
+                    PRICE_INGEST_FAILED (including overlapping-window conflicts and unparseable values), and 400 when \
+                    the batch envelope itself is invalid.
+                    """)
+    @ApiResponse(responseCode = "200", description = "Batch processed; check per-record success and failure results.")
+    @ApiResponse(responseCode = "400", description = "Invalid batch envelope.")
+    @ApiResponse(responseCode = "403", description = "Insufficient permissions.")
     public ResponseEntity<BulkIngestResponse> bulkIngest(
-            @Valid @RequestBody @NonNull BulkIngestRequest<BasePriceBulkIngestRecord> request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Batch envelope of base-price records to ingest, scoped to a job and location.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Single price window",
+                                                            value = BULK_INGEST_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BulkIngestRequest<BasePriceBulkIngestRecord> request) {
         return super.bulkIngest(request);
     }
 

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/PriceNormalizationController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/PriceNormalizationController.java
@@ -2,6 +2,8 @@ package com.positivity.price.internal.controller;
 
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
@@ -22,14 +24,34 @@ public class PriceNormalizationController {
 
     private static final Logger log = LoggerFactory.getLogger(PriceNormalizationController.class);
 
-    @Operation(summary = "Normalize pricing", description = "Normalize and standardize pricing data across the system.")
+    @Operation(operationId = "normalizePricing", summary = "Normalize Pricing Data", description = """
+                    Normalizes and standardizes pricing data across the system; this operation is a declared \
+                    placeholder that is not yet implemented.
+                    Use this tool only to probe for the future normalization capability; use calculatePriceQuote \
+                    instead for any real pricing work, since no normalization logic exists yet.
+                    Preconditions: none; any authenticated caller is accepted.
+                    Required inputs: none are read; the optional JSON body is accepted but ignored.
+                    Emits a PRICE_NORMALIZATION_NORMALIZE event even though no normalization is performed and no state \
+                    changes.
+                    Returns 501 unconditionally until the operation is implemented.
+                    """)
     @ApiResponse(responseCode = "501", description = "Not yet implemented.")
     @ApiResponse(responseCode = "400", description = "Invalid request body.")
     @ApiResponse(responseCode = "500", description = "Internal server error.")
     @EmitEvent(id = "PRICE_NORMALIZATION_NORMALIZE", apiVersion = "1")
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/normalize")
-    public ResponseEntity<Object> normalizePricing(@RequestBody(required = false) Object requestBody) {
+    public ResponseEntity<Object> normalizePricing(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Optional free-form normalization payload; currently ignored because the endpoint is unimplemented.",
+                            required = false,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Empty payload", value = "{}")))
+                    @RequestBody(required = false)
+                    Object requestBody) {
         log.info("POST /v1/price/normalize");
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/PriceQuoteController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/PriceQuoteController.java
@@ -7,6 +7,7 @@ import com.positivity.price.service.PriceQuoteService;
 import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,10 +45,24 @@ public class PriceQuoteController {
     @PostMapping
     @EmitEvent(id = "PRICE_QUOTE_CALCULATE", apiVersion = "1")
     @PreAuthorize("isAuthenticated()")
-    @Operation(
-            summary = "Calculate contextual price quote",
-            description =
-                    "Calculates a contextual price quote using request inputs such as product, location, customer tier, and pricing context.")
+    @Operation(operationId = "calculatePriceQuote", summary = "Calculate Contextual Price Quote", description = """
+                    Calculates a contextual unit and extended price for a product by resolving, in order, the base \
+                    MSRP effective at the pricing instant, then an active location price override that replaces the \
+                    running price, then a customer tier discount rate applied to the running price.
+                    Use this tool to price a line for an estimate or cart; do not use applyPromotionOffer here, \
+                    because promotions are layered onto the estimate separately, and use getPricingSnapshotById to \
+                    re-read a previously captured price instead of recalculating.
+                    Preconditions: a base price for the product and quote currency must be effective at the pricing \
+                    instant; location overrides and tier rules are optional layers that apply only when active.
+                    Required inputs: productId, locationId, and customerTierId (UUIDs) plus quantity (minimum 1); \
+                    effectiveTimestamp defaults to the current time, and currency defaults to the configured \
+                    pos.price.default-currency (USD unless overridden).
+                    Emits a PRICE_QUOTE_CALCULATE event but writes no pricing state; the unit price is rounded \
+                    half-even to two decimals, priceSource is MSRP_FALLBACK when only the base price applied and \
+                    CALCULATED otherwise, and each resolution step is itemised in pricingBreakdown.
+                    Returns 404 with code PRICE_BASE_UNAVAILABLE when no base price is effective for the product, \
+                    currency, and instant.
+                    """)
     @ApiResponse(responseCode = "200", description = "Price quote calculated successfully.")
     @ApiResponse(
             responseCode = "400",
@@ -61,7 +76,25 @@ public class PriceQuoteController {
             responseCode = "404",
             description = "No base price effective for the product at the pricing instant (PRICE_BASE_UNAVAILABLE).",
             content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<PriceQuoteResponse> calculatePriceQuote(@Valid @RequestBody PriceQuoteRequest request) {
+    public ResponseEntity<PriceQuoteResponse> calculatePriceQuote(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Pricing context identifying the product, quantity, location, customer tier, and optional instant and currency.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Tiered quote", value = """
+                                                                    {"productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01",
+                                                                     "quantity":2,
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b02",
+                                                                     "customerTierId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b03",
+                                                                     "effectiveTimestamp":"2026-03-05T21:15:00Z",
+                                                                     "currency":"USD"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    PriceQuoteRequest request) {
         return ResponseEntity.ok(priceQuoteService.calculatePrice(request));
     }
 }

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/PriceRestrictionsController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/PriceRestrictionsController.java
@@ -9,6 +9,8 @@ import com.positivity.price.internal.dto.RestrictionOverrideResponse;
 import com.positivity.price.service.RestrictionEvaluationService;
 import com.positivity.price.service.RestrictionOverrideService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -38,9 +40,23 @@ public class PriceRestrictionsController {
         this.overrideService = overrideService;
     }
 
-    @Operation(
-            summary = "Evaluate price restrictions",
-            description = "Evaluates whether products are subject to restrictions in the given context.")
+    @Operation(operationId = "evaluatePriceRestrictions", summary = "Evaluate Price Restrictions", description = """
+                    Evaluates each submitted product and context entry against active sale-restriction rules and \
+                    returns a per-item decision of ALLOW, BLOCK, ALLOW_WITH_OVERRIDE, or RESTRICTION_UNKNOWN.
+                    Use this tool before quoting or selling a product to learn whether the sale is blocked or needs an \
+                    override; do not use overridePriceRestriction, which records the override itself after a decision \
+                    of ALLOW_WITH_OVERRIDE.
+                    Preconditions: none; items with no matching active rule resolve to ALLOW.
+                    Required inputs: items (at least one), each with productId (UUID), locationTag, serviceTag, and \
+                    context (BROWSE, QUOTE, CHECKOUT, INVOICE_FINALIZE, or COMMIT_SALE); any matching rule with \
+                    overrideable false forces BLOCK, otherwise matching rules yield ALLOW_WITH_OVERRIDE with the \
+                    matched ruleIds.
+                    Emits a PRICE_RESTRICTIONS_EVALUATE event; the evaluation itself is read-only and each item is \
+                    bounded by an 800 ms timeout.
+                    Returns 503 when evaluation fails or times out for an item in a commit-path context (CHECKOUT, \
+                    INVOICE_FINALIZE, COMMIT_SALE), while the same failure on BROWSE or QUOTE degrades that item to a \
+                    RESTRICTION_UNKNOWN decision instead of an error.
+                    """)
     @ApiResponse(responseCode = "200", description = "Evaluation results per product.")
     @ApiResponse(responseCode = "400", description = "Invalid request body.")
     @ApiResponse(responseCode = "401", description = "Authentication required.")
@@ -50,20 +66,48 @@ public class PriceRestrictionsController {
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/restrictions:evaluate")
     public ResponseEntity<RestrictionEvaluationResponse> evaluateRestrictions(
-            @Valid @RequestBody RestrictionEvaluationRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Batch of product/location/service/context entries to test against the active restriction rules.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Checkout evaluation", value = """
+                                                                    {"items":[
+                                                                      {"productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01",
+                                                                       "locationTag":"RETAIL_STORE",
+                                                                       "serviceTag":"POS_SALE",
+                                                                       "context":"CHECKOUT"}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    RestrictionEvaluationRequest request) {
         log.info(
                 "POST /v1/price/restrictions:evaluate items={}", request.items().size());
         List<RestrictionEvaluationResult> results = evaluationService.evaluate(request);
         return ResponseEntity.ok(new RestrictionEvaluationResponse(results));
     }
 
-    @Operation(
-            summary = "Override price restrictions",
-            description = "Issues an override for price restrictions. Requires pricing:restriction:override authority.")
+    @Operation(operationId = "overridePriceRestriction", summary = "Override Price Restrictions", description = """
+                    Issues an audited, time-boxed override of a sale-restriction rule for a specific transaction and \
+                    product.
+                    Use this tool after evaluatePriceRestrictions returns ALLOW_WITH_OVERRIDE; do not use \
+                    deactivateRestrictionRule, which retires the rule for everyone instead of exempting one \
+                    transaction.
+                    Preconditions: the referenced restriction rule must exist; the rule's overrideable flag is not \
+                    re-checked here, so callers must honour a BLOCK decision from evaluation rather than overriding it.
+                    Required inputs: ruleId, transactionId, and productId (UUIDs), overrideContext (BROWSE, QUOTE, \
+                    CHECKOUT, INVOICE_FINALIZE, or COMMIT_SALE), and reasonCode; notes and approvedBy are optional.
+                    Emits a PRICE_RESTRICTIONS_OVERRIDE event and persists an ISSUED audit record capturing the actor \
+                    and the rule's policyVersion; the returned overrideId expires 24 hours after issue.
+                    Returns 404 when the referenced restriction rule does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Override issued. Returns overrideId and expiresAt.")
     @ApiResponse(responseCode = "400", description = "Invalid request body.")
     @ApiResponse(responseCode = "401", description = "Authentication required.")
     @ApiResponse(responseCode = "403", description = "Insufficient permissions to override restrictions.")
+    @ApiResponse(responseCode = "404", description = "Restriction rule not found.")
     @EmitEvent(id = "PRICE_RESTRICTIONS_OVERRIDE", apiVersion = "1")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -71,7 +115,25 @@ public class PriceRestrictionsController {
     @PreAuthorize("hasAuthority('pricing:restriction:override')")
     @PostMapping("/restrictions:override")
     public ResponseEntity<RestrictionOverrideResponse> overrideRestrictions(
-            @Valid @RequestBody RestrictionOverrideRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Override justification tying a restriction rule to the transaction and product it is waived for.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Manager-approved override", value = """
+                                                                    {"ruleId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4c01",
+                                                                     "transactionId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4c02",
+                                                                     "productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01",
+                                                                     "overrideContext":"CHECKOUT",
+                                                                     "reasonCode":"MANAGER_APPROVAL",
+                                                                     "notes":"Customer is a licensed reseller",
+                                                                     "approvedBy":"user-001"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    RestrictionOverrideRequest request) {
         log.info("POST /v1/price/restrictions:override context={}", request.overrideContext());
         RestrictionOverrideResponse response = overrideService.createOverride(request);
         return ResponseEntity.ok(response);

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/PricingSnapshotController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/PricingSnapshotController.java
@@ -38,9 +38,17 @@ public class PricingSnapshotController {
      */
     @GetMapping("/{snapshotId}")
     @PreAuthorize("isAuthenticated()")
-    @Operation(
-            summary = "Get pricing snapshot by ID",
-            description = "Retrieves an immutable pricing snapshot using its snapshot identifier.")
+    @Operation(operationId = "getPricingSnapshotById", summary = "Get Pricing Snapshot By ID", description = """
+                    Returns an immutable pricing snapshot that captured the prices, applied rules, and policy version \
+                    of a past pricing decision.
+                    Use this tool to audit or re-display exactly what was priced at capture time; do not use \
+                    calculatePriceQuote, which computes a fresh price that may differ from the recorded one.
+                    Preconditions: a snapshot with the supplied id must have been persisted by an earlier pricing flow.
+                    Required inputs: snapshotId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; snapshots are immutable and this is a read-only \
+                    projection.
+                    Returns 404 with code SNAPSHOT_NOT_FOUND when no snapshot exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Pricing snapshot returned.")
     @ApiResponse(responseCode = "404", description = "Pricing snapshot not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/PromotionEligibilityRuleController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/PromotionEligibilityRuleController.java
@@ -8,6 +8,8 @@ import com.positivity.price.internal.dto.EligibilityRuleResponse;
 import com.positivity.price.internal.dto.PromotionEligibilityRuleMapper;
 import com.positivity.price.service.EligibilityEvaluationService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -45,14 +47,45 @@ public class PromotionEligibilityRuleController {
             scopes = {"pricing:promotion:manage"})
     @PreAuthorize("hasAuthority('pricing:promotion:manage')")
     @Operation(
-            summary = "Add eligibility rule to promotion offer",
-            description = "Creates and attaches a new eligibility rule to the specified promotion offer.")
+            operationId = "createPromotionEligibilityRule",
+            summary = "Add Eligibility Rule To Promotion Offer",
+            description = """
+                    Creates an eligibility rule and attaches it to the promotion offer identified by promotionId, \
+                    constraining who may receive the promotion.
+                    Use this tool when a promotion must be limited by account list, fleet size, vehicle tag, audience \
+                    type, or campaign code; do not use evaluatePromotionEligibility, which tests a context against the \
+                    existing rules without changing them.
+                    Preconditions: the promotion offer must exist; rules may be added regardless of the offer's status.
+                    Required inputs: conditionType (ACCOUNT_ID_LIST, VEHICLE_TAG, ACCOUNT_FLEET_SIZE, AUDIENCE_TYPE, or \
+                    CAMPAIGN_CODE), an operator supported by that type (IN, NOT_IN, EQUALS, GREATER_THAN_OR_EQUAL_TO), \
+                    and value (max 255 characters; comma-separated for list types); ruleCombination is optional and \
+                    defaults to AND, and at evaluation time the first rule's combination governs all rules.
+                    Emits a PROMOTION_RULE_CREATE event and the rule takes effect on the next eligibility evaluation.
+                    Returns 404 when the promotion offer does not exist, and 400 when conditionType, operator, or value \
+                    is missing or invalid.
+                    """)
     @ApiResponse(responseCode = "201", description = "Eligibility rule created.")
     @ApiResponse(responseCode = "400", description = "Invalid eligibility rule request.")
     @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
     public ResponseEntity<EligibilityRuleResponse> addRule(
-            @PathVariable("promotionId") UUID promotionId, @Valid @RequestBody AddEligibilityRuleRequest request) {
+            @PathVariable("promotionId") UUID promotionId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Eligibility rule definition: the condition, operator, and comparison value to attach.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Fleet size rule", value = """
+                                                                    {"conditionType":"ACCOUNT_FLEET_SIZE",
+                                                                     "operator":"GREATER_THAN_OR_EQUAL_TO",
+                                                                     "value":"25",
+                                                                     "ruleCombination":"AND"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    AddEligibilityRuleRequest request) {
         var rule = eligibilityEvaluationService.addRule(promotionId, request);
         var response = PromotionEligibilityRuleMapper.toResponse(rule);
         URI location = URI.create("/v1/promotions/offers/" + promotionId + "/rules/" + response.getRuleId());
@@ -65,10 +98,22 @@ public class PromotionEligibilityRuleController {
             scopes = {"pricing:promotion:view"})
     @PreAuthorize("hasAuthority('pricing:promotion:view')")
     @Operation(
-            summary = "List eligibility rules for promotion offer",
-            description = "Returns all eligibility rules configured for the specified promotion offer.")
+            operationId = "listPromotionEligibilityRules",
+            summary = "List Eligibility Rules For Promotion Offer",
+            description = """
+                    Lists every eligibility rule currently attached to the promotion offer identified by promotionId.
+                    Use this tool to inspect a promotion's audience constraints before editing them; use \
+                    evaluatePromotionEligibility instead to test whether a concrete account, vehicle, or campaign \
+                    context passes those rules.
+                    Preconditions: none beyond the pricing:promotion:view authority; an unknown promotionId is not \
+                    rejected.
+                    Required inputs: promotionId (UUID) as a path parameter; there is no request body, filtering, or \
+                    paging.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty array both when the promotion has no rules and when the promotionId \
+                    matches no offer, so this operation cannot verify that a promotion exists.
+                    """)
     @ApiResponse(responseCode = "200", description = "Eligibility rules returned.")
-    @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
     public ResponseEntity<List<EligibilityRuleResponse>> getRules(@PathVariable("promotionId") UUID promotionId) {
         List<EligibilityRuleResponse> responses = eligibilityEvaluationService.getRules(promotionId).stream()
@@ -84,8 +129,19 @@ public class PromotionEligibilityRuleController {
             scopes = {"pricing:promotion:manage"})
     @PreAuthorize("hasAuthority('pricing:promotion:manage')")
     @Operation(
-            summary = "Delete eligibility rule",
-            description = "Deletes an eligibility rule from the specified promotion offer.")
+            operationId = "deletePromotionEligibilityRule",
+            summary = "Delete Promotion Eligibility Rule",
+            description = """
+                    Deletes a single eligibility rule from a promotion offer, widening the promotion's audience from \
+                    the next evaluation onward.
+                    Use this tool to remove one constraint while keeping the offer and its other rules; do not use \
+                    deactivatePromotionOffer, which withdraws the entire offer rather than one rule.
+                    Preconditions: a rule with ruleId must exist and belong to the promotion identified by promotionId.
+                    Required inputs: promotionId (UUID) and ruleId (UUID) as path parameters; there is no request body.
+                    Emits a PROMOTION_RULE_DELETE event; the deletion is permanent and cannot be undone.
+                    Returns 404 when no rule with ruleId exists under that promotion, including when the rule belongs \
+                    to a different offer.
+                    """)
     @ApiResponse(responseCode = "204", description = "Eligibility rule deleted.")
     @ApiResponse(responseCode = "404", description = "Promotion offer or rule not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
@@ -102,14 +158,43 @@ public class PromotionEligibilityRuleController {
             scopes = {"pricing:promotion:apply"})
     @PreAuthorize("hasAuthority('pricing:promotion:apply')")
     @Operation(
-            summary = "Evaluate promotion eligibility",
-            description = "Evaluates whether a promotion offer is eligible for the provided evaluation context.")
+            operationId = "evaluatePromotionEligibility",
+            summary = "Evaluate Promotion Eligibility",
+            description = """
+                    Evaluates whether the supplied account, vehicle, audience, and campaign context passes the \
+                    eligibility rules attached to a promotion offer, returning an eligible flag and a reason code.
+                    Use this tool to pre-check eligibility without consuming promotion usage; do not use \
+                    applyPromotionOffer, which applies the discount and increments the offer's usage count.
+                    Preconditions: the first rule's ruleCombination governs the evaluation (AND requires every rule to \
+                    pass, OR requires any one); a promotion with no rules, or an unknown promotionId, evaluates to \
+                    eligible because only the stored rules are consulted.
+                    Required inputs: a context body whose fields are all optional; accountId and vehicleId (UUIDs), \
+                    audienceType (compared case-insensitively), and campaignCode, where omitting a field that a rule \
+                    needs fails that rule with a missing-context reason code such as MISSING_ACCOUNT_CONTEXT.
+                    Emits a PROMOTION_RULE_EVALUATE event; no promotion state or usage count changes.
+                    Returns 200 with eligible true or false and a reason code such as ELIGIBLE, ACCOUNT_NOT_IN_LIST, \
+                    FLEET_SIZE_TOO_SMALL, or VEHICLE_TAG_NOT_PRESENT; 400 occurs only for an unparseable body.
+                    """)
     @ApiResponse(responseCode = "200", description = "Eligibility evaluation result returned.")
     @ApiResponse(responseCode = "400", description = "Invalid evaluation request.")
-    @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
     public ResponseEntity<EligibilityDecisionResponse> evaluateEligibility(
-            @PathVariable("promotionId") UUID promotionId, @RequestBody EligibilityContext context) {
+            @PathVariable("promotionId") UUID promotionId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Account, vehicle, audience, and campaign context the promotion's rules are evaluated against.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Fleet account context", value = """
+                                                                    {"accountId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "vehicleId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "audienceType":"COMMERCIAL",
+                                                                     "campaignCode":"SPRING-FLEET-2026"}
+                                                                    """)))
+                    @RequestBody
+                    EligibilityContext context) {
         var decision = eligibilityEvaluationService.evaluateEligibility(
                 promotionId,
                 context == null ? null : context.getAccountId(),

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/PromotionOfferController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/PromotionOfferController.java
@@ -8,6 +8,8 @@ import com.positivity.price.internal.dto.PromotionOfferMapper;
 import com.positivity.price.internal.dto.PromotionOfferResponse;
 import com.positivity.price.service.PromotionOfferService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -29,6 +31,17 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Promotion Offers", description = "Promotion offer lifecycle operations")
 public class PromotionOfferController {
 
+    private static final String APPLY_PROMOTION_EXAMPLE = """
+            {"promotionCode":"SUMMER20",
+             "estimateContext":{
+               "estimateId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01",
+               "customerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02",
+               "vehicleId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03",
+               "lineItems":[{"sku":"P001","quantity":1,"unitPrice":500.00}],
+               "subtotal":500.00,
+               "appliedPromoCodes":[]}}
+            """;
+
     private final PromotionOfferService promotionOfferService;
 
     public PromotionOfferController(PromotionOfferService promotionOfferService) {
@@ -41,14 +54,47 @@ public class PromotionOfferController {
             name = "bearerAuth",
             scopes = {"pricing:promotion:manage"})
     @PreAuthorize("hasAuthority('pricing:promotion:manage')")
-    @Operation(
-            summary = "Create promotion offer",
-            description = "Creates a new promotion offer with code, lifecycle settings, and discount policy.")
+    @Operation(operationId = "createPromotionOffer", summary = "Create Promotion Offer", description = """
+                    Creates a promotion offer in DRAFT status with a unique promo code, a validity window, and a \
+                    discount policy.
+                    Use this tool to define a new promotion; do not use activatePromotionOffer, which only transitions \
+                    an existing offer to ACTIVE, and note that a DRAFT offer cannot be applied until activated.
+                    Preconditions: no offer may already exist with the same promoCode, and startDate must not be after \
+                    endDate.
+                    Required inputs: promoCode (max 64 characters), name, discountType (PERCENT_LABOR, PERCENT_PARTS, \
+                    or FIXED_INVOICE), discountValue (minimum 0.01, two decimal places), startDate, and endDate; \
+                    usageLimit and storeCode are optional and default to unlimited usage and no store scoping.
+                    Emits a PROMOTION_OFFER_CREATE event and persists the offer with status DRAFT and a zero usage \
+                    count.
+                    Returns 409 when the promoCode already exists, and 422 when startDate is after endDate.
+                    """)
     @ApiResponse(responseCode = "201", description = "Promotion offer created.")
     @ApiResponse(responseCode = "400", description = "Invalid promotion offer request.")
     @ApiResponse(responseCode = "409", description = "Promotion code already exists.")
+    @ApiResponse(responseCode = "422", description = "startDate is after endDate.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
-    public ResponseEntity<PromotionOfferResponse> createOffer(@Valid @RequestBody CreatePromotionOfferRequest request) {
+    public ResponseEntity<PromotionOfferResponse> createOffer(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Promotion offer definition: promo code, discount policy, and validity window.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Percent labor promotion", value = """
+                                                                    {"promoCode":"SUMMER20",
+                                                                     "name":"Summer Labor Discount",
+                                                                     "description":"20% off labor for seasonal service",
+                                                                     "discountType":"PERCENT_LABOR",
+                                                                     "discountValue":20.00,
+                                                                     "startDate":"2026-06-01",
+                                                                     "endDate":"2026-08-31",
+                                                                     "usageLimit":100,
+                                                                     "storeCode":"NYC-001"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CreatePromotionOfferRequest request) {
         var offer = promotionOfferService.createOffer(request);
         var response = PromotionOfferMapper.toResponse(offer);
         URI location = URI.create("/v1/promotions/offers/" + response.getPromotionOfferId());
@@ -60,9 +106,16 @@ public class PromotionOfferController {
             name = "bearerAuth",
             scopes = {"pricing:promotion:view"})
     @PreAuthorize("hasAuthority('pricing:promotion:view')")
-    @Operation(
-            summary = "Get promotion offer by ID",
-            description = "Retrieves a promotion offer using its unique identifier.")
+    @Operation(operationId = "getPromotionOfferById", summary = "Get Promotion Offer By ID", description = """
+                    Returns the full promotion offer, including status, discount policy, validity window, and usage \
+                    counters.
+                    Use this tool when the promotion offer's UUID is already known; use getPromotionOfferByCode instead \
+                    when only the customer-facing promo code is available.
+                    Preconditions: the promotion offer must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no promotion offer exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Promotion offer returned.")
     @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
@@ -76,9 +129,16 @@ public class PromotionOfferController {
             name = "bearerAuth",
             scopes = {"pricing:promotion:view"})
     @PreAuthorize("hasAuthority('pricing:promotion:view')")
-    @Operation(
-            summary = "Get promotion offer by code",
-            description = "Retrieves a promotion offer using its promotion code.")
+    @Operation(operationId = "getPromotionOfferByCode", summary = "Get Promotion Offer By Code", description = """
+                    Returns the promotion offer that owns the supplied customer-facing promo code.
+                    Use this tool when only the promo code from marketing material is known; use \
+                    getPromotionOfferById instead when the offer's UUID is available.
+                    Preconditions: an offer with exactly that promoCode must exist; the lookup is an exact match on \
+                    the code.
+                    Required inputs: promoCode (max 64 characters) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no promotion offer exists for the supplied code.
+                    """)
     @ApiResponse(responseCode = "200", description = "Promotion offer returned.")
     @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
@@ -93,12 +153,21 @@ public class PromotionOfferController {
             name = "bearerAuth",
             scopes = {"pricing:promotion:manage"})
     @PreAuthorize("hasAuthority('pricing:promotion:manage')")
-    @Operation(
-            summary = "Activate promotion offer",
-            description = "Activates a promotion offer so it becomes eligible for application.")
+    @Operation(operationId = "activatePromotionOffer", summary = "Activate Promotion Offer", description = """
+                    Transitions a promotion offer to ACTIVE so applyPromotionOffer will accept its promo code within \
+                    the validity window.
+                    Use this tool to publish a DRAFT offer or re-enable an INACTIVE one; do not use \
+                    createPromotionOffer, which creates a new offer that still starts in DRAFT.
+                    Preconditions: the offer must exist, must not be EXPIRED, and its endDate must not already be in \
+                    the past.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a PROMOTION_OFFER_ACTIVATE event and sets the status to ACTIVE immediately.
+                    Returns 404 when the offer does not exist, and 422 when the offer is EXPIRED or its end date has \
+                    already passed.
+                    """)
     @ApiResponse(responseCode = "200", description = "Promotion offer activated.")
     @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
-    @ApiResponse(responseCode = "409", description = "Promotion offer cannot be activated in current state.")
+    @ApiResponse(responseCode = "422", description = "Promotion offer cannot be activated in current state.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
     public ResponseEntity<PromotionOfferResponse> activateOffer(@PathVariable("id") UUID promotionOfferId) {
         var offer = promotionOfferService.activateOffer(promotionOfferId);
@@ -111,11 +180,21 @@ public class PromotionOfferController {
             name = "bearerAuth",
             scopes = {"pricing:promotion:manage"})
     @PreAuthorize("hasAuthority('pricing:promotion:manage')")
-    @Operation(
-            summary = "Deactivate promotion offer",
-            description = "Deactivates a promotion offer so it is no longer eligible for application.")
+    @Operation(operationId = "deactivatePromotionOffer", summary = "Deactivate Promotion Offer", description = """
+                    Transitions an ACTIVE promotion offer to INACTIVE so its promo code is no longer accepted by \
+                    applyPromotionOffer.
+                    Use this tool to withdraw a live offer while keeping its history and rules; do not use \
+                    deletePromotionEligibilityRule, which removes a single audience rule rather than the offer.
+                    Preconditions: the offer must exist and currently be ACTIVE; DRAFT, INACTIVE, and EXPIRED offers \
+                    cannot be deactivated.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a PROMOTION_OFFER_DEACTIVATE event; the offer can later be re-enabled with \
+                    activatePromotionOffer.
+                    Returns 404 when the offer does not exist, and 422 when the offer is not currently ACTIVE.
+                    """)
     @ApiResponse(responseCode = "200", description = "Promotion offer deactivated.")
     @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
+    @ApiResponse(responseCode = "422", description = "Promotion offer is not currently ACTIVE.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
     public ResponseEntity<PromotionOfferResponse> deactivateOffer(@PathVariable("id") UUID promotionOfferId) {
         var offer = promotionOfferService.deactivateOffer(promotionOfferId);
@@ -129,14 +208,45 @@ public class PromotionOfferController {
             scopes = {"pricing:promotion:apply"})
     @PreAuthorize("hasAuthority('pricing:promotion:apply')")
     @Operation(
-            summary = "Apply promotion offer during estimate pricing",
-            description =
-                    "Applies a promotion offer to pricing inputs and returns resulting discount and adjusted totals.")
+            operationId = "applyPromotionOffer",
+            summary = "Apply Promotion Offer During Estimate Pricing",
+            description = """
+                    Applies a promotion code to an estimate's pricing context and returns the discount adjustment and \
+                    the adjusted total.
+                    Use this tool at estimate time to price in a promotion; use evaluatePromotionEligibility instead \
+                    for a dry-run check, because this operation consumes one usage against the offer's usageLimit.
+                    Preconditions: the offer must be ACTIVE, the current date must fall within startDate and endDate, \
+                    the context must pass the offer's eligibility rules, the usage limit must not be exhausted, and no \
+                    promo code may already be applied because only one promotion is allowed per estimate.
+                    Required inputs: promotionCode and estimateContext with estimateId, customerId, subtotal, and at \
+                    least one line item; PERCENT_LABOR and PERCENT_PARTS both currently discount the full subtotal by \
+                    the percentage, while FIXED_INVOICE subtracts the fixed discountValue.
+                    Emits a PROMOTION_OFFER_APPLY event and atomically increments the offer's usage count.
+                    Returns 400 with code PROMO_NOT_FOUND when the code is unknown, PROMO_NOT_APPLICABLE when the \
+                    offer is inactive, outside its date range, ineligible for the context, or over its usage limit, \
+                    and PROMO_MULTIPLE_NOT_ALLOWED when the estimate already carries an applied promo code.
+                    """)
     @ApiResponse(responseCode = "200", description = "Promotion offer applied.")
-    @ApiResponse(responseCode = "400", description = "Invalid promotion application request.")
-    @ApiResponse(responseCode = "404", description = "Promotion offer not found or not eligible.")
+    @ApiResponse(
+            responseCode = "400",
+            description =
+                    "Invalid request, unknown promo code, promotion not applicable, or promotion already applied.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
-    public ResponseEntity<ApplyPromotionResponse> applyPromotion(@RequestBody @Valid ApplyPromotionRequest request) {
+    public ResponseEntity<ApplyPromotionResponse> applyPromotion(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Promotion code plus the estimate context (customer, line items, subtotal) it is applied against.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Apply to estimate",
+                                                            value = APPLY_PROMOTION_EXAMPLE)))
+                    @RequestBody
+                    @Valid
+                    ApplyPromotionRequest request) {
         return ResponseEntity.ok(promotionOfferService.applyPromotion(request));
     }
 }

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/RestrictionRuleController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/RestrictionRuleController.java
@@ -5,6 +5,8 @@ import com.positivity.price.internal.dto.CreateRestrictionRuleRequest;
 import com.positivity.price.internal.dto.RestrictionRuleResponse;
 import com.positivity.price.service.RestrictionRuleService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -37,9 +39,22 @@ public class RestrictionRuleController {
         this.restrictionRuleService = restrictionRuleService;
     }
 
-    @Operation(
-            summary = "Create a restriction rule",
-            description = "Creates a price restriction rule for a product, location tag, and service tag combination.")
+    @Operation(operationId = "createRestrictionRule", summary = "Create A Restriction Rule", description = """
+                    Creates an active sale-restriction rule that blocks or gates a product for a location tag and \
+                    service tag combination.
+                    Use this tool to configure a standing restriction policy; do not use overridePriceRestriction, \
+                    which grants a one-time transaction exemption from an existing rule.
+                    Preconditions: none are checked beyond authorization; duplicate rules for the same product and tag \
+                    combination are not rejected, so each call appends a new rule.
+                    Required inputs: productId (UUID), locationTag (ALL_LOCATIONS, RETAIL_STORE, WAREHOUSE, \
+                    MOBILE_SERVICE, FRANCHISE, or TEST_LOCATION), serviceTag (POS_SALE, WORKORDER, ESTIMATE, INVOICE, \
+                    or DELIVERY), effectiveFrom (date), and overrideable; effectiveTo is optional, and policyVersion \
+                    defaults to 1 when omitted.
+                    Emits a PRICE_RESTRICTION_RULE_CREATE event and the rule participates in evaluation immediately; \
+                    a rule with overrideable false forces a BLOCK decision that cannot be overridden.
+                    Returns 201 with the stored rule, and 400 when a required field is missing or a tag is not a valid \
+                    enum value.
+                    """)
     @ApiResponse(responseCode = "201", description = "Restriction rule created.")
     @ApiResponse(responseCode = "400", description = "Invalid request.")
     @ApiResponse(responseCode = "401", description = "Authentication required.")
@@ -51,15 +66,43 @@ public class RestrictionRuleController {
     @PreAuthorize("hasAuthority('pricing:restriction:manage')")
     @PostMapping
     public ResponseEntity<@NonNull RestrictionRuleResponse> createRule(
-            @Valid @RequestBody @NonNull CreateRestrictionRuleRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Restriction rule definition scoping a product restriction to location and service tags.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Overrideable retail restriction",
+                                                            value = """
+                                                                    {"productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01",
+                                                                     "locationTag":"RETAIL_STORE",
+                                                                     "serviceTag":"POS_SALE",
+                                                                     "effectiveFrom":"2026-03-01",
+                                                                     "effectiveTo":"2026-12-31",
+                                                                     "policyVersion":3,
+                                                                     "overrideable":true}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    CreateRestrictionRuleRequest request) {
         log.info("POST /v1/price/restrictions/rules productId={}", request.productId());
         RestrictionRuleResponse response = restrictionRuleService.createRule(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @Operation(
-            summary = "Get a restriction rule by ID",
-            description = "Returns the active or inactive restriction rule identified by the supplied rule ID.")
+    @Operation(operationId = "getRestrictionRuleById", summary = "Get A Restriction Rule By ID", description = """
+                    Returns a single sale-restriction rule, active or inactive, identified by its rule id.
+                    Use this tool when the rule id is already known, typically from an evaluation result's ruleIds; \
+                    use listRestrictionRules instead to browse the active rule set.
+                    Preconditions: the rule must exist; inactive rules remain readable through this operation.
+                    Required inputs: ruleId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no restriction rule exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Restriction rule found.")
     @ApiResponse(responseCode = "401", description = "Authentication required.")
     @ApiResponse(responseCode = "404", description = "Restriction rule not found.")
@@ -72,9 +115,15 @@ public class RestrictionRuleController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(
-            summary = "List all active restriction rules",
-            description = "Returns all currently active price restriction rules that can affect pricing decisions.")
+    @Operation(operationId = "listRestrictionRules", summary = "List All Active Restriction Rules", description = """
+                    Lists every currently active sale-restriction rule that can affect pricing and sale decisions.
+                    Use this tool to review the standing restriction policy; use getRestrictionRuleById instead to \
+                    fetch one rule, including deactivated rules, which this listing omits.
+                    Preconditions: none beyond an authenticated caller.
+                    Required inputs: none; there is no request body, filtering, or paging.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty array when no active restriction rules exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of restriction rules.")
     @ApiResponse(responseCode = "401", description = "Authentication required.")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
@@ -86,10 +135,18 @@ public class RestrictionRuleController {
         return ResponseEntity.ok(rules);
     }
 
-    @Operation(
-            summary = "Deactivate a restriction rule",
-            description =
-                    "Deactivates the specified restriction rule so it no longer participates in price restriction evaluation.")
+    @Operation(operationId = "deactivateRestrictionRule", summary = "Deactivate A Restriction Rule", description = """
+                    Deactivates a sale-restriction rule so it no longer participates in restriction evaluation.
+                    Use this tool to retire a standing restriction for everyone; do not use overridePriceRestriction, \
+                    which leaves the rule active and exempts only a single transaction.
+                    Preconditions: the rule must exist and still be active; deactivation is not idempotent, so \
+                    repeating it fails.
+                    Required inputs: ruleId (UUID) as a path parameter; there is no request body.
+                    Emits a PRICE_RESTRICTION_RULE_DEACTIVATE event, sets active to false, and stamps effectiveTo with \
+                    the current date.
+                    Returns 404 when no restriction rule exists for the supplied id; calling it on an already inactive \
+                    rule produces a server error rather than a no-op.
+                    """)
     @ApiResponse(responseCode = "200", description = "Restriction rule deactivated.")
     @ApiResponse(responseCode = "401", description = "Authentication required.")
     @ApiResponse(responseCode = "403", description = "Insufficient permissions.")

--- a/pos-vehicle-inventory/openapi.yaml
+++ b/pos-vehicle-inventory/openapi.yaml
@@ -26,8 +26,20 @@ paths:
       tags:
       - Vehicle Preferences
       summary: Get vehicle care preferences
-      description: Retrieves the care preferences for a vehicle. Returns 404 if no preferences exist.
-      operationId: getPreferences
+      description: 'Returns the care-preference document for a vehicle, including the free-form preferences map, the structured service interval in months and any service notes.
+
+        Use this tool to read what a customer wants for vehicle care; do not use getVehicle, which returns the registry record itself and carries no preferences.
+
+        Preconditions: a preference document must already have been stored for the vehicle, because vehicles start with no preferences.
+
+        Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 with an empty body when no preference document exists for the vehicle.
+
+        '
+      operationId: getVehiclePreferences
       parameters:
       - name: vehicleId
         in: path
@@ -57,8 +69,20 @@ paths:
       tags:
       - Vehicle Preferences
       summary: Create or update vehicle care preferences
-      description: Upserts preferences for a vehicle. If preferences exist, replaces them entirely. Use PATCH for partial updates.
-      operationId: upsertPreferences
+      description: 'Creates or fully replaces the care-preference document for a vehicle, storing the preferences map and the structured service interval.
+
+        Use this tool to set preferences wholesale; use mergeVehiclePreferences instead for partial changes, because this operation replaces the entire map and a null serviceIntervalMonths clears the stored interval override.
+
+        Preconditions: the vehicle must exist in the registry; an existing preference document is replaced and a missing one is created.
+
+        Required inputs: preferences (a map, which may be empty but not null); serviceIntervalMonths is optional and must be between 1 and 120 months, a legacy serviceIntervalMonths key inside the map is promoted into the structured column, and serviceNotes, createdByUserId and updatedByUserId are optional.
+
+        Emits a VEHICLE_PREFERENCES_UPSERT event and queues a vehicle.care-preference.updated fact for CRM consumers.
+
+        Returns 200 with the saved document for both create and replace, 404 with a RESOURCE_NOT_FOUND ApiError when the vehicle does not exist, and 400 with a VALIDATION_ERROR ApiError when serviceIntervalMonths is outside 1 to 120.
+
+        '
+      operationId: upsertVehiclePreferences
       parameters:
       - name: vehicleId
         in: path
@@ -68,10 +92,22 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Complete care-preference document that replaces whatever is currently stored for the vehicle.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PreferencesUpsertDto'
+            examples:
+              Full preference document:
+                description: Full preference document
+                value:
+                  preferences:
+                    preferredOil: 5W-30
+                    tireRotationInterval: 5000
+                  serviceIntervalMonths: 6
+                  serviceNotes: Customer prefers synthetic oil only
+                  createdByUserId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  updatedByUserId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '200':
@@ -106,8 +142,20 @@ paths:
       tags:
       - Vehicle Preferences
       summary: Delete vehicle care preferences
-      description: Removes all preferences for a vehicle
-      operationId: deletePreferences
+      description: 'Removes the entire care-preference document for a vehicle when one exists.
+
+        Use this tool to clear all stored preferences at once; do not use mergeVehiclePreferences to blank individual keys when the intent is a full reset.
+
+        Preconditions: none; the operation is idempotent and a vehicle without preferences is left untouched.
+
+        Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+
+        Emits a VEHICLE_PREFERENCES_DELETE event, and queues a vehicle.care-preference.updated tombstone fact for CRM consumers only when a document was actually removed.
+
+        Returns 204 in all cases, including when no preference document exists, because deletion is idempotent.
+
+        '
+      operationId: deleteVehiclePreferences
       parameters:
       - name: vehicleId
         in: path
@@ -129,8 +177,20 @@ paths:
       tags:
       - Vehicle Preferences
       summary: Partially update vehicle care preferences
-      description: Merges provided preference fields into existing preferences without replacing the entire map
-      operationId: mergePreferences
+      description: 'Merges the supplied preference keys into a vehicle''s existing care-preference document without replacing the rest of the map.
+
+        Use this tool for partial changes such as one key or the interval alone; do not use upsertVehiclePreferences, which replaces the whole map and clears the interval when it is omitted.
+
+        Preconditions: a preference document must already exist for the vehicle, because this operation cannot create one.
+
+        Required inputs: no body field is individually mandatory; partialPreferences keys overwrite matching stored keys, serviceIntervalMonths must be between 1 and 120 months and leaves the stored value unchanged when null, and a legacy serviceIntervalMonths key inside the map is promoted into the structured column rather than kept in the blob.
+
+        Emits a VEHICLE_PREFERENCES_MERGE event and queues a vehicle.care-preference.updated fact for CRM consumers.
+
+        Returns 200 with the merged document, 404 with a RESOURCE_NOT_FOUND ApiError when no preference document exists for the vehicle, and 400 with a VALIDATION_ERROR ApiError when an interval value is out of range or not a whole number.
+
+        '
+      operationId: mergeVehiclePreferences
       parameters:
       - name: vehicleId
         in: path
@@ -140,10 +200,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Subset of preference fields to merge into the existing care-preference document.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PreferencesMergeDto'
+            examples:
+              Partial preference merge:
+                description: Partial preference merge
+                value:
+                  partialPreferences:
+                    tireRotationInterval: 7500
+                  serviceIntervalMonths: 6
+                  updatedByUserId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '200':
@@ -167,7 +236,19 @@ paths:
       tags:
       - Vehicle API
       summary: Get vehicle by ID
-      description: Retrieve a vehicle by its unique ID.
+      description: 'Returns a single vehicle from the legacy vehicle store by its UUID primary key.
+
+        Use this tool when the legacy vehicle id is already known; use getVehicleLegacyByVin instead when only the VIN is known, and do not use getVehicle, which reads the separate registry store.
+
+        Preconditions: the vehicle must exist in the legacy store; legacy deletes are hard deletes, so a deleted vehicle is gone rather than flagged inactive.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 with an empty body when no legacy vehicle exists for the supplied id.
+
+        '
       operationId: getVehicleLegacy
       parameters:
       - name: id
@@ -177,7 +258,7 @@ paths:
         schema:
           type: string
           format: uuid
-        example: 1
+        example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
       responses:
         '200':
           description: Vehicle found and returned.
@@ -199,7 +280,19 @@ paths:
       tags:
       - Vehicle API
       summary: Update vehicle by ID
-      description: Update an existing vehicle's details by its ID.
+      description: 'Replaces the core fields of an existing legacy vehicle identified by its UUID, applying make, model, year, VIN and vehicleType from the request.
+
+        Use this tool to correct a legacy record by id; use updateVehicleLegacyByVin instead when only the VIN is known, and do not use updateVehicle, which patches registry vehicles field by field.
+
+        Preconditions: the vehicle must already exist in the legacy store; the request is a full replacement of core fields rather than a partial patch.
+
+        Required inputs: id (UUID) as a path parameter plus make, model and year in the body (year between 1886 and the current year plus one); vin and vehicleType are optional.
+
+        Emits a VEHICLE_UPDATE event; no replica fact is published from the legacy surface.
+
+        Returns 404 with an empty body when the id is unknown, and 400 with a VALIDATION_ERROR ApiError when make, model or year is missing or invalid.
+
+        '
       operationId: updateVehicleLegacy
       parameters:
       - name: id
@@ -209,12 +302,22 @@ paths:
         schema:
           type: string
           format: uuid
-        example: 1
+        example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
       requestBody:
+        description: Full replacement values for the legacy vehicle's core fields.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/VehicleLegacyRequest'
+            examples:
+              Legacy vehicle:
+                description: Legacy vehicle
+                value:
+                  make: Honda
+                  model: Accord
+                  year: 2003
+                  vin: 1HGCM82633A004352
+                  vehicleType: CAR
         required: true
       responses:
         '200':
@@ -237,7 +340,19 @@ paths:
       tags:
       - Vehicle API
       summary: Delete vehicle by ID
-      description: Delete a vehicle from the inventory by its ID.
+      description: 'Permanently deletes a vehicle from the legacy vehicle store; the row is removed rather than deactivated.
+
+        Use this tool to purge a legacy record by id; do not use deleteVehicle, which soft-deactivates a registry vehicle and keeps it readable.
+
+        Preconditions: the vehicle must exist in the legacy store; deletion is not recoverable through this API.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a VEHICLE_DELETE event; no replica fact is published from the legacy surface.
+
+        Returns 204 on successful deletion, and 404 with an empty body when the id is unknown.
+
+        '
       operationId: deleteVehicleLegacy
       parameters:
       - name: id
@@ -247,7 +362,7 @@ paths:
         schema:
           type: string
           format: uuid
-        example: 1
+        example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
       responses:
         '204':
           description: Vehicle deleted successfully.
@@ -262,8 +377,20 @@ paths:
       tags:
       - Vehicle API
       summary: Get vehicle by VIN
-      description: Retrieve a vehicle by its VIN.
-      operationId: getVehicleByVIN
+      description: 'Returns a single vehicle from the legacy vehicle store by VIN, trimming the supplied value before the lookup.
+
+        Use this tool when only the VIN of a legacy record is known; use getVehicleLegacy instead when the id is known, and do not use getVehicleByVin, which reads the registry store with normalized VINs.
+
+        Preconditions: the vehicle must exist in the legacy store; the lookup is an exact match on the trimmed VIN, not a normalized or partial match.
+
+        Required inputs: vin as a non-blank path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 with an empty body when no legacy vehicle carries the VIN, and 400 with a VALIDATION_ERROR ApiError when the VIN is blank.
+
+        '
+      operationId: getVehicleLegacyByVin
       parameters:
       - name: vin
         in: path
@@ -293,8 +420,20 @@ paths:
       tags:
       - Vehicle API
       summary: Update vehicle by VIN
-      description: Update an existing vehicle's details by its VIN.
-      operationId: updateVehicleByVIN
+      description: 'Replaces the core fields of an existing legacy vehicle located by VIN, applying make, model, year and vehicleType from the request.
+
+        Use this tool to correct a legacy record when only the VIN is known; use updateVehicleLegacy instead when the id is known, and do not use updateVehicle, which patches registry vehicles.
+
+        Preconditions: a vehicle with the trimmed VIN must already exist in the legacy store; the request fully replaces core fields rather than patching them.
+
+        Required inputs: vin as a path parameter plus make, model and year in the body (year between 1886 and the current year plus one); vehicleType is optional.
+
+        Emits a VEHICLE_UPDATE event; no replica fact is published from the legacy surface.
+
+        Returns 404 with an empty body when no legacy vehicle carries the VIN, and 400 with a VALIDATION_ERROR ApiError when a required body field is missing or invalid.
+
+        '
+      operationId: updateVehicleLegacyByVin
       parameters:
       - name: vin
         in: path
@@ -304,10 +443,20 @@ paths:
           type: string
         example: 1HGCM82633A004352
       requestBody:
+        description: Full replacement values for the legacy vehicle's core fields.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/VehicleLegacyRequest'
+            examples:
+              Legacy vehicle:
+                description: Legacy vehicle
+                value:
+                  make: Honda
+                  model: Accord
+                  year: 2003
+                  vin: 1HGCM82633A004352
+                  vehicleType: CAR
         required: true
       responses:
         '200':
@@ -330,8 +479,20 @@ paths:
       tags:
       - Vehicle API
       summary: Delete vehicle by VIN
-      description: Delete a vehicle from the inventory by its VIN.
-      operationId: deleteVehicleByVIN
+      description: 'Permanently deletes a vehicle from the legacy vehicle store located by VIN; the row is removed rather than deactivated.
+
+        Use this tool to purge a legacy record when only the VIN is known; use deleteVehicleLegacy instead when the id is known, and do not use deleteVehicle, which soft-deactivates registry vehicles.
+
+        Preconditions: a vehicle with the trimmed VIN must exist in the legacy store; deletion is not recoverable through this API.
+
+        Required inputs: vin as a non-blank path parameter; there is no request body.
+
+        Emits a VEHICLE_DELETE event; no replica fact is published from the legacy surface.
+
+        Returns 204 on successful deletion, and 404 with an empty body when no legacy vehicle carries the VIN.
+
+        '
+      operationId: deleteVehicleLegacyByVin
       parameters:
       - name: vin
         in: path
@@ -354,7 +515,19 @@ paths:
       tags:
       - Vehicle Registry API
       summary: Get vehicle by ID
-      description: Retrieve a vehicle by its unique ID
+      description: 'Returns a single vehicle registry record by its vehicleId, whether the vehicle is active or deactivated.
+
+        Use this tool when the registry id is already known; use getVehicleByVin instead for VIN lookups, use searchVehicles for free-text discovery, and do not use getVehicleLegacy, which reads the legacy store.
+
+        Preconditions: the record must exist in the registry; deactivated vehicles are still returned, so callers must check the isActive flag.
+
+        Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 with an empty body when no registry record exists for the supplied vehicleId.
+
+        '
       operationId: getVehicle
       parameters:
       - name: vehicleId
@@ -385,7 +558,19 @@ paths:
       tags:
       - Vehicle Registry API
       summary: Update vehicle
-      description: Update an existing vehicle by ID
+      description: 'Applies a partial update to a vehicle registry record; only fields present in the body are changed, and the VIN itself cannot be modified here.
+
+        Use this tool to correct registry data or transfer ownership, since a new accountId moves the vehicle to that party and consumer replicas move their vehicle-party association from the emitted fact (ADR-0044); do not use updateVehicleLegacy, which fully replaces legacy records.
+
+        Preconditions: the record must exist in the registry; deactivated vehicles can still be updated.
+
+        Required inputs: vehicleId (UUID) as a path parameter and at least one body field among accountId, unitNumber, description, licensePlate, licensePlateJurisdiction, year, make, model and trim; a provided unitNumber or description must be non-blank, and year must be between 1886 and 2100.
+
+        Emits a VEHICLE_UPDATE event and queues a vehicle.vehicle.updated fact on the vehicle.events.v1 outbox for downstream replicas.
+
+        Returns 404 with a RESOURCE_NOT_FOUND ApiError when the vehicleId is unknown, and 400 with a VALIDATION_FAILED ApiError when no field is provided or a provided field violates its constraints.
+
+        '
       operationId: updateVehicle
       parameters:
       - name: vehicleId
@@ -396,10 +581,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Subset of mutable vehicle fields to change; omitted fields keep their stored values.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateVehicleRequest'
+            examples:
+              Partial update:
+                description: Partial update
+                value:
+                  description: 2003 Honda Accord EX Sedan, repainted
+                  licensePlate: XYZ7890
+                  licensePlateJurisdiction: TX
         required: true
       responses:
         '200':
@@ -428,7 +621,19 @@ paths:
       tags:
       - Vehicle Registry API
       summary: Delete vehicle
-      description: Deactivate a vehicle by ID
+      description: 'Deactivates a vehicle registry record by setting isActive to false; the row is retained and remains readable by id and by VIN.
+
+        Use this tool to retire a registry vehicle while preserving history and releasing its VIN for reuse by a future active vehicle; do not use deleteVehicleLegacy, which hard-deletes from the legacy store.
+
+        Preconditions: the record must exist in the registry; deactivating an already inactive vehicle is accepted and simply re-emits the replica fact.
+
+        Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+
+        Emits a VEHICLE_DELETE event and queues a vehicle.vehicle.updated fact with isActive false on the vehicle.events.v1 outbox, which tells downstream replicas to treat the vehicle as retired.
+
+        Returns 204 on successful deactivation, and 404 with a RESOURCE_NOT_FOUND ApiError when the vehicleId is unknown.
+
+        '
       operationId: deleteVehicle
       parameters:
       - name: vehicleId
@@ -452,8 +657,20 @@ paths:
       tags:
       - Vehicle Search
       summary: Search vehicles (query parameter)
-      description: Alternative search endpoint using query parameters. Useful for browser-based queries.
-      operationId: searchByQuery
+      description: 'Searches vehicle registry records using query parameters, applying the same ranking as searchVehicles with exact matches first, then prefix matches, then optional contains matches.
+
+        Use this tool for browser-friendly or link-style searches; use searchVehicles instead when the client can send a JSON body, and use getVehicleByVin when the full 17-character VIN is already known.
+
+        Preconditions: none beyond registry data existing; the match field is inferred from the query shape exactly as in searchVehicles.
+
+        Required inputs: q (non-blank, at least 3 characters, or 6 when VIN-shaped); limit defaults to 25 and is capped at 50, and enableContains defaults to false.
+
+        Emits a VEHICLE_SEARCH event; no vehicle state changes.
+
+        Returns 200 with ranked results plus totalCount and hasMore, and 400 with a VALIDATION_ERROR ApiError when q is empty or shorter than the minimum for its inferred type.
+
+        '
+      operationId: searchVehiclesByQuery
       parameters:
       - name: q
         in: query
@@ -497,13 +714,33 @@ paths:
       tags:
       - Vehicle Search
       summary: Search vehicles
-      description: 'Search for vehicles by VIN, license plate, unit number, or description. Results are ranked by relevance: exact match > prefix match > contains match.'
-      operationId: search
+      description: 'Searches vehicle registry records with a single free-text query, ranking exact matches ahead of prefix matches ahead of optional contains matches.
+
+        Use this tool for vehicle discovery from a JSON body; use searchVehiclesByQuery for the query-parameter variant, and use getVehicleByVin instead when the full 17-character VIN is already known.
+
+        Preconditions: none beyond registry data existing; the match field is inferred from the query shape, with six or more alphanumeric characters searched as a VIN (seventeen as an exact VIN), shorter queries searched against license plates, and the remainder searched against unit number plus description.
+
+        Required inputs: query (non-blank, at least 3 characters, or 6 when VIN-shaped); limit defaults to 25 and is capped at 50, enableContainsMatching defaults to false, and cursor is reserved and currently ignored.
+
+        Emits a VEHICLE_SEARCH event; no vehicle state changes.
+
+        Returns 200 with ranked results plus totalCount and hasMore, and 400 with a VALIDATION_ERROR ApiError when the query is empty or shorter than the minimum for its inferred type.
+
+        '
+      operationId: searchVehicles
       requestBody:
+        description: Free-text search criteria with an optional result limit and matching strategy flag.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SearchVehiclesRequest'
+            examples:
+              VIN prefix search:
+                description: VIN prefix search
+                value:
+                  query: 1HGCM8
+                  limit: 25
+                  enableContainsMatching: false
         required: true
       responses:
         '200':
@@ -526,24 +763,55 @@ paths:
     post:
       tags:
       - Vehicle Bulk Ingest API
-      summary: Bulk ingest records
-      description: Accepts a batch of domain records for bulk import. Returns per-record results.
-      operationId: bulkIngest
+      summary: Bulk ingest vehicle records
+      description: 'Ingests a batch of vehicle records into the registry, creating each row independently through the same validation as createVehicle and reporting a per-row outcome.
+
+        Use this tool for bulk loads such as fleet imports; do not use createVehicle, which registers one vehicle per call, and do not retry a whole batch blindly, because rows that already succeeded would then fail as duplicate VINs.
+
+        Preconditions: the caller must hold the vehicle-inventory:registry:create authority, and each row''s VIN must be valid and not already held by an active vehicle for that row to succeed.
+
+        Required inputs: jobId (UUID), locationId (UUID) and a non-empty records array whose entries require accountId (UUID), vin (17 characters), unitNumber and description; licensePlate, licensePlateJurisdiction, year, make, model and trim are optional per record, and operatorId is optional on the envelope.
+
+        Emits a VEHICLE_BULK_INGEST event, and every successfully created row also queues a vehicle.vehicle.updated fact on the vehicle.events.v1 outbox for downstream replicas.
+
+        Returns 200 with per-row results even when some rows fail, since row failures carry the VEHICLE_INGEST_FAILED error code instead of an error status, and 400 with a VALIDATION_FAILED ApiError when the envelope is missing jobId or locationId or the records array is empty.
+
+        '
+      operationId: bulkIngestVehicles
       requestBody:
+        description: Batch envelope carrying the ingest job, target location and the vehicle records to create.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BulkIngestRequestVehicleBulkIngestRecord'
+            examples:
+              Single-record batch:
+                description: Single-record batch
+                value:
+                  jobId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
+                  operatorId: user-jdoe
+                  records:
+                  - accountId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                    vin: 1HGCM82633A004352
+                    unitNumber: UNIT-1042
+                    description: 2003 Honda Accord EX Sedan
+                    licensePlate: ABC1234
+                    licensePlateJurisdiction: CA
+                    year: 2003
+                    make: Honda
+                    model: Accord
+                    trim: EX
         required: true
       responses:
         '200':
-          description: Batch processed (check per-record success/failure in response)
+          description: Batch processed; check per-record success and failure counts.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BulkIngestResponse'
         '400':
-          description: Invalid request payload
+          description: Invalid request envelope.
           content:
             application/json:
               schema:
@@ -558,8 +826,20 @@ paths:
       tags:
       - Vehicle API
       summary: Get all vehicles
-      description: Retrieve a list of all vehicles in the inventory.
-      operationId: getAllVehicles
+      description: 'Returns every vehicle in the legacy vehicle store as a flat list with no paging or filtering.
+
+        Use this tool to enumerate the legacy store; do not use searchVehicles, which queries the registry store, and prefer getVehicleLegacy when a specific id is already known.
+
+        Preconditions: none; an empty store simply yields an empty list.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 in all cases, including an empty JSON array when the store holds no vehicles.
+
+        '
+      operationId: listVehiclesLegacy
       responses:
         '200':
           description: List of vehicles returned successfully.
@@ -577,13 +857,35 @@ paths:
       tags:
       - Vehicle API
       summary: Create a new vehicle
-      description: Add a new vehicle to the inventory.
+      description: 'Creates a vehicle in the legacy vehicle store, persisting make, model, year and an optional VIN without enforcing VIN uniqueness.
+
+        Use this tool only when maintaining the legacy CRUD surface under /v1/vehicles-legacy; do not use it for registry vehicles, which createVehicle owns and which replicate to consumer services.
+
+        Preconditions: none beyond an authenticated caller; duplicate VINs are accepted because the legacy store has no uniqueness check.
+
+        Required inputs: make, model and year (year between 1886 and the current year plus one); vin is optional on this operation but must not be blank when present, and vehicleType is optional and limited to CAR, VAN, COMMERCIAL_TRUCK, PASSENGER_TRUCK or TRUCK.
+
+        Emits a VEHICLE_CREATE event; no replica fact is published, because the legacy store does not feed the vehicle.events.v1 stream.
+
+        Returns 200 with the stored vehicle, and 400 with a VALIDATION_ERROR ApiError when make, model or year is missing, year is out of range, vin is blank or vehicleType is unsupported.
+
+        '
       operationId: createVehicleLegacy
       requestBody:
+        description: Legacy vehicle to store, identified by its core make, model, year and optional VIN fields.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/VehicleLegacyRequest'
+            examples:
+              Legacy vehicle:
+                description: Legacy vehicle
+                value:
+                  make: Honda
+                  model: Accord
+                  year: 2003
+                  vin: 1HGCM82633A004352
+                  vehicleType: CAR
         required: true
       responses:
         '200':
@@ -601,13 +903,35 @@ paths:
       tags:
       - Vehicle API
       summary: Create vehicle by VIN
-      description: Add a new vehicle to the inventory using its VIN.
-      operationId: createVehicleByVIN
+      description: 'Creates a vehicle in the legacy vehicle store with the VIN treated as mandatory, trimming the supplied value before storing it.
+
+        Use this tool when the VIN is the identifying field for a legacy record; do not use createVehicleLegacy, which accepts a missing VIN, and do not use createVehicle, which writes the registry store.
+
+        Preconditions: none beyond an authenticated caller; the VIN is not checked for uniqueness or 17-character format by this legacy surface.
+
+        Required inputs: make, model, year and vin in the body (year between 1886 and the current year plus one); vehicleType is optional and limited to CAR, VAN, COMMERCIAL_TRUCK, PASSENGER_TRUCK or TRUCK.
+
+        Emits a VEHICLE_CREATE event; no replica fact is published from the legacy surface.
+
+        Returns 200 with the stored vehicle, and 400 with a VALIDATION_ERROR ApiError when make, model, year or vin is missing or invalid.
+
+        '
+      operationId: createVehicleLegacyByVin
       requestBody:
+        description: Legacy vehicle to store, with the VIN required as its identifying field.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/VehicleLegacyRequest'
+            examples:
+              Legacy vehicle:
+                description: Legacy vehicle
+                value:
+                  make: Honda
+                  model: Accord
+                  year: 2003
+                  vin: 1HGCM82633A004352
+                  vehicleType: CAR
         required: true
       responses:
         '200':
@@ -625,13 +949,40 @@ paths:
       tags:
       - Vehicle Registry API
       summary: Create vehicle
-      description: Create a new vehicle registry record
+      description: 'Creates an active vehicle registry record after validating and normalizing the VIN, which must be globally unique among active vehicles.
+
+        Use this tool to register a single vehicle whose changes replicate to consumer services; do not use bulkIngestVehicles, which loads batches with per-row results, and do not use createVehicleLegacy, which writes the unreplicated legacy store.
+
+        Preconditions: no active vehicle may already hold the same normalized VIN; a deactivated vehicle releases its VIN for reuse.
+
+        Required inputs: accountId (UUID) and vin (17 characters after separators are stripped, with letters I, O and Q rejected); unitNumber and description are optional and stored as empty strings when omitted, and licensePlate, licensePlateJurisdiction, year, make, model and trim are optional.
+
+        Emits a VEHICLE_CREATE event and queues a vehicle.vehicle.updated fact on the vehicle.events.v1 outbox for downstream replicas.
+
+        Returns 201 with the created record, and 400 with a VALIDATION_ERROR ApiError when the VIN is malformed or an active vehicle already holds the same normalized VIN; the duplicate-VIN case is reported as 400, not 409.
+
+        '
       operationId: createVehicle
       requestBody:
+        description: Registry vehicle to create, owned by one account and identified by a globally unique VIN.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateVehicleRequest'
+            examples:
+              Registry vehicle:
+                description: Registry vehicle
+                value:
+                  accountId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  vin: 1HGCM82633A004352
+                  unitNumber: UNIT-1042
+                  description: 2003 Honda Accord EX Sedan
+                  licensePlate: ABC1234
+                  licensePlateJurisdiction: CA
+                  year: 2003
+                  make: Honda
+                  model: Accord
+                  trim: EX
         required: true
       responses:
         '201':
@@ -655,7 +1006,19 @@ paths:
       tags:
       - Vehicle Registry API
       summary: Get vehicle by VIN
-      description: Retrieve a vehicle by VIN
+      description: 'Returns a single vehicle registry record by VIN, normalizing the supplied value by trimming, uppercasing and stripping separators before the lookup.
+
+        Use this tool when the full 17-character VIN is known; use searchVehicles instead for partial VIN prefixes, and do not use getVehicleLegacyByVin, which reads the legacy store.
+
+        Preconditions: a record with the normalized VIN must exist in the registry; active and deactivated vehicles are both returned.
+
+        Required inputs: vin as a path parameter, exactly 17 characters; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 with an empty body when no registry record carries the normalized VIN, and 400 with a VALIDATION_FAILED ApiError when the path VIN is not exactly 17 characters.
+
+        '
       operationId: getVehicleByVin
       parameters:
       - name: vin
@@ -781,7 +1144,7 @@ components:
       - version
     VehicleLegacyRequest:
       type: object
-      description: Vehicle object to be created
+      description: Legacy request payload for creating or updating a vehicle
       properties:
         id:
           type: string
@@ -866,7 +1229,7 @@ components:
       - year
     UpdateVehicleRequest:
       type: object
-      description: Vehicle update request
+      description: Request payload for partially updating mutable vehicle fields.
       properties:
         accountId:
           type: string
@@ -1264,7 +1627,7 @@ components:
       - success
     CreateVehicleRequest:
       type: object
-      description: Vehicle creation request
+      description: Request payload for creating a vehicle record.
       properties:
         accountId:
           type: string

--- a/pos-vehicle-inventory/openapi.yaml
+++ b/pos-vehicle-inventory/openapi.yaml
@@ -166,9 +166,7 @@ paths:
           format: uuid
       responses:
         '204':
-          description: Preferences deleted successfully
-        '404':
-          description: No preferences found to delete
+          description: Preferences deleted, or no preference document existed (idempotent delete)
       security:
       - bearerAuth: []
       x-required-permissions:

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleBulkIngestController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleBulkIngestController.java
@@ -8,6 +8,10 @@ import com.positivity.events.EmitEvent;
 import com.positivity.shared.dto.CreateVehicleRequest;
 import com.positivity.vehicle.internal.dto.VehicleBulkIngestRecord;
 import com.positivity.vehicle.service.VehicleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
@@ -33,14 +37,65 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Vehicle Bulk Ingest API", description = "Bulk import vehicle records")
 public class VehicleBulkIngestController extends AbstractBulkIngestController<VehicleBulkIngestRecord> {
 
+    private static final String BULK_INGEST_EXAMPLE = """
+            {"jobId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01",
+             "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02",
+             "operatorId":"user-jdoe",
+             "records":[
+               {"accountId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                "vin":"1HGCM82633A004352",
+                "unitNumber":"UNIT-1042",
+                "description":"2003 Honda Accord EX Sedan",
+                "licensePlate":"ABC1234",
+                "licensePlateJurisdiction":"CA",
+                "year":2003,
+                "make":"Honda",
+                "model":"Accord",
+                "trim":"EX"}]}
+            """;
+
     private final VehicleService vehicleService;
 
+    @Operation(operationId = "bulkIngestVehicles", summary = "Bulk ingest vehicle records", description = """
+                    Ingests a batch of vehicle records into the registry, creating each row independently through \
+                    the same validation as createVehicle and reporting a per-row outcome.
+                    Use this tool for bulk loads such as fleet imports; do not use createVehicle, which registers \
+                    one vehicle per call, and do not retry a whole batch blindly, because rows that already \
+                    succeeded would then fail as duplicate VINs.
+                    Preconditions: the caller must hold the vehicle-inventory:registry:create authority, and each \
+                    row's VIN must be valid and not already held by an active vehicle for that row to succeed.
+                    Required inputs: jobId (UUID), locationId (UUID) and a non-empty records array whose entries \
+                    require accountId (UUID), vin (17 characters), unitNumber and description; licensePlate, \
+                    licensePlateJurisdiction, year, make, model and trim are optional per record, and operatorId \
+                    is optional on the envelope.
+                    Emits a VEHICLE_BULK_INGEST event, and every successfully created row also queues a \
+                    vehicle.vehicle.updated fact on the vehicle.events.v1 outbox for downstream replicas.
+                    Returns 200 with per-row results even when some rows fail, since row failures carry the \
+                    VEHICLE_INGEST_FAILED error code instead of an error status, and 400 with a VALIDATION_FAILED \
+                    ApiError when the envelope is missing jobId or locationId or the records array is empty.
+                    """)
+    @ApiResponse(responseCode = "200", description = "Batch processed; check per-record success and failure counts.")
+    @ApiResponse(responseCode = "400", description = "Invalid request envelope.")
     @Override
     @PostMapping("/bulk-ingest")
     @PreAuthorize("hasAuthority('vehicle-inventory:registry:create')")
     @EmitEvent(id = "VEHICLE_BULK_INGEST", apiVersion = "1")
     public ResponseEntity<BulkIngestResponse> bulkIngest(
-            @Valid @RequestBody @NonNull BulkIngestRequest<VehicleBulkIngestRecord> request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Batch envelope carrying the ingest job, target location and the vehicle"
+                                    + " records to create.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Single-record batch",
+                                                            value = BULK_INGEST_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BulkIngestRequest<VehicleBulkIngestRecord> request) {
         return super.bulkIngest(request);
     }
 

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleController.java
@@ -6,6 +6,8 @@ import com.positivity.vehicle.internal.dto.VehicleLegacyResponse;
 import com.positivity.vehicle.service.VehicleLegacyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -38,83 +40,199 @@ import org.springframework.web.bind.annotation.RestController;
 @PreAuthorize("isAuthenticated()")
 @RequestMapping("/v1/vehicles-legacy")
 public class VehicleController {
+
+    private static final String LEGACY_VEHICLE_EXAMPLE = """
+            {"make":"Honda",
+             "model":"Accord",
+             "year":2003,
+             "vin":"1HGCM82633A004352",
+             "vehicleType":"CAR"}
+            """;
+
     private final VehicleLegacyService vehicleLegacyService;
 
-    @Operation(
-            operationId = "createVehicleLegacy",
-            summary = "Create a new vehicle",
-            description = "Add a new vehicle to the inventory.")
+    @Operation(operationId = "createVehicleLegacy", summary = "Create a new vehicle", description = """
+                    Creates a vehicle in the legacy vehicle store, persisting make, model, year and an optional VIN \
+                    without enforcing VIN uniqueness.
+                    Use this tool only when maintaining the legacy CRUD surface under /v1/vehicles-legacy; do not use \
+                    it for registry vehicles, which createVehicle owns and which replicate to consumer services.
+                    Preconditions: none beyond an authenticated caller; duplicate VINs are accepted because the \
+                    legacy store has no uniqueness check.
+                    Required inputs: make, model and year (year between 1886 and the current year plus one); vin is \
+                    optional on this operation but must not be blank when present, and vehicleType is optional and \
+                    limited to CAR, VAN, COMMERCIAL_TRUCK, PASSENGER_TRUCK or TRUCK.
+                    Emits a VEHICLE_CREATE event; no replica fact is published, because the legacy store does not \
+                    feed the vehicle.events.v1 stream.
+                    Returns 200 with the stored vehicle, and 400 with a VALIDATION_ERROR ApiError when make, model \
+                    or year is missing, year is out of range, vin is blank or vehicleType is unsupported.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle created successfully.")
     @EmitEvent(id = "VEHICLE_CREATE", apiVersion = "1")
     @PostMapping
     public ResponseEntity<VehicleLegacyResponse> createVehicle(
-            @Parameter(description = "Vehicle object to be created") @RequestBody VehicleLegacyRequest vehicle) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Legacy vehicle to store, identified by its core make, model, year"
+                                    + " and optional VIN fields.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Legacy vehicle",
+                                                            value = LEGACY_VEHICLE_EXAMPLE)))
+                    @RequestBody
+                    VehicleLegacyRequest vehicle) {
         return ResponseEntity.ok(vehicleLegacyService.createVehicle(vehicle));
     }
 
-    @Operation(
-            operationId = "getVehicleLegacy",
-            summary = "Get vehicle by ID",
-            description = "Retrieve a vehicle by its unique ID.")
+    @Operation(operationId = "getVehicleLegacy", summary = "Get vehicle by ID", description = """
+                    Returns a single vehicle from the legacy vehicle store by its UUID primary key.
+                    Use this tool when the legacy vehicle id is already known; use getVehicleLegacyByVin instead \
+                    when only the VIN is known, and do not use getVehicle, which reads the separate registry store.
+                    Preconditions: the vehicle must exist in the legacy store; legacy deletes are hard deletes, so \
+                    a deleted vehicle is gone rather than flagged inactive.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 with an empty body when no legacy vehicle exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle found and returned.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @GetMapping("/{id}")
     public ResponseEntity<VehicleLegacyResponse> getVehicle(
-            @Parameter(description = "ID of the vehicle to retrieve", example = "1") @PathVariable UUID id) {
+            @Parameter(description = "ID of the vehicle to retrieve", example = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b")
+                    @PathVariable
+                    UUID id) {
         return vehicleLegacyService
                 .getVehicle(id)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @Operation(summary = "Get all vehicles", description = "Retrieve a list of all vehicles in the inventory.")
+    @Operation(operationId = "listVehiclesLegacy", summary = "Get all vehicles", description = """
+                    Returns every vehicle in the legacy vehicle store as a flat list with no paging or filtering.
+                    Use this tool to enumerate the legacy store; do not use searchVehicles, which queries the \
+                    registry store, and prefer getVehicleLegacy when a specific id is already known.
+                    Preconditions: none; an empty store simply yields an empty list.
+                    Required inputs: none; there are no parameters and no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 in all cases, including an empty JSON array when the store holds no vehicles.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of vehicles returned successfully.")
     @GetMapping
     public List<VehicleLegacyResponse> getAllVehicles() {
         return vehicleLegacyService.getAllVehicles();
     }
 
-    @Operation(
-            operationId = "updateVehicleLegacy",
-            summary = "Update vehicle by ID",
-            description = "Update an existing vehicle's details by its ID.")
+    @Operation(operationId = "updateVehicleLegacy", summary = "Update vehicle by ID", description = """
+                    Replaces the core fields of an existing legacy vehicle identified by its UUID, applying make, \
+                    model, year, VIN and vehicleType from the request.
+                    Use this tool to correct a legacy record by id; use updateVehicleLegacyByVin instead when only \
+                    the VIN is known, and do not use updateVehicle, which patches registry vehicles field by field.
+                    Preconditions: the vehicle must already exist in the legacy store; the request is a full \
+                    replacement of core fields rather than a partial patch.
+                    Required inputs: id (UUID) as a path parameter plus make, model and year in the body (year \
+                    between 1886 and the current year plus one); vin and vehicleType are optional.
+                    Emits a VEHICLE_UPDATE event; no replica fact is published from the legacy surface.
+                    Returns 404 with an empty body when the id is unknown, and 400 with a VALIDATION_ERROR ApiError \
+                    when make, model or year is missing or invalid.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle updated successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @EmitEvent(id = "VEHICLE_UPDATE", apiVersion = "1")
     @PutMapping("/{id}")
     public ResponseEntity<VehicleLegacyResponse> updateVehicle(
-            @Parameter(description = "ID of the vehicle to update", example = "1") @PathVariable UUID id,
-            @Parameter(description = "Updated vehicle object") @RequestBody VehicleLegacyRequest updated) {
+            @Parameter(description = "ID of the vehicle to update", example = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b")
+                    @PathVariable
+                    UUID id,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement values for the legacy vehicle's core fields.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Legacy vehicle",
+                                                            value = LEGACY_VEHICLE_EXAMPLE)))
+                    @RequestBody
+                    VehicleLegacyRequest updated) {
         // ResponseEntity.of: 200 + body when present, 404 when empty (Sonar S6863).
         return ResponseEntity.of(vehicleLegacyService.updateVehicle(id, updated));
     }
 
-    @Operation(
-            operationId = "deleteVehicleLegacy",
-            summary = "Delete vehicle by ID",
-            description = "Delete a vehicle from the inventory by its ID.")
+    @Operation(operationId = "deleteVehicleLegacy", summary = "Delete vehicle by ID", description = """
+                    Permanently deletes a vehicle from the legacy vehicle store; the row is removed rather than \
+                    deactivated.
+                    Use this tool to purge a legacy record by id; do not use deleteVehicle, which soft-deactivates \
+                    a registry vehicle and keeps it readable.
+                    Preconditions: the vehicle must exist in the legacy store; deletion is not recoverable through \
+                    this API.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a VEHICLE_DELETE event; no replica fact is published from the legacy surface.
+                    Returns 204 on successful deletion, and 404 with an empty body when the id is unknown.
+                    """)
     @ApiResponse(responseCode = "204", description = "Vehicle deleted successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @EmitEvent(id = "VEHICLE_DELETE", apiVersion = "1")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteVehicle(
-            @Parameter(description = "ID of the vehicle to delete", example = "1") @PathVariable UUID id) {
+            @Parameter(description = "ID of the vehicle to delete", example = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b")
+                    @PathVariable
+                    UUID id) {
         if (!vehicleLegacyService.deleteVehicle(id)) {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Create vehicle by VIN", description = "Add a new vehicle to the inventory using its VIN.")
+    @Operation(operationId = "createVehicleLegacyByVin", summary = "Create vehicle by VIN", description = """
+                    Creates a vehicle in the legacy vehicle store with the VIN treated as mandatory, trimming the \
+                    supplied value before storing it.
+                    Use this tool when the VIN is the identifying field for a legacy record; do not use \
+                    createVehicleLegacy, which accepts a missing VIN, and do not use createVehicle, which writes \
+                    the registry store.
+                    Preconditions: none beyond an authenticated caller; the VIN is not checked for uniqueness or \
+                    17-character format by this legacy surface.
+                    Required inputs: make, model, year and vin in the body (year between 1886 and the current year \
+                    plus one); vehicleType is optional and limited to CAR, VAN, COMMERCIAL_TRUCK, PASSENGER_TRUCK \
+                    or TRUCK.
+                    Emits a VEHICLE_CREATE event; no replica fact is published from the legacy surface.
+                    Returns 200 with the stored vehicle, and 400 with a VALIDATION_ERROR ApiError when make, model, \
+                    year or vin is missing or invalid.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle created successfully.")
     @EmitEvent(id = "VEHICLE_CREATE", apiVersion = "1")
     @PostMapping("/vin")
     public ResponseEntity<VehicleLegacyResponse> createVehicleByVIN(
-            @Parameter(description = "Vehicle object to be created") @RequestBody VehicleLegacyRequest vehicle) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Legacy vehicle to store, with the VIN required as its identifying field.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Legacy vehicle",
+                                                            value = LEGACY_VEHICLE_EXAMPLE)))
+                    @RequestBody
+                    VehicleLegacyRequest vehicle) {
         return ResponseEntity.ok(vehicleLegacyService.createVehicleByVin(vehicle));
     }
 
-    @Operation(summary = "Get vehicle by VIN", description = "Retrieve a vehicle by its VIN.")
+    @Operation(operationId = "getVehicleLegacyByVin", summary = "Get vehicle by VIN", description = """
+                    Returns a single vehicle from the legacy vehicle store by VIN, trimming the supplied value \
+                    before the lookup.
+                    Use this tool when only the VIN of a legacy record is known; use getVehicleLegacy instead when \
+                    the id is known, and do not use getVehicleByVin, which reads the registry store with normalized \
+                    VINs.
+                    Preconditions: the vehicle must exist in the legacy store; the lookup is an exact match on the \
+                    trimmed VIN, not a normalized or partial match.
+                    Required inputs: vin as a non-blank path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 with an empty body when no legacy vehicle carries the VIN, and 400 with a \
+                    VALIDATION_ERROR ApiError when the VIN is blank.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle found and returned.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @GetMapping("/vin/{vin}")
@@ -125,7 +243,19 @@ public class VehicleController {
         return ResponseEntity.of(vehicleLegacyService.getVehicleByVin(vin));
     }
 
-    @Operation(summary = "Update vehicle by VIN", description = "Update an existing vehicle's details by its VIN.")
+    @Operation(operationId = "updateVehicleLegacyByVin", summary = "Update vehicle by VIN", description = """
+                    Replaces the core fields of an existing legacy vehicle located by VIN, applying make, model, \
+                    year and vehicleType from the request.
+                    Use this tool to correct a legacy record when only the VIN is known; use updateVehicleLegacy \
+                    instead when the id is known, and do not use updateVehicle, which patches registry vehicles.
+                    Preconditions: a vehicle with the trimmed VIN must already exist in the legacy store; the \
+                    request fully replaces core fields rather than patching them.
+                    Required inputs: vin as a path parameter plus make, model and year in the body (year between \
+                    1886 and the current year plus one); vehicleType is optional.
+                    Emits a VEHICLE_UPDATE event; no replica fact is published from the legacy surface.
+                    Returns 404 with an empty body when no legacy vehicle carries the VIN, and 400 with a \
+                    VALIDATION_ERROR ApiError when a required body field is missing or invalid.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle updated successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @EmitEvent(id = "VEHICLE_UPDATE", apiVersion = "1")
@@ -133,12 +263,35 @@ public class VehicleController {
     public ResponseEntity<VehicleLegacyResponse> updateVehicleByVIN(
             @Parameter(description = "VIN of the vehicle to update", example = "1HGCM82633A004352") @PathVariable
                     String vin,
-            @Parameter(description = "Updated vehicle object") @RequestBody VehicleLegacyRequest updated) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement values for the legacy vehicle's core fields.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Legacy vehicle",
+                                                            value = LEGACY_VEHICLE_EXAMPLE)))
+                    @RequestBody
+                    VehicleLegacyRequest updated) {
         // ResponseEntity.of: 200 + body when present, 404 when empty (Sonar S6863).
         return ResponseEntity.of(vehicleLegacyService.updateVehicleByVin(vin, updated));
     }
 
-    @Operation(summary = "Delete vehicle by VIN", description = "Delete a vehicle from the inventory by its VIN.")
+    @Operation(operationId = "deleteVehicleLegacyByVin", summary = "Delete vehicle by VIN", description = """
+                    Permanently deletes a vehicle from the legacy vehicle store located by VIN; the row is removed \
+                    rather than deactivated.
+                    Use this tool to purge a legacy record when only the VIN is known; use deleteVehicleLegacy \
+                    instead when the id is known, and do not use deleteVehicle, which soft-deactivates registry \
+                    vehicles.
+                    Preconditions: a vehicle with the trimmed VIN must exist in the legacy store; deletion is not \
+                    recoverable through this API.
+                    Required inputs: vin as a non-blank path parameter; there is no request body.
+                    Emits a VEHICLE_DELETE event; no replica fact is published from the legacy surface.
+                    Returns 204 on successful deletion, and 404 with an empty body when no legacy vehicle carries \
+                    the VIN.
+                    """)
     @ApiResponse(responseCode = "204", description = "Vehicle deleted successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @EmitEvent(id = "VEHICLE_DELETE", apiVersion = "1")

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehiclePreferencesController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehiclePreferencesController.java
@@ -8,6 +8,7 @@ import com.positivity.vehicle.service.VehiclePreferencesService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,11 +45,33 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/vehicles/{vehicleId}/preferences")
 public class VehiclePreferencesController {
 
+    private static final String UPSERT_EXAMPLE = """
+            {"preferences":{"preferredOil":"5W-30","tireRotationInterval":5000},
+             "serviceIntervalMonths":6,
+             "serviceNotes":"Customer prefers synthetic oil only",
+             "createdByUserId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+             "updatedByUserId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"}
+            """;
+
+    private static final String MERGE_EXAMPLE = """
+            {"partialPreferences":{"tireRotationInterval":7500},
+             "serviceIntervalMonths":6,
+             "updatedByUserId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"}
+            """;
+
     private final VehiclePreferencesService preferencesService;
 
-    @Operation(
-            summary = "Get vehicle care preferences",
-            description = "Retrieves the care preferences for a vehicle. Returns 404 if no preferences exist.")
+    @Operation(operationId = "getVehiclePreferences", summary = "Get vehicle care preferences", description = """
+                    Returns the care-preference document for a vehicle, including the free-form preferences map, \
+                    the structured service interval in months and any service notes.
+                    Use this tool to read what a customer wants for vehicle care; do not use getVehicle, which \
+                    returns the registry record itself and carries no preferences.
+                    Preconditions: a preference document must already have been stored for the vehicle, because \
+                    vehicles start with no preferences.
+                    Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 with an empty body when no preference document exists for the vehicle.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Preferences found and returned",
@@ -67,9 +90,26 @@ public class VehiclePreferencesController {
     }
 
     @Operation(
+            operationId = "upsertVehiclePreferences",
             summary = "Create or update vehicle care preferences",
-            description =
-                    "Upserts preferences for a vehicle. If preferences exist, replaces them entirely. Use PATCH for partial updates.")
+            description = """
+                    Creates or fully replaces the care-preference document for a vehicle, storing the preferences \
+                    map and the structured service interval.
+                    Use this tool to set preferences wholesale; use mergeVehiclePreferences instead for partial \
+                    changes, because this operation replaces the entire map and a null serviceIntervalMonths \
+                    clears the stored interval override.
+                    Preconditions: the vehicle must exist in the registry; an existing preference document is \
+                    replaced and a missing one is created.
+                    Required inputs: preferences (a map, which may be empty but not null); serviceIntervalMonths \
+                    is optional and must be between 1 and 120 months, a legacy serviceIntervalMonths key inside \
+                    the map is promoted into the structured column, and serviceNotes, createdByUserId and \
+                    updatedByUserId are optional.
+                    Emits a VEHICLE_PREFERENCES_UPSERT event and queues a vehicle.care-preference.updated fact for \
+                    CRM consumers.
+                    Returns 200 with the saved document for both create and replace, 404 with a \
+                    RESOURCE_NOT_FOUND ApiError when the vehicle does not exist, and 400 with a VALIDATION_ERROR \
+                    ApiError when serviceIntervalMonths is outside 1 to 120.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Preferences updated successfully",
@@ -84,7 +124,20 @@ public class VehiclePreferencesController {
     @EmitEvent(id = "VEHICLE_PREFERENCES_UPSERT", apiVersion = "1")
     public ResponseEntity<VehicleCarePreferenceResponse> upsertPreferences(
             @Parameter(description = "Vehicle ID") @PathVariable UUID vehicleId,
-            @Valid @RequestBody PreferencesUpsertDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Complete care-preference document that replaces whatever is currently"
+                                    + " stored for the vehicle.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Full preference document",
+                                                            value = UPSERT_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    PreferencesUpsertDto request) {
 
         log.info(
                 "PUT /v1/vehicles/{}/preferences - keys={}",
@@ -104,9 +157,26 @@ public class VehiclePreferencesController {
     }
 
     @Operation(
+            operationId = "mergeVehiclePreferences",
             summary = "Partially update vehicle care preferences",
-            description =
-                    "Merges provided preference fields into existing preferences without replacing the entire map")
+            description = """
+                    Merges the supplied preference keys into a vehicle's existing care-preference document without \
+                    replacing the rest of the map.
+                    Use this tool for partial changes such as one key or the interval alone; do not use \
+                    upsertVehiclePreferences, which replaces the whole map and clears the interval when it is \
+                    omitted.
+                    Preconditions: a preference document must already exist for the vehicle, because this \
+                    operation cannot create one.
+                    Required inputs: no body field is individually mandatory; partialPreferences keys overwrite \
+                    matching stored keys, serviceIntervalMonths must be between 1 and 120 months and leaves the \
+                    stored value unchanged when null, and a legacy serviceIntervalMonths key inside the map is \
+                    promoted into the structured column rather than kept in the blob.
+                    Emits a VEHICLE_PREFERENCES_MERGE event and queues a vehicle.care-preference.updated fact for \
+                    CRM consumers.
+                    Returns 200 with the merged document, 404 with a RESOURCE_NOT_FOUND ApiError when no \
+                    preference document exists for the vehicle, and 400 with a VALIDATION_ERROR ApiError when an \
+                    interval value is out of range or not a whole number.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Preferences merged successfully",
@@ -116,7 +186,20 @@ public class VehiclePreferencesController {
     @EmitEvent(id = "VEHICLE_PREFERENCES_MERGE", apiVersion = "1")
     public ResponseEntity<VehicleCarePreferenceResponse> mergePreferences(
             @Parameter(description = "Vehicle ID") @PathVariable UUID vehicleId,
-            @Valid @RequestBody PreferencesMergeDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Subset of preference fields to merge into the existing care-preference"
+                                    + " document.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Partial preference merge",
+                                                            value = MERGE_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    PreferencesMergeDto request) {
 
         // partialPreferences is optional: a PATCH may update only serviceIntervalMonths.
         Map<String, Object> partialPreferences =
@@ -128,7 +211,18 @@ public class VehiclePreferencesController {
         return ResponseEntity.ok(VehicleCarePreferenceMapper.toResponse(preference));
     }
 
-    @Operation(summary = "Delete vehicle care preferences", description = "Removes all preferences for a vehicle")
+    @Operation(operationId = "deleteVehiclePreferences", summary = "Delete vehicle care preferences", description = """
+                    Removes the entire care-preference document for a vehicle when one exists.
+                    Use this tool to clear all stored preferences at once; do not use mergeVehiclePreferences to \
+                    blank individual keys when the intent is a full reset.
+                    Preconditions: none; the operation is idempotent and a vehicle without preferences is left \
+                    untouched.
+                    Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+                    Emits a VEHICLE_PREFERENCES_DELETE event, and queues a vehicle.care-preference.updated \
+                    tombstone fact for CRM consumers only when a document was actually removed.
+                    Returns 204 in all cases, including when no preference document exists, because deletion is \
+                    idempotent.
+                    """)
     @ApiResponse(responseCode = "204", description = "Preferences deleted successfully")
     @ApiResponse(responseCode = "404", description = "No preferences found to delete")
     @DeleteMapping

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehiclePreferencesController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehiclePreferencesController.java
@@ -223,8 +223,9 @@ public class VehiclePreferencesController {
                     Returns 204 in all cases, including when no preference document exists, because deletion is \
                     idempotent.
                     """)
-    @ApiResponse(responseCode = "204", description = "Preferences deleted successfully")
-    @ApiResponse(responseCode = "404", description = "No preferences found to delete")
+    @ApiResponse(
+            responseCode = "204",
+            description = "Preferences deleted, or no preference document existed (idempotent delete)")
     @DeleteMapping
     @EmitEvent(id = "VEHICLE_PREFERENCES_DELETE", apiVersion = "1")
     public ResponseEntity<Void> deletePreferences(@Parameter(description = "Vehicle ID") @PathVariable UUID vehicleId) {

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleRegistryController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleRegistryController.java
@@ -7,6 +7,8 @@ import com.positivity.shared.dto.VehicleResponse;
 import com.positivity.vehicle.service.VehicleService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -45,21 +47,81 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/vehicle-registry")
 public class VehicleRegistryController {
 
+    private static final String CREATE_VEHICLE_EXAMPLE = """
+            {"accountId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+             "vin":"1HGCM82633A004352",
+             "unitNumber":"UNIT-1042",
+             "description":"2003 Honda Accord EX Sedan",
+             "licensePlate":"ABC1234",
+             "licensePlateJurisdiction":"CA",
+             "year":2003,
+             "make":"Honda",
+             "model":"Accord",
+             "trim":"EX"}
+            """;
+
+    private static final String UPDATE_VEHICLE_EXAMPLE = """
+            {"description":"2003 Honda Accord EX Sedan, repainted",
+             "licensePlate":"XYZ7890",
+             "licensePlateJurisdiction":"TX"}
+            """;
+
     private final VehicleService vehicleService;
 
-    @Operation(summary = "Create vehicle", description = "Create a new vehicle registry record")
+    @Operation(operationId = "createVehicle", summary = "Create vehicle", description = """
+                    Creates an active vehicle registry record after validating and normalizing the VIN, which must \
+                    be globally unique among active vehicles.
+                    Use this tool to register a single vehicle whose changes replicate to consumer services; do not \
+                    use bulkIngestVehicles, which loads batches with per-row results, and do not use \
+                    createVehicleLegacy, which writes the unreplicated legacy store.
+                    Preconditions: no active vehicle may already hold the same normalized VIN; a deactivated \
+                    vehicle releases its VIN for reuse.
+                    Required inputs: accountId (UUID) and vin (17 characters after separators are stripped, with \
+                    letters I, O and Q rejected); unitNumber and description are optional and stored as empty \
+                    strings when omitted, and licensePlate, licensePlateJurisdiction, year, make, model and trim \
+                    are optional.
+                    Emits a VEHICLE_CREATE event and queues a vehicle.vehicle.updated fact on the vehicle.events.v1 \
+                    outbox for downstream replicas.
+                    Returns 201 with the created record, and 400 with a VALIDATION_ERROR ApiError when the VIN is \
+                    malformed or an active vehicle already holds the same normalized VIN; the duplicate-VIN case is \
+                    reported as 400, not 409.
+                    """)
     @ApiResponse(responseCode = "201", description = "Vehicle created successfully.")
     @ApiResponse(responseCode = "400", description = "Invalid vehicle request.")
     @EmitEvent(id = "VEHICLE_CREATE", apiVersion = "1")
     @PostMapping
     public ResponseEntity<VehicleResponse> createVehicle(
-            @Parameter(description = "Vehicle creation request", required = true) @Valid @NotNull @RequestBody
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Registry vehicle to create, owned by one account and identified by a"
+                                    + " globally unique VIN.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Registry vehicle",
+                                                            value = CREATE_VEHICLE_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
                     CreateVehicleRequest request) {
         VehicleResponse response = vehicleService.createVehicle(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @Operation(summary = "Get vehicle by ID", description = "Retrieve a vehicle by its unique ID")
+    @Operation(operationId = "getVehicle", summary = "Get vehicle by ID", description = """
+                    Returns a single vehicle registry record by its vehicleId, whether the vehicle is active or \
+                    deactivated.
+                    Use this tool when the registry id is already known; use getVehicleByVin instead for VIN \
+                    lookups, use searchVehicles for free-text discovery, and do not use getVehicleLegacy, which \
+                    reads the legacy store.
+                    Preconditions: the record must exist in the registry; deactivated vehicles are still returned, \
+                    so callers must check the isActive flag.
+                    Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 with an empty body when no registry record exists for the supplied vehicleId.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle retrieved successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @GetMapping("/{vehicleId}")
@@ -71,7 +133,18 @@ public class VehicleRegistryController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @Operation(summary = "Get vehicle by VIN", description = "Retrieve a vehicle by VIN")
+    @Operation(operationId = "getVehicleByVin", summary = "Get vehicle by VIN", description = """
+                    Returns a single vehicle registry record by VIN, normalizing the supplied value by trimming, \
+                    uppercasing and stripping separators before the lookup.
+                    Use this tool when the full 17-character VIN is known; use searchVehicles instead for partial \
+                    VIN prefixes, and do not use getVehicleLegacyByVin, which reads the legacy store.
+                    Preconditions: a record with the normalized VIN must exist in the registry; active and \
+                    deactivated vehicles are both returned.
+                    Required inputs: vin as a path parameter, exactly 17 characters; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 with an empty body when no registry record carries the normalized VIN, and 400 \
+                    with a VALIDATION_FAILED ApiError when the path VIN is not exactly 17 characters.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle retrieved successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @GetMapping("/vin/{vin}")
@@ -84,7 +157,23 @@ public class VehicleRegistryController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @Operation(summary = "Update vehicle", description = "Update an existing vehicle by ID")
+    @Operation(operationId = "updateVehicle", summary = "Update vehicle", description = """
+                    Applies a partial update to a vehicle registry record; only fields present in the body are \
+                    changed, and the VIN itself cannot be modified here.
+                    Use this tool to correct registry data or transfer ownership, since a new accountId moves the \
+                    vehicle to that party and consumer replicas move their vehicle-party association from the \
+                    emitted fact (ADR-0044); do not use updateVehicleLegacy, which fully replaces legacy records.
+                    Preconditions: the record must exist in the registry; deactivated vehicles can still be updated.
+                    Required inputs: vehicleId (UUID) as a path parameter and at least one body field among \
+                    accountId, unitNumber, description, licensePlate, licensePlateJurisdiction, year, make, model \
+                    and trim; a provided unitNumber or description must be non-blank, and year must be between \
+                    1886 and 2100.
+                    Emits a VEHICLE_UPDATE event and queues a vehicle.vehicle.updated fact on the vehicle.events.v1 \
+                    outbox for downstream replicas.
+                    Returns 404 with a RESOURCE_NOT_FOUND ApiError when the vehicleId is unknown, and 400 with a \
+                    VALIDATION_FAILED ApiError when no field is provided or a provided field violates its \
+                    constraints.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle updated successfully.")
     @ApiResponse(responseCode = "400", description = "Invalid vehicle request.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
@@ -92,13 +181,39 @@ public class VehicleRegistryController {
     @PutMapping("/{vehicleId}")
     public ResponseEntity<VehicleResponse> updateVehicle(
             @Parameter(description = "Vehicle UUID", required = true) @PathVariable @NotNull UUID vehicleId,
-            @Parameter(description = "Vehicle update request", required = true) @Valid @NotNull @RequestBody
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Subset of mutable vehicle fields to change; omitted fields keep their"
+                                    + " stored values.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Partial update",
+                                                            value = UPDATE_VEHICLE_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
                     UpdateVehicleRequest request) {
         VehicleResponse response = vehicleService.updateVehicle(vehicleId, request);
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "Delete vehicle", description = "Deactivate a vehicle by ID")
+    @Operation(operationId = "deleteVehicle", summary = "Delete vehicle", description = """
+                    Deactivates a vehicle registry record by setting isActive to false; the row is retained and \
+                    remains readable by id and by VIN.
+                    Use this tool to retire a registry vehicle while preserving history and releasing its VIN for \
+                    reuse by a future active vehicle; do not use deleteVehicleLegacy, which hard-deletes from the \
+                    legacy store.
+                    Preconditions: the record must exist in the registry; deactivating an already inactive vehicle \
+                    is accepted and simply re-emits the replica fact.
+                    Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+                    Emits a VEHICLE_DELETE event and queues a vehicle.vehicle.updated fact with isActive false on \
+                    the vehicle.events.v1 outbox, which tells downstream replicas to treat the vehicle as retired.
+                    Returns 204 on successful deactivation, and 404 with a RESOURCE_NOT_FOUND ApiError when the \
+                    vehicleId is unknown.
+                    """)
     @ApiResponse(responseCode = "204", description = "Vehicle deleted successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @EmitEvent(id = "VEHICLE_DELETE", apiVersion = "1")

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleSearchController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleSearchController.java
@@ -7,6 +7,7 @@ import com.positivity.vehicle.service.VehicleSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -34,12 +35,31 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/vehicles/search")
 public class VehicleSearchController {
 
+    private static final String SEARCH_EXAMPLE = """
+            {"query":"1HGCM8",
+             "limit":25,
+             "enableContainsMatching":false}
+            """;
+
     private final VehicleSearchService searchService;
 
-    @Operation(
-            summary = "Search vehicles",
-            description = "Search for vehicles by VIN, license plate, unit number, or description. "
-                    + "Results are ranked by relevance: exact match > prefix match > contains match.")
+    @Operation(operationId = "searchVehicles", summary = "Search vehicles", description = """
+                    Searches vehicle registry records with a single free-text query, ranking exact matches ahead \
+                    of prefix matches ahead of optional contains matches.
+                    Use this tool for vehicle discovery from a JSON body; use searchVehiclesByQuery for the \
+                    query-parameter variant, and use getVehicleByVin instead when the full 17-character VIN is \
+                    already known.
+                    Preconditions: none beyond registry data existing; the match field is inferred from the query \
+                    shape, with six or more alphanumeric characters searched as a VIN (seventeen as an exact VIN), \
+                    shorter queries searched against license plates, and the remainder searched against unit \
+                    number plus description.
+                    Required inputs: query (non-blank, at least 3 characters, or 6 when VIN-shaped); limit \
+                    defaults to 25 and is capped at 50, enableContainsMatching defaults to false, and cursor is \
+                    reserved and currently ignored.
+                    Emits a VEHICLE_SEARCH event; no vehicle state changes.
+                    Returns 200 with ranked results plus totalCount and hasMore, and 400 with a VALIDATION_ERROR \
+                    ApiError when the query is empty or shorter than the minimum for its inferred type.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Search results returned",
@@ -47,7 +67,18 @@ public class VehicleSearchController {
     @ApiResponse(responseCode = "400", description = "Invalid search query")
     @PostMapping
     @EmitEvent(id = "VEHICLE_SEARCH", apiVersion = "1")
-    public ResponseEntity<SearchVehiclesResponse> search(@RequestBody SearchVehiclesRequest request) {
+    public ResponseEntity<SearchVehiclesResponse> search(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Free-text search criteria with an optional result limit and matching"
+                                    + " strategy flag.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "VIN prefix search", value = SEARCH_EXAMPLE)))
+                    @RequestBody
+                    SearchVehiclesRequest request) {
 
         log.info(
                 "POST /v1/vehicles/search - query(mask)='{}', limit={}",
@@ -58,9 +89,20 @@ public class VehicleSearchController {
         return ResponseEntity.ok(results);
     }
 
-    @Operation(
-            summary = "Search vehicles (query parameter)",
-            description = "Alternative search endpoint using query parameters. Useful for browser-based queries.")
+    @Operation(operationId = "searchVehiclesByQuery", summary = "Search vehicles (query parameter)", description = """
+                    Searches vehicle registry records using query parameters, applying the same ranking as \
+                    searchVehicles with exact matches first, then prefix matches, then optional contains matches.
+                    Use this tool for browser-friendly or link-style searches; use searchVehicles instead when the \
+                    client can send a JSON body, and use getVehicleByVin when the full 17-character VIN is already \
+                    known.
+                    Preconditions: none beyond registry data existing; the match field is inferred from the query \
+                    shape exactly as in searchVehicles.
+                    Required inputs: q (non-blank, at least 3 characters, or 6 when VIN-shaped); limit defaults to \
+                    25 and is capped at 50, and enableContains defaults to false.
+                    Emits a VEHICLE_SEARCH event; no vehicle state changes.
+                    Returns 200 with ranked results plus totalCount and hasMore, and 400 with a VALIDATION_ERROR \
+                    ApiError when q is empty or shorter than the minimum for its inferred type.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Search results returned",


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (platform-wide API documentation standard, #1263 rollout wave B of E)
- Parent STORY (durion): ADR-0042 (`durion/docs/adr/0042-openapi-annotation-standards.adr.md`)
- Child issue: louisburroughs/durion-positivity-backend#1263
- Domain: `domain:platform` (price, vehicle-inventory, mcp-server, people-contact, invoice)

## Contract References
- Contract guide entry (durion): `domains/platform/.business-rules/BACKEND_CONTRACT_GUIDE.md` — no contract semantics change; spec deltas are description/operationId/requestBody metadata and error-schema declarations.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controllers
- [x] `openapi.yaml` regenerated for all five modules; aggregate unchanged
- [ ] Angular SDK regenerated — deferred to a single regen after the full wave stack lands

## Scope

**Wave B of the #1263 rollout**, stacked on #1291 (wave A):

| module | ops | request bodies annotated |
| --- | --- | --- |
| pos-price | 20 | 10 |
| pos-vehicle-inventory | 21 | 10 |
| pos-mcp-server | 22 | 12 |
| pos-people-contact | 25 | 10 |
| pos-invoice | 30 | 18 |

**Validator change in this wave:** the spec-level "request body missing explicit required flag" check is removed. springdoc omits `required: false` (the OpenAPI default) from generated specs, so the check could never pass for a genuinely optional body — first hit by pos-price `normalizePricing` and pos-mcp-server `confirmWritePlan`, whose Spring bindings are `@RequestBody(required = false)`. The explicit-flag rule stays as an annotation-level convention in `docs/OPENAPI_DESCRIPTION_STANDARD.md`; description and example remain spec-enforced.

**Code-derived corrections now in the contract text (highlights):**
- pos-vehicle-inventory: duplicate VIN → 400 (not 409); deactivation releases the VIN; legacy vs registry APIs disambiguated per operation; `patchMobileUnit`-class traps called out.
- pos-price: promotion activate maps to 422 (annotation said 409); restriction override skips the overrideable re-check and expires in 24h; unreachable 404s removed from apply/eligibility ops.
- pos-mcp-server: LLM-config controller has no exception-handler coverage → unknown-id/duplicate errors surface as 500 today (descriptions say so; follow-up advice recommended).
- pos-invoice: `refundPayment` persists a FAILED record and still returns 201 — callers must read the returned status; finalize's tax-commit PENDING_COMMIT outage tolerance documented end to end; idempotency anchors (workorderId/orderId/idempotencyKey/externalReference) stated per operation.
- pos-people-contact: `replaceContactPoints` writes for an unknown person succeed silently and it is the module's only unaudited state change — flagged for follow-up.

## Tests
- [x] `OpenApiRepositoryValidationTest` green with all five at depth-STRICT; validator unit suite updated for the required-flag removal
- [ ] Integration — n/a
- [ ] Provider behavioral contract tests — n/a
- How to run:
```bash
./mvnw -pl pos-openapi-validation -DskipTests=false test
```

## Risk & Rollback
- Risk level: Low — annotation/documentation only.
- Rollback plan: revert, or flip the five `annotationDepth` entries back to `REPORT_ONLY`.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, rollout branch `docs/1263-wave-b`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a
- [x] Links to parent + child issues are present
