### PR TITLE
docs(openapi): ADR-0042 wave D — 3 modules to depth-STRICT (#1263)

### DIFF
--- a/docs/OPENAPI_DESCRIPTION_STANDARD.md
+++ b/docs/OPENAPI_DESCRIPTION_STANDARD.md
@@ -174,7 +174,9 @@ public ResponseEntity<SupplierAccount> createSupplierAccount(
 Required:
 
 - `description` — what the body represents, one sentence. Not a repeat of the summary.
-- `required` — stated explicitly, even when true.
+- `required` — stated explicitly, even when false for a genuinely optional body. (Annotation-level
+  convention only: springdoc omits `required: false` from the generated spec because it is the
+  OpenAPI default, so the validator cannot check this on the spec.)
 - at least one `@ExampleObject` with a realistic, schema-valid value. Use UUID v7 shaped ids.
 
 The DTO's own `@Schema` field annotations are covered by ADR-0042 §5 and are not part of this
@@ -204,7 +206,6 @@ The checks, and the message each emits:
 | Error conditions | `description missing error conditions ("Returns <code> when ...")` |
 | Negative guidance | `description missing negative guidance ("do not use ..." / "... instead")` |
 | Request body description | `request body missing description (ADR-0042 §3)` |
-| Request body `required` | `request body missing explicit required flag (ADR-0042 §3)` |
 | Request body example | `request body missing example (ADR-0042 §3)` |
 
 Run the checks:

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -39,8 +39,20 @@ paths:
     get:
       tags:
       - Products API
-      summary: Get a product by ID
-      description: Retrieves a specific product by its unique ID.
+      summary: Get a Product by ID
+      description: 'Returns the full product record including identity codes, manufacturer data, category, dimensions, tracking level and lifecycle state.
+
+        Use this tool when the productId is already known; use searchCatalogProducts instead to find products by text or filters.
+
+        Preconditions: the product must exist.
+
+        Required inputs: productId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no product exists for the supplied id.
+
+        '
       operationId: getProductById
       parameters:
       - name: productId
@@ -70,8 +82,20 @@ paths:
     put:
       tags:
       - Products API
-      summary: Update product master record
-      description: Updates mutable product master fields. SKU is immutable.
+      summary: Update Product Master Record
+      description: 'Replaces the mutable master-data fields of a product — name, description, unit of measure, manufacturer, category, UPC and attributes — while the SKU stays immutable.
+
+        Use this tool to correct product master data; do not use updateProductLifecycle, which changes selling state, and do not use updateProductTrackingLevel, which changes stock tracking.
+
+        Preconditions: the product must exist, and a sku field in the body must either be omitted or match the stored SKU exactly.
+
+        Required inputs: productId (UUID) path parameter plus non-blank name, description, unitOfMeasure and mpn; omitted optional fields such as upc and categoryId are cleared, not preserved.
+
+        Emits a CATALOG_PRODUCT_UPDATED event, publishes a product fact for downstream replicas, and invalidates the product-detail cache.
+
+        Returns 404 when the product does not exist, 400 when the body tries to change the SKU or names a categoryId that does not resolve, and 409 when the manufacturerId plus mpn pair collides with another product.
+
+        '
       operationId: updateProduct
       parameters:
       - name: productId
@@ -82,10 +106,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Replacement master-data fields; sku may be omitted or must equal the stored value, and omitted optional fields are cleared.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ProductUpdateRequestDto'
+            examples:
+              Correct description and category:
+                description: Correct description and category
+                value:
+                  name: All-Terrain Tire 265/70R17
+                  description: All-terrain LT tire, 265/70R17, load range E
+                  unitOfMeasure: EA
+                  mpn: AT3-26570R17
+                  upc: 036121960222
+                  categoryId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '200':
@@ -120,8 +155,20 @@ paths:
     put:
       tags:
       - Product UoM API
-      summary: Update product UoM conversion
-      description: Updates factor, precision scale, and optionally the UoM role. The UoM code is immutable. Re-emits the product contract event.
+      summary: Update Product UoM Conversion
+      description: 'Updates the conversion factor, precision scale and optionally the type of one product UoM entry; the UoM code itself is immutable.
+
+        Use this tool to correct a factor or reclassify an entry; do not use addProductUom, which adds a new code, or deleteProductUom, which removes one.
+
+        Preconditions: the product must exist and the UoM entry must belong to it; changing the type to BASE requires factorToBase exactly 1, and omitting uomType keeps the current type.
+
+        Required inputs: productId and uomId (UUIDs) path parameters plus a positive factorToBase; uomType and precisionScale are optional.
+
+        Emits a CATALOG_PRODUCT_UOM_UPDATE event and re-publishes the product fact with a bumped aggregate version so downstream replicas refresh.
+
+        Returns 404 when the product or the UoM entry does not exist under that product, and 400 when factorToBase is not positive or a BASE entry''s factor is not 1.
+
+        '
       operationId: updateProductUom
       parameters:
       - name: productId
@@ -139,10 +186,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Replacement factor and precision for the entry; uomType is optional and keeps the current role when omitted.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ProductUomUpdateRequestDto'
+            examples:
+              Correct pack factor:
+                description: Correct pack factor
+                value:
+                  uomType: PACK
+                  factorToBase: 24
+                  precisionScale: 0
         required: true
       responses:
         '200':
@@ -170,8 +225,20 @@ paths:
     delete:
       tags:
       - Product UoM API
-      summary: Delete product UoM conversion
-      description: Removes a UoM from the product's conversion set and re-emits the product contract event.
+      summary: Delete Product UoM Conversion
+      description: 'Removes one unit-of-measure entry from a product''s conversion set permanently; there is no soft delete.
+
+        Use this tool when a purchase or pack unit no longer applies to the product; do not use updateProductUom, which changes an entry''s factor or type while keeping it.
+
+        Preconditions: the product must exist and the UoM entry must belong to it; no guard prevents deleting the BASE entry, so callers must not orphan the conversion set.
+
+        Required inputs: productId and uomId (UUIDs) as path parameters; there is no request body.
+
+        Emits a CATALOG_PRODUCT_UOM_DELETE event and re-publishes the product fact with a bumped aggregate version so downstream replicas refresh.
+
+        Returns 204 on success, and 404 when the product or the UoM entry does not exist under that product.
+
+        '
       operationId: deleteProductUom
       parameters:
       - name: productId
@@ -201,9 +268,21 @@ paths:
     put:
       tags:
       - Products API
-      summary: Set product tracking level
-      description: Sets the product's stock tracking level (NONE, LOT, or SERIAL; default NONE) and re-emits the product contract event for downstream replicas.
-      operationId: updateTrackingLevel
+      summary: Set Product Tracking Level
+      description: 'Sets the product''s stock tracking level to NONE, LOT or SERIAL, controlling whether inventory tracks the product per lot or per serial number.
+
+        Use this tool when a product''s tracking granularity changes; do not use updateProduct, which replaces master-data fields and does not touch the tracking level.
+
+        Preconditions: the product must exist; no transition rules apply between levels.
+
+        Required inputs: productId (UUID) path parameter and trackingLevel in the body, one of NONE, LOT or SERIAL.
+
+        Emits a CATALOG_PRODUCT_TRACKING_LEVEL_UPDATE event, re-publishes the product fact so downstream replicas pick up the new level, and invalidates the product-detail cache.
+
+        Returns 404 when the product does not exist, and 400 when trackingLevel is missing or not a valid enum value.
+
+        '
+      operationId: updateProductTrackingLevel
       parameters:
       - name: productId
         in: path
@@ -213,10 +292,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The stock tracking granularity to apply to the product.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ProductTrackingLevelUpdateRequestDto'
+            examples:
+              Track by serial number:
+                description: Track by serial number
+                value:
+                  trackingLevel: SERIAL
         required: true
       responses:
         '200':
@@ -245,9 +330,21 @@ paths:
     put:
       tags:
       - Product MSRP API
-      summary: Update MSRP
-      description: Updates a non-historical MSRP record.
-      operationId: updateMsrp
+      summary: Update Product MSRP
+      description: 'Rewrites a current or future MSRP record''s amount, currency and effective window; records whose window already ended are immutable history.
+
+        Use this tool to correct or reschedule an existing record; do not use createProductMsrp, which adds a new window alongside the existing ones.
+
+        Preconditions: the record must exist, belong to the given product, and not have an effectiveEndDate in the past; a version in the body must match the record''s current version, and the new window must not overlap other records.
+
+        Required inputs: productId and msrpId (UUIDs) path parameters plus a positive amount, a 3-letter ISO currency and effectiveStartDate; version is optional but recommended.
+
+        Emits a CATALOG_MSRP_UPDATE event; active-MSRP resolution reflects the change immediately.
+
+        Returns 404 when the record does not exist under that product, 409 when the version mismatches or the dates overlap another record, and 400 when the record is historical or the amount, currency or window is invalid.
+
+        '
+      operationId: updateProductMsrp
       parameters:
       - name: productId
         in: path
@@ -262,10 +359,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Replacement amount, currency and effective window for the record; include version to guard against concurrent edits.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateMsrpRequestDto'
+            examples:
+              Reprice with version guard:
+                description: Reprice with version guard
+                value:
+                  amount: 139.99
+                  currency: USD
+                  effectiveStartDate: 2026-09-01
+                  effectiveEndDate: 2026-12-31
+                  createdByUserId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  version: 0
         required: true
       responses:
         '200':
@@ -307,8 +415,20 @@ paths:
     get:
       tags:
       - Products API
-      summary: Get product lifecycle state
-      description: Retrieves lifecycle state and replacement suggestions for a product.
+      summary: Get Product Lifecycle State
+      description: 'Returns a product''s lifecycle state — ACTIVE, INACTIVE or DISCONTINUED, defaulting to ACTIVE when never set — together with its effective instant, last-change audit fields and ordered replacement options.
+
+        Use this tool to inspect selling state before a transition; do not use updateProductLifecycle, which changes the state, and use listProductReplacements when only the replacements are needed.
+
+        Preconditions: the product must exist.
+
+        Required inputs: productId (UUID) as a path parameter; there is no request body.
+
+        Emits a CATALOG_PRODUCT_LIFECYCLE_GET audit event; no state changes.
+
+        Returns 404 when no product exists for the supplied id.
+
+        '
       operationId: getProductLifecycle
       parameters:
       - name: productId
@@ -341,9 +461,21 @@ paths:
     put:
       tags:
       - Products API
-      summary: Set product lifecycle state
-      description: Sets lifecycle state to ACTIVE, INACTIVE, or DISCONTINUED with effective date semantics.
-      operationId: setLifecycleState
+      summary: Set Product Lifecycle State
+      description: 'Transitions a product''s lifecycle state to ACTIVE, INACTIVE or DISCONTINUED with an effective instant; discontinuation is one-way, a DISCONTINUED product can never be reactivated and callers must record a replacement via addProductReplacement instead.
+
+        Use this tool to change selling state; do not use updateProduct, which edits master data, and do not use deleteCatalogItem, which removes the row outright.
+
+        Preconditions: the product must exist and must not already be in the requested state; any transition into DISCONTINUED requires the product:lifecycle:override_discontinued authority and a non-blank overrideReason.
+
+        Required inputs: productId (UUID) path parameter plus lifecycleState and either effectiveAt (instant) or effectiveDate (date, resolved to UTC start of day); effectiveAt more than two seconds in the past is rejected.
+
+        Emits a CATALOG_PRODUCT_LIFECYCLE_UPDATE event, publishes a product fact for downstream replicas, and invalidates the product-detail cache.
+
+        Returns 404 when the product does not exist, 409 when attempting to leave DISCONTINUED, 403 when the discontinued-override authority is missing, and 400 when the state is unchanged, the effective time is absent or in the past, or overrideReason is missing for a discontinuation.
+
+        '
+      operationId: updateProductLifecycle
       parameters:
       - name: productId
         in: path
@@ -353,10 +485,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Target lifecycle state and when it takes effect; overrideReason is mandatory for transitions into DISCONTINUED.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ProductLifecycleUpdateRequest'
+            examples:
+              Discontinue at year end:
+                description: Discontinue at year end
+                value:
+                  lifecycleState: DISCONTINUED
+                  effectiveDate: 2026-12-31
+                  overrideReason: Manufacturer ended production
         required: true
       responses:
         '200':
@@ -400,8 +540,20 @@ paths:
     get:
       tags:
       - UOM Conversion API
-      summary: Get conversion
-      description: Retrieves a unit-of-measure conversion by its ID.
+      summary: Get UoM Conversion by ID
+      description: 'Returns one unit-of-measure conversion with its from and to codes, factor and active flag; inactive conversions are returned here even though listUomConversions hides them.
+
+        Use this tool when the conversion id is already known; use listUomConversions instead to browse the active table.
+
+        Preconditions: the conversion must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no conversion exists for the supplied id.
+
+        '
       operationId: getUomConversionById
       parameters:
       - name: id
@@ -431,8 +583,20 @@ paths:
     put:
       tags:
       - UOM Conversion API
-      summary: Update conversion factor
-      description: Updates the conversion factor and mutable fields for an existing conversion.
+      summary: Update UoM Conversion Factor
+      description: 'Updates the factor of an existing unit-of-measure conversion; the from and to codes are immutable, so redefining a pair means deactivating this conversion and creating a new one.
+
+        Use this tool to correct a factor; do not use createUomConversion, which adds a new pair, or deactivateUomConversion, which retires one.
+
+        Preconditions: the conversion must exist; a self-conversion must keep factor 1.
+
+        Required inputs: id (UUID) path parameter and a positive conversionFactor in the body, stored at six decimal places.
+
+        Emits a CATALOG_UOM_CONVERSION_UPDATE event; derived inverse factors reflect the change immediately.
+
+        Returns 404 when no conversion exists for the supplied id, and 400 when the factor is not positive or a self-conversion factor is not 1.
+
+        '
       operationId: updateUomConversion
       parameters:
       - name: id
@@ -443,10 +607,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The corrected conversion factor for the existing from/to pair.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UomConversionUpdateRequestDto'
+            examples:
+              Correct factor:
+                description: Correct factor
+                value:
+                  conversionFactor: 24
         required: true
       responses:
         '200':
@@ -474,8 +644,20 @@ paths:
     delete:
       tags:
       - UOM Conversion API
-      summary: Deactivate conversion
-      description: Deactivates a conversion so it is excluded from active conversion results.
+      summary: Deactivate UoM Conversion
+      description: 'Marks a unit-of-measure conversion inactive so it disappears from listUomConversions and from factor lookups; the row is kept and remains readable by id.
+
+        Use this tool to retire a conversion pair; do not use updateUomConversion, which changes the factor while keeping it active — there is no reactivation endpoint, so recreate the pair with createUomConversion if it is needed again.
+
+        Preconditions: the conversion must exist; deactivating an already inactive conversion succeeds idempotently.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a CATALOG_UOM_CONVERSION_DEACTIVATE event; product-level UoM sets are unaffected.
+
+        Returns 204 on success, and 404 when no conversion exists for the supplied id.
+
+        '
       operationId: deactivateUomConversion
       parameters:
       - name: id
@@ -498,9 +680,21 @@ paths:
     get:
       tags:
       - Supplier Item Cost API
-      summary: Get supplier cost structure
-      description: Returns the supplier item cost structure identified by the supplied cost structure ID.
-      operationId: getCostStructure
+      summary: Get Supplier Cost Structure
+      description: 'Returns one supplier item cost structure with its base cost and volume tiers sorted by minimum quantity.
+
+        Use this tool when the cost structure id is already known; use listSupplierItemCosts instead to find structures by itemId or supplierId.
+
+        Preconditions: the cost structure must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no cost structure exists for the supplied id.
+
+        '
+      operationId: getSupplierItemCost
       parameters:
       - name: id
         in: path
@@ -529,9 +723,21 @@ paths:
     put:
       tags:
       - Supplier Item Cost API
-      summary: Update supplier cost structure
-      description: Updates the supplier item cost structure identified by the supplied cost structure ID.
-      operationId: updateCostStructure
+      summary: Update Supplier Cost Structure
+      description: 'Replaces a supplier item cost structure wholesale — supplier, item, currency, base cost and the entire tier list are overwritten with the submitted values.
+
+        Use this tool to reprice or re-tier an existing structure; do not use createSupplierItemCost, which adds a structure for a pair that has none yet.
+
+        Preconditions: the structure must exist, and repointing it at a different supplier and item pair must not collide with another structure for that pair; tiers follow the same contiguity rules as creation.
+
+        Required inputs: id (UUID) path parameter plus supplierId, itemId and a 3-letter currencyCode; the tier list submitted replaces the previous one entirely.
+
+        Emits a CATALOG_SUPPLIER_COST_UPDATE event; no item or catalog pricing records are touched.
+
+        Returns 404 when no cost structure exists for the supplied id, 409 when the supplier and item pair collides with another structure, and 400 when the currency code or tier structure is invalid.
+
+        '
+      operationId: updateSupplierItemCost
       parameters:
       - name: id
         in: path
@@ -540,10 +746,22 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Full replacement of the structure; the submitted tier list overwrites the stored tiers entirely.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SupplierItemCostUpdateRequestDto'
+            examples:
+              Reprice base cost:
+                description: Reprice base cost
+                value:
+                  supplierId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  itemId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  currencyCode: USD
+                  baseCost: 11.0
+                  tiers:
+                  - minQuantity: 1
+                    unitCost: 11.0
         required: true
       responses:
         '200':
@@ -566,9 +784,21 @@ paths:
     delete:
       tags:
       - Supplier Item Cost API
-      summary: Delete supplier cost structure
-      description: Deletes the supplier item cost structure identified by the supplied cost structure ID.
-      operationId: deleteCostStructure
+      summary: Delete Supplier Cost Structure
+      description: 'Permanently deletes a supplier item cost structure and its volume tiers; there is no soft delete or history.
+
+        Use this tool when a supplier no longer offers the item; use updateSupplierItemCost instead to change prices while keeping the structure.
+
+        Preconditions: the cost structure must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a CATALOG_SUPPLIER_COST_DELETE event; item costs recorded elsewhere are unaffected.
+
+        Returns 204 on success, and 404 when no cost structure exists for the supplied id.
+
+        '
+      operationId: deleteSupplierItemCost
       parameters:
       - name: id
         in: path
@@ -590,8 +820,20 @@ paths:
     get:
       tags:
       - Price Book API
-      summary: Get price book
-      description: Retrieves a price book by ID, including its configuration metadata.
+      summary: Get Price Book
+      description: 'Returns one price book with its name, scope, default flag, status and optimistic-lock version.
+
+        Use this tool when the priceBookId is already known; use listPriceBookRules instead to inspect the rules it contains, since there is no endpoint that lists price books.
+
+        Preconditions: the price book must exist.
+
+        Required inputs: priceBookId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no price book exists for the supplied id.
+
+        '
       operationId: getPriceBook
       parameters:
       - name: priceBookId
@@ -621,8 +863,20 @@ paths:
     put:
       tags:
       - Price Book API
-      summary: Update price book
-      description: Updates mutable fields of an existing price book.
+      summary: Update Price Book
+      description: 'Updates a price book''s name, scope and scopeId, and optionally its default flag and status; isDefault and status are left unchanged when omitted, unlike the other fields which are replaced.
+
+        Use this tool to rename, re-scope, deactivate or promote a book; do not use updatePriceBookRule, which edits an individual rule inside the book.
+
+        Preconditions: the price book must exist.
+
+        Required inputs: priceBookId (UUID) path parameter plus name and scope; scopeId is mandatory for LOCATION and CUSTOMER_TIER scopes.
+
+        Emits a CATALOG_PRICE_BOOK_UPDATE event; the book''s rules are untouched.
+
+        Returns 404 when no price book exists for the supplied id, and 400 when name is blank, scope is missing, or scopeId is absent for a LOCATION or CUSTOMER_TIER scope.
+
+        '
       operationId: updatePriceBook
       parameters:
       - name: priceBookId
@@ -632,10 +886,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Replacement name, scope and scopeId; isDefault and status only change when present in the body.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PriceBookCreateRequestDto'
+            examples:
+              Deactivate a book:
+                description: Deactivate a book
+                value:
+                  name: Downtown Store Pricing
+                  scope: LOCATION
+                  scopeId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  status: INACTIVE
         required: true
       responses:
         '200':
@@ -659,9 +922,21 @@ paths:
     put:
       tags:
       - Price Book API
-      summary: Update price book rule
-      description: Updates an existing pricing rule in a price book.
-      operationId: updateRule
+      summary: Update Price Book Rule
+      description: 'Replaces the target, pricing logic, condition, priority and effective window of an existing price book rule, keeping its status.
+
+        Use this tool to change a rule in place; do not use deactivatePriceBookRule, which retires the rule, and do not use createPriceBookRule, which adds a new one.
+
+        Preconditions: the rule must exist and belong to the given price book; a version supplied in the body must match the rule''s current version, and the change must not conflict with another rule''s overlapping window.
+
+        Required inputs: priceBookId and ruleId (UUIDs) path parameters plus targetType, pricingLogic, effectiveStartAt and createdByUserId; version is optional but recommended for optimistic locking.
+
+        Emits a CATALOG_PRICE_BOOK_RULE_UPDATE event; resolution reflects the new values immediately.
+
+        Returns 404 when the rule does not exist under that price book, 409 when the version mismatches or the change conflicts with an existing rule in overlapping dates, and 400 when required fields are missing or invalid.
+
+        '
+      operationId: updatePriceBookRule
       parameters:
       - name: priceBookId
         in: path
@@ -676,10 +951,22 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Replacement rule values; include version to guard against concurrent edits of the same rule.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PriceBookRuleCreateRequestDto'
+            examples:
+              Reprice with version guard:
+                description: Reprice with version guard
+                value:
+                  targetType: SKU
+                  targetId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  pricingLogic: '{"amounts":{"USD":"119.99"},"defaultCurrency":"USD"}'
+                  priority: 10
+                  effectiveStartAt: 2026-09-01 00:00:00+00:00
+                  createdByUserId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  version: 0
         required: true
       responses:
         '200':
@@ -702,9 +989,21 @@ paths:
     delete:
       tags:
       - Price Book API
-      summary: Deactivate price book rule
-      description: Deactivates a price book rule so it is no longer considered in price resolution.
-      operationId: deactivateRule
+      summary: Deactivate Price Book Rule
+      description: 'Sets a price book rule''s status to INACTIVE so price resolution stops considering it; the rule row is kept, not deleted.
+
+        Use this tool to retire a rule; do not use updatePriceBookRule, which changes its values while leaving it active — there is no endpoint to reactivate a rule, so treat this as one-way.
+
+        Preconditions: the rule must exist and belong to the given price book.
+
+        Required inputs: priceBookId and ruleId (UUIDs) as path parameters; there is no request body.
+
+        Emits a CATALOG_PRICE_BOOK_RULE_DEACTIVATE event; subsequent resolveProductPrice calls no longer match the rule.
+
+        Returns 204 on success, and 404 when the rule does not exist under that price book.
+
+        '
+      operationId: deactivatePriceBookRule
       parameters:
       - name: priceBookId
         in: path
@@ -730,9 +1029,21 @@ paths:
     put:
       tags:
       - Item Cost API
-      summary: Update standard item cost
-      description: Updates the standard cost for the specified item and returns the refreshed item cost values.
-      operationId: updateStandardCost
+      summary: Update Standard Item Cost
+      description: 'Sets the standard cost of an item to a new value, rounding it to four decimal places, and writes an audit entry recording the old value, new value, actor and reason.
+
+        Use this tool for a deliberate manual cost change; do not use getItemCosts, which only reads the current values — last and average cost cannot be set here, they move only from purchase-order receipt events.
+
+        Preconditions: none; an item with no cost record yet gets one initialised with zero quantity on hand, so this call never fails on a missing item.
+
+        Required inputs: itemId (UUID) path parameter plus a positive newCost and a non-blank reasonCode in the body.
+
+        Emits a CATALOG_ITEM_COST_STANDARD_UPDATE event and appends a MANUAL audit row.
+
+        Returns 400 when newCost is missing or not positive, or when reasonCode is blank.
+
+        '
+      operationId: updateStandardItemCost
       parameters:
       - name: itemId
         in: path
@@ -741,10 +1052,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The new standard cost and the business reason for changing it.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateStandardCostRequestDto'
+            examples:
+              Annual cost revision:
+                description: Annual cost revision
+                value:
+                  newCost: 42.5
+                  reasonCode: ANNUAL_REVIEW
         required: true
       responses:
         '200':
@@ -770,8 +1088,20 @@ paths:
     get:
       tags:
       - Catalog API
-      summary: Get a catalog by ID
-      description: Retrieves a specific catalog by its unique ID.
+      summary: Get a Catalog by ID
+      description: 'Returns one named catalog with the ids of the products, services and non-inventory products it groups.
+
+        Use this tool when the catalogId is already known; use listCatalogsByName instead to find catalogs by a name fragment.
+
+        Preconditions: the catalog must exist.
+
+        Required inputs: catalogId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no catalog exists for the supplied id.
+
+        '
       operationId: getCatalogById
       parameters:
       - name: catalogId
@@ -801,8 +1131,20 @@ paths:
     put:
       tags:
       - Catalog API
-      summary: Update an existing catalog
-      description: Updates an existing catalog.
+      summary: Update an Existing Catalog
+      description: 'Replaces a catalog''s name, description and full membership lists with the supplied values; this is a full replacement, not a merge, so omitted item ids are removed from the catalog.
+
+        Use this tool to rename a catalog or change which items it groups; do not use createCatalog, which adds a new catalog, and do not use updateCatalogItem, which edits the items themselves.
+
+        Preconditions: the catalog must exist; ids in the three membership lists that do not resolve are silently dropped rather than rejected.
+
+        Required inputs: catalogId (UUID) path parameter and the complete replacement body including name; an omitted id list clears that membership.
+
+        Emits a CATALOG_CATALOG_UPDATE event; the referenced items themselves are not modified.
+
+        Returns 404 when no catalog exists for the supplied id.
+
+        '
       operationId: updateCatalog
       parameters:
       - name: catalogId
@@ -813,11 +1155,21 @@ paths:
           type: string
           format: uuid
       requestBody:
-        description: Updated catalog object
+        description: Complete replacement state for the catalog; membership lists overwrite the existing ones rather than merging.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CatalogDto'
+            examples:
+              Rename and reduce membership:
+                description: Rename and reduce membership
+                value:
+                  name: All-Season Tires
+                  description: Renamed lineup
+                  productIds:
+                  - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  serviceIds: []
+                  nonInventoryProductIds: []
         required: true
       responses:
         '200':
@@ -845,8 +1197,20 @@ paths:
     delete:
       tags:
       - Catalog API
-      summary: Delete a catalog
-      description: Deletes a catalog by its ID.
+      summary: Delete a Catalog
+      description: 'Permanently deletes a catalog grouping; the products, services and non-inventory products it referenced are untouched and remain available.
+
+        Use this tool to retire a grouping that is no longer needed; do not use deleteCatalogItem, which deletes the underlying items themselves.
+
+        Preconditions: the catalog must exist; there is no soft delete or archive state, so the row is removed outright.
+
+        Required inputs: catalogId (UUID) as a path parameter; there is no request body.
+
+        Emits a CATALOG_CATALOG_DELETE event; member items are not cascaded.
+
+        Returns 204 when the catalog is removed, and 404 when no catalog exists for the supplied id.
+
+        '
       operationId: deleteCatalog
       parameters:
       - name: catalogId
@@ -869,8 +1233,20 @@ paths:
     put:
       tags:
       - Catalog Items API
-      summary: Update an existing catalog item
-      description: Updates an existing product, service, or non-inventory product in the catalog.
+      summary: Update an Existing Catalog Item
+      description: 'Replaces a catalog item of the given type with the supplied state; fields omitted from the body are overwritten with null, so this is a full replacement, not a patch.
+
+        Use this tool to edit an item created through createCatalogItem; do not use updateProduct, which is the product-master path that protects SKU immutability — this endpoint applies no such guard.
+
+        Preconditions: an item of the given type must exist under the supplied id; the type determines which repository is consulted, so a product id passed with type service resolves to 404.
+
+        Required inputs: type (product, service or noninventory, case-insensitive), catalogId (UUID) and the complete replacement body.
+
+        Emits a CATALOG_ITEM_UPDATE event; no catalog groupings are touched.
+
+        Returns 404 when no item of that type exists for the supplied id, and 400 when the type is not one of the three supported values.
+
+        '
       operationId: updateCatalogItem
       parameters:
       - name: type
@@ -887,10 +1263,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Complete replacement state for the item; omitted fields are cleared because the update overwrites the whole row.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CatalogItemRequestDto'
+            examples:
+              Rename a service:
+                description: Rename a service
+                value:
+                  name: Tire Rotation and Balance
+                  shortDescription: Rotate and balance four tires
+                  longDescription: Rotate all four tires and balance each wheel
         required: true
       responses:
         '200':
@@ -918,8 +1302,20 @@ paths:
     delete:
       tags:
       - Catalog Items API
-      summary: Delete a catalog item
-      description: Deletes a product, service, or non-inventory product from the catalog by its ID.
+      summary: Delete a Catalog Item
+      description: 'Permanently deletes a product, service or non-inventory product row by id; this is a hard delete with no archive state.
+
+        Use this tool to remove an item outright; use updateProductLifecycle instead when a product should stop selling but keep its history, and use deleteCatalog to remove a grouping rather than its items.
+
+        Preconditions: an item of the given type must exist under the supplied id.
+
+        Required inputs: type (product, service or noninventory, case-insensitive) and catalogId (UUID) as path parameters; there is no request body.
+
+        Emits a CATALOG_ITEM_DELETE event; catalogs that referenced the item are not rewritten by this call.
+
+        Returns 204 when the item is removed, 404 when no item of that type exists for the supplied id, and 400 when the type is not one of the three supported values.
+
+        '
       operationId: deleteCatalogItem
       parameters:
       - name: type
@@ -950,14 +1346,39 @@ paths:
     post:
       tags:
       - Products API
-      summary: Create product master record
-      description: Creates a product master record with immutable SKU and uniqueness checks.
+      summary: Create Product Master Record
+      description: 'Creates a product master record with an immutable SKU, status ACTIVE, and uniqueness enforced on SKU and on the manufacturerId plus mpn pair.
+
+        Use this tool for governed product-master entry; do not use createCatalogItem, which is the lightweight catalog-item path with no duplicate checks, and do not use bulkIngestCatalogProducts, which loads many products in one call.
+
+        Preconditions: no product may already use the SKU (case-insensitive), and when manufacturerId is supplied no product may already pair it with the same mpn; a supplied categoryId must resolve.
+
+        Required inputs: name, description, unitOfMeasure, sku and mpn, all non-blank; manufacturerId, categoryId, upc and attributes are optional, and a upc also becomes the productCode with type UPC.
+
+        Emits a CATALOG_PRODUCT_CREATED event, publishes a product fact for downstream replicas, and invalidates the product-detail cache.
+
+        Returns 409 when the SKU or the manufacturerId plus mpn pair already exists, and 400 when the supplied categoryId does not resolve.
+
+        '
       operationId: createProduct
       requestBody:
+        description: Product master data to register; sku becomes immutable after creation and upc, when supplied, also becomes the productCode.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ProductCreateRequestDto'
+            examples:
+              New tire product:
+                description: New tire product
+                value:
+                  name: All-Terrain Tire 265/70R17
+                  description: All-terrain light truck tire, 265/70R17
+                  unitOfMeasure: EA
+                  sku: TIRE-AT-2657017
+                  mpn: AT3-26570R17
+                  upc: 036121960222
+                  manufacturerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  categoryId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '201':
@@ -986,8 +1407,20 @@ paths:
     get:
       tags:
       - Product UoM API
-      summary: List product UoM conversions
-      description: Returns the product's UoM conversion set ordered by UoM code.
+      summary: List Product UoM Conversions
+      description: 'Returns the product''s unit-of-measure conversion set ordered by UoM code, each entry carrying its type, factor to base and precision scale.
+
+        Use this tool to read a product''s unit conversions; use listUomConversions instead for the global, product-independent conversion table.
+
+        Preconditions: the product must exist.
+
+        Required inputs: productId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the product does not exist, and 200 with an empty array when the product defines no UoM entries.
+
+        '
       operationId: listProductUoms
       parameters:
       - name: productId
@@ -1021,8 +1454,20 @@ paths:
     post:
       tags:
       - Product UoM API
-      summary: Add product UoM conversion
-      description: Adds a purchase/pack (or base) UoM with its conversion factor to the product's base UoM and a precision scale. Re-emits the product contract event.
+      summary: Add Product UoM Conversion
+      description: 'Adds a unit-of-measure entry to a product''s conversion set, binding a UoM code to its factor relative to the product''s base unit; the code is normalised to upper case and the factor stored at six decimal places.
+
+        Use this tool to define how a purchase or pack unit converts for one product; do not use createUomConversion, which defines global cross-unit conversions not tied to a product.
+
+        Preconditions: the product must exist and must not already define the UoM code; a BASE-type entry must carry factorToBase exactly 1.
+
+        Required inputs: productId (UUID) path parameter plus uomCode, uomType (BASE, PURCHASE or PACK) and a positive factorToBase; precisionScale is optional.
+
+        Emits a CATALOG_PRODUCT_UOM_CREATE event and re-publishes the product fact with a bumped aggregate version so downstream replicas refresh.
+
+        Returns 404 when the product does not exist, 409 when the UoM code is already defined for the product, and 400 when factorToBase is not positive or a BASE entry''s factor is not 1.
+
+        '
       operationId: addProductUom
       parameters:
       - name: productId
@@ -1033,10 +1478,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: 'UoM entry to add: the code, its role for this product, and how many base units one such unit represents.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ProductUomCreateRequestDto'
+            examples:
+              Case of twelve:
+                description: Case of twelve
+                value:
+                  uomCode: CS12
+                  uomType: PACK
+                  factorToBase: 12
+                  precisionScale: 0
         required: true
       responses:
         '201':
@@ -1071,9 +1525,21 @@ paths:
     get:
       tags:
       - Products API
-      summary: List replacement products
-      description: Returns replacement options for a product.
-      operationId: getReplacements
+      summary: List Replacement Products
+      description: 'Returns the non-deleted replacement options recorded for a product, ordered by priority, each with its replacement product id, notes and effective instant.
+
+        Use this tool to see what supersedes a discontinued product; do not use addProductReplacement, which records a new option, and use getPartSubstitutes to resolve the full substitute product records instead of the option rows.
+
+        Preconditions: the product must exist; replacements are normally present only on DISCONTINUED products.
+
+        Required inputs: productId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no product exists for the supplied id, and 200 with an empty array when the product has no replacements.
+
+        '
+      operationId: listProductReplacements
       parameters:
       - name: productId
         in: path
@@ -1101,9 +1567,21 @@ paths:
     post:
       tags:
       - Products API
-      summary: Add replacement product
-      description: Adds a replacement suggestion to a discontinued product.
-      operationId: addReplacementProduct
+      summary: Add Replacement Product
+      description: 'Records a replacement suggestion on a discontinued product, pointing buyers at the product that supersedes it, ordered among other options by priorityOrder.
+
+        Use this tool after discontinuing a product via updateProductLifecycle; do not use listProductReplacements, which only reads the recorded options.
+
+        Preconditions: the original product must exist and be in lifecycle state DISCONTINUED, and the replacement product must itself exist and differ from the original.
+
+        Required inputs: productId (UUID) path parameter plus replacementProductId (UUID) and priorityOrder greater than zero; notes are optional and effectiveAt defaults to now when omitted.
+
+        Emits a CATALOG_PRODUCT_REPLACEMENT_ADD event and invalidates the product-detail cache for the original product.
+
+        Returns 404 when the original or replacement product does not exist, 409 when the original product is not DISCONTINUED, and 400 when the replacement equals the original or priorityOrder is not positive.
+
+        '
+      operationId: addProductReplacement
       parameters:
       - name: productId
         in: path
@@ -1113,10 +1591,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Replacement suggestion pointing at the superseding product, with its ranking among other options.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ProductReplacementRequest'
+            examples:
+              Primary replacement:
+                description: Primary replacement
+                value:
+                  replacementProductId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  priorityOrder: 1
+                  notes: Direct successor model
         required: true
       responses:
         '201':
@@ -1148,9 +1634,21 @@ paths:
     get:
       tags:
       - Product MSRP API
-      summary: List MSRP history
-      description: Returns all MSRP records for a product.
-      operationId: listMsrp
+      summary: List Product MSRP History
+      description: 'Returns every MSRP record for a product — past, current and scheduled — ordered by effective start date, newest first.
+
+        Use this tool to audit price history or find an msrpId to edit; use getActiveProductMsrp instead for just the record in force on a date.
+
+        Preconditions: the product must exist.
+
+        Required inputs: productId (UUID) as a path parameter; there is no filtering or paging.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the product does not exist, and 200 with an empty array when it has no MSRP records.
+
+        '
+      operationId: listProductMsrpHistory
       parameters:
       - name: productId
         in: path
@@ -1173,9 +1671,21 @@ paths:
     post:
       tags:
       - Product MSRP API
-      summary: Create MSRP
-      description: Creates a product MSRP record with effective date constraints.
-      operationId: createMsrp
+      summary: Create Product MSRP
+      description: 'Creates an MSRP record for a product with an effective date window; amounts are stored at four decimal places and the currency is normalised to upper case.
+
+        Use this tool to schedule a new list price period; do not use updateProductMsrp, which edits an existing record, and note that only one open-ended record (no effectiveEndDate) may exist per product.
+
+        Preconditions: the product must exist, the new window must not overlap any existing MSRP window, and no other open-ended record may exist when effectiveEndDate is omitted.
+
+        Required inputs: productId (UUID) path parameter plus a positive amount, a 3-letter ISO currency and effectiveStartDate; effectiveEndDate and createdByUserId are optional.
+
+        Emits a CATALOG_MSRP_CREATE event; the record participates in active-MSRP resolution and resolveProductPrice fallback from its start date.
+
+        Returns 404 when the product does not exist, 409 when the dates overlap an existing record, and 400 when the amount is not positive, the currency is not a 3-letter code, the window is inverted, or a second open-ended record is attempted.
+
+        '
+      operationId: createProductMsrp
       parameters:
       - name: productId
         in: path
@@ -1184,10 +1694,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: 'New MSRP window: amount, ISO currency and effective dates; omit effectiveEndDate for an open-ended price.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateMsrpRequestDto'
+            examples:
+              Open-ended MSRP:
+                description: Open-ended MSRP
+                value:
+                  amount: 149.99
+                  currency: USD
+                  effectiveStartDate: 2026-09-01
+                  createdByUserId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
         required: true
       responses:
         '201':
@@ -1223,8 +1742,20 @@ paths:
     get:
       tags:
       - UOM Conversion API
-      summary: List active conversions
-      description: Returns all active unit-of-measure conversion records.
+      summary: List Active UoM Conversions
+      description: 'Returns every active unit-of-measure conversion in the global table; deactivated conversions are excluded.
+
+        Use this tool to survey available conversions or find a conversion id; use getUomConversionById instead when the id is already known, and listProductUoms for a product''s own unit set.
+
+        Preconditions: none; the list is unfiltered and unpaged.
+
+        Required inputs: none, and there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty array when no active conversions exist, so an empty result is not an error condition.
+
+        '
       operationId: listUomConversions
       responses:
         '200':
@@ -1242,14 +1773,35 @@ paths:
     post:
       tags:
       - UOM Conversion API
-      summary: Create UOM conversion
-      description: Creates a new unit-of-measure conversion record.
+      summary: Create UoM Conversion
+      description: 'Creates a global, directional unit-of-measure conversion stating how many target units one source unit represents; codes are normalised to upper case and the factor stored at six decimal places.
+
+        Use this tool for conversions that apply across the whole catalog; do not use addProductUom, which defines a conversion for a single product''s own unit set.
+
+        Preconditions: no active conversion may already exist for the same from and to code pair; a self-conversion (same code both sides) must carry factor 1.
+
+        Required inputs: fromUomCode, toUomCode and a positive conversionFactor; createdBy is optional.
+
+        Emits a CATALOG_UOM_CONVERSION_CREATE event; the reverse direction is derived at read time, not stored.
+
+        Returns 409 when an active conversion already exists for the pair, and 400 when either code is blank, the factor is not positive, or a self-conversion factor is not 1.
+
+        '
       operationId: createUomConversion
       requestBody:
+        description: Directional conversion pair with the factor of target units per one source unit.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UomConversionCreateRequestDto'
+            examples:
+              Case to each:
+                description: Case to each
+                value:
+                  fromUomCode: CS
+                  toUomCode: EA
+                  conversionFactor: 12
+                  createdBy: catalog-admin
         required: true
       responses:
         '201':
@@ -1272,14 +1824,41 @@ paths:
     post:
       tags:
       - Supplier Item Cost API
-      summary: Create supplier cost structure
-      description: Creates a supplier-specific item cost structure with the submitted supplier, item, and tier details.
-      operationId: createCostStructure
+      summary: Create Supplier Cost Structure
+      description: 'Creates the cost structure one supplier charges for one item: a base cost plus optional volume tiers, unique per supplier and item pair.
+
+        Use this tool to record supplier purchasing costs; do not use updateStandardItemCost, which sets the item''s internal standard cost, and use updateSupplierItemCost to change a structure that already exists.
+
+        Preconditions: no cost structure may already exist for the supplier and item pair; tiers, when supplied, must start at minQuantity 1, be contiguous and non-overlapping, and only the final tier may leave maxQuantity null, which it must.
+
+        Required inputs: supplierId (UUID), itemId (UUID) and a 3-letter currencyCode; baseCost is optional but cannot be negative, and each tier needs minQuantity and a positive unitCost.
+
+        Emits a CATALOG_SUPPLIER_COST_CREATE event; no item or catalog pricing records are touched.
+
+        Returns 409 when a structure already exists for the supplier and item pair, and 400 when the currency code is invalid or the tier structure violates the contiguity rules.
+
+        '
+      operationId: createSupplierItemCost
       requestBody:
+        description: 'Cost structure for one supplier and item pair: base cost plus contiguous volume tiers whose final tier is open-ended.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SupplierItemCostCreateRequestDto'
+            examples:
+              Two-tier structure:
+                description: Two-tier structure
+                value:
+                  supplierId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  itemId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  currencyCode: USD
+                  baseCost: 10.5
+                  tiers:
+                  - minQuantity: 1
+                    maxQuantity: 49
+                    unitCost: 10.5
+                  - minQuantity: 50
+                    unitCost: 9.25
         required: true
       responses:
         '201':
@@ -1309,8 +1888,20 @@ paths:
     get:
       tags:
       - Substitution Group API
-      summary: List substitution groups
-      description: Returns all substitution groups with their member product ids.
+      summary: List Substitution Groups
+      description: 'Returns every substitution group with its name, notes and member product ids ordered by when each member joined.
+
+        Use this tool to discover a groupId or survey interchangeability sets; use getSubstitutionGroup instead when the id is already known.
+
+        Preconditions: none; the list is unfiltered and unpaged.
+
+        Required inputs: none, and there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty array when no groups exist, so an empty result is not an error condition.
+
+        '
       operationId: listSubstitutionGroups
       responses:
         '200':
@@ -1328,14 +1919,33 @@ paths:
     post:
       tags:
       - Substitution Group API
-      summary: Create substitution group
-      description: Creates an empty substitution group; add members afterwards.
+      summary: Create Substitution Group
+      description: 'Creates an empty, named substitution group — a set of mutually interchangeable products in which each product may belong to at most one group.
+
+        Use this tool to establish the group before populating it; do not use addSubstitutionGroupMember, which adds products to a group that already exists, and do not confuse groups with addProductReplacement, which records one-way successors for discontinued products.
+
+        Preconditions: none; group names are not checked for uniqueness.
+
+        Required inputs: name (non-blank, trimmed on save); notes are optional.
+
+        Emits a CATALOG_SUBSTITUTION_GROUP_CREATE event; no product facts are re-published until members are added.
+
+        Returns 201 with the group and an empty productIds list, and 400 when name is missing or blank.
+
+        '
       operationId: createSubstitutionGroup
       requestBody:
+        description: Name and optional notes for the new interchangeability group.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SubstitutionGroupCreateRequestDto'
+            examples:
+              Oil filter group:
+                description: Oil filter group
+                value:
+                  name: Oil Filters PH3593A-Compatible
+                  notes: Cross-brand equivalents for PH3593A fitment
         required: true
       responses:
         '201':
@@ -1358,8 +1968,20 @@ paths:
     post:
       tags:
       - Substitution Group API
-      summary: Add product to substitution group
-      description: Adds a product to the group (a product belongs to at most one group) and re-emits the product contract event for every member.
+      summary: Add Substitution Group Member
+      description: 'Adds a product to a substitution group, making it mutually interchangeable with every other member; membership is exclusive, a product can belong to only one group at a time.
+
+        Use this tool to grow an interchangeability set; do not use addProductReplacement, which records a one-way successor for a discontinued product rather than a symmetric substitute.
+
+        Preconditions: the group and the product must both exist, and the product must not already belong to any substitution group, including this one.
+
+        Required inputs: groupId (UUID) path parameter and productId (UUID) in the body.
+
+        Emits a CATALOG_SUBSTITUTION_GROUP_MEMBER_ADD event and re-publishes the product fact for every member of the group so downstream replicas learn the new association.
+
+        Returns 404 when the group or the product does not exist, and 409 when the product already belongs to a substitution group.
+
+        '
       operationId: addSubstitutionGroupMember
       parameters:
       - name: groupId
@@ -1370,10 +1992,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The product to add as an interchangeable member of the group.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SubstitutionGroupMemberRequestDto'
+            examples:
+              Add product:
+                description: Add product
+                value:
+                  productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
         required: true
       responses:
         '200':
@@ -1408,14 +2036,37 @@ paths:
     post:
       tags:
       - Products API
-      summary: Create location price override
-      description: Creates a location-specific price override and enforces guardrails for margin and discount limits.
+      summary: Create Location Price Override
+      description: 'Creates a location-specific price override for one product, enforcing the location''s guardrail policy; discounts at or below the auto-approval threshold activate immediately, larger discounts are stored as PENDING_APPROVAL with an approval request assigned to a deterministic approver.
+
+        Use this tool to discount a product at one location; do not use upsertLocationGuardrailPolicy, which sets the limits themselves, and use approveLocationPriceOverride to activate a pending one.
+
+        Preconditions: the product must exist and a LOCATION guardrail policy must already exist for the locationId; any currently ACTIVE override for the same location and product is set INACTIVE.
+
+        Required inputs: locationId, productId, createdByUserId (UUIDs), positive basePrice and overridePrice with overridePrice not exceeding basePrice; cost is optional and enables the margin check when present.
+
+        Emits a CATALOG_LOCATION_OVERRIDE_CREATE event and invalidates the product-detail cache for that location.
+
+        Returns 404 when the product does not exist, and 400 when no guardrail policy exists for the location, the discount exceeds maxDiscountPercent, or the margin falls below minMarginPercent; callers must read the returned status to learn whether the override is ACTIVE or PENDING_APPROVAL.
+
+        '
       operationId: createLocationPriceOverride
       requestBody:
+        description: Override pricing for one product at one location; cost is optional and enables the minimum-margin guardrail check.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LocationPriceOverrideCreateRequestDto'
+            examples:
+              Discounted price:
+                description: Discounted price
+                value:
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  createdByUserId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d
+                  basePrice: 100.0
+                  cost: 60.0
+                  overridePrice: 92.5
         required: true
       responses:
         '201':
@@ -1444,8 +2095,20 @@ paths:
     post:
       tags:
       - Products API
-      summary: Reject pending location price override
-      description: Rejects a pending override, persists rejection metadata, and marks the request as terminal.
+      summary: Reject Pending Price Override
+      description: 'Rejects a PENDING_APPROVAL location price override, recording who rejected it and why, and closing its approval request as REJECTED; the decision is terminal, a rejected override cannot be revived.
+
+        Use this tool to decline a pending override; do not use approveLocationPriceOverride, which activates it instead.
+
+        Preconditions: the override must exist, be in PENDING_APPROVAL status, have an open approval request, and the supplied version must match the override''s current version.
+
+        Required inputs: overrideId (UUID) path parameter plus version (long), actorUserId (UUID), and non-blank rejectionReasonCode and rejectionNotes in the body.
+
+        Emits a CATALOG_LOCATION_OVERRIDE_REJECT event and invalidates the product-detail cache for the override''s location.
+
+        Returns 404 when the override or its approval request cannot be found, 400 when the override is not in PENDING_APPROVAL status or the rejection reason or notes are blank, and 409 when the supplied version does not match the current one.
+
+        '
       operationId: rejectLocationPriceOverride
       parameters:
       - name: overrideId
@@ -1456,10 +2119,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Rejection decision carrying the acting user, the override's current version, and a mandatory reason code with notes.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LocationPriceOverrideDecisionRequestDto'
+            examples:
+              Reject below margin:
+                description: Reject below margin
+                value:
+                  version: 0
+                  actorUserId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  rejectionReasonCode: MARGIN_TOO_LOW
+                  rejectionNotes: Margin would fall below store target
         required: true
       responses:
         '200':
@@ -1496,8 +2168,20 @@ paths:
     post:
       tags:
       - Products API
-      summary: Approve pending location price override
-      description: Approves a pending override and activates it as the effective location price.
+      summary: Approve Pending Price Override
+      description: 'Approves a PENDING_APPROVAL location price override, setting it ACTIVE and closing its approval request as APPROVED.
+
+        Use this tool to grant a pending override; do not use rejectLocationPriceOverride, which terminally declines it instead.
+
+        Preconditions: the override must exist, be in PENDING_APPROVAL status, have an open approval request, and the supplied version must match the override''s current version.
+
+        Required inputs: overrideId (UUID) path parameter plus version (long) and actorUserId (UUID) in the body; rejection fields are ignored on approval.
+
+        Emits a CATALOG_LOCATION_OVERRIDE_APPROVE event and invalidates the product-detail cache for the override''s location.
+
+        Returns 404 when the override or its approval request cannot be found, 400 when the override is not in PENDING_APPROVAL status, and 409 when the supplied version does not match the current one.
+
+        '
       operationId: approveLocationPriceOverride
       parameters:
       - name: overrideId
@@ -1508,10 +2192,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Approval decision carrying the acting user and the override's current version for optimistic-lock verification.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LocationPriceOverrideDecisionRequestDto'
+            examples:
+              Approve:
+                description: Approve
+                value:
+                  version: 0
+                  actorUserId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
         required: true
       responses:
         '200':
@@ -1548,14 +2239,35 @@ paths:
     post:
       tags:
       - Products API
-      summary: Upsert location guardrail policy
-      description: Creates or updates the active LOCATION guardrail policy used by price overrides.
+      summary: Upsert Location Guardrail Policy
+      description: 'Creates or updates the LOCATION-scoped guardrail policy that createLocationPriceOverride enforces for discount, margin and auto-approval limits.
+
+        Use this tool to set pricing guardrails for a location before overrides are created there; do not use createLocationPriceOverride, which applies a price and is rejected until a policy exists.
+
+        Preconditions: none; when a policy already exists for the scopeId its limits are overwritten, otherwise a new policy row is created.
+
+        Required inputs: scopeId (the location UUID), minMarginPercent, maxDiscountPercent and autoApprovalThresholdPercent, all mandatory.
+
+        Emits a CATALOG_GUARDRAIL_POLICY_UPSERT event; existing overrides are not re-evaluated, the new limits apply only to overrides created afterwards.
+
+        Returns 400 when any of the four fields is missing; the 200 response body carries only the locationId, not the stored limits.
+
+        '
       operationId: upsertLocationGuardrailPolicy
       requestBody:
+        description: 'Guardrail limits for one location: minimum margin, maximum discount and the discount threshold under which overrides auto-approve.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GuardrailPolicyUpsertRequestDto'
+            examples:
+              Location policy:
+                description: Location policy
+                value:
+                  scopeId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  minMarginPercent: 15.0
+                  maxDiscountPercent: 25.0
+                  autoApprovalThresholdPercent: 10.0
         required: true
       responses:
         '200':
@@ -1578,14 +2290,36 @@ paths:
     post:
       tags:
       - Price Book API
-      summary: Create price book
-      description: Creates a new price book used to group and apply pricing rules.
+      summary: Create Price Book
+      description: 'Creates a price book — a scoped container of pricing rules — with scope COMPANY_DEFAULT, LOCATION or CUSTOMER_TIER and an initial status defaulting to ACTIVE.
+
+        Use this tool to establish a rule container before adding rules; do not use createPriceBookRule, which adds rules to a book that already exists.
+
+        Preconditions: none; no uniqueness is enforced, so creating a second default book for the same scope is possible and should be avoided by the caller.
+
+        Required inputs: name and scope; scopeId is mandatory for LOCATION and CUSTOMER_TIER scopes, while isDefault defaults to false and status defaults to ACTIVE.
+
+        Emits a CATALOG_PRICE_BOOK_CREATE event; no rules exist until they are added.
+
+        Returns 400 when name is blank, scope is missing, or scopeId is absent for a LOCATION or CUSTOMER_TIER scope.
+
+        '
       operationId: createPriceBook
       requestBody:
+        description: 'Price book definition: a name, its scope, and for LOCATION or CUSTOMER_TIER scopes the id of the location or tier it prices.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PriceBookCreateRequestDto'
+            examples:
+              Location price book:
+                description: Location price book
+                value:
+                  name: Downtown Store Pricing
+                  scope: LOCATION
+                  scopeId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  isDefault: false
+                  status: ACTIVE
         required: true
       responses:
         '201':
@@ -1609,9 +2343,21 @@ paths:
     get:
       tags:
       - Price Book API
-      summary: List price book rules
-      description: Returns all rules associated with a price book.
-      operationId: listRules
+      summary: List Price Book Rules
+      description: 'Returns every rule in a price book — ACTIVE and INACTIVE alike — with target, pricing logic, condition, priority, effective window, status and version.
+
+        Use this tool to inspect a book''s rule set; use resolveProductPrice instead to evaluate which rule wins for a concrete product and context.
+
+        Preconditions: the price book must exist.
+
+        Required inputs: priceBookId (UUID) as a path parameter; there is no filtering or paging.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no price book exists for the supplied id, and 200 with an empty array when the book has no rules.
+
+        '
+      operationId: listPriceBookRules
       parameters:
       - name: priceBookId
         in: path
@@ -1634,9 +2380,21 @@ paths:
     post:
       tags:
       - Price Book API
-      summary: Create price book rule
-      description: Adds a new pricing rule to a specific price book.
-      operationId: createRule
+      summary: Create Price Book Rule
+      description: 'Adds an ACTIVE pricing rule to a price book, targeting a single SKU, a CATEGORY taxonomy node or GLOBAL, with an effective window and an optional LOCATION or CUSTOMER_TIER condition.
+
+        Use this tool to define a reference price; do not use resolveProductPrice, which evaluates rules, and do not use updatePriceBookRule, which edits a rule that already exists.
+
+        Preconditions: the price book must exist, and no ACTIVE rule with the same target, condition and an overlapping effective window may already exist in the book.
+
+        Required inputs: targetType (SKU, CATEGORY or GLOBAL), targetId for non-GLOBAL targets, pricingLogic as JSON of the form {"amounts":{"USD":"10.00"},"defaultCurrency":"USD"}, effectiveStartAt and createdByUserId; priority defaults to 0, conditionType defaults to NONE, and a LOCATION conditionValue must be a UUID string.
+
+        Emits a CATALOG_PRICE_BOOK_RULE_CREATE event; the rule participates in resolution immediately once its window opens.
+
+        Returns 404 when the price book does not exist, 409 when the rule conflicts with an existing rule in overlapping dates, and 400 when required fields are missing or the effective window is inverted.
+
+        '
+      operationId: createPriceBookRule
       parameters:
       - name: priceBookId
         in: path
@@ -1645,10 +2403,22 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: 'Rule definition: target, JSON pricingLogic with per-currency amounts, optional condition, priority and effective window.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PriceBookRuleCreateRequestDto'
+            examples:
+              SKU rule in USD:
+                description: SKU rule in USD
+                value:
+                  targetType: SKU
+                  targetId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  pricingLogic: '{"amounts":{"USD":"129.99"},"defaultCurrency":"USD"}'
+                  conditionType: NONE
+                  priority: 10
+                  effectiveStartAt: 2026-09-01 00:00:00+00:00
+                  createdByUserId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '201':
@@ -1672,14 +2442,35 @@ paths:
     post:
       tags:
       - Price Book API
-      summary: Resolve reference/list product price
-      description: 'Resolves the reference/list price for a product using applicable price books and rules. Candidate book precedence: explicit priceBookId, then active LOCATION book, then active CUSTOMER_TIER book (customerTierId), then COMPANY_DEFAULT. The result is catalog reference data (ADR-0054) — transactional sell prices are resolved by pos-price, never by this endpoint.'
-      operationId: resolvePrice
+      summary: Resolve Reference Product Price
+      description: 'Resolves a product''s catalog reference or list price by picking one candidate price book — the explicit priceBookId first, otherwise the active LOCATION book, then the active CUSTOMER_TIER book, then the COMPANY_DEFAULT book — and selecting the winning ACTIVE rule by SKU over CATEGORY over GLOBAL specificity, then priority; when no rule matches, the active MSRP is returned with fallbackReason MSRP_FALLBACK.
+
+        Use this tool for catalog reference pricing per ADR-0054; do not use it for transactional sell prices, which pos-price owns, and do not use getEffectiveLocationPrice, which reads location override records instead of price book rules.
+
+        Preconditions: the product must exist; price books and rules are optional, since MSRP fallback covers their absence.
+
+        Required inputs: productId (UUID); priceBookId, locationId, customerTierId, customerTier, currency and asOf are optional, with asOf defaulting to today and currency required only when a winning rule configures multiple currencies without a defaultCurrency.
+
+        Emits a CATALOG_PRICE_BOOK_RESOLVE_PRICE audit event; no pricing data changes.
+
+        Returns 404 when the product or an explicitly supplied priceBookId does not exist, 400 when the requested currency is not configured in the winning rule''s pricingLogic, and 200 with source UNAVAILABLE and fallbackReason PRICE_BASE_DATA_MISSING when neither a rule nor an MSRP applies.
+
+        '
+      operationId: resolveProductPrice
       requestBody:
+        description: 'Resolution context: the product plus optional book, location, customer tier, currency and as-of date that steer candidate book selection.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ResolvePriceRequestDto'
+            examples:
+              Location-context resolution:
+                description: Location-context resolution
+                value:
+                  productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  currency: USD
+                  asOf: 2026-09-15
         required: true
       responses:
         '200':
@@ -1697,15 +2488,38 @@ paths:
     post:
       tags:
       - Catalog API
-      summary: Add a new catalog
-      description: Adds a new catalog.
-      operationId: addCatalog
+      summary: Create a New Catalog
+      description: 'Creates a named catalog that groups existing products, services and non-inventory products for presentation; the catalog does not own the items, it only references them.
+
+        Use this tool to define a new grouping; do not use updateCatalog, which replaces a catalog that already exists, and do not use createCatalogItem, which creates the underlying items themselves.
+
+        Preconditions: any ids listed in productIds, serviceIds or nonInventoryProductIds should already exist; ids that do not resolve are silently dropped from the stored catalog rather than rejected.
+
+        Required inputs: name; description and the three id lists are optional and default to empty.
+
+        Emits a CATALOG_CATALOG_CREATE event; no product, service or non-inventory records are modified.
+
+        Returns 201 with the stored catalog, whose id lists reflect only the references that resolved, so callers should compare them against what was sent.
+
+        '
+      operationId: createCatalog
       requestBody:
-        description: Catalog object to be added
+        description: 'Catalog to create: a name plus optional lists of existing product, service and non-inventory product ids to group.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CatalogDto'
+            examples:
+              Catalog with two products:
+                description: Catalog with two products
+                value:
+                  name: Winter Tires
+                  description: Seasonal winter tire lineup
+                  productIds:
+                  - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  serviceIds: []
+                  nonInventoryProductIds: []
         required: true
       responses:
         '201':
@@ -1728,14 +2542,41 @@ paths:
     post:
       tags:
       - Catalog Bulk Ingest API
-      summary: Bulk ingest records
-      description: Accepts a batch of domain records for bulk import. Returns per-record results.
-      operationId: bulkIngest
+      summary: Bulk Import Catalog Products
+      description: 'Imports a batch of catalog products in one call, creating each record through the same governed path as createProduct and reporting a per-row success or failure verdict.
+
+        Use this tool to load many products at once; do not use createProduct, which registers a single product and surfaces its errors as HTTP statuses rather than row results.
+
+        Preconditions: each row''s SKU must not already exist (case-insensitive), or that row fails with CATALOG_INGEST_FAILED while the rest of the batch proceeds.
+
+        Required inputs: jobId (UUID), locationId (UUID) and a non-empty records array; per record, unitOfMeasure defaults to EA, description defaults to the name, and mpn falls back to the sku then the name, while price, categoryName and subcategoryName are accepted but ignored in this wave.
+
+        Emits a CATALOG_BULK_INGEST event; each successful row also publishes a product fact and invalidates the product-detail cache.
+
+        Returns 200 even when rows fail, so callers must inspect successCount, failureCount and the per-row results rather than the HTTP status.
+
+        '
+      operationId: bulkIngestCatalogProducts
       requestBody:
+        description: Batch of product records to create for one ingest job scoped to a location.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BulkIngestRequestCatalogBulkIngestRecord'
+            examples:
+              Two-product batch:
+                description: Two-product batch
+                value:
+                  jobId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  records:
+                  - sku: TIRE-AT-2657017
+                    name: All-Terrain Tire 265/70R17
+                    upc: 036121960222
+                    mpn: AT3-26570R17
+                    unitOfMeasure: EA
+                  - sku: WIP-22-PREM
+                    name: Premium Wiper Blade 22in
         required: true
       responses:
         '200':
@@ -1759,9 +2600,21 @@ paths:
     post:
       tags:
       - Catalog Items API
-      summary: Add a new catalog item
-      description: Adds a new product, service, or non-inventory product to the catalog.
-      operationId: addCatalogItem
+      summary: Add a New Catalog Item
+      description: 'Creates a catalog item of the given type: a product, a service, or a non-inventory product.
+
+        Use this tool for quick item entry across the three item types; do not use createProduct, which is the richer product-master path that enforces SKU and manufacturer-part uniqueness — this endpoint performs no duplicate checks.
+
+        Preconditions: none; for type service and noninventory only name, shortDescription and longDescription are persisted, while type product also stores manufacturer, SKU, productCode, material, color, warranty and specifications fields.
+
+        Required inputs: type path parameter, one of product, service or noninventory (case-insensitive), plus a body with at least name.
+
+        Emits a CATALOG_ITEM_CREATE event; no catalog groupings are touched.
+
+        Returns 400 when the type path parameter is not one of the three supported values.
+
+        '
+      operationId: createCatalogItem
       parameters:
       - name: type
         in: path
@@ -1770,10 +2623,24 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Item to create; only name, shortDescription and longDescription are stored for services and non-inventory products, products store the full field set.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CatalogItemRequestDto'
+            examples:
+              New product item:
+                description: New product item
+                value:
+                  name: Premium Wiper Blade 22in
+                  shortDescription: 22-inch beam wiper blade
+                  longDescription: All-weather beam wiper blade, 22 inch
+                  sku: WIP-22-PREM
+                  productCode: 036121960221
+                  manufacturerPartNumber: PWB-22
+                  manufacturerName: ClearView
+                  material: Rubber
+                  color: Black
         required: true
       responses:
         '201':
@@ -1796,8 +2663,20 @@ paths:
     get:
       tags:
       - Products API
-      summary: Get substitute parts
-      description: Returns list of substitute parts for a given productId.
+      summary: Get Substitute Parts
+      description: 'Returns the full product records of a product''s recorded replacements, resolved from its replacement options in priority order with duplicates and dangling references dropped.
+
+        Use this tool when selling and a substitute product''s details are needed directly; use listProductReplacements instead for the raw option rows with priority and notes.
+
+        Preconditions: the product must exist; substitutes appear only after replacements were recorded via addProductReplacement.
+
+        Required inputs: productId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no product exists for the supplied id, and 200 with an empty array when no replacement products resolve.
+
+        '
       operationId: getPartSubstitutes
       parameters:
       - name: productId
@@ -1830,9 +2709,21 @@ paths:
     get:
       tags:
       - Product MSRP API
-      summary: Get active MSRP
-      description: Returns MSRP active for the provided asOf date (or today).
-      operationId: getActiveMsrp
+      summary: Get Active Product MSRP
+      description: 'Returns the single MSRP record whose effective window covers the requested date.
+
+        Use this tool to read the list price in force on a date; use listProductMsrpHistory instead to see every past and scheduled record.
+
+        Preconditions: the product must exist and an MSRP window must cover the date.
+
+        Required inputs: productId (UUID) path parameter; asOf is an optional ISO date defaulting to today.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the product does not exist or no MSRP window covers the requested date.
+
+        '
+      operationId: getActiveProductMsrp
       parameters:
       - name: productId
         in: path
@@ -1868,8 +2759,20 @@ paths:
     get:
       tags:
       - Products API
-      summary: Get product details with pricing and availability
-      description: Retrieves a consolidated view of product information including catalog data, location-specific pricing, and availability. Implements graceful degradation and returns partial data when non-critical services are unavailable.
+      summary: Get Product Detail With Pricing
+      description: 'Returns a consolidated product view for one location: catalog data, location-specific pricing, availability and lead time, with a confidence indicator describing how complete the data is.
+
+        Use this tool for a sales-facing view of one product at one store; use getProductById instead for raw master data, and getEffectiveLocationPrice for the override-derived price alone.
+
+        Preconditions: the product must exist; pricing and availability sources may be degraded, in which case partial data is returned rather than an error.
+
+        Required inputs: productId (UUID) path parameter and location_id (UUID) query parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the product does not exist, and 400 when location_id is missing or malformed; a 200 may still carry partial data, so callers should inspect the confidence field.
+
+        '
       operationId: getProductDetailView
       parameters:
       - name: productId
@@ -1919,8 +2822,20 @@ paths:
     get:
       tags:
       - Substitution Group API
-      summary: Get substitution group
-      description: Retrieves a substitution group with its member product ids.
+      summary: Get Substitution Group
+      description: 'Returns one substitution group with its name, notes and member product ids ordered by when each member joined.
+
+        Use this tool when the groupId is already known; use listSubstitutionGroups instead to discover groups.
+
+        Preconditions: the group must exist.
+
+        Required inputs: groupId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no substitution group exists for the supplied id.
+
+        '
       operationId: getSubstitutionGroup
       parameters:
       - name: groupId
@@ -1950,8 +2865,20 @@ paths:
     delete:
       tags:
       - Substitution Group API
-      summary: Delete substitution group
-      description: Deletes a group and its memberships, re-emitting the product contract event for every former member.
+      summary: Delete Substitution Group
+      description: 'Deletes a substitution group and all of its memberships permanently, freeing every former member to join another group; the products themselves are untouched.
+
+        Use this tool to dissolve a whole group; use removeSubstitutionGroupMember instead to take a single product out while keeping the group.
+
+        Preconditions: the group must exist; there is no soft delete or archive.
+
+        Required inputs: groupId (UUID) as a path parameter; there is no request body.
+
+        Emits a CATALOG_SUBSTITUTION_GROUP_DELETE event and re-publishes the product fact for every former member so downstream replicas drop the association.
+
+        Returns 204 on success, and 404 when no substitution group exists for the supplied id.
+
+        '
       operationId: deleteSubstitutionGroup
       parameters:
       - name: groupId
@@ -1974,8 +2901,20 @@ paths:
     get:
       tags:
       - Products API
-      summary: Get a service by ID
-      description: Retrieves a specific service by its unique ID.
+      summary: Get a Service by ID
+      description: 'Returns one catalog service record with its name, short description and long description.
+
+        Use this tool when the serviceId is already known; use searchCatalogServices instead to find services by partial name.
+
+        Preconditions: the service must exist.
+
+        Required inputs: serviceId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no service exists for the supplied id.
+
+        '
       operationId: getServiceById
       parameters:
       - name: serviceId
@@ -2006,9 +2945,21 @@ paths:
     get:
       tags:
       - Products API
-      summary: Search catalog services
-      description: Free-text substring search over service names for typeahead selection.
-      operationId: searchServices
+      summary: Search Catalog Services
+      description: 'Searches services by a case-insensitive substring of the service name, ordered by name, sized for typeahead selection.
+
+        Use this tool to find a serviceId by partial name; use getServiceById instead when the id is known, and listServicesByName for exact whole-name matches.
+
+        Preconditions: none; a blank or missing q returns an empty list rather than all services.
+
+        Required inputs: q as the substring to match; limit is optional, defaults to 20 and is clamped to 1-100.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty array when q is blank or nothing matches, so an empty result is not an error condition.
+
+        '
+      operationId: searchCatalogServices
       parameters:
       - name: q
         in: query
@@ -2041,9 +2992,21 @@ paths:
     get:
       tags:
       - Products API
-      summary: Get services by name
-      description: Retrieves a list of services matching the given name.
-      operationId: getServiceByName
+      summary: List Services by Exact Name
+      description: 'Returns every catalog service whose name equals the supplied value exactly; this is a whole-name match, not a substring search.
+
+        Use this tool only when the exact service name is known; use searchCatalogServices instead for partial, typeahead-style matching.
+
+        Preconditions: none; an empty result simply means no service carries that exact name.
+
+        Required inputs: name as a path parameter; there is no paging and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty array when nothing matches, so an empty result is not an error condition.
+
+        '
+      operationId: listServicesByName
       parameters:
       - name: name
         in: path
@@ -2066,9 +3029,21 @@ paths:
     get:
       tags:
       - Products API
-      summary: Search catalog products
-      description: Cursor-based product search with optional free-text query and exact filters for brand, category, and SKU. Pass detailed=true to enrich each row inline with lifecycle state + effective instant and the product's active MSRP (amount, currency, effective window), resolved server-side in a single request. Products without an active MSRP return null price fields.
-      operationId: searchProducts
+      summary: Search Catalog Products
+      description: 'Searches products with an optional free-text query over name and description plus exact case-insensitive filters for brand, category and SKU, paged by an opaque cursor.
+
+        Use this tool to find products by partial text or filters; use getProductById instead when the id is known, and listProductsByName only for exact whole-name matches.
+
+        Preconditions: none; a malformed or missing cursor silently restarts at the first page rather than failing.
+
+        Required inputs: all parameters are optional; limit defaults to 20 and is clamped to 1-100, and detailed defaults to false — pass detailed=true to enrich each row with lifecycle state, its effective instant and the active MSRP, with null price fields for products lacking an active MSRP.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty items array when nothing matches, so an empty result is not an error condition.
+
+        '
+      operationId: searchCatalogProducts
       parameters:
       - name: q
         in: query
@@ -2136,8 +3111,20 @@ paths:
     get:
       tags:
       - Products API
-      summary: Get effective location price
-      description: 'Resolves effective price using precedence: ACTIVE override first, otherwise base price.'
+      summary: Get Effective Location Price
+      description: 'Resolves the price a location currently charges for a product from its override records: the newest ACTIVE override wins, otherwise a PENDING_APPROVAL override reports its basePrice as the effective price with status PENDING_APPROVAL.
+
+        Use this tool to check what an override has done to a product''s price at one location; do not use getProductDetailView, which returns the full consolidated pricing and availability view.
+
+        Preconditions: at least one ACTIVE or PENDING_APPROVAL override must exist for the pair; a product with no override history at the location has no answer here.
+
+        Required inputs: locationId and productId (UUIDs) as path parameters; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no ACTIVE or PENDING_APPROVAL override exists for the location and product pair, even if the product itself exists.
+
+        '
       operationId: getEffectiveLocationPrice
       parameters:
       - name: locationId
@@ -2175,8 +3162,20 @@ paths:
     get:
       tags:
       - Products API
-      summary: Get a non-inventory product by ID
-      description: Retrieves a specific non-inventory product by its unique ID.
+      summary: Get Non-Inventory Product by ID
+      description: 'Returns one non-inventory product — an item sold without stock tracking, such as a fee or shop supply — with its name and descriptions.
+
+        Use this tool when the id is already known; use listNonInventoryProductsByName instead to find non-inventory products by exact name.
+
+        Preconditions: the non-inventory product must exist.
+
+        Required inputs: productId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no non-inventory product exists for the supplied id.
+
+        '
       operationId: getNonInventoryProductById
       parameters:
       - name: productId
@@ -2207,9 +3206,21 @@ paths:
     get:
       tags:
       - Products API
-      summary: Get non-inventory products by name
-      description: Retrieves a list of non-inventory products matching the given name.
-      operationId: getNonInventoryProductByName
+      summary: List Non-Inventory Products by Name
+      description: 'Returns every non-inventory product whose name equals the supplied value exactly; this is a whole-name match, not a substring search.
+
+        Use this tool only when the exact name is known; use getNonInventoryProductById instead when the id is available, since there is no substring search for non-inventory products.
+
+        Preconditions: none; an empty result simply means no non-inventory product carries that exact name.
+
+        Required inputs: name as a path parameter; there is no paging and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty array when nothing matches, so an empty result is not an error condition.
+
+        '
+      operationId: listNonInventoryProductsByName
       parameters:
       - name: name
         in: path
@@ -2232,9 +3243,21 @@ paths:
     get:
       tags:
       - Products API
-      summary: Get products by name
-      description: Retrieves a list of products matching the given name.
-      operationId: getProductByName
+      summary: List Products by Exact Name
+      description: 'Returns every product whose name equals the supplied value exactly; this is a whole-name match, not a substring search.
+
+        Use this tool only when the exact product name is known; use searchCatalogProducts instead for partial text, brand, category or SKU matching.
+
+        Preconditions: none; an empty result simply means no product carries that exact name.
+
+        Required inputs: name as a path parameter; there is no paging and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty array when nothing matches, so an empty result is not an error condition.
+
+        '
+      operationId: listProductsByName
       parameters:
       - name: name
         in: path
@@ -2257,8 +3280,20 @@ paths:
     get:
       tags:
       - Item Cost API
-      summary: Get current item costs
-      description: Returns the current standard, average, and last known cost values for the specified item.
+      summary: Get Current Item Costs
+      description: 'Returns the item''s current standard, average and last known costs in one record.
+
+        Use this tool to read cost values; do not use updateStandardItemCost, which changes the standard cost, and use getItemCostAuditHistory for who changed what and when.
+
+        Preconditions: none; an item with no cost record yet returns the itemId with all three cost fields null rather than an error.
+
+        Required inputs: itemId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 in all cases, so callers must treat null cost fields as absence of cost data rather than relying on a 404.
+
+        '
       operationId: getItemCosts
       parameters:
       - name: itemId
@@ -2283,9 +3318,21 @@ paths:
     get:
       tags:
       - Item Cost API
-      summary: Get item cost audit history
-      description: Returns the recorded audit history entries for item cost changes on the specified item.
-      operationId: getAuditHistory
+      summary: Get Item Cost Audit History
+      description: 'Returns every recorded cost change for an item, newest first, each entry naming the cost type changed, old and new value, the actor, the change source and any reason code.
+
+        Use this tool to trace how a cost reached its current value; use getItemCosts instead for just the current numbers.
+
+        Preconditions: none; entries exist only after manual standard-cost updates or purchase-order receipt events have touched the item.
+
+        Required inputs: itemId (UUID) as a path parameter; there is no request body and no paging.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty array when the item has no cost history, so an empty result is not an error condition.
+
+        '
+      operationId: getItemCostAuditHistory
       parameters:
       - name: itemId
         in: path
@@ -2309,9 +3356,21 @@ paths:
     get:
       tags:
       - Catalog API
-      summary: Get catalogs by name
-      description: Retrieves a list of catalogs matching the given name.
-      operationId: getCatalogByName
+      summary: List Catalogs by Name
+      description: 'Returns every catalog whose name contains the supplied fragment, matched case-insensitively.
+
+        Use this tool to discover a catalogId by name; use getCatalogById instead when the id is already known.
+
+        Preconditions: none; an empty result simply means no catalog name contains the fragment.
+
+        Required inputs: name (path parameter) as a case-insensitive substring; there is no paging and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty array when nothing matches, so an empty result is not an error condition.
+
+        '
+      operationId: listCatalogsByName
       parameters:
       - name: name
         in: path
@@ -2334,9 +3393,21 @@ paths:
     get:
       tags:
       - Supplier Item Cost List API
-      summary: List supplier cost structures
-      description: Returns a paginated list of supplier cost structures. At least one of itemId or supplierId must be provided.
-      operationId: listCostStructures
+      summary: List Supplier Cost Structures
+      description: 'Returns a page of supplier item cost structures filtered by item, by supplier, or by both combined with AND semantics.
+
+        Use this tool to find which suppliers price an item or which items a supplier prices; use getSupplierItemCost instead when the structure id is already known.
+
+        Preconditions: at least one of itemId or supplierId must be supplied; an unfiltered listing is deliberately not offered.
+
+        Required inputs: itemId or supplierId (UUIDs) as query parameters, plus standard Spring page, size and sort parameters.
+
+        Emits a CATALOG_SUPPLIER_COST_LIST audit event; no cost data changes.
+
+        Returns 400 when neither itemId nor supplierId is provided, and 200 with an empty page when the filters match nothing.
+
+        '
+      operationId: listSupplierItemCosts
       parameters:
       - name: itemId
         in: query
@@ -2397,8 +3468,20 @@ paths:
     delete:
       tags:
       - Substitution Group API
-      summary: Remove product from substitution group
-      description: Removes a product from the group and re-emits the product contract event for the removed product and every remaining member.
+      summary: Remove Substitution Group Member
+      description: 'Removes a product from a substitution group, ending its interchangeability with the remaining members and freeing it to join another group.
+
+        Use this tool to take one product out; use deleteSubstitutionGroup instead to dissolve the entire group at once.
+
+        Preconditions: the group must exist and the product must currently be a member of that specific group.
+
+        Required inputs: groupId and productId (UUIDs) as path parameters; there is no request body.
+
+        Emits a CATALOG_SUBSTITUTION_GROUP_MEMBER_REMOVE event and re-publishes the product fact for the removed product and every remaining member.
+
+        Returns 200 with the group''s remaining membership, and 404 when the group does not exist or the product is not a member of it.
+
+        '
       operationId: removeSubstitutionGroupMember
       parameters:
       - name: groupId
@@ -4780,14 +5863,14 @@ components:
         offset:
           type: integer
           format: int64
-        paged:
-          type: boolean
         pageNumber:
           type: integer
           format: int32
         pageSize:
           type: integer
           format: int32
+        paged:
+          type: boolean
         sort:
           $ref: '#/components/schemas/SortObject'
         unpaged:

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/CatalogBulkIngestController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/CatalogBulkIngestController.java
@@ -8,6 +8,9 @@ import com.positivity.catalog.internal.dto.CatalogBulkIngestRecord;
 import com.positivity.catalog.internal.dto.ProductCreateRequestDto;
 import com.positivity.catalog.service.ProductMasterDataService;
 import com.positivity.events.EmitEvent;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
@@ -39,9 +42,43 @@ public class CatalogBulkIngestController extends AbstractBulkIngestController<Ca
     @Override
     @PostMapping("/bulk-ingest")
     @PreAuthorize("hasAuthority('catalog:product:create')")
+    @Operation(operationId = "bulkIngestCatalogProducts", summary = "Bulk Import Catalog Products", description = """
+            Imports a batch of catalog products in one call, creating each record through the same governed \
+            path as createProduct and reporting a per-row success or failure verdict.
+            Use this tool to load many products at once; do not use createProduct, which registers a single \
+            product and surfaces its errors as HTTP statuses rather than row results.
+            Preconditions: each row's SKU must not already exist (case-insensitive), or that row fails with \
+            CATALOG_INGEST_FAILED while the rest of the batch proceeds.
+            Required inputs: jobId (UUID), locationId (UUID) and a non-empty records array; per record, \
+            unitOfMeasure defaults to EA, description defaults to the name, and mpn falls back to the sku \
+            then the name, while price, categoryName and subcategoryName are accepted but ignored in this \
+            wave.
+            Emits a CATALOG_BULK_INGEST event; each successful row also publishes a product fact and \
+            invalidates the product-detail cache.
+            Returns 200 even when rows fail, so callers must inspect successCount, failureCount and the \
+            per-row results rather than the HTTP status.
+            """)
     @EmitEvent(id = "CATALOG_BULK_INGEST", apiVersion = "1")
     public ResponseEntity<BulkIngestResponse> bulkIngest(
-            @Valid @RequestBody @NonNull BulkIngestRequest<CatalogBulkIngestRecord> request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Batch of product records to create for one ingest job scoped to a" + " location.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Two-product batch", value = """
+                                                                    {"jobId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "records":[
+                                                                       {"sku":"TIRE-AT-2657017","name":"All-Terrain Tire 265/70R17",
+                                                                        "upc":"036121960222","mpn":"AT3-26570R17","unitOfMeasure":"EA"},
+                                                                       {"sku":"WIP-22-PREM","name":"Premium Wiper Blade 22in"}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BulkIngestRequest<CatalogBulkIngestRecord> request) {
         return super.bulkIngest(request);
     }
 

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/CatalogController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/CatalogController.java
@@ -6,6 +6,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,7 +38,15 @@ public class CatalogController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/{catalogId}")
-    @Operation(summary = "Get a catalog by ID", description = "Retrieves a specific catalog by its unique ID.")
+    @Operation(operationId = "getCatalogById", summary = "Get a Catalog by ID", description = """
+            Returns one named catalog with the ids of the products, services and non-inventory products it groups.
+            Use this tool when the catalogId is already known; use listCatalogsByName instead to find catalogs by \
+            a name fragment.
+            Preconditions: the catalog must exist.
+            Required inputs: catalogId (UUID) as a path parameter; there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when no catalog exists for the supplied id.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Successfully retrieved catalog",
@@ -56,7 +65,15 @@ public class CatalogController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/name/{name}")
-    @Operation(summary = "Get catalogs by name", description = "Retrieves a list of catalogs matching the given name.")
+    @Operation(operationId = "listCatalogsByName", summary = "List Catalogs by Name", description = """
+            Returns every catalog whose name contains the supplied fragment, matched case-insensitively.
+            Use this tool to discover a catalogId by name; use getCatalogById instead when the id is already known.
+            Preconditions: none; an empty result simply means no catalog name contains the fragment.
+            Required inputs: name (path parameter) as a case-insensitive substring; there is no paging and no \
+            request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 200 with an empty array when nothing matches, so an empty result is not an error condition.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Successfully retrieved catalogs",
@@ -71,7 +88,18 @@ public class CatalogController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PostMapping
-    @Operation(summary = "Add a new catalog", description = "Adds a new catalog.")
+    @Operation(operationId = "createCatalog", summary = "Create a New Catalog", description = """
+            Creates a named catalog that groups existing products, services and non-inventory products for \
+            presentation; the catalog does not own the items, it only references them.
+            Use this tool to define a new grouping; do not use updateCatalog, which replaces a catalog that \
+            already exists, and do not use createCatalogItem, which creates the underlying items themselves.
+            Preconditions: any ids listed in productIds, serviceIds or nonInventoryProductIds should already \
+            exist; ids that do not resolve are silently dropped from the stored catalog rather than rejected.
+            Required inputs: name; description and the three id lists are optional and default to empty.
+            Emits a CATALOG_CATALOG_CREATE event; no product, service or non-inventory records are modified.
+            Returns 201 with the stored catalog, whose id lists reflect only the references that resolved, so \
+            callers should compare them against what was sent.
+            """)
     @ApiResponse(
             responseCode = "201",
             description = "Catalog created successfully",
@@ -80,9 +108,22 @@ public class CatalogController {
     @EmitEvent(id = "CATALOG_CATALOG_CREATE", apiVersion = "1")
     public ResponseEntity<CatalogDto> addCatalog(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            description = "Catalog object to be added",
+                            description =
+                                    "Catalog to create: a name plus optional lists of existing product, service and"
+                                            + " non-inventory product ids to group.",
                             required = true,
-                            content = @Content(schema = @Schema(implementation = CatalogDto.class)))
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = CatalogDto.class),
+                                            examples = @ExampleObject(name = "Catalog with two products", value = """
+                                                                    {"name":"Winter Tires",
+                                                                     "description":"Seasonal winter tire lineup",
+                                                                     "productIds":["018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                                   "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"],
+                                                                     "serviceIds":[],
+                                                                     "nonInventoryProductIds":[]}
+                                                                    """)))
                     @RequestBody
                     CatalogDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(catalogService.addCatalog(request));
@@ -93,7 +134,18 @@ public class CatalogController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PutMapping("/{catalogId}")
-    @Operation(summary = "Update an existing catalog", description = "Updates an existing catalog.")
+    @Operation(operationId = "updateCatalog", summary = "Update an Existing Catalog", description = """
+            Replaces a catalog's name, description and full membership lists with the supplied values; this is a \
+            full replacement, not a merge, so omitted item ids are removed from the catalog.
+            Use this tool to rename a catalog or change which items it groups; do not use createCatalog, which \
+            adds a new catalog, and do not use updateCatalogItem, which edits the items themselves.
+            Preconditions: the catalog must exist; ids in the three membership lists that do not resolve are \
+            silently dropped rather than rejected.
+            Required inputs: catalogId (UUID) path parameter and the complete replacement body including name; \
+            an omitted id list clears that membership.
+            Emits a CATALOG_CATALOG_UPDATE event; the referenced items themselves are not modified.
+            Returns 404 when no catalog exists for the supplied id.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Catalog updated successfully",
@@ -104,9 +156,21 @@ public class CatalogController {
     public ResponseEntity<CatalogDto> updateCatalog(
             @Parameter(description = "ID of the catalog to update") @PathVariable UUID catalogId,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            description = "Updated catalog object",
+                            description = "Complete replacement state for the catalog; membership lists overwrite the"
+                                    + " existing ones rather than merging.",
                             required = true,
-                            content = @Content(schema = @Schema(implementation = CatalogDto.class)))
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = CatalogDto.class),
+                                            examples =
+                                                    @ExampleObject(name = "Rename and reduce membership", value = """
+                                                                    {"name":"All-Season Tires",
+                                                                     "description":"Renamed lineup",
+                                                                     "productIds":["018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"],
+                                                                     "serviceIds":[],
+                                                                     "nonInventoryProductIds":[]}
+                                                                    """)))
                     @RequestBody
                     CatalogDto request) {
         return catalogService
@@ -120,7 +184,17 @@ public class CatalogController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_DELETE"})
     @DeleteMapping("/{catalogId}")
-    @Operation(summary = "Delete a catalog", description = "Deletes a catalog by its ID.")
+    @Operation(operationId = "deleteCatalog", summary = "Delete a Catalog", description = """
+            Permanently deletes a catalog grouping; the products, services and non-inventory products it \
+            referenced are untouched and remain available.
+            Use this tool to retire a grouping that is no longer needed; do not use deleteCatalogItem, which \
+            deletes the underlying items themselves.
+            Preconditions: the catalog must exist; there is no soft delete or archive state, so the row is \
+            removed outright.
+            Required inputs: catalogId (UUID) as a path parameter; there is no request body.
+            Emits a CATALOG_CATALOG_DELETE event; member items are not cascaded.
+            Returns 204 when the catalog is removed, and 404 when no catalog exists for the supplied id.
+            """)
     @ApiResponse(responseCode = "204", description = "Catalog deleted successfully")
     @ApiResponse(responseCode = "404", description = "Catalog not found")
     @EmitEvent(id = "CATALOG_CATALOG_DELETE", apiVersion = "1")

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/CatalogItemController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/CatalogItemController.java
@@ -7,6 +7,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -36,9 +37,19 @@ public class CatalogItemController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PostMapping("/{type}")
-    @Operation(
-            summary = "Add a new catalog item",
-            description = "Adds a new product, service, or non-inventory product to the catalog.")
+    @Operation(operationId = "createCatalogItem", summary = "Add a New Catalog Item", description = """
+            Creates a catalog item of the given type: a product, a service, or a non-inventory product.
+            Use this tool for quick item entry across the three item types; do not use createProduct, which is \
+            the richer product-master path that enforces SKU and manufacturer-part uniqueness — this endpoint \
+            performs no duplicate checks.
+            Preconditions: none; for type service and noninventory only name, shortDescription and \
+            longDescription are persisted, while type product also stores manufacturer, SKU, productCode, \
+            material, color, warranty and specifications fields.
+            Required inputs: type path parameter, one of product, service or noninventory (case-insensitive), \
+            plus a body with at least name.
+            Emits a CATALOG_ITEM_CREATE event; no catalog groupings are touched.
+            Returns 400 when the type path parameter is not one of the three supported values.
+            """)
     @ApiResponse(
             responseCode = "201",
             description = "Catalog item created successfully",
@@ -50,7 +61,26 @@ public class CatalogItemController {
     @EmitEvent(id = "CATALOG_ITEM_CREATE", apiVersion = "1")
     public ResponseEntity<CatalogItemResponseDto> addCatalogItem(
             @Parameter(description = "Type of catalog item (product, service, noninventory)") @PathVariable String type,
-            @RequestBody CatalogItemRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Item to create; only name, shortDescription and longDescription are stored"
+                                    + " for services and non-inventory products, products store the full field set.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = CatalogItemRequestDto.class),
+                                            examples = @ExampleObject(name = "New product item", value = """
+                                                                    {"name":"Premium Wiper Blade 22in",
+                                                                     "shortDescription":"22-inch beam wiper blade",
+                                                                     "longDescription":"All-weather beam wiper blade, 22 inch",
+                                                                     "sku":"WIP-22-PREM",
+                                                                     "productCode":"036121960221",
+                                                                     "manufacturerPartNumber":"PWB-22",
+                                                                     "manufacturerName":"ClearView",
+                                                                     "material":"Rubber","color":"Black"}
+                                                                    """)))
+                    @RequestBody
+                    CatalogItemRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(catalogService.addCatalogItem(type, request));
     }
 
@@ -59,9 +89,19 @@ public class CatalogItemController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PutMapping("/{type}/{catalogId}")
-    @Operation(
-            summary = "Update an existing catalog item",
-            description = "Updates an existing product, service, or non-inventory product in the catalog.")
+    @Operation(operationId = "updateCatalogItem", summary = "Update an Existing Catalog Item", description = """
+            Replaces a catalog item of the given type with the supplied state; fields omitted from the body are \
+            overwritten with null, so this is a full replacement, not a patch.
+            Use this tool to edit an item created through createCatalogItem; do not use updateProduct, which is \
+            the product-master path that protects SKU immutability — this endpoint applies no such guard.
+            Preconditions: an item of the given type must exist under the supplied id; the type determines which \
+            repository is consulted, so a product id passed with type service resolves to 404.
+            Required inputs: type (product, service or noninventory, case-insensitive), catalogId (UUID) and the \
+            complete replacement body.
+            Emits a CATALOG_ITEM_UPDATE event; no catalog groupings are touched.
+            Returns 404 when no item of that type exists for the supplied id, and 400 when the type is not one \
+            of the three supported values.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Catalog item updated successfully",
@@ -75,7 +115,21 @@ public class CatalogItemController {
     public ResponseEntity<CatalogItemResponseDto> updateCatalogItem(
             @Parameter(description = "Type of catalog item (product, service, noninventory)") @PathVariable String type,
             @Parameter(description = "ID of the catalog item to update") @PathVariable UUID catalogId,
-            @RequestBody CatalogItemRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Complete replacement state for the item; omitted fields are cleared"
+                                    + " because the update overwrites the whole row.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = CatalogItemRequestDto.class),
+                                            examples = @ExampleObject(name = "Rename a service", value = """
+                                                                    {"name":"Tire Rotation and Balance",
+                                                                     "shortDescription":"Rotate and balance four tires",
+                                                                     "longDescription":"Rotate all four tires and balance each wheel"}
+                                                                    """)))
+                    @RequestBody
+                    CatalogItemRequestDto request) {
         return catalogService
                 .updateCatalogItem(type, catalogId, request)
                 .map(ResponseEntity::ok)
@@ -87,9 +141,18 @@ public class CatalogItemController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_DELETE"})
     @DeleteMapping("/{type}/{catalogId}")
-    @Operation(
-            summary = "Delete a catalog item",
-            description = "Deletes a product, service, or non-inventory product from the catalog by its ID.")
+    @Operation(operationId = "deleteCatalogItem", summary = "Delete a Catalog Item", description = """
+            Permanently deletes a product, service or non-inventory product row by id; this is a hard delete \
+            with no archive state.
+            Use this tool to remove an item outright; use updateProductLifecycle instead when a product should \
+            stop selling but keep its history, and use deleteCatalog to remove a grouping rather than its items.
+            Preconditions: an item of the given type must exist under the supplied id.
+            Required inputs: type (product, service or noninventory, case-insensitive) and catalogId (UUID) as \
+            path parameters; there is no request body.
+            Emits a CATALOG_ITEM_DELETE event; catalogs that referenced the item are not rewritten by this call.
+            Returns 204 when the item is removed, 404 when no item of that type exists for the supplied id, and \
+            400 when the type is not one of the three supported values.
+            """)
     @ApiResponse(responseCode = "204", description = "Catalog item deleted successfully")
     @ApiResponse(responseCode = "400", description = "Invalid item type")
     @ApiResponse(responseCode = "404", description = "Catalog item not found")

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ItemCostController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ItemCostController.java
@@ -8,6 +8,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -39,10 +40,19 @@ public class ItemCostController {
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_MANAGER", "inventory.cost.standard.update"})
-    @Operation(
-            summary = "Update standard item cost",
-            description =
-                    "Updates the standard cost for the specified item and returns the refreshed item cost values.")
+    @Operation(operationId = "updateStandardItemCost", summary = "Update Standard Item Cost", description = """
+            Sets the standard cost of an item to a new value, rounding it to four decimal places, and writes \
+            an audit entry recording the old value, new value, actor and reason.
+            Use this tool for a deliberate manual cost change; do not use getItemCosts, which only reads the \
+            current values — last and average cost cannot be set here, they move only from purchase-order \
+            receipt events.
+            Preconditions: none; an item with no cost record yet gets one initialised with zero quantity on \
+            hand, so this call never fails on a missing item.
+            Required inputs: itemId (UUID) path parameter plus a positive newCost and a non-blank reasonCode \
+            in the body.
+            Emits a CATALOG_ITEM_COST_STANDARD_UPDATE event and appends a MANUAL audit row.
+            Returns 400 when newCost is missing or not positive, or when reasonCode is blank.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Updated",
@@ -51,7 +61,19 @@ public class ItemCostController {
     @EmitEvent(id = "CATALOG_ITEM_COST_STANDARD_UPDATE", apiVersion = "1")
     public ResponseEntity<ItemCostsDto> updateStandardCost(
             @Parameter(required = true) @PathVariable UUID itemId,
-            @Valid @RequestBody UpdateStandardCostRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The new standard cost and the business reason for changing it.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = UpdateStandardCostRequestDto.class),
+                                            examples = @ExampleObject(name = "Annual cost revision", value = """
+                                                                    {"newCost":42.5000,"reasonCode":"ANNUAL_REVIEW"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    UpdateStandardCostRequestDto request) {
         return ResponseEntity.ok(itemCostService.updateStandardCost(itemId, request));
     }
 
@@ -60,9 +82,17 @@ public class ItemCostController {
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_MANAGER", "ROLE_CATALOG_VIEW"})
-    @Operation(
-            summary = "Get current item costs",
-            description = "Returns the current standard, average, and last known cost values for the specified item.")
+    @Operation(operationId = "getItemCosts", summary = "Get Current Item Costs", description = """
+            Returns the item's current standard, average and last known costs in one record.
+            Use this tool to read cost values; do not use updateStandardItemCost, which changes the standard \
+            cost, and use getItemCostAuditHistory for who changed what and when.
+            Preconditions: none; an item with no cost record yet returns the itemId with all three cost \
+            fields null rather than an error.
+            Required inputs: itemId (UUID) as a path parameter; there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 200 in all cases, so callers must treat null cost fields as absence of cost data rather \
+            than relying on a 404.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Found",
@@ -76,9 +106,18 @@ public class ItemCostController {
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_MANAGER", "ROLE_CATALOG_VIEW"})
-    @Operation(
-            summary = "Get item cost audit history",
-            description = "Returns the recorded audit history entries for item cost changes on the specified item.")
+    @Operation(operationId = "getItemCostAuditHistory", summary = "Get Item Cost Audit History", description = """
+            Returns every recorded cost change for an item, newest first, each entry naming the cost type \
+            changed, old and new value, the actor, the change source and any reason code.
+            Use this tool to trace how a cost reached its current value; use getItemCosts instead for just \
+            the current numbers.
+            Preconditions: none; entries exist only after manual standard-cost updates or purchase-order \
+            receipt events have touched the item.
+            Required inputs: itemId (UUID) as a path parameter; there is no request body and no paging.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 200 with an empty array when the item has no cost history, so an empty result is not an \
+            error condition.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Found",

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/PriceBookController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/PriceBookController.java
@@ -11,6 +11,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -45,16 +46,43 @@ public class PriceBookController {
             name = "bearerAuth",
             scopes = {"catalog:price_book:write"})
     @PostMapping
-    @Operation(
-            summary = "Create price book",
-            description = "Creates a new price book used to group and apply pricing rules.")
+    @Operation(operationId = "createPriceBook", summary = "Create Price Book", description = """
+            Creates a price book — a scoped container of pricing rules — with scope COMPANY_DEFAULT, LOCATION \
+            or CUSTOMER_TIER and an initial status defaulting to ACTIVE.
+            Use this tool to establish a rule container before adding rules; do not use createPriceBookRule, \
+            which adds rules to a book that already exists.
+            Preconditions: none; no uniqueness is enforced, so creating a second default book for the same \
+            scope is possible and should be avoided by the caller.
+            Required inputs: name and scope; scopeId is mandatory for LOCATION and CUSTOMER_TIER scopes, \
+            while isDefault defaults to false and status defaults to ACTIVE.
+            Emits a CATALOG_PRICE_BOOK_CREATE event; no rules exist until they are added.
+            Returns 400 when name is blank, scope is missing, or scopeId is absent for a LOCATION or \
+            CUSTOMER_TIER scope.
+            """)
     @ApiResponse(
             responseCode = "201",
             description = "Price book created",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = PriceBookDto.class)))
     @ApiResponse(responseCode = "400", description = "Invalid payload")
     @EmitEvent(id = "CATALOG_PRICE_BOOK_CREATE", apiVersion = "1")
-    public ResponseEntity<PriceBookDto> createPriceBook(@Valid @RequestBody PriceBookCreateRequestDto request) {
+    public ResponseEntity<PriceBookDto> createPriceBook(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Price book definition: a name, its scope, and for LOCATION or"
+                                    + " CUSTOMER_TIER scopes the id of the location or tier it prices.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = PriceBookCreateRequestDto.class),
+                                            examples = @ExampleObject(name = "Location price book", value = """
+                                                                    {"name":"Downtown Store Pricing",
+                                                                     "scope":"LOCATION",
+                                                                     "scopeId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "isDefault":false,"status":"ACTIVE"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    PriceBookCreateRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(priceBookService.createPriceBook(request));
     }
 
@@ -63,9 +91,15 @@ public class PriceBookController {
             name = "bearerAuth",
             scopes = {"catalog:price_book:read"})
     @GetMapping("/{priceBookId}")
-    @Operation(
-            summary = "Get price book",
-            description = "Retrieves a price book by ID, including its configuration metadata.")
+    @Operation(operationId = "getPriceBook", summary = "Get Price Book", description = """
+            Returns one price book with its name, scope, default flag, status and optimistic-lock version.
+            Use this tool when the priceBookId is already known; use listPriceBookRules instead to inspect \
+            the rules it contains, since there is no endpoint that lists price books.
+            Preconditions: the price book must exist.
+            Required inputs: priceBookId (UUID) as a path parameter; there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when no price book exists for the supplied id.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Price book returned",
@@ -80,7 +114,18 @@ public class PriceBookController {
             name = "bearerAuth",
             scopes = {"catalog:price_book:write"})
     @PutMapping("/{priceBookId}")
-    @Operation(summary = "Update price book", description = "Updates mutable fields of an existing price book.")
+    @Operation(operationId = "updatePriceBook", summary = "Update Price Book", description = """
+            Updates a price book's name, scope and scopeId, and optionally its default flag and status; \
+            isDefault and status are left unchanged when omitted, unlike the other fields which are replaced.
+            Use this tool to rename, re-scope, deactivate or promote a book; do not use updatePriceBookRule, \
+            which edits an individual rule inside the book.
+            Preconditions: the price book must exist.
+            Required inputs: priceBookId (UUID) path parameter plus name and scope; scopeId is mandatory for \
+            LOCATION and CUSTOMER_TIER scopes.
+            Emits a CATALOG_PRICE_BOOK_UPDATE event; the book's rules are untouched.
+            Returns 404 when no price book exists for the supplied id, and 400 when name is blank, scope is \
+            missing, or scopeId is absent for a LOCATION or CUSTOMER_TIER scope.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Price book updated",
@@ -89,7 +134,23 @@ public class PriceBookController {
     @EmitEvent(id = "CATALOG_PRICE_BOOK_UPDATE", apiVersion = "1")
     public ResponseEntity<PriceBookDto> updatePriceBook(
             @Parameter(required = true) @PathVariable UUID priceBookId,
-            @Valid @RequestBody PriceBookCreateRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Replacement name, scope and scopeId; isDefault and status only change"
+                                    + " when present in the body.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = PriceBookCreateRequestDto.class),
+                                            examples = @ExampleObject(name = "Deactivate a book", value = """
+                                                                    {"name":"Downtown Store Pricing",
+                                                                     "scope":"LOCATION",
+                                                                     "scopeId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "status":"INACTIVE"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    PriceBookCreateRequestDto request) {
         return ResponseEntity.ok(priceBookService.updatePriceBook(priceBookId, request));
     }
 
@@ -98,7 +159,23 @@ public class PriceBookController {
             name = "bearerAuth",
             scopes = {"catalog:price_book:write"})
     @PostMapping("/{priceBookId}/rules")
-    @Operation(summary = "Create price book rule", description = "Adds a new pricing rule to a specific price book.")
+    @Operation(operationId = "createPriceBookRule", summary = "Create Price Book Rule", description = """
+            Adds an ACTIVE pricing rule to a price book, targeting a single SKU, a CATEGORY taxonomy node or \
+            GLOBAL, with an effective window and an optional LOCATION or CUSTOMER_TIER condition.
+            Use this tool to define a reference price; do not use resolveProductPrice, which evaluates rules, \
+            and do not use updatePriceBookRule, which edits a rule that already exists.
+            Preconditions: the price book must exist, and no ACTIVE rule with the same target, condition and \
+            an overlapping effective window may already exist in the book.
+            Required inputs: targetType (SKU, CATEGORY or GLOBAL), targetId for non-GLOBAL targets, \
+            pricingLogic as JSON of the form {"amounts":{"USD":"10.00"},"defaultCurrency":"USD"}, \
+            effectiveStartAt and createdByUserId; priority defaults to 0, conditionType defaults to NONE, \
+            and a LOCATION conditionValue must be a UUID string.
+            Emits a CATALOG_PRICE_BOOK_RULE_CREATE event; the rule participates in resolution immediately \
+            once its window opens.
+            Returns 404 when the price book does not exist, 409 when the rule conflicts with an existing \
+            rule in overlapping dates, and 400 when required fields are missing or the effective window is \
+            inverted.
+            """)
     @ApiResponse(
             responseCode = "201",
             description = "Price book rule created",
@@ -108,7 +185,25 @@ public class PriceBookController {
     @EmitEvent(id = "CATALOG_PRICE_BOOK_RULE_CREATE", apiVersion = "1")
     public ResponseEntity<PriceBookRuleDto> createRule(
             @Parameter(required = true) @PathVariable UUID priceBookId,
-            @Valid @RequestBody PriceBookRuleCreateRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Rule definition: target, JSON pricingLogic with per-currency amounts,"
+                                    + " optional condition, priority and effective window.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = PriceBookRuleCreateRequestDto.class),
+                                            examples = @ExampleObject(name = "SKU rule in USD", value = """
+                                                                    {"targetType":"SKU",
+                                                                     "targetId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "pricingLogic":"{\\"amounts\\":{\\"USD\\":\\"129.99\\"},\\"defaultCurrency\\":\\"USD\\"}",
+                                                                     "conditionType":"NONE","priority":10,
+                                                                     "effectiveStartAt":"2026-09-01T00:00:00Z",
+                                                                     "createdByUserId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    PriceBookRuleCreateRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(priceBookService.createRule(priceBookId, request));
     }
 
@@ -117,7 +212,21 @@ public class PriceBookController {
             name = "bearerAuth",
             scopes = {"catalog:price_book:write"})
     @PutMapping("/{priceBookId}/rules/{ruleId}")
-    @Operation(summary = "Update price book rule", description = "Updates an existing pricing rule in a price book.")
+    @Operation(operationId = "updatePriceBookRule", summary = "Update Price Book Rule", description = """
+            Replaces the target, pricing logic, condition, priority and effective window of an existing price \
+            book rule, keeping its status.
+            Use this tool to change a rule in place; do not use deactivatePriceBookRule, which retires the \
+            rule, and do not use createPriceBookRule, which adds a new one.
+            Preconditions: the rule must exist and belong to the given price book; a version supplied in the \
+            body must match the rule's current version, and the change must not conflict with another rule's \
+            overlapping window.
+            Required inputs: priceBookId and ruleId (UUIDs) path parameters plus targetType, pricingLogic, \
+            effectiveStartAt and createdByUserId; version is optional but recommended for optimistic locking.
+            Emits a CATALOG_PRICE_BOOK_RULE_UPDATE event; resolution reflects the new values immediately.
+            Returns 404 when the rule does not exist under that price book, 409 when the version mismatches \
+            or the change conflicts with an existing rule in overlapping dates, and 400 when required fields \
+            are missing or invalid.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Price book rule updated",
@@ -128,7 +237,27 @@ public class PriceBookController {
     public ResponseEntity<PriceBookRuleDto> updateRule(
             @Parameter(required = true) @PathVariable UUID priceBookId,
             @Parameter(required = true) @PathVariable UUID ruleId,
-            @Valid @RequestBody PriceBookRuleCreateRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Replacement rule values; include version to guard against concurrent"
+                                    + " edits of the same rule.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = PriceBookRuleCreateRequestDto.class),
+                                            examples =
+                                                    @ExampleObject(name = "Reprice with version guard", value = """
+                                                                    {"targetType":"SKU",
+                                                                     "targetId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "pricingLogic":"{\\"amounts\\":{\\"USD\\":\\"119.99\\"},\\"defaultCurrency\\":\\"USD\\"}",
+                                                                     "priority":10,
+                                                                     "effectiveStartAt":"2026-09-01T00:00:00Z",
+                                                                     "createdByUserId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "version":0}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    PriceBookRuleCreateRequestDto request) {
         return ResponseEntity.ok(priceBookService.updateRule(priceBookId, ruleId, request));
     }
 
@@ -137,9 +266,17 @@ public class PriceBookController {
             name = "bearerAuth",
             scopes = {"catalog:price_book:write"})
     @DeleteMapping("/{priceBookId}/rules/{ruleId}")
-    @Operation(
-            summary = "Deactivate price book rule",
-            description = "Deactivates a price book rule so it is no longer considered in price resolution.")
+    @Operation(operationId = "deactivatePriceBookRule", summary = "Deactivate Price Book Rule", description = """
+            Sets a price book rule's status to INACTIVE so price resolution stops considering it; the rule \
+            row is kept, not deleted.
+            Use this tool to retire a rule; do not use updatePriceBookRule, which changes its values while \
+            leaving it active — there is no endpoint to reactivate a rule, so treat this as one-way.
+            Preconditions: the rule must exist and belong to the given price book.
+            Required inputs: priceBookId and ruleId (UUIDs) as path parameters; there is no request body.
+            Emits a CATALOG_PRICE_BOOK_RULE_DEACTIVATE event; subsequent resolveProductPrice calls no longer \
+            match the rule.
+            Returns 204 on success, and 404 when the rule does not exist under that price book.
+            """)
     @ApiResponse(responseCode = "204", description = "Rule deactivated")
     @EmitEvent(id = "CATALOG_PRICE_BOOK_RULE_DEACTIVATE", apiVersion = "1")
     public ResponseEntity<Void> deactivateRule(
@@ -154,7 +291,17 @@ public class PriceBookController {
             name = "bearerAuth",
             scopes = {"catalog:price_book:read"})
     @GetMapping("/{priceBookId}/rules")
-    @Operation(summary = "List price book rules", description = "Returns all rules associated with a price book.")
+    @Operation(operationId = "listPriceBookRules", summary = "List Price Book Rules", description = """
+            Returns every rule in a price book — ACTIVE and INACTIVE alike — with target, pricing logic, \
+            condition, priority, effective window, status and version.
+            Use this tool to inspect a book's rule set; use resolveProductPrice instead to evaluate which \
+            rule wins for a concrete product and context.
+            Preconditions: the price book must exist.
+            Required inputs: priceBookId (UUID) as a path parameter; there is no filtering or paging.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when no price book exists for the supplied id, and 200 with an empty array when the \
+            book has no rules.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Rule list returned",
@@ -170,13 +317,25 @@ public class PriceBookController {
             name = "bearerAuth",
             scopes = {"catalog:price_book:read"})
     @PostMapping("/resolve-price")
-    @Operation(
-            summary = "Resolve reference/list product price",
-            description = "Resolves the reference/list price for a product using applicable price books and"
-                    + " rules. Candidate book precedence: explicit priceBookId, then active LOCATION book,"
-                    + " then active CUSTOMER_TIER book (customerTierId), then COMPANY_DEFAULT. The result is"
-                    + " catalog reference data (ADR-0054) — transactional sell prices are resolved by"
-                    + " pos-price, never by this endpoint.")
+    @Operation(operationId = "resolveProductPrice", summary = "Resolve Reference Product Price", description = """
+            Resolves a product's catalog reference or list price by picking one candidate price book — the \
+            explicit priceBookId first, otherwise the active LOCATION book, then the active CUSTOMER_TIER \
+            book, then the COMPANY_DEFAULT book — and selecting the winning ACTIVE rule by SKU over CATEGORY \
+            over GLOBAL specificity, then priority; when no rule matches, the active MSRP is returned with \
+            fallbackReason MSRP_FALLBACK.
+            Use this tool for catalog reference pricing per ADR-0054; do not use it for transactional sell \
+            prices, which pos-price owns, and do not use getEffectiveLocationPrice, which reads location \
+            override records instead of price book rules.
+            Preconditions: the product must exist; price books and rules are optional, since MSRP fallback \
+            covers their absence.
+            Required inputs: productId (UUID); priceBookId, locationId, customerTierId, customerTier, \
+            currency and asOf are optional, with asOf defaulting to today and currency required only when a \
+            winning rule configures multiple currencies without a defaultCurrency.
+            Emits a CATALOG_PRICE_BOOK_RESOLVE_PRICE audit event; no pricing data changes.
+            Returns 404 when the product or an explicitly supplied priceBookId does not exist, 400 when the \
+            requested currency is not configured in the winning rule's pricingLogic, and 200 with source \
+            UNAVAILABLE and fallbackReason PRICE_BASE_DATA_MISSING when neither a rule nor an MSRP applies.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Resolved price returned",
@@ -185,7 +344,24 @@ public class PriceBookController {
                             mediaType = "application/json",
                             schema = @Schema(implementation = ResolvePriceResponseDto.class)))
     @EmitEvent(id = "CATALOG_PRICE_BOOK_RESOLVE_PRICE", apiVersion = "1")
-    public ResponseEntity<ResolvePriceResponseDto> resolvePrice(@Valid @RequestBody ResolvePriceRequestDto request) {
+    public ResponseEntity<ResolvePriceResponseDto> resolvePrice(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Resolution context: the product plus optional book, location, customer"
+                                    + " tier, currency and as-of date that steer candidate book selection.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = ResolvePriceRequestDto.class),
+                                            examples =
+                                                    @ExampleObject(name = "Location-context resolution", value = """
+                                                                    {"productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "currency":"USD","asOf":"2026-09-15"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    ResolvePriceRequestDto request) {
         return ResponseEntity.ok(priceBookService.resolvePrice(request));
     }
 }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -68,8 +69,22 @@ public class ProductController {
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PostMapping("/pricing/guardrail-policies")
     @Operation(
-            summary = "Upsert location guardrail policy",
-            description = "Creates or updates the active LOCATION guardrail policy used by price overrides.")
+            operationId = "upsertLocationGuardrailPolicy",
+            summary = "Upsert Location Guardrail Policy",
+            description = """
+            Creates or updates the LOCATION-scoped guardrail policy that createLocationPriceOverride enforces \
+            for discount, margin and auto-approval limits.
+            Use this tool to set pricing guardrails for a location before overrides are created there; do not \
+            use createLocationPriceOverride, which applies a price and is rejected until a policy exists.
+            Preconditions: none; when a policy already exists for the scopeId its limits are overwritten, \
+            otherwise a new policy row is created.
+            Required inputs: scopeId (the location UUID), minMarginPercent, maxDiscountPercent and \
+            autoApprovalThresholdPercent, all mandatory.
+            Emits a CATALOG_GUARDRAIL_POLICY_UPSERT event; existing overrides are not re-evaluated, the new \
+            limits apply only to overrides created afterwards.
+            Returns 400 when any of the four fields is missing; the 200 response body carries only the \
+            locationId, not the stored limits.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Guardrail policy upserted",
@@ -80,7 +95,23 @@ public class ProductController {
     @ApiResponse(responseCode = "400", description = "Invalid policy payload")
     @EmitEvent(id = "CATALOG_GUARDRAIL_POLICY_UPSERT", apiVersion = "1")
     public ResponseEntity<LocationPriceOverrideResponseDto> upsertLocationGuardrailPolicy(
-            @Valid @RequestBody GuardrailPolicyUpsertRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Guardrail limits for one location: minimum margin, maximum discount and"
+                                    + " the discount threshold under which overrides auto-approve.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = GuardrailPolicyUpsertRequestDto.class),
+                                            examples = @ExampleObject(name = "Location policy", value = """
+                                                                    {"scopeId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "minMarginPercent":15.0,
+                                                                     "maxDiscountPercent":25.0,
+                                                                     "autoApprovalThresholdPercent":10.0}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    GuardrailPolicyUpsertRequestDto request) {
         return ResponseEntity.ok(locationPriceOverrideService.upsertLocationGuardrailPolicy(request));
     }
 
@@ -90,9 +121,25 @@ public class ProductController {
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PostMapping("/pricing/location-overrides")
     @Operation(
-            summary = "Create location price override",
-            description =
-                    "Creates a location-specific price override and enforces guardrails for margin and discount limits.")
+            operationId = "createLocationPriceOverride",
+            summary = "Create Location Price Override",
+            description = """
+            Creates a location-specific price override for one product, enforcing the location's guardrail \
+            policy; discounts at or below the auto-approval threshold activate immediately, larger discounts \
+            are stored as PENDING_APPROVAL with an approval request assigned to a deterministic approver.
+            Use this tool to discount a product at one location; do not use upsertLocationGuardrailPolicy, \
+            which sets the limits themselves, and use approveLocationPriceOverride to activate a pending one.
+            Preconditions: the product must exist and a LOCATION guardrail policy must already exist for the \
+            locationId; any currently ACTIVE override for the same location and product is set INACTIVE.
+            Required inputs: locationId, productId, createdByUserId (UUIDs), positive basePrice and \
+            overridePrice with overridePrice not exceeding basePrice; cost is optional and enables the \
+            margin check when present.
+            Emits a CATALOG_LOCATION_OVERRIDE_CREATE event and invalidates the product-detail cache for that \
+            location.
+            Returns 404 when the product does not exist, and 400 when no guardrail policy exists for the \
+            location, the discount exceeds maxDiscountPercent, or the margin falls below minMarginPercent; \
+            callers must read the returned status to learn whether the override is ACTIVE or PENDING_APPROVAL.
+            """)
     @ApiResponse(
             responseCode = "201",
             description = "Override created",
@@ -104,7 +151,26 @@ public class ProductController {
     @ApiResponse(responseCode = "403", description = "Forbidden")
     @EmitEvent(id = "CATALOG_LOCATION_OVERRIDE_CREATE", apiVersion = "1")
     public ResponseEntity<LocationPriceOverrideResponseDto> createLocationPriceOverride(
-            @Valid @RequestBody LocationPriceOverrideCreateRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Override pricing for one product at one location; cost is optional and"
+                                    + " enables the minimum-margin guardrail check.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    LocationPriceOverrideCreateRequestDto.class),
+                                            examples = @ExampleObject(name = "Discounted price", value = """
+                                                                    {"locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "createdByUserId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d",
+                                                                     "basePrice":100.00,"cost":60.00,"overridePrice":92.50}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    LocationPriceOverrideCreateRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(locationPriceOverrideService.createOverride(request));
     }
 
@@ -113,9 +179,19 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/pricing/effective-price/{locationId}/{productId}")
-    @Operation(
-            summary = "Get effective location price",
-            description = "Resolves effective price using precedence: ACTIVE override first, otherwise base price.")
+    @Operation(operationId = "getEffectiveLocationPrice", summary = "Get Effective Location Price", description = """
+            Resolves the price a location currently charges for a product from its override records: the newest \
+            ACTIVE override wins, otherwise a PENDING_APPROVAL override reports its basePrice as the effective \
+            price with status PENDING_APPROVAL.
+            Use this tool to check what an override has done to a product's price at one location; do not use \
+            getProductDetailView, which returns the full consolidated pricing and availability view.
+            Preconditions: at least one ACTIVE or PENDING_APPROVAL override must exist for the pair; a product \
+            with no override history at the location has no answer here.
+            Required inputs: locationId and productId (UUIDs) as path parameters; there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when no ACTIVE or PENDING_APPROVAL override exists for the location and product pair, \
+            even if the product itself exists.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Effective price returned",
@@ -136,8 +212,22 @@ public class ProductController {
             scopes = {"ROLE_ADMIN", "pricing:override:approve"})
     @PostMapping("/pricing/location-overrides/{overrideId}/approve")
     @Operation(
-            summary = "Approve pending location price override",
-            description = "Approves a pending override and activates it as the effective location price.")
+            operationId = "approveLocationPriceOverride",
+            summary = "Approve Pending Price Override",
+            description = """
+            Approves a PENDING_APPROVAL location price override, setting it ACTIVE and closing its approval \
+            request as APPROVED.
+            Use this tool to grant a pending override; do not use rejectLocationPriceOverride, which \
+            terminally declines it instead.
+            Preconditions: the override must exist, be in PENDING_APPROVAL status, have an open approval \
+            request, and the supplied version must match the override's current version.
+            Required inputs: overrideId (UUID) path parameter plus version (long) and actorUserId (UUID) in \
+            the body; rejection fields are ignored on approval.
+            Emits a CATALOG_LOCATION_OVERRIDE_APPROVE event and invalidates the product-detail cache for the \
+            override's location.
+            Returns 404 when the override or its approval request cannot be found, 400 when the override is \
+            not in PENDING_APPROVAL status, and 409 when the supplied version does not match the current one.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Override approved",
@@ -151,7 +241,24 @@ public class ProductController {
     @EmitEvent(id = "CATALOG_LOCATION_OVERRIDE_APPROVE", apiVersion = "1")
     public ResponseEntity<LocationPriceOverrideResponseDto> approveLocationPriceOverride(
             @Parameter(description = "Override ID", required = true) @PathVariable UUID overrideId,
-            @Valid @RequestBody LocationPriceOverrideDecisionRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Approval decision carrying the acting user and the override's current"
+                                    + " version for optimistic-lock verification.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    LocationPriceOverrideDecisionRequestDto.class),
+                                            examples = @ExampleObject(name = "Approve", value = """
+                                                                    {"version":0,
+                                                                     "actorUserId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    LocationPriceOverrideDecisionRequestDto request) {
         return ResponseEntity.ok(locationPriceOverrideService.approveOverride(overrideId, request));
     }
 
@@ -161,8 +268,23 @@ public class ProductController {
             scopes = {"ROLE_ADMIN", "pricing:override:approve"})
     @PostMapping("/pricing/location-overrides/{overrideId}/reject")
     @Operation(
-            summary = "Reject pending location price override",
-            description = "Rejects a pending override, persists rejection metadata, and marks the request as terminal.")
+            operationId = "rejectLocationPriceOverride",
+            summary = "Reject Pending Price Override",
+            description = """
+            Rejects a PENDING_APPROVAL location price override, recording who rejected it and why, and closing \
+            its approval request as REJECTED; the decision is terminal, a rejected override cannot be revived.
+            Use this tool to decline a pending override; do not use approveLocationPriceOverride, which \
+            activates it instead.
+            Preconditions: the override must exist, be in PENDING_APPROVAL status, have an open approval \
+            request, and the supplied version must match the override's current version.
+            Required inputs: overrideId (UUID) path parameter plus version (long), actorUserId (UUID), and \
+            non-blank rejectionReasonCode and rejectionNotes in the body.
+            Emits a CATALOG_LOCATION_OVERRIDE_REJECT event and invalidates the product-detail cache for the \
+            override's location.
+            Returns 404 when the override or its approval request cannot be found, 400 when the override is \
+            not in PENDING_APPROVAL status or the rejection reason or notes are blank, and 409 when the \
+            supplied version does not match the current one.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Override rejected",
@@ -176,7 +298,26 @@ public class ProductController {
     @EmitEvent(id = "CATALOG_LOCATION_OVERRIDE_REJECT", apiVersion = "1")
     public ResponseEntity<LocationPriceOverrideResponseDto> rejectLocationPriceOverride(
             @Parameter(description = "Override ID", required = true) @PathVariable UUID overrideId,
-            @Valid @RequestBody LocationPriceOverrideDecisionRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Rejection decision carrying the acting user, the override's current"
+                                    + " version, and a mandatory reason code with notes.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    LocationPriceOverrideDecisionRequestDto.class),
+                                            examples = @ExampleObject(name = "Reject below margin", value = """
+                                                                    {"version":0,
+                                                                     "actorUserId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "rejectionReasonCode":"MARGIN_TOO_LOW",
+                                                                     "rejectionNotes":"Margin would fall below store target"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    LocationPriceOverrideDecisionRequestDto request) {
         return ResponseEntity.ok(locationPriceOverrideService.rejectOverride(overrideId, request));
     }
 
@@ -185,13 +326,20 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/search")
-    @Operation(
-            summary = "Search catalog products",
-            description =
-                    "Cursor-based product search with optional free-text query and exact filters for brand, category, and SKU. "
-                            + "Pass detailed=true to enrich each row inline with lifecycle state + effective instant and the "
-                            + "product's active MSRP (amount, currency, effective window), resolved server-side in a single "
-                            + "request. Products without an active MSRP return null price fields.")
+    @Operation(operationId = "searchCatalogProducts", summary = "Search Catalog Products", description = """
+            Searches products with an optional free-text query over name and description plus exact \
+            case-insensitive filters for brand, category and SKU, paged by an opaque cursor.
+            Use this tool to find products by partial text or filters; use getProductById instead when the id \
+            is known, and listProductsByName only for exact whole-name matches.
+            Preconditions: none; a malformed or missing cursor silently restarts at the first page rather \
+            than failing.
+            Required inputs: all parameters are optional; limit defaults to 20 and is clamped to 1-100, and \
+            detailed defaults to false — pass detailed=true to enrich each row with lifecycle state, its \
+            effective instant and the active MSRP, with null price fields for products lacking an active MSRP.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 200 with an empty items array when nothing matches, so an empty result is not an error \
+            condition.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Search results",
@@ -233,9 +381,21 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @PostMapping
-    @Operation(
-            summary = "Create product master record",
-            description = "Creates a product master record with immutable SKU and uniqueness checks.")
+    @Operation(operationId = "createProduct", summary = "Create Product Master Record", description = """
+            Creates a product master record with an immutable SKU, status ACTIVE, and uniqueness enforced on \
+            SKU and on the manufacturerId plus mpn pair.
+            Use this tool for governed product-master entry; do not use createCatalogItem, which is the \
+            lightweight catalog-item path with no duplicate checks, and do not use bulkIngestCatalogProducts, \
+            which loads many products in one call.
+            Preconditions: no product may already use the SKU (case-insensitive), and when manufacturerId is \
+            supplied no product may already pair it with the same mpn; a supplied categoryId must resolve.
+            Required inputs: name, description, unitOfMeasure, sku and mpn, all non-blank; manufacturerId, \
+            categoryId, upc and attributes are optional, and a upc also becomes the productCode with type UPC.
+            Emits a CATALOG_PRODUCT_CREATED event, publishes a product fact for downstream replicas, and \
+            invalidates the product-detail cache.
+            Returns 409 when the SKU or the manufacturerId plus mpn pair already exists, and 400 when the \
+            supplied categoryId does not resolve.
+            """)
     @ApiResponse(
             responseCode = "201",
             description = "Product created",
@@ -243,7 +403,28 @@ public class ProductController {
     @ApiResponse(responseCode = "400", description = "Validation error")
     @ApiResponse(responseCode = "409", description = "Business conflict")
     @EmitEvent(id = "CATALOG_PRODUCT_CREATED", apiVersion = "1")
-    public ResponseEntity<ProductDto> createProduct(@Valid @RequestBody ProductCreateRequestDto request) {
+    public ResponseEntity<ProductDto> createProduct(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Product master data to register; sku becomes immutable after creation and"
+                                    + " upc, when supplied, also becomes the productCode.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = ProductCreateRequestDto.class),
+                                            examples = @ExampleObject(name = "New tire product", value = """
+                                                                    {"name":"All-Terrain Tire 265/70R17",
+                                                                     "description":"All-terrain light truck tire, 265/70R17",
+                                                                     "unitOfMeasure":"EA",
+                                                                     "sku":"TIRE-AT-2657017",
+                                                                     "mpn":"AT3-26570R17",
+                                                                     "upc":"036121960222",
+                                                                     "manufacturerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "categoryId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    ProductCreateRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(productMasterDataService.createProduct(request));
     }
 
@@ -252,9 +433,21 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PutMapping("/{productId}")
-    @Operation(
-            summary = "Update product master record",
-            description = "Updates mutable product master fields. SKU is immutable.")
+    @Operation(operationId = "updateProduct", summary = "Update Product Master Record", description = """
+            Replaces the mutable master-data fields of a product — name, description, unit of measure, \
+            manufacturer, category, UPC and attributes — while the SKU stays immutable.
+            Use this tool to correct product master data; do not use updateProductLifecycle, which changes \
+            selling state, and do not use updateProductTrackingLevel, which changes stock tracking.
+            Preconditions: the product must exist, and a sku field in the body must either be omitted or \
+            match the stored SKU exactly.
+            Required inputs: productId (UUID) path parameter plus non-blank name, description, unitOfMeasure \
+            and mpn; omitted optional fields such as upc and categoryId are cleared, not preserved.
+            Emits a CATALOG_PRODUCT_UPDATED event, publishes a product fact for downstream replicas, and \
+            invalidates the product-detail cache.
+            Returns 404 when the product does not exist, 400 when the body tries to change the SKU or names a \
+            categoryId that does not resolve, and 409 when the manufacturerId plus mpn pair collides with \
+            another product.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Product updated",
@@ -265,7 +458,28 @@ public class ProductController {
     @EmitEvent(id = "CATALOG_PRODUCT_UPDATED", apiVersion = "1")
     public ResponseEntity<ProductDto> updateProduct(
             @Parameter(description = "ID of the product to update", required = true) @PathVariable UUID productId,
-            @Valid @RequestBody ProductUpdateRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Replacement master-data fields; sku may be omitted or must equal the"
+                                    + " stored value, and omitted optional fields are cleared.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = ProductUpdateRequestDto.class),
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Correct description and category",
+                                                            value = """
+                                                                    {"name":"All-Terrain Tire 265/70R17",
+                                                                     "description":"All-terrain LT tire, 265/70R17, load range E",
+                                                                     "unitOfMeasure":"EA",
+                                                                     "mpn":"AT3-26570R17",
+                                                                     "upc":"036121960222",
+                                                                     "categoryId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    ProductUpdateRequestDto request) {
         return ResponseEntity.ok(productMasterDataService.updateProduct(productId, request));
     }
 
@@ -274,10 +488,19 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PutMapping("/{productId}/tracking-level")
-    @Operation(
-            summary = "Set product tracking level",
-            description = "Sets the product's stock tracking level (NONE, LOT, or SERIAL; default NONE) and"
-                    + " re-emits the product contract event for downstream replicas.")
+    @Operation(operationId = "updateProductTrackingLevel", summary = "Set Product Tracking Level", description = """
+            Sets the product's stock tracking level to NONE, LOT or SERIAL, controlling whether inventory \
+            tracks the product per lot or per serial number.
+            Use this tool when a product's tracking granularity changes; do not use updateProduct, which \
+            replaces master-data fields and does not touch the tracking level.
+            Preconditions: the product must exist; no transition rules apply between levels.
+            Required inputs: productId (UUID) path parameter and trackingLevel in the body, one of NONE, LOT \
+            or SERIAL.
+            Emits a CATALOG_PRODUCT_TRACKING_LEVEL_UPDATE event, re-publishes the product fact so downstream \
+            replicas pick up the new level, and invalidates the product-detail cache.
+            Returns 404 when the product does not exist, and 400 when trackingLevel is missing or not a \
+            valid enum value.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Tracking level updated",
@@ -287,7 +510,22 @@ public class ProductController {
     @EmitEvent(id = "CATALOG_PRODUCT_TRACKING_LEVEL_UPDATE", apiVersion = "1")
     public ResponseEntity<ProductDto> updateTrackingLevel(
             @Parameter(description = "ID of the product", required = true) @PathVariable UUID productId,
-            @Valid @RequestBody ProductTrackingLevelUpdateRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The stock tracking granularity to apply to the product.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    ProductTrackingLevelUpdateRequestDto.class),
+                                            examples = @ExampleObject(name = "Track by serial number", value = """
+                                                                    {"trackingLevel":"SERIAL"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    ProductTrackingLevelUpdateRequestDto request) {
         return ResponseEntity.ok(productMasterDataService.updateTrackingLevel(productId, request));
     }
 
@@ -296,7 +534,16 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/{productId}")
-    @Operation(summary = "Get a product by ID", description = "Retrieves a specific product by its unique ID.")
+    @Operation(operationId = "getProductById", summary = "Get a Product by ID", description = """
+            Returns the full product record including identity codes, manufacturer data, category, dimensions, \
+            tracking level and lifecycle state.
+            Use this tool when the productId is already known; use searchCatalogProducts instead to find \
+            products by text or filters.
+            Preconditions: the product must exist.
+            Required inputs: productId (UUID) as a path parameter; there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when no product exists for the supplied id.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Successfully retrieved product",
@@ -315,7 +562,16 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/name/{name}")
-    @Operation(summary = "Get products by name", description = "Retrieves a list of products matching the given name.")
+    @Operation(operationId = "listProductsByName", summary = "List Products by Exact Name", description = """
+            Returns every product whose name equals the supplied value exactly; this is a whole-name match, \
+            not a substring search.
+            Use this tool only when the exact product name is known; use searchCatalogProducts instead for \
+            partial text, brand, category or SKU matching.
+            Preconditions: none; an empty result simply means no product carries that exact name.
+            Required inputs: name as a path parameter; there is no paging and no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 200 with an empty array when nothing matches, so an empty result is not an error condition.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Successfully retrieved products",
@@ -330,10 +586,18 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/{productId}/detail")
-    @Operation(
-            summary = "Get product details with pricing and availability",
-            description =
-                    "Retrieves a consolidated view of product information including catalog data, location-specific pricing, and availability. Implements graceful degradation and returns partial data when non-critical services are unavailable.")
+    @Operation(operationId = "getProductDetailView", summary = "Get Product Detail With Pricing", description = """
+            Returns a consolidated product view for one location: catalog data, location-specific pricing, \
+            availability and lead time, with a confidence indicator describing how complete the data is.
+            Use this tool for a sales-facing view of one product at one store; use getProductById instead for \
+            raw master data, and getEffectiveLocationPrice for the override-derived price alone.
+            Preconditions: the product must exist; pricing and availability sources may be degraded, in which \
+            case partial data is returned rather than an error.
+            Required inputs: productId (UUID) path parameter and location_id (UUID) query parameter.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when the product does not exist, and 400 when location_id is missing or malformed; a \
+            200 may still carry partial data, so callers should inspect the confidence field.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Successfully retrieved product details (may be partial if some services unavailable)",
@@ -371,9 +635,18 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/services/search")
-    @Operation(
-            summary = "Search catalog services",
-            description = "Free-text substring search over service names for typeahead selection.")
+    @Operation(operationId = "searchCatalogServices", summary = "Search Catalog Services", description = """
+            Searches services by a case-insensitive substring of the service name, ordered by name, sized for \
+            typeahead selection.
+            Use this tool to find a serviceId by partial name; use getServiceById instead when the id is \
+            known, and listServicesByName for exact whole-name matches.
+            Preconditions: none; a blank or missing q returns an empty list rather than all services.
+            Required inputs: q as the substring to match; limit is optional, defaults to 20 and is clamped \
+            to 1-100.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 200 with an empty array when q is blank or nothing matches, so an empty result is not an \
+            error condition.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Matching services",
@@ -398,7 +671,15 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/services/{serviceId}")
-    @Operation(summary = "Get a service by ID", description = "Retrieves a specific service by its unique ID.")
+    @Operation(operationId = "getServiceById", summary = "Get a Service by ID", description = """
+            Returns one catalog service record with its name, short description and long description.
+            Use this tool when the serviceId is already known; use searchCatalogServices instead to find \
+            services by partial name.
+            Preconditions: the service must exist.
+            Required inputs: serviceId (UUID) as a path parameter; there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when no service exists for the supplied id.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Successfully retrieved service",
@@ -417,7 +698,16 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/services/name/{name}")
-    @Operation(summary = "Get services by name", description = "Retrieves a list of services matching the given name.")
+    @Operation(operationId = "listServicesByName", summary = "List Services by Exact Name", description = """
+            Returns every catalog service whose name equals the supplied value exactly; this is a whole-name \
+            match, not a substring search.
+            Use this tool only when the exact service name is known; use searchCatalogServices instead for \
+            partial, typeahead-style matching.
+            Preconditions: none; an empty result simply means no service carries that exact name.
+            Required inputs: name as a path parameter; there is no paging and no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 200 with an empty array when nothing matches, so an empty result is not an error condition.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Successfully retrieved services",
@@ -433,8 +723,18 @@ public class ProductController {
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/noninventory/{productId}")
     @Operation(
-            summary = "Get a non-inventory product by ID",
-            description = "Retrieves a specific non-inventory product by its unique ID.")
+            operationId = "getNonInventoryProductById",
+            summary = "Get Non-Inventory Product by ID",
+            description = """
+            Returns one non-inventory product — an item sold without stock tracking, such as a fee or shop \
+            supply — with its name and descriptions.
+            Use this tool when the id is already known; use listNonInventoryProductsByName instead to find \
+            non-inventory products by exact name.
+            Preconditions: the non-inventory product must exist.
+            Required inputs: productId (UUID) as a path parameter; there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when no non-inventory product exists for the supplied id.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Successfully retrieved non-inventory product",
@@ -457,8 +757,18 @@ public class ProductController {
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/noninventory/name/{name}")
     @Operation(
-            summary = "Get non-inventory products by name",
-            description = "Retrieves a list of non-inventory products matching the given name.")
+            operationId = "listNonInventoryProductsByName",
+            summary = "List Non-Inventory Products by Name",
+            description = """
+            Returns every non-inventory product whose name equals the supplied value exactly; this is a \
+            whole-name match, not a substring search.
+            Use this tool only when the exact name is known; use getNonInventoryProductById instead when the \
+            id is available, since there is no substring search for non-inventory products.
+            Preconditions: none; an empty result simply means no non-inventory product carries that exact name.
+            Required inputs: name as a path parameter; there is no paging and no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 200 with an empty array when nothing matches, so an empty result is not an error condition.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Successfully retrieved non-inventory products",
@@ -476,9 +786,17 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW", "product:lifecycle:update"})
     @GetMapping("/{productId}/lifecycle")
-    @Operation(
-            summary = "Get product lifecycle state",
-            description = "Retrieves lifecycle state and replacement suggestions for a product.")
+    @Operation(operationId = "getProductLifecycle", summary = "Get Product Lifecycle State", description = """
+            Returns a product's lifecycle state — ACTIVE, INACTIVE or DISCONTINUED, defaulting to ACTIVE when \
+            never set — together with its effective instant, last-change audit fields and ordered replacement \
+            options.
+            Use this tool to inspect selling state before a transition; do not use updateProductLifecycle, \
+            which changes the state, and use listProductReplacements when only the replacements are needed.
+            Preconditions: the product must exist.
+            Required inputs: productId (UUID) as a path parameter; there is no request body.
+            Emits a CATALOG_PRODUCT_LIFECYCLE_GET audit event; no state changes.
+            Returns 404 when no product exists for the supplied id.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Successfully retrieved lifecycle state",
@@ -498,7 +816,19 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW", "product:lifecycle:update"})
     @GetMapping("/{productId}/replacements")
-    @Operation(summary = "List replacement products", description = "Returns replacement options for a product.")
+    @Operation(operationId = "listProductReplacements", summary = "List Replacement Products", description = """
+            Returns the non-deleted replacement options recorded for a product, ordered by priority, each \
+            with its replacement product id, notes and effective instant.
+            Use this tool to see what supersedes a discontinued product; do not use addProductReplacement, \
+            which records a new option, and use getPartSubstitutes to resolve the full substitute product \
+            records instead of the option rows.
+            Preconditions: the product must exist; replacements are normally present only on DISCONTINUED \
+            products.
+            Required inputs: productId (UUID) as a path parameter; there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when no product exists for the supplied id, and 200 with an empty array when the \
+            product has no replacements.
+            """)
     @ApiResponse(responseCode = "200", description = "Replacements listed")
     public ResponseEntity<List<ProductLifecycleResponse.ReplacementOption>> getReplacements(
             @Parameter(description = "ID of the product", required = true) @PathVariable UUID productId) {
@@ -510,9 +840,24 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT", "product:lifecycle:update"})
     @PutMapping("/{productId}/lifecycle")
-    @Operation(
-            summary = "Set product lifecycle state",
-            description = "Sets lifecycle state to ACTIVE, INACTIVE, or DISCONTINUED with effective date semantics.")
+    @Operation(operationId = "updateProductLifecycle", summary = "Set Product Lifecycle State", description = """
+            Transitions a product's lifecycle state to ACTIVE, INACTIVE or DISCONTINUED with an effective \
+            instant; discontinuation is one-way, a DISCONTINUED product can never be reactivated and callers \
+            must record a replacement via addProductReplacement instead.
+            Use this tool to change selling state; do not use updateProduct, which edits master data, and do \
+            not use deleteCatalogItem, which removes the row outright.
+            Preconditions: the product must exist and must not already be in the requested state; any \
+            transition into DISCONTINUED requires the product:lifecycle:override_discontinued authority and a \
+            non-blank overrideReason.
+            Required inputs: productId (UUID) path parameter plus lifecycleState and either effectiveAt \
+            (instant) or effectiveDate (date, resolved to UTC start of day); effectiveAt more than two \
+            seconds in the past is rejected.
+            Emits a CATALOG_PRODUCT_LIFECYCLE_UPDATE event, publishes a product fact for downstream replicas, \
+            and invalidates the product-detail cache.
+            Returns 404 when the product does not exist, 409 when attempting to leave DISCONTINUED, 403 when \
+            the discontinued-override authority is missing, and 400 when the state is unchanged, the \
+            effective time is absent or in the past, or overrideReason is missing for a discontinuation.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Lifecycle state updated successfully",
@@ -527,7 +872,21 @@ public class ProductController {
     @EmitEvent(id = "CATALOG_PRODUCT_LIFECYCLE_UPDATE", apiVersion = "1")
     public ResponseEntity<ProductLifecycleResponse> setLifecycleState(
             @Parameter(description = "ID of the product", required = true) @PathVariable UUID productId,
-            @RequestBody ProductLifecycleUpdateRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Target lifecycle state and when it takes effect; overrideReason is"
+                                    + " mandatory for transitions into DISCONTINUED.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = ProductLifecycleUpdateRequest.class),
+                                            examples = @ExampleObject(name = "Discontinue at year end", value = """
+                                                                    {"lifecycleState":"DISCONTINUED",
+                                                                     "effectiveDate":"2026-12-31",
+                                                                     "overrideReason":"Manufacturer ended production"}
+                                                                    """)))
+                    @RequestBody
+                    ProductLifecycleUpdateRequest request) {
         return ResponseEntity.ok(productLifecycleService.updateLifecycle(productId, request));
     }
 
@@ -536,16 +895,42 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT", "product:lifecycle:update"})
     @PostMapping("/{productId}/replacements")
-    @Operation(
-            summary = "Add replacement product",
-            description = "Adds a replacement suggestion to a discontinued product.")
+    @Operation(operationId = "addProductReplacement", summary = "Add Replacement Product", description = """
+            Records a replacement suggestion on a discontinued product, pointing buyers at the product that \
+            supersedes it, ordered among other options by priorityOrder.
+            Use this tool after discontinuing a product via updateProductLifecycle; do not use \
+            listProductReplacements, which only reads the recorded options.
+            Preconditions: the original product must exist and be in lifecycle state DISCONTINUED, and the \
+            replacement product must itself exist and differ from the original.
+            Required inputs: productId (UUID) path parameter plus replacementProductId (UUID) and \
+            priorityOrder greater than zero; notes are optional and effectiveAt defaults to now when omitted.
+            Emits a CATALOG_PRODUCT_REPLACEMENT_ADD event and invalidates the product-detail cache for the \
+            original product.
+            Returns 404 when the original or replacement product does not exist, 409 when the original \
+            product is not DISCONTINUED, and 400 when the replacement equals the original or priorityOrder \
+            is not positive.
+            """)
     @ApiResponse(responseCode = "201", description = "Replacement added successfully")
     @ApiResponse(responseCode = "400", description = "Validation error")
     @ApiResponse(responseCode = "404", description = "Product not found")
     @EmitEvent(id = "CATALOG_PRODUCT_REPLACEMENT_ADD", apiVersion = "1")
     public ResponseEntity<ProductLifecycleResponse.ReplacementOption> addReplacementProduct(
             @Parameter(description = "ID of discontinued product", required = true) @PathVariable UUID productId,
-            @RequestBody ProductReplacementRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Replacement suggestion pointing at the superseding product, with its"
+                                    + " ranking among other options.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = ProductReplacementRequest.class),
+                                            examples = @ExampleObject(name = "Primary replacement", value = """
+                                                                    {"replacementProductId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "priorityOrder":1,
+                                                                     "notes":"Direct successor model"}
+                                                                    """)))
+                    @RequestBody
+                    ProductReplacementRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(productLifecycleService.addReplacement(productId, request));
     }
@@ -555,9 +940,18 @@ public class ProductController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/{productId}/substitutes")
-    @Operation(
-            summary = "Get substitute parts",
-            description = "Returns list of substitute parts for a given productId.")
+    @Operation(operationId = "getPartSubstitutes", summary = "Get Substitute Parts", description = """
+            Returns the full product records of a product's recorded replacements, resolved from its \
+            replacement options in priority order with duplicates and dangling references dropped.
+            Use this tool when selling and a substitute product's details are needed directly; use \
+            listProductReplacements instead for the raw option rows with priority and notes.
+            Preconditions: the product must exist; substitutes appear only after replacements were recorded \
+            via addProductReplacement.
+            Required inputs: productId (UUID) as a path parameter; there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when no product exists for the supplied id, and 200 with an empty array when no \
+            replacement products resolve.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Substitute parts returned",

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductMsrpController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductMsrpController.java
@@ -9,6 +9,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -45,7 +46,22 @@ public class ProductMsrpController {
             name = "bearerAuth",
             scopes = {"catalog:msrp:write"})
     @PostMapping
-    @Operation(summary = "Create MSRP", description = "Creates a product MSRP record with effective date constraints.")
+    @Operation(operationId = "createProductMsrp", summary = "Create Product MSRP", description = """
+            Creates an MSRP record for a product with an effective date window; amounts are stored at four \
+            decimal places and the currency is normalised to upper case.
+            Use this tool to schedule a new list price period; do not use updateProductMsrp, which edits an \
+            existing record, and note that only one open-ended record (no effectiveEndDate) may exist per \
+            product.
+            Preconditions: the product must exist, the new window must not overlap any existing MSRP window, \
+            and no other open-ended record may exist when effectiveEndDate is omitted.
+            Required inputs: productId (UUID) path parameter plus a positive amount, a 3-letter ISO currency \
+            and effectiveStartDate; effectiveEndDate and createdByUserId are optional.
+            Emits a CATALOG_MSRP_CREATE event; the record participates in active-MSRP resolution and \
+            resolveProductPrice fallback from its start date.
+            Returns 404 when the product does not exist, 409 when the dates overlap an existing record, and \
+            400 when the amount is not positive, the currency is not a 3-letter code, the window is \
+            inverted, or a second open-ended record is attempted.
+            """)
     @ApiResponse(
             responseCode = "201",
             description = "MSRP created",
@@ -56,7 +72,22 @@ public class ProductMsrpController {
     @EmitEvent(id = "CATALOG_MSRP_CREATE", apiVersion = "1")
     public ResponseEntity<ProductMsrpDto> createMsrp(
             @Parameter(required = true) @PathVariable UUID productId,
-            @Valid @RequestBody CreateMsrpRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "New MSRP window: amount, ISO currency and effective dates; omit"
+                                    + " effectiveEndDate for an open-ended price.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = CreateMsrpRequestDto.class),
+                                            examples = @ExampleObject(name = "Open-ended MSRP", value = """
+                                                                    {"amount":149.9900,"currency":"USD",
+                                                                     "effectiveStartDate":"2026-09-01",
+                                                                     "createdByUserId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CreateMsrpRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(productMsrpService.createMsrp(productId, request));
     }
 
@@ -65,7 +96,21 @@ public class ProductMsrpController {
             name = "bearerAuth",
             scopes = {"catalog:msrp:write"})
     @PutMapping("/{msrpId}")
-    @Operation(summary = "Update MSRP", description = "Updates a non-historical MSRP record.")
+    @Operation(operationId = "updateProductMsrp", summary = "Update Product MSRP", description = """
+            Rewrites a current or future MSRP record's amount, currency and effective window; records whose \
+            window already ended are immutable history.
+            Use this tool to correct or reschedule an existing record; do not use createProductMsrp, which \
+            adds a new window alongside the existing ones.
+            Preconditions: the record must exist, belong to the given product, and not have an \
+            effectiveEndDate in the past; a version in the body must match the record's current version, and \
+            the new window must not overlap other records.
+            Required inputs: productId and msrpId (UUIDs) path parameters plus a positive amount, a 3-letter \
+            ISO currency and effectiveStartDate; version is optional but recommended.
+            Emits a CATALOG_MSRP_UPDATE event; active-MSRP resolution reflects the change immediately.
+            Returns 404 when the record does not exist under that product, 409 when the version mismatches \
+            or the dates overlap another record, and 400 when the record is historical or the amount, \
+            currency or window is invalid.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "MSRP updated",
@@ -78,7 +123,25 @@ public class ProductMsrpController {
     public ResponseEntity<ProductMsrpDto> updateMsrp(
             @Parameter(required = true) @PathVariable UUID productId,
             @Parameter(required = true) @PathVariable UUID msrpId,
-            @Valid @RequestBody UpdateMsrpRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Replacement amount, currency and effective window for the record;"
+                                    + " include version to guard against concurrent edits.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = UpdateMsrpRequestDto.class),
+                                            examples =
+                                                    @ExampleObject(name = "Reprice with version guard", value = """
+                                                                    {"amount":139.9900,"currency":"USD",
+                                                                     "effectiveStartDate":"2026-09-01",
+                                                                     "effectiveEndDate":"2026-12-31",
+                                                                     "createdByUserId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "version":0}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    UpdateMsrpRequestDto request) {
         return ResponseEntity.ok(productMsrpService.updateMsrp(productId, msrpId, request));
     }
 
@@ -87,7 +150,16 @@ public class ProductMsrpController {
             name = "bearerAuth",
             scopes = {"catalog:msrp:read"})
     @GetMapping("/active")
-    @Operation(summary = "Get active MSRP", description = "Returns MSRP active for the provided asOf date (or today).")
+    @Operation(operationId = "getActiveProductMsrp", summary = "Get Active Product MSRP", description = """
+            Returns the single MSRP record whose effective window covers the requested date.
+            Use this tool to read the list price in force on a date; use listProductMsrpHistory instead to \
+            see every past and scheduled record.
+            Preconditions: the product must exist and an MSRP window must cover the date.
+            Required inputs: productId (UUID) path parameter; asOf is an optional ISO date defaulting to \
+            today.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when the product does not exist or no MSRP window covers the requested date.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Active MSRP returned",
@@ -108,7 +180,17 @@ public class ProductMsrpController {
             name = "bearerAuth",
             scopes = {"catalog:msrp:read"})
     @GetMapping
-    @Operation(summary = "List MSRP history", description = "Returns all MSRP records for a product.")
+    @Operation(operationId = "listProductMsrpHistory", summary = "List Product MSRP History", description = """
+            Returns every MSRP record for a product — past, current and scheduled — ordered by effective \
+            start date, newest first.
+            Use this tool to audit price history or find an msrpId to edit; use getActiveProductMsrp instead \
+            for just the record in force on a date.
+            Preconditions: the product must exist.
+            Required inputs: productId (UUID) as a path parameter; there is no filtering or paging.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when the product does not exist, and 200 with an empty array when it has no MSRP \
+            records.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "MSRP records returned",

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductUomController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductUomController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,11 +44,21 @@ public class ProductUomController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PostMapping
-    @Operation(
-            summary = "Add product UoM conversion",
-            description = "Adds a purchase/pack (or base) UoM with its conversion factor to the product's base UoM"
-                    + " and a precision scale. Re-emits the product contract event.",
-            operationId = "addProductUom")
+    @Operation(operationId = "addProductUom", summary = "Add Product UoM Conversion", description = """
+            Adds a unit-of-measure entry to a product's conversion set, binding a UoM code to its factor \
+            relative to the product's base unit; the code is normalised to upper case and the factor stored \
+            at six decimal places.
+            Use this tool to define how a purchase or pack unit converts for one product; do not use \
+            createUomConversion, which defines global cross-unit conversions not tied to a product.
+            Preconditions: the product must exist and must not already define the UoM code; a BASE-type entry \
+            must carry factorToBase exactly 1.
+            Required inputs: productId (UUID) path parameter plus uomCode, uomType (BASE, PURCHASE or PACK) \
+            and a positive factorToBase; precisionScale is optional.
+            Emits a CATALOG_PRODUCT_UOM_CREATE event and re-publishes the product fact with a bumped \
+            aggregate version so downstream replicas refresh.
+            Returns 404 when the product does not exist, 409 when the UoM code is already defined for the \
+            product, and 400 when factorToBase is not positive or a BASE entry's factor is not 1.
+            """)
     @ApiResponse(
             responseCode = "201",
             description = "Product UoM created",
@@ -58,7 +69,21 @@ public class ProductUomController {
     @EmitEvent(id = "CATALOG_PRODUCT_UOM_CREATE", apiVersion = "1")
     public ResponseEntity<ProductUomDto> addProductUom(
             @Parameter(description = "Product ID", required = true) @PathVariable UUID productId,
-            @Valid @RequestBody ProductUomCreateRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "UoM entry to add: the code, its role for this product, and how many"
+                                    + " base units one such unit represents.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = ProductUomCreateRequestDto.class),
+                                            examples = @ExampleObject(name = "Case of twelve", value = """
+                                                                    {"uomCode":"CS12","uomType":"PACK",
+                                                                     "factorToBase":12,"precisionScale":0}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    ProductUomCreateRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(productUomService.addProductUom(productId, request));
     }
 
@@ -67,10 +92,17 @@ public class ProductUomController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping
-    @Operation(
-            summary = "List product UoM conversions",
-            description = "Returns the product's UoM conversion set ordered by UoM code.",
-            operationId = "listProductUoms")
+    @Operation(operationId = "listProductUoms", summary = "List Product UoM Conversions", description = """
+            Returns the product's unit-of-measure conversion set ordered by UoM code, each entry carrying its \
+            type, factor to base and precision scale.
+            Use this tool to read a product's unit conversions; use listUomConversions instead for the \
+            global, product-independent conversion table.
+            Preconditions: the product must exist.
+            Required inputs: productId (UUID) as a path parameter; there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when the product does not exist, and 200 with an empty array when the product \
+            defines no UoM entries.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Product UoMs listed",
@@ -89,11 +121,20 @@ public class ProductUomController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PutMapping("/{uomId}")
-    @Operation(
-            summary = "Update product UoM conversion",
-            description = "Updates factor, precision scale, and optionally the UoM role. The UoM code is immutable."
-                    + " Re-emits the product contract event.",
-            operationId = "updateProductUom")
+    @Operation(operationId = "updateProductUom", summary = "Update Product UoM Conversion", description = """
+            Updates the conversion factor, precision scale and optionally the type of one product UoM entry; \
+            the UoM code itself is immutable.
+            Use this tool to correct a factor or reclassify an entry; do not use addProductUom, which adds a \
+            new code, or deleteProductUom, which removes one.
+            Preconditions: the product must exist and the UoM entry must belong to it; changing the type to \
+            BASE requires factorToBase exactly 1, and omitting uomType keeps the current type.
+            Required inputs: productId and uomId (UUIDs) path parameters plus a positive factorToBase; \
+            uomType and precisionScale are optional.
+            Emits a CATALOG_PRODUCT_UOM_UPDATE event and re-publishes the product fact with a bumped \
+            aggregate version so downstream replicas refresh.
+            Returns 404 when the product or the UoM entry does not exist under that product, and 400 when \
+            factorToBase is not positive or a BASE entry's factor is not 1.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Product UoM updated",
@@ -104,7 +145,20 @@ public class ProductUomController {
     public ResponseEntity<ProductUomDto> updateProductUom(
             @Parameter(description = "Product ID", required = true) @PathVariable UUID productId,
             @Parameter(description = "Product UoM ID", required = true) @PathVariable UUID uomId,
-            @Valid @RequestBody ProductUomUpdateRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Replacement factor and precision for the entry; uomType is optional"
+                                    + " and keeps the current role when omitted.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = ProductUomUpdateRequestDto.class),
+                                            examples = @ExampleObject(name = "Correct pack factor", value = """
+                                                                    {"uomType":"PACK","factorToBase":24,"precisionScale":0}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    ProductUomUpdateRequestDto request) {
         return ResponseEntity.ok(productUomService.updateProductUom(productId, uomId, request));
     }
 
@@ -113,10 +167,19 @@ public class ProductUomController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @DeleteMapping("/{uomId}")
-    @Operation(
-            summary = "Delete product UoM conversion",
-            description = "Removes a UoM from the product's conversion set and re-emits the product contract event.",
-            operationId = "deleteProductUom")
+    @Operation(operationId = "deleteProductUom", summary = "Delete Product UoM Conversion", description = """
+            Removes one unit-of-measure entry from a product's conversion set permanently; there is no soft \
+            delete.
+            Use this tool when a purchase or pack unit no longer applies to the product; do not use \
+            updateProductUom, which changes an entry's factor or type while keeping it.
+            Preconditions: the product must exist and the UoM entry must belong to it; no guard prevents \
+            deleting the BASE entry, so callers must not orphan the conversion set.
+            Required inputs: productId and uomId (UUIDs) as path parameters; there is no request body.
+            Emits a CATALOG_PRODUCT_UOM_DELETE event and re-publishes the product fact with a bumped \
+            aggregate version so downstream replicas refresh.
+            Returns 204 on success, and 404 when the product or the UoM entry does not exist under that \
+            product.
+            """)
     @ApiResponse(responseCode = "204", description = "Product UoM deleted")
     @ApiResponse(responseCode = "404", description = "Product or UoM not found")
     @EmitEvent(id = "CATALOG_PRODUCT_UOM_DELETE", apiVersion = "1")

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/SubstitutionGroupController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/SubstitutionGroupController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,10 +43,19 @@ public class SubstitutionGroupController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PostMapping
-    @Operation(
-            summary = "Create substitution group",
-            description = "Creates an empty substitution group; add members afterwards.",
-            operationId = "createSubstitutionGroup")
+    @Operation(operationId = "createSubstitutionGroup", summary = "Create Substitution Group", description = """
+            Creates an empty, named substitution group — a set of mutually interchangeable products in which \
+            each product may belong to at most one group.
+            Use this tool to establish the group before populating it; do not use \
+            addSubstitutionGroupMember, which adds products to a group that already exists, and do not \
+            confuse groups with addProductReplacement, which records one-way successors for discontinued \
+            products.
+            Preconditions: none; group names are not checked for uniqueness.
+            Required inputs: name (non-blank, trimmed on save); notes are optional.
+            Emits a CATALOG_SUBSTITUTION_GROUP_CREATE event; no product facts are re-published until members \
+            are added.
+            Returns 201 with the group and an empty productIds list, and 400 when name is missing or blank.
+            """)
     @ApiResponse(
             responseCode = "201",
             description = "Substitution group created",
@@ -56,7 +66,20 @@ public class SubstitutionGroupController {
     @ApiResponse(responseCode = "400", description = "Validation error")
     @EmitEvent(id = "CATALOG_SUBSTITUTION_GROUP_CREATE", apiVersion = "1")
     public ResponseEntity<SubstitutionGroupDto> createGroup(
-            @Valid @RequestBody SubstitutionGroupCreateRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Name and optional notes for the new interchangeability group.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = SubstitutionGroupCreateRequestDto.class),
+                                            examples = @ExampleObject(name = "Oil filter group", value = """
+                                                                    {"name":"Oil Filters PH3593A-Compatible",
+                                                                     "notes":"Cross-brand equivalents for PH3593A fitment"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    SubstitutionGroupCreateRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(substitutionGroupService.createGroup(request));
     }
 
@@ -65,10 +88,17 @@ public class SubstitutionGroupController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping
-    @Operation(
-            summary = "List substitution groups",
-            description = "Returns all substitution groups with their member product ids.",
-            operationId = "listSubstitutionGroups")
+    @Operation(operationId = "listSubstitutionGroups", summary = "List Substitution Groups", description = """
+            Returns every substitution group with its name, notes and member product ids ordered by when \
+            each member joined.
+            Use this tool to discover a groupId or survey interchangeability sets; use getSubstitutionGroup \
+            instead when the id is already known.
+            Preconditions: none; the list is unfiltered and unpaged.
+            Required inputs: none, and there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 200 with an empty array when no groups exist, so an empty result is not an error \
+            condition.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Substitution groups listed",
@@ -85,10 +115,16 @@ public class SubstitutionGroupController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/{groupId}")
-    @Operation(
-            summary = "Get substitution group",
-            description = "Retrieves a substitution group with its member product ids.",
-            operationId = "getSubstitutionGroup")
+    @Operation(operationId = "getSubstitutionGroup", summary = "Get Substitution Group", description = """
+            Returns one substitution group with its name, notes and member product ids ordered by when each \
+            member joined.
+            Use this tool when the groupId is already known; use listSubstitutionGroups instead to discover \
+            groups.
+            Preconditions: the group must exist.
+            Required inputs: groupId (UUID) as a path parameter; there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when no substitution group exists for the supplied id.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Substitution group found",
@@ -107,11 +143,17 @@ public class SubstitutionGroupController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @DeleteMapping("/{groupId}")
-    @Operation(
-            summary = "Delete substitution group",
-            description = "Deletes a group and its memberships, re-emitting the product contract event"
-                    + " for every former member.",
-            operationId = "deleteSubstitutionGroup")
+    @Operation(operationId = "deleteSubstitutionGroup", summary = "Delete Substitution Group", description = """
+            Deletes a substitution group and all of its memberships permanently, freeing every former member \
+            to join another group; the products themselves are untouched.
+            Use this tool to dissolve a whole group; use removeSubstitutionGroupMember instead to take a \
+            single product out while keeping the group.
+            Preconditions: the group must exist; there is no soft delete or archive.
+            Required inputs: groupId (UUID) as a path parameter; there is no request body.
+            Emits a CATALOG_SUBSTITUTION_GROUP_DELETE event and re-publishes the product fact for every \
+            former member so downstream replicas drop the association.
+            Returns 204 on success, and 404 when no substitution group exists for the supplied id.
+            """)
     @ApiResponse(responseCode = "204", description = "Substitution group deleted")
     @ApiResponse(responseCode = "404", description = "Substitution group not found")
     @EmitEvent(id = "CATALOG_SUBSTITUTION_GROUP_DELETE", apiVersion = "1")
@@ -126,11 +168,19 @@ public class SubstitutionGroupController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PostMapping("/{groupId}/members")
-    @Operation(
-            summary = "Add product to substitution group",
-            description = "Adds a product to the group (a product belongs to at most one group) and re-emits the"
-                    + " product contract event for every member.",
-            operationId = "addSubstitutionGroupMember")
+    @Operation(operationId = "addSubstitutionGroupMember", summary = "Add Substitution Group Member", description = """
+            Adds a product to a substitution group, making it mutually interchangeable with every other \
+            member; membership is exclusive, a product can belong to only one group at a time.
+            Use this tool to grow an interchangeability set; do not use addProductReplacement, which records \
+            a one-way successor for a discontinued product rather than a symmetric substitute.
+            Preconditions: the group and the product must both exist, and the product must not already \
+            belong to any substitution group, including this one.
+            Required inputs: groupId (UUID) path parameter and productId (UUID) in the body.
+            Emits a CATALOG_SUBSTITUTION_GROUP_MEMBER_ADD event and re-publishes the product fact for every \
+            member of the group so downstream replicas learn the new association.
+            Returns 404 when the group or the product does not exist, and 409 when the product already \
+            belongs to a substitution group.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Member added",
@@ -144,7 +194,19 @@ public class SubstitutionGroupController {
     @EmitEvent(id = "CATALOG_SUBSTITUTION_GROUP_MEMBER_ADD", apiVersion = "1")
     public ResponseEntity<SubstitutionGroupDto> addMember(
             @Parameter(description = "Substitution group ID", required = true) @PathVariable UUID groupId,
-            @Valid @RequestBody SubstitutionGroupMemberRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The product to add as an interchangeable member of the group.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = SubstitutionGroupMemberRequestDto.class),
+                                            examples = @ExampleObject(name = "Add product", value = """
+                                                                    {"productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    SubstitutionGroupMemberRequestDto request) {
         return ResponseEntity.ok(substitutionGroupService.addMember(groupId, request));
     }
 
@@ -154,10 +216,21 @@ public class SubstitutionGroupController {
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @DeleteMapping("/{groupId}/members/{productId}")
     @Operation(
-            summary = "Remove product from substitution group",
-            description = "Removes a product from the group and re-emits the product contract event for the removed"
-                    + " product and every remaining member.",
-            operationId = "removeSubstitutionGroupMember")
+            operationId = "removeSubstitutionGroupMember",
+            summary = "Remove Substitution Group Member",
+            description = """
+            Removes a product from a substitution group, ending its interchangeability with the remaining \
+            members and freeing it to join another group.
+            Use this tool to take one product out; use deleteSubstitutionGroup instead to dissolve the \
+            entire group at once.
+            Preconditions: the group must exist and the product must currently be a member of that specific \
+            group.
+            Required inputs: groupId and productId (UUIDs) as path parameters; there is no request body.
+            Emits a CATALOG_SUBSTITUTION_GROUP_MEMBER_REMOVE event and re-publishes the product fact for the \
+            removed product and every remaining member.
+            Returns 200 with the group's remaining membership, and 404 when the group does not exist or the \
+            product is not a member of it.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Member removed",

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/SupplierItemCostController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/SupplierItemCostController.java
@@ -8,6 +8,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,10 +42,21 @@ public class SupplierItemCostController {
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"catalog:supplier_cost:write"})
-    @Operation(
-            summary = "Create supplier cost structure",
-            description =
-                    "Creates a supplier-specific item cost structure with the submitted supplier, item, and tier details.")
+    @Operation(operationId = "createSupplierItemCost", summary = "Create Supplier Cost Structure", description = """
+            Creates the cost structure one supplier charges for one item: a base cost plus optional volume \
+            tiers, unique per supplier and item pair.
+            Use this tool to record supplier purchasing costs; do not use updateStandardItemCost, which sets \
+            the item's internal standard cost, and use updateSupplierItemCost to change a structure that \
+            already exists.
+            Preconditions: no cost structure may already exist for the supplier and item pair; tiers, when \
+            supplied, must start at minQuantity 1, be contiguous and non-overlapping, and only the final \
+            tier may leave maxQuantity null, which it must.
+            Required inputs: supplierId (UUID), itemId (UUID) and a 3-letter currencyCode; baseCost is \
+            optional but cannot be negative, and each tier needs minQuantity and a positive unitCost.
+            Emits a CATALOG_SUPPLIER_COST_CREATE event; no item or catalog pricing records are touched.
+            Returns 409 when a structure already exists for the supplier and item pair, and 400 when the \
+            currency code is invalid or the tier structure violates the contiguity rules.
+            """)
     @ApiResponse(
             responseCode = "201",
             description = "Created",
@@ -56,7 +68,25 @@ public class SupplierItemCostController {
     @ApiResponse(responseCode = "409", description = "Duplicate supplier and item combination")
     @EmitEvent(id = "CATALOG_SUPPLIER_COST_CREATE", apiVersion = "1")
     public ResponseEntity<SupplierItemCostDto> createCostStructure(
-            @Valid @RequestBody SupplierItemCostCreateRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Cost structure for one supplier and item pair: base cost plus contiguous"
+                                    + " volume tiers whose final tier is open-ended.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = SupplierItemCostCreateRequestDto.class),
+                                            examples = @ExampleObject(name = "Two-tier structure", value = """
+                                                                    {"supplierId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "itemId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "currencyCode":"USD","baseCost":10.50,
+                                                                     "tiers":[
+                                                                       {"minQuantity":1,"maxQuantity":49,"unitCost":10.50},
+                                                                       {"minQuantity":50,"maxQuantity":null,"unitCost":9.25}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    SupplierItemCostCreateRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(supplierItemCostService.createCostStructure(request));
     }
 
@@ -65,9 +95,16 @@ public class SupplierItemCostController {
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"catalog:supplier_cost:read"})
-    @Operation(
-            summary = "Get supplier cost structure",
-            description = "Returns the supplier item cost structure identified by the supplied cost structure ID.")
+    @Operation(operationId = "getSupplierItemCost", summary = "Get Supplier Cost Structure", description = """
+            Returns one supplier item cost structure with its base cost and volume tiers sorted by minimum \
+            quantity.
+            Use this tool when the cost structure id is already known; use listSupplierItemCosts instead to \
+            find structures by itemId or supplierId.
+            Preconditions: the cost structure must exist.
+            Required inputs: id (UUID) as a path parameter; there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when no cost structure exists for the supplied id.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Found",
@@ -85,9 +122,21 @@ public class SupplierItemCostController {
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"catalog:supplier_cost:write"})
-    @Operation(
-            summary = "Update supplier cost structure",
-            description = "Updates the supplier item cost structure identified by the supplied cost structure ID.")
+    @Operation(operationId = "updateSupplierItemCost", summary = "Update Supplier Cost Structure", description = """
+            Replaces a supplier item cost structure wholesale — supplier, item, currency, base cost and the \
+            entire tier list are overwritten with the submitted values.
+            Use this tool to reprice or re-tier an existing structure; do not use createSupplierItemCost, \
+            which adds a structure for a pair that has none yet.
+            Preconditions: the structure must exist, and repointing it at a different supplier and item pair \
+            must not collide with another structure for that pair; tiers follow the same contiguity rules as \
+            creation.
+            Required inputs: id (UUID) path parameter plus supplierId, itemId and a 3-letter currencyCode; \
+            the tier list submitted replaces the previous one entirely.
+            Emits a CATALOG_SUPPLIER_COST_UPDATE event; no item or catalog pricing records are touched.
+            Returns 404 when no cost structure exists for the supplied id, 409 when the supplier and item \
+            pair collides with another structure, and 400 when the currency code or tier structure is \
+            invalid.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Updated",
@@ -99,7 +148,24 @@ public class SupplierItemCostController {
     @EmitEvent(id = "CATALOG_SUPPLIER_COST_UPDATE", apiVersion = "1")
     public ResponseEntity<SupplierItemCostDto> updateCostStructure(
             @Parameter(required = true) @PathVariable UUID id,
-            @Valid @RequestBody SupplierItemCostUpdateRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement of the structure; the submitted tier list overwrites"
+                                    + " the stored tiers entirely.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = SupplierItemCostUpdateRequestDto.class),
+                                            examples = @ExampleObject(name = "Reprice base cost", value = """
+                                                                    {"supplierId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "itemId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "currencyCode":"USD","baseCost":11.00,
+                                                                     "tiers":[
+                                                                       {"minQuantity":1,"maxQuantity":null,"unitCost":11.00}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    SupplierItemCostUpdateRequestDto request) {
         return ResponseEntity.ok(supplierItemCostService.updateCostStructure(id, request));
     }
 
@@ -108,9 +174,16 @@ public class SupplierItemCostController {
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"catalog:supplier_cost:write"})
-    @Operation(
-            summary = "Delete supplier cost structure",
-            description = "Deletes the supplier item cost structure identified by the supplied cost structure ID.")
+    @Operation(operationId = "deleteSupplierItemCost", summary = "Delete Supplier Cost Structure", description = """
+            Permanently deletes a supplier item cost structure and its volume tiers; there is no soft delete \
+            or history.
+            Use this tool when a supplier no longer offers the item; use updateSupplierItemCost instead to \
+            change prices while keeping the structure.
+            Preconditions: the cost structure must exist.
+            Required inputs: id (UUID) as a path parameter; there is no request body.
+            Emits a CATALOG_SUPPLIER_COST_DELETE event; item costs recorded elsewhere are unaffected.
+            Returns 204 on success, and 404 when no cost structure exists for the supplied id.
+            """)
     @ApiResponse(responseCode = "204", description = "Deleted")
     @ApiResponse(responseCode = "404", description = "Not found")
     @EmitEvent(id = "CATALOG_SUPPLIER_COST_DELETE", apiVersion = "1")

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/SupplierItemCostListController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/SupplierItemCostListController.java
@@ -36,10 +36,19 @@ public class SupplierItemCostListController {
             name = "bearerAuth",
             scopes = {"catalog:supplier_cost:read"})
     @EmitEvent(id = "CATALOG_SUPPLIER_COST_LIST", apiVersion = "1")
-    @Operation(
-            summary = "List supplier cost structures",
-            description =
-                    "Returns a paginated list of supplier cost structures. At least one of itemId or supplierId must be provided.")
+    @Operation(operationId = "listSupplierItemCosts", summary = "List Supplier Cost Structures", description = """
+            Returns a page of supplier item cost structures filtered by item, by supplier, or by both \
+            combined with AND semantics.
+            Use this tool to find which suppliers price an item or which items a supplier prices; use \
+            getSupplierItemCost instead when the structure id is already known.
+            Preconditions: at least one of itemId or supplierId must be supplied; an unfiltered listing is \
+            deliberately not offered.
+            Required inputs: itemId or supplierId (UUIDs) as query parameters, plus standard Spring page, \
+            size and sort parameters.
+            Emits a CATALOG_SUPPLIER_COST_LIST audit event; no cost data changes.
+            Returns 400 when neither itemId nor supplierId is provided, and 200 with an empty page when the \
+            filters match nothing.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "OK",

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/UomConversionController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/UomConversionController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,10 +42,20 @@ public class UomConversionController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PostMapping
-    @Operation(
-            summary = "Create UOM conversion",
-            description = "Creates a new unit-of-measure conversion record.",
-            operationId = "createUomConversion")
+    @Operation(operationId = "createUomConversion", summary = "Create UoM Conversion", description = """
+            Creates a global, directional unit-of-measure conversion stating how many target units one \
+            source unit represents; codes are normalised to upper case and the factor stored at six decimal \
+            places.
+            Use this tool for conversions that apply across the whole catalog; do not use addProductUom, \
+            which defines a conversion for a single product's own unit set.
+            Preconditions: no active conversion may already exist for the same from and to code pair; a \
+            self-conversion (same code both sides) must carry factor 1.
+            Required inputs: fromUomCode, toUomCode and a positive conversionFactor; createdBy is optional.
+            Emits a CATALOG_UOM_CONVERSION_CREATE event; the reverse direction is derived at read time, not \
+            stored.
+            Returns 409 when an active conversion already exists for the pair, and 400 when either code is \
+            blank, the factor is not positive, or a self-conversion factor is not 1.
+            """)
     @ApiResponse(
             responseCode = "201",
             description = "Conversion created",
@@ -52,7 +63,22 @@ public class UomConversionController {
                     @Content(mediaType = "application/json", schema = @Schema(implementation = UomConversionDto.class)))
     @ApiResponse(responseCode = "400", description = "Invalid request")
     @EmitEvent(id = "CATALOG_UOM_CONVERSION_CREATE", apiVersion = "1")
-    public ResponseEntity<UomConversionDto> create(@Valid @RequestBody UomConversionCreateRequestDto request) {
+    public ResponseEntity<UomConversionDto> create(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Directional conversion pair with the factor of target units per one"
+                                    + " source unit.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = UomConversionCreateRequestDto.class),
+                                            examples = @ExampleObject(name = "Case to each", value = """
+                                                                    {"fromUomCode":"CS","toUomCode":"EA",
+                                                                     "conversionFactor":12,"createdBy":"catalog-admin"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    UomConversionCreateRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(uomConversionService.createConversion(request));
     }
 
@@ -61,10 +87,17 @@ public class UomConversionController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping
-    @Operation(
-            summary = "List active conversions",
-            description = "Returns all active unit-of-measure conversion records.",
-            operationId = "listUomConversions")
+    @Operation(operationId = "listUomConversions", summary = "List Active UoM Conversions", description = """
+            Returns every active unit-of-measure conversion in the global table; deactivated conversions are \
+            excluded.
+            Use this tool to survey available conversions or find a conversion id; use getUomConversionById \
+            instead when the id is already known, and listProductUoms for a product's own unit set.
+            Preconditions: none; the list is unfiltered and unpaged.
+            Required inputs: none, and there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 200 with an empty array when no active conversions exist, so an empty result is not an \
+            error condition.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Conversions listed",
@@ -81,10 +114,16 @@ public class UomConversionController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
     @GetMapping("/{id}")
-    @Operation(
-            summary = "Get conversion",
-            description = "Retrieves a unit-of-measure conversion by its ID.",
-            operationId = "getUomConversionById")
+    @Operation(operationId = "getUomConversionById", summary = "Get UoM Conversion by ID", description = """
+            Returns one unit-of-measure conversion with its from and to codes, factor and active flag; \
+            inactive conversions are returned here even though listUomConversions hides them.
+            Use this tool when the conversion id is already known; use listUomConversions instead to browse \
+            the active table.
+            Preconditions: the conversion must exist.
+            Required inputs: id (UUID) as a path parameter; there is no request body.
+            No events are emitted and no state changes; this is a read-only projection.
+            Returns 404 when no conversion exists for the supplied id.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Conversion found",
@@ -100,10 +139,19 @@ public class UomConversionController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PutMapping("/{id}")
-    @Operation(
-            summary = "Update conversion factor",
-            description = "Updates the conversion factor and mutable fields for an existing conversion.",
-            operationId = "updateUomConversion")
+    @Operation(operationId = "updateUomConversion", summary = "Update UoM Conversion Factor", description = """
+            Updates the factor of an existing unit-of-measure conversion; the from and to codes are immutable, \
+            so redefining a pair means deactivating this conversion and creating a new one.
+            Use this tool to correct a factor; do not use createUomConversion, which adds a new pair, or \
+            deactivateUomConversion, which retires one.
+            Preconditions: the conversion must exist; a self-conversion must keep factor 1.
+            Required inputs: id (UUID) path parameter and a positive conversionFactor in the body, stored at \
+            six decimal places.
+            Emits a CATALOG_UOM_CONVERSION_UPDATE event; derived inverse factors reflect the change \
+            immediately.
+            Returns 404 when no conversion exists for the supplied id, and 400 when the factor is not \
+            positive or a self-conversion factor is not 1.
+            """)
     @ApiResponse(
             responseCode = "200",
             description = "Conversion updated",
@@ -114,7 +162,19 @@ public class UomConversionController {
     @EmitEvent(id = "CATALOG_UOM_CONVERSION_UPDATE", apiVersion = "1")
     public ResponseEntity<UomConversionDto> update(
             @Parameter(description = "Conversion ID") @PathVariable UUID id,
-            @Valid @RequestBody UomConversionUpdateRequestDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The corrected conversion factor for the existing from/to pair.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = UomConversionUpdateRequestDto.class),
+                                            examples = @ExampleObject(name = "Correct factor", value = """
+                                                                    {"conversionFactor":24}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    UomConversionUpdateRequestDto request) {
         return ResponseEntity.ok(uomConversionService.updateConversion(id, request));
     }
 
@@ -123,10 +183,18 @@ public class UomConversionController {
             name = "bearerAuth",
             scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @DeleteMapping("/{id}")
-    @Operation(
-            summary = "Deactivate conversion",
-            description = "Deactivates a conversion so it is excluded from active conversion results.",
-            operationId = "deactivateUomConversion")
+    @Operation(operationId = "deactivateUomConversion", summary = "Deactivate UoM Conversion", description = """
+            Marks a unit-of-measure conversion inactive so it disappears from listUomConversions and from \
+            factor lookups; the row is kept and remains readable by id.
+            Use this tool to retire a conversion pair; do not use updateUomConversion, which changes the \
+            factor while keeping it active — there is no reactivation endpoint, so recreate the pair with \
+            createUomConversion if it is needed again.
+            Preconditions: the conversion must exist; deactivating an already inactive conversion succeeds \
+            idempotently.
+            Required inputs: id (UUID) as a path parameter; there is no request body.
+            Emits a CATALOG_UOM_CONVERSION_DEACTIVATE event; product-level UoM sets are unaffected.
+            Returns 204 on success, and 404 when no conversion exists for the supplied id.
+            """)
     @ApiResponse(responseCode = "204", description = "Conversion deactivated")
     @ApiResponse(responseCode = "404", description = "Conversion not found")
     @EmitEvent(id = "CATALOG_UOM_CONVERSION_DEACTIVATE", apiVersion = "1")

--- a/pos-customer/openapi.yaml
+++ b/pos-customer/openapi.yaml
@@ -55,8 +55,20 @@ paths:
     get:
       tags:
       - Customer API
-      summary: Get customer by ID
-      description: Retrieve a customer by their unique ID.
+      summary: Get Customer By Id
+      description: 'Returns one customer as a flat CustomerDTO, checking commercial parties first and falling back to person parties.
+
+        Use this tool for the legacy flat customer view; use getParty or getSnapshotByParty instead for the richer party projections.
+
+        Preconditions: a commercial or person party must exist for the supplied id.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when neither a commercial nor a person party exists for the supplied id.
+
+        '
       operationId: getCustomerById
       parameters:
       - name: id
@@ -88,8 +100,20 @@ paths:
     put:
       tags:
       - Customer API
-      summary: Update an existing customer
-      description: Update the details of an existing customer.
+      summary: Update Customer Record
+      description: 'Updates an existing customer''s flat record, with the body''s customerType selecting whether the commercial or person store is searched for the id.
+
+        Use this tool only for the legacy flat customer API; the customerType in the body must match the store the customer actually lives in, or the lookup misses, so do not use it to change a customer from PERSON to COMMERCIAL.
+
+        Preconditions: a party of the type named by customerType must exist for the supplied id.
+
+        Required inputs: id (UUID) as a path parameter and the CustomerDTO body including customerType; only fields present in the DTO mapping are applied.
+
+        Emits a CUSTOMER_CUSTOMER_UPDATE event and publishes a party-changed customer fact.
+
+        Returns 404 when no party of the selected type exists for the supplied id.
+
+        '
       operationId: updateCustomer
       parameters:
       - name: id
@@ -101,10 +125,19 @@ paths:
           format: uuid
         example: 123e4567-e89b-12d3-a456-426614174000
       requestBody:
+        description: The revised customer fields; customerType must name the store the customer already lives in.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CustomerDTO'
+            examples:
+              Update address:
+                description: Update address
+                value:
+                  firstName: Dana
+                  lastName: Ortiz
+                  customerType: PERSON
+                  primaryAddress: 200 Lavaca St, Austin, TX 78701
         required: true
       responses:
         '200':
@@ -127,8 +160,20 @@ paths:
     delete:
       tags:
       - Customer API
-      summary: Delete a customer
-      description: Delete a customer by their unique ID.
+      summary: Delete Customer Record
+      description: 'Hard-deletes a customer row, trying the commercial store first and then the person store, and publishes a party-deleted fact for the removed record.
+
+        Use this tool only when a customer record must be physically removed; do not use it for duplicates — use mergeParties instead, whose MERGED status preserves history, since this deletion is not reversible.
+
+        Preconditions: a commercial or person party must exist for the supplied id.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a CUSTOMER_CUSTOMER_DELETE event and publishes a party-deleted customer fact.
+
+        Returns 404 when neither store holds a party for the supplied id.
+
+        '
       operationId: deleteCustomer
       parameters:
       - name: id
@@ -153,8 +198,20 @@ paths:
     get:
       tags:
       - CRM Tags
-      summary: Get tag
-      description: Retrieve a single tag by id
+      summary: Get Tag By Id
+      description: 'Returns one catalog tag with its name, category, color, active flag, and assignment count.
+
+        Use this tool when the tag id is already known; use listTags instead to browse the catalog.
+
+        Preconditions: the tag must exist in the catalog.
+
+        Required inputs: tagId (UUID) as a path parameter; there is no request body.
+
+        Emits a CRM_TAG_GET audit event; no state changes occur.
+
+        Returns 404 when no tag exists for the supplied tagId.
+
+        '
       operationId: getTag
       parameters:
       - name: tagId
@@ -182,8 +239,20 @@ paths:
     put:
       tags:
       - CRM Tags
-      summary: Update tag
-      description: Rename, recolour, recategorize, or retire a tag
+      summary: Update Catalog Tag
+      description: 'Renames, recolours, recategorizes, or retires a catalog tag; setting active false stops new assignments while keeping existing ones.
+
+        Use this tool when changing how a tag looks or retiring it; use deleteTag instead to remove the tag and every assignment of it.
+
+        Preconditions: the tag must exist, and the new name must not collide with another tag case-insensitively.
+
+        Required inputs: tagId (UUID) as a path parameter and name in the body; category, color, and active are optional.
+
+        Emits a CRM_TAG_UPDATE event; existing assignments are untouched.
+
+        Returns 404 when the tag does not exist, and 409 when the new name is already taken.
+
+        '
       operationId: updateTag
       parameters:
       - name: tagId
@@ -193,10 +262,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The revised tag attributes; omitted optional fields are cleared or left defaulted.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpsertPartyTagRequest'
+            examples:
+              Retire tag:
+                description: Retire tag
+                value:
+                  name: Fleet VIP
+                  category: Loyalty
+                  active: false
         required: true
       responses:
         '200':
@@ -219,8 +296,20 @@ paths:
     delete:
       tags:
       - CRM Tags
-      summary: Delete tag
-      description: Remove a tag from the catalog along with every assignment of it
+      summary: Delete Catalog Tag
+      description: 'Removes a tag from the catalog together with every assignment of it on every party.
+
+        Use this tool only when the tag and its history should disappear entirely; use updateTag with active false instead to retire a tag while keeping existing assignments.
+
+        Preconditions: the tag must exist; deletion is not reversible.
+
+        Required inputs: tagId (UUID) as a path parameter; there is no request body.
+
+        Emits a CRM_TAG_DELETE event; all assignment rows for the tag are removed.
+
+        Returns 404 when no tag exists for the supplied tagId.
+
+        '
       operationId: deleteTag
       parameters:
       - name: tagId
@@ -245,9 +334,21 @@ paths:
     get:
       tags:
       - CRM Segments
-      summary: Get segment
-      description: Retrieve a segment definition by id
-      operationId: get
+      summary: Get Segment Definition
+      description: 'Returns one segment''s definition, including its type, audience type, predicate for DYNAMIC segments, active flag, and member count.
+
+        Use this tool when the segment id is already known; use listSegments instead to browse segments, and resolveSegment to compute who currently matches.
+
+        Preconditions: the segment must exist.
+
+        Required inputs: segmentId (UUID) as a path parameter; there is no request body.
+
+        Emits a CRM_SEGMENT_GET audit event; no state changes occur.
+
+        Returns 404 when no segment exists for the supplied segmentId.
+
+        '
+      operationId: getSegment
       parameters:
       - name: segmentId
         in: path
@@ -274,9 +375,21 @@ paths:
     put:
       tags:
       - CRM Segments
-      summary: Update segment
-      description: Update a segment's name, description, predicate, or active flag. Type and audience type are immutable.
-      operationId: update
+      summary: Update Audience Segment
+      description: 'Updates a segment''s name, description, predicate, or active flag; type and audienceType are immutable after creation because switching kinds would strand pinned members or a predicate.
+
+        Use this tool when refining an existing segment; use createSegment instead when a different type or audience type is needed.
+
+        Preconditions: the segment must exist, the new name must not collide with another segment case-insensitively, and the submitted type and audienceType must equal the stored values.
+
+        Required inputs: segmentId (UUID) as a path parameter plus the full upsert body with name, audienceType, and type restated; predicate rules follow the segment''s type and active is optional.
+
+        Emits a CRM_SEGMENT_UPDATE event and republishes the segment definition.
+
+        Returns 404 when the segment does not exist, 409 when the name is taken, and 422 when type or audienceType differ from the stored segment or the predicate is invalid.
+
+        '
+      operationId: updateSegment
       parameters:
       - name: segmentId
         in: path
@@ -285,10 +398,25 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The revised segment definition; type and audienceType must match the stored segment.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpsertSegmentRequest'
+            examples:
+              Rename and deactivate:
+                description: Rename and deactivate
+                value:
+                  name: Gold-tier accounts (retired)
+                  audienceType: COMMERCIAL
+                  type: DYNAMIC
+                  predicate:
+                    nodeType: COMPARISON
+                    attribute: party.accountTier
+                    operator: IN
+                    values:
+                    - GOLD
+                  active: false
         required: true
       responses:
         '200':
@@ -313,9 +441,21 @@ paths:
     delete:
       tags:
       - CRM Segments
-      summary: Delete segment
-      description: Delete a segment and its pinned membership
-      operationId: delete
+      summary: Delete Audience Segment
+      description: 'Deletes a segment and all of its pinned membership rows permanently.
+
+        Use this tool when a segment is no longer wanted at all; use updateSegment with active false instead to retire a segment while keeping its definition.
+
+        Preconditions: the segment must exist; deletion is not reversible.
+
+        Required inputs: segmentId (UUID) as a path parameter; there is no request body.
+
+        Emits a CRM_SEGMENT_DELETE event and publishes a deletion notice so consumers drop the segment.
+
+        Returns 404 when no segment exists for the supplied segmentId.
+
+        '
+      operationId: deleteSegment
       parameters:
       - name: segmentId
         in: path
@@ -339,9 +479,21 @@ paths:
     get:
       tags:
       - CRM Marketing Consent
-      summary: Get marketing consent
-      description: Per-channel marketing consent plus the effective send eligibility for each channel
-      operationId: getConsent
+      summary: Get Marketing Consent Summary
+      description: 'Returns a party''s per-channel marketing consent (EMAIL and SMS, each OPT_IN, OPT_OUT, or UNSET) together with the account gate, quiet hours, monthly send cap, and the resolved send eligibility per channel.
+
+        Use this tool when reviewing a party''s full consent state; use resolveMarketingEligibility instead when only a single allow or deny decision for one channel is needed.
+
+        Preconditions: the party must exist as either a commercial or person party.
+
+        Required inputs: partyId (UUID) as a path parameter; there is no request body.
+
+        Emits a CRM_MARKETING_CONSENT_GET audit event; no state changes occur.
+
+        Returns 404 when no party exists for the supplied partyId.
+
+        '
+      operationId: getMarketingConsent
       parameters:
       - name: partyId
         in: path
@@ -368,9 +520,21 @@ paths:
     put:
       tags:
       - CRM Marketing Consent
-      summary: Update marketing consent
-      description: Update per-channel marketing consent. Only channels present in the request change; each change writes one immutable consent-audit entry.
-      operationId: updateConsent
+      summary: Update Marketing Consent
+      description: 'Updates a party''s per-channel marketing consent; only channels present in the request change, and each actual change appends one immutable consent-audit entry attributed to the calling user.
+
+        Use this tool when a party grants or withdraws marketing consent; do not use setAccountMarketingGate, which is the account-level hard gate overriding all contact consent, and do not use upsertCommunicationPreferences, which stores transactional channel preferences rather than marketing consent.
+
+        Preconditions: the party must exist as either a commercial or person party; re-submitting an unchanged value is an idempotent no-op that writes no audit row.
+
+        Required inputs: partyId (UUID) as a path parameter; marketingEmailConsent and marketingSmsConsent take OPT_IN, OPT_OUT, or UNSET, source defaults to CSR, and optOutReason, quietHoursStart, quietHoursEnd, and maxMarketingSendsPerMonth are optional.
+
+        Emits a CRM_MARKETING_CONSENT_UPDATE event and republishes the resolved eligibility decision for both channels so downstream consumers never hold a stale allow.
+
+        Returns 404 when no party exists for the supplied partyId.
+
+        '
+      operationId: updateMarketingConsent
       parameters:
       - name: partyId
         in: path
@@ -379,10 +543,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Partial consent update; only the channels and settings present in the body are changed.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateMarketingConsentRequest'
+            examples:
+              Email opt-out via CSR:
+                description: Email opt-out via CSR
+                value:
+                  marketingEmailConsent: OPT_OUT
+                  optOutReason: NOT_INTERESTED
+                  source: CSR
         required: true
       responses:
         '200':
@@ -404,9 +576,21 @@ paths:
     put:
       tags:
       - CRM Marketing Consent
-      summary: Set account marketing gate
-      description: Set or clear the commercial-account hard gate. When set, no marketing reaches the account on any channel regardless of individual contact consent.
-      operationId: setAccountGate
+      summary: Set Account Marketing Gate
+      description: 'Sets or clears the commercial-account marketing hard gate; while set, no marketing reaches the account on any channel regardless of individual contact consent.
+
+        Use this tool when an entire commercial account must be excluded from marketing; do not use updateMarketingConsent, which changes one party''s per-channel consent and cannot override the gate.
+
+        Preconditions: the party must exist as a commercial party; person parties have no account gate, and setting the gate to its current value is an idempotent no-op.
+
+        Required inputs: partyId (UUID) as a path parameter and optOut (boolean) as a query parameter, where true engages the gate and false clears it; there is no request body.
+
+        Emits a CRM_MARKETING_ACCOUNT_GATE_SET event, and when the gate actually flips it republishes the resolved eligibility decisions for both channels.
+
+        Returns 404 when no commercial party exists for the supplied partyId.
+
+        '
+      operationId: setAccountMarketingGate
       parameters:
       - name: partyId
         in: path
@@ -439,8 +623,20 @@ paths:
     put:
       tags:
       - CRM Contacts
-      summary: Update contact roles
-      description: Assign or update role assignments for a specific contact within a party
+      summary: Update Contact Role Assignments
+      description: 'Replaces the full set of role assignments for one contact on a commercial account; existing assignments for that contact are deleted and the submitted list is written in their place.
+
+        Use this tool when changing what a known contact does for an account; use getContactsWithRoles instead to read current assignments, and note that submitting an empty roles list removes the contact''s roles entirely.
+
+        Preconditions: the commercial party and the contact person must both exist; assigning a role as primary automatically demotes any existing primary contact for that role.
+
+        Required inputs: partyId and contactId (UUIDs) as path parameters, plus roles, a list where each entry has roleCode (BILLING, PAYMENT_AUTHORIZER, OPERATIONS, PRIMARY_BUSINESS_CONTACT, or TECHNICAL) and an optional isPrimary flag defaulting to false.
+
+        Emits a CRM_CONTACT_ROLES_UPDATE event; assignments are rewritten in place.
+
+        Returns 404 when the party or contact person cannot be found, and 400 when a roleCode is not a recognized role.
+
+        '
       operationId: updateContactRoles
       parameters:
       - name: partyId
@@ -458,10 +654,20 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The complete replacement set of role assignments for this contact on the account.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateContactRolesRequest'
+            examples:
+              Primary billing contact:
+                description: Primary billing contact
+                value:
+                  roles:
+                  - roleCode: BILLING
+                    isPrimary: true
+                  - roleCode: OPERATIONS
+                    isPrimary: false
         required: true
       responses:
         '200':
@@ -485,9 +691,21 @@ paths:
     put:
       tags:
       - CRM Inquiries
-      summary: Update inquiry status
-      description: Move an inquiry to CONTACTED or CLOSED. CONVERTED is reached by converting it.
-      operationId: updateStatus
+      summary: Update Inquiry Status
+      description: 'Moves an inquiry through its lifecycle to CONTACTED or CLOSED, optionally recording a resolution note.
+
+        Use this tool for ordinary status progression; do not use it to reach CONVERTED, which is only reachable through convertInquiry because conversion creates or links a party.
+
+        Preconditions: the inquiry must exist and the transition must be legal — NEW may move to CONTACTED or CLOSED, CONTACTED may move to CLOSED, and CONVERTED and CLOSED are terminal.
+
+        Required inputs: inquiryId (UUID) as a path parameter and status (CONTACTED or CLOSED) as a required query parameter; resolutionNote is optional and there is no request body.
+
+        Emits a CRM_INQUIRY_STATUS_UPDATE event; only the inquiry record changes.
+
+        Returns 404 when the inquiry does not exist, and 422 when CONVERTED is requested directly or the transition is illegal from the current status.
+
+        '
+      operationId: updateInquiryStatus
       parameters:
       - name: inquiryId
         in: path
@@ -532,9 +750,21 @@ paths:
     put:
       tags:
       - CRM Inquiries
-      summary: Assign inquiry
-      description: Assign or unassign an inquiry
-      operationId: assign
+      summary: Assign Inquiry
+      description: 'Assigns an inquiry to a staff member for follow-through, or returns it to the shared queue when assignedTo is omitted.
+
+        Use this tool when routing a triaged inquiry to an owner; do not use updateInquiryStatus, which moves the lifecycle state rather than ownership.
+
+        Preconditions: the inquiry must exist; assignment is allowed in any status.
+
+        Required inputs: inquiryId (UUID) as a path parameter; assignedTo is an optional query parameter whose omission unassigns the inquiry, and there is no request body.
+
+        Emits a CRM_INQUIRY_ASSIGN event; only the inquiry''s assignee changes.
+
+        Returns 404 when no inquiry exists for the supplied inquiryId.
+
+        '
+      operationId: assignInquiry
       parameters:
       - name: inquiryId
         in: path
@@ -567,9 +797,21 @@ paths:
     put:
       tags:
       - CRM Follow-ups
-      summary: Assign follow-up
-      description: Assign or unassign a follow-up task
-      operationId: assign_1
+      summary: Assign Follow-Up Task
+      description: 'Assigns an open follow-up task to a CSR, or returns it to the shared queue when assignedTo is omitted.
+
+        Use this tool when routing queue work to a specific person; do not use completeFollowUpTask or dismissFollowUpTask, which close the task rather than route it.
+
+        Preconditions: the task must exist and still be OPEN; closed tasks cannot be modified and a new follow-up must be raised instead.
+
+        Required inputs: taskId (UUID) as a path parameter; assignedTo is an optional query parameter whose omission unassigns the task, and there is no request body.
+
+        Emits a CRM_FOLLOWUP_ASSIGN event; only the task''s assignee changes.
+
+        Returns 404 when the task does not exist, and 422 when the task is already DONE or DISMISSED.
+
+        '
+      operationId: assignFollowUpTask
       parameters:
       - name: taskId
         in: path
@@ -604,8 +846,20 @@ paths:
     put:
       tags:
       - CRM Party Relationships
-      summary: Designate primary billing contact
-      description: Sets a relationship as the primary billing contact, demoting any existing primary
+      summary: Designate Primary Billing Contact
+      description: 'Promotes an existing relationship to be the account''s primary billing contact, atomically demoting any current primary.
+
+        Use this tool when the billing contact changes on an account; do not use createPartyRelationship, which is for a person not yet related to the account and can set the flag at creation time.
+
+        Preconditions: the relationship must exist, must belong to the account in the path, must carry the BILLING role, and must be active as of today.
+
+        Required inputs: partyId and relationshipId (UUIDs) as path parameters; there is no request body.
+
+        Emits a CRM_RELATIONSHIP_PRIMARY_BILLING_UPDATE event; the previous primary, if any, is demoted in the same transaction.
+
+        Returns 404 when the relationship does not exist, and 400 when it belongs to a different party, lacks the BILLING role, or is no longer active.
+
+        '
       operationId: designatePrimaryBillingContact
       parameters:
       - name: partyId
@@ -642,8 +896,20 @@ paths:
     put:
       tags:
       - CRM Accounts
-      summary: Upsert billing rules for a party
-      description: Create or update the billing rules configuration for a commercial party.
+      summary: Upsert Party Billing Rules
+      description: 'Creates or replaces the embedded billing-rules configuration on a commercial party, covering PO requirement, tax exemption, credit hold, auto-pay, payment terms, credit limit, currency, and invoice delivery method.
+
+        Use this tool when configuring how a commercial account is billed; do not use createCommercialAccount, which only sets billingTermsId at creation and cannot change billing flags afterwards.
+
+        Preconditions: a commercial party must exist for the supplied partyId; the whole rules block is replaced on every call rather than patched field by field.
+
+        Required inputs: partyId (UUID) as a path parameter; boolean flags poRequired, taxExempt, creditHold, and autoPayEnabled default to false when omitted, and paymentTerms, creditLimit, currency, and invoiceDeliveryMethod (EMAIL, MAIL, PORTAL) are optional.
+
+        Emits a CUSTOMER_BILLING_RULES_UPSERT event; the rules are stored on the party record itself.
+
+        Returns 404 when no commercial party exists for the supplied partyId.
+
+        '
       operationId: upsertBillingRules
       parameters:
       - name: partyId
@@ -655,10 +921,24 @@ paths:
           format: uuid
         example: f47ac10b-58cc-4372-a567-0e02b2c3d479
       requestBody:
+        description: Complete billing-rules configuration that replaces the party's current rules block.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpsertBillingRulesRequest'
+            examples:
+              Net-30 with PO:
+                description: Net-30 with PO
+                value:
+                  paymentTerms: NET_30
+                  creditLimit: 25000.0
+                  currency: USD
+                  taxExempt: false
+                  poRequired: true
+                  creditHold: false
+                  autoPayEnabled: false
+                  invoiceDeliveryMethod: EMAIL
+                  billingAddressId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d
         required: true
       responses:
         '200':
@@ -682,14 +962,38 @@ paths:
     post:
       tags:
       - Promotion Redemptions
-      summary: Record promotion redemption
-      description: Record a promotion redemption idempotently
-      operationId: recordRedemption
+      summary: Record Promotion Redemption
+      description: 'Records that a promotion was redeemed on a workorder, increments the promotion''s usage counter, and stamps the recording user; the pair of promotionId and workorderId is the idempotency key.
+
+        Use this tool when a discount is actually applied at checkout or invoicing; use listPromotionRedemptionsByCustomer instead to read what a customer has redeemed.
+
+        Preconditions: no redemption may already exist for the same promotionId and workorderId pair; the referenced promotion, customer, and workorder ids are recorded as supplied without cross-service validation.
+
+        Required inputs: promotionId, customerId, and workorderId (UUIDs), discountAmount, discountType (max 50), and promotionCode (max 100); invoiceId, campaignCode, and redemptionTimestamp (defaulting to now) are optional, and recordedOverLimit defaults to false and switches the stored status to RECORDED_OVER_LIMIT.
+
+        Emits a PROMOTION_REDEMPTION_RECORD event and publishes a redemption-recorded fact for every redemption so marketing keeps a non-attributed baseline.
+
+        Returns 409 when the promotion has already been redeemed on that workorder, and 400 when a required field is missing.
+
+        '
+      operationId: recordPromotionRedemption
       requestBody:
+        description: The redemption to record, keyed for idempotency by promotionId and workorderId.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RecordRedemptionRequest'
+            examples:
+              Coupon redemption:
+                description: Coupon redemption
+                value:
+                  promotionId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a62
+                  customerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  workorderId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a63
+                  discountAmount: 25.0
+                  discountType: FIXED_AMOUNT
+                  promotionCode: SPRING25
+                  campaignCode: SPRING-2026
         required: true
       responses:
         '201':
@@ -711,14 +1015,41 @@ paths:
     post:
       tags:
       - Customer Bulk Ingest API
-      summary: Bulk ingest records
-      description: Accepts a batch of domain records for bulk import. Returns per-record results.
-      operationId: bulkIngest
+      summary: Bulk Ingest Customer Records
+      description: 'Imports a batch of individual customer records, creating each one through the same path as createPerson so canonical identities land in pos-people, and reports a per-row success or failure result without aborting the batch.
+
+        Use this tool for migrations and file imports of individuals; do not use createPerson row by row for large loads, and note this path cannot create commercial accounts.
+
+        Preconditions: none beyond authorization; rows that fail validation are reported with errorCode CUSTOMER_INGEST_FAILED while the rest of the batch proceeds.
+
+        Required inputs: jobId (UUID), locationId (UUID), and a non-empty records list where each record has firstName and lastName (each max 100) and optionally email, phoneNumber, primaryAddress, and customerNumber; preferredContactMethod is derived as EMAIL when an email is present and PHONE_CALL otherwise, and operatorId falls back to the security context when absent or not a UUID.
+
+        Emits a CUSTOMER_BULK_INGEST event, and each successful row publishes a party-changed customer fact and writes contact points to pos-people.
+
+        Returns 200 with per-row results including failures, and 400 when jobId, locationId, or the records list is missing or empty.
+
+        '
+      operationId: bulkIngestCustomers
       requestBody:
+        description: The ingest job envelope with the batch of customer records to import.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BulkIngestRequestCustomerBulkIngestRecord'
+            examples:
+              Two-record batch:
+                description: Two-record batch
+                value:
+                  jobId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a64
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a65
+                  operatorId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a66
+                  records:
+                  - firstName: Dana
+                    lastName: Ortiz
+                    email: dana.ortiz@example.com
+                  - firstName: Sam
+                    lastName: Rivera
+                    phoneNumber: '+15125550143'
         required: true
       responses:
         '200':
@@ -742,9 +1073,21 @@ paths:
     get:
       tags:
       - Customer API
-      summary: Get all customers
-      description: Retrieve a paginated list of customers by type (PERSON or COMMERCIAL). Defaults to PERSON customers if no type specified. When a name and/or email filter is supplied, performs a server-side search instead of an unfiltered listing (scalable typeahead).
-      operationId: getAllCustomers
+      summary: List Customers By Type
+      description: 'Returns a page of customers of one party type, switching to a server-side typeahead search when a name or email filter is supplied.
+
+        Use this tool for the legacy flat customer listing keyed by customerType; use browseParties instead for the unified directory that merges commercial and individual customers in one result.
+
+        Preconditions: none; an empty page is returned when nothing matches.
+
+        Required inputs: none; customerType defaults to PERSON and accepts PERSON or COMMERCIAL, name and email are optional case-insensitive filters, and paging defaults to page 0, size 20, sorted by customerNumber.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty page rather than an error when no customer matches.
+
+        '
+      operationId: listCustomers
       parameters:
       - name: customerType
         in: query
@@ -789,14 +1132,35 @@ paths:
     post:
       tags:
       - Customer API
-      summary: Create a new customer
-      description: Add a new customer to the system.
+      summary: Create Customer Record
+      description: 'Creates a customer from a flat CustomerDTO, routed by customerType to either the commercial or person party store.
+
+        Use this tool only for the legacy flat customer API; use createCommercialAccount instead for commercial onboarding with duplicate checking, and createPerson for individuals so the canonical identity lands in pos-people.
+
+        Preconditions: none beyond authorization; no duplicate detection is performed.
+
+        Required inputs: firstName and lastName (each max 100); customerType selects the store, where COMMERCIAL routes to the commercial service and anything else creates a person party, and customerNumber, primaryAddress, and vehicleVins are optional.
+
+        Emits a CUSTOMER_CUSTOMER_CREATE event and publishes a party-changed customer fact.
+
+        Returns 201 with the stored customer on success; field validation is not enforced on this legacy path, so a malformed JSON body producing 400 is the only rejection.
+
+        '
       operationId: createCustomer
       requestBody:
+        description: The flat customer record to store; customerType routes it to the commercial or person store.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CustomerDTO'
+            examples:
+              Individual customer:
+                description: Individual customer
+                value:
+                  firstName: Dana
+                  lastName: Ortiz
+                  customerType: PERSON
+                  primaryAddress: 100 Congress Ave, Austin, TX 78701
         required: true
       responses:
         '201':
@@ -814,8 +1178,20 @@ paths:
     get:
       tags:
       - CRM Tags
-      summary: List tags
-      description: List the CRM tag catalog with assignment counts
+      summary: List Tag Catalog
+      description: 'Returns the CRM tag catalog with each tag''s category, color, active flag, and assignment count.
+
+        Use this tool when browsing available tags before assigning one; use listPartyTags instead to see which tags a specific party carries.
+
+        Preconditions: none; inactive tags are omitted unless explicitly requested.
+
+        Required inputs: none; includeInactive defaults to false, and there is no request body.
+
+        Emits a CRM_TAG_LIST audit event; no state changes occur.
+
+        Returns 200 with an empty list rather than an error when the catalog is empty.
+
+        '
       operationId: listTags
       parameters:
       - name: includeInactive
@@ -843,14 +1219,35 @@ paths:
     post:
       tags:
       - CRM Tags
-      summary: Create tag
-      description: Add a new tag to the CRM tag catalog
+      summary: Create Catalog Tag
+      description: 'Adds a new tag to the CRM tag catalog for later assignment to parties.
+
+        Use this tool when a new label is needed; do not use assignTagToParty, which attaches an existing catalog tag to a party.
+
+        Preconditions: no existing tag may already use the same name case-insensitively.
+
+        Required inputs: name (non-blank, max 100); category, color, and active (default true) are optional.
+
+        Emits a CRM_TAG_CREATE event; the tag becomes immediately assignable when active.
+
+        Returns 409 when a tag with the same name already exists, and 400 when name is blank.
+
+        '
       operationId: createTag
       requestBody:
+        description: The new tag's name and optional presentation attributes.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpsertPartyTagRequest'
+            examples:
+              Fleet VIP tag:
+                description: Fleet VIP tag
+                value:
+                  name: Fleet VIP
+                  category: Loyalty
+                  color: '#D4AF37'
+                  active: true
         required: true
       responses:
         '201':
@@ -874,9 +1271,21 @@ paths:
     get:
       tags:
       - CRM Suppression
-      summary: List suppression entries
-      description: List suppressed addresses, newest first
-      operationId: list
+      summary: List Suppression Entries
+      description: 'Returns hard-suppressed marketing addresses newest first, showing only a masked address hint and the normalized hash — raw addresses are never stored or returned.
+
+        Use this tool when reviewing the suppression list; use checkAddressSuppression instead to test one specific address before a send.
+
+        Preconditions: none; an empty page is returned when nothing matches.
+
+        Required inputs: none; channel optionally filters on EMAIL or SMS, page defaults to 0, and size defaults to 50 clamped between 1 and 200.
+
+        Emits a CRM_SUPPRESSION_LIST audit event; no state changes occur.
+
+        Returns 200 with an empty page rather than an error when the list is empty.
+
+        '
+      operationId: listSuppressionEntries
       parameters:
       - name: channel
         in: query
@@ -917,14 +1326,36 @@ paths:
     post:
       tags:
       - CRM Suppression
-      summary: Suppress an address
-      description: 'Hard-block an address from marketing. Idempotent: re-adding returns the existing entry.'
-      operationId: add
+      summary: Suppress Marketing Address
+      description: 'Hard-blocks an address from marketing on one channel, storing only a normalized hash and a masked hint of the address.
+
+        Use this tool for bounce feeds, spam complaints, and legal do-not-contact requests; do not use updateMarketingConsent, which records a party''s choice and can be reversed by the party, whereas suppression outranks consent entirely.
+
+        Preconditions: none; the call is idempotent, and re-adding an already-suppressed address returns the existing entry without touching the audit trail.
+
+        Required inputs: channel (EMAIL or SMS), address (raw, max 320 characters), and reason (HARD_BOUNCE, SPAM_COMPLAINT, LEGAL_DNC, MANUAL, or UNSUBSCRIBE_LINK); partyId is optional and source defaults to CSR.
+
+        Emits a CRM_SUPPRESSION_ADD event and publishes a suppression-changed fact when a new entry is actually created.
+
+        Returns 400 when channel, address, or reason is missing, and 201 with the existing entry when the address was already suppressed.
+
+        '
+      operationId: addSuppressionEntry
       requestBody:
+        description: The address to hard-block, the channel it applies to, and why it is being suppressed.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AddSuppressionRequest'
+            examples:
+              Hard bounce:
+                description: Hard bounce
+                value:
+                  channel: EMAIL
+                  address: bounced@example.com
+                  partyId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  reason: HARD_BOUNCE
+                  source: SYSTEM
         required: true
       responses:
         '201':
@@ -946,9 +1377,21 @@ paths:
     get:
       tags:
       - CRM Segments
-      summary: List segments
-      description: List saved segments, optionally filtered by audience type
-      operationId: list_1
+      summary: List Audience Segments
+      description: 'Returns all saved audience segments with their type, audience type, active flag, and member counts, optionally filtered by audience type.
+
+        Use this tool when browsing or picking a segment; use getSegment instead when the segment id is already known.
+
+        Preconditions: none; an empty list is returned when no segment matches.
+
+        Required inputs: none; audienceType optionally filters on COMMERCIAL or INDIVIDUAL, and there is no request body.
+
+        Emits a CRM_SEGMENT_LIST audit event; no state changes occur.
+
+        Returns 200 with an empty list rather than an error when no segments exist.
+
+        '
+      operationId: listSegments
       parameters:
       - name: audienceType
         in: query
@@ -977,14 +1420,43 @@ paths:
     post:
       tags:
       - CRM Segments
-      summary: Create segment
-      description: Create a static or dynamic segment. Dynamic predicates are validated against the attribute catalog.
-      operationId: create
+      summary: Create Audience Segment
+      description: 'Creates a saved audience segment, either STATIC with an explicitly pinned member list or DYNAMIC with a predicate validated against the attribute catalog.
+
+        Use this tool when defining a new audience; do not use updateSegment, which modifies an existing segment and cannot change its type or audience type.
+
+        Preconditions: no existing segment may already use the same name case-insensitively; a DYNAMIC segment must carry a predicate and a STATIC one must not.
+
+        Required inputs: name (max 150), audienceType (COMMERCIAL or INDIVIDUAL), and type (STATIC or DYNAMIC); description, predicate, and active are optional.
+
+        Emits a CRM_SEGMENT_CREATE event and publishes the segment definition to consumers.
+
+        Returns 409 when the name is already taken, and 422 when the predicate is missing on a DYNAMIC segment, present on a STATIC one, or references attributes outside the catalog.
+
+        '
+      operationId: createSegment
       requestBody:
+        description: The segment definition; DYNAMIC segments carry a predicate tree over catalog attributes, STATIC ones do not.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpsertSegmentRequest'
+            examples:
+              Dynamic gold-tier segment:
+                description: Dynamic gold-tier segment
+                value:
+                  name: Gold-tier commercial accounts
+                  description: Commercial parties at GOLD tier or above
+                  audienceType: COMMERCIAL
+                  type: DYNAMIC
+                  predicate:
+                    nodeType: COMPARISON
+                    attribute: party.accountTier
+                    operator: IN
+                    values:
+                    - GOLD
+                    - PLATINUM
+                    - ENTERPRISE
         required: true
       responses:
         '201':
@@ -1008,9 +1480,21 @@ paths:
     post:
       tags:
       - CRM Segments
-      summary: Resolve segment
-      description: Resolve a segment to a match count, an optional per-channel eligible count, and a masked sample
-      operationId: resolve
+      summary: Resolve Segment Audience
+      description: 'Resolves a segment to its current match count, an optional per-channel eligible count that folds in consent and suppression, and a masked sample of members; the full recipient list is never returned, so the preview cannot become a bulk PII export.
+
+        Use this tool when previewing an audience before a campaign; use getSegment instead for the stored definition without computing membership.
+
+        Preconditions: the segment must exist; eligible counts are computed only when a channel is supplied.
+
+        Required inputs: segmentId (UUID) as a path parameter; channel (EMAIL or SMS) is optional, and sampleSize defaults to 10 and is clamped to the server''s maximum.
+
+        Emits a CRM_SEGMENT_RESOLVE audit event; no state changes occur.
+
+        Returns 404 when no segment exists for the supplied segmentId, and 200 with a truncated flag when the match list was capped during resolution.
+
+        '
+      operationId: resolveSegment
       parameters:
       - name: segmentId
         in: path
@@ -1053,9 +1537,21 @@ paths:
     post:
       tags:
       - CRM Segments
-      summary: Pin members
-      description: Add parties to a static segment; already-present parties are ignored
-      operationId: addMembers
+      summary: Pin Segment Members
+      description: 'Pins parties onto a STATIC segment''s member list, recording who added them and when; parties already in the segment are silently skipped.
+
+        Use this tool when curating a hand-picked audience; do not use it on a DYNAMIC segment, whose membership is computed from its predicate by resolveSegment.
+
+        Preconditions: the segment must exist and be STATIC.
+
+        Required inputs: segmentId (UUID) as a path parameter and partyIds, a non-empty list of up to 5000 UUIDs; duplicates in the list are collapsed.
+
+        Emits a CRM_SEGMENT_MEMBERS_ADD event; only new membership rows are written.
+
+        Returns 404 when the segment does not exist, and 422 when the segment is DYNAMIC.
+
+        '
+      operationId: addSegmentMembers
       parameters:
       - name: segmentId
         in: path
@@ -1064,10 +1560,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The party ids to pin onto the static segment's member list.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SegmentMembersRequest'
+            examples:
+              Pin two parties:
+                description: Pin two parties
+                value:
+                  partyIds:
+                  - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '200':
@@ -1091,14 +1595,38 @@ paths:
     post:
       tags:
       - CRM Public Inquiry
-      summary: Submit an inquiry
-      description: Public, unauthenticated capture of a service or fleet-quote request. Rate-limited per submitter; returns only a reference id.
-      operationId: submit
+      summary: Submit Public Inquiry
+      description: 'Accepts an anonymous service or fleet-quote inquiry from the public web form, rate-limited per hashed submitter fingerprint, and returns only a reference id and NEW status so the endpoint cannot be used to enumerate existing customers.
+
+        Use this tool only for the unauthenticated public form when the deployment has enabled it via pos.customer.inquiry.public.enabled; do not use captureInquiry here, which is the authenticated staff path and is not rate-limited.
+
+        Preconditions: the public-inquiry feature flag must be enabled and the submitter must be under the per-source rate ceiling; the raw source address is never stored, only a truncated SHA-256 fingerprint.
+
+        Required inputs: channel, audienceType (COMMERCIAL or INDIVIDUAL), contactName, and at least one of email or phone; message and interest fields are optional.
+
+        Emits a CRM_PUBLIC_INQUIRY_SUBMIT event and persists the inquiry in NEW status, unassigned in the shared triage queue.
+
+        Returns 429 when the submitter has exceeded the rate limit, and 400 when required fields are missing or neither email nor phone is supplied.
+
+        '
+      operationId: submitPublicInquiry
       requestBody:
+        description: The public web-form inquiry, carrying who is asking and how to reach them.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SubmitInquiryRequest'
+            examples:
+              Web-form service inquiry:
+                description: Web-form service inquiry
+                value:
+                  channel: WEB_FORM
+                  audienceType: INDIVIDUAL
+                  contactName: Sam Rivera
+                  email: sam.rivera@example.com
+                  vehicleOfInterest: 2018 Honda CR-V
+                  serviceOfInterest: Timing belt replacement
+                  message: Looking for a quote and earliest availability
         required: true
       responses:
         '202':
@@ -1115,8 +1643,20 @@ paths:
     get:
       tags:
       - CRM Persons
-      summary: Search persons
-      description: Searches for persons matching the specified criteria
+      summary: Search Individual Persons
+      description: 'Searches individual customers by delegating the text query to pos-people, which matches first name, last name, primary email, and username, and returns only persons that also have a local CRM person-party.
+
+        Use this tool when locating an individual by name or email; use getPerson instead when the person id is already known, and note phone search is best-effort only because pos-people does not index phone numbers.
+
+        Preconditions: at least one of name, email, or phone should be supplied; when all are blank an empty list is returned without searching.
+
+        Required inputs: none individually; the first non-blank of name, email, and phone becomes the query, limit defaults to 20, and offset defaults to 0.
+
+        Emits a CRM_PERSON_SEARCH audit event; no state changes occur.
+
+        Returns 200 with an empty list rather than an error when nothing matches or the offset is beyond the result set.
+
+        '
       operationId: searchPersons
       parameters:
       - name: name
@@ -1186,14 +1726,41 @@ paths:
     post:
       tags:
       - CRM Persons
-      summary: Create a new person
-      description: Creates an individual person record in the CRM system
+      summary: Create Individual Person Record
+      description: 'Creates an individual customer: the canonical person identity is resolved or created in pos-people (the source of truth for names and contact points), and a thin person-party link with a generated CUST-PER customer number is stored locally.
+
+        Use this tool when onboarding an individual customer; do not use createCommercialAccount, which creates an organization, and note that if the identity already has a local person-party the existing record is returned instead of a duplicate.
+
+        Preconditions: none beyond authorization; contact points are validated before any identity is created so an invalid email persists nothing.
+
+        Required inputs: firstName, lastName, and preferredContactMethod (EMAIL, PHONE_CALL, SMS, or NONE); emails and phones are optional lists whose entries carry a value and an isPrimary flag, phone type defaults to PHONE_MOBILE, and emails are stored lowercase.
+
+        Emits a CRM_PERSON_CREATE event, publishes a party-changed customer fact, and writes the contact points to pos-people.
+
+        Returns 400 when firstName, lastName, or preferredContactMethod is missing or an email value is malformed.
+
+        '
       operationId: createPerson
       requestBody:
+        description: The individual's name, preferred contact method, and contact points to register.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreatePersonRequest'
+            examples:
+              Individual with email and mobile:
+                description: Individual with email and mobile
+                value:
+                  firstName: Dana
+                  lastName: Ortiz
+                  preferredContactMethod: EMAIL
+                  emails:
+                  - value: dana.ortiz@example.com
+                    isPrimary: true
+                  phones:
+                  - value: '+15125550142'
+                    type: PHONE_MOBILE
+                    isPrimary: true
         required: true
       responses:
         '201':
@@ -1229,8 +1796,20 @@ paths:
     get:
       tags:
       - CRM Tags
-      summary: List party tags
-      description: List the tags currently attached to a party
+      summary: List Party Tag Assignments
+      description: 'Returns the tags currently attached to one party, with who assigned each tag, when, and through which source.
+
+        Use this tool when reviewing a party''s labels; use listTags instead for the full catalog of assignable tags.
+
+        Preconditions: none; an unknown partyId yields an empty list rather than an error.
+
+        Required inputs: partyId (UUID) as a path parameter; there is no request body.
+
+        Emits a CRM_PARTY_TAG_LIST audit event; no state changes occur.
+
+        Returns 200 with an empty list rather than an error when the party has no tags.
+
+        '
       operationId: listPartyTags
       parameters:
       - name: partyId
@@ -1258,9 +1837,21 @@ paths:
     post:
       tags:
       - CRM Tags
-      summary: Assign tag to party
-      description: 'Attach a tag to a party. Idempotent: re-assigning returns the existing assignment.'
-      operationId: assignTag
+      summary: Assign Tag To Party
+      description: 'Attaches a catalog tag to a party, recording the assigning user, timestamp, and source.
+
+        Use this tool when labeling a party; do not use createTag, which adds a new tag to the catalog without attaching it to anyone.
+
+        Preconditions: the tag must exist and, for a new assignment, be active; the call is idempotent, and re-assigning an already-attached tag returns the existing assignment even when the tag has since been retired.
+
+        Required inputs: partyId (UUID) as a path parameter and tagId (UUID) in the body; source defaults to MANUAL and accepts MANUAL, CAMPAIGN, IMPORT, or RULE.
+
+        Emits a CRM_PARTY_TAG_ASSIGN event and publishes a party-tag-changed fact when a new assignment is created.
+
+        Returns 404 when the tag does not exist, and 400 when the tag is inactive and not already assigned.
+
+        '
+      operationId: assignTagToParty
       parameters:
       - name: partyId
         in: path
@@ -1269,10 +1860,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The catalog tag to attach to the party and how the assignment originated.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AssignPartyTagRequest'
+            examples:
+              Manual assignment:
+                description: Manual assignment
+                value:
+                  tagId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a61
+                  source: MANUAL
         required: true
       responses:
         '200':
@@ -1296,9 +1894,21 @@ paths:
     get:
       tags:
       - CRM Interactions
-      summary: List party interactions
-      description: Interaction history for a party, newest first, optionally filtered by type
-      operationId: list_2
+      summary: List Party Interaction Timeline
+      description: 'Returns a party''s interaction timeline newest first, unifying campaign sends, CSR touches, and workorder notes, with interaction bodies passed through redaction before they are returned.
+
+        Use this tool when reviewing a party''s touch history; do not use recordInteraction, which appends a new entry to the timeline instead of reading it.
+
+        Preconditions: none; an unknown partyId simply yields an empty page rather than an error.
+
+        Required inputs: partyId (UUID) as a path parameter; type optionally filters to one of CAMPAIGN_SEND, EMAIL, SMS, CALL, FOLLOW_UP, NOTE, or WORKORDER_NOTE, page defaults to 0, and size defaults to 50 with a clamp between 1 and 200.
+
+        Emits a CRM_INTERACTION_LIST audit event; no state changes occur.
+
+        Returns 200 with an empty page rather than an error when the party has no interactions.
+
+        '
+      operationId: listPartyInteractions
       parameters:
       - name: partyId
         in: path
@@ -1350,9 +1960,21 @@ paths:
     post:
       tags:
       - CRM Interactions
-      summary: Record an interaction
-      description: Record a CSR-initiated touch (call, email, note) on a party's timeline
-      operationId: record
+      summary: Record Party Interaction
+      description: 'Records a CSR-initiated touch such as a call, email, or note on a party''s interaction timeline, stamping the acting username from the security context.
+
+        Use this tool when logging a manual customer touch; do not use listPartyInteractions, which reads the timeline, and note that campaign and workorder interactions are ingested from events rather than through this endpoint.
+
+        Preconditions: none are checked against the party; the interaction is stored against the supplied partyId as-is.
+
+        Required inputs: partyId (UUID) as a path parameter and type (CAMPAIGN_SEND, EMAIL, SMS, CALL, FOLLOW_UP, NOTE, or WORKORDER_NOTE) in the body; direction defaults to OUTBOUND, occurredAt defaults to now, and channel accepts EMAIL or SMS.
+
+        Emits a CRM_INTERACTION_RECORD event and persists the interaction row.
+
+        Returns 400 when type is missing or subject, summary, or body exceed their length limits.
+
+        '
+      operationId: recordInteraction
       parameters:
       - name: partyId
         in: path
@@ -1361,10 +1983,20 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The CSR touch to append to the party's timeline, typed by interaction kind and optional channel.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RecordInteractionRequest'
+            examples:
+              Follow-up call note:
+                description: Follow-up call note
+                value:
+                  type: CALL
+                  direction: OUTBOUND
+                  subject: Brake job follow-up
+                  summary: Customer satisfied, will book alignment next month
+                  occurredAt: 2026-08-10 15:30:00+00:00
         required: true
       responses:
         '201':
@@ -1386,9 +2018,21 @@ paths:
     get:
       tags:
       - CRM Follow-ups
-      summary: List party follow-ups
-      description: Follow-up tasks raised against a party
-      operationId: listForParty
+      summary: List Party Follow-Up Tasks
+      description: 'Returns the follow-up tasks raised against one party, ordered by due date then creation time, optionally filtered by status.
+
+        Use this tool when reviewing outstanding work for a specific customer; use getFollowUpQueue instead for the cross-party CSR work queue.
+
+        Preconditions: none; an unknown partyId yields an empty page rather than an error.
+
+        Required inputs: partyId (UUID) as a path parameter; status optionally filters on OPEN, DONE, or DISMISSED, page defaults to 0, and size defaults to 50 clamped between 1 and 200.
+
+        Emits a CRM_FOLLOWUP_LIST audit event; no state changes occur.
+
+        Returns 200 with an empty page rather than an error when the party has no follow-ups.
+
+        '
+      operationId: listPartyFollowUps
       parameters:
       - name: partyId
         in: path
@@ -1436,9 +2080,21 @@ paths:
     post:
       tags:
       - CRM Follow-ups
-      summary: Raise follow-up task
-      description: Raise a follow-up task against a party
-      operationId: create_1
+      summary: Raise Follow-Up Task
+      description: 'Raises a new OPEN follow-up task against a party, recording the creating user from the security context.
+
+        Use this tool when a customer needs a future touch such as a declined-service or service-due follow-up; do not use completeFollowUpTask or dismissFollowUpTask, which close an existing task.
+
+        Preconditions: the party must exist as either a commercial or person party.
+
+        Required inputs: partyId (UUID) as a path parameter and type in the body (DECLINED_SERVICE_FOLLOWUP, SERVICE_DUE_REMINDER, FLEET_CHECKIN, CAMPAIGN_RESPONSE, or GENERAL); vehicleId, dueDate, assignedTo, reason, sourceWorkorderId, and notes are optional, and an omitted assignedTo leaves the task in the shared queue.
+
+        Emits a CRM_FOLLOWUP_CREATE event and persists the task with status OPEN.
+
+        Returns 404 when no party exists for the supplied partyId, and 400 when type is missing.
+
+        '
+      operationId: createFollowUpTask
       parameters:
       - name: partyId
         in: path
@@ -1447,10 +2103,20 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The follow-up work to schedule against the party, typed by follow-up kind.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateFollowUpTaskRequest'
+            examples:
+              Declined-service follow-up:
+                description: Declined-service follow-up
+                value:
+                  type: DECLINED_SERVICE_FOLLOWUP
+                  vehicleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5e
+                  dueDate: 2026-09-01
+                  reason: Declined rear brake pads at last visit
+                  notes: 'Quote given: $420 parts and labor'
         required: true
       responses:
         '201':
@@ -1472,8 +2138,20 @@ paths:
     get:
       tags:
       - CRM Communication Preferences
-      summary: Get communication preferences
-      description: Retrieve communication preferences and consent flags for a party
+      summary: Get Communication Preferences
+      description: 'Returns the persisted communication preferences and consent flags for a party, covering email, SMS, phone, and marketing channels plus the free-form consent flag map.
+
+        Use this tool when reading a party''s current contact-channel opt-ins; do not use getAccountCommunicationPreferences, a legacy accounts-scoped stub that only returns N/A placeholders.
+
+        Preconditions: the party must exist as either a commercial or person party; a party with no stored preference record is reported with every channel defaulted to OPT_OUT and version 0.
+
+        Required inputs: partyId (UUID) as a path parameter; there is no request body.
+
+        Emits a CRM_COMMUNICATION_PREFERENCES_GET audit event; no state changes occur.
+
+        Returns 404 when no party exists for the supplied partyId.
+
+        '
       operationId: getCommunicationPreferences
       parameters:
       - name: partyId
@@ -1502,8 +2180,20 @@ paths:
     post:
       tags:
       - CRM Communication Preferences
-      summary: Create or update communication preferences
-      description: Set or update communication preferences and consent flags for a party
+      summary: Upsert Communication Preferences
+      description: 'Creates or updates the persisted communication-preference record for a party, replacing channel preferences, consent flags, and the preferences note.
+
+        Use this tool when recording a party''s contact-channel opt-in or opt-out choices; do not use upsertAccountCommunicationPreferences, a legacy accounts-scoped stub that does not persist anything.
+
+        Preconditions: the party must exist as either a commercial or person party.
+
+        Required inputs: partyId (UUID) as a path parameter and a JSON body; omitted emailPreference, smsPreference, phonePreference, or marketingPreference values default to OPT_OUT, and updateSource defaults to APP.
+
+        Emits a CRM_COMMUNICATION_PREFERENCES_UPSERT event and writes the preference record, reporting operationType CREATED or UPDATED with a new version.
+
+        Returns 404 when no party exists for the supplied partyId.
+
+        '
       operationId: upsertCommunicationPreferences
       parameters:
       - name: partyId
@@ -1514,10 +2204,24 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Channel preferences, consent flags, and audit source to store for the party; omitted channels default to OPT_OUT.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpsertCommunicationPreferencesRequest'
+            examples:
+              Email opt-in with consent flags:
+                description: Email opt-in with consent flags
+                value:
+                  emailPreference: OPT_IN
+                  smsPreference: OPT_OUT
+                  phonePreference: OPT_OUT
+                  marketingPreference: OPT_IN
+                  consentFlags:
+                    serviceReminders: true
+                    promotions: false
+                  preferencesNote: Customer asked for email only
+                  updateSource: ADMIN
         required: true
       responses:
         '200':
@@ -1541,9 +2245,21 @@ paths:
     get:
       tags:
       - CRM Inquiries
-      summary: List inquiries
-      description: Inbound inquiries, newest first
-      operationId: list_3
+      summary: List Inbound Inquiries
+      description: 'Returns inbound service and fleet-quote inquiries newest first, optionally filtered by lifecycle status.
+
+        Use this tool when triaging the inquiry queue; use getInquiry instead when the inquiry id is already known.
+
+        Preconditions: none; an empty page is returned when nothing matches.
+
+        Required inputs: none; status optionally filters on NEW, CONTACTED, CONVERTED, or CLOSED, page defaults to 0, and size defaults to 50 clamped between 1 and 200.
+
+        Emits a CRM_INQUIRY_LIST audit event; no state changes occur.
+
+        Returns 200 with an empty page rather than an error when no inquiry matches.
+
+        '
+      operationId: listInquiries
       parameters:
       - name: status
         in: query
@@ -1586,14 +2302,38 @@ paths:
     post:
       tags:
       - CRM Inquiries
-      summary: Capture inquiry
-      description: Record an inquiry taken by phone, walk-in, or referral
-      operationId: capture
+      summary: Capture Staff-Taken Inquiry
+      description: 'Records an inbound inquiry taken by staff over phone, walk-in, email, or referral, creating it in NEW status and deliberately unassigned so it lands in the shared queue.
+
+        Use this tool for staff-entered inquiries on the authenticated API; do not use submitPublicInquiry, which is the anonymous rate-limited public web-form path.
+
+        Preconditions: none beyond authorization; no party needs to exist yet.
+
+        Required inputs: channel (WEB_FORM, PHONE, WALK_IN, EMAIL, REFERRAL, or CAMPAIGN), audienceType (COMMERCIAL or INDIVIDUAL), contactName, and at least one of email or phone; organizationName, vehicleOfInterest, serviceOfInterest, message, and campaignCode are optional.
+
+        Emits a CRM_INQUIRY_CAPTURE event and persists the inquiry.
+
+        Returns 400 when required fields are missing or when neither email nor phone is supplied, since an unreachable enquirer cannot be actioned.
+
+        '
+      operationId: captureInquiry
       requestBody:
+        description: The inquiry as taken by staff, including how it arrived and how to reach the enquirer.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SubmitInquiryRequest'
+            examples:
+              Phone fleet inquiry:
+                description: Phone fleet inquiry
+                value:
+                  channel: PHONE
+                  audienceType: COMMERCIAL
+                  contactName: Dana Ortiz
+                  organizationName: Ortiz Landscaping
+                  email: dana@ortizlandscaping.example
+                  phone: +1-512-555-0142
+                  serviceOfInterest: Fleet maintenance quote for 6 trucks
         required: true
       responses:
         '201':
@@ -1615,9 +2355,21 @@ paths:
     post:
       tags:
       - CRM Inquiries
-      summary: Convert inquiry
-      description: Turn the inquiry into a PROSPECT party, or link it to an existing party when the enquirer is already known
-      operationId: convert
+      summary: Convert Inquiry To Party
+      description: 'Converts an inquiry into CRM state: a commercial inquiry with no existingPartyId creates a new commercial party in lifecycle stage PROSPECT, while supplying existingPartyId links the inquiry to that party instead; either way the inquiry becomes CONVERTED.
+
+        Use this tool when an enquirer becomes a prospect or is recognized as an existing customer; do not use updateInquiryStatus, which rejects CONVERTED as a direct status change.
+
+        Preconditions: the inquiry must exist in an open status (NEW or CONTACTED); an INDIVIDUAL-audience inquiry can only be converted by linking an existing party, because creating a person party requires a verified identity in pos-people-contact.
+
+        Required inputs: inquiryId (UUID) as a path parameter; existingPartyId (UUID) is an optional query parameter naming a known party to link, and there is no request body.
+
+        Emits a CRM_INQUIRY_CONVERT event; a new PROSPECT commercial party may be created and the inquiry is stamped with the resulting partyId.
+
+        Returns 404 when the inquiry or the supplied existingPartyId cannot be found, and 422 when the inquiry is already CONVERTED or CLOSED, or when an individual inquiry has no party to link.
+
+        '
+      operationId: convertInquiry
       parameters:
       - name: inquiryId
         in: path
@@ -1653,9 +2405,21 @@ paths:
     post:
       tags:
       - CRM Follow-ups
-      summary: Dismiss follow-up
-      description: Close a follow-up as deliberately not pursued, recording why
-      operationId: dismiss
+      summary: Dismiss Follow-Up Task
+      description: 'Closes an open follow-up task as DISMISSED, recording why it is deliberately not being pursued.
+
+        Use this tool when a follow-up should be abandoned, for example because the customer already returned; use completeFollowUpTask instead when the touch was actually made.
+
+        Preconditions: the task must exist and still be OPEN; dismissal is final and a new task must be raised to revisit the customer.
+
+        Required inputs: taskId (UUID) as a path parameter and outcome (non-blank, max 500) in the body explaining the dismissal; booking references are accepted but normally absent.
+
+        Emits a CRM_FOLLOWUP_DISMISS event and stamps closedAt and closedBy on the task.
+
+        Returns 404 when the task does not exist, 422 when it is already DONE or DISMISSED, and 400 when outcome is blank.
+
+        '
+      operationId: dismissFollowUpTask
       parameters:
       - name: taskId
         in: path
@@ -1664,10 +2428,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The reason this follow-up is being closed without being pursued.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CloseFollowUpTaskRequest'
+            examples:
+              No longer relevant:
+                description: No longer relevant
+                value:
+                  outcome: Vehicle was sold; service no longer needed
         required: true
       responses:
         '200':
@@ -1691,9 +2461,21 @@ paths:
     post:
       tags:
       - CRM Follow-ups
-      summary: Complete follow-up
-      description: Close a follow-up as worked, recording the outcome and any resulting booking
-      operationId: complete
+      summary: Complete Follow-Up Task
+      description: 'Closes an open follow-up task as DONE, recording the outcome and any workorder or appointment that resulted from the touch.
+
+        Use this tool when the follow-up was actually worked; use dismissFollowUpTask instead when the task is being deliberately abandoned without contact.
+
+        Preconditions: the task must exist and still be OPEN; a closed task cannot be reopened, so a new follow-up must be raised to try again.
+
+        Required inputs: taskId (UUID) as a path parameter and outcome (non-blank, max 500) in the body; bookedWorkorderId and bookedAppointmentId are optional booking references.
+
+        Emits a CRM_FOLLOWUP_COMPLETE event and stamps closedAt and closedBy on the task.
+
+        Returns 404 when the task does not exist, 422 when it is already DONE or DISMISSED, and 400 when outcome is blank.
+
+        '
+      operationId: completeFollowUpTask
       parameters:
       - name: taskId
         in: path
@@ -1702,10 +2484,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The worked outcome of the follow-up and any booking it produced.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CloseFollowUpTaskRequest'
+            examples:
+              Booked the declined work:
+                description: Booked the declined work
+                value:
+                  outcome: Customer booked rear brake job for next week
+                  bookedWorkorderId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5f
         required: true
       responses:
         '200':
@@ -1729,9 +2518,21 @@ paths:
     post:
       tags:
       - CRM Party Relationships
-      summary: Create a party relationship
-      description: Creates a relationship between a commercial account and an individual person
-      operationId: createRelationship
+      summary: Create Party Relationship
+      description: 'Creates a dated relationship that links an individual person to a commercial account in one or more roles, optionally marking the person as the primary billing contact.
+
+        Use this tool when associating a known person with a commercial account; do not use updateContactRoles, which manages the separate contact-role assignment model, and do not use createPerson, which creates the person record itself.
+
+        Preconditions: the commercial party and the person must both exist, and no active relationship may already cover the same party, person, and role for today''s date; isPrimaryBillingContact requires the BILLING role in the same request.
+
+        Required inputs: partyId (UUID) as a path parameter, plus personId (UUID), roles (one or more of APPROVER, BILLING, PRIMARY_CONTACT, DRIVER, TECHNICAL), and effectiveStartDate; effectiveEndDate and isPrimaryBillingContact (default false) are optional.
+
+        Emits a CRM_RELATIONSHIP_CREATE event, atomically demotes any existing primary billing contact when one is designated, and re-emits the person''s identity fact.
+
+        Returns 404 when the party or person cannot be found, 409 when an overlapping active relationship already exists for a requested role, and 400 when isPrimaryBillingContact is set without the BILLING role.
+
+        '
+      operationId: createPartyRelationship
       parameters:
       - name: partyId
         in: path
@@ -1741,10 +2542,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The person, roles, and effective dates of the relationship being established with the account.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreatePartyRelationshipRequest'
+            examples:
+              Primary billing contact:
+                description: Primary billing contact
+                value:
+                  personId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a60
+                  roles:
+                  - BILLING
+                  - PRIMARY_CONTACT
+                  isPrimaryBillingContact: true
+                  effectiveStartDate: 2026-08-13
         required: true
       responses:
         '201':
@@ -1792,14 +2604,37 @@ paths:
     post:
       tags:
       - CRM Accounts
-      summary: Resolve account tier
-      description: Resolve or compute the account tier based on business rules
+      summary: Resolve Account Tier
+      description: 'Computes the recommended tier for a commercial account from annual revenue, active contract count, and account age thresholds, and optionally applies it to the account.
+
+        Use this tool when a tier recommendation or recalculation is needed; do not use getAccountTier, which only reads the stored tier without recomputing it.
+
+        Preconditions: a commercial party must exist for the accountId; when applyTier is true, a manual tier override on the account blocks application unless forceRecalculation is also true.
+
+        Required inputs: accountId (UUID string); annualRevenue, activeContractCount, and accountAgeMonths are optional scoring inputs, and applyTier and forceRecalculation both default to false, so the default call is a dry run.
+
+        Emits a CUSTOMER_ACCOUNT_TIER_RESOLVE event; when the tier is applied the account record is updated with assignedBy SYSTEM and a customer fact is republished.
+
+        Returns 404 when the account does not exist or the accountId is not a valid UUID.
+
+        '
       operationId: resolveAccountTier
       requestBody:
+        description: Tier scoring inputs for one account, plus flags controlling whether the resolved tier is applied.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ResolveAccountTierRequest'
+            examples:
+              Dry-run resolution:
+                description: Dry-run resolution
+                value:
+                  accountId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  annualRevenue: 275000
+                  activeContractCount: 3
+                  accountAgeMonths: 18
+                  applyTier: false
+                  forceRecalculation: false
         required: true
       responses:
         '200':
@@ -1823,8 +2658,20 @@ paths:
     get:
       tags:
       - CRM Accounts
-      summary: Browse parties
-      description: Browse parties with paging and sorting. The service sorts by legalName ascending by default, appends partyId ascending as a stable tie-breaker whenever the requested sort list does not explicitly include partyId, and applies case-insensitive legalName sorting.
+      summary: Browse Customer Directory
+      description: 'Returns a paged customer directory that unifies commercial parties and standalone individual customers, with person names and contact points resolved from pos-people.
+
+        Use this tool when listing or typeahead-filtering customers by name, status, party type, or customer number; do not use searchParties, which filters commercial parties only by structured criteria, and use getParty instead when the party id is already known.
+
+        Preconditions: none; an empty page is returned when nothing matches, and a pos-people outage degrades person names to null rather than failing the request.
+
+        Required inputs: none; page defaults to 0 with size 20, the name filter matches legal name, display name, or customer number case-insensitively, status matches ACTIVE, INACTIVE, ON_HOLD, or MERGED, sortField is name (default) or customerNumber, and sortOrder is asc (default) or desc with partyId as a stable tie-breaker.
+
+        Emits a CUSTOMER_PARTY_BROWSE audit event; no state changes occur.
+
+        Returns 200 with an empty results array rather than an error when no party matches the filters.
+
+        '
       operationId: browseParties
       parameters:
       - name: pageable
@@ -1886,14 +2733,38 @@ paths:
     post:
       tags:
       - CRM Accounts
-      summary: Create commercial account
-      description: Create a new commercial party/account in the CRM system
+      summary: Create Commercial Account
+      description: 'Creates a commercial party record with status ACTIVE and a generated customer number of the form CUST-XXXXXXXX.
+
+        Use this tool when onboarding a new commercial customer; do not use searchParties or checkPartyDuplicates, which only look up existing parties, and run checkPartyDuplicates first to avoid creating a duplicate, because no uniqueness check is applied here.
+
+        Preconditions: none beyond authorization; the service performs no duplicate detection on legalName.
+
+        Required inputs: legalName (non-blank, max 255); partyType defaults to COMMERCIAL and must be PERSON, COMMERCIAL, or UNKNOWN when supplied; displayName, taxId, billingTermsId, and externalIdentifiers are optional.
+
+        Emits a CUSTOMER_PARTY_CREATE event and publishes a party-changed customer fact.
+
+        Returns 400 when legalName is missing or blank, or when partyType is not a recognized value.
+
+        '
       operationId: createCommercialAccount
       requestBody:
+        description: Commercial party to create; legalName is the only mandatory field and no duplicate check is applied.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateCommercialAccountRequest'
+            examples:
+              New commercial account:
+                description: New commercial account
+                value:
+                  legalName: Acme Fleet Services LLC
+                  displayName: Acme Fleet
+                  taxId: 12-3456789
+                  partyType: COMMERCIAL
+                  externalIdentifiers:
+                    ERP: AC-1001
+        required: true
       responses:
         '201':
           description: Account created successfully
@@ -1914,14 +2785,34 @@ paths:
     post:
       tags:
       - CRM Accounts
-      summary: Resolve party display names
-      description: Batch-resolve party ids to display names. Consumed server-side by sibling services (e.g. pos-invoice) that store only the party id and need the display name to enrich finder/search rows. Unknown or unresolvable ids are omitted from the response.
+      summary: Resolve Party Display Names
+      description: 'Batch-resolves party ids to display names for both commercial and person parties, for sibling services such as pos-invoice that store only the party id.
+
+        Use this tool when enriching rows that already carry party ids; do not use getParty, which returns the full identity projection for a single party per call.
+
+        Preconditions: none; unknown or unresolvable ids are silently omitted from the response rather than causing an error.
+
+        Required inputs: partyIds, a non-empty list of up to 200 UUIDs; null entries and duplicates are dropped before resolution.
+
+        Emits a CUSTOMER_PARTY_RESOLVE audit event; no state changes occur.
+
+        Returns 400 when partyIds is empty or exceeds 200 entries, and 200 with a possibly shorter list than requested when some ids cannot be resolved.
+
+        '
       operationId: resolvePartyNames
       requestBody:
+        description: Batch of party ids whose display names should be resolved.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PartyNameResolveRequest'
+            examples:
+              Two-party batch:
+                description: Two-party batch
+                value:
+                  partyIds:
+                  - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '200':
@@ -1945,8 +2836,20 @@ paths:
     post:
       tags:
       - CRM Accounts
-      summary: Create vehicle for party
-      description: Associate a new vehicle with a party/customer
+      summary: Associate Vehicle With Party
+      description: 'Associates a vehicle VIN with a commercial party by appending it to the party''s owned VIN list.
+
+        Use this tool when recording that a commercial account operates a vehicle; do not use it to change vehicle details, and note the VIN list is account-level rather than a full vehicle record.
+
+        Preconditions: a commercial party must exist for the supplied partyId, and the VIN must not already be associated with that party.
+
+        Required inputs: partyId (UUID) as a path parameter and vinNumber (max 17 characters) in the body; unitNumber, description, licensePlate, and licensePlateRegion are optional.
+
+        Emits a CUSTOMER_VEHICLE_CREATE event and republishes the party-changed customer fact.
+
+        Returns 404 when the party does not exist, 409 when the VIN is already associated with the party, and 400 when vinNumber is missing or blank.
+
+        '
       operationId: createVehicleForParty
       parameters:
       - name: partyId
@@ -1957,10 +2860,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Vehicle identification to associate with the party, keyed by VIN.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateVehicleForPartyRequest'
+            examples:
+              Fleet truck:
+                description: Fleet truck
+                value:
+                  vinNumber: 1FTFW1ET5DFC10312
+                  unitNumber: TRK-42
+                  description: 2019 Ford F-150 service truck
+                  licensePlate: ABC1234
+                  licensePlateRegion: TX
+        required: true
       responses:
         '201':
           description: Vehicle created successfully
@@ -1983,8 +2897,20 @@ paths:
     post:
       tags:
       - CRM Accounts
-      summary: Merge parties
-      description: Merge multiple parties into a single party record
+      summary: Merge Duplicate Commercial Parties
+      description: 'Merges one duplicate commercial party into a surviving party: relationships are reassigned to the survivor, external identifiers and vehicle VINs are copied over, and the losing party''s status is set to MERGED.
+
+        Use this tool when checkPartyDuplicates has confirmed two records represent the same customer; do not use createCommercialAccount to work around duplicates, and note the merge is not reversible through this API.
+
+        Preconditions: both the surviving party (path) and losing party (body) must exist as commercial parties and must be different records.
+
+        Required inputs: partyId of the survivor as a path parameter, plus losingPartyId (UUID string) and a justification of up to 1000 characters in the body.
+
+        Emits a CUSTOMER_PARTY_MERGE event and republishes customer facts for both parties and for contacts whose account linkage moved.
+
+        Returns 404 when either party cannot be found, and 400 when losingPartyId or justification is missing, losingPartyId is not a valid UUID, or both ids refer to the same party.
+
+        '
       operationId: mergeParties
       parameters:
       - name: partyId
@@ -1995,10 +2921,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Identifies the losing party to fold into the survivor and records the audit justification for the merge.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/MergePartiesRequest'
+            examples:
+              Merge duplicate:
+                description: Merge duplicate
+                value:
+                  losingPartyId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  justification: Duplicate created during fleet onboarding import
+        required: true
       responses:
         '200':
           description: Parties merged successfully
@@ -2021,9 +2955,21 @@ paths:
     get:
       tags:
       - CRM Accounts
-      summary: Get communication preferences
-      description: Retrieve communication preferences and consent flags for a party
-      operationId: getCommunicationPreferences_1
+      summary: Get Account Communication Preferences
+      description: 'Returns a legacy account-scoped communication-preference projection for a commercial party in which every channel currently reports the placeholder value N/A.
+
+        Use this tool only for the legacy accounts-scoped path; use getCommunicationPreferences instead, which reads the persisted per-party preference record with real channel values and consent flags.
+
+        Preconditions: a commercial party must exist for the supplied partyId.
+
+        Required inputs: partyId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no commercial party exists for the supplied partyId.
+
+        '
+      operationId: getAccountCommunicationPreferences
       parameters:
       - name: partyId
         in: path
@@ -2051,9 +2997,21 @@ paths:
     post:
       tags:
       - CRM Accounts
-      summary: Create or update communication preferences
-      description: Set or update communication preferences and consent flags for a party
-      operationId: upsertCommunicationPreferences_1
+      summary: Upsert Account Communication Preferences
+      description: 'Acknowledges an account-scoped communication-preference submission for a commercial party without persisting any preference values; this legacy path only validates the party and returns SUCCESS.
+
+        Use this tool only for the legacy accounts-scoped path; use upsertCommunicationPreferences instead, which actually stores channel preferences and consent flags per party.
+
+        Preconditions: a commercial party must exist for the supplied partyId.
+
+        Required inputs: partyId (UUID) as a path parameter and a non-null JSON body; the preference fields themselves are accepted but not stored.
+
+        Emits a CUSTOMER_COMMUNICATION_PREFERENCE_UPSERT audit event; no preference record is written.
+
+        Returns 404 when no commercial party exists for the supplied partyId, and 400 when the request body is missing.
+
+        '
+      operationId: upsertAccountCommunicationPreferences
       parameters:
       - name: partyId
         in: path
@@ -2063,10 +3021,20 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Channel preference values acknowledged by this legacy endpoint; the values are validated but not stored.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpsertCommunicationPreferencesRequest'
+            examples:
+              Opt-in email only:
+                description: Opt-in email only
+                value:
+                  emailPreference: OPT_IN
+                  smsPreference: OPT_OUT
+                  phonePreference: OPT_OUT
+                  updateSource: ADMIN
+        required: true
       responses:
         '200':
           description: Preferences updated successfully
@@ -2089,14 +3057,34 @@ paths:
     post:
       tags:
       - CRM Accounts
-      summary: Search parties
-      description: Search for parties based on various criteria
+      summary: Search Commercial Parties
+      description: 'Searches commercial party records by structured criteria such as name, tax id, party type, and status, returning all matches in a single unpaged result set.
+
+        Use this tool when filtering commercial parties by structured attributes like taxId; use browseParties instead for the paged, unified directory that also includes individual customers, and checkPartyDuplicates for pre-create duplicate detection by legal name.
+
+        Preconditions: none; an omitted or empty body matches every commercial party.
+
+        Required inputs: none; name, email, phone, taxId, partyType, and status are all optional filters, and the pageNumber and pageSize fields are accepted but not applied, so the full match list is always returned.
+
+        Emits a CUSTOMER_PARTY_SEARCH audit event; no state changes occur.
+
+        Returns 200 with an empty results array rather than an error when no party matches.
+
+        '
       operationId: searchParties
       requestBody:
+        description: Optional structured filter criteria; every supplied field narrows the match and an empty body matches all commercial parties.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SearchPartiesRequest'
+            examples:
+              Filter by name and status:
+                description: Filter by name and status
+                value:
+                  name: Acme
+                  partyType: COMMERCIAL
+                  status: ACTIVE
       responses:
         '200':
           description: Search results returned
@@ -2117,9 +3105,21 @@ paths:
     get:
       tags:
       - Promotion Redemptions
-      summary: Get redemptions by customer
-      description: Retrieve all recorded redemptions for a customer
-      operationId: getRedemptionsByCustomer
+      summary: List Customer Promotion Redemptions
+      description: 'Returns every promotion redemption recorded for one customer, including discount amounts, codes, statuses, and timestamps.
+
+        Use this tool when reviewing a customer''s redemption history, for example to enforce per-customer limits; use recordPromotionRedemption instead to record a new redemption.
+
+        Preconditions: none; an unknown customerId yields an empty list rather than an error.
+
+        Required inputs: customerId (UUID) as a path parameter; there is no request body.
+
+        Emits a PROMOTION_REDEMPTION_LIST audit event; no state changes occur.
+
+        Returns 200 with an empty list rather than an error when the customer has no redemptions.
+
+        '
+      operationId: listPromotionRedemptionsByCustomer
       parameters:
       - name: customerId
         in: path
@@ -2147,9 +3147,21 @@ paths:
     get:
       tags:
       - Customer Requirements
-      summary: Check whether a customer meets requirements
-      description: Returns true when the customer is active and, for commercial parties, not on credit hold.
-      operationId: requirementsMet
+      summary: Check Customer Requirements Met
+      description: 'Evaluates whether a customer is eligible for customer-facing workflows: the party must have ACTIVE status, and a commercial party must additionally not be on credit hold.
+
+        Use this tool as a gate before starting orders or workorders for a customer; use getBillingRules instead to see the underlying credit-hold configuration.
+
+        Preconditions: a commercial or person party must exist for the supplied id.
+
+        Required inputs: id (UUID, the party id) as a path parameter; there is no request body.
+
+        Emits a CUSTOMER_REQUIREMENTS_MET_GET audit event; no state changes occur.
+
+        Returns 404 when no party exists for the supplied id, and 200 with a bare boolean verdict otherwise.
+
+        '
+      operationId: checkCustomerRequirementsMet
       parameters:
       - name: id
         in: path
@@ -2180,8 +3192,20 @@ paths:
     get:
       tags:
       - CRM Vehicles
-      summary: List vehicles for customer
-      description: Retrieve all vehicle summaries (vehicleId, VIN, make/model/year) associated with a customer. Returns the vehicle UUIDs the frontend needs to build estimates for a given Durion customer.
+      summary: List Customer Vehicles
+      description: 'Returns the vehicle summaries (vehicleId, VIN, make, model, year) associated with a customer, resolved from the party''s VIN set against the local ext_vehicle replica of pos-vehicle-inventory.
+
+        Use this tool when the vehicle UUIDs for a known customer are needed, for example to build an estimate; use getVehicleForCustomer instead for one vehicle''s full record, and note vehicle writes go to pos-vehicle-inventory, not this module.
+
+        Preconditions: the customer must exist as a person or commercial party; VINs whose vehicle events have not yet been replicated are silently dropped from the list.
+
+        Required inputs: customerId (UUID, the party id) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no party exists for the supplied customerId, and 200 with an empty list when the customer owns no resolvable vehicles.
+
+        '
       operationId: listVehiclesForCustomer
       parameters:
       - name: customerId
@@ -2213,9 +3237,21 @@ paths:
     get:
       tags:
       - CRM Vehicles
-      summary: Get vehicle for customer
-      description: Retrieve a specific vehicle for a given customer
-      operationId: getVehiclesForCustomer
+      summary: Get Customer Vehicle
+      description: 'Returns one vehicle''s record from the local ext_vehicle replica, verified to belong to the named customer through the party''s VIN association.
+
+        Use this tool when both the customer and vehicle ids are known; use listVehiclesForCustomer instead to discover which vehicles a customer owns.
+
+        Preconditions: the customer must exist, the vehicle must exist in the replica, and the vehicle must be associated with that customer.
+
+        Required inputs: customerId and vehicleId (UUIDs) as path parameters; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the customer, the vehicle, or the ownership association cannot be resolved.
+
+        '
+      operationId: getVehicleForCustomer
       parameters:
       - name: customerId
         in: path
@@ -2251,9 +3287,21 @@ paths:
     get:
       tags:
       - CRM Suppression
-      summary: Check address suppression
-      description: Whether a raw address is currently blocked on a channel. Used by send pipelines.
-      operationId: check
+      summary: Check Address Suppression
+      description: 'Reports whether a raw address is currently hard-blocked on a channel by normalizing and hashing it and looking the hash up in the suppression list.
+
+        Use this tool from send pipelines immediately before dispatch; use resolveMarketingEligibility instead for the full party-level decision that also folds in consent and the account gate.
+
+        Preconditions: none; suppression outranks consent, so a true result must block the send regardless of opt-in state.
+
+        Required inputs: channel (EMAIL or SMS) and address (the raw address to test) as required query parameters; the raw address is used only for hashing and never stored.
+
+        Emits a CRM_SUPPRESSION_CHECK audit event; no state changes occur.
+
+        Returns 200 with a bare boolean body, true when the address is suppressed on that channel and false otherwise.
+
+        '
+      operationId: checkAddressSuppression
       parameters:
       - name: channel
         in: query
@@ -2286,9 +3334,21 @@ paths:
     get:
       tags:
       - CRM Snapshots
-      summary: Fetch snapshot by vehicle
-      description: Returns party snapshot based on vehicle ownership
-      operationId: fetchByVehicle
+      summary: Get CRM Snapshot By Vehicle
+      description: 'Returns the CRM snapshot of the commercial party that owns a vehicle, resolved through the vehicle-to-party association replicated from vehicle events.
+
+        Use this tool when only a vehicle id is known, for example at service check-in; use getSnapshotByParty instead when the party id is already known.
+
+        Preconditions: the vehicle must be associated with a commercial party in the local replica; recently registered vehicles may not have been replicated yet.
+
+        Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+
+        Emits a CRM_SNAPSHOT_VEHICLE_RETRIEVE audit event; no state changes occur.
+
+        Returns 404 when no owning party can be resolved for the supplied vehicleId.
+
+        '
+      operationId: getSnapshotByVehicle
       parameters:
       - name: vehicleId
         in: path
@@ -2317,9 +3377,21 @@ paths:
     get:
       tags:
       - CRM Snapshots
-      summary: Fetch snapshot by party
-      description: Returns complete party snapshot with accounts, contacts, vehicles
-      operationId: fetchByParty
+      summary: Get CRM Snapshot By Party
+      description: 'Returns a consolidated CRM snapshot for a party — account summary, contacts, vehicle summaries, and preferences — assembled for commercial or person parties and served from a cache when a fresh copy exists.
+
+        Use this tool when a caller needs the whole customer picture in one call; use getParty instead for just the identity fields, and getSnapshotByVehicle when only a vehicle id is known.
+
+        Preconditions: a commercial or person party must exist for the supplied partyId.
+
+        Required inputs: partyId (UUID) as a path parameter; there is no request body, and the snapshotMetadata.source field reports CACHE or CRM_API depending on where the data came from.
+
+        Emits a CRM_SNAPSHOT_PARTY_RETRIEVE audit event; the snapshot cache may be populated but no domain state changes.
+
+        Returns 404 when neither a commercial nor a person party exists for the supplied partyId.
+
+        '
+      operationId: getSnapshotByParty
       parameters:
       - name: partyId
         in: path
@@ -2348,8 +3420,20 @@ paths:
     get:
       tags:
       - CRM Snapshots
-      summary: Get billing rules for a commercial party
-      description: Returns the billing rule reference for a commercial party. Returns default billing rules when the party has no explicitly configured rules. Enforcement of these rules is the responsibility of downstream services.
+      summary: Get Party Billing Rules
+      description: 'Returns the billing-rules reference for a party, falling back to default rules when a commercial party has no explicitly configured rules and for person parties, which have no configurable rules; enforcement of the rules belongs to downstream services.
+
+        Use this tool when reading how an account should be billed; use upsertBillingRules instead to change the configuration.
+
+        Preconditions: a commercial or person party must exist for the supplied partyId.
+
+        Required inputs: partyId (UUID) as a path parameter; there is no request body.
+
+        Emits a CRM_SNAPSHOT_BILLING_RULES_GET audit event; no state changes occur.
+
+        Returns 404 when no party exists for the supplied partyId, and 200 with defaults rather than an error when rules were never configured.
+
+        '
       operationId: getBillingRules
       parameters:
       - name: partyId
@@ -2387,9 +3471,21 @@ paths:
     get:
       tags:
       - CRM Segments
-      summary: List the segment attribute catalog
-      description: Every whitelisted attribute a dynamic predicate may reference, with operand kind, allowed operators, and description
-      operationId: attributeCatalog
+      summary: List Segment Attribute Catalog
+      description: 'Returns the whitelist of attributes a dynamic segment predicate may reference, each with its operand kind, allowed operators, and description.
+
+        Use this tool before createSegment or updateSegment to build a valid DYNAMIC predicate; do not use listSegments, which lists saved segments rather than the predicate vocabulary.
+
+        Preconditions: none; the catalog is fixed in code per audience type.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        Emits a CRM_SEGMENT_ATTRIBUTES audit event; no state changes occur.
+
+        Returns 200 with the full catalog in every successful call; there are no business error responses.
+
+        '
+      operationId: listSegmentAttributes
       responses:
         '200':
           description: Attribute catalog returned
@@ -2410,8 +3506,20 @@ paths:
     get:
       tags:
       - CRM Persons
-      summary: Get a person by ID
-      description: Retrieves an individual person record by their unique identifier
+      summary: Get Person By Id
+      description: 'Returns the CRM view of an individual person by their canonical pos-people person id, including their customer number and preferred contact method.
+
+        Use this tool when the person id is already known; use searchPersons instead when locating a person by name or email.
+
+        Preconditions: a local person-party link must exist for the canonical person id.
+
+        Required inputs: personId (UUID, the canonical pos-people id) as a path parameter; there is no request body.
+
+        Emits a CRM_PERSON_GET audit event; no state changes occur.
+
+        Returns 404 when no person-party exists for the supplied personId.
+
+        '
       operationId: getPerson
       parameters:
       - name: personId
@@ -2455,9 +3563,21 @@ paths:
     get:
       tags:
       - CRM Marketing Consent
-      summary: Resolve send eligibility
-      description: Fold the account gate, governing contact consent, and suppression into a single allow/deny decision for one channel
-      operationId: resolveEligibility
+      summary: Resolve Marketing Send Eligibility
+      description: 'Resolves a single allow-or-deny marketing send decision for one party and channel by folding together the account gate, the governing party''s consent, and the suppression list, where suppression is a hard block layered on top of an opt-in.
+
+        Use this tool immediately before sending marketing to a party; use getMarketingConsent instead when the full consent summary rather than one decision is needed.
+
+        Preconditions: none; unknown parties resolve to a deny decision rather than an error.
+
+        Required inputs: partyId (UUID) as a path parameter and channel (EMAIL or SMS) as a required query parameter.
+
+        Emits a CRM_MARKETING_ELIGIBILITY_GET audit event; no state changes occur.
+
+        Returns 200 with allowed false and a reason code such as SUPPRESSED when the send must not happen, and 400 when channel is not EMAIL or SMS.
+
+        '
+      operationId: resolveMarketingEligibility
       parameters:
       - name: partyId
         in: path
@@ -2491,8 +3611,20 @@ paths:
     get:
       tags:
       - CRM Contacts
-      summary: Get contacts with roles
-      description: Retrieve all contacts for a party including their role assignments
+      summary: Get Party Contacts With Roles
+      description: 'Returns every contact person assigned a role on a commercial account, with names, emails, and phones resolved from pos-people and each contact''s role assignments and primary flags.
+
+        Use this tool when listing who represents a commercial account and in what capacity; do not use updateContactRoles, which rewrites one contact''s role assignments.
+
+        Preconditions: a commercial party must exist for the supplied partyId; a pos-people outage degrades contact names and contact points to null rather than failing.
+
+        Required inputs: partyId (UUID) as a path parameter; there is no request body.
+
+        Emits a CRM_CONTACTS_LIST audit event; no state changes occur.
+
+        Returns 404 when no commercial party exists for the supplied partyId, and 200 with an empty contacts list when the account has no role assignments.
+
+        '
       operationId: getContactsWithRoles
       parameters:
       - name: partyId
@@ -2522,8 +3654,20 @@ paths:
     get:
       tags:
       - CRM Marketing Consent
-      summary: Get consent history
-      description: Append-only marketing-consent audit trail for a party, newest first
+      summary: Get Consent Audit History
+      description: 'Returns the append-only marketing-consent audit trail for a party, newest first, with one entry per actual consent change recording the channel, old and new values, reason, source, and acting user.
+
+        Use this tool when auditing how a party''s consent reached its current state; use getMarketingConsent instead for the current consent summary and eligibility.
+
+        Preconditions: none; a party with no recorded consent changes yields an empty page rather than an error.
+
+        Required inputs: partyId (UUID) as a path parameter; page defaults to 0 and size defaults to 50 with a clamp between 1 and 200.
+
+        No events are emitted by the consent trail itself beyond the CRM_CONSENT_HISTORY_GET audit event this read emits; no state changes occur.
+
+        Returns 200 with an empty page rather than an error when no history exists.
+
+        '
       operationId: getConsentHistory
       parameters:
       - name: partyId
@@ -2564,9 +3708,21 @@ paths:
     get:
       tags:
       - CRM Inquiries
-      summary: Get inquiry
-      description: Retrieve a single inquiry
-      operationId: get_1
+      summary: Get Inquiry
+      description: 'Returns one inbound inquiry with its channel, audience type, contact details, interest fields, status, assignee, and any linked party.
+
+        Use this tool when the inquiry id is already known; use listInquiries instead to find inquiries by status.
+
+        Preconditions: the inquiry must exist.
+
+        Required inputs: inquiryId (UUID) as a path parameter; there is no request body.
+
+        Emits a CRM_INQUIRY_GET audit event; no state changes occur.
+
+        Returns 404 when no inquiry exists for the supplied inquiryId.
+
+        '
+      operationId: getInquiry
       parameters:
       - name: inquiryId
         in: path
@@ -2594,9 +3750,21 @@ paths:
     get:
       tags:
       - CRM Follow-ups
-      summary: Follow-up queue
-      description: The CSR work queue, ordered by due date. All filters are optional.
-      operationId: queue
+      summary: Get Follow-Up Work Queue
+      description: 'Returns the CSR follow-up work queue across all parties, ordered by due date, optionally filtered by status, assignee, and task type.
+
+        Use this tool when working the shared queue of outstanding follow-ups; use listPartyFollowUps instead to see tasks raised against one specific party.
+
+        Preconditions: none; an empty page is returned when no task matches the filters.
+
+        Required inputs: none; status filters on OPEN, DONE, or DISMISSED, type filters on DECLINED_SERVICE_FOLLOWUP, SERVICE_DUE_REMINDER, FLEET_CHECKIN, CAMPAIGN_RESPONSE, or GENERAL, page defaults to 0, and size defaults to 50 clamped between 1 and 200.
+
+        Emits a CRM_FOLLOWUP_QUEUE audit event; no state changes occur.
+
+        Returns 200 with an empty page rather than an error when the queue is clear.
+
+        '
+      operationId: getFollowUpQueue
       parameters:
       - name: status
         in: query
@@ -2655,9 +3823,21 @@ paths:
     get:
       tags:
       - CRM Follow-ups
-      summary: Get follow-up task
-      description: Retrieve a single follow-up task
-      operationId: get_2
+      summary: Get Follow-Up Task
+      description: 'Returns one follow-up task with its party, vehicle, type, due date, assignee, status, and any recorded outcome and booking references.
+
+        Use this tool when the task id is already known; use getFollowUpQueue instead to discover tasks by status, assignee, or type.
+
+        Preconditions: the follow-up task must exist.
+
+        Required inputs: taskId (UUID) as a path parameter; there is no request body.
+
+        Emits a CRM_FOLLOWUP_GET audit event; no state changes occur.
+
+        Returns 404 when no follow-up task exists for the supplied taskId.
+
+        '
+      operationId: getFollowUpTask
       parameters:
       - name: taskId
         in: path
@@ -2685,9 +3865,21 @@ paths:
     get:
       tags:
       - CRM Party Relationships
-      summary: Get contacts for a commercial account
-      description: Retrieves all individuals associated with a commercial account with their roles
-      operationId: getContacts
+      summary: Get Commercial Account Contacts
+      description: 'Returns the individuals related to a commercial account through party relationships, with their roles, primary-billing flag, effective dates, and status.
+
+        Use this tool when listing who is associated with an account through the relationship model; use getContactsWithRoles instead for the contact-role assignment view of the same account.
+
+        Preconditions: the commercial party must exist.
+
+        Required inputs: partyId (UUID) as a path parameter; roles optionally filters on APPROVER, BILLING, PRIMARY_CONTACT, DRIVER, or TECHNICAL, and status optionally filters on ACTIVE or INACTIVE.
+
+        Emits a CRM_ACCOUNT_CONTACTS_GET audit event; no state changes occur.
+
+        Returns 404 when no commercial party exists for the supplied partyId.
+
+        '
+      operationId: getCommercialAccountContacts
       parameters:
       - name: partyId
         in: path
@@ -2751,8 +3943,20 @@ paths:
     get:
       tags:
       - CRM Accounts
-      summary: List billing terms
-      description: Returns the reference list of all available billing terms. This is a static reference endpoint; it does not vary per party or account.
+      summary: List Billing Term Options
+      description: 'Returns the static reference list of billing term options: NET_30, NET_60, NET_90, COD, and PREPAID, each with a display label and net-day count.
+
+        Use this tool when populating a billing-terms dropdown before createCommercialAccount or upsertBillingRules; do not use upsertBillingRules to discover valid terms, which writes configuration rather than listing options.
+
+        Preconditions: none; the list is compiled into the service and identical for every caller.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        No events are emitted and no state changes; this is a read-only reference lookup.
+
+        Returns 200 with the full five-entry list in every successful call; there are no business error responses.
+
+        '
       operationId: listBillingTerms
       responses:
         '200':
@@ -2788,9 +3992,21 @@ paths:
     get:
       tags:
       - CRM Person-Link Reconciliation
-      summary: Reconcile person links
-      description: Verify every person_party.person_id resolves to a pos-people person (ADR-0015 I1).
-      operationId: reconcile
+      summary: Reconcile Person Links
+      description: 'Produces an integrity report verifying that every person_party.person_id in this module resolves to a canonical person in pos-people, the precondition for keeping person_party as a thin link under ADR-0015.
+
+        Use this tool for admin integrity checks after imports or migrations; do not use searchPersons, which looks up individual customers rather than auditing link health.
+
+        Preconditions: pos-people must be reachable to resolve the links being verified.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        No events are emitted and no state changes; the report is computed on demand and nothing is repaired automatically.
+
+        Returns 200 with the reconciliation report, including any person ids that failed to resolve.
+
+        '
+      operationId: reconcilePersonLinks
       responses:
         '200':
           description: Reconciliation report returned
@@ -2804,8 +4020,20 @@ paths:
     get:
       tags:
       - CRM Accounts
-      summary: Get account tier
-      description: Retrieve the tier level for a specific account
+      summary: Get Account Tier
+      description: 'Returns the currently assigned tier for a commercial account, including who assigned it, when, and whether a manual override is active; unassigned accounts report STANDARD.
+
+        Use this tool when the stored tier of a known commercial account is needed; do not use resolveAccountTier, which recomputes a recommended tier from revenue and contract inputs.
+
+        Preconditions: a commercial party must exist for the accountId; person parties have no tier.
+
+        Required inputs: accountId (UUID) as a path parameter; there is no request body.
+
+        Emits a CUSTOMER_ACCOUNT_TIER_GET audit event; no state changes occur.
+
+        Returns 404 when no commercial account exists for the supplied accountId.
+
+        '
       operationId: getAccountTier
       parameters:
       - name: accountId
@@ -2835,8 +4063,20 @@ paths:
     get:
       tags:
       - CRM Accounts
-      summary: Get party details
-      description: Retrieve details for a specific party by ID
+      summary: Get Party Details
+      description: 'Returns the identity projection of a single party, resolving commercial parties first and falling back to person parties, whose display name is resolved from the person directory.
+
+        Use this tool when a party id is already known; use browseParties or searchParties instead when locating a party by name, status, or customer number.
+
+        Preconditions: a commercial or person party must exist for the supplied partyId.
+
+        Required inputs: partyId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when neither a commercial nor a person party exists for the supplied partyId.
+
+        '
       operationId: getParty
       parameters:
       - name: partyId
@@ -2866,8 +4106,20 @@ paths:
     get:
       tags:
       - CRM Accounts
-      summary: Check for duplicate commercial parties
-      description: Search for existing parties with a similar legal name to detect potential duplicates before creating a new commercial account.
+      summary: Check Commercial Party Duplicates
+      description: 'Checks for existing commercial parties whose legal name contains the supplied name, flagging case-insensitive exact matches as EXACT with score 1.0 and other containment matches as FUZZY with score 0.7.
+
+        Use this tool before createCommercialAccount to avoid creating a duplicate customer; do not use searchParties for this, which does not classify match strength or surface an exactMatchPartyId.
+
+        Preconditions: none; the check reads existing commercial parties only.
+
+        Required inputs: legalName as a query parameter with at least 2 non-whitespace characters; there is no request body.
+
+        Emits a CUSTOMER_PARTY_DUPLICATE_CHECK audit event; no state changes occur.
+
+        Returns 400 when legalName is blank or shorter than 2 characters after trimming, and 200 with duplicatesFound false when no similar party exists.
+
+        '
       operationId: checkPartyDuplicates
       parameters:
       - name: legalName
@@ -2899,9 +4151,21 @@ paths:
     delete:
       tags:
       - CRM Suppression
-      summary: Lift a suppression
-      description: Remove a suppression entry
-      operationId: remove
+      summary: Lift Address Suppression
+      description: 'Removes one suppression entry, allowing marketing to reach the address again subject to normal consent rules.
+
+        Use this tool when an address was suppressed in error or a legal block is lifted; do not use updateMarketingConsent for this, which cannot override a suppression entry.
+
+        Preconditions: the suppression entry must exist.
+
+        Required inputs: suppressionId (UUID) as a path parameter; there is no request body.
+
+        Emits a CRM_SUPPRESSION_REMOVE event and publishes a suppression-changed fact so consumers stop blocking the address.
+
+        Returns 404 when no suppression entry exists for the supplied suppressionId.
+
+        '
+      operationId: removeSuppressionEntry
       parameters:
       - name: suppressionId
         in: path
@@ -2925,9 +4189,21 @@ paths:
     delete:
       tags:
       - CRM Segments
-      summary: Unpin member
-      description: Remove a party from a static segment
-      operationId: removeMember
+      summary: Unpin Segment Member
+      description: 'Removes one party from a static segment''s pinned member list.
+
+        Use this tool when a hand-picked party should leave the audience; do not use deleteSegment, which removes the whole segment and every member with it.
+
+        Preconditions: none are enforced; removing a party that is not a member, or naming an unknown segment, is a silent no-op.
+
+        Required inputs: segmentId and partyId (UUIDs) as path parameters; there is no request body.
+
+        Emits a CRM_SEGMENT_MEMBER_REMOVE event; at most one membership row is deleted.
+
+        Returns 204 in every authorized call, including when nothing was actually removed.
+
+        '
+      operationId: removeSegmentMember
       parameters:
       - name: segmentId
         in: path
@@ -2955,9 +4231,21 @@ paths:
     delete:
       tags:
       - CRM Tags
-      summary: Remove tag from party
-      description: 'Detach a tag from a party. Idempotent: removing an absent tag succeeds.'
-      operationId: removeTag
+      summary: Remove Tag From Party
+      description: 'Detaches a tag from a party while leaving the tag itself in the catalog.
+
+        Use this tool when a label no longer applies to a party; use deleteTag instead to remove the tag from the catalog and every party at once.
+
+        Preconditions: none; removing a tag that is not assigned is an idempotent no-op.
+
+        Required inputs: partyId and tagId (UUIDs) as path parameters; there is no request body.
+
+        Emits a CRM_PARTY_TAG_REMOVE event and publishes a party-tag-changed fact when an assignment was actually removed.
+
+        Returns 204 in every authorized call, including when nothing was assigned.
+
+        '
+      operationId: removeTagFromParty
       parameters:
       - name: partyId
         in: path
@@ -2985,9 +4273,21 @@ paths:
     delete:
       tags:
       - CRM Party Relationships
-      summary: Deactivate a party relationship
-      description: Soft-deletes a relationship by setting its effective end date
-      operationId: deactivateRelationship
+      summary: Deactivate Party Relationship
+      description: 'Soft-deletes a relationship between a person and a commercial account by setting its effective end date to today; the historical record is retained.
+
+        Use this tool when a person no longer represents the account; do not use createPartyRelationship to fix a wrong assignment without first deactivating the old one, since overlapping active roles are rejected.
+
+        Preconditions: the relationship must exist; the partyId in the path is not validated against the relationship on this operation.
+
+        Required inputs: partyId and relationshipId (UUIDs) as path parameters; there is no request body.
+
+        Emits a CRM_RELATIONSHIP_DEACTIVATE event and re-emits the person''s identity fact because their account linkage changed.
+
+        Returns 404 when no relationship exists for the supplied relationshipId.
+
+        '
+      operationId: deactivatePartyRelationship
       parameters:
       - name: partyId
         in: path
@@ -3021,7 +4321,7 @@ components:
   schemas:
     CustomerDTO:
       type: object
-      description: Customer object to be created
+      description: Customer data transfer object for API operations
       properties:
         id:
           type: string
@@ -3485,7 +4785,7 @@ components:
       - roleCode
     UpdateContactRolesRequest:
       type: object
-      description: Role assignment request
+      description: Request to update the set of role assignments for a contact
       properties:
         version:
           type: string
@@ -4679,7 +5979,7 @@ components:
       - type
     UpsertCommunicationPreferencesRequest:
       type: object
-      description: Communication preferences to set
+      description: Request to upsert communication preferences and consent flags for a party
       properties:
         version:
           type: string
@@ -4886,7 +6186,7 @@ components:
       - roles
     ResolveAccountTierRequest:
       type: object
-      description: Tier resolution request
+      description: Request to compute account tier based on business rules
       properties:
         accountId:
           type: string
@@ -4898,16 +6198,19 @@ components:
           type: number
           description: Annual revenue or spending for tier calculation
           example: 125000.0
+          minimum: 0
         activeContractCount:
           type: integer
           format: int32
           description: Number of active contracts or subscriptions
           example: 3
+          minimum: 0
         accountAgeMonths:
           type: integer
           format: int32
           description: Account age in months
           example: 18
+          minimum: 0
         applyTier:
           type: boolean
           description: Whether to apply the resolved tier or just return the recommendation
@@ -4974,7 +6277,7 @@ components:
       - tierApplied
     CreateCommercialAccountRequest:
       type: object
-      description: Commercial account creation request
+      description: Request to create a commercial account (party)
       properties:
         legalName:
           type: string
@@ -5150,7 +6453,7 @@ components:
       - partyId
     CreateVehicleForPartyRequest:
       type: object
-      description: Vehicle creation request
+      description: Request to create a vehicle record for a party
       properties:
         vinNumber:
           type: string
@@ -5232,7 +6535,7 @@ components:
       - vehicleId
     MergePartiesRequest:
       type: object
-      description: Merge request with source party IDs
+      description: Request to merge a duplicate (losing) party into a survivor party
       properties:
         survivorPartyId:
           type: string
@@ -5291,7 +6594,7 @@ components:
       - survivorPartyId
     SearchPartiesRequest:
       type: object
-      description: Search criteria
+      description: Request to search parties with optional filters and pagination
       properties:
         name:
           type: string
@@ -5462,12 +6765,12 @@ components:
     PageCustomerDTO:
       type: object
       properties:
-        totalElements:
-          type: integer
-          format: int64
         totalPages:
           type: integer
           format: int32
+        totalElements:
+          type: integer
+          format: int64
         size:
           type: integer
           format: int32
@@ -5478,17 +6781,17 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
     PageableObject:

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmAccountsController.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -70,7 +71,16 @@ public class CrmAccountsController {
         this.accountTierService = accountTierService;
     }
 
-    @Operation(summary = "Get account tier", description = "Retrieve the tier level for a specific account")
+    @Operation(operationId = "getAccountTier", summary = "Get Account Tier", description = """
+                    Returns the currently assigned tier for a commercial account, including who assigned it, \
+                    when, and whether a manual override is active; unassigned accounts report STANDARD.
+                    Use this tool when the stored tier of a known commercial account is needed; do not use \
+                    resolveAccountTier, which recomputes a recommended tier from revenue and contract inputs.
+                    Preconditions: a commercial party must exist for the accountId; person parties have no tier.
+                    Required inputs: accountId (UUID) as a path parameter; there is no request body.
+                    Emits a CUSTOMER_ACCOUNT_TIER_GET audit event; no state changes occur.
+                    Returns 404 when no commercial account exists for the supplied accountId.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -101,9 +111,20 @@ public class CrmAccountsController {
         }
     }
 
-    @Operation(
-            summary = "Resolve account tier",
-            description = "Resolve or compute the account tier based on business rules")
+    @Operation(operationId = "resolveAccountTier", summary = "Resolve Account Tier", description = """
+                    Computes the recommended tier for a commercial account from annual revenue, active contract \
+                    count, and account age thresholds, and optionally applies it to the account.
+                    Use this tool when a tier recommendation or recalculation is needed; do not use \
+                    getAccountTier, which only reads the stored tier without recomputing it.
+                    Preconditions: a commercial party must exist for the accountId; when applyTier is true, a \
+                    manual tier override on the account blocks application unless forceRecalculation is also true.
+                    Required inputs: accountId (UUID string); annualRevenue, activeContractCount, and \
+                    accountAgeMonths are optional scoring inputs, and applyTier and forceRecalculation both \
+                    default to false, so the default call is a dry run.
+                    Emits a CUSTOMER_ACCOUNT_TIER_RESOLVE event; when the tier is applied the account record is \
+                    updated with assignedBy SYSTEM and a customer fact is republished.
+                    Returns 404 when the account does not exist or the accountId is not a valid UUID.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -124,7 +145,22 @@ public class CrmAccountsController {
     @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_VIEW + "')")
     @EmitEvent(id = "CUSTOMER_ACCOUNT_TIER_RESOLVE", apiVersion = "1")
     public ResponseEntity<ResolveAccountTierResponse> resolveAccountTier(
-            @Parameter(description = "Tier resolution request", required = true) @RequestBody
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Tier scoring inputs for one account, plus flags controlling whether the resolved tier is applied.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Dry-run resolution", value = """
+                                                                    {"accountId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "annualRevenue":275000,
+                                                                     "activeContractCount":3,
+                                                                     "accountAgeMonths":18,
+                                                                     "applyTier":false,
+                                                                     "forceRecalculation":false}
+                                                                    """)))
+                    @RequestBody
                     ResolveAccountTierRequest body) {
         try {
             ResolveAccountTierResponse response = accountTierService.resolveAccountTier(body);
@@ -137,9 +173,20 @@ public class CrmAccountsController {
 
     // --- Party/Commercial Account Management (Issue #176) ---
 
-    @Operation(
-            summary = "Create commercial account",
-            description = "Create a new commercial party/account in the CRM system")
+    @Operation(operationId = "createCommercialAccount", summary = "Create Commercial Account", description = """
+                    Creates a commercial party record with status ACTIVE and a generated customer number of the \
+                    form CUST-XXXXXXXX.
+                    Use this tool when onboarding a new commercial customer; do not use searchParties or \
+                    checkPartyDuplicates, which only look up existing parties, and run checkPartyDuplicates \
+                    first to avoid creating a duplicate, because no uniqueness check is applied here.
+                    Preconditions: none beyond authorization; the service performs no duplicate detection on \
+                    legalName.
+                    Required inputs: legalName (non-blank, max 255); partyType defaults to COMMERCIAL and must \
+                    be PERSON, COMMERCIAL, or UNKNOWN when supplied; displayName, taxId, billingTermsId, and \
+                    externalIdentifiers are optional.
+                    Emits a CUSTOMER_PARTY_CREATE event and publishes a party-changed customer fact.
+                    Returns 400 when legalName is missing or blank, or when partyType is not a recognized value.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -159,7 +206,20 @@ public class CrmAccountsController {
     @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_CREATE + "')")
     @EmitEvent(id = "CUSTOMER_PARTY_CREATE", apiVersion = "1")
     public ResponseEntity<CreateCommercialAccountResponse> createCommercialAccount(
-            @Parameter(description = "Commercial account creation request", required = false)
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Commercial party to create; legalName is the only mandatory field and no duplicate check is applied.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "New commercial account", value = """
+                                                                    {"legalName":"Acme Fleet Services LLC",
+                                                                     "displayName":"Acme Fleet",
+                                                                     "taxId":"12-3456789",
+                                                                     "partyType":"COMMERCIAL",
+                                                                     "externalIdentifiers":{"ERP":"AC-1001"}}
+                                                                    """)))
                     @RequestBody(required = false)
                     CreateCommercialAccountRequest body) {
         log.info("createCommercialAccount");
@@ -167,7 +227,16 @@ public class CrmAccountsController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @Operation(summary = "Get party details", description = "Retrieve details for a specific party by ID")
+    @Operation(operationId = "getParty", summary = "Get Party Details", description = """
+                    Returns the identity projection of a single party, resolving commercial parties first and \
+                    falling back to person parties, whose display name is resolved from the person directory.
+                    Use this tool when a party id is already known; use browseParties or searchParties instead \
+                    when locating a party by name, status, or customer number.
+                    Preconditions: a commercial or person party must exist for the supplied partyId.
+                    Required inputs: partyId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when neither a commercial nor a person party exists for the supplied partyId.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -194,12 +263,22 @@ public class CrmAccountsController {
 
     // --- Party Search and Merge (Issue #173) ---
 
-    @Operation(
-            summary = "Browse parties",
-            description =
-                    "Browse parties with paging and sorting. The service sorts by legalName ascending by default, "
-                            + "appends partyId ascending as a stable tie-breaker whenever the requested sort list "
-                            + "does not explicitly include partyId, and applies case-insensitive legalName sorting.")
+    @Operation(operationId = "browseParties", summary = "Browse Customer Directory", description = """
+                    Returns a paged customer directory that unifies commercial parties and standalone \
+                    individual customers, with person names and contact points resolved from pos-people.
+                    Use this tool when listing or typeahead-filtering customers by name, status, party type, \
+                    or customer number; do not use searchParties, which filters commercial parties only by \
+                    structured criteria, and use getParty instead when the party id is already known.
+                    Preconditions: none; an empty page is returned when nothing matches, and a pos-people \
+                    outage degrades person names to null rather than failing the request.
+                    Required inputs: none; page defaults to 0 with size 20, the name filter matches legal \
+                    name, display name, or customer number case-insensitively, status matches ACTIVE, \
+                    INACTIVE, ON_HOLD, or MERGED, sortField is name (default) or customerNumber, and \
+                    sortOrder is asc (default) or desc with partyId as a stable tie-breaker.
+                    Emits a CUSTOMER_PARTY_BROWSE audit event; no state changes occur.
+                    Returns 200 with an empty results array rather than an error when no party matches the \
+                    filters.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -255,7 +334,19 @@ public class CrmAccountsController {
                 partyService.browseParties(pageable, name, status, partyType, customerNumber, sortField, sortOrder));
     }
 
-    @Operation(summary = "Search parties", description = "Search for parties based on various criteria")
+    @Operation(operationId = "searchParties", summary = "Search Commercial Parties", description = """
+                    Searches commercial party records by structured criteria such as name, tax id, party type, \
+                    and status, returning all matches in a single unpaged result set.
+                    Use this tool when filtering commercial parties by structured attributes like taxId; use \
+                    browseParties instead for the paged, unified directory that also includes individual \
+                    customers, and checkPartyDuplicates for pre-create duplicate detection by legal name.
+                    Preconditions: none; an omitted or empty body matches every commercial party.
+                    Required inputs: none; name, email, phone, taxId, partyType, and status are all optional \
+                    filters, and the pageNumber and pageSize fields are accepted but not applied, so the full \
+                    match list is always returned.
+                    Emits a CUSTOMER_PARTY_SEARCH audit event; no state changes occur.
+                    Returns 200 with an empty results array rather than an error when no party matches.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -275,18 +366,36 @@ public class CrmAccountsController {
     @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_VIEW + "')")
     @EmitEvent(id = "CUSTOMER_PARTY_SEARCH", apiVersion = "1")
     public ResponseEntity<SearchPartiesResponse> searchParties(
-            @Parameter(description = "Search criteria", required = false) @RequestBody(required = false)
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Optional structured filter criteria; every supplied field narrows the match and an empty body matches all commercial parties.",
+                            required = false,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Filter by name and status", value = """
+                                                                    {"name":"Acme","partyType":"COMMERCIAL","status":"ACTIVE"}
+                                                                    """)))
+                    @RequestBody(required = false)
                     SearchPartiesRequest body) {
         log.info("searchParties");
         SearchPartiesResponse response = partyService.searchParties(body);
         return ResponseEntity.ok(response);
     }
 
-    @Operation(
-            summary = "Resolve party display names",
-            description = "Batch-resolve party ids to display names. Consumed server-side by sibling services "
-                    + "(e.g. pos-invoice) that store only the party id and need the display name to enrich "
-                    + "finder/search rows. Unknown or unresolvable ids are omitted from the response.")
+    @Operation(operationId = "resolvePartyNames", summary = "Resolve Party Display Names", description = """
+                    Batch-resolves party ids to display names for both commercial and person parties, for \
+                    sibling services such as pos-invoice that store only the party id.
+                    Use this tool when enriching rows that already carry party ids; do not use getParty, which \
+                    returns the full identity projection for a single party per call.
+                    Preconditions: none; unknown or unresolvable ids are silently omitted from the response \
+                    rather than causing an error.
+                    Required inputs: partyIds, a non-empty list of up to 200 UUIDs; null entries and \
+                    duplicates are dropped before resolution.
+                    Emits a CUSTOMER_PARTY_RESOLVE audit event; no state changes occur.
+                    Returns 400 when partyIds is empty or exceeds 200 entries, and 200 with a possibly \
+                    shorter list than requested when some ids cannot be resolved.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -306,12 +415,41 @@ public class CrmAccountsController {
             scopes = {CrmPermissionRegistry.PARTY_VIEW})
     @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_VIEW + "')")
     @EmitEvent(id = "CUSTOMER_PARTY_RESOLVE", apiVersion = "1")
-    public ResponseEntity<List<PartyNameRef>> resolvePartyNames(@Valid @RequestBody PartyNameResolveRequest body) {
+    public ResponseEntity<List<PartyNameRef>> resolvePartyNames(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Batch of party ids whose display names should be resolved.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Two-party batch", value = """
+                                                                    {"partyIds":["018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                                 "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    PartyNameResolveRequest body) {
         log.info("resolvePartyNames count={}", body.partyIds().size());
         return ResponseEntity.ok(partyService.resolveNames(body.partyIds()));
     }
 
-    @Operation(summary = "Merge parties", description = "Merge multiple parties into a single party record")
+    @Operation(operationId = "mergeParties", summary = "Merge Duplicate Commercial Parties", description = """
+                    Merges one duplicate commercial party into a surviving party: relationships are reassigned \
+                    to the survivor, external identifiers and vehicle VINs are copied over, and the losing \
+                    party's status is set to MERGED.
+                    Use this tool when checkPartyDuplicates has confirmed two records represent the same \
+                    customer; do not use createCommercialAccount to work around duplicates, and note the merge \
+                    is not reversible through this API.
+                    Preconditions: both the surviving party (path) and losing party (body) must exist as \
+                    commercial parties and must be different records.
+                    Required inputs: partyId of the survivor as a path parameter, plus losingPartyId (UUID \
+                    string) and a justification of up to 1000 characters in the body.
+                    Emits a CUSTOMER_PARTY_MERGE event and republishes customer facts for both parties and \
+                    for contacts whose account linkage moved.
+                    Returns 404 when either party cannot be found, and 400 when losingPartyId or \
+                    justification is missing, losingPartyId is not a valid UUID, or both ids refer to the \
+                    same party.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -333,7 +471,17 @@ public class CrmAccountsController {
     @EmitEvent(id = "CUSTOMER_PARTY_MERGE", apiVersion = "1")
     public ResponseEntity<MergePartiesResponse> mergeParties(
             @Parameter(description = "Target party ID", required = true) @PathVariable UUID partyId,
-            @Parameter(description = "Merge request with source party IDs", required = false)
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Identifies the losing party to fold into the survivor and records the audit justification for the merge.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Merge duplicate", value = """
+                                                                    {"losingPartyId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "justification":"Duplicate created during fleet onboarding import"}
+                                                                    """)))
                     @RequestBody(required = false)
                     MergePartiesRequest body) {
         log.info("mergeParties partyId={}", partyId);
@@ -344,8 +492,19 @@ public class CrmAccountsController {
     // --- Communication Preferences (Issue #171) ---
 
     @Operation(
-            summary = "Get communication preferences",
-            description = "Retrieve communication preferences and consent flags for a party")
+            operationId = "getAccountCommunicationPreferences",
+            summary = "Get Account Communication Preferences",
+            description = """
+                    Returns a legacy account-scoped communication-preference projection for a commercial \
+                    party in which every channel currently reports the placeholder value N/A.
+                    Use this tool only for the legacy accounts-scoped path; use getCommunicationPreferences \
+                    instead, which reads the persisted per-party preference record with real channel values \
+                    and consent flags.
+                    Preconditions: a commercial party must exist for the supplied partyId.
+                    Required inputs: partyId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no commercial party exists for the supplied partyId.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -372,8 +531,22 @@ public class CrmAccountsController {
     }
 
     @Operation(
-            summary = "Create or update communication preferences",
-            description = "Set or update communication preferences and consent flags for a party")
+            operationId = "upsertAccountCommunicationPreferences",
+            summary = "Upsert Account Communication Preferences",
+            description = """
+                    Acknowledges an account-scoped communication-preference submission for a commercial party \
+                    without persisting any preference values; this legacy path only validates the party and \
+                    returns SUCCESS.
+                    Use this tool only for the legacy accounts-scoped path; use upsertCommunicationPreferences \
+                    instead, which actually stores channel preferences and consent flags per party.
+                    Preconditions: a commercial party must exist for the supplied partyId.
+                    Required inputs: partyId (UUID) as a path parameter and a non-null JSON body; the \
+                    preference fields themselves are accepted but not stored.
+                    Emits a CUSTOMER_COMMUNICATION_PREFERENCE_UPSERT audit event; no preference record is \
+                    written.
+                    Returns 404 when no commercial party exists for the supplied partyId, and 400 when the \
+                    request body is missing.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -400,7 +573,19 @@ public class CrmAccountsController {
     @EmitEvent(id = "CUSTOMER_COMMUNICATION_PREFERENCE_UPSERT", apiVersion = "1")
     public ResponseEntity<UpsertCommunicationPreferencesResponse> upsertCommunicationPreferences(
             @Parameter(description = "Party ID", required = true) @PathVariable UUID partyId,
-            @Parameter(description = "Communication preferences to set", required = false)
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Channel preference values acknowledged by this legacy endpoint; the values are validated but not stored.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Opt-in email only", value = """
+                                                                    {"emailPreference":"OPT_IN",
+                                                                     "smsPreference":"OPT_OUT",
+                                                                     "phonePreference":"OPT_OUT",
+                                                                     "updateSource":"ADMIN"}
+                                                                    """)))
                     @RequestBody(required = false)
                     UpsertCommunicationPreferencesRequest body) {
         log.info("upsertCommunicationPreferences partyId={}", partyId);
@@ -410,7 +595,20 @@ public class CrmAccountsController {
 
     // --- Vehicle Management (Issue #169) ---
 
-    @Operation(summary = "Create vehicle for party", description = "Associate a new vehicle with a party/customer")
+    @Operation(operationId = "createVehicleForParty", summary = "Associate Vehicle With Party", description = """
+                    Associates a vehicle VIN with a commercial party by appending it to the party's owned VIN \
+                    list.
+                    Use this tool when recording that a commercial account operates a vehicle; do not use it \
+                    to change vehicle details, and note the VIN list is account-level rather than a full \
+                    vehicle record.
+                    Preconditions: a commercial party must exist for the supplied partyId, and the VIN must \
+                    not already be associated with that party.
+                    Required inputs: partyId (UUID) as a path parameter and vinNumber (max 17 characters) in \
+                    the body; unitNumber, description, licensePlate, and licensePlateRegion are optional.
+                    Emits a CUSTOMER_VEHICLE_CREATE event and republishes the party-changed customer fact.
+                    Returns 404 when the party does not exist, 409 when the VIN is already associated with \
+                    the party, and 400 when vinNumber is missing or blank.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -432,18 +630,40 @@ public class CrmAccountsController {
     @EmitEvent(id = "CUSTOMER_VEHICLE_CREATE", apiVersion = "1")
     public ResponseEntity<CreateVehicleForPartyResponse> createVehicleForParty(
             @Parameter(description = "Party ID", required = true) @PathVariable UUID partyId,
-            @Parameter(description = "Vehicle creation request", required = false) @RequestBody(required = false)
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Vehicle identification to associate with the party, keyed by VIN.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Fleet truck", value = """
+                                                                    {"vinNumber":"1FTFW1ET5DFC10312",
+                                                                     "unitNumber":"TRK-42",
+                                                                     "description":"2019 Ford F-150 service truck",
+                                                                     "licensePlate":"ABC1234",
+                                                                     "licensePlateRegion":"TX"}
+                                                                    """)))
+                    @RequestBody(required = false)
                     CreateVehicleForPartyRequest body) {
         log.info("createVehicleForParty partyId={}", partyId);
         CreateVehicleForPartyResponse response = partyService.createVehicleForParty(partyId, body);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @Operation(
-            operationId = "checkPartyDuplicates",
-            summary = "Check for duplicate commercial parties",
-            description =
-                    "Search for existing parties with a similar legal name to detect potential duplicates before creating a new commercial account.")
+    @Operation(operationId = "checkPartyDuplicates", summary = "Check Commercial Party Duplicates", description = """
+                    Checks for existing commercial parties whose legal name contains the supplied name, \
+                    flagging case-insensitive exact matches as EXACT with score 1.0 and other containment \
+                    matches as FUZZY with score 0.7.
+                    Use this tool before createCommercialAccount to avoid creating a duplicate customer; do \
+                    not use searchParties for this, which does not classify match strength or surface an \
+                    exactMatchPartyId.
+                    Preconditions: none; the check reads existing commercial parties only.
+                    Required inputs: legalName as a query parameter with at least 2 non-whitespace \
+                    characters; there is no request body.
+                    Emits a CUSTOMER_PARTY_DUPLICATE_CHECK audit event; no state changes occur.
+                    Returns 400 when legalName is blank or shorter than 2 characters after trimming, and 200 \
+                    with duplicatesFound false when no similar party exists.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -478,10 +698,22 @@ public class CrmAccountsController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(
-            operationId = "upsertBillingRules",
-            summary = "Upsert billing rules for a party",
-            description = "Create or update the billing rules configuration for a commercial party.")
+    @Operation(operationId = "upsertBillingRules", summary = "Upsert Party Billing Rules", description = """
+                    Creates or replaces the embedded billing-rules configuration on a commercial party, \
+                    covering PO requirement, tax exemption, credit hold, auto-pay, payment terms, credit \
+                    limit, currency, and invoice delivery method.
+                    Use this tool when configuring how a commercial account is billed; do not use \
+                    createCommercialAccount, which only sets billingTermsId at creation and cannot change \
+                    billing flags afterwards.
+                    Preconditions: a commercial party must exist for the supplied partyId; the whole rules \
+                    block is replaced on every call rather than patched field by field.
+                    Required inputs: partyId (UUID) as a path parameter; boolean flags poRequired, taxExempt, \
+                    creditHold, and autoPayEnabled default to false when omitted, and paymentTerms, \
+                    creditLimit, currency, and invoiceDeliveryMethod (EMAIL, MAIL, PORTAL) are optional.
+                    Emits a CUSTOMER_BILLING_RULES_UPSERT event; the rules are stored on the party record \
+                    itself.
+                    Returns 404 when no commercial party exists for the supplied partyId.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -505,7 +737,27 @@ public class CrmAccountsController {
             @Parameter(description = "Party ID", required = true, example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")
                     @PathVariable
                     UUID partyId,
-            @RequestBody @jakarta.validation.Valid UpsertBillingRulesRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Complete billing-rules configuration that replaces the party's current rules block.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Net-30 with PO", value = """
+                                                                    {"paymentTerms":"NET_30",
+                                                                     "creditLimit":25000.00,
+                                                                     "currency":"USD",
+                                                                     "taxExempt":false,
+                                                                     "poRequired":true,
+                                                                     "creditHold":false,
+                                                                     "autoPayEnabled":false,
+                                                                     "invoiceDeliveryMethod":"EMAIL",
+                                                                     "billingAddressId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d"}
+                                                                    """)))
+                    @RequestBody
+                    @jakarta.validation.Valid
+                    UpsertBillingRulesRequest request) {
         BillingRuleRef result = partyService.upsertBillingRulesForParty(partyId, request);
         return ResponseEntity.ok(result);
     }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmBillingTermsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmBillingTermsController.java
@@ -43,10 +43,18 @@ public class CrmBillingTermsController {
                     .netDays(-1)
                     .build());
 
-    @Operation(
-            summary = "List billing terms",
-            description = "Returns the reference list of all available billing terms. "
-                    + "This is a static reference endpoint; it does not vary per party or account.")
+    @Operation(operationId = "listBillingTerms", summary = "List Billing Term Options", description = """
+                    Returns the static reference list of billing term options: NET_30, NET_60, NET_90, COD, \
+                    and PREPAID, each with a display label and net-day count.
+                    Use this tool when populating a billing-terms dropdown before createCommercialAccount or \
+                    upsertBillingRules; do not use upsertBillingRules to discover valid terms, which writes \
+                    configuration rather than listing options.
+                    Preconditions: none; the list is compiled into the service and identical for every caller.
+                    Required inputs: none; there are no parameters and no request body.
+                    No events are emitted and no state changes; this is a read-only reference lookup.
+                    Returns 200 with the full five-entry list in every successful call; there are no \
+                    business error responses.
+                    """)
     @ApiResponse(responseCode = "200", description = "Billing terms retrieved successfully")
     @ApiResponse(responseCode = "401", description = "Authentication required")
     @ApiResponse(

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmCommunicationPreferencesController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmCommunicationPreferencesController.java
@@ -9,6 +9,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -56,8 +57,21 @@ public class CrmCommunicationPreferencesController {
      * Requires: CONTACT_PREFERENCE_VIEW permission
      */
     @Operation(
-            summary = "Get communication preferences",
-            description = "Retrieve communication preferences and consent flags for a party")
+            operationId = "getCommunicationPreferences",
+            summary = "Get Communication Preferences",
+            description = """
+                    Returns the persisted communication preferences and consent flags for a party, covering \
+                    email, SMS, phone, and marketing channels plus the free-form consent flag map.
+                    Use this tool when reading a party's current contact-channel opt-ins; do not use \
+                    getAccountCommunicationPreferences, a legacy accounts-scoped stub that only returns N/A \
+                    placeholders.
+                    Preconditions: the party must exist as either a commercial or person party; a party with \
+                    no stored preference record is reported with every channel defaulted to OPT_OUT and \
+                    version 0.
+                    Required inputs: partyId (UUID) as a path parameter; there is no request body.
+                    Emits a CRM_COMMUNICATION_PREFERENCES_GET audit event; no state changes occur.
+                    Returns 404 when no party exists for the supplied partyId.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -96,8 +110,22 @@ public class CrmCommunicationPreferencesController {
      * Requires: CONTACT_PREFERENCE_EDIT permission
      */
     @Operation(
-            summary = "Create or update communication preferences",
-            description = "Set or update communication preferences and consent flags for a party")
+            operationId = "upsertCommunicationPreferences",
+            summary = "Upsert Communication Preferences",
+            description = """
+                    Creates or updates the persisted communication-preference record for a party, replacing \
+                    channel preferences, consent flags, and the preferences note.
+                    Use this tool when recording a party's contact-channel opt-in or opt-out choices; do not \
+                    use upsertAccountCommunicationPreferences, a legacy accounts-scoped stub that does not \
+                    persist anything.
+                    Preconditions: the party must exist as either a commercial or person party.
+                    Required inputs: partyId (UUID) as a path parameter and a JSON body; omitted \
+                    emailPreference, smsPreference, phonePreference, or marketingPreference values default to \
+                    OPT_OUT, and updateSource defaults to APP.
+                    Emits a CRM_COMMUNICATION_PREFERENCES_UPSERT event and writes the preference record, \
+                    reporting operationType CREATED or UPDATED with a new version.
+                    Returns 404 when no party exists for the supplied partyId.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -124,7 +152,27 @@ public class CrmCommunicationPreferencesController {
     @EmitEvent(id = "CRM_COMMUNICATION_PREFERENCES_UPSERT", apiVersion = "1")
     public ResponseEntity<UpsertCommunicationPreferencesResponse> upsertCommunicationPreferences(
             @Parameter(description = "Party ID", required = true) @PathVariable @NonNull UUID partyId,
-            @Parameter(description = "Communication preferences to set", required = true) @RequestBody @NonNull
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Channel preferences, consent flags, and audit source to store for the party; omitted channels default to OPT_OUT.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Email opt-in with consent flags",
+                                                            value = """
+                                                                    {"emailPreference":"OPT_IN",
+                                                                     "smsPreference":"OPT_OUT",
+                                                                     "phonePreference":"OPT_OUT",
+                                                                     "marketingPreference":"OPT_IN",
+                                                                     "consentFlags":{"serviceReminders":true,"promotions":false},
+                                                                     "preferencesNote":"Customer asked for email only",
+                                                                     "updateSource":"ADMIN"}
+                                                                    """)))
+                    @RequestBody
+                    @NonNull
                     UpsertCommunicationPreferencesRequest request) {
 
         try {

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmConsentController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmConsentController.java
@@ -11,6 +11,7 @@ import com.positivity.customer.service.MarketingConsentService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -43,9 +44,17 @@ public class CrmConsentController {
         this.marketingConsentService = marketingConsentService;
     }
 
-    @Operation(
-            summary = "Get marketing consent",
-            description = "Per-channel marketing consent plus the effective send eligibility for each channel")
+    @Operation(operationId = "getMarketingConsent", summary = "Get Marketing Consent Summary", description = """
+                    Returns a party's per-channel marketing consent (EMAIL and SMS, each OPT_IN, OPT_OUT, or \
+                    UNSET) together with the account gate, quiet hours, monthly send cap, and the resolved \
+                    send eligibility per channel.
+                    Use this tool when reviewing a party's full consent state; use resolveMarketingEligibility \
+                    instead when only a single allow or deny decision for one channel is needed.
+                    Preconditions: the party must exist as either a commercial or person party.
+                    Required inputs: partyId (UUID) as a path parameter; there is no request body.
+                    Emits a CRM_MARKETING_CONSENT_GET audit event; no state changes occur.
+                    Returns 404 when no party exists for the supplied partyId.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -64,10 +73,23 @@ public class CrmConsentController {
         return ResponseEntity.ok(marketingConsentService.getConsent(partyId));
     }
 
-    @Operation(
-            summary = "Update marketing consent",
-            description =
-                    "Update per-channel marketing consent. Only channels present in the request change; each change writes one immutable consent-audit entry.")
+    @Operation(operationId = "updateMarketingConsent", summary = "Update Marketing Consent", description = """
+                    Updates a party's per-channel marketing consent; only channels present in the request \
+                    change, and each actual change appends one immutable consent-audit entry attributed to \
+                    the calling user.
+                    Use this tool when a party grants or withdraws marketing consent; do not use \
+                    setAccountMarketingGate, which is the account-level hard gate overriding all contact \
+                    consent, and do not use upsertCommunicationPreferences, which stores transactional \
+                    channel preferences rather than marketing consent.
+                    Preconditions: the party must exist as either a commercial or person party; re-submitting \
+                    an unchanged value is an idempotent no-op that writes no audit row.
+                    Required inputs: partyId (UUID) as a path parameter; marketingEmailConsent and \
+                    marketingSmsConsent take OPT_IN, OPT_OUT, or UNSET, source defaults to CSR, and \
+                    optOutReason, quietHoursStart, quietHoursEnd, and maxMarketingSendsPerMonth are optional.
+                    Emits a CRM_MARKETING_CONSENT_UPDATE event and republishes the resolved eligibility \
+                    decision for both channels so downstream consumers never hold a stale allow.
+                    Returns 404 when no party exists for the supplied partyId.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -83,14 +105,39 @@ public class CrmConsentController {
     @PreAuthorize("hasAuthority('crm:consent:manage')")
     @EmitEvent(id = "CRM_MARKETING_CONSENT_UPDATE", apiVersion = "1")
     public ResponseEntity<MarketingConsentSummaryResponse> updateConsent(
-            @PathVariable UUID partyId, @Valid @RequestBody UpdateMarketingConsentRequest request) {
+            @PathVariable UUID partyId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Partial consent update; only the channels and settings present in the body are changed.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Email opt-out via CSR", value = """
+                                                                    {"marketingEmailConsent":"OPT_OUT",
+                                                                     "optOutReason":"NOT_INTERESTED",
+                                                                     "source":"CSR"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    UpdateMarketingConsentRequest request) {
         return ResponseEntity.ok(marketingConsentService.updateConsent(partyId, request));
     }
 
-    @Operation(
-            summary = "Set account marketing gate",
-            description =
-                    "Set or clear the commercial-account hard gate. When set, no marketing reaches the account on any channel regardless of individual contact consent.")
+    @Operation(operationId = "setAccountMarketingGate", summary = "Set Account Marketing Gate", description = """
+                    Sets or clears the commercial-account marketing hard gate; while set, no marketing \
+                    reaches the account on any channel regardless of individual contact consent.
+                    Use this tool when an entire commercial account must be excluded from marketing; do not \
+                    use updateMarketingConsent, which changes one party's per-channel consent and cannot \
+                    override the gate.
+                    Preconditions: the party must exist as a commercial party; person parties have no \
+                    account gate, and setting the gate to its current value is an idempotent no-op.
+                    Required inputs: partyId (UUID) as a path parameter and optOut (boolean) as a query \
+                    parameter, where true engages the gate and false clears it; there is no request body.
+                    Emits a CRM_MARKETING_ACCOUNT_GATE_SET event, and when the gate actually flips it \
+                    republishes the resolved eligibility decisions for both channels.
+                    Returns 404 when no commercial party exists for the supplied partyId.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -110,9 +157,20 @@ public class CrmConsentController {
         return ResponseEntity.ok(marketingConsentService.setAccountMarketingOptOut(partyId, optOut));
     }
 
-    @Operation(
-            summary = "Get consent history",
-            description = "Append-only marketing-consent audit trail for a party, newest first")
+    @Operation(operationId = "getConsentHistory", summary = "Get Consent Audit History", description = """
+                    Returns the append-only marketing-consent audit trail for a party, newest first, with \
+                    one entry per actual consent change recording the channel, old and new values, reason, \
+                    source, and acting user.
+                    Use this tool when auditing how a party's consent reached its current state; use \
+                    getMarketingConsent instead for the current consent summary and eligibility.
+                    Preconditions: none; a party with no recorded consent changes yields an empty page \
+                    rather than an error.
+                    Required inputs: partyId (UUID) as a path parameter; page defaults to 0 and size \
+                    defaults to 50 with a clamp between 1 and 200.
+                    No events are emitted by the consent trail itself beyond the CRM_CONSENT_HISTORY_GET \
+                    audit event this read emits; no state changes occur.
+                    Returns 200 with an empty page rather than an error when no history exists.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -134,9 +192,21 @@ public class CrmConsentController {
     }
 
     @Operation(
-            summary = "Resolve send eligibility",
-            description =
-                    "Fold the account gate, governing contact consent, and suppression into a single allow/deny decision for one channel")
+            operationId = "resolveMarketingEligibility",
+            summary = "Resolve Marketing Send Eligibility",
+            description = """
+                    Resolves a single allow-or-deny marketing send decision for one party and channel by \
+                    folding together the account gate, the governing party's consent, and the suppression \
+                    list, where suppression is a hard block layered on top of an opt-in.
+                    Use this tool immediately before sending marketing to a party; use getMarketingConsent \
+                    instead when the full consent summary rather than one decision is needed.
+                    Preconditions: none; unknown parties resolve to a deny decision rather than an error.
+                    Required inputs: partyId (UUID) as a path parameter and channel (EMAIL or SMS) as a \
+                    required query parameter.
+                    Emits a CRM_MARKETING_ELIGIBILITY_GET audit event; no state changes occur.
+                    Returns 200 with allowed false and a reason code such as SUPPRESSED when the send must \
+                    not happen, and 400 when channel is not EMAIL or SMS.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmContactsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmContactsController.java
@@ -9,6 +9,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -53,9 +54,19 @@ public class CrmContactsController {
      * GET /v1/crm/parties/{partyId}/contacts
      * Requires: CONTACT_VIEW permission
      */
-    @Operation(
-            summary = "Get contacts with roles",
-            description = "Retrieve all contacts for a party including their role assignments")
+    @Operation(operationId = "getContactsWithRoles", summary = "Get Party Contacts With Roles", description = """
+                    Returns every contact person assigned a role on a commercial account, with names, \
+                    emails, and phones resolved from pos-people and each contact's role assignments and \
+                    primary flags.
+                    Use this tool when listing who represents a commercial account and in what capacity; do \
+                    not use updateContactRoles, which rewrites one contact's role assignments.
+                    Preconditions: a commercial party must exist for the supplied partyId; a pos-people \
+                    outage degrades contact names and contact points to null rather than failing.
+                    Required inputs: partyId (UUID) as a path parameter; there is no request body.
+                    Emits a CRM_CONTACTS_LIST audit event; no state changes occur.
+                    Returns 404 when no commercial party exists for the supplied partyId, and 200 with an \
+                    empty contacts list when the account has no role assignments.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -92,9 +103,23 @@ public class CrmContactsController {
      * PUT /v1/crm/parties/{partyId}/contacts/{contactId}/roles
      * Requires: CONTACT_ROLE_ASSIGN permission
      */
-    @Operation(
-            summary = "Update contact roles",
-            description = "Assign or update role assignments for a specific contact within a party")
+    @Operation(operationId = "updateContactRoles", summary = "Update Contact Role Assignments", description = """
+                    Replaces the full set of role assignments for one contact on a commercial account; \
+                    existing assignments for that contact are deleted and the submitted list is written in \
+                    their place.
+                    Use this tool when changing what a known contact does for an account; use \
+                    getContactsWithRoles instead to read current assignments, and note that submitting an \
+                    empty roles list removes the contact's roles entirely.
+                    Preconditions: the commercial party and the contact person must both exist; assigning a \
+                    role as primary automatically demotes any existing primary contact for that role.
+                    Required inputs: partyId and contactId (UUIDs) as path parameters, plus roles, a list \
+                    where each entry has roleCode (BILLING, PAYMENT_AUTHORIZER, OPERATIONS, \
+                    PRIMARY_BUSINESS_CONTACT, or TECHNICAL) and an optional isPrimary flag defaulting to \
+                    false.
+                    Emits a CRM_CONTACT_ROLES_UPDATE event; assignments are rewritten in place.
+                    Returns 404 when the party or contact person cannot be found, and 400 when a roleCode is \
+                    not a recognized role.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -117,7 +142,19 @@ public class CrmContactsController {
     public ResponseEntity<UpdateContactRolesResponse> updateContactRoles(
             @Parameter(description = "Party ID", required = true) @PathVariable @NonNull UUID partyId,
             @Parameter(description = "Contact ID", required = true) @PathVariable @NonNull UUID contactId,
-            @Parameter(description = "Role assignment request", required = true) @RequestBody @NonNull
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "The complete replacement set of role assignments for this contact on the account.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Primary billing contact", value = """
+                                                                    {"roles":[{"roleCode":"BILLING","isPrimary":true},
+                                                                              {"roleCode":"OPERATIONS","isPrimary":false}]}
+                                                                    """)))
+                    @RequestBody
+                    @NonNull
                     UpdateContactRolesRequest request) {
 
         try {

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmFollowUpController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmFollowUpController.java
@@ -11,6 +11,7 @@ import com.positivity.customer.service.FollowUpTaskService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -47,9 +48,18 @@ public class CrmFollowUpController {
         this.followUpTaskService = followUpTaskService;
     }
 
-    @Operation(
-            summary = "Follow-up queue",
-            description = "The CSR work queue, ordered by due date. All filters are optional.")
+    @Operation(operationId = "getFollowUpQueue", summary = "Get Follow-Up Work Queue", description = """
+                    Returns the CSR follow-up work queue across all parties, ordered by due date, optionally \
+                    filtered by status, assignee, and task type.
+                    Use this tool when working the shared queue of outstanding follow-ups; use \
+                    listPartyFollowUps instead to see tasks raised against one specific party.
+                    Preconditions: none; an empty page is returned when no task matches the filters.
+                    Required inputs: none; status filters on OPEN, DONE, or DISMISSED, type filters on \
+                    DECLINED_SERVICE_FOLLOWUP, SERVICE_DUE_REMINDER, FLEET_CHECKIN, CAMPAIGN_RESPONSE, or \
+                    GENERAL, page defaults to 0, and size defaults to 50 clamped between 1 and 200.
+                    Emits a CRM_FOLLOWUP_QUEUE audit event; no state changes occur.
+                    Returns 200 with an empty page rather than an error when the queue is clear.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -72,7 +82,16 @@ public class CrmFollowUpController {
         return ResponseEntity.ok(followUpTaskService.queue(status, assignedTo, type, page, size));
     }
 
-    @Operation(summary = "Get follow-up task", description = "Retrieve a single follow-up task")
+    @Operation(operationId = "getFollowUpTask", summary = "Get Follow-Up Task", description = """
+                    Returns one follow-up task with its party, vehicle, type, due date, assignee, status, \
+                    and any recorded outcome and booking references.
+                    Use this tool when the task id is already known; use getFollowUpQueue instead to \
+                    discover tasks by status, assignee, or type.
+                    Preconditions: the follow-up task must exist.
+                    Required inputs: taskId (UUID) as a path parameter; there is no request body.
+                    Emits a CRM_FOLLOWUP_GET audit event; no state changes occur.
+                    Returns 404 when no follow-up task exists for the supplied taskId.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -91,7 +110,18 @@ public class CrmFollowUpController {
         return ResponseEntity.ok(followUpTaskService.get(taskId));
     }
 
-    @Operation(summary = "List party follow-ups", description = "Follow-up tasks raised against a party")
+    @Operation(operationId = "listPartyFollowUps", summary = "List Party Follow-Up Tasks", description = """
+                    Returns the follow-up tasks raised against one party, ordered by due date then creation \
+                    time, optionally filtered by status.
+                    Use this tool when reviewing outstanding work for a specific customer; use \
+                    getFollowUpQueue instead for the cross-party CSR work queue.
+                    Preconditions: none; an unknown partyId yields an empty page rather than an error.
+                    Required inputs: partyId (UUID) as a path parameter; status optionally filters on OPEN, \
+                    DONE, or DISMISSED, page defaults to 0, and size defaults to 50 clamped between 1 and \
+                    200.
+                    Emits a CRM_FOLLOWUP_LIST audit event; no state changes occur.
+                    Returns 200 with an empty page rather than an error when the party has no follow-ups.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -113,7 +143,20 @@ public class CrmFollowUpController {
         return ResponseEntity.ok(followUpTaskService.listForParty(partyId, status, page, size));
     }
 
-    @Operation(summary = "Raise follow-up task", description = "Raise a follow-up task against a party")
+    @Operation(operationId = "createFollowUpTask", summary = "Raise Follow-Up Task", description = """
+                    Raises a new OPEN follow-up task against a party, recording the creating user from the \
+                    security context.
+                    Use this tool when a customer needs a future touch such as a declined-service or \
+                    service-due follow-up; do not use completeFollowUpTask or dismissFollowUpTask, which \
+                    close an existing task.
+                    Preconditions: the party must exist as either a commercial or person party.
+                    Required inputs: partyId (UUID) as a path parameter and type in the body \
+                    (DECLINED_SERVICE_FOLLOWUP, SERVICE_DUE_REMINDER, FLEET_CHECKIN, CAMPAIGN_RESPONSE, or \
+                    GENERAL); vehicleId, dueDate, assignedTo, reason, sourceWorkorderId, and notes are \
+                    optional, and an omitted assignedTo leaves the task in the shared queue.
+                    Emits a CRM_FOLLOWUP_CREATE event and persists the task with status OPEN.
+                    Returns 404 when no party exists for the supplied partyId, and 400 when type is missing.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "201",
@@ -129,11 +172,40 @@ public class CrmFollowUpController {
     @PreAuthorize("hasAuthority('crm:followup:manage')")
     @EmitEvent(id = "CRM_FOLLOWUP_CREATE", apiVersion = "1")
     public ResponseEntity<FollowUpTaskResponse> create(
-            @PathVariable UUID partyId, @Valid @RequestBody CreateFollowUpTaskRequest request) {
+            @PathVariable UUID partyId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The follow-up work to schedule against the party, typed by follow-up kind.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "Declined-service follow-up", value = """
+                                                                    {"type":"DECLINED_SERVICE_FOLLOWUP",
+                                                                     "vehicleId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5e",
+                                                                     "dueDate":"2026-09-01",
+                                                                     "reason":"Declined rear brake pads at last visit",
+                                                                     "notes":"Quote given: $420 parts and labor"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CreateFollowUpTaskRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(followUpTaskService.create(partyId, request));
     }
 
-    @Operation(summary = "Assign follow-up", description = "Assign or unassign a follow-up task")
+    @Operation(operationId = "assignFollowUpTask", summary = "Assign Follow-Up Task", description = """
+                    Assigns an open follow-up task to a CSR, or returns it to the shared queue when \
+                    assignedTo is omitted.
+                    Use this tool when routing queue work to a specific person; do not use \
+                    completeFollowUpTask or dismissFollowUpTask, which close the task rather than route it.
+                    Preconditions: the task must exist and still be OPEN; closed tasks cannot be modified \
+                    and a new follow-up must be raised instead.
+                    Required inputs: taskId (UUID) as a path parameter; assignedTo is an optional query \
+                    parameter whose omission unassigns the task, and there is no request body.
+                    Emits a CRM_FOLLOWUP_ASSIGN event; only the task's assignee changes.
+                    Returns 404 when the task does not exist, and 422 when the task is already DONE or \
+                    DISMISSED.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -154,9 +226,19 @@ public class CrmFollowUpController {
         return ResponseEntity.ok(followUpTaskService.assign(taskId, assignedTo));
     }
 
-    @Operation(
-            summary = "Complete follow-up",
-            description = "Close a follow-up as worked, recording the outcome and any resulting booking")
+    @Operation(operationId = "completeFollowUpTask", summary = "Complete Follow-Up Task", description = """
+                    Closes an open follow-up task as DONE, recording the outcome and any workorder or \
+                    appointment that resulted from the touch.
+                    Use this tool when the follow-up was actually worked; use dismissFollowUpTask instead \
+                    when the task is being deliberately abandoned without contact.
+                    Preconditions: the task must exist and still be OPEN; a closed task cannot be reopened, \
+                    so a new follow-up must be raised to try again.
+                    Required inputs: taskId (UUID) as a path parameter and outcome (non-blank, max 500) in \
+                    the body; bookedWorkorderId and bookedAppointmentId are optional booking references.
+                    Emits a CRM_FOLLOWUP_COMPLETE event and stamps closedAt and closedBy on the task.
+                    Returns 404 when the task does not exist, 422 when it is already DONE or DISMISSED, and \
+                    400 when outcome is blank.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -173,13 +255,36 @@ public class CrmFollowUpController {
     @PreAuthorize("hasAuthority('crm:followup:manage')")
     @EmitEvent(id = "CRM_FOLLOWUP_COMPLETE", apiVersion = "1")
     public ResponseEntity<FollowUpTaskResponse> complete(
-            @PathVariable UUID taskId, @Valid @RequestBody CloseFollowUpTaskRequest request) {
+            @PathVariable UUID taskId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The worked outcome of the follow-up and any booking it produced.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Booked the declined work", value = """
+                                                                    {"outcome":"Customer booked rear brake job for next week",
+                                                                     "bookedWorkorderId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5f"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CloseFollowUpTaskRequest request) {
         return ResponseEntity.ok(followUpTaskService.complete(taskId, request));
     }
 
-    @Operation(
-            summary = "Dismiss follow-up",
-            description = "Close a follow-up as deliberately not pursued, recording why")
+    @Operation(operationId = "dismissFollowUpTask", summary = "Dismiss Follow-Up Task", description = """
+                    Closes an open follow-up task as DISMISSED, recording why it is deliberately not being \
+                    pursued.
+                    Use this tool when a follow-up should be abandoned, for example because the customer \
+                    already returned; use completeFollowUpTask instead when the touch was actually made.
+                    Preconditions: the task must exist and still be OPEN; dismissal is final and a new task \
+                    must be raised to revisit the customer.
+                    Required inputs: taskId (UUID) as a path parameter and outcome (non-blank, max 500) in \
+                    the body explaining the dismissal; booking references are accepted but normally absent.
+                    Emits a CRM_FOLLOWUP_DISMISS event and stamps closedAt and closedBy on the task.
+                    Returns 404 when the task does not exist, 422 when it is already DONE or DISMISSED, and \
+                    400 when outcome is blank.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -196,7 +301,19 @@ public class CrmFollowUpController {
     @PreAuthorize("hasAuthority('crm:followup:manage')")
     @EmitEvent(id = "CRM_FOLLOWUP_DISMISS", apiVersion = "1")
     public ResponseEntity<FollowUpTaskResponse> dismiss(
-            @PathVariable UUID taskId, @Valid @RequestBody CloseFollowUpTaskRequest request) {
+            @PathVariable UUID taskId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The reason this follow-up is being closed without being pursued.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "No longer relevant", value = """
+                                                                    {"outcome":"Vehicle was sold; service no longer needed"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CloseFollowUpTaskRequest request) {
         return ResponseEntity.ok(followUpTaskService.dismiss(taskId, request));
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmInquiryController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmInquiryController.java
@@ -9,6 +9,7 @@ import com.positivity.customer.service.InquiryService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -40,7 +41,17 @@ public class CrmInquiryController {
         this.inquiryService = inquiryService;
     }
 
-    @Operation(summary = "List inquiries", description = "Inbound inquiries, newest first")
+    @Operation(operationId = "listInquiries", summary = "List Inbound Inquiries", description = """
+                    Returns inbound service and fleet-quote inquiries newest first, optionally filtered by \
+                    lifecycle status.
+                    Use this tool when triaging the inquiry queue; use getInquiry instead when the inquiry \
+                    id is already known.
+                    Preconditions: none; an empty page is returned when nothing matches.
+                    Required inputs: none; status optionally filters on NEW, CONTACTED, CONVERTED, or \
+                    CLOSED, page defaults to 0, and size defaults to 50 clamped between 1 and 200.
+                    Emits a CRM_INQUIRY_LIST audit event; no state changes occur.
+                    Returns 200 with an empty page rather than an error when no inquiry matches.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -61,7 +72,16 @@ public class CrmInquiryController {
         return ResponseEntity.ok(inquiryService.list(status, page, size));
     }
 
-    @Operation(summary = "Get inquiry", description = "Retrieve a single inquiry")
+    @Operation(operationId = "getInquiry", summary = "Get Inquiry", description = """
+                    Returns one inbound inquiry with its channel, audience type, contact details, interest \
+                    fields, status, assignee, and any linked party.
+                    Use this tool when the inquiry id is already known; use listInquiries instead to find \
+                    inquiries by status.
+                    Preconditions: the inquiry must exist.
+                    Required inputs: inquiryId (UUID) as a path parameter; there is no request body.
+                    Emits a CRM_INQUIRY_GET audit event; no state changes occur.
+                    Returns 404 when no inquiry exists for the supplied inquiryId.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -80,7 +100,20 @@ public class CrmInquiryController {
         return ResponseEntity.ok(inquiryService.get(inquiryId));
     }
 
-    @Operation(summary = "Capture inquiry", description = "Record an inquiry taken by phone, walk-in, or referral")
+    @Operation(operationId = "captureInquiry", summary = "Capture Staff-Taken Inquiry", description = """
+                    Records an inbound inquiry taken by staff over phone, walk-in, email, or referral, \
+                    creating it in NEW status and deliberately unassigned so it lands in the shared queue.
+                    Use this tool for staff-entered inquiries on the authenticated API; do not use \
+                    submitPublicInquiry, which is the anonymous rate-limited public web-form path.
+                    Preconditions: none beyond authorization; no party needs to exist yet.
+                    Required inputs: channel (WEB_FORM, PHONE, WALK_IN, EMAIL, REFERRAL, or CAMPAIGN), \
+                    audienceType (COMMERCIAL or INDIVIDUAL), contactName, and at least one of email or \
+                    phone; organizationName, vehicleOfInterest, serviceOfInterest, message, and \
+                    campaignCode are optional.
+                    Emits a CRM_INQUIRY_CAPTURE event and persists the inquiry.
+                    Returns 400 when required fields are missing or when neither email nor phone is \
+                    supplied, since an unreachable enquirer cannot be actioned.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "201",
@@ -95,11 +128,40 @@ public class CrmInquiryController {
             scopes = {CrmPermissionRegistry.INQUIRY_MANAGE})
     @PreAuthorize("hasAuthority('crm:inquiry:manage')")
     @EmitEvent(id = "CRM_INQUIRY_CAPTURE", apiVersion = "1")
-    public ResponseEntity<InquiryResponse> capture(@Valid @RequestBody SubmitInquiryRequest request) {
+    public ResponseEntity<InquiryResponse> capture(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "The inquiry as taken by staff, including how it arrived and how to reach the enquirer.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Phone fleet inquiry", value = """
+                                                                    {"channel":"PHONE",
+                                                                     "audienceType":"COMMERCIAL",
+                                                                     "contactName":"Dana Ortiz",
+                                                                     "organizationName":"Ortiz Landscaping",
+                                                                     "email":"dana@ortizlandscaping.example",
+                                                                     "phone":"+1-512-555-0142",
+                                                                     "serviceOfInterest":"Fleet maintenance quote for 6 trucks"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    SubmitInquiryRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(inquiryService.capture(request));
     }
 
-    @Operation(summary = "Assign inquiry", description = "Assign or unassign an inquiry")
+    @Operation(operationId = "assignInquiry", summary = "Assign Inquiry", description = """
+                    Assigns an inquiry to a staff member for follow-through, or returns it to the shared \
+                    queue when assignedTo is omitted.
+                    Use this tool when routing a triaged inquiry to an owner; do not use \
+                    updateInquiryStatus, which moves the lifecycle state rather than ownership.
+                    Preconditions: the inquiry must exist; assignment is allowed in any status.
+                    Required inputs: inquiryId (UUID) as a path parameter; assignedTo is an optional query \
+                    parameter whose omission unassigns the inquiry, and there is no request body.
+                    Emits a CRM_INQUIRY_ASSIGN event; only the inquiry's assignee changes.
+                    Returns 404 when no inquiry exists for the supplied inquiryId.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -119,9 +181,20 @@ public class CrmInquiryController {
         return ResponseEntity.ok(inquiryService.assign(inquiryId, assignedTo));
     }
 
-    @Operation(
-            summary = "Update inquiry status",
-            description = "Move an inquiry to CONTACTED or CLOSED. CONVERTED is reached by converting it.")
+    @Operation(operationId = "updateInquiryStatus", summary = "Update Inquiry Status", description = """
+                    Moves an inquiry through its lifecycle to CONTACTED or CLOSED, optionally recording a \
+                    resolution note.
+                    Use this tool for ordinary status progression; do not use it to reach CONVERTED, which \
+                    is only reachable through convertInquiry because conversion creates or links a party.
+                    Preconditions: the inquiry must exist and the transition must be legal — NEW may move \
+                    to CONTACTED or CLOSED, CONTACTED may move to CLOSED, and CONVERTED and CLOSED are \
+                    terminal.
+                    Required inputs: inquiryId (UUID) as a path parameter and status (CONTACTED or CLOSED) \
+                    as a required query parameter; resolutionNote is optional and there is no request body.
+                    Emits a CRM_INQUIRY_STATUS_UPDATE event; only the inquiry record changes.
+                    Returns 404 when the inquiry does not exist, and 422 when CONVERTED is requested \
+                    directly or the transition is illegal from the current status.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -147,10 +220,24 @@ public class CrmInquiryController {
         return ResponseEntity.ok(inquiryService.updateStatus(inquiryId, status, resolutionNote));
     }
 
-    @Operation(
-            summary = "Convert inquiry",
-            description =
-                    "Turn the inquiry into a PROSPECT party, or link it to an existing party when the enquirer is already known")
+    @Operation(operationId = "convertInquiry", summary = "Convert Inquiry To Party", description = """
+                    Converts an inquiry into CRM state: a commercial inquiry with no existingPartyId creates \
+                    a new commercial party in lifecycle stage PROSPECT, while supplying existingPartyId \
+                    links the inquiry to that party instead; either way the inquiry becomes CONVERTED.
+                    Use this tool when an enquirer becomes a prospect or is recognized as an existing \
+                    customer; do not use updateInquiryStatus, which rejects CONVERTED as a direct status \
+                    change.
+                    Preconditions: the inquiry must exist in an open status (NEW or CONTACTED); an \
+                    INDIVIDUAL-audience inquiry can only be converted by linking an existing party, because \
+                    creating a person party requires a verified identity in pos-people-contact.
+                    Required inputs: inquiryId (UUID) as a path parameter; existingPartyId (UUID) is an \
+                    optional query parameter naming a known party to link, and there is no request body.
+                    Emits a CRM_INQUIRY_CONVERT event; a new PROSPECT commercial party may be created and \
+                    the inquiry is stamped with the resulting partyId.
+                    Returns 404 when the inquiry or the supplied existingPartyId cannot be found, and 422 \
+                    when the inquiry is already CONVERTED or CLOSED, or when an individual inquiry has no \
+                    party to link.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmInteractionController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmInteractionController.java
@@ -9,6 +9,7 @@ import com.positivity.customer.service.CustomerInteractionService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -42,9 +43,19 @@ public class CrmInteractionController {
         this.interactionService = interactionService;
     }
 
-    @Operation(
-            summary = "List party interactions",
-            description = "Interaction history for a party, newest first, optionally filtered by type")
+    @Operation(operationId = "listPartyInteractions", summary = "List Party Interaction Timeline", description = """
+                    Returns a party's interaction timeline newest first, unifying campaign sends, CSR \
+                    touches, and workorder notes, with interaction bodies passed through redaction before \
+                    they are returned.
+                    Use this tool when reviewing a party's touch history; do not use recordInteraction, which \
+                    appends a new entry to the timeline instead of reading it.
+                    Preconditions: none; an unknown partyId simply yields an empty page rather than an error.
+                    Required inputs: partyId (UUID) as a path parameter; type optionally filters to one of \
+                    CAMPAIGN_SEND, EMAIL, SMS, CALL, FOLLOW_UP, NOTE, or WORKORDER_NOTE, page defaults to 0, \
+                    and size defaults to 50 with a clamp between 1 and 200.
+                    Emits a CRM_INTERACTION_LIST audit event; no state changes occur.
+                    Returns 200 with an empty page rather than an error when the party has no interactions.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -66,9 +77,20 @@ public class CrmInteractionController {
         return ResponseEntity.ok(interactionService.listForParty(partyId, type, page, size));
     }
 
-    @Operation(
-            summary = "Record an interaction",
-            description = "Record a CSR-initiated touch (call, email, note) on a party's timeline")
+    @Operation(operationId = "recordInteraction", summary = "Record Party Interaction", description = """
+                    Records a CSR-initiated touch such as a call, email, or note on a party's interaction \
+                    timeline, stamping the acting username from the security context.
+                    Use this tool when logging a manual customer touch; do not use listPartyInteractions, \
+                    which reads the timeline, and note that campaign and workorder interactions are ingested \
+                    from events rather than through this endpoint.
+                    Preconditions: none are checked against the party; the interaction is stored against the \
+                    supplied partyId as-is.
+                    Required inputs: partyId (UUID) as a path parameter and type (CAMPAIGN_SEND, EMAIL, SMS, \
+                    CALL, FOLLOW_UP, NOTE, or WORKORDER_NOTE) in the body; direction defaults to OUTBOUND, \
+                    occurredAt defaults to now, and channel accepts EMAIL or SMS.
+                    Emits a CRM_INTERACTION_RECORD event and persists the interaction row.
+                    Returns 400 when type is missing or subject, summary, or body exceed their length limits.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "201",
@@ -84,7 +106,24 @@ public class CrmInteractionController {
     @PreAuthorize("hasAuthority('crm:interaction:manage')")
     @EmitEvent(id = "CRM_INTERACTION_RECORD", apiVersion = "1")
     public ResponseEntity<CustomerInteractionResponse> record(
-            @PathVariable UUID partyId, @Valid @RequestBody RecordInteractionRequest request) {
+            @PathVariable UUID partyId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "The CSR touch to append to the party's timeline, typed by interaction kind and optional channel.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Follow-up call note", value = """
+                                                                    {"type":"CALL",
+                                                                     "direction":"OUTBOUND",
+                                                                     "subject":"Brake job follow-up",
+                                                                     "summary":"Customer satisfied, will book alignment next month",
+                                                                     "occurredAt":"2026-08-10T15:30:00Z"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    RecordInteractionRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(interactionService.record(partyId, request));
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmPartyRelationshipController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmPartyRelationshipController.java
@@ -9,6 +9,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -83,9 +84,24 @@ public class CrmPartyRelationshipController {
             scopes = {"crm:relationship:create"})
     @PreAuthorize("hasAuthority('crm:relationship:create')")
     @EmitEvent(id = "CRM_RELATIONSHIP_CREATE", apiVersion = "1")
-    @Operation(
-            summary = "Create a party relationship",
-            description = "Creates a relationship between a commercial account and an individual person")
+    @Operation(operationId = "createPartyRelationship", summary = "Create Party Relationship", description = """
+                    Creates a dated relationship that links an individual person to a commercial account in \
+                    one or more roles, optionally marking the person as the primary billing contact.
+                    Use this tool when associating a known person with a commercial account; do not use \
+                    updateContactRoles, which manages the separate contact-role assignment model, and do not \
+                    use createPerson, which creates the person record itself.
+                    Preconditions: the commercial party and the person must both exist, and no active \
+                    relationship may already cover the same party, person, and role for today's date; \
+                    isPrimaryBillingContact requires the BILLING role in the same request.
+                    Required inputs: partyId (UUID) as a path parameter, plus personId (UUID), roles (one or \
+                    more of APPROVER, BILLING, PRIMARY_CONTACT, DRIVER, TECHNICAL), and effectiveStartDate; \
+                    effectiveEndDate and isPrimaryBillingContact (default false) are optional.
+                    Emits a CRM_RELATIONSHIP_CREATE event, atomically demotes any existing primary billing \
+                    contact when one is designated, and re-emits the person's identity fact.
+                    Returns 404 when the party or person cannot be found, 409 when an overlapping active \
+                    relationship already exists for a requested role, and 400 when isPrimaryBillingContact \
+                    is set without the BILLING role.
+                    """)
     @ApiResponse(
             responseCode = "201",
             description = "Relationship created successfully",
@@ -97,7 +113,22 @@ public class CrmPartyRelationshipController {
     @ApiResponse(responseCode = "403", description = "Forbidden - missing required permission")
     public ResponseEntity<CreatePartyRelationshipResponse> createRelationship(
             @Parameter(description = "The commercial account party ID") @PathVariable UUID partyId,
-            @Valid @RequestBody CreatePartyRelationshipRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "The person, roles, and effective dates of the relationship being established with the account.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Primary billing contact", value = """
+                                                                    {"personId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a60",
+                                                                     "roles":["BILLING","PRIMARY_CONTACT"],
+                                                                     "isPrimaryBillingContact":true,
+                                                                     "effectiveStartDate":"2026-08-13"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CreatePartyRelationshipRequest request,
             Principal principal) {
 
         log.info(
@@ -132,8 +163,21 @@ public class CrmPartyRelationshipController {
     @PreAuthorize("hasAuthority('crm:relationship:read')")
     @EmitEvent(id = "CRM_ACCOUNT_CONTACTS_GET", apiVersion = "1")
     @Operation(
-            summary = "Get contacts for a commercial account",
-            description = "Retrieves all individuals associated with a commercial account with their roles")
+            operationId = "getCommercialAccountContacts",
+            summary = "Get Commercial Account Contacts",
+            description = """
+                    Returns the individuals related to a commercial account through party relationships, \
+                    with their roles, primary-billing flag, effective dates, and status.
+                    Use this tool when listing who is associated with an account through the relationship \
+                    model; use getContactsWithRoles instead for the contact-role assignment view of the \
+                    same account.
+                    Preconditions: the commercial party must exist.
+                    Required inputs: partyId (UUID) as a path parameter; roles optionally filters on \
+                    APPROVER, BILLING, PRIMARY_CONTACT, DRIVER, or TECHNICAL, and status optionally filters \
+                    on ACTIVE or INACTIVE.
+                    Emits a CRM_ACCOUNT_CONTACTS_GET audit event; no state changes occur.
+                    Returns 404 when no commercial party exists for the supplied partyId.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Contacts retrieved successfully",
@@ -175,8 +219,23 @@ public class CrmPartyRelationshipController {
     @PreAuthorize("hasAuthority('crm:relationship:update')")
     @EmitEvent(id = "CRM_RELATIONSHIP_PRIMARY_BILLING_UPDATE", apiVersion = "1")
     @Operation(
-            summary = "Designate primary billing contact",
-            description = "Sets a relationship as the primary billing contact, demoting any existing primary")
+            operationId = "designatePrimaryBillingContact",
+            summary = "Designate Primary Billing Contact",
+            description = """
+                    Promotes an existing relationship to be the account's primary billing contact, \
+                    atomically demoting any current primary.
+                    Use this tool when the billing contact changes on an account; do not use \
+                    createPartyRelationship, which is for a person not yet related to the account and can \
+                    set the flag at creation time.
+                    Preconditions: the relationship must exist, must belong to the account in the path, \
+                    must carry the BILLING role, and must be active as of today.
+                    Required inputs: partyId and relationshipId (UUIDs) as path parameters; there is no \
+                    request body.
+                    Emits a CRM_RELATIONSHIP_PRIMARY_BILLING_UPDATE event; the previous primary, if any, is \
+                    demoted in the same transaction.
+                    Returns 404 when the relationship does not exist, and 400 when it belongs to a \
+                    different party, lacks the BILLING role, or is no longer active.
+                    """)
     @ApiResponse(responseCode = "204", description = "Primary billing contact updated")
     @ApiResponse(responseCode = "400", description = "Invalid request - relationship must have BILLING role")
     @ApiResponse(responseCode = "404", description = "Relationship not found")
@@ -215,8 +274,22 @@ public class CrmPartyRelationshipController {
     @PreAuthorize("hasAuthority('crm:relationship:delete')")
     @EmitEvent(id = "CRM_RELATIONSHIP_DEACTIVATE", apiVersion = "1")
     @Operation(
-            summary = "Deactivate a party relationship",
-            description = "Soft-deletes a relationship by setting its effective end date")
+            operationId = "deactivatePartyRelationship",
+            summary = "Deactivate Party Relationship",
+            description = """
+                    Soft-deletes a relationship between a person and a commercial account by setting its \
+                    effective end date to today; the historical record is retained.
+                    Use this tool when a person no longer represents the account; do not use \
+                    createPartyRelationship to fix a wrong assignment without first deactivating the old \
+                    one, since overlapping active roles are rejected.
+                    Preconditions: the relationship must exist; the partyId in the path is not validated \
+                    against the relationship on this operation.
+                    Required inputs: partyId and relationshipId (UUIDs) as path parameters; there is no \
+                    request body.
+                    Emits a CRM_RELATIONSHIP_DEACTIVATE event and re-emits the person's identity fact \
+                    because their account linkage changed.
+                    Returns 404 when no relationship exists for the supplied relationshipId.
+                    """)
     @ApiResponse(responseCode = "204", description = "Relationship deactivated")
     @ApiResponse(responseCode = "404", description = "Relationship not found")
     @ApiResponse(responseCode = "401", description = "Unauthorized")

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmPersonController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmPersonController.java
@@ -8,6 +8,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -72,7 +73,23 @@ public class CrmPersonController {
             scopes = {"crm:person:create"})
     @PreAuthorize("hasAuthority('crm:person:create')")
     @EmitEvent(id = "CRM_PERSON_CREATE", apiVersion = "1")
-    @Operation(summary = "Create a new person", description = "Creates an individual person record in the CRM system")
+    @Operation(operationId = "createPerson", summary = "Create Individual Person Record", description = """
+                    Creates an individual customer: the canonical person identity is resolved or created in \
+                    pos-people (the source of truth for names and contact points), and a thin person-party \
+                    link with a generated CUST-PER customer number is stored locally.
+                    Use this tool when onboarding an individual customer; do not use \
+                    createCommercialAccount, which creates an organization, and note that if the identity \
+                    already has a local person-party the existing record is returned instead of a duplicate.
+                    Preconditions: none beyond authorization; contact points are validated before any \
+                    identity is created so an invalid email persists nothing.
+                    Required inputs: firstName, lastName, and preferredContactMethod (EMAIL, PHONE_CALL, \
+                    SMS, or NONE); emails and phones are optional lists whose entries carry a value and an \
+                    isPrimary flag, phone type defaults to PHONE_MOBILE, and emails are stored lowercase.
+                    Emits a CRM_PERSON_CREATE event, publishes a party-changed customer fact, and writes \
+                    the contact points to pos-people.
+                    Returns 400 when firstName, lastName, or preferredContactMethod is missing or an email \
+                    value is malformed.
+                    """)
     @ApiResponse(
             responseCode = "201",
             description = "Person created successfully",
@@ -81,7 +98,27 @@ public class CrmPersonController {
     @ApiResponse(responseCode = "401", description = "Unauthorized")
     @ApiResponse(responseCode = "403", description = "Forbidden - missing required permission")
     public ResponseEntity<CreatePersonResponse> createPerson(
-            @Valid @RequestBody CreatePersonRequest request, Principal principal) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "The individual's name, preferred contact method, and contact points to register.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Individual with email and mobile",
+                                                            value = """
+                                                                    {"firstName":"Dana",
+                                                                     "lastName":"Ortiz",
+                                                                     "preferredContactMethod":"EMAIL",
+                                                                     "emails":[{"value":"dana.ortiz@example.com","isPrimary":true}],
+                                                                     "phones":[{"value":"+15125550142","type":"PHONE_MOBILE","isPrimary":true}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CreatePersonRequest request,
+            Principal principal) {
 
         log.info(
                 "Creating person: firstName={}, lastName={}, user={}",
@@ -107,9 +144,17 @@ public class CrmPersonController {
             scopes = {"crm:person:read"})
     @PreAuthorize("hasAuthority('crm:person:read')")
     @EmitEvent(id = "CRM_PERSON_GET", apiVersion = "1")
-    @Operation(
-            summary = "Get a person by ID",
-            description = "Retrieves an individual person record by their unique identifier")
+    @Operation(operationId = "getPerson", summary = "Get Person By Id", description = """
+                    Returns the CRM view of an individual person by their canonical pos-people person id, \
+                    including their customer number and preferred contact method.
+                    Use this tool when the person id is already known; use searchPersons instead when \
+                    locating a person by name or email.
+                    Preconditions: a local person-party link must exist for the canonical person id.
+                    Required inputs: personId (UUID, the canonical pos-people id) as a path parameter; \
+                    there is no request body.
+                    Emits a CRM_PERSON_GET audit event; no state changes occur.
+                    Returns 404 when no person-party exists for the supplied personId.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Person found",
@@ -142,7 +187,21 @@ public class CrmPersonController {
             scopes = {"crm:person:read"})
     @PreAuthorize("hasAuthority('crm:person:read')")
     @EmitEvent(id = "CRM_PERSON_SEARCH", apiVersion = "1")
-    @Operation(summary = "Search persons", description = "Searches for persons matching the specified criteria")
+    @Operation(operationId = "searchPersons", summary = "Search Individual Persons", description = """
+                    Searches individual customers by delegating the text query to pos-people, which matches \
+                    first name, last name, primary email, and username, and returns only persons that also \
+                    have a local CRM person-party.
+                    Use this tool when locating an individual by name or email; use getPerson instead when \
+                    the person id is already known, and note phone search is best-effort only because \
+                    pos-people does not index phone numbers.
+                    Preconditions: at least one of name, email, or phone should be supplied; when all are \
+                    blank an empty list is returned without searching.
+                    Required inputs: none individually; the first non-blank of name, email, and phone \
+                    becomes the query, limit defaults to 20, and offset defaults to 0.
+                    Emits a CRM_PERSON_SEARCH audit event; no state changes occur.
+                    Returns 200 with an empty list rather than an error when nothing matches or the offset \
+                    is beyond the result set.
+                    """)
     @ApiResponse(responseCode = "200", description = "Search results returned")
     @ApiResponse(responseCode = "401", description = "Unauthorized")
     @ApiResponse(responseCode = "403", description = "Forbidden - missing required permission")

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmSegmentController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmSegmentController.java
@@ -13,6 +13,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -51,7 +52,17 @@ public class CrmSegmentController {
         this.segmentService = segmentService;
     }
 
-    @Operation(summary = "List segments", description = "List saved segments, optionally filtered by audience type")
+    @Operation(operationId = "listSegments", summary = "List Audience Segments", description = """
+                    Returns all saved audience segments with their type, audience type, active flag, and \
+                    member counts, optionally filtered by audience type.
+                    Use this tool when browsing or picking a segment; use getSegment instead when the \
+                    segment id is already known.
+                    Preconditions: none; an empty list is returned when no segment matches.
+                    Required inputs: none; audienceType optionally filters on COMMERCIAL or INDIVIDUAL, and \
+                    there is no request body.
+                    Emits a CRM_SEGMENT_LIST audit event; no state changes occur.
+                    Returns 200 with an empty list rather than an error when no segments exist.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -73,10 +84,17 @@ public class CrmSegmentController {
         return ResponseEntity.ok(segmentService.list(audienceType));
     }
 
-    @Operation(
-            summary = "List the segment attribute catalog",
-            description =
-                    "Every whitelisted attribute a dynamic predicate may reference, with operand kind, allowed operators, and description")
+    @Operation(operationId = "listSegmentAttributes", summary = "List Segment Attribute Catalog", description = """
+                    Returns the whitelist of attributes a dynamic segment predicate may reference, each with \
+                    its operand kind, allowed operators, and description.
+                    Use this tool before createSegment or updateSegment to build a valid DYNAMIC predicate; \
+                    do not use listSegments, which lists saved segments rather than the predicate vocabulary.
+                    Preconditions: none; the catalog is fixed in code per audience type.
+                    Required inputs: none; there are no parameters and no request body.
+                    Emits a CRM_SEGMENT_ATTRIBUTES audit event; no state changes occur.
+                    Returns 200 with the full catalog in every successful call; there are no business error \
+                    responses.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -99,7 +117,16 @@ public class CrmSegmentController {
         return ResponseEntity.ok(segmentService.attributeCatalog());
     }
 
-    @Operation(summary = "Get segment", description = "Retrieve a segment definition by id")
+    @Operation(operationId = "getSegment", summary = "Get Segment Definition", description = """
+                    Returns one segment's definition, including its type, audience type, predicate for \
+                    DYNAMIC segments, active flag, and member count.
+                    Use this tool when the segment id is already known; use listSegments instead to browse \
+                    segments, and resolveSegment to compute who currently matches.
+                    Preconditions: the segment must exist.
+                    Required inputs: segmentId (UUID) as a path parameter; there is no request body.
+                    Emits a CRM_SEGMENT_GET audit event; no state changes occur.
+                    Returns 404 when no segment exists for the supplied segmentId.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -118,10 +145,19 @@ public class CrmSegmentController {
         return ResponseEntity.ok(segmentService.get(segmentId));
     }
 
-    @Operation(
-            summary = "Create segment",
-            description =
-                    "Create a static or dynamic segment. Dynamic predicates are validated against the attribute catalog.")
+    @Operation(operationId = "createSegment", summary = "Create Audience Segment", description = """
+                    Creates a saved audience segment, either STATIC with an explicitly pinned member list or \
+                    DYNAMIC with a predicate validated against the attribute catalog.
+                    Use this tool when defining a new audience; do not use updateSegment, which modifies an \
+                    existing segment and cannot change its type or audience type.
+                    Preconditions: no existing segment may already use the same name case-insensitively; a \
+                    DYNAMIC segment must carry a predicate and a STATIC one must not.
+                    Required inputs: name (max 150), audienceType (COMMERCIAL or INDIVIDUAL), and type \
+                    (STATIC or DYNAMIC); description, predicate, and active are optional.
+                    Emits a CRM_SEGMENT_CREATE event and publishes the segment definition to consumers.
+                    Returns 409 when the name is already taken, and 422 when the predicate is missing on a \
+                    DYNAMIC segment, present on a STATIC one, or references attributes outside the catalog.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "201",
@@ -137,14 +173,46 @@ public class CrmSegmentController {
             scopes = {CrmPermissionRegistry.SEGMENT_MANAGE})
     @PreAuthorize("hasAuthority('crm:segment:manage')")
     @EmitEvent(id = "CRM_SEGMENT_CREATE", apiVersion = "1")
-    public ResponseEntity<SegmentResponse> create(@Valid @RequestBody UpsertSegmentRequest request) {
+    public ResponseEntity<SegmentResponse> create(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "The segment definition; DYNAMIC segments carry a predicate tree over catalog attributes, STATIC ones do not.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Dynamic gold-tier segment", value = """
+                                                                    {"name":"Gold-tier commercial accounts",
+                                                                     "description":"Commercial parties at GOLD tier or above",
+                                                                     "audienceType":"COMMERCIAL",
+                                                                     "type":"DYNAMIC",
+                                                                     "predicate":{"nodeType":"COMPARISON",
+                                                                                  "attribute":"party.accountTier",
+                                                                                  "operator":"IN",
+                                                                                  "values":["GOLD","PLATINUM","ENTERPRISE"]}}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    UpsertSegmentRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(segmentService.create(request));
     }
 
-    @Operation(
-            summary = "Update segment",
-            description =
-                    "Update a segment's name, description, predicate, or active flag. Type and audience type are immutable.")
+    @Operation(operationId = "updateSegment", summary = "Update Audience Segment", description = """
+                    Updates a segment's name, description, predicate, or active flag; type and audienceType \
+                    are immutable after creation because switching kinds would strand pinned members or a \
+                    predicate.
+                    Use this tool when refining an existing segment; use createSegment instead when a \
+                    different type or audience type is needed.
+                    Preconditions: the segment must exist, the new name must not collide with another \
+                    segment case-insensitively, and the submitted type and audienceType must equal the \
+                    stored values.
+                    Required inputs: segmentId (UUID) as a path parameter plus the full upsert body with \
+                    name, audienceType, and type restated; predicate rules follow the segment's type and \
+                    active is optional.
+                    Emits a CRM_SEGMENT_UPDATE event and republishes the segment definition.
+                    Returns 404 when the segment does not exist, 409 when the name is taken, and 422 when \
+                    type or audienceType differ from the stored segment or the predicate is invalid.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -165,11 +233,40 @@ public class CrmSegmentController {
     @PreAuthorize("hasAuthority('crm:segment:manage')")
     @EmitEvent(id = "CRM_SEGMENT_UPDATE", apiVersion = "1")
     public ResponseEntity<SegmentResponse> update(
-            @PathVariable UUID segmentId, @Valid @RequestBody UpsertSegmentRequest request) {
+            @PathVariable UUID segmentId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "The revised segment definition; type and audienceType must match the stored segment.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Rename and deactivate", value = """
+                                                                    {"name":"Gold-tier accounts (retired)",
+                                                                     "audienceType":"COMMERCIAL",
+                                                                     "type":"DYNAMIC",
+                                                                     "predicate":{"nodeType":"COMPARISON",
+                                                                                  "attribute":"party.accountTier",
+                                                                                  "operator":"IN",
+                                                                                  "values":["GOLD"]},
+                                                                     "active":false}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    UpsertSegmentRequest request) {
         return ResponseEntity.ok(segmentService.update(segmentId, request));
     }
 
-    @Operation(summary = "Delete segment", description = "Delete a segment and its pinned membership")
+    @Operation(operationId = "deleteSegment", summary = "Delete Audience Segment", description = """
+                    Deletes a segment and all of its pinned membership rows permanently.
+                    Use this tool when a segment is no longer wanted at all; use updateSegment with active \
+                    false instead to retire a segment while keeping its definition.
+                    Preconditions: the segment must exist; deletion is not reversible.
+                    Required inputs: segmentId (UUID) as a path parameter; there is no request body.
+                    Emits a CRM_SEGMENT_DELETE event and publishes a deletion notice so consumers drop the \
+                    segment.
+                    Returns 404 when no segment exists for the supplied segmentId.
+                    """)
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "Segment deleted", content = @Content),
         @ApiResponse(responseCode = "404", description = "Segment not found", content = @Content),
@@ -186,9 +283,17 @@ public class CrmSegmentController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Pin members",
-            description = "Add parties to a static segment; already-present parties are ignored")
+    @Operation(operationId = "addSegmentMembers", summary = "Pin Segment Members", description = """
+                    Pins parties onto a STATIC segment's member list, recording who added them and when; \
+                    parties already in the segment are silently skipped.
+                    Use this tool when curating a hand-picked audience; do not use it on a DYNAMIC segment, \
+                    whose membership is computed from its predicate by resolveSegment.
+                    Preconditions: the segment must exist and be STATIC.
+                    Required inputs: segmentId (UUID) as a path parameter and partyIds, a non-empty list of \
+                    up to 5000 UUIDs; duplicates in the list are collapsed.
+                    Emits a CRM_SEGMENT_MEMBERS_ADD event; only new membership rows are written.
+                    Returns 404 when the segment does not exist, and 422 when the segment is DYNAMIC.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -205,11 +310,34 @@ public class CrmSegmentController {
     @PreAuthorize("hasAuthority('crm:segment:manage')")
     @EmitEvent(id = "CRM_SEGMENT_MEMBERS_ADD", apiVersion = "1")
     public ResponseEntity<SegmentResponse> addMembers(
-            @PathVariable UUID segmentId, @Valid @RequestBody SegmentMembersRequest request) {
+            @PathVariable UUID segmentId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The party ids to pin onto the static segment's member list.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Pin two parties", value = """
+                                                                    {"partyIds":["018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                                 "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    SegmentMembersRequest request) {
         return ResponseEntity.ok(segmentService.addMembers(segmentId, request));
     }
 
-    @Operation(summary = "Unpin member", description = "Remove a party from a static segment")
+    @Operation(operationId = "removeSegmentMember", summary = "Unpin Segment Member", description = """
+                    Removes one party from a static segment's pinned member list.
+                    Use this tool when a hand-picked party should leave the audience; do not use \
+                    deleteSegment, which removes the whole segment and every member with it.
+                    Preconditions: none are enforced; removing a party that is not a member, or naming an \
+                    unknown segment, is a silent no-op.
+                    Required inputs: segmentId and partyId (UUIDs) as path parameters; there is no request \
+                    body.
+                    Emits a CRM_SEGMENT_MEMBER_REMOVE event; at most one membership row is deleted.
+                    Returns 204 in every authorized call, including when nothing was actually removed.
+                    """)
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "Member removed", content = @Content),
         @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
@@ -225,10 +353,20 @@ public class CrmSegmentController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Resolve segment",
-            description =
-                    "Resolve a segment to a match count, an optional per-channel eligible count, and a masked sample")
+    @Operation(operationId = "resolveSegment", summary = "Resolve Segment Audience", description = """
+                    Resolves a segment to its current match count, an optional per-channel eligible count \
+                    that folds in consent and suppression, and a masked sample of members; the full \
+                    recipient list is never returned, so the preview cannot become a bulk PII export.
+                    Use this tool when previewing an audience before a campaign; use getSegment instead for \
+                    the stored definition without computing membership.
+                    Preconditions: the segment must exist; eligible counts are computed only when a channel \
+                    is supplied.
+                    Required inputs: segmentId (UUID) as a path parameter; channel (EMAIL or SMS) is \
+                    optional, and sampleSize defaults to 10 and is clamped to the server's maximum.
+                    Emits a CRM_SEGMENT_RESOLVE audit event; no state changes occur.
+                    Returns 404 when no segment exists for the supplied segmentId, and 200 with a truncated \
+                    flag when the match list was capped during resolution.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmSnapshotController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmSnapshotController.java
@@ -45,9 +45,22 @@ public class CrmSnapshotController {
         this.vehicleOps = vehicleOps;
     }
 
-    @Operation(
-            summary = "Fetch snapshot by party",
-            description = "Returns complete party snapshot with accounts, contacts, vehicles")
+    @Operation(operationId = "getSnapshotByParty", summary = "Get CRM Snapshot By Party", description = """
+                    Returns a consolidated CRM snapshot for a party — account summary, contacts, vehicle \
+                    summaries, and preferences — assembled for commercial or person parties and served from \
+                    a cache when a fresh copy exists.
+                    Use this tool when a caller needs the whole customer picture in one call; use getParty \
+                    instead for just the identity fields, and getSnapshotByVehicle when only a vehicle id \
+                    is known.
+                    Preconditions: a commercial or person party must exist for the supplied partyId.
+                    Required inputs: partyId (UUID) as a path parameter; there is no request body, and the \
+                    snapshotMetadata.source field reports CACHE or CRM_API depending on where the data came \
+                    from.
+                    Emits a CRM_SNAPSHOT_PARTY_RETRIEVE audit event; the snapshot cache may be populated \
+                    but no domain state changes.
+                    Returns 404 when neither a commercial nor a person party exists for the supplied \
+                    partyId.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -72,12 +85,18 @@ public class CrmSnapshotController {
                 : ResponseEntity.notFound().build();
     }
 
-    @Operation(
-            operationId = "getBillingRules",
-            summary = "Get billing rules for a commercial party",
-            description = "Returns the billing rule reference for a commercial party. "
-                    + "Returns default billing rules when the party has no explicitly configured rules. "
-                    + "Enforcement of these rules is the responsibility of downstream services.")
+    @Operation(operationId = "getBillingRules", summary = "Get Party Billing Rules", description = """
+                    Returns the billing-rules reference for a party, falling back to default rules when a \
+                    commercial party has no explicitly configured rules and for person parties, which have \
+                    no configurable rules; enforcement of the rules belongs to downstream services.
+                    Use this tool when reading how an account should be billed; use upsertBillingRules \
+                    instead to change the configuration.
+                    Preconditions: a commercial or person party must exist for the supplied partyId.
+                    Required inputs: partyId (UUID) as a path parameter; there is no request body.
+                    Emits a CRM_SNAPSHOT_BILLING_RULES_GET audit event; no state changes occur.
+                    Returns 404 when no party exists for the supplied partyId, and 200 with defaults rather \
+                    than an error when rules were never configured.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "200", description = "Billing rules returned"),
@@ -96,7 +115,17 @@ public class CrmSnapshotController {
         return ResponseEntity.ok(rules);
     }
 
-    @Operation(summary = "Fetch snapshot by vehicle", description = "Returns party snapshot based on vehicle ownership")
+    @Operation(operationId = "getSnapshotByVehicle", summary = "Get CRM Snapshot By Vehicle", description = """
+                    Returns the CRM snapshot of the commercial party that owns a vehicle, resolved through \
+                    the vehicle-to-party association replicated from vehicle events.
+                    Use this tool when only a vehicle id is known, for example at service check-in; use \
+                    getSnapshotByParty instead when the party id is already known.
+                    Preconditions: the vehicle must be associated with a commercial party in the local \
+                    replica; recently registered vehicles may not have been replicated yet.
+                    Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+                    Emits a CRM_SNAPSHOT_VEHICLE_RETRIEVE audit event; no state changes occur.
+                    Returns 404 when no owning party can be resolved for the supplied vehicleId.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmSuppressionController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmSuppressionController.java
@@ -9,6 +9,7 @@ import com.positivity.customer.service.SuppressionService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -45,7 +46,17 @@ public class CrmSuppressionController {
         this.suppressionService = suppressionService;
     }
 
-    @Operation(summary = "List suppression entries", description = "List suppressed addresses, newest first")
+    @Operation(operationId = "listSuppressionEntries", summary = "List Suppression Entries", description = """
+                    Returns hard-suppressed marketing addresses newest first, showing only a masked address \
+                    hint and the normalized hash — raw addresses are never stored or returned.
+                    Use this tool when reviewing the suppression list; use checkAddressSuppression instead \
+                    to test one specific address before a send.
+                    Preconditions: none; an empty page is returned when nothing matches.
+                    Required inputs: none; channel optionally filters on EMAIL or SMS, page defaults to 0, \
+                    and size defaults to 50 clamped between 1 and 200.
+                    Emits a CRM_SUPPRESSION_LIST audit event; no state changes occur.
+                    Returns 200 with an empty page rather than an error when the list is empty.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -66,9 +77,20 @@ public class CrmSuppressionController {
         return ResponseEntity.ok(suppressionService.list(channel, page, size));
     }
 
-    @Operation(
-            summary = "Check address suppression",
-            description = "Whether a raw address is currently blocked on a channel. Used by send pipelines.")
+    @Operation(operationId = "checkAddressSuppression", summary = "Check Address Suppression", description = """
+                    Reports whether a raw address is currently hard-blocked on a channel by normalizing and \
+                    hashing it and looking the hash up in the suppression list.
+                    Use this tool from send pipelines immediately before dispatch; use \
+                    resolveMarketingEligibility instead for the full party-level decision that also folds \
+                    in consent and the account gate.
+                    Preconditions: none; suppression outranks consent, so a true result must block the send \
+                    regardless of opt-in state.
+                    Required inputs: channel (EMAIL or SMS) and address (the raw address to test) as \
+                    required query parameters; the raw address is used only for hashing and never stored.
+                    Emits a CRM_SUPPRESSION_CHECK audit event; no state changes occur.
+                    Returns 200 with a bare boolean body, true when the address is suppressed on that \
+                    channel and false otherwise.
+                    """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Result returned"),
         @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
@@ -84,9 +106,22 @@ public class CrmSuppressionController {
         return ResponseEntity.ok(suppressionService.isSuppressed(channel, address));
     }
 
-    @Operation(
-            summary = "Suppress an address",
-            description = "Hard-block an address from marketing. Idempotent: re-adding returns the existing entry.")
+    @Operation(operationId = "addSuppressionEntry", summary = "Suppress Marketing Address", description = """
+                    Hard-blocks an address from marketing on one channel, storing only a normalized hash \
+                    and a masked hint of the address.
+                    Use this tool for bounce feeds, spam complaints, and legal do-not-contact requests; do \
+                    not use updateMarketingConsent, which records a party's choice and can be reversed by \
+                    the party, whereas suppression outranks consent entirely.
+                    Preconditions: none; the call is idempotent, and re-adding an already-suppressed \
+                    address returns the existing entry without touching the audit trail.
+                    Required inputs: channel (EMAIL or SMS), address (raw, max 320 characters), and reason \
+                    (HARD_BOUNCE, SPAM_COMPLAINT, LEGAL_DNC, MANUAL, or UNSUBSCRIBE_LINK); partyId is \
+                    optional and source defaults to CSR.
+                    Emits a CRM_SUPPRESSION_ADD event and publishes a suppression-changed fact when a new \
+                    entry is actually created.
+                    Returns 400 when channel, address, or reason is missing, and 201 with the existing \
+                    entry when the address was already suppressed.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "201",
@@ -101,11 +136,38 @@ public class CrmSuppressionController {
             scopes = {CrmPermissionRegistry.SUPPRESSION_MANAGE})
     @PreAuthorize("hasAuthority('crm:suppression:manage')")
     @EmitEvent(id = "CRM_SUPPRESSION_ADD", apiVersion = "1")
-    public ResponseEntity<SuppressionEntryResponse> add(@Valid @RequestBody AddSuppressionRequest request) {
+    public ResponseEntity<SuppressionEntryResponse> add(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "The address to hard-block, the channel it applies to, and why it is being suppressed.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Hard bounce", value = """
+                                                                    {"channel":"EMAIL",
+                                                                     "address":"bounced@example.com",
+                                                                     "partyId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "reason":"HARD_BOUNCE",
+                                                                     "source":"SYSTEM"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    AddSuppressionRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(suppressionService.add(request));
     }
 
-    @Operation(summary = "Lift a suppression", description = "Remove a suppression entry")
+    @Operation(operationId = "removeSuppressionEntry", summary = "Lift Address Suppression", description = """
+                    Removes one suppression entry, allowing marketing to reach the address again subject to \
+                    normal consent rules.
+                    Use this tool when an address was suppressed in error or a legal block is lifted; do \
+                    not use updateMarketingConsent for this, which cannot override a suppression entry.
+                    Preconditions: the suppression entry must exist.
+                    Required inputs: suppressionId (UUID) as a path parameter; there is no request body.
+                    Emits a CRM_SUPPRESSION_REMOVE event and publishes a suppression-changed fact so \
+                    consumers stop blocking the address.
+                    Returns 404 when no suppression entry exists for the supplied suppressionId.
+                    """)
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "Suppression lifted", content = @Content),
         @ApiResponse(responseCode = "404", description = "Suppression entry not found", content = @Content),

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmTagController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmTagController.java
@@ -10,6 +10,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -45,7 +46,16 @@ public class CrmTagController {
         this.partyTagService = partyTagService;
     }
 
-    @Operation(summary = "List tags", description = "List the CRM tag catalog with assignment counts")
+    @Operation(operationId = "listTags", summary = "List Tag Catalog", description = """
+                    Returns the CRM tag catalog with each tag's category, color, active flag, and \
+                    assignment count.
+                    Use this tool when browsing available tags before assigning one; use listPartyTags \
+                    instead to see which tags a specific party carries.
+                    Preconditions: none; inactive tags are omitted unless explicitly requested.
+                    Required inputs: none; includeInactive defaults to false, and there is no request body.
+                    Emits a CRM_TAG_LIST audit event; no state changes occur.
+                    Returns 200 with an empty list rather than an error when the catalog is empty.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -67,7 +77,16 @@ public class CrmTagController {
         return ResponseEntity.ok(partyTagService.listTags(includeInactive));
     }
 
-    @Operation(summary = "Get tag", description = "Retrieve a single tag by id")
+    @Operation(operationId = "getTag", summary = "Get Tag By Id", description = """
+                    Returns one catalog tag with its name, category, color, active flag, and assignment \
+                    count.
+                    Use this tool when the tag id is already known; use listTags instead to browse the \
+                    catalog.
+                    Preconditions: the tag must exist in the catalog.
+                    Required inputs: tagId (UUID) as a path parameter; there is no request body.
+                    Emits a CRM_TAG_GET audit event; no state changes occur.
+                    Returns 404 when no tag exists for the supplied tagId.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -86,7 +105,16 @@ public class CrmTagController {
         return ResponseEntity.ok(partyTagService.getTag(tagId));
     }
 
-    @Operation(summary = "Create tag", description = "Add a new tag to the CRM tag catalog")
+    @Operation(operationId = "createTag", summary = "Create Catalog Tag", description = """
+                    Adds a new tag to the CRM tag catalog for later assignment to parties.
+                    Use this tool when a new label is needed; do not use assignTagToParty, which attaches an \
+                    existing catalog tag to a party.
+                    Preconditions: no existing tag may already use the same name case-insensitively.
+                    Required inputs: name (non-blank, max 100); category, color, and active (default true) \
+                    are optional.
+                    Emits a CRM_TAG_CREATE event; the tag becomes immediately assignable when active.
+                    Returns 409 when a tag with the same name already exists, and 400 when name is blank.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "201",
@@ -102,11 +130,37 @@ public class CrmTagController {
             scopes = {CrmPermissionRegistry.TAG_MANAGE})
     @PreAuthorize("hasAuthority('crm:tag:manage')")
     @EmitEvent(id = "CRM_TAG_CREATE", apiVersion = "1")
-    public ResponseEntity<PartyTagResponse> createTag(@Valid @RequestBody UpsertPartyTagRequest request) {
+    public ResponseEntity<PartyTagResponse> createTag(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The new tag's name and optional presentation attributes.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Fleet VIP tag", value = """
+                                                                    {"name":"Fleet VIP",
+                                                                     "category":"Loyalty",
+                                                                     "color":"#D4AF37",
+                                                                     "active":true}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    UpsertPartyTagRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(partyTagService.createTag(request));
     }
 
-    @Operation(summary = "Update tag", description = "Rename, recolour, recategorize, or retire a tag")
+    @Operation(operationId = "updateTag", summary = "Update Catalog Tag", description = """
+                    Renames, recolours, recategorizes, or retires a catalog tag; setting active false stops \
+                    new assignments while keeping existing ones.
+                    Use this tool when changing how a tag looks or retiring it; use deleteTag instead to \
+                    remove the tag and every assignment of it.
+                    Preconditions: the tag must exist, and the new name must not collide with another tag \
+                    case-insensitively.
+                    Required inputs: tagId (UUID) as a path parameter and name in the body; category, \
+                    color, and active are optional.
+                    Emits a CRM_TAG_UPDATE event; existing assignments are untouched.
+                    Returns 404 when the tag does not exist, and 409 when the new name is already taken.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -123,11 +177,34 @@ public class CrmTagController {
     @PreAuthorize("hasAuthority('crm:tag:manage')")
     @EmitEvent(id = "CRM_TAG_UPDATE", apiVersion = "1")
     public ResponseEntity<PartyTagResponse> updateTag(
-            @PathVariable UUID tagId, @Valid @RequestBody UpsertPartyTagRequest request) {
+            @PathVariable UUID tagId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "The revised tag attributes; omitted optional fields are cleared or left defaulted.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Retire tag", value = """
+                                                                    {"name":"Fleet VIP",
+                                                                     "category":"Loyalty",
+                                                                     "active":false}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    UpsertPartyTagRequest request) {
         return ResponseEntity.ok(partyTagService.updateTag(tagId, request));
     }
 
-    @Operation(summary = "Delete tag", description = "Remove a tag from the catalog along with every assignment of it")
+    @Operation(operationId = "deleteTag", summary = "Delete Catalog Tag", description = """
+                    Removes a tag from the catalog together with every assignment of it on every party.
+                    Use this tool only when the tag and its history should disappear entirely; use \
+                    updateTag with active false instead to retire a tag while keeping existing assignments.
+                    Preconditions: the tag must exist; deletion is not reversible.
+                    Required inputs: tagId (UUID) as a path parameter; there is no request body.
+                    Emits a CRM_TAG_DELETE event; all assignment rows for the tag are removed.
+                    Returns 404 when no tag exists for the supplied tagId.
+                    """)
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "Tag deleted", content = @Content),
         @ApiResponse(responseCode = "404", description = "Tag not found", content = @Content),
@@ -144,7 +221,16 @@ public class CrmTagController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "List party tags", description = "List the tags currently attached to a party")
+    @Operation(operationId = "listPartyTags", summary = "List Party Tag Assignments", description = """
+                    Returns the tags currently attached to one party, with who assigned each tag, when, and \
+                    through which source.
+                    Use this tool when reviewing a party's labels; use listTags instead for the full \
+                    catalog of assignable tags.
+                    Preconditions: none; an unknown partyId yields an empty list rather than an error.
+                    Required inputs: partyId (UUID) as a path parameter; there is no request body.
+                    Emits a CRM_PARTY_TAG_LIST audit event; no state changes occur.
+                    Returns 200 with an empty list rather than an error when the party has no tags.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -167,9 +253,20 @@ public class CrmTagController {
         return ResponseEntity.ok(partyTagService.listPartyTags(partyId));
     }
 
-    @Operation(
-            summary = "Assign tag to party",
-            description = "Attach a tag to a party. Idempotent: re-assigning returns the existing assignment.")
+    @Operation(operationId = "assignTagToParty", summary = "Assign Tag To Party", description = """
+                    Attaches a catalog tag to a party, recording the assigning user, timestamp, and source.
+                    Use this tool when labeling a party; do not use createTag, which adds a new tag to the \
+                    catalog without attaching it to anyone.
+                    Preconditions: the tag must exist and, for a new assignment, be active; the call is \
+                    idempotent, and re-assigning an already-attached tag returns the existing assignment \
+                    even when the tag has since been retired.
+                    Required inputs: partyId (UUID) as a path parameter and tagId (UUID) in the body; \
+                    source defaults to MANUAL and accepts MANUAL, CAMPAIGN, IMPORT, or RULE.
+                    Emits a CRM_PARTY_TAG_ASSIGN event and publishes a party-tag-changed fact when a new \
+                    assignment is created.
+                    Returns 404 when the tag does not exist, and 400 when the tag is inactive and not \
+                    already assigned.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
@@ -186,13 +283,33 @@ public class CrmTagController {
     @PreAuthorize("hasAuthority('crm:tag:assign')")
     @EmitEvent(id = "CRM_PARTY_TAG_ASSIGN", apiVersion = "1")
     public ResponseEntity<PartyTagAssignmentResponse> assignTag(
-            @PathVariable UUID partyId, @Valid @RequestBody AssignPartyTagRequest request) {
+            @PathVariable UUID partyId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The catalog tag to attach to the party and how the assignment originated.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Manual assignment", value = """
+                                                                    {"tagId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a61",
+                                                                     "source":"MANUAL"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    AssignPartyTagRequest request) {
         return ResponseEntity.ok(partyTagService.assignTag(partyId, request));
     }
 
-    @Operation(
-            summary = "Remove tag from party",
-            description = "Detach a tag from a party. Idempotent: removing an absent tag succeeds.")
+    @Operation(operationId = "removeTagFromParty", summary = "Remove Tag From Party", description = """
+                    Detaches a tag from a party while leaving the tag itself in the catalog.
+                    Use this tool when a label no longer applies to a party; use deleteTag instead to \
+                    remove the tag from the catalog and every party at once.
+                    Preconditions: none; removing a tag that is not assigned is an idempotent no-op.
+                    Required inputs: partyId and tagId (UUIDs) as path parameters; there is no request body.
+                    Emits a CRM_PARTY_TAG_REMOVE event and publishes a party-tag-changed fact when an \
+                    assignment was actually removed.
+                    Returns 204 in every authorized call, including when nothing was assigned.
+                    """)
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "Tag removed", content = @Content),
         @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmVehiclesController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CrmVehiclesController.java
@@ -37,10 +37,21 @@ public class CrmVehiclesController {
 
     private final CrmVehicleService crmVehicleService;
 
-    @Operation(
-            summary = "List vehicles for customer",
-            description = "Retrieve all vehicle summaries (vehicleId, VIN, make/model/year) associated with a customer."
-                    + " Returns the vehicle UUIDs the frontend needs to build estimates for a given Durion customer.")
+    @Operation(operationId = "listVehiclesForCustomer", summary = "List Customer Vehicles", description = """
+                    Returns the vehicle summaries (vehicleId, VIN, make, model, year) associated with a \
+                    customer, resolved from the party's VIN set against the local ext_vehicle replica of \
+                    pos-vehicle-inventory.
+                    Use this tool when the vehicle UUIDs for a known customer are needed, for example to \
+                    build an estimate; use getVehicleForCustomer instead for one vehicle's full record, and \
+                    note vehicle writes go to pos-vehicle-inventory, not this module.
+                    Preconditions: the customer must exist as a person or commercial party; VINs whose \
+                    vehicle events have not yet been replicated are silently dropped from the list.
+                    Required inputs: customerId (UUID, the party id) as a path parameter; there is no \
+                    request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no party exists for the supplied customerId, and 200 with an empty \
+                    list when the customer owns no resolvable vehicles.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -77,7 +88,19 @@ public class CrmVehiclesController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @Operation(summary = "Get vehicle for customer", description = "Retrieve a specific vehicle for a given customer")
+    @Operation(operationId = "getVehicleForCustomer", summary = "Get Customer Vehicle", description = """
+                    Returns one vehicle's record from the local ext_vehicle replica, verified to belong to \
+                    the named customer through the party's VIN association.
+                    Use this tool when both the customer and vehicle ids are known; use \
+                    listVehiclesForCustomer instead to discover which vehicles a customer owns.
+                    Preconditions: the customer must exist, the vehicle must exist in the replica, and the \
+                    vehicle must be associated with that customer.
+                    Required inputs: customerId and vehicleId (UUIDs) as path parameters; there is no \
+                    request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when the customer, the vehicle, or the ownership association cannot be \
+                    resolved.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CustomerBulkIngestController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CustomerBulkIngestController.java
@@ -42,11 +42,52 @@ public class CustomerBulkIngestController extends AbstractBulkIngestController<C
     private final PersonService personService;
 
     @Override
+    @io.swagger.v3.oas.annotations.Operation(
+            operationId = "bulkIngestCustomers",
+            summary = "Bulk Ingest Customer Records",
+            description = """
+                    Imports a batch of individual customer records, creating each one through the same path \
+                    as createPerson so canonical identities land in pos-people, and reports a per-row \
+                    success or failure result without aborting the batch.
+                    Use this tool for migrations and file imports of individuals; do not use createPerson \
+                    row by row for large loads, and note this path cannot create commercial accounts.
+                    Preconditions: none beyond authorization; rows that fail validation are reported with \
+                    errorCode CUSTOMER_INGEST_FAILED while the rest of the batch proceeds.
+                    Required inputs: jobId (UUID), locationId (UUID), and a non-empty records list where \
+                    each record has firstName and lastName (each max 100) and optionally email, \
+                    phoneNumber, primaryAddress, and customerNumber; preferredContactMethod is derived as \
+                    EMAIL when an email is present and PHONE_CALL otherwise, and operatorId falls back to \
+                    the security context when absent or not a UUID.
+                    Emits a CUSTOMER_BULK_INGEST event, and each successful row publishes a party-changed \
+                    customer fact and writes contact points to pos-people.
+                    Returns 200 with per-row results including failures, and 400 when jobId, locationId, or \
+                    the records list is missing or empty.
+                    """)
     @PostMapping("/bulk-ingest")
     @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_CREATE + "')")
     @EmitEvent(id = "CUSTOMER_BULK_INGEST", apiVersion = "1")
     public ResponseEntity<BulkIngestResponse> bulkIngest(
-            @Valid @RequestBody @NonNull BulkIngestRequest<CustomerBulkIngestRecord> request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The ingest job envelope with the batch of customer records to import.",
+                            required = true,
+                            content =
+                                    @io.swagger.v3.oas.annotations.media.Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                                            name = "Two-record batch",
+                                                            value = """
+                                                                    {"jobId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a64",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a65",
+                                                                     "operatorId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a66",
+                                                                     "records":[
+                                                                       {"firstName":"Dana","lastName":"Ortiz","email":"dana.ortiz@example.com"},
+                                                                       {"firstName":"Sam","lastName":"Rivera","phoneNumber":"+15125550143"}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BulkIngestRequest<CustomerBulkIngestRecord> request) {
         return super.bulkIngest(request);
     }
 

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CustomerController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CustomerController.java
@@ -8,6 +8,8 @@ import com.positivity.customer.service.CustomerService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
@@ -43,12 +45,19 @@ public class CustomerController {
         this.personService = personService;
     }
 
-    @Operation(
-            summary = "Get all customers",
-            description =
-                    "Retrieve a paginated list of customers by type (PERSON or COMMERCIAL). Defaults to PERSON customers"
-                            + " if no type specified. When a name and/or email filter is supplied, performs a"
-                            + " server-side search instead of an unfiltered listing (scalable typeahead).")
+    @Operation(operationId = "listCustomers", summary = "List Customers By Type", description = """
+                    Returns a page of customers of one party type, switching to a server-side typeahead \
+                    search when a name or email filter is supplied.
+                    Use this tool for the legacy flat customer listing keyed by customerType; use \
+                    browseParties instead for the unified directory that merges commercial and individual \
+                    customers in one result.
+                    Preconditions: none; an empty page is returned when nothing matches.
+                    Required inputs: none; customerType defaults to PERSON and accepts PERSON or \
+                    COMMERCIAL, name and email are optional case-insensitive filters, and paging defaults \
+                    to page 0, size 20, sorted by customerNumber.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty page rather than an error when no customer matches.
+                    """)
     @ApiResponse(responseCode = "200", description = "Page of customers returned successfully.")
     @GetMapping
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -80,7 +89,16 @@ public class CustomerController {
         return service.getAllCustomers(pageable);
     }
 
-    @Operation(summary = "Get customer by ID", description = "Retrieve a customer by their unique ID.")
+    @Operation(operationId = "getCustomerById", summary = "Get Customer By Id", description = """
+                    Returns one customer as a flat CustomerDTO, checking commercial parties first and \
+                    falling back to person parties.
+                    Use this tool for the legacy flat customer view; use getParty or getSnapshotByParty \
+                    instead for the richer party projections.
+                    Preconditions: a commercial or person party must exist for the supplied id.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when neither a commercial nor a person party exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Customer found and returned.")
     @ApiResponse(responseCode = "404", description = "Customer not found.")
     @GetMapping("/{id}")
@@ -101,7 +119,20 @@ public class CustomerController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @Operation(summary = "Create a new customer", description = "Add a new customer to the system.")
+    @Operation(operationId = "createCustomer", summary = "Create Customer Record", description = """
+                    Creates a customer from a flat CustomerDTO, routed by customerType to either the \
+                    commercial or person party store.
+                    Use this tool only for the legacy flat customer API; use createCommercialAccount \
+                    instead for commercial onboarding with duplicate checking, and createPerson for \
+                    individuals so the canonical identity lands in pos-people.
+                    Preconditions: none beyond authorization; no duplicate detection is performed.
+                    Required inputs: firstName and lastName (each max 100); customerType selects the store, \
+                    where COMMERCIAL routes to the commercial service and anything else creates a person \
+                    party, and customerNumber, primaryAddress, and vehicleVins are optional.
+                    Emits a CUSTOMER_CUSTOMER_CREATE event and publishes a party-changed customer fact.
+                    Returns 201 with the stored customer on success; field validation is not enforced on \
+                    this legacy path, so a malformed JSON body producing 400 is the only rejection.
+                    """)
     @ApiResponse(responseCode = "201", description = "Customer created successfully.")
     @PostMapping
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -110,7 +141,21 @@ public class CustomerController {
     @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_CREATE + "')")
     @EmitEvent(id = "CUSTOMER_CUSTOMER_CREATE", apiVersion = "1")
     public ResponseEntity<CustomerDTO> createCustomer(
-            @Parameter(description = "Customer object to be created") @RequestBody CustomerDTO customer) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "The flat customer record to store; customerType routes it to the commercial or person store.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Individual customer", value = """
+                                                                    {"firstName":"Dana",
+                                                                     "lastName":"Ortiz",
+                                                                     "customerType":"PERSON",
+                                                                     "primaryAddress":"100 Congress Ave, Austin, TX 78701"}
+                                                                    """)))
+                    @RequestBody
+                    CustomerDTO customer) {
         log.info("Creating new customer: {}", customer);
         CustomerService service =
                 COMMERCIAL.equalsIgnoreCase(customer.getCustomerType()) ? commercialService : personService;
@@ -118,7 +163,18 @@ public class CustomerController {
         return ResponseEntity.status(201).body(saved);
     }
 
-    @Operation(summary = "Update an existing customer", description = "Update the details of an existing customer.")
+    @Operation(operationId = "updateCustomer", summary = "Update Customer Record", description = """
+                    Updates an existing customer's flat record, with the body's customerType selecting \
+                    whether the commercial or person store is searched for the id.
+                    Use this tool only for the legacy flat customer API; the customerType in the body must \
+                    match the store the customer actually lives in, or the lookup misses, so do not use it \
+                    to change a customer from PERSON to COMMERCIAL.
+                    Preconditions: a party of the type named by customerType must exist for the supplied id.
+                    Required inputs: id (UUID) as a path parameter and the CustomerDTO body including \
+                    customerType; only fields present in the DTO mapping are applied.
+                    Emits a CUSTOMER_CUSTOMER_UPDATE event and publishes a party-changed customer fact.
+                    Returns 404 when no party of the selected type exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Customer updated successfully.")
     @ApiResponse(responseCode = "404", description = "Customer not found.")
     @PutMapping("/{id}")
@@ -131,7 +187,21 @@ public class CustomerController {
             @Parameter(description = "ID of the customer to update", example = "123e4567-e89b-12d3-a456-426614174000")
                     @PathVariable
                     UUID id,
-            @Parameter(description = "Updated customer object") @RequestBody CustomerDTO customer) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "The revised customer fields; customerType must name the store the customer already lives in.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Update address", value = """
+                                                                    {"firstName":"Dana",
+                                                                     "lastName":"Ortiz",
+                                                                     "customerType":"PERSON",
+                                                                     "primaryAddress":"200 Lavaca St, Austin, TX 78701"}
+                                                                    """)))
+                    @RequestBody
+                    CustomerDTO customer) {
         log.info("Updating customer with id: {}", id);
         CustomerService service =
                 COMMERCIAL.equalsIgnoreCase(customer.getCustomerType()) ? commercialService : personService;
@@ -140,7 +210,17 @@ public class CustomerController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @Operation(summary = "Delete a customer", description = "Delete a customer by their unique ID.")
+    @Operation(operationId = "deleteCustomer", summary = "Delete Customer Record", description = """
+                    Hard-deletes a customer row, trying the commercial store first and then the person \
+                    store, and publishes a party-deleted fact for the removed record.
+                    Use this tool only when a customer record must be physically removed; do not use it for \
+                    duplicates — use mergeParties instead, whose MERGED status preserves history, since this \
+                    deletion is not reversible.
+                    Preconditions: a commercial or person party must exist for the supplied id.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a CUSTOMER_CUSTOMER_DELETE event and publishes a party-deleted customer fact.
+                    Returns 404 when neither store holds a party for the supplied id.
+                    """)
     @ApiResponse(responseCode = "204", description = "Customer deleted successfully.")
     @ApiResponse(responseCode = "404", description = "Customer not found.")
     @DeleteMapping("/{id}")

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CustomerRequirementsController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CustomerRequirementsController.java
@@ -32,8 +32,19 @@ public class CustomerRequirementsController {
     private final CustomerRequirementsService customerRequirementsService;
 
     @Operation(
-            summary = "Check whether a customer meets requirements",
-            description = "Returns true when the customer is active and, for commercial parties, not on credit hold.")
+            operationId = "checkCustomerRequirementsMet",
+            summary = "Check Customer Requirements Met",
+            description = """
+                    Evaluates whether a customer is eligible for customer-facing workflows: the party must \
+                    have ACTIVE status, and a commercial party must additionally not be on credit hold.
+                    Use this tool as a gate before starting orders or workorders for a customer; use \
+                    getBillingRules instead to see the underlying credit-hold configuration.
+                    Preconditions: a commercial or person party must exist for the supplied id.
+                    Required inputs: id (UUID, the party id) as a path parameter; there is no request body.
+                    Emits a CUSTOMER_REQUIREMENTS_MET_GET audit event; no state changes occur.
+                    Returns 404 when no party exists for the supplied id, and 200 with a bare boolean \
+                    verdict otherwise.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/PersonLinkReconciliationController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/PersonLinkReconciliationController.java
@@ -28,9 +28,19 @@ public class PersonLinkReconciliationController {
         this.reconciliationService = reconciliationService;
     }
 
-    @Operation(
-            summary = "Reconcile person links",
-            description = "Verify every person_party.person_id resolves to a pos-people person (ADR-0015 I1).")
+    @Operation(operationId = "reconcilePersonLinks", summary = "Reconcile Person Links", description = """
+                    Produces an integrity report verifying that every person_party.person_id in this module \
+                    resolves to a canonical person in pos-people, the precondition for keeping person_party \
+                    as a thin link under ADR-0015.
+                    Use this tool for admin integrity checks after imports or migrations; do not use \
+                    searchPersons, which looks up individual customers rather than auditing link health.
+                    Preconditions: pos-people must be reachable to resolve the links being verified.
+                    Required inputs: none; there are no parameters and no request body.
+                    No events are emitted and no state changes; the report is computed on demand and \
+                    nothing is repaired automatically.
+                    Returns 200 with the reconciliation report, including any person ids that failed to \
+                    resolve.
+                    """)
     @ApiResponse(responseCode = "200", description = "Reconciliation report returned")
     @GetMapping("/reconcile")
     @PreAuthorize("hasAuthority('" + CrmPermissionRegistry.PARTY_VIEW + "')")

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/PromotionRedemptionController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/PromotionRedemptionController.java
@@ -7,6 +7,7 @@ import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -35,7 +36,24 @@ public class PromotionRedemptionController {
         this.promotionRedemptionService = promotionRedemptionService;
     }
 
-    @Operation(summary = "Record promotion redemption", description = "Record a promotion redemption idempotently")
+    @Operation(operationId = "recordPromotionRedemption", summary = "Record Promotion Redemption", description = """
+                    Records that a promotion was redeemed on a workorder, increments the promotion's usage \
+                    counter, and stamps the recording user; the pair of promotionId and workorderId is the \
+                    idempotency key.
+                    Use this tool when a discount is actually applied at checkout or invoicing; use \
+                    listPromotionRedemptionsByCustomer instead to read what a customer has redeemed.
+                    Preconditions: no redemption may already exist for the same promotionId and workorderId \
+                    pair; the referenced promotion, customer, and workorder ids are recorded as supplied \
+                    without cross-service validation.
+                    Required inputs: promotionId, customerId, and workorderId (UUIDs), discountAmount, \
+                    discountType (max 50), and promotionCode (max 100); invoiceId, campaignCode, and \
+                    redemptionTimestamp (defaulting to now) are optional, and recordedOverLimit defaults to \
+                    false and switches the stored status to RECORDED_OVER_LIMIT.
+                    Emits a PROMOTION_REDEMPTION_RECORD event and publishes a redemption-recorded fact for \
+                    every redemption so marketing keeps a non-attributed baseline.
+                    Returns 409 when the promotion has already been redeemed on that workorder, and 400 \
+                    when a required field is missing.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -55,14 +73,43 @@ public class PromotionRedemptionController {
     @PreAuthorize("hasAuthority('crm:promotion_redemption:record')")
     @EmitEvent(id = "PROMOTION_REDEMPTION_RECORD", apiVersion = "1")
     public ResponseEntity<PromotionRedemptionResponse> recordRedemption(
-            @Valid @RequestBody RecordRedemptionRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "The redemption to record, keyed for idempotency by promotionId and workorderId.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Coupon redemption", value = """
+                                                                    {"promotionId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a62",
+                                                                     "customerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "workorderId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a63",
+                                                                     "discountAmount":25.00,
+                                                                     "discountType":"FIXED_AMOUNT",
+                                                                     "promotionCode":"SPRING25",
+                                                                     "campaignCode":"SPRING-2026"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    RecordRedemptionRequest request) {
         PromotionRedemptionResponse response = promotionRedemptionService.recordRedemption(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @Operation(
-            summary = "Get redemptions by customer",
-            description = "Retrieve all recorded redemptions for a customer")
+            operationId = "listPromotionRedemptionsByCustomer",
+            summary = "List Customer Promotion Redemptions",
+            description = """
+                    Returns every promotion redemption recorded for one customer, including discount \
+                    amounts, codes, statuses, and timestamps.
+                    Use this tool when reviewing a customer's redemption history, for example to enforce \
+                    per-customer limits; use recordPromotionRedemption instead to record a new redemption.
+                    Preconditions: none; an unknown customerId yields an empty list rather than an error.
+                    Required inputs: customerId (UUID) as a path parameter; there is no request body.
+                    Emits a PROMOTION_REDEMPTION_LIST audit event; no state changes occur.
+                    Returns 200 with an empty list rather than an error when the customer has no \
+                    redemptions.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Promotion redemptions returned",

--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/PublicInquiryController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/PublicInquiryController.java
@@ -7,6 +7,7 @@ import com.positivity.customer.service.InquiryService;
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -75,10 +76,23 @@ public class PublicInquiryController {
         this.inquiryService = inquiryService;
     }
 
-    @Operation(
-            summary = "Submit an inquiry",
-            description =
-                    "Public, unauthenticated capture of a service or fleet-quote request. Rate-limited per submitter; returns only a reference id.")
+    @Operation(operationId = "submitPublicInquiry", summary = "Submit Public Inquiry", description = """
+                    Accepts an anonymous service or fleet-quote inquiry from the public web form, \
+                    rate-limited per hashed submitter fingerprint, and returns only a reference id and NEW \
+                    status so the endpoint cannot be used to enumerate existing customers.
+                    Use this tool only for the unauthenticated public form when the deployment has enabled \
+                    it via pos.customer.inquiry.public.enabled; do not use captureInquiry here, which is \
+                    the authenticated staff path and is not rate-limited.
+                    Preconditions: the public-inquiry feature flag must be enabled and the submitter must \
+                    be under the per-source rate ceiling; the raw source address is never stored, only a \
+                    truncated SHA-256 fingerprint.
+                    Required inputs: channel, audienceType (COMMERCIAL or INDIVIDUAL), contactName, and at \
+                    least one of email or phone; message and interest fields are optional.
+                    Emits a CRM_PUBLIC_INQUIRY_SUBMIT event and persists the inquiry in NEW status, \
+                    unassigned in the shared triage queue.
+                    Returns 429 when the submitter has exceeded the rate limit, and 400 when required \
+                    fields are missing or neither email nor phone is supplied.
+                    """)
     @ApiResponses({
         @ApiResponse(
                 responseCode = "202",
@@ -91,7 +105,25 @@ public class PublicInquiryController {
     @PreAuthorize("permitAll()")
     @EmitEvent(id = "CRM_PUBLIC_INQUIRY_SUBMIT", apiVersion = "1")
     public ResponseEntity<InquiryAcceptedResponse> submit(
-            @Valid @RequestBody SubmitInquiryRequest request, HttpServletRequest httpRequest) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The public web-form inquiry, carrying who is asking and how to reach them.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Web-form service inquiry", value = """
+                                                                    {"channel":"WEB_FORM",
+                                                                     "audienceType":"INDIVIDUAL",
+                                                                     "contactName":"Sam Rivera",
+                                                                     "email":"sam.rivera@example.com",
+                                                                     "vehicleOfInterest":"2018 Honda CR-V",
+                                                                     "serviceOfInterest":"Timing belt replacement",
+                                                                     "message":"Looking for a quote and earliest availability"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    SubmitInquiryRequest request,
+            HttpServletRequest httpRequest) {
         UUID inquiryId = inquiryService.captureFromPublicForm(request, fingerprint(httpRequest));
         return ResponseEntity.status(HttpStatus.ACCEPTED)
                 .body(new InquiryAcceptedResponse(inquiryId, InquiryStatus.NEW.name()));

--- a/pos-invoice/openapi.yaml
+++ b/pos-invoice/openapi.yaml
@@ -29,8 +29,20 @@ paths:
     get:
       tags:
       - Billing Rules
-      summary: Get billing rules for a party/customer
-      description: Retrieve the current billing rules configuration for a commercial account
+      summary: Get Billing Rules for a Party
+      description: 'Returns the billing rules configured for a commercial account party: purchase-order requirement, payment terms code, invoice delivery method, and invoice grouping strategy.
+
+        Use this tool when the billing configuration of a known party is needed before invoicing; do not use upsertBillingRules, which creates or replaces the configuration.
+
+        Preconditions: a billing rules record must already exist for the party, created explicitly or defaulted when the commercial account was provisioned.
+
+        Required inputs: partyId (UUID) as a path parameter; there is no request body.
+
+        Emits a BILLING_RULES_GET audit event; no state changes — this is a read-only projection.
+
+        Returns 404 when no billing rules are configured for the party, and 400 with an empty body when partyId is not a well-formed UUID.
+
+        '
       operationId: getBillingRules
       parameters:
       - name: partyId
@@ -59,8 +71,20 @@ paths:
     put:
       tags:
       - Billing Rules
-      summary: Create or update billing rules
-      description: Idempotent upsert of billing rules for a commercial account
+      summary: Create or Update Billing Rules
+      description: 'Creates or replaces the billing rules for a commercial account party in one idempotent upsert keyed on the path partyId, which overrides any partyId carried in the body.
+
+        Use this tool when configuring how a party is invoiced; use getBillingRules instead to read the current configuration without changing it.
+
+        Preconditions: paymentTermsCode must belong to the validated vocabulary (DUE_ON_RECEIPT, NET_10, NET_15, NET_30, NET_45, NET_60); a missing record is created and an existing one is updated in place.
+
+        Required inputs: partyId (UUID path), purchaseOrderRequired (boolean), paymentTermsCode, invoiceDeliveryMethod (EMAIL, PORTAL, MAIL) and invoiceGroupingStrategy (PER_WORKORDER, PER_VEHICLE, SINGLE_INVOICE); updatedBy is taken from the security context, never from the body.
+
+        Emits a BILLING_RULES_UPSERT event and publishes a billing-rules-updated notification; due dates of already-finalized invoices are never recomputed from a terms change.
+
+        Returns 201 when the record is created, 200 when an existing record is updated, and 400 with an empty body when partyId is not a well-formed UUID.
+
+        '
       operationId: upsertBillingRules
       parameters:
       - name: partyId
@@ -69,10 +93,20 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Billing rules configuration to store for the party.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BillingRulesDTO'
+            examples:
+              Net-30 emailed per-workorder invoicing:
+                description: Net-30 emailed per-workorder invoicing
+                value:
+                  partyId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  purchaseOrderRequired: true
+                  paymentTermsCode: NET_30
+                  invoiceDeliveryMethod: EMAIL
+                  invoiceGroupingStrategy: PER_WORKORDER
         required: true
       responses:
         '200':
@@ -102,14 +136,36 @@ paths:
     post:
       tags:
       - StandaloneRefund
-      summary: Record standalone refund for a customer party
-      description: Record a refund anchored to a customer party when no invoice exists in the system; the disbursement itself happens out of band
-      operationId: refundPartyStandalone
+      summary: Record Standalone Party Refund
+      description: 'Records a refund anchored directly to a customer party when no invoice exists in this system, such as a vendor-paid warranty settlement on a predecessor-system sale; the cash disbursement itself happens out of band.
+
+        Use this tool only when there is no invoice to anchor to; use createStandaloneInvoiceRefund instead when an invoice is on file, and refundPayment when the captured payment itself exists.
+
+        Preconditions: the caller needs the finance-only ISSUE_MANUAL_REFUND authority; because there is no invoice, no refundable-amount cap applies.
+
+        Required inputs: partyId (non-blank, max 64 characters), amount (positive) and reason (a RefundReason); notes and externalReference are optional, and a retry replaying the same externalReference among the party''s purely party-anchored records returns the existing record.
+
+        Emits an INVOICE_PARTY_STANDALONE_REFUND event and stores a COMPLETED refund record anchored to the party; no gateway call is made.
+
+        Returns 201 with the refund record, and 400 when partyId is blank.
+
+        '
+      operationId: createStandalonePartyRefund
       requestBody:
+        description: Out-of-band refund to record against a customer party with no invoice on file.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PartyStandaloneRefundRequest'
+            examples:
+              Vendor-paid settlement:
+                description: Vendor-paid settlement
+                value:
+                  partyId: party-000123
+                  amount: 25.0
+                  reason: CUSTOMER_RETURN
+                  notes: Vendor-paid warranty settlement, no invoice on file
+                  externalReference: WC-2026-000042
         required: true
       responses:
         '201':
@@ -132,14 +188,41 @@ paths:
     post:
       tags:
       - Invoice
-      summary: Create invoice
-      description: Create invoice draft from completed workorder data
+      summary: Create Invoice Draft from Workorder
+      description: 'Creates a DRAFT invoice from completed workorder data, pricing the supplied line items, calculating draft tax against the shop location''s jurisdiction, and assigning the permanent invoice number immediately.
+
+        Use this tool for workorder billing; do not use createInvoiceFromOrder, which fronts a sales order at counter-sale checkout with order-authoritative totals.
+
+        Preconditions: the workorder must be complete enough to bill; the call is idempotent on workorderId — a replay returns the workorder''s existing invoice instead of creating a duplicate.
+
+        Required inputs: workorderId (UUID); estimateId, approvalId, locationId, customerId, idempotencyKey and lineItems (description, quantity, unitPrice, amount, optional type) are optional, and a missing lineItems list produces an empty zero-subtotal draft.
+
+        Emits an INVOICE_CREATE event, persists the per-line tax breakdown, and publishes an invoice-updated notification.
+
+        Returns 201 with the invoice (existing or new), and 400 when workorderId is missing.
+
+        '
       operationId: createInvoice
       requestBody:
+        description: Workorder billing data the invoice draft is built from.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/InvoiceCreationRequest'
+            examples:
+              Workorder invoice draft:
+                description: Workorder invoice draft
+                value:
+                  workorderId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a30
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a31
+                  customerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a32
+                  idempotencyKey: inv-create-wo-1234
+                  lineItems:
+                  - description: Brake pad replacement
+                    quantity: 2.0
+                    unitPrice: 45.0
+                    amount: 90.0
+                    type: LABOR
         required: true
       responses:
         '201':
@@ -157,8 +240,20 @@ paths:
     post:
       tags:
       - Invoice
-      summary: Revert finalized invoice
-      description: 'Revert a FINALIZED invoice back to DRAFT within 24h of finalization and before GL posting (Story #13, AC6)'
+      summary: Revert Finalized Invoice to Draft
+      description: 'Reverts a FINALIZED invoice back to DRAFT within 24 hours of finalization, before GL posting has made it immutable, and voids the provider tax document committed at finalization.
+
+        Use this tool to correct a wrongly finalized invoice; do not use cancelInvoice, which terminally cancels a DRAFT invoice on the order-void path.
+
+        Preconditions: the invoice must be FINALIZED (POSTED is immutable), less than 24 hours must have elapsed since finalizedAt, and callers without invoice:finalize:override (or a manager/admin role) must supply a valid elevation token from elevateManagerApproval as managerApprovalCode.
+
+        Required inputs: invoiceId (UUID) as a path parameter plus managerApprovalCode and a reason in the body; the reverting actor and approving manager are captured for audit.
+
+        Emits an INVOICE_DRAFT_REVERT event, publishes an invoice-updated notification, and issues a tax void toward pos-tax for the reverted document.
+
+        Returns 200 with the DRAFT invoice, 404 when the invoice does not exist, 409 when it is POSTED, not FINALIZED, or the 24-hour window has expired, and 400 when the approval code is blank, invalid, or expired.
+
+        '
       operationId: revertInvoice
       parameters:
       - name: invoiceId
@@ -168,10 +263,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Manager approval and business reason authorizing the reversion.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RevertRequest'
+            examples:
+              Revert with approval:
+                description: Revert with approval
+                value:
+                  managerApprovalCode: MGR-ELEV-TOKEN-abc123
+                  reason: Incorrect line item billed
         required: true
       responses:
         '200':
@@ -190,9 +292,21 @@ paths:
     get:
       tags:
       - PaymentReversal
-      summary: List refunds for an invoice
-      description: Return every refund record anchored to the invoice — payment-intent refunds whose intent belongs to the invoice and standalone invoice-anchored refunds alike — for warranty settlement reconciliation
-      operationId: listRefunds
+      summary: List Refunds for an Invoice
+      description: 'Returns every refund record anchored to the invoice — refunds of captured payment intents and standalone invoice-anchored refunds alike — for warranty-settlement reconciliation.
+
+        Use this tool to reconcile what has already been returned before issuing another refund; do not use refundPayment or createStandaloneInvoiceRefund, which create refunds rather than list them.
+
+        Preconditions: the invoice must exist; the caller needs the invoice:manage authority.
+
+        Required inputs: invoiceId (UUID) as a path parameter; there is no request body or filtering.
+
+        Emits an INVOICE_REFUND_LIST audit event; no state changes — this is a read-only projection.
+
+        Returns 404 when no invoice exists for the supplied id.
+
+        '
+      operationId: listInvoiceRefunds
       parameters:
       - name: invoiceId
         in: path
@@ -224,9 +338,21 @@ paths:
     post:
       tags:
       - StandaloneRefund
-      summary: Record standalone refund for an invoice
-      description: Record a refund against an invoice whose original payment is not in the system; the disbursement itself happens out of band
-      operationId: refundInvoiceStandalone
+      summary: Record Standalone Invoice Refund
+      description: 'Records a refund against an invoice whose original payment is not in this system — predecessor-system sales, pre-deploy invoices, vendor-paid warranty work — while the cash disbursement itself happens out of band (till, check, or vendor payment).
+
+        Use this tool only when no captured payment intent exists to refund; do not use refundPayment, which reverses a CAPTURED gateway payment, and use createStandalonePartyRefund instead when no invoice is on file at all.
+
+        Preconditions: the invoice must exist, the caller needs the finance-only ISSUE_MANUAL_REFUND authority, and cumulative refunds across payment-anchored and standalone records may not exceed the invoice total.
+
+        Required inputs: amount (positive) and reason (a RefundReason such as CUSTOMER_RETURN); notes and externalReference are optional, and a retry replaying the same externalReference returns the existing record instead of double-recording.
+
+        Emits an INVOICE_STANDALONE_REFUND event and stores a COMPLETED refund record anchored to the invoice; no gateway call is made.
+
+        Returns 201 with the refund record, 404 when the invoice does not exist, and 422 when the amount exceeds the invoice''s remaining refundable balance.
+
+        '
+      operationId: createStandaloneInvoiceRefund
       parameters:
       - name: invoiceId
         in: path
@@ -235,10 +361,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Out-of-band refund to record against the invoice.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/StandaloneRefundRequest'
+            examples:
+              Walk-in warranty refund:
+                description: Walk-in warranty refund
+                value:
+                  amount: 25.0
+                  reason: CUSTOMER_RETURN
+                  notes: Walk-in warranty claim on a predecessor-system cash sale
+                  externalReference: WC-2026-000042
         required: true
       responses:
         '201':
@@ -267,8 +402,20 @@ paths:
     post:
       tags:
       - Receipt
-      summary: Generate invoice receipt
-      description: Generate a receipt for an invoice payment using the requested terminal and template
+      summary: Generate Receipt for Invoice Payment
+      description: 'Generates a receipt record for an invoice payment, assigning a unique reference built from the invoice number, a UTC timestamp and a per-invoice sequence, with the cashier taken from the security context.
+
+        Use this tool once per payment after tender; do not use reprintReceipt, which duplicates a receipt that already exists.
+
+        Preconditions: the invoice and payment intent must exist, the intent must belong to the invoice, and the caller needs the GENERATE_RECEIPT authority.
+
+        Required inputs: paymentIntentId (UUID), terminalId, templateId and templateVersion.
+
+        Emits an INVOICE_RECEIPT_GENERATE event and stores the receipt in GENERATED status with a zero reprint count; the receipt also becomes a downloadable artifact of the invoice.
+
+        Returns 201 with the receipt reference, 404 when the invoice or payment intent does not exist or the intent belongs to a different invoice, and 403 when the GENERATE_RECEIPT authority is missing.
+
+        '
       operationId: generateReceipt
       parameters:
       - name: invoiceId
@@ -278,10 +425,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Payment, terminal and template identifying what the receipt documents.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/GenerateReceiptRequest'
+            examples:
+              Counter receipt:
+                description: Counter receipt
+                value:
+                  paymentIntentId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a60
+                  terminalId: TERM-001
+                  templateId: RECEIPT_DEFAULT
+                  templateVersion: '1'
         required: true
       responses:
         '201':
@@ -304,8 +460,20 @@ paths:
     post:
       tags:
       - Receipt
-      summary: Reprint invoice receipt
-      description: Create a reprint of an existing receipt and record the reason for the reprint
+      summary: Reprint an Existing Receipt
+      description: 'Records a reprint of an existing receipt, incrementing its reprint count and capturing the reason and the reprinting actor for audit.
+
+        Use this tool when a customer needs a duplicate copy; do not use generateReceipt, which creates a new receipt for a payment that has none yet.
+
+        Preconditions: the receipt must exist, and its reprint count must be below 5 unless the caller holds the SUPERVISOR_OVERRIDE authority.
+
+        Required inputs: receiptId (UUID) as a path parameter and a non-blank reason in the body.
+
+        Emits an INVOICE_RECEIPT_REPRINT event and updates the receipt''s reprint count, last reprint reason and last reprinted-by.
+
+        Returns 200 with the receipt, 404 when the receipt does not exist, and 409 when the reprint limit of 5 is exceeded without a supervisor override.
+
+        '
       operationId: reprintReceipt
       parameters:
       - name: invoiceId
@@ -321,10 +489,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Business reason the duplicate copy is being produced.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ReprintReceiptRequest'
+            examples:
+              Duplicate copy:
+                description: Duplicate copy
+                value:
+                  reason: Customer requested a duplicate copy
         required: true
       responses:
         '200':
@@ -353,9 +527,21 @@ paths:
     post:
       tags:
       - Receipt
-      summary: Record printed receipt delivery
-      description: Record the delivery status for a printed receipt associated with an invoice
-      operationId: recordPrintDelivery
+      summary: Record Printed Receipt Delivery Status
+      description: 'Records the outcome of printing a receipt at the terminal, stamping the receipt''s delivery method as PRINT with the reported status; the physical printing itself happens client-side, not here.
+
+        Use this tool after the terminal reports its print result; do not use recordReceiptEmailDelivery, which records an email delivery attempt with its recipient address.
+
+        Preconditions: the receipt must already exist via generateReceipt.
+
+        Required inputs: receiptId (UUID) as a path parameter and status (SUCCESS or FAILED) in the body.
+
+        Emits an INVOICE_RECEIPT_PRINT_DELIVERY event and overwrites the receipt''s delivery method and status.
+
+        Returns 200 with an empty body on success, and 404 when the receipt does not exist.
+
+        '
+      operationId: recordReceiptPrintDelivery
       parameters:
       - name: invoiceId
         in: path
@@ -370,10 +556,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Print outcome reported by the terminal.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PrintDeliveryRequest'
+            examples:
+              Successful print:
+                description: Successful print
+                value:
+                  status: SUCCESS
         required: true
       responses:
         '200':
@@ -388,9 +580,21 @@ paths:
     post:
       tags:
       - Receipt
-      summary: Email invoice receipt
-      description: Send an invoice receipt by email and record the delivery status for the attempt
-      operationId: sendEmailReceipt
+      summary: Record Emailed Receipt Delivery Status
+      description: 'Records the outcome of emailing a receipt to a customer, stamping the receipt''s delivery method as EMAIL with the recipient address and the reported status; this endpoint records the attempt rather than dispatching the email itself.
+
+        Use this tool after an email delivery attempt completes; do not use recordReceiptPrintDelivery, which records a terminal print outcome.
+
+        Preconditions: the receipt must already exist via generateReceipt.
+
+        Required inputs: receiptId (UUID) as a path parameter plus emailAddress and status (SUCCESS or FAILED) in the body.
+
+        Emits an INVOICE_RECEIPT_EMAIL_DELIVERY event and overwrites the receipt''s delivery method, address and status.
+
+        Returns 200 with an empty body on success, and 404 when the receipt does not exist.
+
+        '
+      operationId: recordReceiptEmailDelivery
       parameters:
       - name: invoiceId
         in: path
@@ -405,10 +609,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Recipient address and outcome of the email delivery attempt.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/EmailDeliveryRequest'
+            examples:
+              Successful email:
+                description: Successful email
+                value:
+                  emailAddress: customer@example.com
+                  status: SUCCESS
         required: true
       responses:
         '200':
@@ -423,8 +634,20 @@ paths:
     post:
       tags:
       - Payment
-      summary: Initiate card payment
-      description: Initiate a SALE_CAPTURE or AUTH_ONLY card payment against an invoice
+      summary: Initiate Card Payment on Invoice
+      description: 'Initiates a card payment against an invoice through the payment gateway, creating a payment intent that is CAPTURED immediately (SALE_CAPTURE) or left AUTHORIZED as a hold (AUTH_ONLY).
+
+        Use this tool to take card tender; do not use capturePayment, which settles an existing AUTH_ONLY hold rather than starting a new payment.
+
+        Preconditions: the invoice must exist; the caller needs the PROCESS_PAYMENT authority, plus OVERRIDE_PAYMENT_LIMIT when the amount exceeds 500.00 and SELECT_PAYMENT_FLOW to choose AUTH_ONLY.
+
+        Required inputs: paymentFlow (SALE_CAPTURE or AUTH_ONLY), amount (positive), idempotencyKey and paymentToken (tokenised card reference, never a PAN); a replayed idempotencyKey with an identical payload returns the existing intent instead of charging twice.
+
+        Emits an INVOICE_PAYMENT_INITIATE event and records the gateway result on the intent.
+
+        Returns 201 with the intent, 404 when the invoice does not exist, 409 when the idempotencyKey was already used with a different payload, 422 when the gateway declines, and 403 when a required payment authority is missing.
+
+        '
       operationId: initiatePayment
       parameters:
       - name: invoiceId
@@ -434,10 +657,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: 'Card tender details: flow, amount, idempotency key and tokenised card reference.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/InitiatePaymentRequest'
+            examples:
+              One-step sale capture:
+                description: One-step sale capture
+                value:
+                  paymentFlow: SALE_CAPTURE
+                  amount: 149.99
+                  idempotencyKey: idem-018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a50
+                  paymentToken: tok_1NXyZ2eZvKYlo2Cabc12345
         required: true
       responses:
         '201':
@@ -478,8 +710,20 @@ paths:
     post:
       tags:
       - PaymentReversal
-      summary: Void authorized payment
-      description: Void a previously authorized invoice payment before it is captured
+      summary: Void Authorized Payment Hold
+      description: 'Voids a previously authorized invoice payment hold at the gateway before it is captured, releasing the customer''s funds without any money movement.
+
+        Use this tool on an AUTHORIZED hold; do not use refundPayment, which returns funds from a payment that was already CAPTURED.
+
+        Preconditions: the payment intent must belong to the invoice and be AUTHORIZED, the caller needs the VOID_PAYMENT authority, and less than 24 hours may have elapsed since authorization unless the caller also holds SUPERVISOR_OVERRIDE.
+
+        Required inputs: reason (CUSTOMER_REQUEST, DUPLICATE_AUTHORIZATION, ENTRY_ERROR, FRAUD_PREVENTION, MANAGER_DISCRETION or OTHER); notes are optional free text.
+
+        Emits an INVOICE_PAYMENT_VOID event, moves the intent to VOIDED, and publishes a payment-voided notification.
+
+        Returns 200 with an empty body on success, 404 when the intent does not exist under the invoice, 409 when the intent is not AUTHORIZED, 422 when the 24-hour void window has expired, and 500 when the gateway rejects the void.
+
+        '
       operationId: voidPayment
       parameters:
       - name: invoiceId
@@ -495,10 +739,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Reason and optional notes explaining why the authorization is released.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/VoidPaymentRequest'
+            examples:
+              Customer cancelled:
+                description: Customer cancelled
+                value:
+                  reason: CUSTOMER_REQUEST
+                  notes: Customer cancelled before pickup
         required: true
       responses:
         '200':
@@ -517,8 +768,20 @@ paths:
     post:
       tags:
       - PaymentReversal
-      summary: Refund captured payment
-      description: Create a refund for a captured invoice payment and record the refund details
+      summary: Refund a Captured Payment
+      description: 'Refunds all or part of a CAPTURED invoice payment through the gateway and records the refund against the payment intent.
+
+        Use this tool when the original card payment lives in this system; do not use voidPayment, which releases an uncaptured hold, and use createStandaloneInvoiceRefund instead when the original payment is not on file.
+
+        Preconditions: the payment intent must belong to the invoice and be CAPTURED, the caller needs the REFUND_PAYMENT authority, less than 180 days may have elapsed since capture unless the caller holds SUPERVISOR_OVERRIDE, and cumulative refunds may not exceed the captured amount.
+
+        Required inputs: amount (positive) and reason (a RefundReason such as CUSTOMER_RETURN or SERVICE_ERROR); notes and externalReference are optional, and a retry replaying the same externalReference returns the existing refund instead of paying twice.
+
+        Emits an INVOICE_PAYMENT_REFUND event and publishes a payment-refunded notification on success; a gateway failure is persisted as a FAILED refund record, so callers must read the returned status rather than treating 201 as completed.
+
+        Returns 201 with the refund record, 404 when the intent does not exist under the invoice, 409 when the intent is not CAPTURED, and 422 when the 180-day window has expired or the amount exceeds the remaining refundable balance.
+
+        '
       operationId: refundPayment
       parameters:
       - name: invoiceId
@@ -534,10 +797,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Refund amount, business reason and optional external correlation for the captured payment.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RefundPaymentRequest'
+            examples:
+              Partial return refund:
+                description: Partial return refund
+                value:
+                  amount: 25.0
+                  reason: CUSTOMER_RETURN
+                  notes: Returned damaged part
+                  externalReference: WC-2026-000042
         required: true
       responses:
         '201':
@@ -572,8 +844,20 @@ paths:
     post:
       tags:
       - Payment
-      summary: Capture authorized payment hold
-      description: Capture all or part of a previously authorized invoice payment hold
+      summary: Capture Authorized Payment Hold
+      description: 'Captures all or part of a previously authorized AUTH_ONLY payment hold at the gateway; when the captured amount is below the authorized amount, the remainder of the hold is voided.
+
+        Use this tool to settle an existing AUTHORIZED intent; do not use initiatePayment, which starts a new payment, and use voidPayment instead to release the hold without taking funds.
+
+        Preconditions: the payment intent must belong to the invoice and be in AUTHORIZED status; the caller needs the MANUAL_CAPTURE authority.
+
+        Required inputs: amount (positive, up to the authorized amount) and captureIdempotencyKey, which is forwarded to the gateway so a retried capture settles at most once.
+
+        Emits an INVOICE_PAYMENT_CAPTURE event; the intent moves to CAPTURED on success or CAPTURE_FAILED on decline, and an ambiguous gateway response is resolved by a status inquiry before failing.
+
+        Returns 200 with the captured intent, 404 when the intent does not exist under the invoice, 409 when the intent is not AUTHORIZED, 422 when the gateway declines the capture, and 403 when the MANUAL_CAPTURE authority is missing.
+
+        '
       operationId: capturePayment
       parameters:
       - name: invoiceId
@@ -589,10 +873,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Amount to settle from the authorized hold and the capture idempotency key.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CaptureAmountRequest'
+            examples:
+              Partial capture:
+                description: Partial capture
+                value:
+                  amount: 89.99
+                  captureIdempotencyKey: capture-018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a51
         required: true
       responses:
         '200':
@@ -621,8 +912,20 @@ paths:
     post:
       tags:
       - Invoice
-      summary: Finalize invoice
-      description: 'Transition invoice from DRAFT to FINALIZED; enforces permission matrix and emits InvoiceFinalized event for async GL posting (Story #13)'
+      summary: Finalize a Draft Invoice
+      description: 'Transitions an invoice from DRAFT to FINALIZED: runs the committable tax calculation, freezes tax, totals, payment terms and due date, then commits the provider tax document.
+
+        Use this tool when the sale is ready to issue; do not use revertInvoice, which undoes a finalization, and mint the managerApprovalCode with elevateManagerApproval when one is needed.
+
+        Preconditions: the invoice must be DRAFT with tax already calculated; callers without invoice:finalize:override (or a manager/admin role) need a valid elevation token as managerApprovalCode when the stored total exceeds 500.00.
+
+        Required inputs: invoiceId (UUID) as a path parameter; managerApprovalCode and overrideReason in the body are optional below the cap and for override holders.
+
+        Emits an INVOICE_FINALIZED event and publishes the async accounting event that drives GL posting; the tax commit tolerates a provider outage by recording PENDING_COMMIT in pos-tax for the re-commit job, and is skipped entirely when nothing is taxable.
+
+        Returns 200 with the finalized invoice, 404 when the invoice does not exist, 409 when the invoice is not DRAFT or tax has not been calculated, and 400 when a required managerApprovalCode is missing, invalid, or expired.
+
+        '
       operationId: finalizeInvoice
       parameters:
       - name: invoiceId
@@ -632,10 +935,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Optional manager-approval material for finalizations above the amount cap.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/FinalizationRequest'
+            examples:
+              Finalize with manager approval:
+                description: Finalize with manager approval
+                value:
+                  managerApprovalCode: MGR-ELEV-TOKEN-abc123
+                  overrideReason: Customer pre-approved by branch manager
         required: true
       responses:
         '200':
@@ -654,8 +964,20 @@ paths:
     post:
       tags:
       - Invoice
-      summary: Cancel a draft invoice
-      description: Terminal cancel of a DRAFT invoice before any money moved (order-void path). Rejected with 409 when the invoice has left DRAFT or carries an authorized/captured payment. Idempotent — cancelling a CANCELLED invoice returns 200.
+      summary: Cancel a Draft Invoice
+      description: 'Cancels a DRAFT invoice terminally before any money has moved, the invoice-side effect of an order void.
+
+        Use this tool when an order is voided before tender; do not use revertInvoice, which returns a FINALIZED invoice to DRAFT, and do not use it when payments exist — reverse those first through voidPayment or refundPayment (order cancellation saga).
+
+        Preconditions: the invoice must still be DRAFT and must carry no AUTHORIZED or CAPTURED payment intent; cancelling an already CANCELLED invoice is an idempotent no-op.
+
+        Required inputs: invoiceId (UUID) as a path parameter; there is no request body.
+
+        Emits an INVOICE_CANCEL event and sets the invoice status to CANCELLED.
+
+        Returns 200 when cancelled or already cancelled, 409 when the invoice has left DRAFT or carries an authorized/captured payment, and 404 when the invoice does not exist.
+
+        '
       operationId: cancelInvoice
       parameters:
       - name: invoiceId
@@ -686,9 +1008,21 @@ paths:
     post:
       tags:
       - invoice-artifact-controller
-      summary: Create a short-lived download token for an invoice artifact
-      description: Issues a short-lived signed token bound to the invoice and artifact. The token is presented to the public download endpoint so a browser can fetch the file via a direct link.
-      operationId: createDownloadToken
+      summary: Create Artifact Download Token
+      description: 'Issues a short-lived signed token bound to one invoice artifact, so a browser can fetch the PDF through the public download link without an Authorization header.
+
+        Use this tool after listInvoiceArtifacts has supplied an artifactRefId; do not use downloadInvoiceArtifact without a token — it rejects unsigned requests.
+
+        Preconditions: the invoice must exist and the artifact reference must belong to that invoice (an invoice ref must match the path invoice, a receipt ref must be one of its receipts).
+
+        Required inputs: invoiceId (UUID) and artifactRefId (opaque reference from listInvoiceArtifacts) as path parameters; there is no request body.
+
+        No events are emitted and no record is stored; the token is stateless, signed, and expires after 300 seconds by default (invoice.artifacts.token-ttl-seconds).
+
+        Returns 404 when the invoice does not exist or the artifact does not belong to it.
+
+        '
+      operationId: createArtifactDownloadToken
       parameters:
       - name: invoiceId
         in: path
@@ -722,9 +1056,21 @@ paths:
     post:
       tags:
       - Invoice
-      summary: Apply invoice adjustment
-      description: Apply discount, fee, correction, or warranty credit to a draft invoice
-      operationId: applyAdjustment
+      summary: Apply Adjustment to Draft Invoice
+      description: 'Applies a monetary adjustment (DISCOUNT, FEE, CORRECTION, or WARRANTY credit) to a DRAFT invoice and recalculates its tax and total.
+
+        Use this tool while the invoice is still DRAFT; do not use it after finalization — tax and totals freeze there, so revertInvoice must return the invoice to DRAFT first.
+
+        Preconditions: the invoice must exist and be in DRAFT status; a retry supplying the same type and externalReference replays idempotently, returning the invoice without double-crediting.
+
+        Required inputs: type, amount (greater than zero), reason, and authorizedBy; externalReference is optional and correlates the adjustment to an external record such as a warranty settlement.
+
+        Emits an INVOICE_ADJUSTMENT_APPLY event, replaces the persisted per-line tax breakdown, and publishes an invoice-updated notification.
+
+        Returns 200 with the recalculated invoice, 404 when the invoice does not exist, 409 when the invoice has left DRAFT, and 400 when the type, amount, reason, or authorizedBy is missing or the amount is not positive.
+
+        '
+      operationId: applyInvoiceAdjustment
       parameters:
       - name: invoiceId
         in: path
@@ -733,10 +1079,20 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Adjustment to add to the draft invoice, with its business justification.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AdjustmentRequest'
+            examples:
+              Warranty credit:
+                description: Warranty credit
+                value:
+                  type: WARRANTY
+                  amount: 25.0
+                  reason: Warranty settlement credit
+                  authorizedBy: jdoe
+                  externalReference: WC-2026-000042
         required: true
       responses:
         '200':
@@ -754,14 +1110,45 @@ paths:
     post:
       tags:
       - Invoice
-      summary: Create invoice from a sales order
-      description: Create the invoice fronting a sales order at checkout (counter sale). Idempotent on orderId — a replay returns the existing invoice with 200. When workorderId is present and a workorder invoice already exists, that invoice is returned for tender instead of creating a duplicate.
+      summary: Create Invoice from Sales Order
+      description: 'Creates the DRAFT invoice fronting a sales order at counter-sale checkout, recording the order''s already-priced subtotal, tax and total verbatim — pos-order and pos-tax are authoritative, so nothing is re-priced here.
+
+        Use this tool at order checkout; do not use createInvoice, which builds and prices a draft from workorder data.
+
+        Preconditions: the order must carry final totals and at least one line; the call is idempotent on orderId, and when workorderId is set an existing workorder invoice is returned for tender instead of creating a duplicate.
+
+        Required inputs: orderId (UUID), subtotal, taxAmount, totalAmount (non-negative) and lines; customerId, locationId and the deposit fields are optional, but depositSourceType and depositSourceId become mandatory when depositAmount is set.
+
+        Emits an INVOICE_CREATE_FROM_ORDER event; a deposit take also registers a deposit credit (idempotent on orderId), and a workorder settlement draws down available deposit credits, reported as depositApplied.
+
+        Returns 201 when a new invoice is created, 200 when an existing invoice is returned (orderId replay or workorder dedupe), and 400 when totals are missing or negative, lines are empty, or deposit fields are inconsistent.
+
+        '
       operationId: createInvoiceFromOrder
       requestBody:
+        description: Sales order snapshot — authoritative totals and sold lines — the invoice records.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/OrderInvoiceCreationRequest'
+            examples:
+              Counter sale:
+                description: Counter sale
+                value:
+                  orderId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a40
+                  customerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a41
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a42
+                  subtotal: 120.0
+                  taxAmount: 9.6
+                  totalAmount: 129.6
+                  lines:
+                  - orderLineId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a43
+                    description: Brake pad set
+                    quantity: 2
+                    unitPrice: 45.0
+                    amount: 90.0
+                    taxAmount: 7.2
+                    type: PART
         required: true
       responses:
         '201':
@@ -785,9 +1172,21 @@ paths:
     get:
       tags:
       - Deposit Credits
-      summary: List deposit credits held against a source document
-      description: Lists all deposit credits associated with the given source type and source id.
-      operationId: listBySource
+      summary: List Deposit Credits by Source
+      description: 'Lists every deposit credit held against one source document, identified by its type and id.
+
+        Use this tool when checking what down-payments a settlement can draw on; use getDepositCredit instead when a specific depositCreditId is already known.
+
+        Preconditions: none — an unknown or credit-free source returns an empty list rather than an error.
+
+        Required inputs: sourceType query parameter (ESTIMATE, WORKORDER or ORDER, case-insensitive) and sourceId (UUID) query parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 422 when sourceType is not one of the known values.
+
+        '
+      operationId: listDepositCreditsBySource
       parameters:
       - name: sourceType
         in: query
@@ -816,14 +1215,37 @@ paths:
     post:
       tags:
       - Deposit Credits
-      summary: Register a deposit credit taken by a sales order
-      description: Creates a deposit credit record tied to the provided source transaction.
-      operationId: createDeposit
+      summary: Register a Deposit Credit
+      description: 'Creates an AVAILABLE deposit credit for a down-payment taken at pos-order checkout, holding the amount against its source document until a settlement invoice draws it down.
+
+        Use this tool when a deposit was tendered against an estimate, workorder, or order; do not use refundDepositCredit, which returns a credit''s remaining balance when the source is cancelled.
+
+        Preconditions: none beyond a priced source document — the call is idempotent on orderId, so a replay for an order that already registered a credit returns the existing record unchanged.
+
+        Required inputs: orderId (UUID, idempotency anchor), sourceType (ESTIMATE, WORKORDER or ORDER), sourceId (UUID) and amount (positive); partyId is optional and currencyCode defaults to USD.
+
+        Emits an INVOICE_DEPOSIT_CREATE event; no invoice records are touched until settlement applies the credit.
+
+        Returns 201 with the credit (existing or new), and 422 when the amount is not positive or the sourceType is not a known value.
+
+        '
+      operationId: createDepositCredit
       requestBody:
+        description: Deposit taken at checkout to register as a credit against its source document.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateDepositRequest'
+            examples:
+              Workorder down-payment:
+                description: Workorder down-payment
+                value:
+                  orderId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a10
+                  sourceType: WORKORDER
+                  sourceId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a11
+                  partyId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a12
+                  amount: 200.0
+                  currencyCode: USD
         required: true
       responses:
         '200':
@@ -840,9 +1262,21 @@ paths:
     post:
       tags:
       - Deposit Credits
-      summary: Refund a deposit credit's remaining balance
-      description: Used when the deposit's source is cancelled after the deposit was taken (spec R7.4).
-      operationId: refundDeposit
+      summary: Refund a Deposit Credit Balance
+      description: 'Zeroes the remaining balance of a deposit credit and marks it REFUNDED, recording that the deposit is returned because its source document was cancelled after the deposit was taken.
+
+        Use this tool on source cancellation (spec R7.4); do not use createDepositCredit, which registers a new deposit, and note the cash disbursement itself is not performed here.
+
+        Preconditions: the deposit credit must exist; a credit already REFUNDED is left unchanged, so the call is idempotent.
+
+        Required inputs: depositCreditId (UUID) as a path parameter; the reason query parameter is optional and defaults to "source cancelled"; there is no request body.
+
+        Emits an INVOICE_DEPOSIT_REFUND event and sets the credit''s status to REFUNDED with a zero remaining balance.
+
+        Returns 200 with the refunded credit, and 404 when no deposit credit exists for the supplied id.
+
+        '
+      operationId: refundDepositCredit
       parameters:
       - name: depositCreditId
         in: path
@@ -870,14 +1304,33 @@ paths:
     post:
       tags:
       - Billing Authorization
-      summary: Mint a manager-approval elevation token
-      description: Verifies the named manager (by employee number) holds invoice:finalize:override and mints a short-lived token scoped to the given invoice, returned as the managerApprovalCode for finalize.
-      operationId: elevate
+      summary: Mint Manager-Approval Elevation Token
+      description: 'Mints a short-lived elevation token scoped to one invoice after verifying that the named manager is an ACTIVE employee holding the invoice:finalize:override authority.
+
+        Use this tool when an actor with invoice:finalize but not invoice:finalize:override needs a managerApprovalCode for finalizeInvoice or revertInvoice; do not use finalizeInvoice directly without a token when the invoice total exceeds the 500.00 service-advisor cap.
+
+        Preconditions: the manager''s employee number must resolve to an ACTIVE person in the local employee replica and that person must hold invoice:finalize:override.
+
+        Required inputs: managerEmployeeNumber and invoiceId (UUID); the token is bound to that invoice only and expires after five minutes by default (invoice.elevation.token-ttl-seconds).
+
+        No events are emitted; the token is signed and stateless, and the grant is audit-logged with the approving manager''s person id.
+
+        Returns 200 with the token and its expiry, and 401 with an empty body when the employee number is unknown or inactive or the person lacks the override authority.
+
+        '
+      operationId: elevateManagerApproval
       requestBody:
+        description: Manager identification and the invoice the elevation token will authorize.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ElevateRequest'
+            examples:
+              Elevation for one invoice:
+                description: Elevation for one invoice
+                value:
+                  managerEmployeeNumber: EMP-0001
+                  invoiceId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a20
         required: true
       responses:
         '200':
@@ -907,8 +1360,20 @@ paths:
     get:
       tags:
       - Invoice
-      summary: Get invoice
-      description: Get invoice details
+      summary: Get Invoice Details
+      description: 'Returns the full invoice detail — status, line items, adjustments, totals, tax breakdown, due date and the resolved workorder number.
+
+        Use this tool when the invoiceId is already known; use searchInvoices instead when locating an invoice by number, customer name or workorder number.
+
+        Preconditions: the invoice must exist.
+
+        Required inputs: invoiceId (UUID) as a path parameter; there is no request body.
+
+        Emits an INVOICE_GET audit event; no state changes — this is a read-only projection.
+
+        Returns 404 when no invoice exists for the supplied id.
+
+        '
       operationId: getInvoice
       parameters:
       - name: invoiceId
@@ -933,9 +1398,21 @@ paths:
     get:
       tags:
       - invoice-artifact-controller
-      summary: List the downloadable artifacts (documents) for an invoice
-      description: Returns the documents available for the invoice (the invoice itself and any receipts) as opaque, URL-safe artifact references with suggested file names and MIME types.
-      operationId: listArtifacts
+      summary: List Downloadable Invoice Artifacts
+      description: 'Returns the downloadable documents for an invoice — always the invoice document itself, plus one entry per generated receipt — as opaque URL-safe artifact references with suggested file names and application/pdf MIME types.
+
+        Use this tool to discover artifactRefId values before minting a download token; do not use downloadInvoiceArtifact directly, which requires a signed token from createArtifactDownloadToken.
+
+        Preconditions: the invoice must exist; receipts appear only after generateReceipt has created them.
+
+        Required inputs: invoiceId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no invoice exists for the supplied id.
+
+        '
+      operationId: listInvoiceArtifacts
       parameters:
       - name: invoiceId
         in: path
@@ -968,9 +1445,21 @@ paths:
     get:
       tags:
       - invoice-artifact-download-controller
-      summary: Download an invoice artifact as PDF using a signed download token
-      description: Streams the artifact as application/pdf. Public endpoint authorized solely by the signed download token (query parameter); intended for browser direct-download links.
-      operationId: download
+      summary: Download Invoice Artifact as PDF
+      description: 'Streams an invoice or receipt artifact as an application/pdf attachment, rendering it on demand through the document service.
+
+        Use this tool (or a browser direct link) with a token minted by createArtifactDownloadToken; do not call it with a bearer token alone — the endpoint is public and authorized solely by the signed download token.
+
+        Preconditions: a valid unexpired download token bound to exactly this invoiceId and artifactRefId, and the artifact must still belong to the invoice.
+
+        Required inputs: invoiceId (UUID) and artifactRefId as path parameters plus the token query parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only render of the stored document data.
+
+        Returns 403 when the token is missing, malformed, expired, or bound to a different artifact, and 404 when the invoice or artifact cannot be resolved.
+
+        '
+      operationId: downloadInvoiceArtifact
       parameters:
       - name: invoiceId
         in: path
@@ -1014,8 +1503,20 @@ paths:
     get:
       tags:
       - Invoice Search
-      summary: Search invoices
-      description: Paginated free-text search for invoices matching the invoice number, customer name, or workorder number.
+      summary: Search Invoices by Free Text
+      description: 'Searches invoices by a free-text term matched against the invoice number, the customer name (resolved via the customer service), or the workorder number, returning a page of finder rows.
+
+        Use this tool to locate an invoice when its id is unknown; use getInvoice instead once the invoiceId is known, and searchInvoiceLines for line-level warranty correlation.
+
+        Preconditions: none — but a blank or missing q short-circuits to an empty page rather than listing all invoices.
+
+        Required inputs: q (free-text term) plus optional page, size and sort parameters; size defaults to 25, is hard-capped at 50, and the default sort is createdAt descending.
+
+        Emits an INVOICE_SEARCH audit event; no state changes — this is a read-only projection.
+
+        Returns 400 when pagination parameters are malformed.
+
+        '
       operationId: searchInvoices
       parameters:
       - name: q
@@ -1057,8 +1558,20 @@ paths:
     get:
       tags:
       - Invoice Search
-      summary: Search invoice line items by customer party
-      description: Returns invoice line items belonging to the given customer party, optionally narrowed by a SKU/description term, flattened with the owning invoice's number, status, and creation time. Newest invoice first, bounded to the newest 200 lines. Built for warranty-claim correlation.
+      summary: Search Invoice Lines by Party
+      description: 'Returns invoice line items belonging to one customer party, flattened with the owning invoice''s number, status and creation time, newest invoice first and bounded to the newest 200 lines; built for warranty-claim origin-line correlation.
+
+        Use this tool to find the invoice line a warranty claim originates from; use searchInvoices instead for invoice-level free-text search.
+
+        Preconditions: none — an unknown party simply returns an empty list.
+
+        Required inputs: partyId (UUID) query parameter; q is an optional SKU or description term narrowing the lines.
+
+        Emits an INVOICE_ITEM_SEARCH audit event; no state changes — this is a read-only projection.
+
+        Returns 400 when partyId is missing or malformed.
+
+        '
       operationId: searchInvoiceLines
       parameters:
       - name: partyId
@@ -1067,6 +1580,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
       - name: q
         in: query
         description: SKU / description term narrowing the lines (optional)
@@ -1103,9 +1617,21 @@ paths:
     get:
       tags:
       - Deposit Credits
-      summary: Get a deposit credit by id
-      description: Retrieves a single deposit credit by its identifier.
-      operationId: getDeposit
+      summary: Get a Deposit Credit
+      description: 'Returns a single deposit credit with its status (AVAILABLE, PARTIALLY_APPLIED, FULLY_APPLIED or REFUNDED), original amount and remaining balance.
+
+        Use this tool when the depositCreditId is already known; use listDepositCreditsBySource instead to find the credits held against an estimate, workorder or order.
+
+        Preconditions: the deposit credit must exist.
+
+        Required inputs: depositCreditId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no deposit credit exists for the supplied id.
+
+        '
+      operationId: getDepositCredit
       parameters:
       - name: depositCreditId
         in: path
@@ -1141,7 +1667,6 @@ components:
           example: 01960003-0000-7000-8000-000000000002
         purchaseOrderRequired:
           type: boolean
-          default: false
           description: Whether a purchase order is required before invoicing
           example: true
         paymentTermsCode:
@@ -1207,6 +1732,7 @@ components:
           type: number
           description: Amount to refund
           example: 25.0
+          minimum: 0
         reason:
           type: string
           description: Reason the refund is being issued
@@ -1576,7 +2102,6 @@ components:
           example: msmith
         requiresManagerApproval:
           type: boolean
-          default: false
           description: Whether finalizing this invoice requires a manager approval code (DRAFT total exceeds the service-advisor threshold)
           example: false
         items:
@@ -1634,6 +2159,7 @@ components:
           type: number
           description: Amount to refund
           example: 25.0
+          minimum: 0
         reason:
           type: string
           description: Reason the refund is being issued
@@ -1770,6 +2296,7 @@ components:
           type: number
           description: Payment amount (must be positive)
           example: 149.99
+          minimum: 0
         idempotencyKey:
           type: string
           description: Client-provided idempotency key for safe retry
@@ -1859,6 +2386,7 @@ components:
           type: number
           description: Amount to refund from the captured payment
           example: 25.0
+          minimum: 0
         reason:
           type: string
           description: Reason the payment is being refunded
@@ -1894,6 +2422,7 @@ components:
           type: number
           description: Amount to capture from the authorized hold
           example: 89.99
+          minimum: 0
         captureIdempotencyKey:
           type: string
           description: Idempotency key ensuring the capture is processed at most once
@@ -1948,7 +2477,6 @@ components:
           example: 50.0
         existing:
           type: boolean
-          default: false
           description: True when an existing invoice was returned (orderId replay or workorder dedupe).
       required:
       - existing
@@ -2132,6 +2660,7 @@ components:
           type: number
           description: Deposit amount
           example: 200.0
+          minimum: 0
         currencyCode:
           type: string
           description: ISO-4217 currency; defaults to USD
@@ -2419,17 +2948,17 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
     PageableObject:

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/BillingRulesController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/BillingRulesController.java
@@ -4,6 +4,8 @@ import com.positivity.events.EmitEvent;
 import com.positivity.invoice.internal.dto.BillingRulesDTO;
 import com.positivity.invoice.service.BillingRulesService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -49,9 +51,18 @@ public class BillingRulesController {
 
     @GetMapping("/{partyId}")
     @EmitEvent(id = "BILLING_RULES_GET", apiVersion = "1")
-    @Operation(
-            summary = "Get billing rules for a party/customer",
-            description = "Retrieve the current billing rules configuration for a commercial account")
+    @Operation(operationId = "getBillingRules", summary = "Get Billing Rules for a Party", description = """
+                    Returns the billing rules configured for a commercial account party: purchase-order requirement, \
+                    payment terms code, invoice delivery method, and invoice grouping strategy.
+                    Use this tool when the billing configuration of a known party is needed before invoicing; do not \
+                    use upsertBillingRules, which creates or replaces the configuration.
+                    Preconditions: a billing rules record must already exist for the party, created explicitly or \
+                    defaulted when the commercial account was provisioned.
+                    Required inputs: partyId (UUID) as a path parameter; there is no request body.
+                    Emits a BILLING_RULES_GET audit event; no state changes — this is a read-only projection.
+                    Returns 404 when no billing rules are configured for the party, and 400 with an empty body when \
+                    partyId is not a well-formed UUID.
+                    """)
     @ApiResponse(responseCode = "200", description = "Billing rules found")
     @ApiResponse(responseCode = "404", description = "No billing rules configured for this party")
     public ResponseEntity<BillingRulesDTO> getBillingRules(@PathVariable @NonNull String partyId) {
@@ -71,14 +82,47 @@ public class BillingRulesController {
 
     @PutMapping("/{partyId}")
     @EmitEvent(id = "BILLING_RULES_UPSERT", apiVersion = "1")
-    @Operation(
-            summary = "Create or update billing rules",
-            description = "Idempotent upsert of billing rules for a commercial account")
+    @Operation(operationId = "upsertBillingRules", summary = "Create or Update Billing Rules", description = """
+                    Creates or replaces the billing rules for a commercial account party in one idempotent upsert \
+                    keyed on the path partyId, which overrides any partyId carried in the body.
+                    Use this tool when configuring how a party is invoiced; use getBillingRules instead to read the \
+                    current configuration without changing it.
+                    Preconditions: paymentTermsCode must belong to the validated vocabulary (DUE_ON_RECEIPT, NET_10, \
+                    NET_15, NET_30, NET_45, NET_60); a missing record is created and an existing one is updated in \
+                    place.
+                    Required inputs: partyId (UUID path), purchaseOrderRequired (boolean), paymentTermsCode, \
+                    invoiceDeliveryMethod (EMAIL, PORTAL, MAIL) and invoiceGroupingStrategy (PER_WORKORDER, \
+                    PER_VEHICLE, SINGLE_INVOICE); updatedBy is taken from the security context, never from the body.
+                    Emits a BILLING_RULES_UPSERT event and publishes a billing-rules-updated notification; due dates \
+                    of already-finalized invoices are never recomputed from a terms change.
+                    Returns 201 when the record is created, 200 when an existing record is updated, and 400 with an \
+                    empty body when partyId is not a well-formed UUID.
+                    """)
     @ApiResponse(responseCode = "200", description = "Billing rules updated")
     @ApiResponse(responseCode = "201", description = "Billing rules created")
     @ApiResponse(responseCode = "400", description = "Invalid billing rules data")
     public ResponseEntity<BillingRulesDTO> upsertBillingRules(
-            @PathVariable @NonNull String partyId, @Valid @RequestBody @NonNull BillingRulesDTO billingRulesDTO) {
+            @PathVariable @NonNull String partyId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Billing rules configuration to store for the party.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Net-30 emailed per-workorder invoicing",
+                                                            value = """
+                                                                    {"partyId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "purchaseOrderRequired":true,
+                                                                     "paymentTermsCode":"NET_30",
+                                                                     "invoiceDeliveryMethod":"EMAIL",
+                                                                     "invoiceGroupingStrategy":"PER_WORKORDER"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BillingRulesDTO billingRulesDTO) {
 
         // Validate partyId format
         if (!VALID_UUID_PATTERN.matcher(partyId).matches()) {

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/DepositCreditController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/DepositCreditController.java
@@ -7,6 +7,8 @@ import com.positivity.invoice.internal.enums.DepositSourceType;
 import com.positivity.invoice.service.DepositCreditService;
 import com.positivity.invoice.service.model.CreateDepositCommand;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -42,13 +44,45 @@ public class DepositCreditController {
     private final DepositCreditService depositCreditService;
 
     @Operation(
-            summary = "Register a deposit credit taken by a sales order",
-            description = "Creates a deposit credit record tied to the provided source transaction.",
+            operationId = "createDepositCredit",
+            summary = "Register a Deposit Credit",
+            description = """
+                    Creates an AVAILABLE deposit credit for a down-payment taken at pos-order checkout, holding the \
+                    amount against its source document until a settlement invoice draws it down.
+                    Use this tool when a deposit was tendered against an estimate, workorder, or order; do not use \
+                    refundDepositCredit, which returns a credit's remaining balance when the source is cancelled.
+                    Preconditions: none beyond a priced source document — the call is idempotent on orderId, so a \
+                    replay for an order that already registered a credit returns the existing record unchanged.
+                    Required inputs: orderId (UUID, idempotency anchor), sourceType (ESTIMATE, WORKORDER or ORDER), \
+                    sourceId (UUID) and amount (positive); partyId is optional and currencyCode defaults to USD.
+                    Emits an INVOICE_DEPOSIT_CREATE event; no invoice records are touched until settlement applies \
+                    the credit.
+                    Returns 201 with the credit (existing or new), and 422 when the amount is not positive or the \
+                    sourceType is not a known value.
+                    """,
             tags = {"Deposit Credits"})
     @PostMapping
     @EmitEvent(id = "INVOICE_DEPOSIT_CREATE", apiVersion = "1")
     @SecurityRequirement(name = "bearerAuth")
-    public ResponseEntity<DepositCreditResponse> createDeposit(@Valid @RequestBody CreateDepositRequest request) {
+    public ResponseEntity<DepositCreditResponse> createDeposit(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Deposit taken at checkout to register as a credit against its source document.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Workorder down-payment", value = """
+                                                                    {"orderId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a10",
+                                                                     "sourceType":"WORKORDER",
+                                                                     "sourceId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a11",
+                                                                     "partyId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a12",
+                                                                     "amount":200.00,
+                                                                     "currencyCode":"USD"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CreateDepositRequest request) {
         DepositCreditResponse response =
                 DepositCreditResponse.from(depositCreditService.createDeposit(new CreateDepositCommand(
                         request.getOrderId(),
@@ -61,8 +95,18 @@ public class DepositCreditController {
     }
 
     @Operation(
-            summary = "Get a deposit credit by id",
-            description = "Retrieves a single deposit credit by its identifier.",
+            operationId = "getDepositCredit",
+            summary = "Get a Deposit Credit",
+            description = """
+                    Returns a single deposit credit with its status (AVAILABLE, PARTIALLY_APPLIED, FULLY_APPLIED or \
+                    REFUNDED), original amount and remaining balance.
+                    Use this tool when the depositCreditId is already known; use listDepositCreditsBySource instead \
+                    to find the credits held against an estimate, workorder or order.
+                    Preconditions: the deposit credit must exist.
+                    Required inputs: depositCreditId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no deposit credit exists for the supplied id.
+                    """,
             tags = {"Deposit Credits"})
     @GetMapping("/{depositCreditId}")
     @SecurityRequirement(name = "bearerAuth")
@@ -71,8 +115,19 @@ public class DepositCreditController {
     }
 
     @Operation(
-            summary = "List deposit credits held against a source document",
-            description = "Lists all deposit credits associated with the given source type and source id.",
+            operationId = "listDepositCreditsBySource",
+            summary = "List Deposit Credits by Source",
+            description = """
+                    Lists every deposit credit held against one source document, identified by its type and id.
+                    Use this tool when checking what down-payments a settlement can draw on; use getDepositCredit \
+                    instead when a specific depositCreditId is already known.
+                    Preconditions: none — an unknown or credit-free source returns an empty list rather than an \
+                    error.
+                    Required inputs: sourceType query parameter (ESTIMATE, WORKORDER or ORDER, case-insensitive) and \
+                    sourceId (UUID) query parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 422 when sourceType is not one of the known values.
+                    """,
             tags = {"Deposit Credits"})
     @GetMapping
     @SecurityRequirement(name = "bearerAuth")
@@ -85,8 +140,21 @@ public class DepositCreditController {
     }
 
     @Operation(
-            summary = "Refund a deposit credit's remaining balance",
-            description = "Used when the deposit's source is cancelled after the deposit was taken (spec R7.4).",
+            operationId = "refundDepositCredit",
+            summary = "Refund a Deposit Credit Balance",
+            description = """
+                    Zeroes the remaining balance of a deposit credit and marks it REFUNDED, recording that the \
+                    deposit is returned because its source document was cancelled after the deposit was taken.
+                    Use this tool on source cancellation (spec R7.4); do not use createDepositCredit, which \
+                    registers a new deposit, and note the cash disbursement itself is not performed here.
+                    Preconditions: the deposit credit must exist; a credit already REFUNDED is left unchanged, so \
+                    the call is idempotent.
+                    Required inputs: depositCreditId (UUID) as a path parameter; the reason query parameter is \
+                    optional and defaults to "source cancelled"; there is no request body.
+                    Emits an INVOICE_DEPOSIT_REFUND event and sets the credit's status to REFUNDED with a zero \
+                    remaining balance.
+                    Returns 200 with the refunded credit, and 404 when no deposit credit exists for the supplied id.
+                    """,
             tags = {"Deposit Credits"})
     @PostMapping("/{depositCreditId}/refund")
     @EmitEvent(id = "INVOICE_DEPOSIT_REFUND", apiVersion = "1")

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/ElevationController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/ElevationController.java
@@ -5,6 +5,8 @@ import com.positivity.invoice.internal.dto.ElevateResponse;
 import com.positivity.invoice.internal.exception.ElevationDeniedException;
 import com.positivity.invoice.internal.service.ElevationService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -48,14 +50,41 @@ public class ElevationController {
 
     @PostMapping("/elevate")
     @Operation(
-            summary = "Mint a manager-approval elevation token",
-            description =
-                    "Verifies the named manager (by employee number) holds invoice:finalize:override and mints"
-                            + " a short-lived token scoped to the given invoice, returned as the managerApprovalCode for finalize.")
+            operationId = "elevateManagerApproval",
+            summary = "Mint Manager-Approval Elevation Token",
+            description = """
+                    Mints a short-lived elevation token scoped to one invoice after verifying that the named manager \
+                    is an ACTIVE employee holding the invoice:finalize:override authority.
+                    Use this tool when an actor with invoice:finalize but not invoice:finalize:override needs a \
+                    managerApprovalCode for finalizeInvoice or revertInvoice; do not use finalizeInvoice directly \
+                    without a token when the invoice total exceeds the 500.00 service-advisor cap.
+                    Preconditions: the manager's employee number must resolve to an ACTIVE person in the local \
+                    employee replica and that person must hold invoice:finalize:override.
+                    Required inputs: managerEmployeeNumber and invoiceId (UUID); the token is bound to that invoice \
+                    only and expires after five minutes by default (invoice.elevation.token-ttl-seconds).
+                    No events are emitted; the token is signed and stateless, and the grant is audit-logged with the \
+                    approving manager's person id.
+                    Returns 200 with the token and its expiry, and 401 with an empty body when the employee number \
+                    is unknown or inactive or the person lacks the override authority.
+                    """)
     @ApiResponse(responseCode = "200", description = "Elevation token minted")
     @ApiResponse(responseCode = "400", description = "Invalid request")
     @ApiResponse(responseCode = "401", description = "Manager approval denied")
-    public ResponseEntity<ElevateResponse> elevate(@Valid @RequestBody @NonNull ElevateRequest request) {
+    public ResponseEntity<ElevateResponse> elevate(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Manager identification and the invoice the elevation token will authorize.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Elevation for one invoice", value = """
+                                                                    {"managerEmployeeNumber":"EMP-0001",
+                                                                     "invoiceId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a20"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    ElevateRequest request) {
         ElevateResponse response = elevationService.elevate(request.getManagerEmployeeNumber(), request.getInvoiceId());
         return ResponseEntity.ok(response);
     }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactController.java
@@ -35,10 +35,19 @@ public class InvoiceArtifactController {
         this.artifactService = artifactService;
     }
 
-    @Operation(
-            summary = "List the downloadable artifacts (documents) for an invoice",
-            description =
-                    "Returns the documents available for the invoice (the invoice itself and any receipts) as opaque, URL-safe artifact references with suggested file names and MIME types.")
+    @Operation(operationId = "listInvoiceArtifacts", summary = "List Downloadable Invoice Artifacts", description = """
+                    Returns the downloadable documents for an invoice — always the invoice document itself, plus one \
+                    entry per generated receipt — as opaque URL-safe artifact references with suggested file names \
+                    and application/pdf MIME types.
+                    Use this tool to discover artifactRefId values before minting a download token; do not use \
+                    downloadInvoiceArtifact directly, which requires a signed token from \
+                    createArtifactDownloadToken.
+                    Preconditions: the invoice must exist; receipts appear only after generateReceipt has created \
+                    them.
+                    Required inputs: invoiceId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no invoice exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Artifacts listed")
     @ApiResponse(responseCode = "404", description = "Invoice not found")
     @SecurityRequirement(name = "bearerAuth")
@@ -51,9 +60,21 @@ public class InvoiceArtifactController {
     }
 
     @Operation(
-            summary = "Create a short-lived download token for an invoice artifact",
-            description =
-                    "Issues a short-lived signed token bound to the invoice and artifact. The token is presented to the public download endpoint so a browser can fetch the file via a direct link.")
+            operationId = "createArtifactDownloadToken",
+            summary = "Create Artifact Download Token",
+            description = """
+                    Issues a short-lived signed token bound to one invoice artifact, so a browser can fetch the PDF \
+                    through the public download link without an Authorization header.
+                    Use this tool after listInvoiceArtifacts has supplied an artifactRefId; do not use \
+                    downloadInvoiceArtifact without a token — it rejects unsigned requests.
+                    Preconditions: the invoice must exist and the artifact reference must belong to that invoice \
+                    (an invoice ref must match the path invoice, a receipt ref must be one of its receipts).
+                    Required inputs: invoiceId (UUID) and artifactRefId (opaque reference from \
+                    listInvoiceArtifacts) as path parameters; there is no request body.
+                    No events are emitted and no record is stored; the token is stateless, signed, and expires after \
+                    300 seconds by default (invoice.artifacts.token-ttl-seconds).
+                    Returns 404 when the invoice does not exist or the artifact does not belong to it.
+                    """)
     @ApiResponse(responseCode = "200", description = "Token issued")
     @ApiResponse(responseCode = "404", description = "Invoice or artifact not found")
     @SecurityRequirement(name = "bearerAuth")

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactDownloadController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceArtifactDownloadController.java
@@ -33,10 +33,21 @@ public class InvoiceArtifactDownloadController {
         this.artifactService = artifactService;
     }
 
-    @Operation(
-            summary = "Download an invoice artifact as PDF using a signed download token",
-            description =
-                    "Streams the artifact as application/pdf. Public endpoint authorized solely by the signed download token (query parameter); intended for browser direct-download links.")
+    @Operation(operationId = "downloadInvoiceArtifact", summary = "Download Invoice Artifact as PDF", description = """
+                    Streams an invoice or receipt artifact as an application/pdf attachment, rendering it on demand \
+                    through the document service.
+                    Use this tool (or a browser direct link) with a token minted by createArtifactDownloadToken; \
+                    do not call it with a bearer token alone — the endpoint is public and authorized solely by the \
+                    signed download token.
+                    Preconditions: a valid unexpired download token bound to exactly this invoiceId and \
+                    artifactRefId, and the artifact must still belong to the invoice.
+                    Required inputs: invoiceId (UUID) and artifactRefId as path parameters plus the token query \
+                    parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only render of the stored document \
+                    data.
+                    Returns 403 when the token is missing, malformed, expired, or bound to a different artifact, and \
+                    404 when the invoice or artifact cannot be resolved.
+                    """)
     @ApiResponse(responseCode = "200", description = "PDF returned")
     @ApiResponse(responseCode = "403", description = "Missing, invalid, or expired token")
     @ApiResponse(responseCode = "404", description = "Invoice or artifact not found")

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceController.java
@@ -13,6 +13,8 @@ import com.positivity.shared.dto.InvoiceGenerationResponse;
 import com.positivity.shared.dto.OrderInvoiceCreationRequest;
 import com.positivity.shared.dto.OrderInvoiceResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -50,32 +52,97 @@ public class InvoiceController {
 
     @PostMapping
     @EmitEvent(id = "INVOICE_CREATE", apiVersion = "1")
-    @Operation(summary = "Create invoice", description = "Create invoice draft from completed workorder data")
+    @Operation(operationId = "createInvoice", summary = "Create Invoice Draft from Workorder", description = """
+                    Creates a DRAFT invoice from completed workorder data, pricing the supplied line items, \
+                    calculating draft tax against the shop location's jurisdiction, and assigning the permanent \
+                    invoice number immediately.
+                    Use this tool for workorder billing; do not use createInvoiceFromOrder, which fronts a sales \
+                    order at counter-sale checkout with order-authoritative totals.
+                    Preconditions: the workorder must be complete enough to bill; the call is idempotent on \
+                    workorderId — a replay returns the workorder's existing invoice instead of creating a duplicate.
+                    Required inputs: workorderId (UUID); estimateId, approvalId, locationId, customerId, \
+                    idempotencyKey and lineItems (description, quantity, unitPrice, amount, optional type) are \
+                    optional, and a missing lineItems list produces an empty zero-subtotal draft.
+                    Emits an INVOICE_CREATE event, persists the per-line tax breakdown, and publishes an \
+                    invoice-updated notification.
+                    Returns 201 with the invoice (existing or new), and 400 when workorderId is missing.
+                    """)
     @ApiResponse(responseCode = "201", description = "Invoice created")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"invoice:manage"})
     public ResponseEntity<InvoiceGenerationResponse> createInvoice(
-            @Valid @RequestBody @NonNull InvoiceCreationRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Workorder billing data the invoice draft is built from.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Workorder invoice draft", value = """
+                                                                    {"workorderId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a30",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a31",
+                                                                     "customerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a32",
+                                                                     "idempotencyKey":"inv-create-wo-1234",
+                                                                     "lineItems":[{"description":"Brake pad replacement",
+                                                                       "quantity":2.0,"unitPrice":45.00,
+                                                                       "amount":90.00,"type":"LABOR"}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    InvoiceCreationRequest request) {
         InvoiceGenerationResponse response = invoiceService.createInvoice(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PostMapping("/from-order")
     @EmitEvent(id = "INVOICE_CREATE_FROM_ORDER", apiVersion = "1")
-    @Operation(
-            summary = "Create invoice from a sales order",
-            description = "Create the invoice fronting a sales order at checkout (counter sale). Idempotent on "
-                    + "orderId — a replay returns the existing invoice with 200. When workorderId is present and a "
-                    + "workorder invoice already exists, that invoice is returned for tender instead of creating a "
-                    + "duplicate.")
+    @Operation(operationId = "createInvoiceFromOrder", summary = "Create Invoice from Sales Order", description = """
+                    Creates the DRAFT invoice fronting a sales order at counter-sale checkout, recording the order's \
+                    already-priced subtotal, tax and total verbatim — pos-order and pos-tax are authoritative, so \
+                    nothing is re-priced here.
+                    Use this tool at order checkout; do not use createInvoice, which builds and prices a draft from \
+                    workorder data.
+                    Preconditions: the order must carry final totals and at least one line; the call is idempotent \
+                    on orderId, and when workorderId is set an existing workorder invoice is returned for tender \
+                    instead of creating a duplicate.
+                    Required inputs: orderId (UUID), subtotal, taxAmount, totalAmount (non-negative) and lines; \
+                    customerId, locationId and the deposit fields are optional, but depositSourceType and \
+                    depositSourceId become mandatory when depositAmount is set.
+                    Emits an INVOICE_CREATE_FROM_ORDER event; a deposit take also registers a deposit credit \
+                    (idempotent on orderId), and a workorder settlement draws down available deposit credits, \
+                    reported as depositApplied.
+                    Returns 201 when a new invoice is created, 200 when an existing invoice is returned (orderId \
+                    replay or workorder dedupe), and 400 when totals are missing or negative, lines are empty, or \
+                    deposit fields are inconsistent.
+                    """)
     @ApiResponse(responseCode = "201", description = "Invoice created")
     @ApiResponse(responseCode = "200", description = "Existing invoice returned (replay or workorder dedupe)")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"invoice:manage"})
     public ResponseEntity<OrderInvoiceResponse> createInvoiceFromOrder(
-            @Valid @RequestBody @NonNull OrderInvoiceCreationRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Sales order snapshot — authoritative totals and sold lines — the invoice records.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Counter sale", value = """
+                                                                    {"orderId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a40",
+                                                                     "customerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a41",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a42",
+                                                                     "subtotal":120.00,"taxAmount":9.60,"totalAmount":129.60,
+                                                                     "lines":[{"orderLineId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a43",
+                                                                       "description":"Brake pad set","quantity":2,
+                                                                       "unitPrice":45.00,"amount":90.00,
+                                                                       "taxAmount":7.20,"type":"PART"}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    OrderInvoiceCreationRequest request) {
         OrderInvoiceResponse response = orderInvoiceService.createInvoiceForOrder(request);
         HttpStatus status = response.isExisting() ? HttpStatus.OK : HttpStatus.CREATED;
         return ResponseEntity.status(status).body(response);
@@ -83,11 +150,19 @@ public class InvoiceController {
 
     @PostMapping("/{invoiceId}/cancel")
     @EmitEvent(id = "INVOICE_CANCEL", apiVersion = "1")
-    @Operation(
-            summary = "Cancel a draft invoice",
-            description = "Terminal cancel of a DRAFT invoice before any money moved (order-void path). Rejected "
-                    + "with 409 when the invoice has left DRAFT or carries an authorized/captured payment. "
-                    + "Idempotent — cancelling a CANCELLED invoice returns 200.")
+    @Operation(operationId = "cancelInvoice", summary = "Cancel a Draft Invoice", description = """
+                    Cancels a DRAFT invoice terminally before any money has moved, the invoice-side effect of an \
+                    order void.
+                    Use this tool when an order is voided before tender; do not use revertInvoice, which returns a \
+                    FINALIZED invoice to DRAFT, and do not use it when payments exist — reverse those first through \
+                    voidPayment or refundPayment (order cancellation saga).
+                    Preconditions: the invoice must still be DRAFT and must carry no AUTHORIZED or CAPTURED payment \
+                    intent; cancelling an already CANCELLED invoice is an idempotent no-op.
+                    Required inputs: invoiceId (UUID) as a path parameter; there is no request body.
+                    Emits an INVOICE_CANCEL event and sets the invoice status to CANCELLED.
+                    Returns 200 when cancelled or already cancelled, 409 when the invoice has left DRAFT or carries \
+                    an authorized/captured payment, and 404 when the invoice does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Invoice cancelled (or already cancelled)")
     @ApiResponse(responseCode = "409", description = "Invoice not cancellable in its current state")
     @SecurityRequirement(
@@ -99,7 +174,16 @@ public class InvoiceController {
 
     @GetMapping("/{invoiceId}")
     @EmitEvent(id = "INVOICE_GET", apiVersion = "1")
-    @Operation(summary = "Get invoice", description = "Get invoice details")
+    @Operation(operationId = "getInvoice", summary = "Get Invoice Details", description = """
+                    Returns the full invoice detail — status, line items, adjustments, totals, tax breakdown, due \
+                    date and the resolved workorder number.
+                    Use this tool when the invoiceId is already known; use searchInvoices instead when locating an \
+                    invoice by number, customer name or workorder number.
+                    Preconditions: the invoice must exist.
+                    Required inputs: invoiceId (UUID) as a path parameter; there is no request body.
+                    Emits an INVOICE_GET audit event; no state changes — this is a read-only projection.
+                    Returns 404 when no invoice exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Invoice found")
     @SecurityRequirement(
             name = "bearerAuth",
@@ -110,47 +194,131 @@ public class InvoiceController {
 
     @PostMapping("/{invoiceId}/adjustments")
     @EmitEvent(id = "INVOICE_ADJUSTMENT_APPLY", apiVersion = "1")
-    @Operation(
-            summary = "Apply invoice adjustment",
-            description = "Apply discount, fee, correction, or warranty credit to a draft invoice")
+    @Operation(operationId = "applyInvoiceAdjustment", summary = "Apply Adjustment to Draft Invoice", description = """
+                    Applies a monetary adjustment (DISCOUNT, FEE, CORRECTION, or WARRANTY credit) to a DRAFT invoice \
+                    and recalculates its tax and total.
+                    Use this tool while the invoice is still DRAFT; do not use it after finalization — tax and \
+                    totals freeze there, so revertInvoice must return the invoice to DRAFT first.
+                    Preconditions: the invoice must exist and be in DRAFT status; a retry supplying the same type \
+                    and externalReference replays idempotently, returning the invoice without double-crediting.
+                    Required inputs: type, amount (greater than zero), reason, and authorizedBy; externalReference \
+                    is optional and correlates the adjustment to an external record such as a warranty settlement.
+                    Emits an INVOICE_ADJUSTMENT_APPLY event, replaces the persisted per-line tax breakdown, and \
+                    publishes an invoice-updated notification.
+                    Returns 200 with the recalculated invoice, 404 when the invoice does not exist, 409 when the \
+                    invoice has left DRAFT, and 400 when the type, amount, reason, or authorizedBy is missing or the \
+                    amount is not positive.
+                    """)
     @ApiResponse(responseCode = "200", description = "Adjustment applied")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"invoice:manage"})
     public ResponseEntity<InvoiceDetailsResponse> applyAdjustment(
-            @PathVariable @NonNull UUID invoiceId, @Valid @RequestBody @NonNull AdjustmentRequest request) {
+            @PathVariable @NonNull UUID invoiceId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Adjustment to add to the draft invoice, with its business justification.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Warranty credit", value = """
+                                                                    {"type":"WARRANTY","amount":25.00,
+                                                                     "reason":"Warranty settlement credit",
+                                                                     "authorizedBy":"jdoe",
+                                                                     "externalReference":"WC-2026-000042"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    AdjustmentRequest request) {
         return ResponseEntity.ok(invoiceService.applyAdjustment(invoiceId, request));
     }
 
     @PostMapping("/{invoiceId}/finalize")
     @EmitEvent(id = "INVOICE_FINALIZED", apiVersion = "1")
-    @Operation(
-            summary = "Finalize invoice",
-            description =
-                    "Transition invoice from DRAFT to FINALIZED; enforces permission matrix and emits InvoiceFinalized event for async GL posting (Story #13)")
+    @Operation(operationId = "finalizeInvoice", summary = "Finalize a Draft Invoice", description = """
+                    Transitions an invoice from DRAFT to FINALIZED: runs the committable tax calculation, freezes \
+                    tax, totals, payment terms and due date, then commits the provider tax document.
+                    Use this tool when the sale is ready to issue; do not use revertInvoice, which undoes a \
+                    finalization, and mint the managerApprovalCode with elevateManagerApproval when one is needed.
+                    Preconditions: the invoice must be DRAFT with tax already calculated; callers without \
+                    invoice:finalize:override (or a manager/admin role) need a valid elevation token as \
+                    managerApprovalCode when the stored total exceeds 500.00.
+                    Required inputs: invoiceId (UUID) as a path parameter; managerApprovalCode and overrideReason in \
+                    the body are optional below the cap and for override holders.
+                    Emits an INVOICE_FINALIZED event and publishes the async accounting event that drives GL \
+                    posting; the tax commit tolerates a provider outage by recording PENDING_COMMIT in pos-tax for \
+                    the re-commit job, and is skipped entirely when nothing is taxable.
+                    Returns 200 with the finalized invoice, 404 when the invoice does not exist, 409 when the \
+                    invoice is not DRAFT or tax has not been calculated, and 400 when a required managerApprovalCode \
+                    is missing, invalid, or expired.
+                    """)
     @ApiResponse(responseCode = "200", description = "Invoice finalized")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"invoice:finalize"})
     @PreAuthorize("hasAuthority('invoice:finalize')")
     public ResponseEntity<InvoiceDetailsResponse> finalizeInvoice(
-            @PathVariable @NonNull UUID invoiceId, @Valid @RequestBody @NonNull FinalizationRequest request) {
+            @PathVariable @NonNull UUID invoiceId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Optional manager-approval material for finalizations above the amount cap.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Finalize with manager approval",
+                                                            value = """
+                                                                    {"managerApprovalCode":"MGR-ELEV-TOKEN-abc123",
+                                                                     "overrideReason":"Customer pre-approved by branch manager"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    FinalizationRequest request) {
         return ResponseEntity.ok(invoiceFinalizationService.completeInvoice(invoiceId, request));
     }
 
     @PostMapping("/{invoiceId}/revert")
     @EmitEvent(id = "INVOICE_DRAFT_REVERT", apiVersion = "1")
-    @Operation(
-            summary = "Revert finalized invoice",
-            description =
-                    "Revert a FINALIZED invoice back to DRAFT within 24h of finalization and before GL posting (Story #13, AC6)")
+    @Operation(operationId = "revertInvoice", summary = "Revert Finalized Invoice to Draft", description = """
+                    Reverts a FINALIZED invoice back to DRAFT within 24 hours of finalization, before GL posting has \
+                    made it immutable, and voids the provider tax document committed at finalization.
+                    Use this tool to correct a wrongly finalized invoice; do not use cancelInvoice, which \
+                    terminally cancels a DRAFT invoice on the order-void path.
+                    Preconditions: the invoice must be FINALIZED (POSTED is immutable), less than 24 hours must have \
+                    elapsed since finalizedAt, and callers without invoice:finalize:override (or a manager/admin \
+                    role) must supply a valid elevation token from elevateManagerApproval as managerApprovalCode.
+                    Required inputs: invoiceId (UUID) as a path parameter plus managerApprovalCode and a reason in \
+                    the body; the reverting actor and approving manager are captured for audit.
+                    Emits an INVOICE_DRAFT_REVERT event, publishes an invoice-updated notification, and issues a tax \
+                    void toward pos-tax for the reverted document.
+                    Returns 200 with the DRAFT invoice, 404 when the invoice does not exist, 409 when it is POSTED, \
+                    not FINALIZED, or the 24-hour window has expired, and 400 when the approval code is blank, \
+                    invalid, or expired.
+                    """)
     @ApiResponse(responseCode = "200", description = "Invoice reverted to DRAFT")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"invoice:finalize"})
     @PreAuthorize("hasAuthority('invoice:finalize')")
     public ResponseEntity<InvoiceDetailsResponse> revertInvoice(
-            @PathVariable @NonNull UUID invoiceId, @Valid @RequestBody @NonNull RevertRequest request) {
+            @PathVariable @NonNull UUID invoiceId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Manager approval and business reason authorizing the reversion.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Revert with approval", value = """
+                                                                    {"managerApprovalCode":"MGR-ELEV-TOKEN-abc123",
+                                                                     "reason":"Incorrect line item billed"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    RevertRequest request) {
         return ResponseEntity.ok(
                 invoiceFinalizationService.revert(invoiceId, request.getManagerApprovalCode(), request.getReason()));
     }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/InvoiceSearchController.java
@@ -46,10 +46,18 @@ public class InvoiceSearchController {
     /** Hard cap on page size so a caller cannot request an unbounded enrichment fan-out. */
     private static final int MAX_PAGE_SIZE = 50;
 
-    @Operation(
-            summary = "Search invoices",
-            description = "Paginated free-text search for invoices matching the invoice number, "
-                    + "customer name, or workorder number.")
+    @Operation(operationId = "searchInvoices", summary = "Search Invoices by Free Text", description = """
+                    Searches invoices by a free-text term matched against the invoice number, the customer name \
+                    (resolved via the customer service), or the workorder number, returning a page of finder rows.
+                    Use this tool to locate an invoice when its id is unknown; use getInvoice instead once the \
+                    invoiceId is known, and searchInvoiceLines for line-level warranty correlation.
+                    Preconditions: none — but a blank or missing q short-circuits to an empty page rather than \
+                    listing all invoices.
+                    Required inputs: q (free-text term) plus optional page, size and sort parameters; size defaults \
+                    to 25, is hard-capped at 50, and the default sort is createdAt descending.
+                    Emits an INVOICE_SEARCH audit event; no state changes — this is a read-only projection.
+                    Returns 400 when pagination parameters are malformed.
+                    """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Page of invoice search results returned."),
         @ApiResponse(
@@ -77,12 +85,18 @@ public class InvoiceSearchController {
         return invoiceSearchService.search(q == null ? "" : q.trim(), capPageSize(pageable));
     }
 
-    @Operation(
-            summary = "Search invoice line items by customer party",
-            description = "Returns invoice line items belonging to the given customer party, "
-                    + "optionally narrowed by a SKU/description term, flattened with the owning "
-                    + "invoice's number, status, and creation time. Newest invoice first, bounded "
-                    + "to the newest 200 lines. Built for warranty-claim correlation.")
+    @Operation(operationId = "searchInvoiceLines", summary = "Search Invoice Lines by Party", description = """
+                    Returns invoice line items belonging to one customer party, flattened with the owning invoice's \
+                    number, status and creation time, newest invoice first and bounded to the newest 200 lines; \
+                    built for warranty-claim origin-line correlation.
+                    Use this tool to find the invoice line a warranty claim originates from; use searchInvoices \
+                    instead for invoice-level free-text search.
+                    Preconditions: none — an unknown party simply returns an empty list.
+                    Required inputs: partyId (UUID) query parameter; q is an optional SKU or description term \
+                    narrowing the lines.
+                    Emits an INVOICE_ITEM_SEARCH audit event; no state changes — this is a read-only projection.
+                    Returns 400 when partyId is missing or malformed.
+                    """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "List of matching invoice line items returned."),
         @ApiResponse(

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/PaymentController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/PaymentController.java
@@ -7,6 +7,8 @@ import com.positivity.invoice.internal.dto.InitiatePaymentRequest;
 import com.positivity.invoice.internal.dto.InitiatePaymentResponse;
 import com.positivity.invoice.service.PaymentService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -59,16 +61,45 @@ public class PaymentController {
     @PostMapping("/{invoiceId}/payments")
     @ResponseStatus(HttpStatus.CREATED)
     @EmitEvent(id = "INVOICE_PAYMENT_INITIATE", apiVersion = "1")
-    @Operation(
-            summary = "Initiate card payment",
-            description = "Initiate a SALE_CAPTURE or AUTH_ONLY card payment against an invoice")
+    @Operation(operationId = "initiatePayment", summary = "Initiate Card Payment on Invoice", description = """
+                    Initiates a card payment against an invoice through the payment gateway, creating a payment \
+                    intent that is CAPTURED immediately (SALE_CAPTURE) or left AUTHORIZED as a hold (AUTH_ONLY).
+                    Use this tool to take card tender; do not use capturePayment, which settles an existing \
+                    AUTH_ONLY hold rather than starting a new payment.
+                    Preconditions: the invoice must exist; the caller needs the PROCESS_PAYMENT authority, plus \
+                    OVERRIDE_PAYMENT_LIMIT when the amount exceeds 500.00 and SELECT_PAYMENT_FLOW to choose \
+                    AUTH_ONLY.
+                    Required inputs: paymentFlow (SALE_CAPTURE or AUTH_ONLY), amount (positive), idempotencyKey and \
+                    paymentToken (tokenised card reference, never a PAN); a replayed idempotencyKey with an \
+                    identical payload returns the existing intent instead of charging twice.
+                    Emits an INVOICE_PAYMENT_INITIATE event and records the gateway result on the intent.
+                    Returns 201 with the intent, 404 when the invoice does not exist, 409 when the idempotencyKey \
+                    was already used with a different payload, 422 when the gateway declines, and 403 when a \
+                    required payment authority is missing.
+                    """)
     @ApiResponse(responseCode = "201", description = "Payment intent created")
     @ApiResponse(responseCode = "400", description = "Invalid or missing required fields")
     @ApiResponse(responseCode = "403", description = "Insufficient permissions")
     @ApiResponse(responseCode = "422", description = "Payment method declined")
     @ApiResponse(responseCode = "503", description = "Payment gateway unavailable")
     public InitiatePaymentResponse initiatePayment(
-            @PathVariable @NonNull UUID invoiceId, @Valid @RequestBody @NonNull InitiatePaymentRequest request) {
+            @PathVariable @NonNull UUID invoiceId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Card tender details: flow, amount, idempotency key and tokenised card reference.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "One-step sale capture", value = """
+                                                                    {"paymentFlow":"SALE_CAPTURE","amount":149.99,
+                                                                     "idempotencyKey":"idem-018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a50",
+                                                                     "paymentToken":"tok_1NXyZ2eZvKYlo2Cabc12345"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    InitiatePaymentRequest request) {
         return paymentService.initiatePayment(invoiceId, request);
     }
 
@@ -82,16 +113,42 @@ public class PaymentController {
      */
     @PostMapping("/{invoiceId}/payments/{paymentId}/capture")
     @EmitEvent(id = "INVOICE_PAYMENT_CAPTURE", apiVersion = "1")
-    @Operation(
-            summary = "Capture authorized payment hold",
-            description = "Capture all or part of a previously authorized invoice payment hold")
+    @Operation(operationId = "capturePayment", summary = "Capture Authorized Payment Hold", description = """
+                    Captures all or part of a previously authorized AUTH_ONLY payment hold at the gateway; when the \
+                    captured amount is below the authorized amount, the remainder of the hold is voided.
+                    Use this tool to settle an existing AUTHORIZED intent; do not use initiatePayment, which starts \
+                    a new payment, and use voidPayment instead to release the hold without taking funds.
+                    Preconditions: the payment intent must belong to the invoice and be in AUTHORIZED status; the \
+                    caller needs the MANUAL_CAPTURE authority.
+                    Required inputs: amount (positive, up to the authorized amount) and captureIdempotencyKey, which \
+                    is forwarded to the gateway so a retried capture settles at most once.
+                    Emits an INVOICE_PAYMENT_CAPTURE event; the intent moves to CAPTURED on success or \
+                    CAPTURE_FAILED on decline, and an ambiguous gateway response is resolved by a status inquiry \
+                    before failing.
+                    Returns 200 with the captured intent, 404 when the intent does not exist under the invoice, 409 \
+                    when the intent is not AUTHORIZED, 422 when the gateway declines the capture, and 403 when the \
+                    MANUAL_CAPTURE authority is missing.
+                    """)
     @ApiResponse(responseCode = "200", description = "Payment captured")
     @ApiResponse(responseCode = "403", description = "Insufficient permissions")
     @ApiResponse(responseCode = "404", description = "Payment intent not found")
     public InitiatePaymentResponse capturePayment(
             @PathVariable @NonNull UUID invoiceId,
             @PathVariable @NonNull UUID paymentId,
-            @Valid @RequestBody @NonNull CaptureAmountRequest body) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Amount to settle from the authorized hold and the capture idempotency key.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Partial capture", value = """
+                                                                    {"amount":89.99,
+                                                                     "captureIdempotencyKey":"capture-018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a51"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    CaptureAmountRequest body) {
         return paymentService.capturePayment(invoiceId, paymentId, body.amount(), body.captureIdempotencyKey());
     }
 

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/PaymentReversalController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/PaymentReversalController.java
@@ -11,6 +11,8 @@ import com.positivity.invoice.internal.enums.VoidReason;
 import com.positivity.invoice.service.PaymentReversalService;
 import com.positivity.invoice.service.RefundPaymentResult;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -47,9 +49,22 @@ public class PaymentReversalController {
 
     @PostMapping("/{invoiceId}/payments/{paymentId}/void")
     @EmitEvent(id = "INVOICE_PAYMENT_VOID", apiVersion = "1")
-    @Operation(
-            summary = "Void authorized payment",
-            description = "Void a previously authorized invoice payment before it is captured")
+    @Operation(operationId = "voidPayment", summary = "Void Authorized Payment Hold", description = """
+                    Voids a previously authorized invoice payment hold at the gateway before it is captured, \
+                    releasing the customer's funds without any money movement.
+                    Use this tool on an AUTHORIZED hold; do not use refundPayment, which returns funds from a \
+                    payment that was already CAPTURED.
+                    Preconditions: the payment intent must belong to the invoice and be AUTHORIZED, the caller needs \
+                    the VOID_PAYMENT authority, and less than 24 hours may have elapsed since authorization unless \
+                    the caller also holds SUPERVISOR_OVERRIDE.
+                    Required inputs: reason (CUSTOMER_REQUEST, DUPLICATE_AUTHORIZATION, ENTRY_ERROR, \
+                    FRAUD_PREVENTION, MANAGER_DISCRETION or OTHER); notes are optional free text.
+                    Emits an INVOICE_PAYMENT_VOID event, moves the intent to VOIDED, and publishes a payment-voided \
+                    notification.
+                    Returns 200 with an empty body on success, 404 when the intent does not exist under the invoice, \
+                    409 when the intent is not AUTHORIZED, 422 when the 24-hour void window has expired, and 500 \
+                    when the gateway rejects the void.
+                    """)
     @ApiResponse(responseCode = "200", description = "Payment voided")
     @ApiResponse(responseCode = "404", description = "Payment intent not found")
     @ApiResponse(responseCode = "409", description = "Invalid payment state")
@@ -57,16 +72,45 @@ public class PaymentReversalController {
     public ResponseEntity<Void> voidPayment(
             @PathVariable @NonNull UUID invoiceId,
             @PathVariable @NonNull UUID paymentId,
-            @Valid @RequestBody @NonNull VoidPaymentRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Reason and optional notes explaining why the authorization is released.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Customer cancelled", value = """
+                                                                    {"reason":"CUSTOMER_REQUEST",
+                                                                     "notes":"Customer cancelled before pickup"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    VoidPaymentRequest request) {
         paymentReversalService.voidPayment(invoiceId, paymentId, request.reason(), request.notes());
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/{invoiceId}/payments/{paymentId}/refunds")
     @EmitEvent(id = "INVOICE_PAYMENT_REFUND", apiVersion = "1")
-    @Operation(
-            summary = "Refund captured payment",
-            description = "Create a refund for a captured invoice payment and record the refund details")
+    @Operation(operationId = "refundPayment", summary = "Refund a Captured Payment", description = """
+                    Refunds all or part of a CAPTURED invoice payment through the gateway and records the refund \
+                    against the payment intent.
+                    Use this tool when the original card payment lives in this system; do not use voidPayment, \
+                    which releases an uncaptured hold, and use createStandaloneInvoiceRefund instead when the \
+                    original payment is not on file.
+                    Preconditions: the payment intent must belong to the invoice and be CAPTURED, the caller needs \
+                    the REFUND_PAYMENT authority, less than 180 days may have elapsed since capture unless the \
+                    caller holds SUPERVISOR_OVERRIDE, and cumulative refunds may not exceed the captured amount.
+                    Required inputs: amount (positive) and reason (a RefundReason such as CUSTOMER_RETURN or \
+                    SERVICE_ERROR); notes and externalReference are optional, and a retry replaying the same \
+                    externalReference returns the existing refund instead of paying twice.
+                    Emits an INVOICE_PAYMENT_REFUND event and publishes a payment-refunded notification on success; \
+                    a gateway failure is persisted as a FAILED refund record, so callers must read the returned \
+                    status rather than treating 201 as completed.
+                    Returns 201 with the refund record, 404 when the intent does not exist under the invoice, 409 \
+                    when the intent is not CAPTURED, and 422 when the 180-day window has expired or the amount \
+                    exceeds the remaining refundable balance.
+                    """)
     @ApiResponse(responseCode = "201", description = "Refund created")
     @ApiResponse(responseCode = "404", description = "Payment intent not found")
     @ApiResponse(responseCode = "409", description = "Invalid payment state")
@@ -74,7 +118,22 @@ public class PaymentReversalController {
     public ResponseEntity<RefundPaymentResponse> refundPayment(
             @PathVariable @NonNull UUID invoiceId,
             @PathVariable @NonNull UUID paymentId,
-            @Valid @RequestBody @NonNull RefundPaymentRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Refund amount, business reason and optional external correlation for the captured payment.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Partial return refund", value = """
+                                                                    {"amount":25.00,"reason":"CUSTOMER_RETURN",
+                                                                     "notes":"Returned damaged part",
+                                                                     "externalReference":"WC-2026-000042"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    RefundPaymentRequest request) {
         var saved = paymentReversalService.refundPayment(
                 invoiceId, paymentId, request.amount(), request.reason(), request.notes(), request.externalReference());
 
@@ -96,11 +155,16 @@ public class PaymentReversalController {
     @GetMapping("/{invoiceId}/refunds")
     @PreAuthorize("hasAuthority('invoice:manage')")
     @EmitEvent(id = "INVOICE_REFUND_LIST", apiVersion = "1")
-    @Operation(
-            summary = "List refunds for an invoice",
-            description = "Return every refund record anchored to the invoice — payment-intent refunds whose"
-                    + " intent belongs to the invoice and standalone invoice-anchored refunds alike —"
-                    + " for warranty settlement reconciliation")
+    @Operation(operationId = "listInvoiceRefunds", summary = "List Refunds for an Invoice", description = """
+                    Returns every refund record anchored to the invoice — refunds of captured payment intents and \
+                    standalone invoice-anchored refunds alike — for warranty-settlement reconciliation.
+                    Use this tool to reconcile what has already been returned before issuing another refund; do not \
+                    use refundPayment or createStandaloneInvoiceRefund, which create refunds rather than list them.
+                    Preconditions: the invoice must exist; the caller needs the invoice:manage authority.
+                    Required inputs: invoiceId (UUID) as a path parameter; there is no request body or filtering.
+                    Emits an INVOICE_REFUND_LIST audit event; no state changes — this is a read-only projection.
+                    Returns 404 when no invoice exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Refund records returned")
     @ApiResponse(responseCode = "404", description = "Invoice not found")
     public List<InvoiceRefundResponse> listRefunds(@PathVariable @NonNull UUID invoiceId) {

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/ReceiptController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/ReceiptController.java
@@ -8,6 +8,8 @@ import com.positivity.invoice.internal.enums.ReceiptDeliveryStatus;
 import com.positivity.invoice.service.Receipt;
 import com.positivity.invoice.service.ReceiptService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,13 +44,41 @@ public class ReceiptController {
     @PostMapping("/{invoiceId}/receipts")
     @ResponseStatus(HttpStatus.CREATED)
     @EmitEvent(id = "INVOICE_RECEIPT_GENERATE", apiVersion = "1")
-    @Operation(
-            summary = "Generate invoice receipt",
-            description = "Generate a receipt for an invoice payment using the requested terminal and template")
+    @Operation(operationId = "generateReceipt", summary = "Generate Receipt for Invoice Payment", description = """
+                    Generates a receipt record for an invoice payment, assigning a unique reference built from the \
+                    invoice number, a UTC timestamp and a per-invoice sequence, with the cashier taken from the \
+                    security context.
+                    Use this tool once per payment after tender; do not use reprintReceipt, which duplicates a \
+                    receipt that already exists.
+                    Preconditions: the invoice and payment intent must exist, the intent must belong to the \
+                    invoice, and the caller needs the GENERATE_RECEIPT authority.
+                    Required inputs: paymentIntentId (UUID), terminalId, templateId and templateVersion.
+                    Emits an INVOICE_RECEIPT_GENERATE event and stores the receipt in GENERATED status with a zero \
+                    reprint count; the receipt also becomes a downloadable artifact of the invoice.
+                    Returns 201 with the receipt reference, 404 when the invoice or payment intent does not exist \
+                    or the intent belongs to a different invoice, and 403 when the GENERATE_RECEIPT authority is \
+                    missing.
+                    """)
     @ApiResponse(responseCode = "201", description = "Receipt generated")
     @ApiResponse(responseCode = "404", description = "Invoice not found")
     public ResponseEntity<ReceiptResponse> generateReceipt(
-            @PathVariable @NonNull UUID invoiceId, @Valid @RequestBody @NonNull GenerateReceiptRequest request) {
+            @PathVariable @NonNull UUID invoiceId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Payment, terminal and template identifying what the receipt documents.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Counter receipt", value = """
+                                                                    {"paymentIntentId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a60",
+                                                                     "terminalId":"TERM-001",
+                                                                     "templateId":"RECEIPT_DEFAULT",
+                                                                     "templateVersion":"1"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    GenerateReceiptRequest request) {
         Receipt receipt = receiptService.generateReceipt(
                 invoiceId,
                 request.paymentIntentId(),
@@ -61,16 +91,38 @@ public class ReceiptController {
     @PostMapping("/{invoiceId}/receipts/{receiptId}/reprint")
     @ResponseStatus(HttpStatus.OK)
     @EmitEvent(id = "INVOICE_RECEIPT_REPRINT", apiVersion = "1")
-    @Operation(
-            summary = "Reprint invoice receipt",
-            description = "Create a reprint of an existing receipt and record the reason for the reprint")
+    @Operation(operationId = "reprintReceipt", summary = "Reprint an Existing Receipt", description = """
+                    Records a reprint of an existing receipt, incrementing its reprint count and capturing the \
+                    reason and the reprinting actor for audit.
+                    Use this tool when a customer needs a duplicate copy; do not use generateReceipt, which creates \
+                    a new receipt for a payment that has none yet.
+                    Preconditions: the receipt must exist, and its reprint count must be below 5 unless the caller \
+                    holds the SUPERVISOR_OVERRIDE authority.
+                    Required inputs: receiptId (UUID) as a path parameter and a non-blank reason in the body.
+                    Emits an INVOICE_RECEIPT_REPRINT event and updates the receipt's reprint count, last reprint \
+                    reason and last reprinted-by.
+                    Returns 200 with the receipt, 404 when the receipt does not exist, and 409 when the reprint \
+                    limit of 5 is exceeded without a supervisor override.
+                    """)
     @ApiResponse(responseCode = "200", description = "Receipt reprinted")
     @ApiResponse(responseCode = "404", description = "Receipt not found")
     @ApiResponse(responseCode = "409", description = "Reprint limit exceeded")
     public ResponseEntity<ReceiptResponse> reprintReceipt(
             @PathVariable @NonNull UUID invoiceId,
             @PathVariable @NonNull UUID receiptId,
-            @Valid @RequestBody @NonNull ReprintReceiptRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Business reason the duplicate copy is being produced.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Duplicate copy", value = """
+                                                                    {"reason":"Customer requested a duplicate copy"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    ReprintReceiptRequest request) {
         Receipt receipt = receiptService.reprintReceipt(receiptId, request.reason());
         return ResponseEntity.ok(toResponse(receipt));
     }
@@ -78,14 +130,39 @@ public class ReceiptController {
     @PostMapping("/{invoiceId}/receipts/{receiptId}/print")
     @EmitEvent(id = "INVOICE_RECEIPT_PRINT_DELIVERY", apiVersion = "1")
     @Operation(
-            summary = "Record printed receipt delivery",
-            description = "Record the delivery status for a printed receipt associated with an invoice")
+            operationId = "recordReceiptPrintDelivery",
+            summary = "Record Printed Receipt Delivery Status",
+            description = """
+                    Records the outcome of printing a receipt at the terminal, stamping the receipt's delivery \
+                    method as PRINT with the reported status; the physical printing itself happens client-side, not \
+                    here.
+                    Use this tool after the terminal reports its print result; do not use recordReceiptEmailDelivery, \
+                    which records an email delivery attempt with its recipient address.
+                    Preconditions: the receipt must already exist via generateReceipt.
+                    Required inputs: receiptId (UUID) as a path parameter and status (SUCCESS or FAILED) in the \
+                    body.
+                    Emits an INVOICE_RECEIPT_PRINT_DELIVERY event and overwrites the receipt's delivery method and \
+                    status.
+                    Returns 200 with an empty body on success, and 404 when the receipt does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Print delivery recorded")
     @ApiResponse(responseCode = "404", description = "Receipt not found")
     public ResponseEntity<Void> recordPrintDelivery(
             @PathVariable @NonNull UUID invoiceId,
             @PathVariable @NonNull UUID receiptId,
-            @RequestBody @Valid @NonNull PrintDeliveryRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Print outcome reported by the terminal.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Successful print", value = """
+                                                                    {"status":"SUCCESS"}
+                                                                    """)))
+                    @RequestBody
+                    @Valid
+                    @NonNull
+                    PrintDeliveryRequest request) {
         receiptService.recordPrintDelivery(receiptId, request.status());
         return ResponseEntity.ok().build();
     }
@@ -93,14 +170,40 @@ public class ReceiptController {
     @PostMapping("/{invoiceId}/receipts/{receiptId}/email")
     @EmitEvent(id = "INVOICE_RECEIPT_EMAIL_DELIVERY", apiVersion = "1")
     @Operation(
-            summary = "Email invoice receipt",
-            description = "Send an invoice receipt by email and record the delivery status for the attempt")
+            operationId = "recordReceiptEmailDelivery",
+            summary = "Record Emailed Receipt Delivery Status",
+            description = """
+                    Records the outcome of emailing a receipt to a customer, stamping the receipt's delivery method \
+                    as EMAIL with the recipient address and the reported status; this endpoint records the attempt \
+                    rather than dispatching the email itself.
+                    Use this tool after an email delivery attempt completes; do not use recordReceiptPrintDelivery, \
+                    which records a terminal print outcome.
+                    Preconditions: the receipt must already exist via generateReceipt.
+                    Required inputs: receiptId (UUID) as a path parameter plus emailAddress and status (SUCCESS or \
+                    FAILED) in the body.
+                    Emits an INVOICE_RECEIPT_EMAIL_DELIVERY event and overwrites the receipt's delivery method, \
+                    address and status.
+                    Returns 200 with an empty body on success, and 404 when the receipt does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Email delivery recorded")
     @ApiResponse(responseCode = "404", description = "Receipt not found")
     public ResponseEntity<Void> sendEmailReceipt(
             @PathVariable @NonNull UUID invoiceId,
             @PathVariable @NonNull UUID receiptId,
-            @RequestBody @Valid @NonNull EmailDeliveryRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Recipient address and outcome of the email delivery attempt.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Successful email", value = """
+                                                                    {"emailAddress":"customer@example.com",
+                                                                     "status":"SUCCESS"}
+                                                                    """)))
+                    @RequestBody
+                    @Valid
+                    @NonNull
+                    EmailDeliveryRequest request) {
         receiptService.sendEmailReceipt(receiptId, request.emailAddress(), request.status());
         return ResponseEntity.ok().build();
     }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/StandaloneRefundController.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/controller/StandaloneRefundController.java
@@ -9,6 +9,8 @@ import com.positivity.invoice.internal.enums.RefundReason;
 import com.positivity.invoice.service.PaymentReversalService;
 import com.positivity.invoice.service.RefundPaymentResult;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -54,14 +56,46 @@ public class StandaloneRefundController {
     @PostMapping("/invoices/{invoiceId}/refunds")
     @EmitEvent(id = "INVOICE_STANDALONE_REFUND", apiVersion = "1")
     @Operation(
-            summary = "Record standalone refund for an invoice",
-            description = "Record a refund against an invoice whose original payment is not in the system;"
-                    + " the disbursement itself happens out of band")
+            operationId = "createStandaloneInvoiceRefund",
+            summary = "Record Standalone Invoice Refund",
+            description = """
+                    Records a refund against an invoice whose original payment is not in this system — \
+                    predecessor-system sales, pre-deploy invoices, vendor-paid warranty work — while the cash \
+                    disbursement itself happens out of band (till, check, or vendor payment).
+                    Use this tool only when no captured payment intent exists to refund; do not use refundPayment, \
+                    which reverses a CAPTURED gateway payment, and use createStandalonePartyRefund instead when no \
+                    invoice is on file at all.
+                    Preconditions: the invoice must exist, the caller needs the finance-only ISSUE_MANUAL_REFUND \
+                    authority, and cumulative refunds across payment-anchored and standalone records may not exceed \
+                    the invoice total.
+                    Required inputs: amount (positive) and reason (a RefundReason such as CUSTOMER_RETURN); notes \
+                    and externalReference are optional, and a retry replaying the same externalReference returns \
+                    the existing record instead of double-recording.
+                    Emits an INVOICE_STANDALONE_REFUND event and stores a COMPLETED refund record anchored to the \
+                    invoice; no gateway call is made.
+                    Returns 201 with the refund record, 404 when the invoice does not exist, and 422 when the \
+                    amount exceeds the invoice's remaining refundable balance.
+                    """)
     @ApiResponse(responseCode = "201", description = "Refund recorded")
     @ApiResponse(responseCode = "404", description = "Invoice not found")
     @ApiResponse(responseCode = "422", description = "Insufficient refundable amount")
     public ResponseEntity<RefundPaymentResponse> refundInvoiceStandalone(
-            @PathVariable @NonNull UUID invoiceId, @Valid @RequestBody @NonNull StandaloneRefundRequest request) {
+            @PathVariable @NonNull UUID invoiceId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Out-of-band refund to record against the invoice.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Walk-in warranty refund", value = """
+                                                                    {"amount":25.00,"reason":"CUSTOMER_RETURN",
+                                                                     "notes":"Walk-in warranty claim on a predecessor-system cash sale",
+                                                                     "externalReference":"WC-2026-000042"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    StandaloneRefundRequest request) {
         RefundPaymentResult saved = paymentReversalService.refundInvoiceStandalone(
                 invoiceId, request.amount(), request.reason(), request.notes(), request.externalReference());
         return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(saved));
@@ -70,13 +104,43 @@ public class StandaloneRefundController {
     @PostMapping("/refunds")
     @EmitEvent(id = "INVOICE_PARTY_STANDALONE_REFUND", apiVersion = "1")
     @Operation(
-            summary = "Record standalone refund for a customer party",
-            description = "Record a refund anchored to a customer party when no invoice exists in the system;"
-                    + " the disbursement itself happens out of band")
+            operationId = "createStandalonePartyRefund",
+            summary = "Record Standalone Party Refund",
+            description = """
+                    Records a refund anchored directly to a customer party when no invoice exists in this system, \
+                    such as a vendor-paid warranty settlement on a predecessor-system sale; the cash disbursement \
+                    itself happens out of band.
+                    Use this tool only when there is no invoice to anchor to; use createStandaloneInvoiceRefund \
+                    instead when an invoice is on file, and refundPayment when the captured payment itself exists.
+                    Preconditions: the caller needs the finance-only ISSUE_MANUAL_REFUND authority; because there is \
+                    no invoice, no refundable-amount cap applies.
+                    Required inputs: partyId (non-blank, max 64 characters), amount (positive) and reason (a \
+                    RefundReason); notes and externalReference are optional, and a retry replaying the same \
+                    externalReference among the party's purely party-anchored records returns the existing record.
+                    Emits an INVOICE_PARTY_STANDALONE_REFUND event and stores a COMPLETED refund record anchored to \
+                    the party; no gateway call is made.
+                    Returns 201 with the refund record, and 400 when partyId is blank.
+                    """)
     @ApiResponse(responseCode = "201", description = "Refund recorded")
     @ApiResponse(responseCode = "400", description = "Missing party anchor")
     public ResponseEntity<RefundPaymentResponse> refundPartyStandalone(
-            @Valid @RequestBody @NonNull PartyStandaloneRefundRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Out-of-band refund to record against a customer party with no invoice on file.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Vendor-paid settlement", value = """
+                                                                    {"partyId":"party-000123","amount":25.00,
+                                                                     "reason":"CUSTOMER_RETURN",
+                                                                     "notes":"Vendor-paid warranty settlement, no invoice on file",
+                                                                     "externalReference":"WC-2026-000042"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    PartyStandaloneRefundRequest request) {
         RefundPaymentResult saved = paymentReversalService.refundPartyStandalone(
                 request.partyId(), request.amount(), request.reason(), request.notes(), request.externalReference());
         return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(saved));

--- a/pos-location/openapi.yaml
+++ b/pos-location/openapi.yaml
@@ -31,9 +31,21 @@ paths:
     get:
       tags:
       - Mobile Unit API
-      summary: Get coverage rules
-      description: Get coverage rules for a mobile unit.
-      operationId: getCoverageRules
+      summary: Get Coverage Rules of Mobile Unit
+      description: 'Returns the coverage rules of a mobile unit ordered by ascending priority.
+
+        Use this tool to inspect where a unit currently operates; use findEligibleMobileUnits instead to answer which units cover a given postal code.
+
+        Preconditions: none; an unknown unit id yields an empty list rather than an error.
+
+        Required inputs: id (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the ordered rule list, empty when the unit has no rules or does not exist.
+
+        '
+      operationId: listCoverageRules
       parameters:
       - name: id
         in: path
@@ -58,8 +70,20 @@ paths:
     put:
       tags:
       - Mobile Unit API
-      summary: Replace coverage rules
-      description: Atomically replace coverage rules for a mobile unit.
+      summary: Replace Coverage Rules for Mobile Unit
+      description: 'Atomically replaces the full set of coverage rules for a mobile unit, deleting the existing rules and inserting the supplied ones in one transaction.
+
+        Use this tool whenever coverage changes, sending the complete desired rule set; do not use patchMobileUnit, which cannot modify coverage.
+
+        Preconditions: the mobile unit must exist; a referenced serviceAreaId that does not resolve is stored as a rule without a service area rather than rejected.
+
+        Required inputs: id (UUID) as a path parameter and a body of the form {"rules": [...]}, each rule carrying ruleType and optionally serviceAreaId, priority (defaults to 0), validFrom, validTo and maxDistance.
+
+        Emits a LOCATION_COVERAGE_RULES_REPLACE event.
+
+        Returns 404 when the mobile unit does not exist; an omitted or empty rules array clears all coverage.
+
+        '
       operationId: replaceCoverageRules
       parameters:
       - name: id
@@ -69,10 +93,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Envelope holding the complete replacement rule set under the "rules" key; existing rules not present here are deleted.
         content:
           application/json:
             schema:
               type: object
+            examples:
+              Single service-area rule:
+                description: Single service-area rule
+                value:
+                  rules:
+                  - serviceAreaId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03
+                    ruleType: SERVICE_AREA
+                    priority: 1
+                    validFrom: 2026-06-18
+                    validTo: 2026-12-31
         required: true
       responses:
         '200':
@@ -100,8 +135,20 @@ paths:
     get:
       tags:
       - Location API
-      summary: Get location by ID
-      description: Retrieve a location by its unique ID.
+      summary: Get Location by Unique Identifier
+      description: 'Returns the full location record, including address fields, active flag, responsible person id and type classification, for a known id.
+
+        Use this tool when the location id is already known; use listLocations instead to enumerate, and use validateLocation when only existence and active state are needed.
+
+        Preconditions: the location must exist.
+
+        Required inputs: locationId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no location exists for the supplied id.
+
+        '
       operationId: getLocationById
       parameters:
       - name: locationId
@@ -133,8 +180,20 @@ paths:
     put:
       tags:
       - Location API
-      summary: Update an existing location
-      description: Update the details of an existing location.
+      summary: Update an Existing Location Fully
+      description: 'Replaces the mutable fields of an existing location with the supplied full payload, including address, timezone, operating hours and type.
+
+        Use this tool when the complete corrected state of a location is known; use patchLocation instead to change selected fields and leave the rest untouched.
+
+        Preconditions: the location must exist, and no other location may already use the new name.
+
+        Required inputs: locationId (UUID) as a path parameter plus a full body with name, code and type; omitted optional fields are overwritten with the request values, not preserved.
+
+        Emits a LOCATION_LOCATION_UPDATE event and publishes a location fact for replica consumers.
+
+        Returns 404 when the location does not exist, 409 when the name or code collides with another location, and 422 when the timezone or operating hours are invalid.
+
+        '
       operationId: updateLocation
       parameters:
       - name: locationId
@@ -146,10 +205,33 @@ paths:
           format: uuid
         example: 018e1c9f-6b5a-7890-abcd-1234567890ab
       requestBody:
+        description: Full replacement state for the location; every mutable field is overwritten with the values supplied here.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LocationRequestDTO'
+            examples:
+              Full replacement:
+                description: Full replacement
+                value:
+                  name: Downtown Service Center
+                  code: LOC-001
+                  type:
+                    name: STORE
+                  timezone: America/Chicago
+                  addressLine1: 123 Main St
+                  city: Springfield
+                  state: IL
+                  postalCode: '62704'
+                  country: US
+                  active: true
+                  responsiblePersonId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  operatingHours:
+                  - dayOfWeek: MONDAY
+                    openTime: 08:00
+                    closeTime: 1020
+                  checkInBufferMinutes: 15
+                  cleanupBufferMinutes: 10
         required: true
       responses:
         '200':
@@ -164,6 +246,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LocationResponseDTO'
+        '409':
+          description: Location name or code already taken.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationResponseDTO'
+        '422':
+          description: Invalid timezone or operating hours.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationResponseDTO'
       security:
       - bearerAuth:
         - location:write
@@ -172,8 +266,20 @@ paths:
     delete:
       tags:
       - Location API
-      summary: Delete a location
-      description: Delete a location by its unique ID.
+      summary: Delete a Location by Identifier
+      description: 'Deletes a location permanently by id and publishes a deletion fact so replica consumers drop the row.
+
+        Use this tool only when a location was created in error; use patchLocation with status INACTIVE instead to retire a real site while preserving history.
+
+        Preconditions: the location must exist; there is no child-relationship or usage check, so callers must confirm the location is unreferenced first.
+
+        Required inputs: locationId (UUID) as a path parameter; there is no request body.
+
+        Emits a LOCATION_LOCATION_DELETE event; the row is hard-deleted, not soft-deleted.
+
+        Returns 204 on success and 404 when the location does not exist.
+
+        '
       operationId: deleteLocation
       parameters:
       - name: locationId
@@ -197,8 +303,20 @@ paths:
     patch:
       tags:
       - Location API
-      summary: Patch a location
-      description: Patch selected fields for a location.
+      summary: Patch Selected Fields of a Location
+      description: 'Applies a partial update to a location, changing only the supplied fields: name, status, timezone, operatingHours, holidayClosures, checkInBufferMinutes and cleanupBufferMinutes.
+
+        Use this tool for targeted edits such as deactivation or hours changes; do not use updateLocation, which overwrites every mutable field including address and type.
+
+        Preconditions: the location must exist, and a new name must not be used by another location.
+
+        Required inputs: locationId (UUID) as a path parameter and a body with at least one field; status only accepts the value INACTIVE to deactivate, and reactivation is not supported through this operation.
+
+        Emits a LOCATION_PATCH event and publishes a location fact for replica consumers.
+
+        Returns 404 when the location does not exist, 409 when the new name is taken, and 422 when a supplied timezone or operating-hours entry is invalid.
+
+        '
       operationId: patchLocation
       parameters:
       - name: locationId
@@ -210,10 +328,16 @@ paths:
           format: uuid
         example: 018e1c9f-6b5a-7890-abcd-1234567890ab
       requestBody:
+        description: Partial location payload; only non-null fields are applied and all others are left unchanged.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LocationPatchRequest'
+            examples:
+              Deactivate location:
+                description: Deactivate location
+                value:
+                  status: INACTIVE
         required: true
       responses:
         '200':
@@ -228,6 +352,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LocationResponseDTO'
+        '409':
+          description: Location name already taken.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationResponseDTO'
+        '422':
+          description: Invalid timezone or operating hours.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationResponseDTO'
       security:
       - bearerAuth:
         - location:write
@@ -237,9 +373,21 @@ paths:
     get:
       tags:
       - Site Defaults API
-      summary: Get site defaults
-      description: Retrieve default site configuration for a location.
-      operationId: getDefaults
+      summary: Get Default Storage Locations for Site
+      description: 'Returns the default staging and quarantine storage location ids configured for a site.
+
+        Use this tool when routing received or quarantined inventory; do not use configureSiteDefaults, which overwrites the assignment.
+
+        Preconditions: the site must exist; both ids are null when defaults were never configured.
+
+        Required inputs: locationId (UUID) as a path parameter.
+
+        Emits a LOCATION_SITE_DEFAULTS_GET event; no state changes.
+
+        Returns 404 when the site does not exist.
+
+        '
+      operationId: getSiteDefaults
       parameters:
       - name: locationId
         in: path
@@ -275,9 +423,21 @@ paths:
     put:
       tags:
       - Site Defaults API
-      summary: Configure site defaults
-      description: Create or update default site configuration for a location.
-      operationId: configureDefaults
+      summary: Configure Default Storage Locations for Site
+      description: 'Creates or replaces the default staging and quarantine storage locations of a site in a single idempotent upsert.
+
+        Use this tool when commissioning a site''s receiving flow or moving its defaults; use getSiteDefaults instead to read the current assignment.
+
+        Preconditions: the site must exist, and both referenced storage locations must belong to that site.
+
+        Required inputs: locationId (UUID) as a path parameter and a body with both defaultStagingLocationId and defaultQuarantineLocationId; the two ids must differ.
+
+        Emits a LOCATION_SITE_DEFAULTS_PUT event and republishes the location fact carrying the new defaults.
+
+        Returns 404 when the site does not exist, 400 when either id is missing or both ids are the same, and 422 when a referenced storage location does not belong to the site.
+
+        '
+      operationId: configureSiteDefaults
       parameters:
       - name: locationId
         in: path
@@ -287,10 +447,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Pair of storage location ids to install as the site's staging and quarantine defaults.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SiteDefaultsRequest'
+            examples:
+              Staging and quarantine defaults:
+                description: Staging and quarantine defaults
+                value:
+                  defaultStagingLocationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                  defaultQuarantineLocationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
         required: true
       responses:
         '200':
@@ -317,6 +484,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SiteDefaultsResponse'
+        '422':
+          description: Default storage location does not belong to the site
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SiteDefaultsResponse'
       security:
       - bearerAuth:
         - location:write
@@ -326,9 +499,21 @@ paths:
     get:
       tags:
       - Travel Buffer Policy API
-      summary: List travel buffer policies
-      description: List configured travel buffer policies available for routing and scheduling decisions
-      operationId: list
+      summary: List All Travel Buffer Policies
+      description: 'Lists all travel buffer policies with their buffer type, value and notes.
+
+        Use this tool to discover policy ids for createMobileUnit or patchMobileUnit; use patchTravelBufferPolicy instead to change one.
+
+        Preconditions: none beyond the location:travel-buffer-policy:read authority.
+
+        Required inputs: none; there are no parameters, no paging and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the full unpaginated list.
+
+        '
+      operationId: listTravelBufferPolicies
       responses:
         '200':
           description: Travel buffer policies listed
@@ -346,18 +531,45 @@ paths:
     post:
       tags:
       - Travel Buffer Policy API
-      summary: Create travel buffer policy
-      description: Create a travel buffer policy that defines extra travel time handling rules
-      operationId: create
+      summary: Create a New Travel Buffer Policy
+      description: 'Creates a travel buffer policy that adds slack time around mobile unit travel for scheduling decisions.
+
+        Use this tool before assigning the policy to mobile units via createMobileUnit or patchMobileUnit; do not use patchTravelBufferPolicy, which edits an existing policy.
+
+        Preconditions: the name must not collide with an existing policy.
+
+        Required inputs: name and bufferType, one of FLAT_MINUTES, PERCENTAGE_OF_TRAVEL or DISTANCE_MULTIPLIER; bufferValue is optional, must be non-negative, and is interpreted according to the bufferType.
+
+        Emits a LOCATION_TRAVEL_BUFFER_POLICY_CREATE event.
+
+        Returns 201 with the created policy and 409 when the name is already taken.
+
+        '
+      operationId: createTravelBufferPolicy
       requestBody:
+        description: Travel buffer policy to create, pairing a buffer type with its numeric value.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/TravelBufferPolicyRequest'
+            examples:
+              Flat minutes buffer:
+                description: Flat minutes buffer
+                value:
+                  name: Standard Metro Buffer
+                  bufferType: FLAT_MINUTES
+                  bufferValue: 30
+                  notes: Applies during peak hours only
         required: true
       responses:
         '201':
           description: Travel buffer policy created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TravelBufferPolicyResponse'
+        '409':
+          description: Travel buffer policy name already taken
           content:
             application/json:
               schema:
@@ -371,9 +583,21 @@ paths:
     get:
       tags:
       - Service Area API
-      summary: List service areas
-      description: List configured service areas available for dispatching and coverage management
-      operationId: list_1
+      summary: List All Configured Service Areas
+      description: 'Lists all configured service areas with their postal code sets and active flags.
+
+        Use this tool to discover area ids for coverage rules; use listCoverageRules instead to see which areas a specific mobile unit uses.
+
+        Preconditions: none beyond the location:service-area:read authority.
+
+        Required inputs: none; there are no parameters, no paging and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the full unpaginated list.
+
+        '
+      operationId: listServiceAreas
       responses:
         '200':
           description: Service areas listed
@@ -391,18 +615,49 @@ paths:
     post:
       tags:
       - Service Area API
-      summary: Create service area
-      description: Create a service area that defines where a location can provide service coverage
-      operationId: create_1
+      summary: Create a Postal Code Service Area
+      description: 'Creates a service area, a named set of postal codes that defines where mobile coverage can be offered.
+
+        Use this tool before wiring coverage rules that reference the area; do not use patchServiceArea, which edits an existing area.
+
+        Preconditions: at least one postal code entry must be supplied and every entry must carry a countryCode; the name must not collide with an existing service area.
+
+        Required inputs: name and postalCodes, each entry with postalCode and countryCode; description is optional and active defaults to true.
+
+        Emits a LOCATION_SERVICE_AREA_CREATE event.
+
+        Returns 201 with the created area and 409 when the name is already taken.
+
+        '
+      operationId: createServiceArea
       requestBody:
+        description: Service area to create, defined by its postal code and country code entries.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ServiceAreaRequest'
+            examples:
+              Metro area:
+                description: Metro area
+                value:
+                  name: North Metro
+                  description: Northern metropolitan coverage zone
+                  active: true
+                  postalCodes:
+                  - postalCode: '62704'
+                    countryCode: US
+                  - postalCode: '62711'
+                    countryCode: US
         required: true
       responses:
         '201':
           description: Service area created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceAreaResponse'
+        '409':
+          description: Service area name already taken
           content:
             application/json:
               schema:
@@ -416,8 +671,20 @@ paths:
     get:
       tags:
       - Mobile Unit API
-      summary: List mobile units
-      description: List mobile units with pagination.
+      summary: List Mobile Units With Pagination
+      description: 'Lists all mobile units as a page with status, base location and travel buffer policy references.
+
+        Use this tool to enumerate or browse units; use getMobileUnitById instead when the unit id is known, and findEligibleMobileUnits to match units to a service address.
+
+        Preconditions: none beyond the location:mobile-unit:read authority.
+
+        Required inputs: none; page defaults to 0 and size to 20.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with a page of mobile units, empty when none exist.
+
+        '
       operationId: listMobileUnits
       parameters:
       - name: page
@@ -449,18 +716,53 @@ paths:
     post:
       tags:
       - Mobile Unit API
-      summary: Create mobile unit
-      description: Create a new mobile unit.
+      summary: Create a New Mobile Service Unit
+      description: 'Creates a mobile service unit with an optional base location, travel buffer policy, capability list and initial coverage rules.
+
+        Use this tool when commissioning a van or truck that serves customers off-site; do not use patchMobileUnit, which updates an existing unit, and change coverage later with replaceCoverageRules.
+
+        Preconditions: a unit created with status ACTIVE must include travelBufferPolicyId, capabilityIds and coverageRules; the travel buffer policy must exist, capability ids or codes must resolve to registered capabilities, DISTANCE_TIER coverage rules must be strictly ascending by maxDistance and end with a null catch-all tier, and the name must be unique at the base location.
+
+        Required inputs: name; status defaults to INACTIVE when omitted, and baseLocationId, travelBufferPolicyId, notes, capabilityIds and coverageRules are optional for inactive units.
+
+        Emits a LOCATION_MOBILE_UNIT_CREATE event and persists any supplied coverage rules in the same transaction.
+
+        Returns 201 with the created unit and 409 when the name is already taken at the base location.
+
+        '
       operationId: createMobileUnit
       requestBody:
+        description: Mobile unit to create; an ACTIVE unit must arrive complete with its travel buffer policy, capabilities and coverage rules.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/MobileUnitRequest'
+            examples:
+              Active mobile unit:
+                description: Active mobile unit
+                value:
+                  name: Van 7
+                  baseLocationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                  status: ACTIVE
+                  travelBufferPolicyId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
+                  notes: Equipped with hydraulic lift
+                  capabilityIds:
+                  - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a10
+                  coverageRules:
+                  - serviceAreaId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03
+                    ruleType: SERVICE_AREA
+                    priority: 1
+                    validFrom: 2026-06-18
         required: true
       responses:
         '201':
           description: Mobile unit created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MobileUnitResponse'
+        '409':
+          description: Mobile unit name already taken at the base location.
           content:
             application/json:
               schema:
@@ -474,9 +776,21 @@ paths:
     get:
       tags:
       - Location API
-      summary: Get all locations
-      description: Retrieve a list of all locations.
-      operationId: getAllLocations
+      summary: List All Locations Without Pagination
+      description: 'Lists every location in the system as a flat, unpaginated collection with address, status and type details.
+
+        Use this tool when a complete location inventory is needed at once; use getLocationRoster instead for a paginated sync feed with status and updated-since filtering, and do not use it to fetch a single known id, which is getLocationById.
+
+        Preconditions: none beyond the location:read authority; an empty system returns an empty list.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the full list; there are no business error conditions for this operation.
+
+        '
+      operationId: listLocations
       responses:
         '200':
           description: List of locations returned successfully.
@@ -494,18 +808,65 @@ paths:
     post:
       tags:
       - Location API
-      summary: Create a new location
-      description: Add a new location to the system.
+      summary: Create a New Location Record
+      description: 'Creates a location with address, timezone, operating hours, scheduling buffers and type classification, defaulting status to ACTIVE.
+
+        Use this tool when registering a new physical or logical site; do not use updateLocation, which replaces an existing location, and use bulkIngestLocations for batch imports.
+
+        Preconditions: no existing location may share the same name (case-insensitive) or code, and a type referenced by id must already exist; a type given only by name is created on the fly.
+
+        Required inputs: name, code and type (id or name); timezone must be a valid IANA zone id, operatingHours entries must have unique dayOfWeek values with openTime before closeTime, and active defaults to true.
+
+        Emits a LOCATION_LOCATION_CREATE event and publishes a location fact for replica consumers.
+
+        Returns 409 when the name or code is already taken, 422 when the timezone or operating hours are invalid, and 400 when a referenced location type id is unknown.
+
+        '
       operationId: createLocation
       requestBody:
+        description: Location to create, including its type and optional address, timezone and operating-hours configuration.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LocationRequestDTO'
+            examples:
+              Store location:
+                description: Store location
+                value:
+                  name: Downtown Service Center
+                  code: LOC-001
+                  type:
+                    name: STORE
+                  timezone: America/Chicago
+                  addressLine1: 123 Main St
+                  city: Springfield
+                  state: IL
+                  postalCode: '62704'
+                  country: US
+                  active: true
+                  responsiblePersonId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  operatingHours:
+                  - dayOfWeek: MONDAY
+                    openTime: 08:00
+                    closeTime: 1020
+                  checkInBufferMinutes: 15
+                  cleanupBufferMinutes: 10
         required: true
       responses:
         '201':
           description: Location created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationResponseDTO'
+        '409':
+          description: Location name or code already taken.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationResponseDTO'
+        '422':
+          description: Invalid timezone or operating hours.
           content:
             application/json:
               schema:
@@ -519,9 +880,21 @@ paths:
     get:
       tags:
       - Storage Location API
-      summary: List storage locations
-      description: List storage locations for a site with optional type and status filtering
-      operationId: list_2
+      summary: List Storage Locations of a Site
+      description: 'Lists the storage locations of a site as a page, optionally filtered by type and status.
+
+        Use this tool for paginated browsing; use getStorageLocationTopology instead when the complete unpaginated hierarchy of the site is needed.
+
+        Preconditions: none; an unknown site id yields an empty page rather than an error.
+
+        Required inputs: siteId (UUID) as a path parameter; type (FLOOR, SHELF, BIN, CAGE, TRUCK) and status (ACTIVE, INACTIVE, MAINTENANCE, QUARANTINED) filters are optional, and standard page, size and sort parameters control paging.
+
+        Emits a LOCATION_STORAGE_LOCATION_LIST event; no state changes.
+
+        Returns 200 with a page of storage locations regardless of whether any match the filters.
+
+        '
+      operationId: listStorageLocations
       parameters:
       - name: siteId
         in: path
@@ -570,9 +943,21 @@ paths:
     post:
       tags:
       - Storage Location API
-      summary: Create storage location
-      description: Create a storage location within a site using the provided topology and status details
-      operationId: create_2
+      summary: Create a Storage Location Within Site
+      description: 'Creates a storage location (FLOOR, SHELF, BIN, CAGE or TRUCK) inside a site, always starting in ACTIVE status.
+
+        Use this tool when adding storage topology to a site; do not use patchStorageLocation, which modifies an existing node, and use createBay for vehicle service bays rather than inventory storage.
+
+        Preconditions: the site must exist, the name must be unique within the site (case-insensitive), any barcode must be unique within the site, and a parentStorageLocationId must reference a storage location of the same site.
+
+        Required inputs: name and type; barcode, parentStorageLocationId, capacity and temperature (free-form JSON objects) are optional.
+
+        Emits a LOCATION_STORAGE_LOCATION_CREATE event and publishes a storage-location fact for replica consumers.
+
+        Returns 404 when the site does not exist, 409 when the name or barcode is already used in the site, and 400 when the parent storage location is unknown or belongs to a different site.
+
+        '
+      operationId: createStorageLocation
       parameters:
       - name: siteId
         in: path
@@ -581,14 +966,47 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Storage location to create, positioned in the site's topology via its optional parent reference.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/StorageLocationRequest'
+            examples:
+              Refrigerated bin:
+                description: Refrigerated bin
+                value:
+                  name: Aisle 3 Bin 12
+                  barcode: SL-000312
+                  type: BIN
+                  parentStorageLocationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a10
+                  capacity:
+                    maxUnits: 100
+                  temperature:
+                    min: 2
+                    max: 8
+                    unit: C
         required: true
       responses:
         '201':
           description: Storage location created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageLocationResponse'
+        '400':
+          description: Parent storage location unknown or in another site
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageLocationResponse'
+        '404':
+          description: Site not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageLocationResponse'
+        '409':
+          description: Duplicate name or barcode within the site
           content:
             application/json:
               schema:
@@ -602,8 +1020,20 @@ paths:
     get:
       tags:
       - Bay API
-      summary: List bays
-      description: List bays for a location with optional status and bayType filters.
+      summary: List Service Bays of a Location
+      description: 'Lists the service bays of a location as a page, optionally filtered by status and bayType.
+
+        Use this tool to see bay capacity and status for a shop; use getBay instead when the bay id is already known.
+
+        Preconditions: the location must exist.
+
+        Required inputs: locationId (UUID) as a path parameter; status (ACTIVE or OUT_OF_SERVICE) and bayType filters are optional, and page defaults to 0 with size 20.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the location does not exist; an unrecognized status or bayType filter value fails the request rather than returning an empty page.
+
+        '
       operationId: listBays
       parameters:
       - name: locationId
@@ -643,6 +1073,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PageBayResponse'
+        '404':
+          description: Location not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageBayResponse'
       security:
       - bearerAuth:
         - location:bay:read
@@ -651,8 +1087,20 @@ paths:
     post:
       tags:
       - Bay API
-      summary: Create bay
-      description: Create a new bay for a specific location.
+      summary: Create a Service Bay for Location
+      description: 'Creates a service bay under a location with a type classification, concurrency capacity and optional capability and skill requirements.
+
+        Use this tool when adding physical work capacity to a shop; do not use patchBay, which modifies a bay that already exists, and use createStorageLocation for inventory storage rather than vehicle bays.
+
+        Preconditions: the location must exist, no bay of that location may already use the name (case-insensitive), and any serviceCapabilityIds must match registered service capability codes.
+
+        Required inputs: name, bayType (one of GENERAL_SERVICE, ALIGNMENT, TIRE_SERVICE, HEAVY_DUTY, INSPECTION or WASH_DETAIL) and capacity.maxConcurrentVehicles of at least 1; status is optional, defaults to ACTIVE and only also accepts OUT_OF_SERVICE.
+
+        Emits a LOCATION_BAY_CREATE event; no other records are touched.
+
+        Returns 404 when the location does not exist and 409 when the bay name is already taken at that location.
+
+        '
       operationId: createBay
       parameters:
       - name: locationId
@@ -661,16 +1109,42 @@ paths:
         required: true
         schema:
           type: string
-        example: 1
+        example: 018e1c9f-6b5a-7890-abcd-1234567890ab
       requestBody:
+        description: Service bay to create, with its type classification and concurrent vehicle capacity.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BayRequest'
+            examples:
+              General service bay:
+                description: General service bay
+                value:
+                  name: Bay A1
+                  bayType: GENERAL_SERVICE
+                  capacity:
+                    maxConcurrentVehicles: 2
+                  serviceCapabilityIds:
+                  - ALIGNMENT
+                  skillRequirementIds:
+                  - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a20
+                  status: ACTIVE
         required: true
       responses:
         '201':
           description: Bay created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BayResponse'
+        '404':
+          description: Location not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BayResponse'
+        '409':
+          description: Bay name already taken at this location.
           content:
             application/json:
               schema:
@@ -684,9 +1158,21 @@ paths:
     post:
       tags:
       - Location API
-      summary: Add a parent to a location
-      description: Add a parent relationship to a location.
-      operationId: addParent
+      summary: Add Typed Parent Relationship to Location
+      description: 'Creates a typed parent-child edge between two existing locations, giving the child at most one parent per relationship type.
+
+        Use this tool when building the location hierarchy; do not use listLocationChildren or listLocationDescendants, which only read the hierarchy.
+
+        Preconditions: both locations must exist, the child must not already have a parent of that type, the pair must not already be linked in either direction, and the parent must not be a descendant of the child because cycles are forbidden by ADR-0016.
+
+        Required inputs: childId and parentId (UUIDs) as path parameters and a parentType query parameter, one of HOME_OFFICE, HEADQUARTERS, REGION, DISTRICT, PHYSICAL, ORGANIZATIONAL, FINANCIAL or SHIPPING.
+
+        Emits a LOCATION_PARENT_ADD event and republishes the child''s location fact, which carries the new edge to replica consumers.
+
+        Returns 400 when parentType is not a recognized value; self-parenting, duplicate, inverse or circular relationships are rejected before the edge is written.
+
+        '
+      operationId: addLocationParent
       parameters:
       - name: childId
         in: path
@@ -717,6 +1203,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LocationParentResponseDTO'
+        '400':
+          description: Invalid parentType value.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationParentResponseDTO'
       security:
       - bearerAuth:
         - location:write
@@ -726,14 +1218,44 @@ paths:
     post:
       tags:
       - Location Bulk Ingest API
-      summary: Bulk ingest records
-      description: Accepts a batch of domain records for bulk import. Returns per-record results.
-      operationId: bulkIngest
+      summary: Bulk Import a Batch of Locations
+      description: 'Imports a batch of location records in one call, creating each row independently and reporting per-record success or failure.
+
+        Use this tool for initial data loads or migrations; do not use createLocation, which creates a single location per call.
+
+        Preconditions: names and codes must be unique against existing locations; each record is validated independently, so one failure does not abort the batch.
+
+        Required inputs: jobId, locationId and a non-empty records array, each record with name and code; active defaults to true and locationTypeName defaults to STORE when omitted.
+
+        Emits a LOCATION_BULK_INGEST event, and every successfully created location also publishes a location fact for replica consumers.
+
+        Returns 200 with per-record results even when some records fail (failed rows carry errorCode LOCATION_INGEST_FAILED), and 400 when the batch envelope itself is invalid.
+
+        '
+      operationId: bulkIngestLocations
       requestBody:
+        description: Batch envelope of location records to import, scoped to a bulk ingest job and submitting operator.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BulkIngestRequestLocationBulkIngestRecord'
+            examples:
+              Single-record batch:
+                description: Single-record batch
+                value:
+                  jobId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
+                  operatorId: user-jdoe
+                  records:
+                  - name: Downtown Service Center
+                    code: LOC-001
+                    addressLine1: 123 Main St
+                    city: Springfield
+                    stateOrProvince: IL
+                    postalCode: '62704'
+                    countryCode: US
+                    active: true
+                    locationTypeName: STORE
         required: true
       responses:
         '200':
@@ -757,9 +1279,21 @@ paths:
     patch:
       tags:
       - Travel Buffer Policy API
-      summary: Patch travel buffer policy
-      description: Patch an existing travel buffer policy using the provided partial field updates
-      operationId: patch
+      summary: Patch Fields of Travel Buffer Policy
+      description: 'Applies a partial update to a travel buffer policy, accepting the keys bufferType, bufferValue and notes.
+
+        Use this tool to tune buffer behavior; do not use it to rename a policy, whose name is immutable after createTravelBufferPolicy.
+
+        Preconditions: the policy must exist; the resulting bufferType must remain one of FLAT_MINUTES, PERCENTAGE_OF_TRAVEL or DISTANCE_MULTIPLIER and the resulting bufferValue non-negative.
+
+        Required inputs: id (UUID) as a path parameter and a JSON object of the fields to change; keys other than bufferType, bufferValue and notes are silently ignored.
+
+        Emits a LOCATION_TRAVEL_BUFFER_POLICY_PATCH event.
+
+        Returns 400 when the id is not a valid UUID and 404 when no policy exists for it.
+
+        '
+      operationId: patchTravelBufferPolicy
       parameters:
       - name: id
         in: path
@@ -767,10 +1301,16 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Free-form patch object; only the keys bufferType, bufferValue and notes are recognized.
         content:
           application/json:
             schema:
               type: object
+            examples:
+              Raise buffer value:
+                description: Raise buffer value
+                value:
+                  bufferValue: 45
         required: true
       responses:
         '200':
@@ -800,9 +1340,21 @@ paths:
     patch:
       tags:
       - Service Area API
-      summary: Patch service area
-      description: Patch an existing service area using the provided partial field updates
-      operationId: patch_1
+      summary: Patch Fields of a Service Area
+      description: 'Applies a partial update to a service area, accepting only the keys description and active.
+
+        Use this tool to retire an area with active=false or amend its description; do not use it to rename an area or change its postal codes, which are immutable after createServiceArea.
+
+        Preconditions: the service area must exist.
+
+        Required inputs: id (UUID) as a path parameter and a JSON object; keys other than description and active are silently ignored.
+
+        Emits a LOCATION_SERVICE_AREA_PATCH event.
+
+        Returns 400 when the id is not a valid UUID and 404 when no service area exists for it.
+
+        '
+      operationId: patchServiceArea
       parameters:
       - name: id
         in: path
@@ -810,10 +1362,17 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Free-form patch object; only the keys description and active are recognized.
         content:
           application/json:
             schema:
               type: object
+            examples:
+              Retire area:
+                description: Retire area
+                value:
+                  description: Retired winter zone
+                  active: false
         required: true
       responses:
         '200':
@@ -843,8 +1402,20 @@ paths:
     get:
       tags:
       - Mobile Unit API
-      summary: Get mobile unit
-      description: Get a mobile unit by ID.
+      summary: Get a Mobile Unit by Identifier
+      description: 'Returns a single mobile unit with its status, base location, capability ids and travel buffer policy reference.
+
+        Use this tool when the unit id is already known; use listMobileUnits instead to enumerate, and listCoverageRules to read the unit''s coverage separately.
+
+        Preconditions: the mobile unit must exist.
+
+        Required inputs: id (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no mobile unit exists for the supplied id.
+
+        '
       operationId: getMobileUnitById
       parameters:
       - name: id
@@ -875,8 +1446,20 @@ paths:
     patch:
       tags:
       - Mobile Unit API
-      summary: Patch mobile unit
-      description: Partially update a mobile unit.
+      summary: Patch Fields of a Mobile Unit
+      description: 'Applies a partial update to a mobile unit, accepting the keys name, status, notes and travelBufferPolicyId.
+
+        Use this tool for status transitions and travel-buffer-policy reassignment; use replaceCoverageRules instead to change where the unit operates.
+
+        Preconditions: none are enforced; when the unit id does not exist nothing is persisted and a synthesized response built from the patch is echoed back, so callers must verify existence first with getMobileUnitById.
+
+        Required inputs: id (UUID) as a path parameter and a JSON object of the fields to change; status values are upper-cased and a blank status normalizes to INACTIVE.
+
+        Emits a LOCATION_MOBILE_UNIT_UPDATE event.
+
+        Returns 200 even for unknown ids (with the unpersisted echo) and 409 when a name change collides with another unit at the same base location.
+
+        '
       operationId: patchMobileUnit
       parameters:
       - name: id
@@ -886,14 +1469,27 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Free-form patch object; only the keys name, status, notes and travelBufferPolicyId are recognized.
         content:
           application/json:
             schema:
               type: object
+            examples:
+              Deactivate unit:
+                description: Deactivate unit
+                value:
+                  status: INACTIVE
+                  notes: Winter maintenance
         required: true
       responses:
         '200':
           description: Mobile units managed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MobileUnitResponse'
+        '409':
+          description: Mobile unit name already taken at the base location.
           content:
             application/json:
               schema:
@@ -907,9 +1503,21 @@ paths:
     get:
       tags:
       - Storage Location API
-      summary: Get storage location
-      description: Retrieve a single storage location for a site by its storage location identifier
-      operationId: get
+      summary: Get a Storage Location by Identifier
+      description: 'Returns a single storage location of a site, including capacity and temperature attributes and its parent reference.
+
+        Use this tool when the storage location id and its site are both known; use validateStorageLocation instead when only existence, active state and site ownership must be checked without knowing the site.
+
+        Preconditions: the storage location must exist and belong to the supplied site.
+
+        Required inputs: siteId and storageLocationId (UUIDs) as path parameters.
+
+        Emits a LOCATION_STORAGE_LOCATION_GET event; no state changes.
+
+        Returns 404 when no storage location with that id exists under the site.
+
+        '
+      operationId: getStorageLocation
       parameters:
       - name: siteId
         in: path
@@ -944,9 +1552,21 @@ paths:
     patch:
       tags:
       - Storage Location API
-      summary: Patch storage location
-      description: Patch an existing storage location for a site using the provided partial updates
-      operationId: patch_2
+      summary: Patch Fields of a Storage Location
+      description: 'Applies a partial update to a storage location, covering rename, barcode, reparenting, capacity, temperature and status transitions.
+
+        Use this tool for all storage-location mutations after creation, including deactivation; do not use createStorageLocation, which adds a new node.
+
+        Preconditions: the storage location must exist in the site; a new name or barcode must be unique within the site, a new parent must belong to the same site without creating a cycle, and deactivating a node that still holds on-hand stock requires a destinationStorageLocationId naming an ACTIVE storage location of the same site to receive the transferred inventory.
+
+        Required inputs: siteId and storageLocationId (UUIDs) as path parameters and a body with at least one field; status accepts ACTIVE, INACTIVE, MAINTENANCE or QUARANTINED.
+
+        Emits a LOCATION_STORAGE_LOCATION_UPDATE event, publishes a storage-location fact, and on deactivation with stock triggers an atomic inventory transfer to the destination.
+
+        Returns 404 when the storage location or transfer destination does not exist, 409 when the name or barcode collides or the new parent would create a cycle, 400 when the parent is unknown or in another site, and 422 when deactivation needs a destination that is missing, inactive or the node itself.
+
+        '
+      operationId: patchStorageLocation
       parameters:
       - name: siteId
         in: path
@@ -961,10 +1581,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Partial storage-location payload; only non-null fields are applied, and destinationStorageLocationId is consumed only when deactivating a node that still holds stock.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/StorageLocationPatchRequest'
+            examples:
+              Deactivate with stock transfer:
+                description: Deactivate with stock transfer
+                value:
+                  status: INACTIVE
+                  destinationStorageLocationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a11
         required: true
       responses:
         '200':
@@ -973,8 +1600,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StorageLocationResponse'
+        '400':
+          description: Parent storage location unknown or in another site
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageLocationResponse'
         '404':
           description: Storage location not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageLocationResponse'
+        '409':
+          description: Duplicate name or barcode, or reparenting would create a cycle
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageLocationResponse'
+        '422':
+          description: Deactivation destination missing, inactive or invalid
           content:
             application/json:
               schema:
@@ -988,8 +1633,20 @@ paths:
     get:
       tags:
       - Bay API
-      summary: Get bay
-      description: Get a bay by location and bay id.
+      summary: Get a Service Bay by Identifier
+      description: 'Returns a single service bay of a location, including its capacity, capability and skill requirement details.
+
+        Use this tool when both the location id and bay id are known; use listBays instead to search or enumerate.
+
+        Preconditions: the location must exist and the bay must belong to it.
+
+        Required inputs: locationId and bayId (UUIDs) as path parameters.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the location does not exist or the bay is not found under that location.
+
+        '
       operationId: getBay
       parameters:
       - name: locationId
@@ -1025,8 +1682,20 @@ paths:
     patch:
       tags:
       - Bay API
-      summary: Patch bay
-      description: Patch bay fields including status transition and capacity.
+      summary: Patch Fields of a Service Bay
+      description: 'Applies a partial update to a bay, changing only the supplied fields: name, bayType, status, capacity and the capability or skill requirement lists.
+
+        Use this tool for status transitions between ACTIVE and OUT_OF_SERVICE and for capacity changes; do not use createBay, which adds a new bay.
+
+        Preconditions: the location must exist, the bay must belong to it, and a new name must not collide with another bay at the same location.
+
+        Required inputs: locationId and bayId (UUIDs) as path parameters and a body with at least one field; capacity.maxConcurrentVehicles, when supplied, must be at least 1.
+
+        Emits a LOCATION_BAY_UPDATE event; no other records are touched.
+
+        Returns 404 when the location or bay does not exist and 409 when the new name is already taken at that location.
+
+        '
       operationId: patchBay
       parameters:
       - name: locationId
@@ -1040,14 +1709,32 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Partial bay payload; only non-null fields are applied and all others are left unchanged.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BayPatchRequest'
+            examples:
+              Take bay out of service:
+                description: Take bay out of service
+                value:
+                  status: OUT_OF_SERVICE
         required: true
       responses:
         '200':
           description: Bay updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BayResponse'
+        '404':
+          description: Location or bay not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BayResponse'
+        '409':
+          description: Bay name already taken at this location.
           content:
             application/json:
               schema:
@@ -1061,8 +1748,20 @@ paths:
     get:
       tags:
       - storage-location-validation-controller
-      summary: Validate storage location reference
-      description: Returns existence, active status, and site ownership for a storage location ID.
+      summary: Validate Storage Location Reference State
+      description: 'Returns existence, active status, owning site id and maximum unit capacity for a storage location id without requiring the site to be known.
+
+        Use this tool for inter-service reference validation before storing a storageLocationId; use getStorageLocation instead when the full record is needed and the site id is known.
+
+        Preconditions: none; unknown ids are a valid input.
+
+        Required inputs: storageLocationId (UUID) as a path parameter.
+
+        Emits a LOCATION_STORAGE_LOCATION_VALIDATE event; no state changes.
+
+        Returns 200 always, with exists=false and a null siteId when the id is unknown, and 400 when the path value is not a valid UUID.
+
+        '
       operationId: validateStorageLocation
       parameters:
       - name: storageLocationId
@@ -1100,8 +1799,20 @@ paths:
     get:
       tags:
       - mobile-unit-eligibility-controller
-      summary: Find eligible mobile units
-      description: Return eligible active units for a service request.
+      summary: Find Eligible Mobile Units for Address
+      description: 'Finds the ACTIVE mobile units whose coverage rules include a postal code on a given date, ordered by ascending rule priority.
+
+        Use this tool when dispatching a mobile service request to a customer address; use listMobileUnits instead for plain enumeration without eligibility matching.
+
+        Preconditions: coverage rules must already link units to service areas containing the postal code; units whose status is not ACTIVE are excluded.
+
+        Required inputs: postalCode, countryCode and at (an ISO-8601 instant), all mandatory; the instant is reduced to a UTC calendar date for validFrom and validTo matching.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the eligible units, empty when nothing covers the address on that date.
+
+        '
       operationId: findEligibleMobileUnits
       parameters:
       - name: postalCode
@@ -1138,9 +1849,21 @@ paths:
     get:
       tags:
       - Storage Location API
-      summary: Get storage location topology
-      description: Return every storage location of a site, regardless of status, as a flat unpaginated list with id, name, type, status, and parentStorageLocationId for topology consumers
-      operationId: topology
+      summary: Get Full Storage Location Topology
+      description: 'Returns every storage location of a site, regardless of status, as a flat unpaginated list with id, name, type, status and parentStorageLocationId.
+
+        Use this tool when a rollup or topology consumer needs the whole storage tree in one call; use listStorageLocations instead for paginated, filtered browsing.
+
+        Preconditions: the site must exist.
+
+        Required inputs: siteId (UUID) as a path parameter; there is no filtering.
+
+        Emits a LOCATION_STORAGE_LOCATION_TOPOLOGY event; no state changes.
+
+        Returns 404 when the site does not exist.
+
+        '
+      operationId: getStorageLocationTopology
       parameters:
       - name: siteId
         in: path
@@ -1175,8 +1898,20 @@ paths:
     get:
       tags:
       - Location API
-      summary: Validate location reference
-      description: Return existence and active state for a location ID.
+      summary: Validate Location Existence and Active State
+      description: 'Returns an existence-and-active-state check for a location id without transferring the full record.
+
+        Use this tool for inter-service reference validation before storing a locationId; do not use getLocationById, which returns the full payload and answers 404 for unknown ids.
+
+        Preconditions: none; unknown ids are a valid input.
+
+        Required inputs: locationId (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 always, with exists=false and active=false when the id is unknown, so callers must inspect the flags rather than the status code.
+
+        '
       operationId: validateLocation
       parameters:
       - name: locationId
@@ -1203,9 +1938,21 @@ paths:
     get:
       tags:
       - Location API
-      summary: Get responsible person for a location
-      description: Retrieve the person responsible for a given location.
-      operationId: getResponsiblePerson
+      summary: Get Responsible Person for a Location
+      description: 'Returns the person responsible for a location, resolved from the people-contact replica with name, email and phone details.
+
+        Use this tool to find who owns a site operationally; do not use getLocationById, which returns only the responsiblePersonId without contact details.
+
+        Preconditions: the location must exist and have a responsiblePersonId assigned.
+
+        Required inputs: locationId (UUID) as a path parameter.
+
+        Emits a LOCATION_RESPONSIBLE_PERSON_GET event; no state changes.
+
+        Returns 404 when the location does not exist or no responsible person is assigned; when the replica row has not yet arrived, a 200 with only the person id is returned and names follow with the feed.
+
+        '
+      operationId: getLocationResponsiblePerson
       parameters:
       - name: locationId
         in: path
@@ -1237,9 +1984,21 @@ paths:
     get:
       tags:
       - Location API
-      summary: Get all descendants for a location
-      description: Walk typed parent-child edges downward from a location and return every descendant as a flat list with its immediate parent id and depth (1 = direct child). Traversal is cycle-safe and depth-capped at 20.
-      operationId: getDescendants
+      summary: List All Descendants of a Location
+      description: 'Walks typed parent-child edges downward from a location and returns every descendant as a flat list with its immediate parent id and depth, where depth 1 is a direct child.
+
+        Use this tool when a whole subtree is needed in one call; use listLocationChildren instead for only the direct children of one location.
+
+        Preconditions: the root location must exist; traversal is cycle-safe and silently truncates at depth 20.
+
+        Required inputs: locationId (UUID) as a path parameter; parentType defaults to PHYSICAL when omitted.
+
+        Emits a LOCATION_DESCENDANTS_GET event; no state changes.
+
+        Returns 404 when the root location does not exist and 400 when parentType is not a recognized ParentType value.
+
+        '
+      operationId: listLocationDescendants
       parameters:
       - name: locationId
         in: path
@@ -1290,9 +2049,21 @@ paths:
     get:
       tags:
       - Location API
-      summary: Get all children for a location
-      description: Retrieve all child locations for a given parent location.
-      operationId: getAllChildren
+      summary: List Direct Children of a Location
+      description: 'Returns the direct child locations of a parent location, optionally restricted to one relationship type.
+
+        Use this tool for one level of hierarchy; use listLocationDescendants instead when the whole subtree with depth information is needed.
+
+        Preconditions: none; an unknown or childless parent id yields an empty list rather than an error.
+
+        Required inputs: locationId (UUID) as a path parameter; parentType is optional and, when omitted, edges of every relationship type are returned.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 400 when parentType is supplied but is not a recognized ParentType value.
+
+        '
+      operationId: listLocationChildren
       parameters:
       - name: locationId
         in: path
@@ -1317,6 +2088,14 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/LocationResponseDTO'
+        '400':
+          description: Invalid parentType value.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LocationResponseDTO'
       security:
       - bearerAuth:
         - location:read
@@ -1326,9 +2105,21 @@ paths:
     get:
       tags:
       - Location API
-      summary: Get location roster
-      description: Retrieve paginated location refs for sync consumers.
-      operationId: getRoster
+      summary: Get Paginated Location Roster for Sync
+      description: 'Returns a paginated roster of lightweight location references (id, name, code, status, hrLocationId, timezone, updatedAt) for sync consumers.
+
+        Use this tool when incrementally synchronising locations into another system; do not use listLocations, which returns full unpaginated location payloads.
+
+        Preconditions: none beyond the location:read authority.
+
+        Required inputs: none are mandatory; status filters exactly on the stored status value such as ACTIVE, sinceUpdatedAt is an ISO-8601 instant returning only rows updated after it, and standard page, size and sort parameters control paging.
+
+        Emits a LOCATION_ROSTER_GET event; no location state changes.
+
+        Returns 200 with a page of location refs; an unknown status value yields an empty page rather than an error.
+
+        '
+      operationId: getLocationRoster
       parameters:
       - name: status
         in: query
@@ -1366,9 +2157,21 @@ paths:
     get:
       tags:
       - Location API
-      summary: Get all location parents
-      description: Retrieve all parent relationships for locations.
-      operationId: getAllParents
+      summary: List All Location Parent Relationships
+      description: 'Lists every parent-child relationship edge across all locations, with parentId, childId and parentType.
+
+        Use this tool when a full hierarchy dump is needed; use listLocationChildren instead to read the children of one location, or listLocationDescendants for a deep traversal.
+
+        Preconditions: none beyond the location:read authority.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the full unpaginated edge list.
+
+        '
+      operationId: listLocationParents
       responses:
         '200':
           description: List of location parents returned successfully.
@@ -1448,7 +2251,7 @@ components:
       - date
     LocationRequestDTO:
       type: object
-      description: Location object to be created
+      description: Request payload for creating or updating a location
       properties:
         name:
           type: string
@@ -1521,11 +2324,13 @@ components:
           format: int32
           description: Buffer minutes reserved before appointments for check-in
           example: 15
+          minimum: 0
         cleanupBufferMinutes:
           type: integer
           format: int32
           description: Buffer minutes reserved after appointments for cleanup
           example: 10
+          minimum: 0
         type:
           $ref: '#/components/schemas/LocationTypeDTO'
         parents:
@@ -1684,13 +2489,14 @@ components:
           minLength: 1
         bufferType:
           type: string
-          description: Type of buffer the policy applies
-          example: FIXED_MINUTES
+          description: Type of buffer the policy applies; one of FLAT_MINUTES, PERCENTAGE_OF_TRAVEL or DISTANCE_MULTIPLIER
+          example: FLAT_MINUTES
           minLength: 1
         bufferValue:
           type: number
           description: Numeric value of the buffer (interpretation depends on buffer type)
           example: 30
+          minimum: 0
         notes:
           type: string
           description: Free-text notes about the policy
@@ -1831,6 +2637,7 @@ components:
           format: int32
           description: Evaluation priority of the rule (lower is evaluated first)
           example: 1
+          minimum: 0
         validFrom:
           type: string
           format: date
@@ -1845,12 +2652,13 @@ components:
           type: number
           description: Maximum service distance in kilometres covered by the rule
           example: 25.5
+          minimum: 0
       required:
       - ruleType
       - serviceAreaId
     MobileUnitRequest:
       type: object
-      description: Mobile unit creation request body
+      description: Request payload for creating or updating a mobile unit
       properties:
         name:
           type: string
@@ -2057,7 +2865,7 @@ components:
       - maxConcurrentVehicles
     BayRequest:
       type: object
-      description: Bay creation request body
+      description: Request payload for creating a service bay
       properties:
         name:
           type: string
@@ -2066,8 +2874,8 @@ components:
           minLength: 1
         bayType:
           type: string
-          description: Type classification of the bay
-          example: LIFT
+          description: Type classification of the bay; must be a BayType value
+          example: GENERAL_SERVICE
           minLength: 1
         capacity:
           $ref: '#/components/schemas/BayCapacityRequest'
@@ -2369,7 +3177,7 @@ components:
             unit: C
     LocationPatchRequest:
       type: object
-      description: Partial location payload
+      description: Partial update payload for a location; null fields are left unchanged
       properties:
         name:
           type: string
@@ -2398,11 +3206,13 @@ components:
           format: int32
           description: Buffer minutes reserved before appointments for check-in
           example: 15
+          minimum: 0
         cleanupBufferMinutes:
           type: integer
           format: int32
           description: Buffer minutes reserved after appointments for cleanup
           example: 10
+          minimum: 0
     BayPatchRequest:
       type: object
       description: Partial update payload for a service bay; null fields are left unchanged
@@ -2413,8 +3223,8 @@ components:
           example: Bay A1
         bayType:
           type: string
-          description: Type classification of the bay
-          example: LIFT
+          description: Type classification of the bay; must be a BayType value
+          example: GENERAL_SERVICE
         status:
           type: string
           description: Operational status of the bay
@@ -2475,12 +3285,12 @@ components:
     PageMobileUnitResponse:
       type: object
       properties:
-        totalElements:
-          type: integer
-          format: int64
         totalPages:
           type: integer
           format: int32
+        totalElements:
+          type: integer
+          format: int64
         size:
           type: integer
           format: int32
@@ -2491,17 +3301,17 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
     PageableObject:
@@ -2574,12 +3384,12 @@ components:
     PageStorageLocationResponse:
       type: object
       properties:
-        totalElements:
-          type: integer
-          format: int64
         totalPages:
           type: integer
           format: int32
+        totalElements:
+          type: integer
+          format: int64
         size:
           type: integer
           format: int32
@@ -2590,17 +3400,17 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
     StorageLocationTopologyResponse:
@@ -2728,12 +3538,12 @@ components:
     PageBayResponse:
       type: object
       properties:
-        totalElements:
-          type: integer
-          format: int64
         totalPages:
           type: integer
           format: int32
+        totalElements:
+          type: integer
+          format: int64
         size:
           type: integer
           format: int32
@@ -2744,17 +3554,17 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
     LocationRef:
@@ -2796,12 +3606,12 @@ components:
     PageLocationRef:
       type: object
       properties:
-        totalElements:
-          type: integer
-          format: int64
         totalPages:
           type: integer
           format: int32
+        totalElements:
+          type: integer
+          format: int64
         size:
           type: integer
           format: int32
@@ -2812,17 +3622,17 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
   securitySchemes:

--- a/pos-location/src/main/java/com/positivity/location/internal/controller/BayController.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/controller/BayController.java
@@ -7,6 +7,8 @@ import com.positivity.location.internal.dto.BayResponse;
 import com.positivity.location.service.BayService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,16 +35,35 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/locations/{locationId}/bays")
 public class BayController {
+
+    private static final String BAY_EXAMPLE = """
+            {"name":"Bay A1",
+             "bayType":"GENERAL_SERVICE",
+             "capacity":{"maxConcurrentVehicles":2},
+             "serviceCapabilityIds":["ALIGNMENT"],
+             "skillRequirementIds":["018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a20"],
+             "status":"ACTIVE"}
+            """;
+
     private final BayService bayService;
 
     public BayController(BayService bayService) {
         this.bayService = bayService;
     }
 
-    @Operation(
-            summary = "List bays",
-            description = "List bays for a location with optional status and bayType filters.")
+    @Operation(operationId = "listBays", summary = "List Service Bays of a Location", description = """
+                    Lists the service bays of a location as a page, optionally filtered by status and bayType.
+                    Use this tool to see bay capacity and status for a shop; use getBay instead when the bay id \
+                    is already known.
+                    Preconditions: the location must exist.
+                    Required inputs: locationId (UUID) as a path parameter; status (ACTIVE or OUT_OF_SERVICE) and \
+                    bayType filters are optional, and page defaults to 0 with size 20.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when the location does not exist; an unrecognized status or bayType filter value \
+                    fails the request rather than returning an empty page.
+                    """)
     @ApiResponse(responseCode = "200", description = "Bays retrieved successfully.")
+    @ApiResponse(responseCode = "404", description = "Location not found.")
     @PreAuthorize("hasAuthority('location:bay:read')")
     @SecurityRequirement(
             name = "bearerAuth",
@@ -58,7 +79,16 @@ public class BayController {
         return ResponseEntity.ok(bayService.listBays(parseUuid(locationId), status, bayType, pageable));
     }
 
-    @Operation(summary = "Get bay", description = "Get a bay by location and bay id.")
+    @Operation(operationId = "getBay", summary = "Get a Service Bay by Identifier", description = """
+                    Returns a single service bay of a location, including its capacity, capability and skill \
+                    requirement details.
+                    Use this tool when both the location id and bay id are known; use listBays instead to search \
+                    or enumerate.
+                    Preconditions: the location must exist and the bay must belong to it.
+                    Required inputs: locationId and bayId (UUIDs) as path parameters.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when the location does not exist or the bay is not found under that location.
+                    """)
     @ApiResponse(responseCode = "200", description = "Bay retrieved successfully.")
     @ApiResponse(responseCode = "404", description = "Bay not found.")
     @PreAuthorize("hasAuthority('location:bay:read')")
@@ -72,8 +102,25 @@ public class BayController {
         return ResponseEntity.ok(bayService.getBay(parseUuid(locationId), parseUuid(bayId)));
     }
 
-    @Operation(summary = "Create bay", description = "Create a new bay for a specific location.")
+    @Operation(operationId = "createBay", summary = "Create a Service Bay for Location", description = """
+                    Creates a service bay under a location with a type classification, concurrency capacity and \
+                    optional capability and skill requirements.
+                    Use this tool when adding physical work capacity to a shop; do not use patchBay, which \
+                    modifies a bay that already exists, and use createStorageLocation for inventory storage \
+                    rather than vehicle bays.
+                    Preconditions: the location must exist, no bay of that location may already use the name \
+                    (case-insensitive), and any serviceCapabilityIds must match registered service capability \
+                    codes.
+                    Required inputs: name, bayType (one of GENERAL_SERVICE, ALIGNMENT, TIRE_SERVICE, HEAVY_DUTY, \
+                    INSPECTION or WASH_DETAIL) and capacity.maxConcurrentVehicles of at least 1; status is \
+                    optional, defaults to ACTIVE and only also accepts OUT_OF_SERVICE.
+                    Emits a LOCATION_BAY_CREATE event; no other records are touched.
+                    Returns 404 when the location does not exist and 409 when the bay name is already taken at \
+                    that location.
+                    """)
     @ApiResponse(responseCode = "201", description = "Bay created successfully.")
+    @ApiResponse(responseCode = "404", description = "Location not found.")
+    @ApiResponse(responseCode = "409", description = "Bay name already taken at this location.")
     @EmitEvent(id = "LOCATION_BAY_CREATE", apiVersion = "1")
     @PreAuthorize("hasAuthority('location:bay:manage')")
     @SecurityRequirement(
@@ -81,14 +128,40 @@ public class BayController {
             scopes = {"location:bay:manage"})
     @PostMapping
     public ResponseEntity<BayResponse> createBay(
-            @Parameter(description = "Location ID", example = "1") @PathVariable String locationId,
-            @Parameter(description = "Bay creation request body") @Valid @RequestBody BayRequest request) {
+            @Parameter(description = "Location ID", example = "018e1c9f-6b5a-7890-abcd-1234567890ab") @PathVariable
+                    String locationId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Service bay to create, with its type classification and concurrent"
+                                    + " vehicle capacity.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "General service bay", value = BAY_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    BayRequest request) {
         BayResponse created = bayService.createBay(parseUuid(locationId), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
-    @Operation(summary = "Patch bay", description = "Patch bay fields including status transition and capacity.")
+    @Operation(operationId = "patchBay", summary = "Patch Fields of a Service Bay", description = """
+                    Applies a partial update to a bay, changing only the supplied fields: name, bayType, status, \
+                    capacity and the capability or skill requirement lists.
+                    Use this tool for status transitions between ACTIVE and OUT_OF_SERVICE and for capacity \
+                    changes; do not use createBay, which adds a new bay.
+                    Preconditions: the location must exist, the bay must belong to it, and a new name must not \
+                    collide with another bay at the same location.
+                    Required inputs: locationId and bayId (UUIDs) as path parameters and a body with at least one \
+                    field; capacity.maxConcurrentVehicles, when supplied, must be at least 1.
+                    Emits a LOCATION_BAY_UPDATE event; no other records are touched.
+                    Returns 404 when the location or bay does not exist and 409 when the new name is already \
+                    taken at that location.
+                    """)
     @ApiResponse(responseCode = "200", description = "Bay updated successfully.")
+    @ApiResponse(responseCode = "404", description = "Location or bay not found.")
+    @ApiResponse(responseCode = "409", description = "Bay name already taken at this location.")
     @EmitEvent(id = "LOCATION_BAY_UPDATE", apiVersion = "1")
     @PreAuthorize("hasAuthority('location:bay:manage')")
     @SecurityRequirement(
@@ -96,7 +169,21 @@ public class BayController {
             scopes = {"location:bay:manage"})
     @PatchMapping("/{bayId}")
     public ResponseEntity<BayResponse> patchBay(
-            @PathVariable String locationId, @PathVariable String bayId, @RequestBody BayPatchRequest patchRequest) {
+            @PathVariable String locationId,
+            @PathVariable String bayId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Partial bay payload; only non-null fields are applied and all others"
+                                    + " are left unchanged.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Take bay out of service",
+                                                            value = "{\"status\":\"OUT_OF_SERVICE\"}")))
+                    @RequestBody
+                    BayPatchRequest patchRequest) {
         return ResponseEntity.ok(bayService.patchBay(parseUuid(locationId), parseUuid(bayId), patchRequest));
     }
 

--- a/pos-location/src/main/java/com/positivity/location/internal/controller/LocationBulkIngestController.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/controller/LocationBulkIngestController.java
@@ -9,6 +9,10 @@ import com.positivity.location.internal.dto.LocationBulkIngestRecord;
 import com.positivity.location.internal.dto.LocationRequestDTO;
 import com.positivity.location.internal.dto.LocationTypeDTO;
 import com.positivity.location.service.LocationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -34,13 +38,59 @@ import org.springframework.web.bind.annotation.RestController;
 public class LocationBulkIngestController extends AbstractBulkIngestController<LocationBulkIngestRecord> {
 
     private static final String DEFAULT_LOCATION_TYPE_NAME = "STORE";
+
+    private static final String BULK_INGEST_EXAMPLE = """
+            {"jobId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01",
+             "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02",
+             "operatorId":"user-jdoe",
+             "records":[{"name":"Downtown Service Center",
+                         "code":"LOC-001",
+                         "addressLine1":"123 Main St",
+                         "city":"Springfield",
+                         "stateOrProvince":"IL",
+                         "postalCode":"62704",
+                         "countryCode":"US",
+                         "active":true,
+                         "locationTypeName":"STORE"}]}
+            """;
+
     private final LocationService locationService;
 
     @Override
+    @Operation(operationId = "bulkIngestLocations", summary = "Bulk Import a Batch of Locations", description = """
+                    Imports a batch of location records in one call, creating each row independently and \
+                    reporting per-record success or failure.
+                    Use this tool for initial data loads or migrations; do not use createLocation, which creates \
+                    a single location per call.
+                    Preconditions: names and codes must be unique against existing locations; each record is \
+                    validated independently, so one failure does not abort the batch.
+                    Required inputs: jobId, locationId and a non-empty records array, each record with name and \
+                    code; active defaults to true and locationTypeName defaults to STORE when omitted.
+                    Emits a LOCATION_BULK_INGEST event, and every successfully created location also publishes a \
+                    location fact for replica consumers.
+                    Returns 200 with per-record results even when some records fail (failed rows carry errorCode \
+                    LOCATION_INGEST_FAILED), and 400 when the batch envelope itself is invalid.
+                    """)
+    @ApiResponse(responseCode = "200", description = "Batch processed (check per-record success/failure in response)")
+    @ApiResponse(responseCode = "400", description = "Invalid request payload")
     @PreAuthorize("hasAuthority('location:write')")
     @EmitEvent(id = "LOCATION_BULK_INGEST", apiVersion = "1")
     public ResponseEntity<BulkIngestResponse> bulkIngest(
-            @Valid @RequestBody @NonNull BulkIngestRequest<LocationBulkIngestRecord> request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Batch envelope of location records to import, scoped to a bulk ingest"
+                                    + " job and submitting operator.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Single-record batch",
+                                                            value = BULK_INGEST_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BulkIngestRequest<LocationBulkIngestRecord> request) {
         return super.bulkIngest(request);
     }
 

--- a/pos-location/src/main/java/com/positivity/location/internal/controller/LocationController.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/controller/LocationController.java
@@ -13,6 +13,8 @@ import com.positivity.location.service.LocationRosterService;
 import com.positivity.location.service.LocationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -45,10 +47,38 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/locations")
 @RequiredArgsConstructor
 public class LocationController {
+
+    private static final String LOCATION_EXAMPLE = """
+            {"name":"Downtown Service Center",
+             "code":"LOC-001",
+             "type":{"name":"STORE"},
+             "timezone":"America/Chicago",
+             "addressLine1":"123 Main St",
+             "city":"Springfield",
+             "state":"IL",
+             "postalCode":"62704",
+             "country":"US",
+             "active":true,
+             "responsiblePersonId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+             "operatingHours":[{"dayOfWeek":"MONDAY","openTime":"08:00","closeTime":"17:00"}],
+             "checkInBufferMinutes":15,
+             "cleanupBufferMinutes":10}
+            """;
+
     private final LocationService locationService;
     private final LocationRosterService locationRosterService;
 
-    @Operation(summary = "Get all locations", description = "Retrieve a list of all locations.")
+    @Operation(operationId = "listLocations", summary = "List All Locations Without Pagination", description = """
+                    Lists every location in the system as a flat, unpaginated collection with address, status and \
+                    type details.
+                    Use this tool when a complete location inventory is needed at once; use getLocationRoster \
+                    instead for a paginated sync feed with status and updated-since filtering, and do not use it \
+                    to fetch a single known id, which is getLocationById.
+                    Preconditions: none beyond the location:read authority; an empty system returns an empty list.
+                    Required inputs: none; there are no parameters and no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the full list; there are no business error conditions for this operation.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of locations returned successfully.")
     @PreAuthorize("hasAuthority('location:read')")
     @SecurityRequirement(
@@ -65,7 +95,19 @@ public class LocationController {
      *
      * Issue: CAP-214 #40
      */
-    @Operation(summary = "Get location roster", description = "Retrieve paginated location refs for sync consumers.")
+    @Operation(operationId = "getLocationRoster", summary = "Get Paginated Location Roster for Sync", description = """
+                    Returns a paginated roster of lightweight location references (id, name, code, status, \
+                    hrLocationId, timezone, updatedAt) for sync consumers.
+                    Use this tool when incrementally synchronising locations into another system; do not use \
+                    listLocations, which returns full unpaginated location payloads.
+                    Preconditions: none beyond the location:read authority.
+                    Required inputs: none are mandatory; status filters exactly on the stored status value such \
+                    as ACTIVE, sinceUpdatedAt is an ISO-8601 instant returning only rows updated after it, and \
+                    standard page, size and sort parameters control paging.
+                    Emits a LOCATION_ROSTER_GET event; no location state changes.
+                    Returns 200 with a page of location refs; an unknown status value yields an empty page rather \
+                    than an error.
+                    """)
     @ApiResponse(responseCode = "200", description = "Location roster returned successfully.")
     @PreAuthorize("hasAuthority('location:read')")
     @EmitEvent(id = "LOCATION_ROSTER_GET", apiVersion = "1")
@@ -84,7 +126,16 @@ public class LocationController {
         return locationRosterService.getRoster(status, sinceUpdatedAt, pageable);
     }
 
-    @Operation(summary = "Get location by ID", description = "Retrieve a location by its unique ID.")
+    @Operation(operationId = "getLocationById", summary = "Get Location by Unique Identifier", description = """
+                    Returns the full location record, including address fields, active flag, responsible person \
+                    id and type classification, for a known id.
+                    Use this tool when the location id is already known; use listLocations instead to enumerate, \
+                    and use validateLocation when only existence and active state are needed.
+                    Preconditions: the location must exist.
+                    Required inputs: locationId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no location exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Location found and returned.")
     @ApiResponse(responseCode = "404", description = "Location not found.")
     @PreAuthorize("hasAuthority('location:read')")
@@ -103,8 +154,19 @@ public class LocationController {
     }
 
     @Operation(
-            summary = "Validate location reference",
-            description = "Return existence and active state for a location ID.")
+            operationId = "validateLocation",
+            summary = "Validate Location Existence and Active State",
+            description = """
+                    Returns an existence-and-active-state check for a location id without transferring the full \
+                    record.
+                    Use this tool for inter-service reference validation before storing a locationId; do not use \
+                    getLocationById, which returns the full payload and answers 404 for unknown ids.
+                    Preconditions: none; unknown ids are a valid input.
+                    Required inputs: locationId (UUID) as a path parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 always, with exists=false and active=false when the id is unknown, so callers \
+                    must inspect the flags rather than the status code.
+                    """)
     @ApiResponse(responseCode = "200", description = "Validation result returned.")
     @PreAuthorize("hasAuthority('location:read')")
     @SecurityRequirement(
@@ -118,8 +180,23 @@ public class LocationController {
         return ResponseEntity.ok(locationService.getLocationValidation(locationId));
     }
 
-    @Operation(summary = "Create a new location", description = "Add a new location to the system.")
+    @Operation(operationId = "createLocation", summary = "Create a New Location Record", description = """
+                    Creates a location with address, timezone, operating hours, scheduling buffers and type \
+                    classification, defaulting status to ACTIVE.
+                    Use this tool when registering a new physical or logical site; do not use updateLocation, \
+                    which replaces an existing location, and use bulkIngestLocations for batch imports.
+                    Preconditions: no existing location may share the same name (case-insensitive) or code, and a \
+                    type referenced by id must already exist; a type given only by name is created on the fly.
+                    Required inputs: name, code and type (id or name); timezone must be a valid IANA zone id, \
+                    operatingHours entries must have unique dayOfWeek values with openTime before closeTime, and \
+                    active defaults to true.
+                    Emits a LOCATION_LOCATION_CREATE event and publishes a location fact for replica consumers.
+                    Returns 409 when the name or code is already taken, 422 when the timezone or operating hours \
+                    are invalid, and 400 when a referenced location type id is unknown.
+                    """)
     @ApiResponse(responseCode = "201", description = "Location created successfully.")
+    @ApiResponse(responseCode = "409", description = "Location name or code already taken.")
+    @ApiResponse(responseCode = "422", description = "Invalid timezone or operating hours.")
     @EmitEvent(id = "LOCATION_LOCATION_CREATE", apiVersion = "1")
     @PreAuthorize("hasAuthority('location:write')")
     @SecurityRequirement(
@@ -127,14 +204,38 @@ public class LocationController {
             scopes = {"location:write"})
     @PostMapping
     public ResponseEntity<LocationResponseDTO> createLocation(
-            @Parameter(description = "Location object to be created") @Valid @RequestBody LocationRequestDTO location) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Location to create, including its type and optional address,"
+                                    + " timezone and operating-hours configuration.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "Store location", value = LOCATION_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    LocationRequestDTO location) {
         LocationResponseDTO saved = locationService.createLocation(location);
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
     }
 
-    @Operation(summary = "Update an existing location", description = "Update the details of an existing location.")
+    @Operation(operationId = "updateLocation", summary = "Update an Existing Location Fully", description = """
+                    Replaces the mutable fields of an existing location with the supplied full payload, including \
+                    address, timezone, operating hours and type.
+                    Use this tool when the complete corrected state of a location is known; use patchLocation \
+                    instead to change selected fields and leave the rest untouched.
+                    Preconditions: the location must exist, and no other location may already use the new name.
+                    Required inputs: locationId (UUID) as a path parameter plus a full body with name, code and \
+                    type; omitted optional fields are overwritten with the request values, not preserved.
+                    Emits a LOCATION_LOCATION_UPDATE event and publishes a location fact for replica consumers.
+                    Returns 404 when the location does not exist, 409 when the name or code collides with another \
+                    location, and 422 when the timezone or operating hours are invalid.
+                    """)
     @ApiResponse(responseCode = "200", description = "Location updated successfully.")
     @ApiResponse(responseCode = "404", description = "Location not found.")
+    @ApiResponse(responseCode = "409", description = "Location name or code already taken.")
+    @ApiResponse(responseCode = "422", description = "Invalid timezone or operating hours.")
     @EmitEvent(id = "LOCATION_LOCATION_UPDATE", apiVersion = "1")
     @PreAuthorize("hasAuthority('location:write')")
     @SecurityRequirement(
@@ -145,16 +246,43 @@ public class LocationController {
             @Parameter(description = "ID of the location to update", example = "018e1c9f-6b5a-7890-abcd-1234567890ab")
                     @PathVariable
                     UUID locationId,
-            @Parameter(description = "Updated location object") @Valid @RequestBody LocationRequestDTO location) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement state for the location; every mutable field is"
+                                    + " overwritten with the values supplied here.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Full replacement",
+                                                            value = LOCATION_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    LocationRequestDTO location) {
         return locationService
                 .updateLocation(locationId, location)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @Operation(summary = "Patch a location", description = "Patch selected fields for a location.")
+    @Operation(operationId = "patchLocation", summary = "Patch Selected Fields of a Location", description = """
+                    Applies a partial update to a location, changing only the supplied fields: name, status, \
+                    timezone, operatingHours, holidayClosures, checkInBufferMinutes and cleanupBufferMinutes.
+                    Use this tool for targeted edits such as deactivation or hours changes; do not use \
+                    updateLocation, which overwrites every mutable field including address and type.
+                    Preconditions: the location must exist, and a new name must not be used by another location.
+                    Required inputs: locationId (UUID) as a path parameter and a body with at least one field; \
+                    status only accepts the value INACTIVE to deactivate, and reactivation is not supported \
+                    through this operation.
+                    Emits a LOCATION_PATCH event and publishes a location fact for replica consumers.
+                    Returns 404 when the location does not exist, 409 when the new name is taken, and 422 when a \
+                    supplied timezone or operating-hours entry is invalid.
+                    """)
     @ApiResponse(responseCode = "200", description = "Location patched successfully.")
     @ApiResponse(responseCode = "404", description = "Location not found.")
+    @ApiResponse(responseCode = "409", description = "Location name already taken.")
+    @ApiResponse(responseCode = "422", description = "Invalid timezone or operating hours.")
     @PatchMapping("/{locationId}")
     @PreAuthorize("hasAuthority('location:write')")
     @EmitEvent(id = "LOCATION_PATCH", apiVersion = "1")
@@ -165,11 +293,33 @@ public class LocationController {
             @Parameter(description = "ID of the location to patch", example = "018e1c9f-6b5a-7890-abcd-1234567890ab")
                     @PathVariable
                     UUID locationId,
-            @Parameter(description = "Partial location payload") @RequestBody LocationPatchRequest patch) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Partial location payload; only non-null fields are applied and all"
+                                    + " others are left unchanged.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Deactivate location",
+                                                            value = "{\"status\":\"INACTIVE\"}")))
+                    @RequestBody
+                    LocationPatchRequest patch) {
         return ResponseEntity.ok(locationService.patchLocation(locationId, patch));
     }
 
-    @Operation(summary = "Delete a location", description = "Delete a location by its unique ID.")
+    @Operation(operationId = "deleteLocation", summary = "Delete a Location by Identifier", description = """
+                    Deletes a location permanently by id and publishes a deletion fact so replica consumers drop \
+                    the row.
+                    Use this tool only when a location was created in error; use patchLocation with status \
+                    INACTIVE instead to retire a real site while preserving history.
+                    Preconditions: the location must exist; there is no child-relationship or usage check, so \
+                    callers must confirm the location is unreferenced first.
+                    Required inputs: locationId (UUID) as a path parameter; there is no request body.
+                    Emits a LOCATION_LOCATION_DELETE event; the row is hard-deleted, not soft-deleted.
+                    Returns 204 on success and 404 when the location does not exist.
+                    """)
     @ApiResponse(responseCode = "204", description = "Location deleted successfully.")
     @ApiResponse(responseCode = "404", description = "Location not found.")
     @PreAuthorize("hasAuthority('location:write')")
@@ -189,8 +339,27 @@ public class LocationController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Add a parent to a location", description = "Add a parent relationship to a location.")
+    @Operation(
+            operationId = "addLocationParent",
+            summary = "Add Typed Parent Relationship to Location",
+            description = """
+                    Creates a typed parent-child edge between two existing locations, giving the child at most \
+                    one parent per relationship type.
+                    Use this tool when building the location hierarchy; do not use listLocationChildren or \
+                    listLocationDescendants, which only read the hierarchy.
+                    Preconditions: both locations must exist, the child must not already have a parent of that \
+                    type, the pair must not already be linked in either direction, and the parent must not be a \
+                    descendant of the child because cycles are forbidden by ADR-0016.
+                    Required inputs: childId and parentId (UUIDs) as path parameters and a parentType query \
+                    parameter, one of HOME_OFFICE, HEADQUARTERS, REGION, DISTRICT, PHYSICAL, ORGANIZATIONAL, \
+                    FINANCIAL or SHIPPING.
+                    Emits a LOCATION_PARENT_ADD event and republishes the child's location fact, which carries \
+                    the new edge to replica consumers.
+                    Returns 400 when parentType is not a recognized value; self-parenting, duplicate, inverse or \
+                    circular relationships are rejected before the edge is written.
+                    """)
     @ApiResponse(responseCode = "200", description = "Parent relationship added successfully.")
+    @ApiResponse(responseCode = "400", description = "Invalid parentType value.")
     @EmitEvent(id = "LOCATION_PARENT_ADD", apiVersion = "1")
     @PreAuthorize("hasAuthority('location:write')")
     @SecurityRequirement(
@@ -209,7 +378,19 @@ public class LocationController {
         return ResponseEntity.ok(parent);
     }
 
-    @Operation(summary = "Get all location parents", description = "Retrieve all parent relationships for locations.")
+    @Operation(
+            operationId = "listLocationParents",
+            summary = "List All Location Parent Relationships",
+            description = """
+                    Lists every parent-child relationship edge across all locations, with parentId, childId and \
+                    parentType.
+                    Use this tool when a full hierarchy dump is needed; use listLocationChildren instead to read \
+                    the children of one location, or listLocationDescendants for a deep traversal.
+                    Preconditions: none beyond the location:read authority.
+                    Required inputs: none; there are no parameters and no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the full unpaginated edge list.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of location parents returned successfully.")
     @PreAuthorize("hasAuthority('location:read')")
     @SecurityRequirement(
@@ -220,10 +401,20 @@ public class LocationController {
         return locationService.getAllParentsDto();
     }
 
-    @Operation(
-            summary = "Get all children for a location",
-            description = "Retrieve all child locations for a given parent location.")
+    @Operation(operationId = "listLocationChildren", summary = "List Direct Children of a Location", description = """
+                    Returns the direct child locations of a parent location, optionally restricted to one \
+                    relationship type.
+                    Use this tool for one level of hierarchy; use listLocationDescendants instead when the whole \
+                    subtree with depth information is needed.
+                    Preconditions: none; an unknown or childless parent id yields an empty list rather than an \
+                    error.
+                    Required inputs: locationId (UUID) as a path parameter; parentType is optional and, when \
+                    omitted, edges of every relationship type are returned.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 400 when parentType is supplied but is not a recognized ParentType value.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of child locations returned successfully.")
+    @ApiResponse(responseCode = "400", description = "Invalid parentType value.")
     @PreAuthorize("hasAuthority('location:read')")
     @SecurityRequirement(
             name = "bearerAuth",
@@ -239,8 +430,20 @@ public class LocationController {
     }
 
     @Operation(
-            summary = "Get responsible person for a location",
-            description = "Retrieve the person responsible for a given location.")
+            operationId = "getLocationResponsiblePerson",
+            summary = "Get Responsible Person for a Location",
+            description = """
+                    Returns the person responsible for a location, resolved from the people-contact replica with \
+                    name, email and phone details.
+                    Use this tool to find who owns a site operationally; do not use getLocationById, which \
+                    returns only the responsiblePersonId without contact details.
+                    Preconditions: the location must exist and have a responsiblePersonId assigned.
+                    Required inputs: locationId (UUID) as a path parameter.
+                    Emits a LOCATION_RESPONSIBLE_PERSON_GET event; no state changes.
+                    Returns 404 when the location does not exist or no responsible person is assigned; when the \
+                    replica row has not yet arrived, a 200 with only the person id is returned and names follow \
+                    with the feed.
+                    """)
     @ApiResponse(responseCode = "200", description = "Responsible person found and returned.")
     @ApiResponse(responseCode = "404", description = "Responsible person not found.")
     @EmitEvent(id = "LOCATION_RESPONSIBLE_PERSON_GET", apiVersion = "1")
@@ -266,10 +469,21 @@ public class LocationController {
      * Issue: CAP-214 #655
      */
     @Operation(
-            summary = "Get all descendants for a location",
-            description = "Walk typed parent-child edges downward from a location and return every descendant "
-                    + "as a flat list with its immediate parent id and depth (1 = direct child). "
-                    + "Traversal is cycle-safe and depth-capped at 20.")
+            operationId = "listLocationDescendants",
+            summary = "List All Descendants of a Location",
+            description = """
+                    Walks typed parent-child edges downward from a location and returns every descendant as a \
+                    flat list with its immediate parent id and depth, where depth 1 is a direct child.
+                    Use this tool when a whole subtree is needed in one call; use listLocationChildren instead \
+                    for only the direct children of one location.
+                    Preconditions: the root location must exist; traversal is cycle-safe and silently truncates \
+                    at depth 20.
+                    Required inputs: locationId (UUID) as a path parameter; parentType defaults to PHYSICAL when \
+                    omitted.
+                    Emits a LOCATION_DESCENDANTS_GET event; no state changes.
+                    Returns 404 when the root location does not exist and 400 when parentType is not a recognized \
+                    ParentType value.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of descendant locations returned successfully.")
     @ApiResponse(responseCode = "400", description = "Invalid parentType value.")
     @ApiResponse(responseCode = "404", description = "Location not found.")

--- a/pos-location/src/main/java/com/positivity/location/internal/controller/MobileUnitController.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/controller/MobileUnitController.java
@@ -7,6 +7,8 @@ import com.positivity.location.internal.dto.MobileUnitResponse;
 import com.positivity.location.service.MobileUnitService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,10 +39,45 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 public class MobileUnitController {
 
+    private static final String MOBILE_UNIT_EXAMPLE = """
+            {"name":"Van 7",
+             "baseLocationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01",
+             "status":"ACTIVE",
+             "travelBufferPolicyId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02",
+             "notes":"Equipped with hydraulic lift",
+             "capabilityIds":["018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a10"],
+             "coverageRules":[{"serviceAreaId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03",
+                               "ruleType":"SERVICE_AREA","priority":1,"validFrom":"2026-06-18"}]}
+            """;
+
+    private static final String COVERAGE_RULES_EXAMPLE = """
+            {"rules":[{"serviceAreaId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03",
+                       "ruleType":"SERVICE_AREA","priority":1,
+                       "validFrom":"2026-06-18","validTo":"2026-12-31"}]}
+            """;
+
     private final MobileUnitService mobileUnitService;
 
-    @Operation(summary = "Create mobile unit", description = "Create a new mobile unit.")
+    @Operation(operationId = "createMobileUnit", summary = "Create a New Mobile Service Unit", description = """
+                    Creates a mobile service unit with an optional base location, travel buffer policy, \
+                    capability list and initial coverage rules.
+                    Use this tool when commissioning a van or truck that serves customers off-site; do not use \
+                    patchMobileUnit, which updates an existing unit, and change coverage later with \
+                    replaceCoverageRules.
+                    Preconditions: a unit created with status ACTIVE must include travelBufferPolicyId, \
+                    capabilityIds and coverageRules; the travel buffer policy must exist, capability ids or codes \
+                    must resolve to registered capabilities, DISTANCE_TIER coverage rules must be strictly \
+                    ascending by maxDistance and end with a null catch-all tier, and the name must be unique at \
+                    the base location.
+                    Required inputs: name; status defaults to INACTIVE when omitted, and baseLocationId, \
+                    travelBufferPolicyId, notes, capabilityIds and coverageRules are optional for inactive units.
+                    Emits a LOCATION_MOBILE_UNIT_CREATE event and persists any supplied coverage rules in the \
+                    same transaction.
+                    Returns 201 with the created unit and 409 when the name is already taken at the base \
+                    location.
+                    """)
     @ApiResponse(responseCode = "201", description = "Mobile unit created successfully.")
+    @ApiResponse(responseCode = "409", description = "Mobile unit name already taken at the base location.")
     @EmitEvent(id = "LOCATION_MOBILE_UNIT_CREATE", apiVersion = "1")
     @PreAuthorize("hasAuthority('location:mobile-unit:manage')")
     @SecurityRequirement(
@@ -48,12 +85,33 @@ public class MobileUnitController {
             scopes = {"location:mobile-unit:manage"})
     @PostMapping
     public ResponseEntity<MobileUnitResponse> createMobileUnit(
-            @Parameter(description = "Mobile unit creation request body") @RequestBody MobileUnitRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Mobile unit to create; an ACTIVE unit must arrive complete with its"
+                                    + " travel buffer policy, capabilities and coverage rules.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Active mobile unit",
+                                                            value = MOBILE_UNIT_EXAMPLE)))
+                    @RequestBody
+                    MobileUnitRequest request) {
         log.info("Creating mobile unit with name(mask)={}", maskForLog(request != null ? request.getName() : null));
         return ResponseEntity.status(HttpStatus.CREATED).body(mobileUnitService.createMobileUnit(request));
     }
 
-    @Operation(summary = "List mobile units", description = "List mobile units with pagination.")
+    @Operation(operationId = "listMobileUnits", summary = "List Mobile Units With Pagination", description = """
+                    Lists all mobile units as a page with status, base location and travel buffer policy \
+                    references.
+                    Use this tool to enumerate or browse units; use getMobileUnitById instead when the unit id is \
+                    known, and findEligibleMobileUnits to match units to a service address.
+                    Preconditions: none beyond the location:mobile-unit:read authority.
+                    Required inputs: none; page defaults to 0 and size to 20.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with a page of mobile units, empty when none exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Mobile units retrieved successfully.")
     @PreAuthorize("hasAuthority('location:mobile-unit:read')")
     @SecurityRequirement(
@@ -65,7 +123,16 @@ public class MobileUnitController {
         return ResponseEntity.ok(mobileUnitService.list(page, size));
     }
 
-    @Operation(summary = "Get mobile unit", description = "Get a mobile unit by ID.")
+    @Operation(operationId = "getMobileUnitById", summary = "Get a Mobile Unit by Identifier", description = """
+                    Returns a single mobile unit with its status, base location, capability ids and travel buffer \
+                    policy reference.
+                    Use this tool when the unit id is already known; use listMobileUnits instead to enumerate, \
+                    and listCoverageRules to read the unit's coverage separately.
+                    Preconditions: the mobile unit must exist.
+                    Required inputs: id (UUID) as a path parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no mobile unit exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Mobile unit returned.")
     @ApiResponse(responseCode = "404", description = "Mobile unit not found.")
     @PreAuthorize("hasAuthority('location:mobile-unit:read')")
@@ -81,8 +148,22 @@ public class MobileUnitController {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Mobile unit not found"));
     }
 
-    @Operation(summary = "Patch mobile unit", description = "Partially update a mobile unit.")
+    @Operation(operationId = "patchMobileUnit", summary = "Patch Fields of a Mobile Unit", description = """
+                    Applies a partial update to a mobile unit, accepting the keys name, status, notes and \
+                    travelBufferPolicyId.
+                    Use this tool for status transitions and travel-buffer-policy reassignment; use \
+                    replaceCoverageRules instead to change where the unit operates.
+                    Preconditions: none are enforced; when the unit id does not exist nothing is persisted and a \
+                    synthesized response built from the patch is echoed back, so callers must verify existence \
+                    first with getMobileUnitById.
+                    Required inputs: id (UUID) as a path parameter and a JSON object of the fields to change; \
+                    status values are upper-cased and a blank status normalizes to INACTIVE.
+                    Emits a LOCATION_MOBILE_UNIT_UPDATE event.
+                    Returns 200 even for unknown ids (with the unpersisted echo) and 409 when a name change \
+                    collides with another unit at the same base location.
+                    """)
     @ApiResponse(responseCode = "200", description = "Mobile units managed successfully.")
+    @ApiResponse(responseCode = "409", description = "Mobile unit name already taken at the base location.")
     @EmitEvent(id = "LOCATION_MOBILE_UNIT_UPDATE", apiVersion = "1")
     @PreAuthorize("hasAuthority('location:mobile-unit:manage')")
     @SecurityRequirement(
@@ -90,11 +171,41 @@ public class MobileUnitController {
             scopes = {"location:mobile-unit:manage"})
     @PatchMapping("/{id}")
     public ResponseEntity<MobileUnitResponse> patchMobileUnit(
-            @PathVariable UUID id, @RequestBody Map<String, Object> patch) {
+            @PathVariable UUID id,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Free-form patch object; only the keys name, status, notes and"
+                                    + " travelBufferPolicyId are recognized.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Deactivate unit",
+                                                            value =
+                                                                    "{\"status\":\"INACTIVE\",\"notes\":\"Winter maintenance\"}")))
+                    @RequestBody
+                    Map<String, Object> patch) {
         return ResponseEntity.ok(mobileUnitService.patch(id, patch));
     }
 
-    @Operation(summary = "Replace coverage rules", description = "Atomically replace coverage rules for a mobile unit.")
+    @Operation(
+            operationId = "replaceCoverageRules",
+            summary = "Replace Coverage Rules for Mobile Unit",
+            description = """
+                    Atomically replaces the full set of coverage rules for a mobile unit, deleting the existing \
+                    rules and inserting the supplied ones in one transaction.
+                    Use this tool whenever coverage changes, sending the complete desired rule set; do not use \
+                    patchMobileUnit, which cannot modify coverage.
+                    Preconditions: the mobile unit must exist; a referenced serviceAreaId that does not resolve \
+                    is stored as a rule without a service area rather than rejected.
+                    Required inputs: id (UUID) as a path parameter and a body of the form {"rules": [...]}, each \
+                    rule carrying ruleType and optionally serviceAreaId, priority (defaults to 0), validFrom, \
+                    validTo and maxDistance.
+                    Emits a LOCATION_COVERAGE_RULES_REPLACE event.
+                    Returns 404 when the mobile unit does not exist; an omitted or empty rules array clears all \
+                    coverage.
+                    """)
     @ApiResponse(responseCode = "200", description = "Coverage rules replaced successfully.")
     @ApiResponse(responseCode = "404", description = "Mobile unit not found.")
     @EmitEvent(id = "LOCATION_COVERAGE_RULES_REPLACE", apiVersion = "1")
@@ -104,13 +215,34 @@ public class MobileUnitController {
             scopes = {"location:mobile-unit:manage"})
     @PutMapping("/{id}/coverage-rules")
     public ResponseEntity<List<CoverageRuleResponse>> replaceCoverageRules(
-            @PathVariable UUID id, @RequestBody Map<String, Object> payload) {
+            @PathVariable UUID id,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Envelope holding the complete replacement rule set under the"
+                                    + " \"rules\" key; existing rules not present here are deleted.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Single service-area rule",
+                                                            value = COVERAGE_RULES_EXAMPLE)))
+                    @RequestBody
+                    Map<String, Object> payload) {
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> rawRules = (List<Map<String, Object>>) payload.getOrDefault("rules", List.of());
         return ResponseEntity.ok(mobileUnitService.replaceCoverageRules(id.toString(), rawRules));
     }
 
-    @Operation(summary = "Get coverage rules", description = "Get coverage rules for a mobile unit.")
+    @Operation(operationId = "listCoverageRules", summary = "Get Coverage Rules of Mobile Unit", description = """
+                    Returns the coverage rules of a mobile unit ordered by ascending priority.
+                    Use this tool to inspect where a unit currently operates; use findEligibleMobileUnits instead \
+                    to answer which units cover a given postal code.
+                    Preconditions: none; an unknown unit id yields an empty list rather than an error.
+                    Required inputs: id (UUID) as a path parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the ordered rule list, empty when the unit has no rules or does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Coverage rules returned.")
     @PreAuthorize("hasAuthority('location:mobile-unit:read')")
     @SecurityRequirement(

--- a/pos-location/src/main/java/com/positivity/location/internal/controller/MobileUnitEligibilityController.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/controller/MobileUnitEligibilityController.java
@@ -29,8 +29,20 @@ public class MobileUnitEligibilityController {
     private final MobileUnitService mobileUnitService;
 
     @Operation(
-            summary = "Find eligible mobile units",
-            description = "Return eligible active units for a service request.")
+            operationId = "findEligibleMobileUnits",
+            summary = "Find Eligible Mobile Units for Address",
+            description = """
+                    Finds the ACTIVE mobile units whose coverage rules include a postal code on a given date, \
+                    ordered by ascending rule priority.
+                    Use this tool when dispatching a mobile service request to a customer address; use \
+                    listMobileUnits instead for plain enumeration without eligibility matching.
+                    Preconditions: coverage rules must already link units to service areas containing the postal \
+                    code; units whose status is not ACTIVE are excluded.
+                    Required inputs: postalCode, countryCode and at (an ISO-8601 instant), all mandatory; the \
+                    instant is reduced to a UTC calendar date for validFrom and validTo matching.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the eligible units, empty when nothing covers the address on that date.
+                    """)
     @ApiResponse(responseCode = "200", description = "Eligible mobile units returned.")
     @PreAuthorize("hasAuthority('location:mobile-unit:read')")
     @GetMapping("/v1/mobile-units:eligible")

--- a/pos-location/src/main/java/com/positivity/location/internal/controller/ServiceAreaController.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/controller/ServiceAreaController.java
@@ -5,6 +5,8 @@ import com.positivity.location.internal.dto.ServiceAreaRequest;
 import com.positivity.location.internal.dto.ServiceAreaResponse;
 import com.positivity.location.service.ServiceAreaService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,25 +35,60 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ServiceAreaController {
 
+    private static final String SERVICE_AREA_EXAMPLE = """
+            {"name":"North Metro",
+             "description":"Northern metropolitan coverage zone",
+             "active":true,
+             "postalCodes":[{"postalCode":"62704","countryCode":"US"},
+                            {"postalCode":"62711","countryCode":"US"}]}
+            """;
+
     private final ServiceAreaService serviceAreaService;
 
-    @Operation(
-            summary = "Create service area",
-            description = "Create a service area that defines where a location can provide service coverage")
+    @Operation(operationId = "createServiceArea", summary = "Create a Postal Code Service Area", description = """
+                    Creates a service area, a named set of postal codes that defines where mobile coverage can be \
+                    offered.
+                    Use this tool before wiring coverage rules that reference the area; do not use \
+                    patchServiceArea, which edits an existing area.
+                    Preconditions: at least one postal code entry must be supplied and every entry must carry a \
+                    countryCode; the name must not collide with an existing service area.
+                    Required inputs: name and postalCodes, each entry with postalCode and countryCode; \
+                    description is optional and active defaults to true.
+                    Emits a LOCATION_SERVICE_AREA_CREATE event.
+                    Returns 201 with the created area and 409 when the name is already taken.
+                    """)
     @ApiResponse(responseCode = "201", description = "Service area created")
+    @ApiResponse(responseCode = "409", description = "Service area name already taken")
     @EmitEvent(id = "LOCATION_SERVICE_AREA_CREATE", apiVersion = "1")
     @PreAuthorize("hasAuthority('location:service-area:manage')")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"location:service-area:manage"})
     @PostMapping
-    public ResponseEntity<ServiceAreaResponse> create(@RequestBody ServiceAreaRequest request) {
+    public ResponseEntity<ServiceAreaResponse> create(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Service area to create, defined by its postal code and country code" + " entries.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "Metro area", value = SERVICE_AREA_EXAMPLE)))
+                    @RequestBody
+                    ServiceAreaRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(serviceAreaService.create(request));
     }
 
-    @Operation(
-            summary = "List service areas",
-            description = "List configured service areas available for dispatching and coverage management")
+    @Operation(operationId = "listServiceAreas", summary = "List All Configured Service Areas", description = """
+                    Lists all configured service areas with their postal code sets and active flags.
+                    Use this tool to discover area ids for coverage rules; use listCoverageRules instead to see \
+                    which areas a specific mobile unit uses.
+                    Preconditions: none beyond the location:service-area:read authority.
+                    Required inputs: none; there are no parameters, no paging and no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the full unpaginated list.
+                    """)
     @ApiResponse(responseCode = "200", description = "Service areas listed")
     @PreAuthorize("hasAuthority('location:service-area:read')")
     @SecurityRequirement(
@@ -62,9 +99,16 @@ public class ServiceAreaController {
         return ResponseEntity.ok(serviceAreaService.list());
     }
 
-    @Operation(
-            summary = "Patch service area",
-            description = "Patch an existing service area using the provided partial field updates")
+    @Operation(operationId = "patchServiceArea", summary = "Patch Fields of a Service Area", description = """
+                    Applies a partial update to a service area, accepting only the keys description and active.
+                    Use this tool to retire an area with active=false or amend its description; do not use it to \
+                    rename an area or change its postal codes, which are immutable after createServiceArea.
+                    Preconditions: the service area must exist.
+                    Required inputs: id (UUID) as a path parameter and a JSON object; keys other than description \
+                    and active are silently ignored.
+                    Emits a LOCATION_SERVICE_AREA_PATCH event.
+                    Returns 400 when the id is not a valid UUID and 404 when no service area exists for it.
+                    """)
     @ApiResponse(responseCode = "200", description = "Service area patched")
     @ApiResponse(responseCode = "400", description = "Invalid service area id")
     @ApiResponse(responseCode = "404", description = "Service area not found")
@@ -74,7 +118,22 @@ public class ServiceAreaController {
             name = "bearerAuth",
             scopes = {"location:service-area:manage"})
     @PatchMapping("/{id}")
-    public ResponseEntity<ServiceAreaResponse> patch(@PathVariable String id, @RequestBody Map<String, Object> patch) {
+    public ResponseEntity<ServiceAreaResponse> patch(
+            @PathVariable String id,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Free-form patch object; only the keys description and active are" + " recognized.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Retire area",
+                                                            value =
+                                                                    "{\"description\":\"Retired winter zone\",\"active\":false}")))
+                    @RequestBody
+                    Map<String, Object> patch) {
         return ResponseEntity.ok(serviceAreaService.patch(id, patch));
     }
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/controller/SiteDefaultsController.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/controller/SiteDefaultsController.java
@@ -7,6 +7,7 @@ import com.positivity.location.service.SiteDefaultsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -37,8 +38,22 @@ public class SiteDefaultsController {
 
     @PutMapping
     @Operation(
-            summary = "Configure site defaults",
-            description = "Create or update default site configuration for a location.")
+            operationId = "configureSiteDefaults",
+            summary = "Configure Default Storage Locations for Site",
+            description = """
+                    Creates or replaces the default staging and quarantine storage locations of a site in a \
+                    single idempotent upsert.
+                    Use this tool when commissioning a site's receiving flow or moving its defaults; use \
+                    getSiteDefaults instead to read the current assignment.
+                    Preconditions: the site must exist, and both referenced storage locations must belong to that \
+                    site.
+                    Required inputs: locationId (UUID) as a path parameter and a body with both \
+                    defaultStagingLocationId and defaultQuarantineLocationId; the two ids must differ.
+                    Emits a LOCATION_SITE_DEFAULTS_PUT event and republishes the location fact carrying the new \
+                    defaults.
+                    Returns 404 when the site does not exist, 400 when either id is missing or both ids are the \
+                    same, and 422 when a referenced storage location does not belong to the site.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Site defaults configured",
@@ -49,6 +64,7 @@ public class SiteDefaultsController {
     @ApiResponse(responseCode = "400", description = "Invalid request payload")
     @ApiResponse(responseCode = "403", description = "Forbidden")
     @ApiResponse(responseCode = "404", description = "Location not found")
+    @ApiResponse(responseCode = "422", description = "Default storage location does not belong to the site")
     @PreAuthorize("hasAuthority('location:write')")
     @EmitEvent(id = "LOCATION_SITE_DEFAULTS_PUT", apiVersion = "1")
     @SecurityRequirement(
@@ -56,12 +72,35 @@ public class SiteDefaultsController {
             scopes = {"location:write"})
     public ResponseEntity<SiteDefaultsResponse> configureDefaults(
             @Parameter(description = "ID of the location", required = true) @PathVariable UUID locationId,
-            @RequestBody SiteDefaultsRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Pair of storage location ids to install as the site's staging and"
+                                    + " quarantine defaults.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Staging and quarantine defaults",
+                                                            value = """
+                                                                    {"defaultStagingLocationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01",
+                                                                     "defaultQuarantineLocationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02"}
+                                                                    """)))
+                    @RequestBody
+                    SiteDefaultsRequest request) {
         return ResponseEntity.ok(siteDefaultsService.configureDefaults(locationId, request));
     }
 
     @GetMapping
-    @Operation(summary = "Get site defaults", description = "Retrieve default site configuration for a location.")
+    @Operation(operationId = "getSiteDefaults", summary = "Get Default Storage Locations for Site", description = """
+                    Returns the default staging and quarantine storage location ids configured for a site.
+                    Use this tool when routing received or quarantined inventory; do not use \
+                    configureSiteDefaults, which overwrites the assignment.
+                    Preconditions: the site must exist; both ids are null when defaults were never configured.
+                    Required inputs: locationId (UUID) as a path parameter.
+                    Emits a LOCATION_SITE_DEFAULTS_GET event; no state changes.
+                    Returns 404 when the site does not exist.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Site defaults returned",

--- a/pos-location/src/main/java/com/positivity/location/internal/controller/StorageLocationController.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/controller/StorageLocationController.java
@@ -10,6 +10,8 @@ import com.positivity.location.internal.enums.StorageLocationType;
 import com.positivity.location.service.StorageLocationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,6 +43,15 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Storage Location API", description = "Operations for managing storage locations within a site")
 public class StorageLocationController {
 
+    private static final String STORAGE_LOCATION_EXAMPLE = """
+            {"name":"Aisle 3 Bin 12",
+             "barcode":"SL-000312",
+             "type":"BIN",
+             "parentStorageLocationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a10",
+             "capacity":{"maxUnits":100},
+             "temperature":{"min":2,"max":8,"unit":"C"}}
+            """;
+
     private final StorageLocationService storageLocationService;
 
     @PostMapping
@@ -48,22 +59,63 @@ public class StorageLocationController {
     @PreAuthorize("hasAuthority('location:write')")
     @EmitEvent(id = "LOCATION_STORAGE_LOCATION_CREATE", apiVersion = "1")
     @Operation(
-            summary = "Create storage location",
-            description = "Create a storage location within a site using the provided topology and status details")
+            operationId = "createStorageLocation",
+            summary = "Create a Storage Location Within Site",
+            description = """
+                    Creates a storage location (FLOOR, SHELF, BIN, CAGE or TRUCK) inside a site, always starting \
+                    in ACTIVE status.
+                    Use this tool when adding storage topology to a site; do not use patchStorageLocation, which \
+                    modifies an existing node, and use createBay for vehicle service bays rather than inventory \
+                    storage.
+                    Preconditions: the site must exist, the name must be unique within the site \
+                    (case-insensitive), any barcode must be unique within the site, and a \
+                    parentStorageLocationId must reference a storage location of the same site.
+                    Required inputs: name and type; barcode, parentStorageLocationId, capacity and temperature \
+                    (free-form JSON objects) are optional.
+                    Emits a LOCATION_STORAGE_LOCATION_CREATE event and publishes a storage-location fact for \
+                    replica consumers.
+                    Returns 404 when the site does not exist, 409 when the name or barcode is already used in the \
+                    site, and 400 when the parent storage location is unknown or belongs to a different site.
+                    """)
     @ApiResponse(responseCode = "201", description = "Storage location created")
+    @ApiResponse(responseCode = "400", description = "Parent storage location unknown or in another site")
+    @ApiResponse(responseCode = "404", description = "Site not found")
+    @ApiResponse(responseCode = "409", description = "Duplicate name or barcode within the site")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"location:write"})
-    public StorageLocationResponse create(@PathVariable UUID siteId, @RequestBody StorageLocationRequest request) {
+    public StorageLocationResponse create(
+            @PathVariable UUID siteId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Storage location to create, positioned in the site's topology via its"
+                                    + " optional parent reference.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Refrigerated bin",
+                                                            value = STORAGE_LOCATION_EXAMPLE)))
+                    @RequestBody
+                    StorageLocationRequest request) {
         return storageLocationService.createStorageLocation(siteId, request);
     }
 
     @GetMapping
     @PreAuthorize("hasAuthority('location:read')")
     @EmitEvent(id = "LOCATION_STORAGE_LOCATION_LIST", apiVersion = "1")
-    @Operation(
-            summary = "List storage locations",
-            description = "List storage locations for a site with optional type and status filtering")
+    @Operation(operationId = "listStorageLocations", summary = "List Storage Locations of a Site", description = """
+                    Lists the storage locations of a site as a page, optionally filtered by type and status.
+                    Use this tool for paginated browsing; use getStorageLocationTopology instead when the \
+                    complete unpaginated hierarchy of the site is needed.
+                    Preconditions: none; an unknown site id yields an empty page rather than an error.
+                    Required inputs: siteId (UUID) as a path parameter; type (FLOOR, SHELF, BIN, CAGE, TRUCK) and \
+                    status (ACTIVE, INACTIVE, MAINTENANCE, QUARANTINED) filters are optional, and standard page, \
+                    size and sort parameters control paging.
+                    Emits a LOCATION_STORAGE_LOCATION_LIST event; no state changes.
+                    Returns 200 with a page of storage locations regardless of whether any match the filters.
+                    """)
     @ApiResponse(responseCode = "200", description = "Storage locations listed")
     @SecurityRequirement(
             name = "bearerAuth",
@@ -85,9 +137,18 @@ public class StorageLocationController {
     @PreAuthorize("hasAuthority('location:read')")
     @EmitEvent(id = "LOCATION_STORAGE_LOCATION_TOPOLOGY", apiVersion = "1")
     @Operation(
-            summary = "Get storage location topology",
-            description = "Return every storage location of a site, regardless of status, as a flat unpaginated "
-                    + "list with id, name, type, status, and parentStorageLocationId for topology consumers")
+            operationId = "getStorageLocationTopology",
+            summary = "Get Full Storage Location Topology",
+            description = """
+                    Returns every storage location of a site, regardless of status, as a flat unpaginated list \
+                    with id, name, type, status and parentStorageLocationId.
+                    Use this tool when a rollup or topology consumer needs the whole storage tree in one call; \
+                    use listStorageLocations instead for paginated, filtered browsing.
+                    Preconditions: the site must exist.
+                    Required inputs: siteId (UUID) as a path parameter; there is no filtering.
+                    Emits a LOCATION_STORAGE_LOCATION_TOPOLOGY event; no state changes.
+                    Returns 404 when the site does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Storage location topology returned")
     @ApiResponse(responseCode = "404", description = "Site not found")
     @SecurityRequirement(
@@ -101,9 +162,17 @@ public class StorageLocationController {
     @GetMapping("/{storageLocationId}")
     @PreAuthorize("hasAuthority('location:read')")
     @EmitEvent(id = "LOCATION_STORAGE_LOCATION_GET", apiVersion = "1")
-    @Operation(
-            summary = "Get storage location",
-            description = "Retrieve a single storage location for a site by its storage location identifier")
+    @Operation(operationId = "getStorageLocation", summary = "Get a Storage Location by Identifier", description = """
+                    Returns a single storage location of a site, including capacity and temperature attributes \
+                    and its parent reference.
+                    Use this tool when the storage location id and its site are both known; use \
+                    validateStorageLocation instead when only existence, active state and site ownership must be \
+                    checked without knowing the site.
+                    Preconditions: the storage location must exist and belong to the supplied site.
+                    Required inputs: siteId and storageLocationId (UUIDs) as path parameters.
+                    Emits a LOCATION_STORAGE_LOCATION_GET event; no state changes.
+                    Returns 404 when no storage location with that id exists under the site.
+                    """)
     @ApiResponse(responseCode = "200", description = "Storage location returned")
     @ApiResponse(responseCode = "404", description = "Storage location not found")
     @SecurityRequirement(
@@ -116,18 +185,53 @@ public class StorageLocationController {
     @PatchMapping("/{storageLocationId}")
     @PreAuthorize("hasAuthority('location:write')")
     @EmitEvent(id = "LOCATION_STORAGE_LOCATION_UPDATE", apiVersion = "1")
-    @Operation(
-            summary = "Patch storage location",
-            description = "Patch an existing storage location for a site using the provided partial updates")
+    @Operation(operationId = "patchStorageLocation", summary = "Patch Fields of a Storage Location", description = """
+                    Applies a partial update to a storage location, covering rename, barcode, reparenting, \
+                    capacity, temperature and status transitions.
+                    Use this tool for all storage-location mutations after creation, including deactivation; do \
+                    not use createStorageLocation, which adds a new node.
+                    Preconditions: the storage location must exist in the site; a new name or barcode must be \
+                    unique within the site, a new parent must belong to the same site without creating a cycle, \
+                    and deactivating a node that still holds on-hand stock requires a \
+                    destinationStorageLocationId naming an ACTIVE storage location of the same site to receive \
+                    the transferred inventory.
+                    Required inputs: siteId and storageLocationId (UUIDs) as path parameters and a body with at \
+                    least one field; status accepts ACTIVE, INACTIVE, MAINTENANCE or QUARANTINED.
+                    Emits a LOCATION_STORAGE_LOCATION_UPDATE event, publishes a storage-location fact, and on \
+                    deactivation with stock triggers an atomic inventory transfer to the destination.
+                    Returns 404 when the storage location or transfer destination does not exist, 409 when the \
+                    name or barcode collides or the new parent would create a cycle, 400 when the parent is \
+                    unknown or in another site, and 422 when deactivation needs a destination that is missing, \
+                    inactive or the node itself.
+                    """)
     @ApiResponse(responseCode = "200", description = "Storage location updated")
+    @ApiResponse(responseCode = "400", description = "Parent storage location unknown or in another site")
     @ApiResponse(responseCode = "404", description = "Storage location not found")
+    @ApiResponse(responseCode = "409", description = "Duplicate name or barcode, or reparenting would create a cycle")
+    @ApiResponse(responseCode = "422", description = "Deactivation destination missing, inactive or invalid")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"location:write"})
     public StorageLocationResponse patch(
             @PathVariable UUID siteId,
             @PathVariable UUID storageLocationId,
-            @RequestBody StorageLocationPatchRequest patch) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Partial storage-location payload; only non-null fields are applied,"
+                                    + " and destinationStorageLocationId is consumed only when deactivating a"
+                                    + " node that still holds stock.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Deactivate with stock transfer",
+                                                            value = """
+                                                                    {"status":"INACTIVE",
+                                                                     "destinationStorageLocationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a11"}
+                                                                    """)))
+                    @RequestBody
+                    StorageLocationPatchRequest patch) {
         return storageLocationService.patchStorageLocation(siteId, storageLocationId, patch);
     }
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/controller/StorageLocationValidationController.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/controller/StorageLocationValidationController.java
@@ -31,8 +31,19 @@ public class StorageLocationValidationController {
 
     @GetMapping("/{storageLocationId}/validation")
     @Operation(
-            summary = "Validate storage location reference",
-            description = "Returns existence, active status, and site ownership for a storage location ID.")
+            operationId = "validateStorageLocation",
+            summary = "Validate Storage Location Reference State",
+            description = """
+                    Returns existence, active status, owning site id and maximum unit capacity for a storage \
+                    location id without requiring the site to be known.
+                    Use this tool for inter-service reference validation before storing a storageLocationId; use \
+                    getStorageLocation instead when the full record is needed and the site id is known.
+                    Preconditions: none; unknown ids are a valid input.
+                    Required inputs: storageLocationId (UUID) as a path parameter.
+                    Emits a LOCATION_STORAGE_LOCATION_VALIDATE event; no state changes.
+                    Returns 200 always, with exists=false and a null siteId when the id is unknown, and 400 when \
+                    the path value is not a valid UUID.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "200", description = "Validation payload returned"),

--- a/pos-location/src/main/java/com/positivity/location/internal/controller/TravelBufferPolicyController.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/controller/TravelBufferPolicyController.java
@@ -5,6 +5,8 @@ import com.positivity.location.internal.dto.TravelBufferPolicyRequest;
 import com.positivity.location.internal.dto.TravelBufferPolicyResponse;
 import com.positivity.location.service.TravelBufferPolicyService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -36,22 +38,56 @@ public class TravelBufferPolicyController {
     private final TravelBufferPolicyService travelBufferPolicyService;
 
     @Operation(
-            summary = "Create travel buffer policy",
-            description = "Create a travel buffer policy that defines extra travel time handling rules")
+            operationId = "createTravelBufferPolicy",
+            summary = "Create a New Travel Buffer Policy",
+            description = """
+                    Creates a travel buffer policy that adds slack time around mobile unit travel for scheduling \
+                    decisions.
+                    Use this tool before assigning the policy to mobile units via createMobileUnit or \
+                    patchMobileUnit; do not use patchTravelBufferPolicy, which edits an existing policy.
+                    Preconditions: the name must not collide with an existing policy.
+                    Required inputs: name and bufferType, one of FLAT_MINUTES, PERCENTAGE_OF_TRAVEL or \
+                    DISTANCE_MULTIPLIER; bufferValue is optional, must be non-negative, and is interpreted \
+                    according to the bufferType.
+                    Emits a LOCATION_TRAVEL_BUFFER_POLICY_CREATE event.
+                    Returns 201 with the created policy and 409 when the name is already taken.
+                    """)
     @ApiResponse(responseCode = "201", description = "Travel buffer policy created")
+    @ApiResponse(responseCode = "409", description = "Travel buffer policy name already taken")
     @EmitEvent(id = "LOCATION_TRAVEL_BUFFER_POLICY_CREATE", apiVersion = "1")
     @PreAuthorize("hasAuthority('location:travel-buffer-policy:manage')")
     @SecurityRequirement(
             name = "bearerAuth",
             scopes = {"location:travel-buffer-policy:manage"})
     @PostMapping
-    public ResponseEntity<TravelBufferPolicyResponse> create(@RequestBody TravelBufferPolicyRequest request) {
+    public ResponseEntity<TravelBufferPolicyResponse> create(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Travel buffer policy to create, pairing a buffer type with its"
+                                    + " numeric value.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Flat minutes buffer", value = """
+                                                                    {"name":"Standard Metro Buffer",
+                                                                     "bufferType":"FLAT_MINUTES",
+                                                                     "bufferValue":30,
+                                                                     "notes":"Applies during peak hours only"}
+                                                                    """)))
+                    @RequestBody
+                    TravelBufferPolicyRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(travelBufferPolicyService.create(request));
     }
 
-    @Operation(
-            summary = "List travel buffer policies",
-            description = "List configured travel buffer policies available for routing and scheduling decisions")
+    @Operation(operationId = "listTravelBufferPolicies", summary = "List All Travel Buffer Policies", description = """
+                    Lists all travel buffer policies with their buffer type, value and notes.
+                    Use this tool to discover policy ids for createMobileUnit or patchMobileUnit; use \
+                    patchTravelBufferPolicy instead to change one.
+                    Preconditions: none beyond the location:travel-buffer-policy:read authority.
+                    Required inputs: none; there are no parameters, no paging and no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the full unpaginated list.
+                    """)
     @ApiResponse(responseCode = "200", description = "Travel buffer policies listed")
     @PreAuthorize("hasAuthority('location:travel-buffer-policy:read')")
     @SecurityRequirement(
@@ -63,8 +99,21 @@ public class TravelBufferPolicyController {
     }
 
     @Operation(
-            summary = "Patch travel buffer policy",
-            description = "Patch an existing travel buffer policy using the provided partial field updates")
+            operationId = "patchTravelBufferPolicy",
+            summary = "Patch Fields of Travel Buffer Policy",
+            description = """
+                    Applies a partial update to a travel buffer policy, accepting the keys bufferType, \
+                    bufferValue and notes.
+                    Use this tool to tune buffer behavior; do not use it to rename a policy, whose name is \
+                    immutable after createTravelBufferPolicy.
+                    Preconditions: the policy must exist; the resulting bufferType must remain one of \
+                    FLAT_MINUTES, PERCENTAGE_OF_TRAVEL or DISTANCE_MULTIPLIER and the resulting bufferValue \
+                    non-negative.
+                    Required inputs: id (UUID) as a path parameter and a JSON object of the fields to change; \
+                    keys other than bufferType, bufferValue and notes are silently ignored.
+                    Emits a LOCATION_TRAVEL_BUFFER_POLICY_PATCH event.
+                    Returns 400 when the id is not a valid UUID and 404 when no policy exists for it.
+                    """)
     @ApiResponse(responseCode = "200", description = "Travel buffer policy patched")
     @ApiResponse(responseCode = "400", description = "Invalid travel buffer policy id")
     @ApiResponse(responseCode = "404", description = "Travel buffer policy not found")
@@ -75,7 +124,20 @@ public class TravelBufferPolicyController {
             scopes = {"location:travel-buffer-policy:manage"})
     @PatchMapping("/{id}")
     public ResponseEntity<TravelBufferPolicyResponse> patch(
-            @PathVariable String id, @RequestBody Map<String, Object> patch) {
+            @PathVariable String id,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Free-form patch object; only the keys bufferType, bufferValue and"
+                                    + " notes are recognized.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Raise buffer value",
+                                                            value = "{\"bufferValue\":45}")))
+                    @RequestBody
+                    Map<String, Object> patch) {
         return ResponseEntity.ok(travelBufferPolicyService.patch(id, patch));
     }
 }

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/BayPatchRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/BayPatchRequest.java
@@ -28,7 +28,10 @@ public class BayPatchRequest {
     @Schema(description = "Display name of the bay", example = "Bay A1", requiredMode = NOT_REQUIRED)
     private String name;
 
-    @Schema(description = "Type classification of the bay", example = "LIFT", requiredMode = NOT_REQUIRED)
+    @Schema(
+            description = "Type classification of the bay; must be a BayType value",
+            example = "GENERAL_SERVICE",
+            requiredMode = NOT_REQUIRED)
     private String bayType;
 
     @Schema(description = "Operational status of the bay", example = "ACTIVE", requiredMode = NOT_REQUIRED)

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/BayRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/BayRequest.java
@@ -32,7 +32,10 @@ public class BayRequest {
     @NotBlank
     private String name;
 
-    @Schema(description = "Type classification of the bay", example = "LIFT", requiredMode = REQUIRED)
+    @Schema(
+            description = "Type classification of the bay; must be a BayType value",
+            example = "GENERAL_SERVICE",
+            requiredMode = REQUIRED)
     @NotBlank
     private String bayType;
 

--- a/pos-location/src/main/java/com/positivity/location/internal/dto/TravelBufferPolicyRequest.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/dto/TravelBufferPolicyRequest.java
@@ -33,7 +33,11 @@ public class TravelBufferPolicyRequest {
     @NotBlank
     private String name;
 
-    @Schema(description = "Type of buffer the policy applies", example = "FIXED_MINUTES", requiredMode = REQUIRED)
+    @Schema(
+            description =
+                    "Type of buffer the policy applies; one of FLAT_MINUTES, PERCENTAGE_OF_TRAVEL or DISTANCE_MULTIPLIER",
+            example = "FLAT_MINUTES",
+            requiredMode = REQUIRED)
     @NotBlank
     private String bufferType;
 

--- a/pos-mcp-server/.flattened-pom.xml
+++ b/pos-mcp-server/.flattened-pom.xml
@@ -21,6 +21,8 @@
   </licenses>
   <properties>
     <maven.compiler.target>25</maven.compiler.target>
+    <jacoco.branch.min>0.63</jacoco.branch.min>
+    <jacoco.line.min>0.75</jacoco.line.min>
     <java.version>25</java.version>
     <maven.compiler.source>25</maven.compiler.source>
   </properties>

--- a/pos-mcp-server/openapi.yaml
+++ b/pos-mcp-server/openapi.yaml
@@ -23,9 +23,21 @@ paths:
     get:
       tags:
       - System Prompts
-      summary: Get system prompt
-      description: Retrieve a single MCP system prompt by its identifier
-      operationId: get
+      summary: Get an MCP System Prompt
+      description: 'Returns a single MCP system prompt by its identifier, including its full content.
+
+        Use this tool when the prompt id (UUID) is already known; use listSystemPrompts instead to discover ids or find a prompt by name.
+
+        Preconditions: a system prompt with the given id must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no system prompt exists for the supplied id.
+
+        '
+      operationId: getSystemPrompt
       parameters:
       - name: id
         in: path
@@ -54,9 +66,21 @@ paths:
     put:
       tags:
       - System Prompts
-      summary: Update system prompt
-      description: Update an existing MCP system prompt by replacing its editable fields
-      operationId: update
+      summary: Update an MCP System Prompt
+      description: 'Replaces the name and content of an existing MCP system prompt.
+
+        Use this tool to edit prompt text or rename a prompt; do not use createSystemPrompt, which adds a new prompt alongside the existing ones.
+
+        Preconditions: the prompt must exist, and when the name is being changed no other prompt may already use the new name.
+
+        Required inputs: id (UUID) as a path parameter plus name and content in the body; both body fields are mandatory and fully replace the stored values.
+
+        Emits a MCP_SYSTEM_PROMPT_UPDATE event and invalidates cached agents built from the prompt so subsequent chats use the new content.
+
+        Returns 200 with the updated prompt, 404 when no prompt exists for the id, and 400 when the new name is already used by another prompt.
+
+        '
+      operationId: updateSystemPrompt
       parameters:
       - name: id
         in: path
@@ -65,10 +89,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Full replacement name and content for the stored prompt.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SystemPromptRequest'
+            examples:
+              Revised assistant prompt:
+                description: Revised assistant prompt
+                value:
+                  name: Workorder Assistant
+                  content: You are a concise assistant that creates and updates workorders.
         required: true
       responses:
         '200':
@@ -91,9 +122,21 @@ paths:
     delete:
       tags:
       - System Prompts
-      summary: Delete system prompt
-      description: Delete an MCP system prompt so it can no longer be selected for agent sessions
-      operationId: delete
+      summary: Delete an MCP System Prompt
+      description: 'Deletes an MCP system prompt so it can no longer be assigned to agent sessions.
+
+        Use this tool to retire a prompt; do not use updateSystemPrompt, which keeps the prompt and changes its fields.
+
+        Preconditions: none; deleting an id that does not exist is a no-op.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a MCP_SYSTEM_PROMPT_DELETE event and, when the prompt existed, invalidates cached agents that were built from it.
+
+        Returns 204 whether or not the prompt existed, making the call idempotent.
+
+        '
+      operationId: deleteSystemPrompt
       parameters:
       - name: id
         in: path
@@ -115,9 +158,21 @@ paths:
     get:
       tags:
       - LLM API Configuration
-      summary: Get an LLM API configuration
-      description: Retrieve a single LLM API provider configuration by its identifier.
-      operationId: get_1
+      summary: Get an LLM API Configuration
+      description: 'Returns a single LLM provider API configuration by its identifier.
+
+        Use this tool when the configuration id (UUID) is already known; use listLlmApiConfigs instead to discover ids.
+
+        Preconditions: a configuration with the given id must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 when the configuration exists; an unknown id is not mapped to a 404 by this module and currently surfaces as a 500 error.
+
+        '
+      operationId: getLlmApiConfig
       parameters:
       - name: id
         in: path
@@ -140,9 +195,21 @@ paths:
     put:
       tags:
       - LLM API Configuration
-      summary: Update an LLM API configuration
-      description: Update an existing LLM API provider configuration by its identifier.
-      operationId: update_1
+      summary: Update an LLM API Configuration
+      description: 'Replaces every editable field of an existing LLM provider API configuration identified by id.
+
+        Use this tool to change a provider''s model, base URL, credential or headers; do not use createLlmApiConfig, which registers an additional configuration.
+
+        Preconditions: the configuration must exist, and when apiId is being changed the new apiId must not already be used by another configuration.
+
+        Required inputs: id (UUID) as a path parameter plus a full body with apiId, model, baseUrl and apiKey; headers defaults to empty when omitted, so a partial body is not merged.
+
+        Emits a MCP_LLM_API_UPDATE event.
+
+        Returns 200 with the updated configuration; an unknown id or a duplicate apiId is rejected, though this module surfaces both as a 500 rather than a 404 or 409.
+
+        '
+      operationId: updateLlmApiConfig
       parameters:
       - name: id
         in: path
@@ -151,10 +218,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Full replacement provider endpoint, model and credential values.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LlmApiConfigRequest'
+            examples:
+              Updated OpenAI provider:
+                description: Updated OpenAI provider
+                value:
+                  apiId: openai-gpt4o
+                  model: gpt-4o
+                  baseUrl: https://api.openai.com/v1
+                  apiKey: sk-proj-xxxxxxxxxxxxxxxx
+                  headers:
+                    X-Org-Id: org-01960003
         required: true
       responses:
         '200':
@@ -171,9 +249,21 @@ paths:
     delete:
       tags:
       - LLM API Configuration
-      summary: Delete an LLM API configuration
-      description: Delete an existing LLM API provider configuration by its identifier.
-      operationId: delete_1
+      summary: Delete an LLM API Configuration
+      description: 'Deletes an LLM provider API configuration so the MCP server can no longer use it to invoke that provider.
+
+        Use this tool to retire a provider configuration; do not use updateLlmApiConfig, which keeps the configuration and changes its fields.
+
+        Preconditions: none; deleting an id that does not exist is a no-op.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a MCP_LLM_API_DELETE event.
+
+        Returns 204 whether or not the configuration existed, making the call idempotent.
+
+        '
+      operationId: deleteLlmApiConfig
       parameters:
       - name: id
         in: path
@@ -193,8 +283,20 @@ paths:
     get:
       tags:
       - MCP Tool Permissions
-      summary: List a tool's permission grants
-      description: Return the permission codes currently granted to a discovered OpenAPI tool.
+      summary: List a Tool's Permission Grants
+      description: 'Returns the permission codes currently granted to a discovered OpenAPI tool.
+
+        Use this tool to inspect why a discovered tool is or is not selectable for a caller; use grantToolPermission or revokeToolPermission instead to change the grants.
+
+        Preconditions: the named tool must exist as a discovered (source openapi) tool; discovered tools are fail-closed and unselectable until at least one grant exists.
+
+        Required inputs: toolName as a path parameter, matching the tool''s registered name exactly.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the grant set (possibly empty), and 404 when no discovered OpenAPI tool has the given name.
+
+        '
       operationId: listToolPermissions
       parameters:
       - name: toolName
@@ -217,8 +319,20 @@ paths:
     post:
       tags:
       - MCP Tool Permissions
-      summary: Grant a permission to a tool
-      description: Grant a permission code to a discovered OpenAPI tool so callers holding it can select the tool. Idempotent. Returns the tool's full permission set.
+      summary: Grant a Permission to a Tool
+      description: 'Grants a permission code to a discovered OpenAPI tool so callers holding that code can select the tool during chat.
+
+        Use this tool to open up a fail-closed discovered operation; do not use revokeToolPermission, which removes a grant.
+
+        Preconditions: the named tool must exist as a discovered (source openapi) tool; granting a code that is already present changes nothing.
+
+        Required inputs: toolName as a path parameter and permissionCode in the body, either the literal AUTHENTICATED or a domain:resource:action code such as event-receiver:event_type:view.
+
+        Emits a MCP_TOOL_PERMISSION_GRANT event; when the grant set actually changes, cached role agents are invalidated so the tool becomes selectable on the next chat turn.
+
+        Returns 201 with the tool''s full permission set (idempotently for repeated grants), 404 when no discovered OpenAPI tool has the given name, and 400 when the permission code does not match the required pattern.
+
+        '
       operationId: grantToolPermission
       parameters:
       - name: toolName
@@ -227,10 +341,16 @@ paths:
         schema:
           type: string
       requestBody:
+        description: The permission code the tool should be selectable under.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ToolPermissionRequest'
+            examples:
+              Domain permission grant:
+                description: Domain permission grant
+                value:
+                  permissionCode: event-receiver:event_type:view
         required: true
       responses:
         '200':
@@ -247,8 +367,20 @@ paths:
     delete:
       tags:
       - MCP Tool Permissions
-      summary: Revoke a permission from a tool
-      description: Revoke a permission code from a discovered OpenAPI tool. Idempotent.
+      summary: Revoke a Permission From a Tool
+      description: 'Revokes a permission code from a discovered OpenAPI tool, removing it from the set that makes the tool selectable.
+
+        Use this tool to withdraw chat access to a discovered operation; do not use grantToolPermission, which adds a grant.
+
+        Preconditions: the named tool must exist as a discovered (source openapi) tool; revoking a code that is not granted changes nothing.
+
+        Required inputs: toolName as a path parameter and permissionCode as a query parameter; there is no request body.
+
+        Emits a MCP_TOOL_PERMISSION_REVOKE event; when the grant set actually changes, cached role agents are invalidated so the tool stops being selectable.
+
+        Returns 204 whether or not the code was granted (idempotent), 404 when no discovered OpenAPI tool has the given name, and 400 when the permission code is blank.
+
+        '
       operationId: revokeToolPermission
       parameters:
       - name: toolName
@@ -274,9 +406,21 @@ paths:
     get:
       tags:
       - System Prompts
-      summary: List system prompts
-      description: List all configured MCP system prompts that can be assigned to agents
-      operationId: list
+      summary: List All MCP System Prompts
+      description: 'Returns every reusable MCP system prompt with its name and content.
+
+        Use this tool to browse prompts or to find a prompt id by name; use getSystemPrompt instead when the id is already known.
+
+        Preconditions: none; an empty list simply means no prompts have been created yet.
+
+        Required inputs: none; there are no filters, no paging and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the full list of prompts.
+
+        '
+      operationId: listSystemPrompts
       responses:
         '200':
           description: System prompts returned
@@ -294,14 +438,33 @@ paths:
     post:
       tags:
       - System Prompts
-      summary: Create system prompt
-      description: Create a new MCP system prompt that can be used during agent orchestration
-      operationId: create
+      summary: Create an MCP System Prompt
+      description: 'Creates a reusable MCP system prompt that agent orchestration can assign to assistant agents.
+
+        Use this tool to add a new named prompt; do not use updateSystemPrompt, which edits a prompt that already exists.
+
+        Preconditions: no prompt may already use the requested name, which is unique across prompts.
+
+        Required inputs: name (unique, human-readable) and content (the prompt text); both are mandatory and non-blank.
+
+        Emits a MCP_SYSTEM_PROMPT_CREATE event and invalidates any cached agents built from a prompt of that name so they rebuild with the new content.
+
+        Returns 201 with the stored prompt, and 400 when a prompt with the same name already exists.
+
+        '
+      operationId: createSystemPrompt
       requestBody:
+        description: The named prompt text to store for assignment to assistant agents.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SystemPromptRequest'
+            examples:
+              Workorder assistant prompt:
+                description: Workorder assistant prompt
+                value:
+                  name: Workorder Assistant
+                  content: You are a helpful assistant that creates workorders.
         required: true
       responses:
         '201':
@@ -325,9 +488,21 @@ paths:
     post:
       tags:
       - NLTI
-      summary: Set the session workflow state
-      description: Advances the operational workflow state of the caller's NLTI session so subsequent chat turns receive the workflow-gated tool set.
-      operationId: setWorkflowState
+      summary: Set the Session Workflow State
+      description: 'Advances the operational workflow state persisted on the caller''s NLTI session so subsequent chat turns receive the workflow-gated tool set for that state.
+
+        Use this tool when a conversation enters or leaves an operational flow such as purchase-order creation; do not use submitNltiRequest, which submits a new prompt and never changes the workflow state directly.
+
+        Preconditions: the session must exist and be owned by the authenticated subject; an unknown session and a session owned by someone else are both rejected as ownership violations.
+
+        Required inputs: sessionId (UUID) as a path parameter and workflowState, one of IDLE, CREATING_PO, RECEIVING_ASN, INVENTORY_RECON or PROCESSING_RETURN; new sessions default to IDLE.
+
+        Emits a NLTI_SESSION_WORKFLOW_STATE_SET event and updates only the session''s workflow state.
+
+        Returns 200 with the persisted state, and 403 when the session does not exist or is not owned by the caller.
+
+        '
+      operationId: setSessionWorkflowState
       parameters:
       - name: sessionId
         in: path
@@ -336,10 +511,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The operational workflow state the session should move to.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/WorkflowStateUpdateRequest'
+            examples:
+              Enter purchase-order flow:
+                description: Enter purchase-order flow
+                value:
+                  workflowState: CREATING_PO
         required: true
       responses:
         '200':
@@ -357,9 +538,21 @@ paths:
     post:
       tags:
       - NLTI
-      summary: Submit a natural language task request
-      description: Submit a natural language task request for asynchronous MCP processing and correlation tracking
-      operationId: submitRequest
+      summary: Submit a Natural Language Task Request
+      description: 'Submits a natural-language prompt for asynchronous task interpretation, classifying the intent as QUERY or ACTION; an ACTION prompt yields a persisted write-plan preview that must be explicitly confirmed and is never executed directly.
+
+        Use this tool to start or continue a natural-language task conversation; do not use confirmWritePlan, which executes a plan this operation has already previewed.
+
+        Preconditions: a supplied sessionId must belong to the calling subject, and a session idle for more than 24 hours is silently replaced with a new one.
+
+        Required inputs: prompt (non-blank text); sessionId (UUID) is optional and a new session is created when it is absent; clientContext is an optional key-value map; an optional X-Correlation-Id header is reused and echoed back, otherwise a correlation id is generated.
+
+        Emits a NLTI_REQUEST_SUBMIT event and persists the request with a SHA-256 prompt hash rather than the raw prompt text.
+
+        Returns 202 with status ACCEPTED or an attached write-plan preview, 403 when the supplied sessionId is owned by another subject, and 429 when the per-session rate limit (default 100 requests) is exceeded.
+
+        '
+      operationId: submitNltiRequest
       parameters:
       - name: X-Correlation-Id
         in: header
@@ -367,10 +560,19 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Natural-language prompt to interpret, with optional session continuity and client context.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/NltiRequestDTO'
+            examples:
+              Workorder prompt:
+                description: Workorder prompt
+                value:
+                  prompt: Create a workorder for an oil change at the downtown store
+                  sessionId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  clientContext:
+                    locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '200':
@@ -388,8 +590,20 @@ paths:
     post:
       tags:
       - NLTI
-      summary: Confirm a previewed write plan
-      description: Executes the exact persisted arguments of the write plan attached to the request. Rejects expired plans, re-checks the caller's permission at execution time, and returns the prior outcome for an already-executed idempotency key instead of re-executing.
+      summary: Confirm a Previewed Write Plan
+      description: 'Executes the previewed write plan attached to an NLTI request, invoking the plan''s target tool with the exact persisted arguments rather than a re-parse of the user''s text.
+
+        Use this tool after submitNltiRequest returned a PENDING_CONFIRMATION write-plan preview and the user approved it; do not use cancelWritePlan, which discards the plan without executing it.
+
+        Preconditions: the plan and its request must exist and belong to the authenticated subject; the plan must not be expired, cancelled or already executing; the caller must still hold the target tool''s permission at execution time; and for MEDIUM or higher risk plans the source-entity versions captured at plan time must be unchanged.
+
+        Required inputs: requestId (UUID) as a path parameter; the body is optional and may carry idempotencyKey, which must match the plan''s key when present.
+
+        Emits a NLTI_WRITE_PLAN_CONFIRM event, appends CONFIRMATION and EXECUTION audit-ledger entries, and executes the target tool; re-confirming a COMPLETE plan returns the prior outcome without re-executing.
+
+        Returns 200 on execution or idempotent replay, 404 when no plan or request exists for the id, 403 when the plan is not owned by the caller or the tool permission is missing, 409 when the plan is cancelled, executing, previously failed, stale, or the idempotency key mismatches, 410 when the plan has expired, and 502 when the target tool call itself fails.
+
+        '
       operationId: confirmWritePlan
       parameters:
       - name: requestId
@@ -404,10 +618,16 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Optional confirmation payload carrying the idempotency key from the plan preview.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ConfirmWritePlanRequest'
+            examples:
+              Confirm with idempotency key:
+                description: Confirm with idempotency key
+                value:
+                  idempotencyKey: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d
       responses:
         '200':
           description: OK
@@ -424,8 +644,20 @@ paths:
     post:
       tags:
       - NLTI
-      summary: Cancel a previewed write plan
-      description: Cancels the pending write plan attached to the request without executing it.
+      summary: Cancel a Previewed Write Plan
+      description: 'Cancels the pending write plan attached to an NLTI request so it can never be executed.
+
+        Use this tool when the user declines a previewed plan; do not use confirmWritePlan, which executes the plan instead of discarding it.
+
+        Preconditions: the plan and its request must exist and belong to the authenticated subject; a plan that is already CANCELLED or EXPIRED is returned unchanged, making the call idempotent.
+
+        Required inputs: requestId (UUID) as a path parameter; there is no request body.
+
+        Emits a NLTI_WRITE_PLAN_CANCEL event and appends a CONFIRMATION audit-ledger entry with outcome cancelled.
+
+        Returns 200 with the plan (idempotently for already-inactive plans), 404 when no plan or request exists for the id, 403 when the plan is not owned by the caller, and 409 when the plan is COMPLETE, EXECUTING or ERROR and can no longer be cancelled.
+
+        '
       operationId: cancelWritePlan
       parameters:
       - name: requestId
@@ -450,14 +682,35 @@ paths:
     post:
       tags:
       - Document Ingestion
-      summary: Queue a document for ingestion into the RAG vector store
-      description: Submit a document for asynchronous ingestion into the RAG vector store. The request includes the document content and optional metadata. The response returns a job ID that can be used to track the ingestion status.
+      summary: Queue a Document for RAG Ingestion
+      description: 'Queues a text document for asynchronous ingestion into the RAG vector store and returns a trackable job.
+
+        Use this tool to add reference content that chat agents can retrieve; do not use getDocumentIngestionJob, which only reads the status of a job that was already queued.
+
+        Preconditions: none beyond the mcp:document:ingest authority; the job is accepted and persisted before any embedding work happens.
+
+        Required inputs: content (non-blank raw text); metadata is an optional key-value map whose document_id entry names the document — when absent a random identifier is generated.
+
+        Emits a MCP_DOCUMENT_INGEST event and creates a PENDING job that is processed in the background through RUNNING to SUCCEEDED or FAILED.
+
+        Returns 202 with the job and a Location header pointing at the job-status resource; embedding failures are reported on the job''s errorMessage, not on this call.
+
+        '
       operationId: ingestDocument
       requestBody:
+        description: Raw document text to embed, with optional identifying metadata.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/DocumentIngestionRequest'
+            examples:
+              Policy document:
+                description: Policy document
+                value:
+                  content: 'Refund policy: customers may return items within 30 days.'
+                  metadata:
+                    document_id: policy-refunds
+                    source: manual
         required: true
       responses:
         '200':
@@ -475,14 +728,32 @@ paths:
     post:
       tags:
       - mcp-chat-controller
-      summary: Execute MCP chat message
-      description: Executes a chat message and returns the full response once complete. For streaming responses, use the /chat/stream endpoint which returns tokens as they are generated.
-      operationId: chat
+      summary: Execute a Blocking MCP Chat Turn
+      description: 'Executes a single chat message against the caller''s permission-scoped assistant agent and returns the complete response text in one blocking call.
+
+        Use this tool for a simple request-response chat turn; do not use streamMcpChat, which returns the same answer incrementally as Server-Sent Events.
+
+        Preconditions: the agent''s tool set is selected from the caller''s granted permission codes and active workflow state, so the same message can produce different results for different callers.
+
+        Required inputs: message (non-blank text); the acting user is derived from the authenticated principal, not from the body.
+
+        Emits a MCP_CHAT_EXECUTE event; the agent may invoke permission-gated tools, RAG retrieval and web search while producing the answer.
+
+        Returns 200 with the full response text, and 429 when the caller''s chat rate limit is exceeded.
+
+        '
+      operationId: executeMcpChat
       requestBody:
+        description: Single user chat message for the assistant agent to answer in full.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ChatRequest'
+            examples:
+              Chat message:
+                description: Chat message
+                value:
+                  message: Show me the open workorders for today
         required: true
       responses:
         '200':
@@ -500,14 +771,32 @@ paths:
     post:
       tags:
       - mcp-streaming-chat-controller
-      summary: Execute MCP streaming chat - returns SSE token stream
-      description: Executes a streaming chat message and returns a stream of tokens as Server-Sent Events (SSE). Each token is sent as an individual SSE with event type 'chat'.
-      operationId: streamChat
+      summary: Stream an MCP Chat Turn Over SSE
+      description: 'Executes a chat message against the caller''s permission-scoped assistant agent and streams the response as Server-Sent Events, one token per event with event type chat.
+
+        Use this tool when the client renders tokens incrementally as they are generated; do not use executeMcpChat, which blocks until the full response is complete.
+
+        Preconditions: the agent''s tool set is selected from the caller''s granted permission codes and active workflow state, so the same message can produce different results for different callers.
+
+        Required inputs: message (non-blank text); the client must accept the text/event-stream media type.
+
+        Emits a MCP_CHAT_STREAM_EXECUTE event; the agent may invoke permission-gated tools, RAG retrieval and web search while streaming.
+
+        Returns 200 with an SSE token stream, and 429 when the caller''s chat rate limit is exceeded.
+
+        '
+      operationId: streamMcpChat
       requestBody:
+        description: Single user chat message whose answer is streamed back token by token.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/StreamChatRequest'
+            examples:
+              Streaming chat message:
+                description: Streaming chat message
+                value:
+                  message: Summarize yesterday's sales
         required: true
       responses:
         '200':
@@ -527,9 +816,21 @@ paths:
     get:
       tags:
       - LLM API Configuration
-      summary: List LLM API configurations
-      description: Retrieve all configured LLM API provider definitions that are available to the MCP server.
-      operationId: list_1
+      summary: List All LLM API Configurations
+      description: 'Returns every configured LLM provider API definition available to the MCP server, including provider base URL and model.
+
+        Use this tool to enumerate provider configurations or to find a configuration id; use getLlmApiConfig instead when the id is already known.
+
+        Preconditions: none; an empty list simply means no provider has been configured yet.
+
+        Required inputs: none; there are no filters, no paging and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the full list of configurations.
+
+        '
+      operationId: listLlmApiConfigs
       responses:
         '200':
           description: OK
@@ -547,14 +848,37 @@ paths:
     post:
       tags:
       - LLM API Configuration
-      summary: Create an LLM API configuration
-      description: Create a new LLM API provider configuration for use by the MCP server.
-      operationId: create_1
+      summary: Create an LLM API Configuration
+      description: 'Creates a new LLM provider API configuration that the MCP server can use to invoke an external model.
+
+        Use this tool to register a new provider endpoint and credential; do not use updateLlmApiConfig, which modifies a configuration that already exists.
+
+        Preconditions: no configuration may already use the requested apiId, which is unique across configurations.
+
+        Required inputs: apiId (stable string identifier), model, baseUrl and apiKey; headers is an optional map of extra HTTP headers and defaults to empty.
+
+        Emits a MCP_LLM_API_CREATE event and stores the credential for later provider calls.
+
+        Returns 201 with the stored configuration; a duplicate apiId is rejected, though this module surfaces that failure as a 500 rather than a 409.
+
+        '
+      operationId: createLlmApiConfig
       requestBody:
+        description: LLM provider endpoint, model and credential to register.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LlmApiConfigRequest'
+            examples:
+              OpenAI provider:
+                description: OpenAI provider
+                value:
+                  apiId: openai-gpt4o
+                  model: gpt-4o
+                  baseUrl: https://api.openai.com/v1
+                  apiKey: sk-proj-xxxxxxxxxxxxxxxx
+                  headers:
+                    X-Org-Id: org-01960003
         required: true
       responses:
         '200':
@@ -572,9 +896,21 @@ paths:
     get:
       tags:
       - NLTI Audit
-      summary: Query the NLTI audit ledger
-      description: Query the NLTI audit ledger with optional filters for correlation ID, time range, and event type. Results are paginated.
-      operationId: queryAudit
+      summary: Query the NLTI Audit Ledger
+      description: 'Returns a page of NLTI audit ledger entries recording request, intent, plan, confirmation and execution events.
+
+        Use this tool to trace what the NLTI pipeline did for a conversation or time window; filter by correlationId rather than paging the whole ledger when tracing a single request.
+
+        Preconditions: none; the ledger is append-only and entries exist only for activity that has already happened.
+
+        Required inputs: all filters are optional — correlationId (UUID) takes precedence, then from and to (ISO-8601 instants, applied only when both are present), then eventType (one of REQUEST, INTENT, PLAN, CONFIRMATION, EXECUTION_STEP, EXECUTION_COMPLETE, EXECUTION_FAILED); results default to page size 20 sorted by timestamp.
+
+        Emits a NLTI_AUDIT_QUERY event; the ledger itself is never modified by this call.
+
+        Returns 200 with a page of audit events, and 400 with code INVALID_EVENT_TYPE when eventType is not one of the supported values.
+
+        '
+      operationId: searchNltiAuditEvents
       parameters:
       - name: correlationId
         in: query
@@ -641,9 +977,21 @@ paths:
     get:
       tags:
       - Document Ingestion
-      summary: Get RAG document ingestion job status
-      description: Retrieve the status and details of an asynchronous document ingestion job using its job ID. The response includes the current status, timestamps, and any error messages if applicable.
-      operationId: getIngestionJob
+      summary: Get Document Ingestion Job Status
+      description: 'Returns the current status of an asynchronous RAG document ingestion job, including timestamps, chunk count and any failure message.
+
+        Use this tool to poll a job created by ingestDocument; do not use ingestDocument again to check progress, since that queues a second ingestion instead.
+
+        Preconditions: the job must exist for the supplied jobId returned by ingestDocument.
+
+        Required inputs: jobId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the job in state PENDING, RUNNING, SUCCEEDED or FAILED, and 404 when no job exists for the id.
+
+        '
+      operationId: getDocumentIngestionJob
       parameters:
       - name: jobId
         in: path
@@ -1169,12 +1517,12 @@ components:
     PageAuditEventResponse:
       type: object
       properties:
-        totalElements:
-          type: integer
-          format: int64
         totalPages:
           type: integer
           format: int32
+        totalElements:
+          type: integer
+          format: int64
         size:
           type: integer
           format: int32
@@ -1185,17 +1533,17 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
     PageableObject:

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/AuditController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/AuditController.java
@@ -39,10 +39,21 @@ class AuditController {
     @GetMapping
     @EmitEvent(id = "NLTI_AUDIT_QUERY", apiVersion = "1")
     @PreAuthorize("hasAuthority('" + McpPermissions.NLTI_AUDIT_READ + "')")
-    @Operation(
-            summary = "Query the NLTI audit ledger",
-            description =
-                    "Query the NLTI audit ledger with optional filters for correlation ID, time range, and event type. Results are paginated.")
+    @Operation(operationId = "searchNltiAuditEvents", summary = "Query the NLTI Audit Ledger", description = """
+                    Returns a page of NLTI audit ledger entries recording request, intent, plan, confirmation and \
+                    execution events.
+                    Use this tool to trace what the NLTI pipeline did for a conversation or time window; filter by \
+                    correlationId rather than paging the whole ledger when tracing a single request.
+                    Preconditions: none; the ledger is append-only and entries exist only for activity that has \
+                    already happened.
+                    Required inputs: all filters are optional — correlationId (UUID) takes precedence, then from \
+                    and to (ISO-8601 instants, applied only when both are present), then eventType (one of \
+                    REQUEST, INTENT, PLAN, CONFIRMATION, EXECUTION_STEP, EXECUTION_COMPLETE, EXECUTION_FAILED); \
+                    results default to page size 20 sorted by timestamp.
+                    Emits a NLTI_AUDIT_QUERY event; the ledger itself is never modified by this call.
+                    Returns 200 with a page of audit events, and 400 with code INVALID_EVENT_TYPE when eventType \
+                    is not one of the supported values.
+                    """)
     ResponseEntity<Page<AuditEventResponse>> queryAudit(
             @RequestParam(required = false) UUID correlationId,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/DocumentIngestionController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/DocumentIngestionController.java
@@ -6,6 +6,8 @@ import com.positivity.mcp.service.DocumentIngestionJob;
 import com.positivity.mcp.service.DocumentIngestionJobStatus;
 import com.positivity.mcp.service.DocumentIngestionService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -42,12 +44,38 @@ public class DocumentIngestionController {
     @PreAuthorize("hasAuthority('" + McpPermissions.MCP_DOCUMENT_INGEST + "')")
     @EmitEvent(id = "MCP_DOCUMENT_INGEST", apiVersion = "1")
     @Operation(
-            summary = "Queue a document for ingestion into the RAG vector store",
-            description =
-                    "Submit a document for asynchronous ingestion into the RAG vector store. The request includes the document content and optional metadata. The response returns a job ID that can be used to track the ingestion status.",
+            operationId = "ingestDocument",
+            summary = "Queue a Document for RAG Ingestion",
+            description = """
+                    Queues a text document for asynchronous ingestion into the RAG vector store and returns a \
+                    trackable job.
+                    Use this tool to add reference content that chat agents can retrieve; do not use \
+                    getDocumentIngestionJob, which only reads the status of a job that was already queued.
+                    Preconditions: none beyond the mcp:document:ingest authority; the job is accepted and \
+                    persisted before any embedding work happens.
+                    Required inputs: content (non-blank raw text); metadata is an optional key-value map whose \
+                    document_id entry names the document — when absent a random identifier is generated.
+                    Emits a MCP_DOCUMENT_INGEST event and creates a PENDING job that is processed in the \
+                    background through RUNNING to SUCCEEDED or FAILED.
+                    Returns 202 with the job and a Location header pointing at the job-status resource; embedding \
+                    failures are reported on the job's errorMessage, not on this call.
+                    """,
             tags = {"Document Ingestion"})
     public ResponseEntity<DocumentIngestionJobResponse> ingestDocument(
-            @RequestBody @Valid @NonNull DocumentIngestionRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Raw document text to embed, with optional identifying metadata.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Policy document", value = """
+                                                                    {"content":"Refund policy: customers may return items within 30 days.",
+                                                                     "metadata":{"document_id":"policy-refunds","source":"manual"}}
+                                                                    """)))
+                    @RequestBody
+                    @Valid
+                    @NonNull
+                    DocumentIngestionRequest request) {
         DocumentIngestionJob job = documentIngestionService.submitDocument(request.content(), request.metadata());
         URI location = URI.create("/v1/mcp/documents/jobs/" + job.jobId());
         return ResponseEntity.accepted().location(location).body(DocumentIngestionJobResponse.from(job));
@@ -56,9 +84,19 @@ public class DocumentIngestionController {
     @GetMapping("/documents/jobs/{jobId}")
     @PreAuthorize("hasAuthority('" + McpPermissions.MCP_DOCUMENT_INGEST + "')")
     @Operation(
-            summary = "Get RAG document ingestion job status",
-            description =
-                    "Retrieve the status and details of an asynchronous document ingestion job using its job ID. The response includes the current status, timestamps, and any error messages if applicable.",
+            operationId = "getDocumentIngestionJob",
+            summary = "Get Document Ingestion Job Status",
+            description = """
+                    Returns the current status of an asynchronous RAG document ingestion job, including \
+                    timestamps, chunk count and any failure message.
+                    Use this tool to poll a job created by ingestDocument; do not use ingestDocument again to \
+                    check progress, since that queues a second ingestion instead.
+                    Preconditions: the job must exist for the supplied jobId returned by ingestDocument.
+                    Required inputs: jobId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the job in state PENDING, RUNNING, SUCCEEDED or FAILED, and 404 when no job \
+                    exists for the id.
+                    """,
             tags = {"Document Ingestion"})
     public ResponseEntity<DocumentIngestionJobResponse> getIngestionJob(@PathVariable @NonNull UUID jobId) {
         return documentIngestionService

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/LlmApiConfigController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/LlmApiConfigController.java
@@ -6,6 +6,8 @@ import com.positivity.mcp.internal.dto.LlmApiConfigResponse;
 import com.positivity.mcp.internal.security.McpPermissions;
 import com.positivity.mcp.service.LlmApiConfigService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
@@ -28,6 +30,14 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "LLM API Configuration", description = "LLM provider API configuration management")
 class LlmApiConfigController {
 
+    private static final String CONFIG_EXAMPLE = """
+            {"apiId":"openai-gpt4o",
+             "model":"gpt-4o",
+             "baseUrl":"https://api.openai.com/v1",
+             "apiKey":"sk-proj-xxxxxxxxxxxxxxxx",
+             "headers":{"X-Org-Id":"org-01960003"}}
+            """;
+
     private final LlmApiConfigService service;
 
     LlmApiConfigController(@NonNull LlmApiConfigService service) {
@@ -40,8 +50,18 @@ class LlmApiConfigController {
             scopes = {"mcp:llm_api:view"})
     @PreAuthorize("hasAuthority('" + McpPermissions.LLM_API_VIEW + "')")
     @Operation(
-            summary = "List LLM API configurations",
-            description = "Retrieve all configured LLM API provider definitions that are available to the MCP server.",
+            operationId = "listLlmApiConfigs",
+            summary = "List All LLM API Configurations",
+            description = """
+                    Returns every configured LLM provider API definition available to the MCP server, including \
+                    provider base URL and model.
+                    Use this tool to enumerate provider configurations or to find a configuration id; use \
+                    getLlmApiConfig instead when the id is already known.
+                    Preconditions: none; an empty list simply means no provider has been configured yet.
+                    Required inputs: none; there are no filters, no paging and no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the full list of configurations.
+                    """,
             tags = {"LLM API Configuration"})
     ResponseEntity<List<LlmApiConfigResponse>> list() {
         return ResponseEntity.ok(service.list());
@@ -53,8 +73,18 @@ class LlmApiConfigController {
             scopes = {"mcp:llm_api:view"})
     @PreAuthorize("hasAuthority('" + McpPermissions.LLM_API_VIEW + "')")
     @Operation(
-            summary = "Get an LLM API configuration",
-            description = "Retrieve a single LLM API provider configuration by its identifier.",
+            operationId = "getLlmApiConfig",
+            summary = "Get an LLM API Configuration",
+            description = """
+                    Returns a single LLM provider API configuration by its identifier.
+                    Use this tool when the configuration id (UUID) is already known; use listLlmApiConfigs instead \
+                    to discover ids.
+                    Preconditions: a configuration with the given id must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 when the configuration exists; an unknown id is not mapped to a 404 by this module \
+                    and currently surfaces as a 500 error.
+                    """,
             tags = {"LLM API Configuration"})
     ResponseEntity<LlmApiConfigResponse> get(@PathVariable @NonNull UUID id) {
         return ResponseEntity.ok(service.get(id));
@@ -67,10 +97,35 @@ class LlmApiConfigController {
     @PreAuthorize("hasAuthority('" + McpPermissions.LLM_API_CREATE + "')")
     @EmitEvent(id = "MCP_LLM_API_CREATE", apiVersion = "1")
     @Operation(
-            summary = "Create an LLM API configuration",
-            description = "Create a new LLM API provider configuration for use by the MCP server.",
+            operationId = "createLlmApiConfig",
+            summary = "Create an LLM API Configuration",
+            description = """
+                    Creates a new LLM provider API configuration that the MCP server can use to invoke an external \
+                    model.
+                    Use this tool to register a new provider endpoint and credential; do not use \
+                    updateLlmApiConfig, which modifies a configuration that already exists.
+                    Preconditions: no configuration may already use the requested apiId, which is unique across \
+                    configurations.
+                    Required inputs: apiId (stable string identifier), model, baseUrl and apiKey; headers is an \
+                    optional map of extra HTTP headers and defaults to empty.
+                    Emits a MCP_LLM_API_CREATE event and stores the credential for later provider calls.
+                    Returns 201 with the stored configuration; a duplicate apiId is rejected, though this module \
+                    surfaces that failure as a 500 rather than a 409.
+                    """,
             tags = {"LLM API Configuration"})
-    ResponseEntity<LlmApiConfigResponse> create(@RequestBody @Validated @NonNull LlmApiConfigRequest request) {
+    ResponseEntity<LlmApiConfigResponse> create(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "LLM provider endpoint, model and credential to register.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "OpenAI provider", value = CONFIG_EXAMPLE)))
+                    @RequestBody
+                    @Validated
+                    @NonNull
+                    LlmApiConfigRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.create(request));
     }
 
@@ -81,11 +136,37 @@ class LlmApiConfigController {
     @PreAuthorize("hasAuthority('" + McpPermissions.LLM_API_UPDATE + "')")
     @EmitEvent(id = "MCP_LLM_API_UPDATE", apiVersion = "1")
     @Operation(
-            summary = "Update an LLM API configuration",
-            description = "Update an existing LLM API provider configuration by its identifier.",
+            operationId = "updateLlmApiConfig",
+            summary = "Update an LLM API Configuration",
+            description = """
+                    Replaces every editable field of an existing LLM provider API configuration identified by id.
+                    Use this tool to change a provider's model, base URL, credential or headers; do not use \
+                    createLlmApiConfig, which registers an additional configuration.
+                    Preconditions: the configuration must exist, and when apiId is being changed the new apiId \
+                    must not already be used by another configuration.
+                    Required inputs: id (UUID) as a path parameter plus a full body with apiId, model, baseUrl and \
+                    apiKey; headers defaults to empty when omitted, so a partial body is not merged.
+                    Emits a MCP_LLM_API_UPDATE event.
+                    Returns 200 with the updated configuration; an unknown id or a duplicate apiId is rejected, \
+                    though this module surfaces both as a 500 rather than a 404 or 409.
+                    """,
             tags = {"LLM API Configuration"})
     ResponseEntity<LlmApiConfigResponse> update(
-            @PathVariable @NonNull UUID id, @RequestBody @Validated @NonNull LlmApiConfigRequest request) {
+            @PathVariable @NonNull UUID id,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement provider endpoint, model and credential values.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Updated OpenAI provider",
+                                                            value = CONFIG_EXAMPLE)))
+                    @RequestBody
+                    @Validated
+                    @NonNull
+                    LlmApiConfigRequest request) {
         return ResponseEntity.ok(service.update(id, request));
     }
 
@@ -96,8 +177,18 @@ class LlmApiConfigController {
     @PreAuthorize("hasAuthority('" + McpPermissions.LLM_API_DELETE + "')")
     @EmitEvent(id = "MCP_LLM_API_DELETE", apiVersion = "1")
     @Operation(
-            summary = "Delete an LLM API configuration",
-            description = "Delete an existing LLM API provider configuration by its identifier.",
+            operationId = "deleteLlmApiConfig",
+            summary = "Delete an LLM API Configuration",
+            description = """
+                    Deletes an LLM provider API configuration so the MCP server can no longer use it to invoke \
+                    that provider.
+                    Use this tool to retire a provider configuration; do not use updateLlmApiConfig, which keeps \
+                    the configuration and changes its fields.
+                    Preconditions: none; deleting an id that does not exist is a no-op.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a MCP_LLM_API_DELETE event.
+                    Returns 204 whether or not the configuration existed, making the call idempotent.
+                    """,
             tags = {"LLM API Configuration"})
     ResponseEntity<Void> delete(@PathVariable @NonNull UUID id) {
         service.delete(id);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpChatController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpChatController.java
@@ -44,24 +44,38 @@ public class McpChatController {
         this.currentUserContextResolver = currentUserContextResolver;
     }
 
-    @Operation(
-            summary = "Execute MCP chat message",
-            description =
-                    "Executes a chat message and returns the full response once complete. For streaming responses, use the /chat/stream endpoint which returns tokens as they are generated.",
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @io.swagger.v3.oas.annotations.media.Content(
-                                            mediaType = org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
-                                            schema =
-                                                    @io.swagger.v3.oas.annotations.media.Schema(
-                                                            implementation = McpChatController.ChatRequest.class))))
+    @Operation(operationId = "executeMcpChat", summary = "Execute a Blocking MCP Chat Turn", description = """
+                    Executes a single chat message against the caller's permission-scoped assistant agent and \
+                    returns the complete response text in one blocking call.
+                    Use this tool for a simple request-response chat turn; do not use streamMcpChat, which returns \
+                    the same answer incrementally as Server-Sent Events.
+                    Preconditions: the agent's tool set is selected from the caller's granted permission codes and \
+                    active workflow state, so the same message can produce different results for different callers.
+                    Required inputs: message (non-blank text); the acting user is derived from the authenticated \
+                    principal, not from the body.
+                    Emits a MCP_CHAT_EXECUTE event; the agent may invoke permission-gated tools, RAG retrieval and \
+                    web search while producing the answer.
+                    Returns 200 with the full response text, and 429 when the caller's chat rate limit is exceeded.
+                    """)
     @PostMapping("/chat")
     @PreAuthorize("hasAuthority('" + McpPermissions.MCP_CHAT_EXECUTE + "')")
     @EmitEvent(id = "MCP_CHAT_EXECUTE", apiVersion = "1")
     public ResponseEntity<ChatResponse> chat(
-            @RequestBody @Valid @NonNull ChatRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Single user chat message for the assistant agent to answer in full.",
+                            required = true,
+                            content =
+                                    @io.swagger.v3.oas.annotations.media.Content(
+                                            mediaType = org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
+                                            examples =
+                                                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                                            name = "Chat message",
+                                                            value =
+                                                                    "{\"message\":\"Show me the open workorders for today\"}")))
+                    @RequestBody
+                    @Valid
+                    @NonNull
+                    ChatRequest request,
             @CurrentSecurityContext(expression = "authentication") @NonNull Authentication authentication) {
 
         CurrentUserContext currentUserContext = currentUserContextResolver.resolve(authentication);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpStreamingChatController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/McpStreamingChatController.java
@@ -47,9 +47,21 @@ public class McpStreamingChatController {
     }
 
     @Operation(
-            summary = "Execute MCP streaming chat - returns SSE token stream",
-            description =
-                    "Executes a streaming chat message and returns a stream of tokens as Server-Sent Events (SSE). Each token is sent as an individual SSE with event type 'chat'.",
+            operationId = "streamMcpChat",
+            summary = "Stream an MCP Chat Turn Over SSE",
+            description = """
+                    Executes a chat message against the caller's permission-scoped assistant agent and streams the \
+                    response as Server-Sent Events, one token per event with event type chat.
+                    Use this tool when the client renders tokens incrementally as they are generated; do not use \
+                    executeMcpChat, which blocks until the full response is complete.
+                    Preconditions: the agent's tool set is selected from the caller's granted permission codes and \
+                    active workflow state, so the same message can produce different results for different callers.
+                    Required inputs: message (non-blank text); the client must accept the text/event-stream media \
+                    type.
+                    Emits a MCP_CHAT_STREAM_EXECUTE event; the agent may invoke permission-gated tools, RAG \
+                    retrieval and web search while streaming.
+                    Returns 200 with an SSE token stream, and 429 when the caller's chat rate limit is exceeded.
+                    """,
             responses = {
                 @ApiResponse(
                         responseCode = "200",
@@ -66,7 +78,20 @@ public class McpStreamingChatController {
     @PreAuthorize("hasAuthority('" + McpPermissions.MCP_CHAT_STREAM + "')")
     @EmitEvent(id = "MCP_CHAT_STREAM_EXECUTE", apiVersion = "1")
     public Flux<ServerSentEvent<String>> streamChat(
-            @RequestBody @Valid @NonNull StreamChatRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Single user chat message whose answer is streamed back token by token.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                            examples =
+                                                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                                            name = "Streaming chat message",
+                                                            value = "{\"message\":\"Summarize yesterday's sales\"}")))
+                    @RequestBody
+                    @Valid
+                    @NonNull
+                    StreamChatRequest request,
             @CurrentSecurityContext(expression = "authentication") @NonNull Authentication authentication) {
 
         CurrentUserContext currentUserContext = currentUserContextResolver.resolve(authentication);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/NltiController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/NltiController.java
@@ -12,6 +12,8 @@ import com.positivity.mcp.internal.service.PermissionCodes;
 import com.positivity.mcp.service.NltiRequestService;
 import com.positivity.security.common.SecurityContextHelper;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -53,12 +55,40 @@ public class NltiController {
     @PostMapping("/requests")
     @EmitEvent(id = "NLTI_REQUEST_SUBMIT", apiVersion = "1")
     @PreAuthorize("hasAuthority('" + McpPermissions.NLTI_REQUEST_SUBMIT + "')")
-    @Operation(
-            summary = "Submit a natural language task request",
-            description =
-                    "Submit a natural language task request for asynchronous MCP processing and correlation tracking")
+    @Operation(operationId = "submitNltiRequest", summary = "Submit a Natural Language Task Request", description = """
+                    Submits a natural-language prompt for asynchronous task interpretation, classifying the intent \
+                    as QUERY or ACTION; an ACTION prompt yields a persisted write-plan preview that must be \
+                    explicitly confirmed and is never executed directly.
+                    Use this tool to start or continue a natural-language task conversation; do not use \
+                    confirmWritePlan, which executes a plan this operation has already previewed.
+                    Preconditions: a supplied sessionId must belong to the calling subject, and a session idle for \
+                    more than 24 hours is silently replaced with a new one.
+                    Required inputs: prompt (non-blank text); sessionId (UUID) is optional and a new session is \
+                    created when it is absent; clientContext is an optional key-value map; an optional \
+                    X-Correlation-Id header is reused and echoed back, otherwise a correlation id is generated.
+                    Emits a NLTI_REQUEST_SUBMIT event and persists the request with a SHA-256 prompt hash rather \
+                    than the raw prompt text.
+                    Returns 202 with status ACCEPTED or an attached write-plan preview, 403 when the supplied \
+                    sessionId is owned by another subject, and 429 when the per-session rate limit (default 100 \
+                    requests) is exceeded.
+                    """)
     ResponseEntity<NltiResponseV1> submitRequest(
-            @Valid @RequestBody @NonNull NltiRequestDTO request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Natural-language prompt to interpret, with optional session continuity and client context.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Workorder prompt", value = """
+                                                                    {"prompt":"Create a workorder for an oil change at the downtown store",
+                                                                     "sessionId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "clientContext":{"locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"}}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    NltiRequestDTO request,
             @RequestHeader(value = NltiCorrelationIdSupport.CORRELATION_ID_HEADER, required = false)
                     String correlationIdHeader,
             @NonNull HttpServletRequest servletRequest) {
@@ -81,12 +111,36 @@ public class NltiController {
     @PostMapping("/sessions/{sessionId}/workflow-state")
     @EmitEvent(id = "NLTI_SESSION_WORKFLOW_STATE_SET", apiVersion = "1")
     @PreAuthorize("hasAuthority('" + McpPermissions.NLTI_REQUEST_SUBMIT + "')")
-    @Operation(
-            summary = "Set the session workflow state",
-            description =
-                    "Advances the operational workflow state of the caller's NLTI session so subsequent chat turns receive the workflow-gated tool set.")
+    @Operation(operationId = "setSessionWorkflowState", summary = "Set the Session Workflow State", description = """
+                    Advances the operational workflow state persisted on the caller's NLTI session so subsequent \
+                    chat turns receive the workflow-gated tool set for that state.
+                    Use this tool when a conversation enters or leaves an operational flow such as purchase-order \
+                    creation; do not use submitNltiRequest, which submits a new prompt and never changes the \
+                    workflow state directly.
+                    Preconditions: the session must exist and be owned by the authenticated subject; an unknown \
+                    session and a session owned by someone else are both rejected as ownership violations.
+                    Required inputs: sessionId (UUID) as a path parameter and workflowState, one of IDLE, \
+                    CREATING_PO, RECEIVING_ASN, INVENTORY_RECON or PROCESSING_RETURN; new sessions default to IDLE.
+                    Emits a NLTI_SESSION_WORKFLOW_STATE_SET event and updates only the session's workflow state.
+                    Returns 200 with the persisted state, and 403 when the session does not exist or is not owned \
+                    by the caller.
+                    """)
     ResponseEntity<WorkflowStateResponse> setWorkflowState(
-            @PathVariable @NonNull UUID sessionId, @Valid @RequestBody @NonNull WorkflowStateUpdateRequest request) {
+            @PathVariable @NonNull UUID sessionId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The operational workflow state the session should move to.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Enter purchase-order flow",
+                                                            value = "{\"workflowState\":\"CREATING_PO\"}")))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    WorkflowStateUpdateRequest request) {
         // Fail fast on a missing authenticated principal rather than defaulting to a sentinel subject:
         // subjectId is the ownership key for this session-mutating call, so an unresolved username must
         // never silently pass through (or mis-attribute the ownership check).
@@ -106,14 +160,41 @@ public class NltiController {
     @PostMapping("/requests/{requestId}/confirm")
     @EmitEvent(id = "NLTI_WRITE_PLAN_CONFIRM", apiVersion = "1")
     @PreAuthorize("hasAuthority('" + McpPermissions.NLTI_REQUEST_SUBMIT + "')")
-    @Operation(
-            summary = "Confirm a previewed write plan",
-            description = "Executes the exact persisted arguments of the write plan attached to the request. "
-                    + "Rejects expired plans, re-checks the caller's permission at execution time, and returns "
-                    + "the prior outcome for an already-executed idempotency key instead of re-executing.")
+    @Operation(operationId = "confirmWritePlan", summary = "Confirm a Previewed Write Plan", description = """
+                    Executes the previewed write plan attached to an NLTI request, invoking the plan's target tool \
+                    with the exact persisted arguments rather than a re-parse of the user's text.
+                    Use this tool after submitNltiRequest returned a PENDING_CONFIRMATION write-plan preview and \
+                    the user approved it; do not use cancelWritePlan, which discards the plan without executing it.
+                    Preconditions: the plan and its request must exist and belong to the authenticated subject; \
+                    the plan must not be expired, cancelled or already executing; the caller must still hold the \
+                    target tool's permission at execution time; and for MEDIUM or higher risk plans the source-entity \
+                    versions captured at plan time must be unchanged.
+                    Required inputs: requestId (UUID) as a path parameter; the body is optional and may carry \
+                    idempotencyKey, which must match the plan's key when present.
+                    Emits a NLTI_WRITE_PLAN_CONFIRM event, appends CONFIRMATION and EXECUTION audit-ledger entries, \
+                    and executes the target tool; re-confirming a COMPLETE plan returns the prior outcome without \
+                    re-executing.
+                    Returns 200 on execution or idempotent replay, 404 when no plan or request exists for the id, \
+                    403 when the plan is not owned by the caller or the tool permission is missing, 409 when the \
+                    plan is cancelled, executing, previously failed, stale, or the idempotency key mismatches, 410 \
+                    when the plan has expired, and 502 when the target tool call itself fails.
+                    """)
     ResponseEntity<WritePlanResponseV1> confirmWritePlan(
             @PathVariable @NonNull UUID requestId,
-            @RequestBody(required = false) ConfirmWritePlanRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Optional confirmation payload carrying the idempotency key from the plan preview.",
+                            required = false,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Confirm with idempotency key",
+                                                            value =
+                                                                    "{\"idempotencyKey\":\"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d\"}")))
+                    @RequestBody(required = false)
+                    ConfirmWritePlanRequest request,
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
         String subjectId = requireSubjectId("write-plan confirmation");
         return ResponseEntity.ok(writePlanService.confirm(
@@ -128,9 +209,19 @@ public class NltiController {
     @PostMapping("/requests/{requestId}/cancel")
     @EmitEvent(id = "NLTI_WRITE_PLAN_CANCEL", apiVersion = "1")
     @PreAuthorize("hasAuthority('" + McpPermissions.NLTI_REQUEST_SUBMIT + "')")
-    @Operation(
-            summary = "Cancel a previewed write plan",
-            description = "Cancels the pending write plan attached to the request without executing it.")
+    @Operation(operationId = "cancelWritePlan", summary = "Cancel a Previewed Write Plan", description = """
+                    Cancels the pending write plan attached to an NLTI request so it can never be executed.
+                    Use this tool when the user declines a previewed plan; do not use confirmWritePlan, which \
+                    executes the plan instead of discarding it.
+                    Preconditions: the plan and its request must exist and belong to the authenticated subject; a \
+                    plan that is already CANCELLED or EXPIRED is returned unchanged, making the call idempotent.
+                    Required inputs: requestId (UUID) as a path parameter; there is no request body.
+                    Emits a NLTI_WRITE_PLAN_CANCEL event and appends a CONFIRMATION audit-ledger entry with \
+                    outcome cancelled.
+                    Returns 200 with the plan (idempotently for already-inactive plans), 404 when no plan or \
+                    request exists for the id, 403 when the plan is not owned by the caller, and 409 when the plan \
+                    is COMPLETE, EXECUTING or ERROR and can no longer be cancelled.
+                    """)
     ResponseEntity<WritePlanResponseV1> cancelWritePlan(@PathVariable @NonNull UUID requestId) {
         String subjectId = requireSubjectId("write-plan cancellation");
         return ResponseEntity.ok(writePlanService.cancel(requestId, subjectId));

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/SystemPromptController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/SystemPromptController.java
@@ -6,6 +6,8 @@ import com.positivity.mcp.internal.dto.SystemPromptResponse;
 import com.positivity.mcp.internal.security.McpPermissions;
 import com.positivity.mcp.service.SystemPromptService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -36,9 +38,15 @@ class SystemPromptController {
     }
 
     @GetMapping
-    @Operation(
-            summary = "List system prompts",
-            description = "List all configured MCP system prompts that can be assigned to agents")
+    @Operation(operationId = "listSystemPrompts", summary = "List All MCP System Prompts", description = """
+                    Returns every reusable MCP system prompt with its name and content.
+                    Use this tool to browse prompts or to find a prompt id by name; use getSystemPrompt instead \
+                    when the id is already known.
+                    Preconditions: none; an empty list simply means no prompts have been created yet.
+                    Required inputs: none; there are no filters, no paging and no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the full list of prompts.
+                    """)
     @ApiResponse(responseCode = "200", description = "System prompts returned")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -49,7 +57,15 @@ class SystemPromptController {
     }
 
     @GetMapping("/{id}")
-    @Operation(summary = "Get system prompt", description = "Retrieve a single MCP system prompt by its identifier")
+    @Operation(operationId = "getSystemPrompt", summary = "Get an MCP System Prompt", description = """
+                    Returns a single MCP system prompt by its identifier, including its full content.
+                    Use this tool when the prompt id (UUID) is already known; use listSystemPrompts instead to \
+                    discover ids or find a prompt by name.
+                    Preconditions: a system prompt with the given id must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no system prompt exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "System prompt returned")
     @ApiResponse(responseCode = "404", description = "System prompt not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -61,9 +77,17 @@ class SystemPromptController {
     }
 
     @PostMapping
-    @Operation(
-            summary = "Create system prompt",
-            description = "Create a new MCP system prompt that can be used during agent orchestration")
+    @Operation(operationId = "createSystemPrompt", summary = "Create an MCP System Prompt", description = """
+                    Creates a reusable MCP system prompt that agent orchestration can assign to assistant agents.
+                    Use this tool to add a new named prompt; do not use updateSystemPrompt, which edits a prompt \
+                    that already exists.
+                    Preconditions: no prompt may already use the requested name, which is unique across prompts.
+                    Required inputs: name (unique, human-readable) and content (the prompt text); both are \
+                    mandatory and non-blank.
+                    Emits a MCP_SYSTEM_PROMPT_CREATE event and invalidates any cached agents built from a prompt \
+                    of that name so they rebuild with the new content.
+                    Returns 201 with the stored prompt, and 400 when a prompt with the same name already exists.
+                    """)
     @ApiResponse(responseCode = "201", description = "System prompt created")
     @ApiResponse(responseCode = "400", description = "System prompt request is invalid")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -71,14 +95,39 @@ class SystemPromptController {
             scopes = {"mcp:system_prompt:create"})
     @PreAuthorize("hasAuthority('" + McpPermissions.SYSTEM_PROMPT_CREATE + "')")
     @EmitEvent(id = "MCP_SYSTEM_PROMPT_CREATE", apiVersion = "1")
-    ResponseEntity<SystemPromptResponse> create(@Validated @RequestBody @NonNull SystemPromptRequest request) {
+    ResponseEntity<SystemPromptResponse> create(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The named prompt text to store for assignment to assistant agents.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "Workorder assistant prompt", value = """
+                                                                    {"name":"Workorder Assistant",
+                                                                     "content":"You are a helpful assistant that creates workorders."}
+                                                                    """)))
+                    @Validated
+                    @RequestBody
+                    @NonNull
+                    SystemPromptRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(systemPromptService.create(request));
     }
 
     @PutMapping("/{id}")
-    @Operation(
-            summary = "Update system prompt",
-            description = "Update an existing MCP system prompt by replacing its editable fields")
+    @Operation(operationId = "updateSystemPrompt", summary = "Update an MCP System Prompt", description = """
+                    Replaces the name and content of an existing MCP system prompt.
+                    Use this tool to edit prompt text or rename a prompt; do not use createSystemPrompt, which \
+                    adds a new prompt alongside the existing ones.
+                    Preconditions: the prompt must exist, and when the name is being changed no other prompt may \
+                    already use the new name.
+                    Required inputs: id (UUID) as a path parameter plus name and content in the body; both body \
+                    fields are mandatory and fully replace the stored values.
+                    Emits a MCP_SYSTEM_PROMPT_UPDATE event and invalidates cached agents built from the prompt so \
+                    subsequent chats use the new content.
+                    Returns 200 with the updated prompt, 404 when no prompt exists for the id, and 400 when the \
+                    new name is already used by another prompt.
+                    """)
     @ApiResponse(responseCode = "200", description = "System prompt updated")
     @ApiResponse(responseCode = "404", description = "System prompt not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -87,14 +136,35 @@ class SystemPromptController {
     @PreAuthorize("hasAuthority('" + McpPermissions.SYSTEM_PROMPT_UPDATE + "')")
     @EmitEvent(id = "MCP_SYSTEM_PROMPT_UPDATE", apiVersion = "1")
     ResponseEntity<SystemPromptResponse> update(
-            @PathVariable @NonNull UUID id, @Validated @RequestBody @NonNull SystemPromptRequest request) {
+            @PathVariable @NonNull UUID id,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement name and content for the stored prompt.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Revised assistant prompt", value = """
+                                                                    {"name":"Workorder Assistant",
+                                                                     "content":"You are a concise assistant that creates and updates workorders."}
+                                                                    """)))
+                    @Validated
+                    @RequestBody
+                    @NonNull
+                    SystemPromptRequest request) {
         return ResponseEntity.ok(systemPromptService.update(id, request));
     }
 
     @DeleteMapping("/{id}")
-    @Operation(
-            summary = "Delete system prompt",
-            description = "Delete an MCP system prompt so it can no longer be selected for agent sessions")
+    @Operation(operationId = "deleteSystemPrompt", summary = "Delete an MCP System Prompt", description = """
+                    Deletes an MCP system prompt so it can no longer be assigned to agent sessions.
+                    Use this tool to retire a prompt; do not use updateSystemPrompt, which keeps the prompt and \
+                    changes its fields.
+                    Preconditions: none; deleting an id that does not exist is a no-op.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a MCP_SYSTEM_PROMPT_DELETE event and, when the prompt existed, invalidates cached agents \
+                    that were built from it.
+                    Returns 204 whether or not the prompt existed, making the call idempotent.
+                    """)
     @ApiResponse(responseCode = "204", description = "System prompt deleted")
     @ApiResponse(responseCode = "404", description = "System prompt not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/ToolPermissionController.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/controller/ToolPermissionController.java
@@ -6,6 +6,8 @@ import com.positivity.mcp.internal.dto.ToolPermissionsResponse;
 import com.positivity.mcp.internal.security.McpPermissions;
 import com.positivity.mcp.internal.service.ToolPermissionAdminService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
@@ -47,8 +49,18 @@ class ToolPermissionController {
     @PreAuthorize("hasAuthority('mcp:tool:view')")
     @Operation(
             operationId = "listToolPermissions",
-            summary = "List a tool's permission grants",
-            description = "Return the permission codes currently granted to a discovered OpenAPI tool.",
+            summary = "List a Tool's Permission Grants",
+            description = """
+                    Returns the permission codes currently granted to a discovered OpenAPI tool.
+                    Use this tool to inspect why a discovered tool is or is not selectable for a caller; use \
+                    grantToolPermission or revokeToolPermission instead to change the grants.
+                    Preconditions: the named tool must exist as a discovered (source openapi) tool; discovered \
+                    tools are fail-closed and unselectable until at least one grant exists.
+                    Required inputs: toolName as a path parameter, matching the tool's registered name exactly.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the grant set (possibly empty), and 404 when no discovered OpenAPI tool has \
+                    the given name.
+                    """,
             tags = {"MCP Tool Permissions"})
     ResponseEntity<ToolPermissionsResponse> list(@PathVariable @NonNull String toolName) {
         return ResponseEntity.ok(service.listPermissions(toolName));
@@ -62,12 +74,40 @@ class ToolPermissionController {
     @PreAuthorize("hasAuthority('mcp:tool:manage')")
     @Operation(
             operationId = "grantToolPermission",
-            summary = "Grant a permission to a tool",
-            description = "Grant a permission code to a discovered OpenAPI tool so callers holding it can select "
-                    + "the tool. Idempotent. Returns the tool's full permission set.",
+            summary = "Grant a Permission to a Tool",
+            description = """
+                    Grants a permission code to a discovered OpenAPI tool so callers holding that code can select \
+                    the tool during chat.
+                    Use this tool to open up a fail-closed discovered operation; do not use \
+                    revokeToolPermission, which removes a grant.
+                    Preconditions: the named tool must exist as a discovered (source openapi) tool; granting a \
+                    code that is already present changes nothing.
+                    Required inputs: toolName as a path parameter and permissionCode in the body, either the \
+                    literal AUTHENTICATED or a domain:resource:action code such as event-receiver:event_type:view.
+                    Emits a MCP_TOOL_PERMISSION_GRANT event; when the grant set actually changes, cached role \
+                    agents are invalidated so the tool becomes selectable on the next chat turn.
+                    Returns 201 with the tool's full permission set (idempotently for repeated grants), 404 when \
+                    no discovered OpenAPI tool has the given name, and 400 when the permission code does not match \
+                    the required pattern.
+                    """,
             tags = {"MCP Tool Permissions"})
     ResponseEntity<ToolPermissionsResponse> grant(
-            @PathVariable @NonNull String toolName, @RequestBody @Validated @NonNull ToolPermissionRequest request) {
+            @PathVariable @NonNull String toolName,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The permission code the tool should be selectable under.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Domain permission grant",
+                                                            value =
+                                                                    "{\"permissionCode\":\"event-receiver:event_type:view\"}")))
+                    @RequestBody
+                    @Validated
+                    @NonNull
+                    ToolPermissionRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(service.grantPermission(toolName, request.permissionCode()));
     }
@@ -80,8 +120,21 @@ class ToolPermissionController {
     @PreAuthorize("hasAuthority('mcp:tool:manage')")
     @Operation(
             operationId = "revokeToolPermission",
-            summary = "Revoke a permission from a tool",
-            description = "Revoke a permission code from a discovered OpenAPI tool. Idempotent.",
+            summary = "Revoke a Permission From a Tool",
+            description = """
+                    Revokes a permission code from a discovered OpenAPI tool, removing it from the set that makes \
+                    the tool selectable.
+                    Use this tool to withdraw chat access to a discovered operation; do not use \
+                    grantToolPermission, which adds a grant.
+                    Preconditions: the named tool must exist as a discovered (source openapi) tool; revoking a \
+                    code that is not granted changes nothing.
+                    Required inputs: toolName as a path parameter and permissionCode as a query parameter; there \
+                    is no request body.
+                    Emits a MCP_TOOL_PERMISSION_REVOKE event; when the grant set actually changes, cached role \
+                    agents are invalidated so the tool stops being selectable.
+                    Returns 204 whether or not the code was granted (idempotent), 404 when no discovered OpenAPI \
+                    tool has the given name, and 400 when the permission code is blank.
+                    """,
             tags = {"MCP Tool Permissions"})
     ResponseEntity<Void> revoke(
             @PathVariable @NonNull String toolName, @RequestParam("permissionCode") @NotBlank @NonNull String code) {

--- a/pos-openapi-validation/src/main/java/com/positivity/openapivalidation/internal/validator/OpenApiAnnotationDepthValidator.java
+++ b/pos-openapi-validation/src/main/java/com/positivity/openapivalidation/internal/validator/OpenApiAnnotationDepthValidator.java
@@ -76,9 +76,10 @@ public class OpenApiAnnotationDepthValidator {
         if (requestBody.getDescription() == null || requestBody.getDescription().isBlank()) {
             findings.add("request body missing description (ADR-0042 §3)");
         }
-        if (requestBody.getRequired() == null) {
-            findings.add("request body missing explicit required flag (ADR-0042 §3)");
-        }
+        // ADR-0042 §3 also wants an explicit `required` flag, but springdoc omits `required: false`
+        // (the OpenAPI default) from generated specs, so absence is indistinguishable from an
+        // explicit false. That rule is therefore enforced at the annotation level by convention
+        // (docs/OPENAPI_DESCRIPTION_STANDARD.md), not here.
         if (!hasExample(requestBody.getContent())) {
             findings.add("request body missing example (ADR-0042 §3)");
         }

--- a/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/validator/OpenApiAnnotationDepthValidatorTest.java
+++ b/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/validator/OpenApiAnnotationDepthValidatorTest.java
@@ -119,7 +119,6 @@ class OpenApiAnnotationDepthValidatorTest {
         assertThat(validator.check(operation))
                 .containsExactly(
                         "request body missing description (ADR-0042 §3)",
-                        "request body missing explicit required flag (ADR-0042 §3)",
                         "request body missing example (ADR-0042 §3)");
     }
 }

--- a/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/validator/OpenApiModuleValidatorTest.java
+++ b/pos-openapi-validation/src/test/java/com/positivity/openapivalidation/internal/validator/OpenApiModuleValidatorTest.java
@@ -98,8 +98,6 @@ class OpenApiModuleValidatorTest {
                         "pos-documents POST /v1/documents: description missing negative guidance"
                                 + " (\"do not use ...\" / \"... instead\")",
                         "pos-documents POST /v1/documents: request body missing description (ADR-0042 §3)",
-                        "pos-documents POST /v1/documents: request body missing explicit required flag"
-                                + " (ADR-0042 §3)",
                         "pos-documents POST /v1/documents: request body missing example (ADR-0042 §3)");
         assertThat(issues).allSatisfy(issue -> assertThat(issue.mode()).isEqualTo(OpenApiModulePolicy.Mode.STRICT));
     }

--- a/pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml
+++ b/pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml
@@ -3,6 +3,7 @@ modules:
     mode: STRICT
   pos-order:
     mode: STRICT
+    annotationDepth: STRICT
   pos-workorder:
     mode: STRICT
   pos-inventory:
@@ -14,8 +15,10 @@ modules:
     mode: STRICT
   pos-location:
     mode: STRICT
+    annotationDepth: STRICT
   pos-people:
     mode: STRICT
+    annotationDepth: STRICT
   pos-catalog:
     mode: STRICT
   pos-shop-manager:
@@ -32,6 +35,7 @@ modules:
     annotationDepth: STRICT
   pos-warranty:
     mode: STRICT
+    annotationDepth: STRICT
   pos-supplier:
     mode: STRICT
     annotationDepth: STRICT

--- a/pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml
+++ b/pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml
@@ -13,6 +13,7 @@ modules:
     annotationDepth: STRICT
   pos-customer:
     mode: STRICT
+    annotationDepth: STRICT
   pos-location:
     mode: STRICT
     annotationDepth: STRICT
@@ -21,6 +22,7 @@ modules:
     annotationDepth: STRICT
   pos-catalog:
     mode: STRICT
+    annotationDepth: STRICT
   pos-shop-manager:
     mode: STRICT
     annotationDepth: STRICT
@@ -53,6 +55,7 @@ modules:
     annotationDepth: STRICT
   pos-security-service:
     mode: STRICT
+    annotationDepth: STRICT
   pos-api-gateway:
     mode: EXCEPTION
     reason: aggregate producer without module paths

--- a/pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml
+++ b/pos-openapi-validation/src/test/resources/openapi/module-inventory.yaml
@@ -9,6 +9,7 @@ modules:
     mode: STRICT
   pos-price:
     mode: STRICT
+    annotationDepth: STRICT
   pos-customer:
     mode: STRICT
   pos-location:
@@ -22,11 +23,13 @@ modules:
     annotationDepth: STRICT
   pos-invoice:
     mode: STRICT
+    annotationDepth: STRICT
   pos-bulk-loader:
     mode: STRICT
     annotationDepth: STRICT
   pos-vehicle-inventory:
     mode: STRICT
+    annotationDepth: STRICT
   pos-warranty:
     mode: STRICT
   pos-supplier:
@@ -51,11 +54,13 @@ modules:
     reason: aggregate producer without module paths
   pos-mcp-server:
     mode: STRICT
+    annotationDepth: STRICT
   pos-marketing:
     mode: STRICT
     annotationDepth: STRICT
   pos-people-contact:
     mode: STRICT
+    annotationDepth: STRICT
   pos-tax:
     mode: STRICT
     annotationDepth: STRICT

--- a/pos-order/openapi.yaml
+++ b/pos-order/openapi.yaml
@@ -25,9 +25,21 @@ paths:
     put:
       tags:
       - Sales Orders
-      summary: Update a sales order cart item quantity
-      description: Update the quantity for an existing sales order line item in a cart.
-      operationId: updateItemQuantity
+      summary: Update a Cart Item Quantity
+      description: 'Updates the quantity of an existing line on a DRAFT sales order cart and recomputes order totals.
+
+        Use this tool to change how many units a line sells; do not use removeCartItem, which deletes the line entirely, and do not use addCartItem, which creates a new line.
+
+        Preconditions: the order must exist and be DRAFT, and the line must exist on that order.
+
+        Required inputs: orderId and lineId as path UUIDs, and quantity (minimum 1) in the body.
+
+        Emits an ORDER_CART_ITEM_UPDATE event, recomputes order totals, and marks tax stale.
+
+        Returns 404 when the order or line does not exist, and 409 when the order is not DRAFT.
+
+        '
+      operationId: updateCartItemQuantity
       parameters:
       - name: orderId
         in: path
@@ -42,10 +54,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The new quantity for the line.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateItemRequest'
+            examples:
+              Set quantity:
+                description: Set quantity
+                value:
+                  quantity: 3
         required: true
       responses:
         '200':
@@ -61,9 +79,21 @@ paths:
     delete:
       tags:
       - Sales Orders
-      summary: Remove an item from a sales order cart
-      description: Remove a line item from an existing sales order cart.
-      operationId: removeItem
+      summary: Remove an Item from a Cart
+      description: 'Removes a line item from a DRAFT sales order cart and recomputes the remaining totals.
+
+        Use this tool to take a line off the sale entirely; do not use updateCartItemQuantity, which keeps the line and changes its quantity.
+
+        Preconditions: the order must exist and be DRAFT; a lineId that is not on the order is silently ignored rather than rejected.
+
+        Required inputs: orderId and lineId as path UUIDs; there is no request body.
+
+        Emits an ORDER_CART_ITEM_REMOVE event, recomputes order totals, and marks tax stale.
+
+        Returns 204 on success, 404 when the order does not exist, and 409 when the order is not DRAFT.
+
+        '
+      operationId: removeCartItem
       parameters:
       - name: orderId
         in: path
@@ -88,8 +118,20 @@ paths:
     put:
       tags:
       - Sales Orders
-      summary: Apply an order-level discount
-      description: Apply or replace the order-level discount (PERCENT or AMOUNT), allocated pro-rata across lines. DRAFT orders only.
+      summary: Apply an Order-Level Discount
+      description: 'Applies or replaces the single order-level discount on a DRAFT cart, allocated pro-rata across lines when totals are recomputed.
+
+        Use this tool for a whole-order concession; do not use applyPriceOverride, which changes one line''s unit price through the price-override approval workflow.
+
+        Preconditions: the order must exist and be DRAFT.
+
+        Required inputs: type (PERCENT or AMOUNT) and a positive value — a PERCENT value must not exceed 100; reasonCode is optional.
+
+        Emits an ORDER_CART_DISCOUNT_APPLY event, recomputes order totals, and marks tax stale.
+
+        Returns 404 when the order does not exist, 409 when the order is not DRAFT, and 422 when the type or value is invalid.
+
+        '
       operationId: applyOrderDiscount
       parameters:
       - name: orderId
@@ -99,10 +141,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The order-level discount to set, replacing any existing one.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/OrderDiscountRequest'
+            examples:
+              Ten percent goodwill:
+                description: Ten percent goodwill
+                value:
+                  type: PERCENT
+                  value: 10
+                  reasonCode: GOODWILL_ADJUSTMENT
         required: true
       responses:
         '200':
@@ -118,8 +168,20 @@ paths:
     delete:
       tags:
       - Sales Orders
-      summary: Remove the order-level discount
-      description: Clear any order-level discount and recompute totals. DRAFT orders only.
+      summary: Remove the Order-Level Discount
+      description: 'Clears any order-level discount from a DRAFT cart and recomputes totals.
+
+        Use this tool to withdraw a whole-order concession; do not use applyOrderDiscount, which sets or replaces the discount.
+
+        Preconditions: the order must exist and be DRAFT; clearing a cart that has no discount succeeds.
+
+        Required inputs: orderId (UUID) as a path parameter; there is no request body.
+
+        Emits an ORDER_CART_DISCOUNT_REMOVE event, recomputes order totals, and marks tax stale.
+
+        Returns 404 when the order does not exist, and 409 when the order is not DRAFT.
+
+        '
       operationId: clearOrderDiscount
       parameters:
       - name: orderId
@@ -143,8 +205,20 @@ paths:
     get:
       tags:
       - Returns
-      summary: List returns for an original order
-      description: Lists return orders created from the specified original order.
+      summary: List Returns for an Original Order
+      description: 'Lists every return order created from one original sales order, newest first.
+
+        Use this tool to review a sale''s return history; use getReturn instead when the return order id is known, or listReturnableLines to see what can still come back.
+
+        Preconditions: none — an original order with no returns simply yields an empty list, and the original order''s existence is not checked.
+
+        Required inputs: originalOrderId (UUID) as a query parameter; there is no request body.
+
+        Emits an ORDER_RETURN_LIST audit event; no state changes — this is a read-only projection.
+
+        Returns 200 with a possibly empty list; there are no business error conditions beyond authorization.
+
+        '
       operationId: listReturns
       parameters:
       - name: originalOrderId
@@ -169,8 +243,20 @@ paths:
     post:
       tags:
       - Returns
-      summary: Create a return against a completed order
-      description: 'Idempotency-Key header supported: a replayed key returns the original return. Over-cap requests return 422 listing each line''s returnableQty.'
+      summary: Create a Return Against a Completed Order
+      description: 'Creates a return order against one COMPLETED sales order, capping each line at its un-refunded remainder (row-locked so concurrent returns serialize) and computing a pro-rata, tax-included refund per line.
+
+        Use this tool to take goods back after a completed sale; do not use cancelOrder or voidOrder, which abandon an order before completion, and check listReturnableLines first to see each line''s remaining returnable quantity.
+
+        Preconditions: the original order must be COMPLETED, every line must be returnable (workorder consumed lines without an imported returnable flag are not), and each sold line may appear at most once in the request.
+
+        Required inputs: originalOrderId (UUID), refundMethod (ORIGINAL_TENDER, STORE_CREDIT or ON_ACCOUNT_CREDIT), and at least one line with originalOrderLineId, a positive returnQty, and condition (RESTOCK, SCRAP or WARRANTY); reasonCode, per-line serialNumbers, and the Idempotency-Key header (replays return the original return) are optional.
+
+        Emits an ORDER_RETURN_CREATE event; a refund total above the approval threshold (default 250.00, configurable via pos.order.return.approval-threshold) parks the return at PENDING_APPROVAL, otherwise it starts at RETURN_REQUESTED ready for processReturn.
+
+        Returns 201 on creation (idempotent replays included), 404 when the original order does not exist, 409 when the original order is not COMPLETED, and 422 when a line exceeds its returnable remainder (each offending line''s returnableQty is listed in fieldErrors), a WARRANTY-condition line must route to pos-warranty, or the lines are duplicated, unknown, or invalid.
+
+        '
       operationId: createReturn
       parameters:
       - name: Idempotency-Key
@@ -180,10 +266,22 @@ paths:
         schema:
           type: string
       requestBody:
+        description: 'The return: source order, refund method, and the lines coming back.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateReturnRequest'
+            examples:
+              Single-line restock return:
+                description: Single-line restock return
+                value:
+                  originalOrderId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                  refundMethod: ORIGINAL_TENDER
+                  reasonCode: DEFECTIVE
+                  lines:
+                  - originalOrderLineId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
+                    returnQty: 1
+                    condition: RESTOCK
         required: true
       responses:
         '200':
@@ -200,8 +298,20 @@ paths:
     post:
       tags:
       - Returns
-      summary: Retry a return saga after a refund failure
-      description: Retries return processing for a return currently in a retryable failed state.
+      summary: Retry a Failed Return Refund
+      description: 'Re-runs the return refund saga for a return parked at REFUND_FAILED, using the same per-intent idempotency so already-reversed payments are never refunded twice.
+
+        Use this tool after fixing the cause of a refund failure; do not use processReturn, which only accepts a return in RETURN_REQUESTED.
+
+        Preconditions: the return must be in REFUND_FAILED; an already COMPLETED return is an idempotent no-op.
+
+        Required inputs: returnOrderId (UUID) as a path parameter; there is no request body.
+
+        Emits an ORDER_RETURN_RETRY event and, on success, publishes the order.order.returned fact that drives the pos-inventory restock of RESTOCK lines.
+
+        Returns 200 when the retry completes (or the return was already COMPLETED), 404 when the return does not exist, and 409 when the status is not REFUND_FAILED or the refund fails again.
+
+        '
       operationId: retryReturn
       parameters:
       - name: returnOrderId
@@ -225,8 +335,20 @@ paths:
     post:
       tags:
       - Returns
-      summary: Reject a pending return
-      description: Rejects a pending return with a provided rejection reason.
+      summary: Reject a Pending Return
+      description: 'Rejects a PENDING_APPROVAL return with a recorded reason, moving it to the terminal REJECTED state and releasing its quantities back to the per-line returnable cap.
+
+        Use this tool to decline an over-threshold return; do not use approveReturn, which releases it into the refund saga instead.
+
+        Preconditions: the return order must exist and be in PENDING_APPROVAL.
+
+        Required inputs: returnOrderId (UUID) as a path parameter and reason in the body.
+
+        Emits an ORDER_RETURN_REJECT event; no refund is issued and no stock moves.
+
+        Returns 404 when the return does not exist, and 409 when the return is not in PENDING_APPROVAL.
+
+        '
       operationId: rejectReturn
       parameters:
       - name: returnOrderId
@@ -236,10 +358,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The business reason the return is being declined.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RejectReturnRequest'
+            examples:
+              Rejection:
+                description: Rejection
+                value:
+                  reason: Refund exceeds policy for this item
         required: true
       responses:
         '200':
@@ -256,8 +384,20 @@ paths:
     post:
       tags:
       - Returns
-      summary: Run the return orchestration saga (refund + restock signal)
-      description: 'From RETURN_REQUESTED: issues the refund and emits order.order.returned. A refund failure parks the return at REFUND_FAILED before any stock movement.'
+      summary: Run the Return Refund Saga
+      description: 'Runs the return orchestration saga from RETURN_REQUESTED: issues the refund (ORIGINAL_TENDER reverses the original order''s settled payments through pos-invoice up to the refund total; STORE_CREDIT and ON_ACCOUNT_CREDIT record the credit intent and require a customer on the return), then completes the return.
+
+        Use this tool to execute an approved or under-threshold return; do not use retryReturn, which only re-drives a return already parked at REFUND_FAILED.
+
+        Preconditions: the return must be in RETURN_REQUESTED (an already COMPLETED return is an idempotent no-op), and an ORIGINAL_TENDER refund needs an invoice and sufficient settled tender on the original order.
+
+        Required inputs: returnOrderId (UUID) as a path parameter; there is no request body.
+
+        Emits an ORDER_RETURN_PROCESS event and publishes an order.order.returned fact after completion, which pos-inventory consumes to restock RESTOCK-condition lines (SCRAP lines are skipped); a refund failure parks the return at REFUND_FAILED before any stock signal.
+
+        Returns 200 when the saga completes (or the return was already COMPLETED), 404 when the return does not exist, and 409 when the status is not RETURN_REQUESTED or the refund leg fails.
+
+        '
       operationId: processReturn
       parameters:
       - name: returnOrderId
@@ -281,8 +421,20 @@ paths:
     post:
       tags:
       - Returns
-      summary: Approve a pending return
-      description: Approves a pending return so it can continue through the return workflow.
+      summary: Approve a Pending Return
+      description: 'Approves a PENDING_APPROVAL return, stamping the approver and moving it to RETURN_REQUESTED so the refund saga can run.
+
+        Use this tool for returns whose refund total exceeded the approval threshold; do not use processReturn, which executes the refund and only accepts a return already in RETURN_REQUESTED.
+
+        Preconditions: the return order must exist and be in PENDING_APPROVAL.
+
+        Required inputs: returnOrderId (UUID) as a path parameter; there is no request body — the approver is taken from the security context.
+
+        Emits an ORDER_RETURN_APPROVE event; no refund or stock movement happens yet.
+
+        Returns 404 when the return does not exist, and 409 when the return is not in PENDING_APPROVAL.
+
+        '
       operationId: approveReturn
       parameters:
       - name: returnOrderId
@@ -306,8 +458,20 @@ paths:
     post:
       tags:
       - Sales Orders
-      summary: Void an unsettled order
-      description: 'Terminal void of a PENDING_PAYMENT order before any settlement: cancels the fronting pos-invoice invoice and transitions the order to VOIDED. Rejected with 409 when settled payments exist (use the cancellation flow) or from any other status (drafts are cancelled, not voided).'
+      summary: Void an Unsettled Order
+      description: 'Voids a PENDING_PAYMENT order before any settlement: cancels the fronting pos-invoice invoice and transitions the order to VOIDED, rolling the void back if the invoice cancel fails.
+
+        Use this tool to abandon a checked-out order that has taken no money; do not use cancelOrder, which runs the cancellation saga for DRAFT and QUOTED orders and reverses settled payments.
+
+        Preconditions: the order must be PENDING_PAYMENT with no settled payment records; voiding an already VOIDED order is an idempotent no-op.
+
+        Required inputs: orderId (UUID) as a path parameter; the body is optional and carries only a free-text reason.
+
+        Emits an ORDER_VOID event.
+
+        Returns 200 on success or an already-voided no-op, 404 when the order does not exist, 409 when settled payments exist (route through cancelOrder) or the status is not PENDING_PAYMENT, and 503 when the invoicing service is unreachable.
+
+        '
       operationId: voidOrder
       parameters:
       - name: orderId
@@ -317,10 +481,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Optional void context; the body may be omitted entirely.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/VoidOrderRequest'
+            examples:
+              Void with reason:
+                description: Void with reason
+                value:
+                  reason: Customer walked away before payment
       responses:
         '200':
           description: OK
@@ -336,9 +506,21 @@ paths:
     post:
       tags:
       - Sales Orders
-      summary: Check out a sales order
-      description: 'Freeze the cart and take it to PENDING_PAYMENT: validates lines/customer/availability, performs the final reprice and tax computation, and creates the fronting invoice at pos-invoice. The Idempotency-Key header is required; a replayed key returns the checked-out order with 200. Settlement completion is asynchronous — the order completes when payment events settle the balance to zero.'
-      operationId: checkout
+      summary: Check Out a Sales Order
+      description: 'Freezes a DRAFT or QUOTED cart into PENDING_PAYMENT: revalidates availability and serial capture, runs the final reprice and tax computation, and synchronously creates the fronting invoice at pos-invoice, rolling the whole checkout back if invoice creation fails.
+
+        Use this tool when the customer is ready to pay; do not use quoteCart, which produces a resumable quote, and do not use voidOrder, which abandons an order already in PENDING_PAYMENT.
+
+        Preconditions: the cart must be non-empty with customer validation not PENDING, every line must have sufficient inventory, serial-tracked lines must carry one serial per unit (lot-tracked at least one), and ON_ACCOUNT additionally requires the order:order:charge_on_account permission and a VALIDATED commercial customer with payment terms and no credit hold.
+
+        Required inputs: the Idempotency-Key header; the body is optional with tenderType DEFAULT or ON_ACCOUNT — DEFAULT settles asynchronously via payment events that complete the order when the balance reaches zero, while ON_ACCOUNT settles against the AR invoice and completes the order immediately.
+
+        Emits an ORDER_CHECKOUT event; an ON_ACCOUNT checkout also records a settled ON_ACCOUNT ledger entry and publishes an order-completed fact.
+
+        Returns 201 on checkout, 200 when the same Idempotency-Key replays the checked-out order, 409 when the key belongs to a different order or the status does not allow checkout, 422 when the cart is empty, customer validation is pending, availability or serial capture is insufficient, or on-account eligibility fails, and 503 when the tax or invoicing service is unreachable.
+
+        '
+      operationId: checkoutOrder
       parameters:
       - name: orderId
         in: path
@@ -353,10 +535,16 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Optional checkout options; omit the body entirely for default tender.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CheckoutRequest'
+            examples:
+              On-account tender:
+                description: On-account tender
+                value:
+                  tenderType: ON_ACCOUNT
       responses:
         '200':
           description: OK
@@ -372,14 +560,35 @@ paths:
     post:
       tags:
       - Register Sessions
-      summary: Open a register session
-      description: Opens a new register session for the provided terminal, location, and clerk context.
-      operationId: openSession
+      summary: Open a Register Session
+      description: 'Opens an OPEN register (drawer) session on a terminal; sales orders created on the terminal while it is open bind to it, and it supplies their location by default.
+
+        Use this tool at the start of a drawer shift; do not use recordCashMovement, which requires a session that is already open.
+
+        Preconditions: the terminal must have no session in OPEN or CLOSING — one drawer per terminal.
+
+        Required inputs: terminalId and openedByClerkId; openingFloat defaults to the terminal''s previous counted close (else zero) when omitted, and locationId defaults from the terminal''s previous session.
+
+        Emits an ORDER_SESSION_OPEN event.
+
+        Returns 201 with the new session, and 409 when the terminal already has an active session.
+
+        '
+      operationId: openRegisterSession
       requestBody:
+        description: The terminal, clerk, and optional opening-float context for the shift.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/OpenSessionRequest'
+            examples:
+              Morning open:
+                description: Morning open
+                value:
+                  terminalId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a60
+                  openedByClerkId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a50
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a90
+                  openingFloat: 150.0
         required: true
       responses:
         '200':
@@ -396,9 +605,21 @@ paths:
     post:
       tags:
       - Register Sessions
-      summary: Confirm a register session close
-      description: Snapshots theoretical cash, computes over/short, and moves the session to CLOSED. An over/short beyond the authorized difference limit requires order:session:approve_variance.
-      operationId: confirmClose
+      summary: Confirm a Register Session Close
+      description: 'Finalizes a CLOSING register session: snapshots theoretical cash (opening float plus net CASH settlements plus signed cash movements), computes the over/short against the counted drawer, and moves the session to CLOSED.
+
+        Use this tool to finish the close after the count; do not use beginSessionClose, which records the count and must run first.
+
+        Preconditions: the session must be in CLOSING, and no order on the session may have re-entered PENDING_PAYMENT since the count began.
+
+        Required inputs: sessionId (UUID) as a path parameter; there is no request body — an over/short beyond the authorized difference limit (default 5.00, configurable via pos.order.session.authorized-difference-limit) additionally requires the order:session:approve_variance permission.
+
+        Emits an ORDER_SESSION_CONFIRM_CLOSE event and publishes a register-session-closed fact carrying per-tender totals and the reconciliation figures.
+
+        Returns 200 with the CLOSED session, 403 when the variance exceeds the limit without the approval permission, 404 when the session does not exist, and 409 when the session is not in CLOSING or an order is still awaiting payment.
+
+        '
+      operationId: confirmSessionClose
       parameters:
       - name: sessionId
         in: path
@@ -421,8 +642,20 @@ paths:
     get:
       tags:
       - Register Sessions
-      summary: List a session's cash movements
-      description: Lists all recorded cash movements for the specified register session.
+      summary: List a Session's Cash Movements
+      description: 'Lists every recorded cash movement for a register session in the order they occurred.
+
+        Use this tool to review drawer ins and outs; use getSessionXReport instead for the aggregated mid-day figures that include tender totals and theoretical cash.
+
+        Preconditions: the session must exist.
+
+        Required inputs: sessionId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with a possibly empty list, and 404 when the session does not exist.
+
+        '
       operationId: listCashMovements
       parameters:
       - name: sessionId
@@ -447,8 +680,20 @@ paths:
     post:
       tags:
       - Register Sessions
-      summary: Record a drawer cash movement
-      description: Records a cash in/out drawer movement against the specified register session.
+      summary: Record a Drawer Cash Movement
+      description: 'Records a PAID_IN or PAID_OUT cash movement against an OPEN register session; movements feed the theoretical-cash calculation at close.
+
+        Use this tool for non-sale drawer cash such as petty cash or bank drops; do not use beginSessionClose, which records the final counted drawer instead.
+
+        Preconditions: the session must exist and be OPEN — movements are rejected once closing has begun.
+
+        Required inputs: movementType (PAID_IN or PAID_OUT), a positive amount, reason, and clerkId.
+
+        Emits an ORDER_SESSION_CASH_MOVEMENT event.
+
+        Returns 201 with the recorded movement, 404 when the session does not exist, 409 when the session is not OPEN, and 422 when the amount is not positive or the movement type is unknown.
+
+        '
       operationId: recordCashMovement
       parameters:
       - name: sessionId
@@ -458,10 +703,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: 'The cash movement: direction, positive amount, reason, and clerk.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CashMovementRequest'
+            examples:
+              Petty cash out:
+                description: Petty cash out
+                value:
+                  movementType: PAID_OUT
+                  amount: 40.0
+                  reason: petty cash to office
+                  clerkId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a50
         required: true
       responses:
         '200':
@@ -478,9 +732,21 @@ paths:
     post:
       tags:
       - Register Sessions
-      summary: Begin closing a register session
-      description: Records the counted cash and moves the session to CLOSING. Blocked while any of its orders are in PENDING_PAYMENT.
-      operationId: beginClose
+      summary: Begin Closing a Register Session
+      description: 'Records the physically counted drawer cash and moves the register session to CLOSING, freezing the terminal against new orders.
+
+        Use this tool to start the drawer count at end of shift; do not use confirmSessionClose, which finalizes a session already in CLOSING.
+
+        Preconditions: the session must exist, must not already be CLOSED, and none of its orders may be in PENDING_PAYMENT.
+
+        Required inputs: countedCash (zero or greater) in the body and sessionId (UUID) as a path parameter.
+
+        Emits an ORDER_SESSION_BEGIN_CLOSE event.
+
+        Returns 200 with the CLOSING session, 404 when the session does not exist, and 409 when the session is already closed or an order on the session is still awaiting payment.
+
+        '
+      operationId: beginSessionClose
       parameters:
       - name: sessionId
         in: path
@@ -489,10 +755,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The physically counted drawer cash at the start of the close.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BeginCloseRequest'
+            examples:
+              Counted drawer:
+                description: Counted drawer
+                value:
+                  countedCash: 310.0
         required: true
       responses:
         '200':
@@ -509,9 +781,21 @@ paths:
     get:
       tags:
       - Price Overrides
-      summary: Get price overrides
-      description: Retrieve price overrides by order ID, status, or date range. At least one filter parameter is required.
-      operationId: getOverridesByOrder
+      summary: Search Price Overrides
+      description: 'Searches price overrides by order id, status, or creation-date range; exactly one filter dimension is applied, with orderId taking precedence over status, which takes precedence over the date range.
+
+        Use this tool to find overrides matching a filter; use getPriceOverride instead when the override id is known, or listPendingPriceOverrides for the approval work queue.
+
+        Preconditions: at least one filter must be supplied, and a date-range search requires both startDate and endDate.
+
+        Required inputs: one of orderId (UUID string), status (an override status such as PENDING_APPROVAL, APPROVED or REJECTED), or startDate plus endDate as ISO-8601 date-times.
+
+        Emits an ORDER_PRICE_OVERRIDE_SEARCH audit event; no state changes.
+
+        Returns 200 with a possibly empty list, 400 when no filter is supplied or orderId is not a UUID, and 422 when status is not a valid override status name.
+
+        '
+      operationId: searchPriceOverrides
       parameters:
       - name: orderId
         in: query
@@ -531,12 +815,14 @@ paths:
         required: false
         schema:
           type: string
+          format: date-time
       - name: endDate
         in: query
         description: End date for date range filter
         required: false
         schema:
           type: string
+          format: date-time
       responses:
         '200':
           description: Overrides retrieved
@@ -562,14 +848,39 @@ paths:
     post:
       tags:
       - Price Overrides
-      summary: Apply price override
-      description: Apply a price override to an order line. May require approval based on override amount.
+      summary: Apply a Price Override
+      description: 'Applies a price override to a single DRAFT order line, auto-approving and repricing the line immediately when the discount is below the approval thresholds (10 percent and 50.00), and otherwise parking it at PENDING_APPROVAL for a manager.
+
+        Use this tool for a one-line price concession; do not use applyOrderDiscount, which spreads a discount pro-rata across the whole order, and do not use approvePriceOverride, which resolves an override that already exists.
+
+        Preconditions: the order must exist and be DRAFT, the order line must exist, and overridePrice must be between zero and originalPrice inclusive.
+
+        Required inputs: orderId, orderLineId, and productId as UUID strings, originalPrice, overridePrice, and reasonCode (for example PRICE_MATCH or GOODWILL_ADJUSTMENT); justification and idempotencyKey are optional, and a replayed key returns the existing override.
+
+        Emits an ORDER_PRICE_OVERRIDE_APPLY event; an auto-approved override immediately rewrites the line''s unit price, recomputes the order subtotal, and publishes a commission-impact fact.
+
+        Returns 201 with status APPROVED or PENDING_APPROVAL, 400 when an id or reasonCode cannot be parsed, 409 when the idempotency key was used with a different payload, and 422 when the order or line cannot be found, the order is not DRAFT, or the override price is negative or above the original.
+
+        '
       operationId: applyPriceOverride
       requestBody:
+        description: 'The line-level override: original and overridden price with an audit reason.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ApplyPriceOverrideRequest'
+            examples:
+              Price match:
+                description: Price match
+                value:
+                  orderId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                  orderLineId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
+                  productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03
+                  originalPrice: 49.99
+                  overridePrice: 39.99
+                  reasonCode: PRICE_MATCH
+                  justification: Competitor price match per store policy
+                  idempotencyKey: req-abc123
         required: true
       responses:
         '201':
@@ -599,8 +910,20 @@ paths:
     post:
       tags:
       - Price Overrides
-      summary: Reject price override
-      description: Reject a pending price override with a reason.
+      summary: Reject a Price Override
+      description: 'Rejects a PENDING_APPROVAL price override, marking it REJECTED with the supplied reason and recording a rejection audit row with the reviewer''s resolved role.
+
+        Use this tool to decline a pending override; do not use approvePriceOverride, which grants it instead.
+
+        Preconditions: the override must exist and be in PENDING_APPROVAL; a rejected override is terminal and never touches the order line''s price.
+
+        Required inputs: overrideId (UUID) as a path parameter and reason in the body; comments are optional, and the reviewer identity and role come from the security context.
+
+        Emits an ORDER_PRICE_OVERRIDE_REJECT event; no commission-impact fact is published for a rejection.
+
+        Returns 404 when the override does not exist, and 422 when the override is not in PENDING_APPROVAL.
+
+        '
       operationId: rejectPriceOverride
       parameters:
       - name: overrideId
@@ -609,12 +932,20 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
         example: 018e1c9f-6b5a-7890-abcd-1234567890ab
       requestBody:
+        description: The rejection reason plus optional reviewer commentary.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RejectPriceOverrideRequest'
+            examples:
+              Rejection with reason:
+                description: Rejection with reason
+                value:
+                  reason: Outside approved discount threshold
+                  comments: Discount exceeds policy limit for this product
         required: true
       responses:
         '200':
@@ -650,8 +981,20 @@ paths:
     post:
       tags:
       - Price Overrides
-      summary: Approve price override
-      description: Approve a pending price override. Validates approver permission level.
+      summary: Approve a Price Override
+      description: 'Approves a PENDING_APPROVAL price override, marking it APPROVED and recording an approval audit row with the reviewer''s role resolved from the caller''s granted roles.
+
+        Use this tool to grant a pending override; do not use rejectPriceOverride, which declines it, and do not use applyPriceOverride, which creates a new override.
+
+        Preconditions: the override must exist and be in PENDING_APPROVAL.
+
+        Required inputs: overrideId (UUID) as a path parameter; the body carries only optional reviewer comments — the approver identity and role come from the security context, not the body.
+
+        Emits an ORDER_PRICE_OVERRIDE_APPROVE event and publishes a commission-impact fact; note that the approval itself does not rewrite the order line''s unit price — the line reprice happens only on the auto-approved apply path.
+
+        Returns 404 when the override does not exist, and 422 when the override is not in PENDING_APPROVAL.
+
+        '
       operationId: approvePriceOverride
       parameters:
       - name: overrideId
@@ -660,12 +1003,19 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
         example: 018e1c9f-6b5a-7890-abcd-1234567890ab
       requestBody:
+        description: Optional reviewer commentary recorded on the approval audit row.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ApprovePriceOverrideRequest'
+            examples:
+              Approval with comment:
+                description: Approval with comment
+                value:
+                  comments: Approved per store manager discretion
         required: true
       responses:
         '200':
@@ -701,8 +1051,20 @@ paths:
     get:
       tags:
       - Sales Orders
-      summary: List sales order carts
-      description: List carts filtered by clerk, terminal, and/or status — the draft-parking/resume surface. Line items are omitted from list results.
+      summary: List Sales Order Carts
+      description: 'Lists sales order carts filtered by clerk, terminal, and status — the draft-parking and resume surface; line items are omitted from list results.
+
+        Use this tool when searching for carts to resume or review; use getOrder instead when the order id is already known and full line detail is needed.
+
+        Preconditions: none beyond an authenticated caller with order view permission.
+
+        Required inputs: none — clerkId, terminalId, and status (a status name such as DRAFT) are optional filters; page defaults to 0 and size defaults to 20, capped at 100.
+
+        Emits an ORDER_CART_LIST audit event; no order state changes.
+
+        Returns 200 with a possibly empty page, and 422 when status is not a valid order status name.
+
+        '
       operationId: listCarts
       parameters:
       - name: clerkId
@@ -753,8 +1115,20 @@ paths:
     post:
       tags:
       - Sales Orders
-      summary: Create a sales order cart
-      description: 'Create a new sales order cart for a customer, terminal, and optional vehicle context. Supports the Idempotency-Key header: a replayed key returns the original cart with 200 instead of creating a duplicate; a replayed key with a different payload returns 409.'
+      summary: Create a Sales Order Cart
+      description: 'Creates a DRAFT sales order cart bound to a clerk and terminal, with optional customer, vehicle, and deposit-source context; a register session open on the terminal binds the cart to it and supplies the location when locationId is omitted.
+
+        Use this tool to start a new sale at the counter; do not use addCartItem, which adds line items to a cart that already exists.
+
+        Preconditions: the terminal must not have a register session in CLOSING, the customer and vehicle must exist in CRM when supplied, and a location must be resolvable from the request or the open session.
+
+        Required inputs: clerkId and terminalId; customerId and vehicleId are optional UUID strings, depositSourceType (ESTIMATE, WORKORDER or ORDER) and depositSourceId must be supplied together, and the optional Idempotency-Key header makes creation replay-safe.
+
+        Emits an ORDER_CART_CREATE event and records the initial DRAFT status-history row.
+
+        Returns 201 on creation, 200 when a replayed Idempotency-Key returns the original cart, 409 when the key was previously used with a different payload, and 422 when the customer or vehicle cannot be validated, the location cannot be resolved, or the terminal''s session is being closed.
+
+        '
       operationId: createCart
       parameters:
       - name: Idempotency-Key
@@ -764,10 +1138,21 @@ paths:
         schema:
           type: string
       requestBody:
+        description: 'Cart-creation context: who is selling, where, and for whom.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateCartRequest'
+            examples:
+              Counter cart with customer:
+                description: Counter cart with customer
+                value:
+                  clerkId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a50
+                  terminalId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a60
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a90
+                  customerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a70
+                  vehicleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a80
+                  label: blue F-150 waiting on customer
         required: true
       responses:
         '200':
@@ -784,9 +1169,21 @@ paths:
     post:
       tags:
       - Sales Orders
-      summary: Convert a cart to a counter quote
-      description: 'Final reprice + tax computation, then DRAFT → QUOTED with a validity horizon. Counter quotes only: workorder-linked orders are quoted via pos-workorder estimates and are rejected here (spec Q3).'
-      operationId: quote
+      summary: Convert a Cart to a Counter Quote
+      description: 'Converts a DRAFT counter cart to QUOTED by running a final reprice and authoritative tax computation and stamping a validity horizon (default P7D, configurable via pos.order.quote.validity).
+
+        Use this tool to hand the customer a priced, resumable counter quote; do not use checkoutOrder, which freezes the cart for payment, and note that workorder-linked orders are quoted via pos-workorder estimates and are rejected here.
+
+        Preconditions: the order must be DRAFT with at least one line, must not reference a workorder directly or through imported lines, and pricing must be reachable for every non-manual, non-source line.
+
+        Required inputs: orderId (UUID) as a path parameter; there is no request body.
+
+        Emits an ORDER_CART_QUOTE event.
+
+        Returns 404 when the order does not exist, 409 when the status does not allow the transition, 422 when the cart is empty, workorder-linked, or pricing is unavailable, and 503 when the tax service cannot be reached.
+
+        '
+      operationId: quoteCart
       parameters:
       - name: orderId
         in: path
@@ -809,8 +1206,20 @@ paths:
     post:
       tags:
       - Sales Orders
-      summary: Reopen a counter quote
-      description: 'QUOTED → DRAFT: clears the validity horizon, best-effort reprices, and marks tax stale.'
+      summary: Reopen a Counter Quote
+      description: 'Reopens a QUOTED counter quote back to DRAFT, clearing the validity horizon so the cart can be edited again.
+
+        Use this tool to resume editing a quoted cart; do not use quoteCart, which moves the cart in the opposite direction from DRAFT to QUOTED.
+
+        Preconditions: the order must be QUOTED.
+
+        Required inputs: orderId (UUID) as a path parameter; there is no request body.
+
+        Emits an ORDER_CART_QUOTE_REOPEN event and best-effort reprices the lines — an unavailable pricing service keeps the old prices, and totals are recomputed with tax marked stale.
+
+        Returns 404 when the order does not exist, and 409 when the order is not QUOTED.
+
+        '
       operationId: reopenQuote
       parameters:
       - name: orderId
@@ -834,9 +1243,21 @@ paths:
     post:
       tags:
       - Sales Orders
-      summary: Add an item to a sales order cart
-      description: 'Add a line item to an existing sales order cart using SKU, quantity, and optional pricing context. A client-supplied lineUuid makes the call replay-safe: a replay with a known lineUuid updates the existing line instead of duplicating it.'
-      operationId: addItem
+      summary: Add an Item to a Cart
+      description: 'Adds a line item to a DRAFT sales order cart, pricing it through the pricing service unless a permissioned manual price is supplied, and marking the line AVAILABLE or BACKORDER from an inventory availability check.
+
+        Use this tool to put a SKU on an existing cart; do not use updateCartItemQuantity, which only changes the quantity of a line already on the cart.
+
+        Preconditions: the order must exist and be DRAFT, and a manual price requires the order:line:enter_manual_price permission.
+
+        Required inputs: itemSku and quantity (minimum 1); manualPrice, reasonCode, notes, and serialNumbers (never more than quantity) are optional, and a client-supplied lineUuid makes the call replay-safe — a replay with a known lineUuid updates that line''s quantity instead of duplicating it.
+
+        Emits an ORDER_CART_ITEM_ADD event, recomputes order totals, and marks tax stale.
+
+        Returns 400 when the SKU is unknown, 404 when the order does not exist, 409 when the order is not DRAFT or the lineUuid was previously used for a different SKU, and 422 when pricing is unavailable or serialNumbers exceed the quantity.
+
+        '
+      operationId: addCartItem
       parameters:
       - name: orderId
         in: path
@@ -845,10 +1266,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: 'The line item to add: SKU, quantity, and optional pricing context.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AddItemRequest'
+            examples:
+              Priced line with replay identity:
+                description: Priced line with replay identity
+                value:
+                  itemSku: SKU-OIL-5W30-1L
+                  quantity: 2
+                  lineUuid: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4aaa
+                  customerNote: Front wipers only
         required: true
       responses:
         '200':
@@ -865,8 +1295,20 @@ paths:
     post:
       tags:
       - Order Cancellation
-      summary: Cancel order
-      description: Initiate cancellation for a sales order cart using the supplied cancellation context.
+      summary: Cancel a Sales Order
+      description: 'Runs the order cancellation saga: transitions the order through CANCEL_REQUESTED, cancels a linked workorder at pos-workexec when workOrderId is supplied, reverses every net-settled payment as refunds through pos-invoice, and finishes at CANCELLED, publishing an order-cancelled fact.
+
+        Use this tool for DRAFT or QUOTED orders and to re-drive CANCEL_FAILED_WORKEXEC or CANCEL_FAILED_BILLING orders from the start; do not use voidOrder, which is the terminal void for an unsettled PENDING_PAYMENT order, and do not use retryOrderCancellation, which re-runs only the billing leg from CANCEL_FAILED_BILLING.
+
+        Preconditions: the order must be DRAFT, QUOTED, CANCEL_FAILED_WORKEXEC or CANCEL_FAILED_BILLING, and settled payments require an invoice reference to refund against.
+
+        Required inputs: cancellationReason; workOrderId is optional and triggers the workorder-cancellation leg, and idempotencyKey is optional (one is generated when absent) — replaying it against an already CANCELLED order returns the original result.
+
+        Emits an ORDER_CART_CANCEL_REQUEST event; refunds are idempotent per payment intent at pos-invoice, and a failed leg parks the order at CANCEL_FAILED_WORKEXEC or CANCEL_FAILED_BILLING.
+
+        Returns 201 when the cancellation completes (or already had for the replayed key), 404 when the order does not exist, and 409 when the current status is not cancellable or a workorder or payment-reversal leg fails.
+
+        '
       operationId: cancelOrder
       parameters:
       - name: orderId
@@ -876,10 +1318,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: 'Cancellation context: the business reason plus optional workorder linkage and replay key.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CancelOrderRequest'
+            examples:
+              Cancel with workorder:
+                description: Cancel with workorder
+                value:
+                  cancellationReason: Customer changed their mind
+                  workOrderId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04
+                  idempotencyKey: cancel-req-abc123
         required: true
       responses:
         '201':
@@ -921,9 +1371,21 @@ paths:
     post:
       tags:
       - Order Cancellation
-      summary: Retry failed cancellation
-      description: Retry a previously failed order cancellation using the original idempotency key.
-      operationId: retryCancellation
+      summary: Retry a Failed Cancellation
+      description: 'Retries the billing leg of a failed order cancellation, re-running the settled-payment reversals and completing the transition to CANCELLED.
+
+        Use this tool after a cancellation parked at CANCEL_FAILED_BILLING; do not use cancelOrder, which starts the saga from the beginning and re-checks the workorder leg as well.
+
+        Preconditions: the order must be in CANCEL_FAILED_BILLING.
+
+        Required inputs: orderId (UUID) as a path parameter and idempotencyKey as a query parameter — the original cancellation key, from which per-intent refund idempotency at pos-invoice is derived.
+
+        Emits an ORDER_CART_CANCEL_RETRY event; a retry that fails again transitions the order to CANCEL_REQUIRES_MANUAL_REVIEW and publishes a review-required fact instead of looping.
+
+        Returns 200 when the cancellation completes on retry, 404 when the order does not exist, and 409 when the order is not in CANCEL_FAILED_BILLING or the reversal fails again.
+
+        '
+      operationId: retryOrderCancellation
       parameters:
       - name: orderId
         in: path
@@ -970,9 +1432,21 @@ paths:
     patch:
       tags:
       - Sales Orders
-      summary: Link a source to a sales order
-      description: Associate an external source reference with an existing sales order cart.
-      operationId: linkSource
+      summary: Link a Source Document to an Order
+      description: 'Imports the line items of a source document (an ESTIMATE or WORKORDER) into a DRAFT cart, merging into same-SKU same-price lines where possible; imported source prices are contractual and are never repriced.
+
+        Use this tool to pull approved estimate or workorder lines onto a sale; do not use addCartItem, which adds individually priced counter lines.
+
+        Preconditions: the order must be DRAFT, a WORKORDER source requires a customer already on the cart, and source lines already linked to the cart are skipped, making the call replay-safe.
+
+        Required inputs: sourceType (ESTIMATE or WORKORDER) and sourceId, both in the body.
+
+        Emits an ORDER_LINK_SOURCE event, recomputes order totals, and marks tax stale.
+
+        Returns 404 when the order does not exist, 409 when the order is not DRAFT, and 422 when the sourceType is unknown or a WORKORDER link is attempted without a customer on the cart.
+
+        '
+      operationId: linkOrderSource
       parameters:
       - name: orderId
         in: path
@@ -981,10 +1455,17 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The source document whose lines are imported into the cart.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LinkSourceRequest'
+            examples:
+              Workorder link:
+                description: Workorder link
+                value:
+                  sourceType: WORKORDER
+                  sourceId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04
         required: true
       responses:
         '200':
@@ -1001,8 +1482,20 @@ paths:
     get:
       tags:
       - Returns
-      summary: Get a return by id
-      description: Fetches a return order by return order identifier.
+      summary: Get a Return by Id
+      description: 'Returns a return order with its status, refund method and total, failure reason when present, and per-line quantities and refunds.
+
+        Use this tool when the return order id is already known; use listReturns instead to find every return created from an original order.
+
+        Preconditions: the return order must exist.
+
+        Required inputs: returnOrderId (UUID) as a path parameter; there is no request body.
+
+        Emits an ORDER_RETURN_GET audit event; no state changes — this is a read-only projection.
+
+        Returns 404 when no return order exists for the supplied id.
+
+        '
       operationId: getReturn
       parameters:
       - name: returnOrderId
@@ -1026,9 +1519,21 @@ paths:
     get:
       tags:
       - Returns
-      summary: Per-line returnable quantities for a completed order
-      description: Returns each completed-order line with its currently returnable quantity.
-      operationId: returnableLines
+      summary: List Returnable Lines for an Order
+      description: 'Returns each line of a COMPLETED order with its sold quantity, already-returned quantity, remaining returnable quantity, and returnable flag.
+
+        Use this tool before createReturn to size a valid return; do not use listReturns, which lists return orders already created rather than remaining capacity.
+
+        Preconditions: the order must exist and be COMPLETED; workorder-consumed lines without an imported returnable flag report zero returnable quantity.
+
+        Required inputs: orderId (UUID) as a query parameter; there is no request body.
+
+        Emits an ORDER_RETURN_RETURNABLE audit event; no state changes — this is a read-only projection.
+
+        Returns 404 when the order does not exist, and 409 when the order is not COMPLETED.
+
+        '
+      operationId: listReturnableLines
       parameters:
       - name: orderId
         in: query
@@ -1053,9 +1558,21 @@ paths:
     get:
       tags:
       - Register Sessions
-      summary: Get a register session by id
-      description: Retrieves register session details and balances for the given session id.
-      operationId: getSession
+      summary: Get a Register Session
+      description: 'Returns a register session with its status, opening float, counted and theoretical cash, over/short, and lifecycle timestamps.
+
+        Use this tool when the session id is already known; use getCurrentRegisterSession instead to resolve the active session from a terminal id.
+
+        Preconditions: the session must exist.
+
+        Required inputs: sessionId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no register session exists for the supplied id.
+
+        '
+      operationId: getRegisterSession
       parameters:
       - name: sessionId
         in: path
@@ -1078,9 +1595,21 @@ paths:
     get:
       tags:
       - Register Sessions
-      summary: Z-report (close summary)
-      description: Returns the end-of-session close summary, including totals and variance metrics.
-      operationId: zReport
+      summary: Z-Report for a Register Session
+      description: 'Returns the Z-report close summary for a register session, including per-tender totals, cash movements, theoretical cash, counted cash, and the over/short variance.
+
+        Use this tool for the end-of-session summary after close; use getSessionXReport instead for interim mid-shift figures.
+
+        Preconditions: the session must exist; the report reflects the session''s current ledger, so it is authoritative once the session is CLOSED.
+
+        Required inputs: sessionId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only report projection.
+
+        Returns 404 when no register session exists for the supplied id.
+
+        '
+      operationId: getSessionZReport
       parameters:
       - name: sessionId
         in: path
@@ -1103,9 +1632,21 @@ paths:
     get:
       tags:
       - Register Sessions
-      summary: X-report (mid-day figures for an open session)
-      description: Returns an interim session report for an open or in-progress register session.
-      operationId: xReport
+      summary: X-Report for a Register Session
+      description: 'Returns an interim X-report for a register session: opening float, per-tender totals, cash settlements, cash movements, theoretical cash, and over/short when a count has been recorded.
+
+        Use this tool for mid-shift figures while the session is open; use getSessionZReport instead for the end-of-session close summary.
+
+        Preconditions: the session must exist; figures are computed live from the session''s current ledger.
+
+        Required inputs: sessionId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only report projection.
+
+        Returns 404 when no register session exists for the supplied id.
+
+        '
+      operationId: getSessionXReport
       parameters:
       - name: sessionId
         in: path
@@ -1128,9 +1669,21 @@ paths:
     get:
       tags:
       - Register Sessions
-      summary: Get the current open session for a terminal
-      description: Returns the OPEN (or CLOSING) session on the terminal, or 204 if none is open.
-      operationId: currentSession
+      summary: Get the Current Session for a Terminal
+      description: 'Returns the active register session on a terminal, preferring an OPEN session and falling back to one in CLOSING.
+
+        Use this tool to resolve which drawer a terminal is on; use getRegisterSession instead when the session id is already known.
+
+        Preconditions: none — a terminal without an active session is a normal outcome.
+
+        Required inputs: terminalId as a query parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the OPEN or CLOSING session, and 204 when the terminal has no active session.
+
+        '
+      operationId: getCurrentRegisterSession
       parameters:
       - name: terminalId
         in: query
@@ -1152,9 +1705,21 @@ paths:
     get:
       tags:
       - Price Overrides
-      summary: Get price override
-      description: Retrieve a specific price override by ID.
-      operationId: getOverride
+      summary: Get a Price Override
+      description: 'Returns one price override with its prices, discount figures, status, audit actors, and lifecycle timestamps.
+
+        Use this tool when the override id is already known; use searchPriceOverrides instead to find overrides by order, status, or date range.
+
+        Preconditions: the override must exist.
+
+        Required inputs: overrideId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no price override exists for the supplied id.
+
+        '
+      operationId: getPriceOverride
       parameters:
       - name: overrideId
         in: path
@@ -1162,6 +1727,7 @@ paths:
         required: true
         schema:
           type: string
+          format: uuid
         example: 018e1c9f-6b5a-7890-abcd-1234567890ab
       responses:
         '200':
@@ -1185,9 +1751,21 @@ paths:
     get:
       tags:
       - Price Overrides
-      summary: Get pending approvals
-      description: Retrieve all price overrides awaiting approval.
-      operationId: getPendingApprovals
+      summary: List Pending Price Override Approvals
+      description: 'Lists every price override sitting in PENDING_APPROVAL — the manager approval work queue.
+
+        Use this tool to fetch what needs a decision; use approvePriceOverride or rejectPriceOverride to act on an entry, and searchPriceOverrides instead for historical or filtered queries.
+
+        Preconditions: none beyond the order:price_override:approve permission.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        Emits an ORDER_PRICE_OVERRIDE_LIST_PENDING audit event; no state changes.
+
+        Returns 200 with a possibly empty list; there are no business error conditions beyond authorization.
+
+        '
+      operationId: listPendingPriceOverrides
       responses:
         '200':
           description: Pending overrides retrieved
@@ -1206,8 +1784,20 @@ paths:
     get:
       tags:
       - Sales Orders
-      summary: Get a sales order by ID
-      description: Retrieve a sales order cart and its current line items by identifier.
+      summary: Get a Sales Order by Id
+      description: 'Returns a sales order with its current line items, totals, status, invoice references, and payment balances.
+
+        Use this tool when the order id is already known; use listCarts instead to search by clerk, terminal or status.
+
+        Preconditions: the order must exist.
+
+        Required inputs: orderId (UUID) as a path parameter; there is no request body and no filtering.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no sales order exists for the supplied id.
+
+        '
       operationId: getOrder
       parameters:
       - name: orderId
@@ -1323,7 +1913,6 @@ components:
             type: string
         returnable:
           type: boolean
-          default: false
           description: Explicit source-document returnability flag (imported lines only; null for counter lines)
       required:
       - itemSku
@@ -1345,6 +1934,7 @@ components:
           type: number
           description: Percent (0-100] or currency amount, per type
           example: 10
+          minimum: 0
         reasonCode:
           type: string
           description: Business reason for the discount
@@ -1414,7 +2004,6 @@ components:
           example: 58.29
         taxStale:
           type: boolean
-          default: false
           description: True when mutations invalidated taxTotal; cleared by quote/checkout tax recompute
           example: false
         orderDiscountType:
@@ -1513,6 +2102,7 @@ components:
           format: int32
           description: Units to return (capped at the un-refunded remainder)
           example: 1
+          minimum: 0
         condition:
           type: string
           description: Disposition of the returned item
@@ -1641,6 +2231,7 @@ components:
           type: number
           description: Starting drawer cash; defaults to the terminal's previous counted close when omitted
           example: 150.0
+          minimum: 0
       required:
       - openedByClerkId
       - terminalId
@@ -1697,6 +2288,7 @@ components:
           type: number
           description: Positive cash amount moved
           example: 40.0
+          minimum: 0
         reason:
           type: string
           description: Reason for the movement
@@ -1741,6 +2333,7 @@ components:
           type: number
           description: Physical cash counted in the drawer
           example: 310.0
+          minimum: 0
       required:
       - countedCash
     ApplyPriceOverrideRequest:
@@ -1843,12 +2436,10 @@ components:
           example: APPROVED
         requiresApproval:
           type: boolean
-          default: false
           description: Whether the override required approval
           example: false
         affectsCommission:
           type: boolean
-          default: false
           description: Whether the override affects sales commission
           example: true
         requestedByUserId:
@@ -1945,12 +2536,10 @@ components:
           example: PENDING_APPROVAL
         requiresApproval:
           type: boolean
-          default: false
           description: Whether the override required approval
           example: true
         affectsCommission:
           type: boolean
-          default: false
           description: Whether the override affects sales commission
           example: true
         requestedByUserId:

--- a/pos-order/src/main/java/com/positivity/order/internal/controller/OrderCancellationController.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/controller/OrderCancellationController.java
@@ -8,6 +8,8 @@ import com.positivity.order.service.OrderCancellationService;
 import com.positivity.order.service.model.CancelOrderCommand;
 import com.positivity.order.service.model.CancellationResult;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -32,8 +34,29 @@ public class OrderCancellationController {
     private final OrderCancellationService orderCancellationService;
 
     @Operation(
-            summary = "Cancel order",
-            description = "Initiate cancellation for a sales order cart using the supplied cancellation context.",
+            operationId = "cancelOrder",
+            summary = "Cancel a Sales Order",
+            description = """
+                    Runs the order cancellation saga: transitions the order through CANCEL_REQUESTED, cancels a \
+                    linked workorder at pos-workexec when workOrderId is supplied, reverses every net-settled \
+                    payment as refunds through pos-invoice, and finishes at CANCELLED, publishing an \
+                    order-cancelled fact.
+                    Use this tool for DRAFT or QUOTED orders and to re-drive CANCEL_FAILED_WORKEXEC or \
+                    CANCEL_FAILED_BILLING orders from the start; do not use voidOrder, which is the terminal void \
+                    for an unsettled PENDING_PAYMENT order, and do not use retryOrderCancellation, which re-runs \
+                    only the billing leg from CANCEL_FAILED_BILLING.
+                    Preconditions: the order must be DRAFT, QUOTED, CANCEL_FAILED_WORKEXEC or \
+                    CANCEL_FAILED_BILLING, and settled payments require an invoice reference to refund against.
+                    Required inputs: cancellationReason; workOrderId is optional and triggers the \
+                    workorder-cancellation leg, and idempotencyKey is optional (one is generated when absent) — \
+                    replaying it against an already CANCELLED order returns the original result.
+                    Emits an ORDER_CART_CANCEL_REQUEST event; refunds are idempotent per payment intent at \
+                    pos-invoice, and a failed leg parks the order at CANCEL_FAILED_WORKEXEC or \
+                    CANCEL_FAILED_BILLING.
+                    Returns 201 when the cancellation completes (or already had for the replayed key), 404 when \
+                    the order does not exist, and 409 when the current status is not cancellable or a workorder or \
+                    payment-reversal leg fails.
+                    """,
             tags = {"Order Cancellation"})
     @ApiResponse(responseCode = "201", description = "Cancellation initiated")
     @ApiResponse(responseCode = "400", description = "Invalid request")
@@ -44,7 +67,22 @@ public class OrderCancellationController {
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_CANCEL + "')")
     @EmitEvent(id = "ORDER_CART_CANCEL_REQUEST", apiVersion = "1")
     public ResponseEntity<CancellationResponse> cancelOrder(
-            @PathVariable UUID orderId, @Valid @RequestBody CancelOrderRequest request) {
+            @PathVariable UUID orderId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Cancellation context: the business reason plus optional workorder"
+                                    + " linkage and replay key.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Cancel with workorder", value = """
+                                                                    {"cancellationReason":"Customer changed their mind",
+                                                                     "workOrderId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04",
+                                                                     "idempotencyKey":"cancel-req-abc123"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CancelOrderRequest request) {
         CancelOrderCommand command = new CancelOrderCommand(
                 request.getCancellationReason(), request.getWorkOrderId(), request.getIdempotencyKey());
         CancellationResult result = orderCancellationService.cancelOrder(orderId, command);
@@ -57,8 +95,22 @@ public class OrderCancellationController {
     }
 
     @Operation(
-            summary = "Retry failed cancellation",
-            description = "Retry a previously failed order cancellation using the original idempotency key.",
+            operationId = "retryOrderCancellation",
+            summary = "Retry a Failed Cancellation",
+            description = """
+                    Retries the billing leg of a failed order cancellation, re-running the settled-payment \
+                    reversals and completing the transition to CANCELLED.
+                    Use this tool after a cancellation parked at CANCEL_FAILED_BILLING; do not use cancelOrder, \
+                    which starts the saga from the beginning and re-checks the workorder leg as well.
+                    Preconditions: the order must be in CANCEL_FAILED_BILLING.
+                    Required inputs: orderId (UUID) as a path parameter and idempotencyKey as a query parameter — \
+                    the original cancellation key, from which per-intent refund idempotency at pos-invoice is \
+                    derived.
+                    Emits an ORDER_CART_CANCEL_RETRY event; a retry that fails again transitions the order to \
+                    CANCEL_REQUIRES_MANUAL_REVIEW and publishes a review-required fact instead of looping.
+                    Returns 200 when the cancellation completes on retry, 404 when the order does not exist, and \
+                    409 when the order is not in CANCEL_FAILED_BILLING or the reversal fails again.
+                    """,
             tags = {"Order Cancellation"})
     @ApiResponse(responseCode = "200", description = "Retry accepted")
     @ApiResponse(responseCode = "403", description = "Insufficient permissions")

--- a/pos-order/src/main/java/com/positivity/order/internal/controller/PriceOverrideController.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/controller/PriceOverrideController.java
@@ -15,6 +15,7 @@ import com.positivity.security.common.SecurityContextHelper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -55,8 +56,27 @@ public class PriceOverrideController {
      * Requires order:price_override:apply permission.
      */
     @Operation(
-            summary = "Apply price override",
-            description = "Apply a price override to an order line. May require approval based on override amount.",
+            operationId = "applyPriceOverride",
+            summary = "Apply a Price Override",
+            description = """
+                    Applies a price override to a single DRAFT order line, auto-approving and repricing the line \
+                    immediately when the discount is below the approval thresholds (10 percent and 50.00), and \
+                    otherwise parking it at PENDING_APPROVAL for a manager.
+                    Use this tool for a one-line price concession; do not use applyOrderDiscount, which spreads a \
+                    discount pro-rata across the whole order, and do not use approvePriceOverride, which resolves \
+                    an override that already exists.
+                    Preconditions: the order must exist and be DRAFT, the order line must exist, and overridePrice \
+                    must be between zero and originalPrice inclusive.
+                    Required inputs: orderId, orderLineId, and productId as UUID strings, originalPrice, \
+                    overridePrice, and reasonCode (for example PRICE_MATCH or GOODWILL_ADJUSTMENT); justification \
+                    and idempotencyKey are optional, and a replayed key returns the existing override.
+                    Emits an ORDER_PRICE_OVERRIDE_APPLY event; an auto-approved override immediately rewrites the \
+                    line's unit price, recomputes the order subtotal, and publishes a commission-impact fact.
+                    Returns 201 with status APPROVED or PENDING_APPROVAL, 400 when an id or reasonCode cannot be \
+                    parsed, 409 when the idempotency key was used with a different payload, and 422 when the order \
+                    or line cannot be found, the order is not DRAFT, or the override price is negative or above \
+                    the original.
+                    """,
             tags = {"Price Overrides"})
     @ApiResponse(
             responseCode = "201",
@@ -71,7 +91,26 @@ public class PriceOverrideController {
     @PreAuthorize("hasAuthority('" + PriceOverridePermissions.PRICE_OVERRIDE_APPLY + "')")
     @EmitEvent(id = "ORDER_PRICE_OVERRIDE_APPLY", apiVersion = "1")
     public ResponseEntity<PriceOverrideResult> applyPriceOverride(
-            @Valid @RequestBody ApplyPriceOverrideRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "The line-level override: original and overridden price with an audit" + " reason.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Price match", value = """
+                                                                    {"orderId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01",
+                                                                     "orderLineId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02",
+                                                                     "productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03",
+                                                                     "originalPrice":49.99,
+                                                                     "overridePrice":39.99,
+                                                                     "reasonCode":"PRICE_MATCH",
+                                                                     "justification":"Competitor price match per store policy",
+                                                                     "idempotencyKey":"req-abc123"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    ApplyPriceOverrideRequest request) {
 
         log.info("Applying price override for order {}", request.getOrderId());
 
@@ -84,8 +123,23 @@ public class PriceOverrideController {
      * Requires order:price_override:approve permission.
      */
     @Operation(
-            summary = "Approve price override",
-            description = "Approve a pending price override. Validates approver permission level.",
+            operationId = "approvePriceOverride",
+            summary = "Approve a Price Override",
+            description = """
+                    Approves a PENDING_APPROVAL price override, marking it APPROVED and recording an approval \
+                    audit row with the reviewer's role resolved from the caller's granted roles.
+                    Use this tool to grant a pending override; do not use rejectPriceOverride, which declines it, \
+                    and do not use applyPriceOverride, which creates a new override.
+                    Preconditions: the override must exist and be in PENDING_APPROVAL.
+                    Required inputs: overrideId (UUID) as a path parameter; the body carries only optional \
+                    reviewer comments — the approver identity and role come from the security context, not the \
+                    body.
+                    Emits an ORDER_PRICE_OVERRIDE_APPROVE event and publishes a commission-impact fact; note that \
+                    the approval itself does not rewrite the order line's unit price — the line reprice happens \
+                    only on the auto-approved apply path.
+                    Returns 404 when the override does not exist, and 422 when the override is not in \
+                    PENDING_APPROVAL.
+                    """,
             tags = {"Price Overrides"})
     @ApiResponse(
             responseCode = "200",
@@ -107,7 +161,20 @@ public class PriceOverrideController {
                             example = "018e1c9f-6b5a-7890-abcd-1234567890ab")
                     @PathVariable
                     UUID overrideId,
-            @Valid @RequestBody ApprovePriceOverrideRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Optional reviewer commentary recorded on the approval audit row.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Approval with comment",
+                                                            value =
+                                                                    "{\"comments\":\"Approved per store manager discretion\"}")))
+                    @Valid
+                    @RequestBody
+                    ApprovePriceOverrideRequest request) {
 
         String role = resolveReviewerRole();
 
@@ -122,8 +189,22 @@ public class PriceOverrideController {
      * Requires order:price_override:reject permission.
      */
     @Operation(
-            summary = "Reject price override",
-            description = "Reject a pending price override with a reason.",
+            operationId = "rejectPriceOverride",
+            summary = "Reject a Price Override",
+            description = """
+                    Rejects a PENDING_APPROVAL price override, marking it REJECTED with the supplied reason and \
+                    recording a rejection audit row with the reviewer's resolved role.
+                    Use this tool to decline a pending override; do not use approvePriceOverride, which grants it \
+                    instead.
+                    Preconditions: the override must exist and be in PENDING_APPROVAL; a rejected override is \
+                    terminal and never touches the order line's price.
+                    Required inputs: overrideId (UUID) as a path parameter and reason in the body; comments are \
+                    optional, and the reviewer identity and role come from the security context.
+                    Emits an ORDER_PRICE_OVERRIDE_REJECT event; no commission-impact fact is published for a \
+                    rejection.
+                    Returns 404 when the override does not exist, and 422 when the override is not in \
+                    PENDING_APPROVAL.
+                    """,
             tags = {"Price Overrides"})
     @ApiResponse(
             responseCode = "200",
@@ -145,7 +226,19 @@ public class PriceOverrideController {
                             example = "018e1c9f-6b5a-7890-abcd-1234567890ab")
                     @PathVariable
                     UUID overrideId,
-            @Valid @RequestBody RejectPriceOverrideRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The rejection reason plus optional reviewer commentary.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Rejection with reason", value = """
+                                                                    {"reason":"Outside approved discount threshold",
+                                                                     "comments":"Discount exceeds policy limit for this product"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    RejectPriceOverrideRequest request) {
 
         String role = resolveReviewerRole();
 
@@ -160,8 +253,18 @@ public class PriceOverrideController {
      * Requires order:price_override:view permission.
      */
     @Operation(
-            summary = "Get price override",
-            description = "Retrieve a specific price override by ID.",
+            operationId = "getPriceOverride",
+            summary = "Get a Price Override",
+            description = """
+                    Returns one price override with its prices, discount figures, status, audit actors, and \
+                    lifecycle timestamps.
+                    Use this tool when the override id is already known; use searchPriceOverrides instead to find \
+                    overrides by order, status, or date range.
+                    Preconditions: the override must exist.
+                    Required inputs: overrideId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no price override exists for the supplied id.
+                    """,
             tags = {"Price Overrides"})
     @ApiResponse(
             responseCode = "200",
@@ -189,9 +292,22 @@ public class PriceOverrideController {
      * Requires order:price_override:view permission.
      */
     @Operation(
-            summary = "Get price overrides",
-            description =
-                    "Retrieve price overrides by order ID, status, or date range. At least one filter parameter is required.",
+            operationId = "searchPriceOverrides",
+            summary = "Search Price Overrides",
+            description = """
+                    Searches price overrides by order id, status, or creation-date range; exactly one filter \
+                    dimension is applied, with orderId taking precedence over status, which takes precedence over \
+                    the date range.
+                    Use this tool to find overrides matching a filter; use getPriceOverride instead when the \
+                    override id is known, or listPendingPriceOverrides for the approval work queue.
+                    Preconditions: at least one filter must be supplied, and a date-range search requires both \
+                    startDate and endDate.
+                    Required inputs: one of orderId (UUID string), status (an override status such as \
+                    PENDING_APPROVAL, APPROVED or REJECTED), or startDate plus endDate as ISO-8601 date-times.
+                    Emits an ORDER_PRICE_OVERRIDE_SEARCH audit event; no state changes.
+                    Returns 200 with a possibly empty list, 400 when no filter is supplied or orderId is not a \
+                    UUID, and 422 when status is not a valid override status name.
+                    """,
             tags = {"Price Overrides"})
     @ApiResponse(responseCode = "200", description = "Overrides retrieved")
     @ApiResponse(responseCode = "400", description = "No filter parameter provided")
@@ -233,8 +349,18 @@ public class PriceOverrideController {
      * Requires order:price_override:approve permission.
      */
     @Operation(
-            summary = "Get pending approvals",
-            description = "Retrieve all price overrides awaiting approval.",
+            operationId = "listPendingPriceOverrides",
+            summary = "List Pending Price Override Approvals",
+            description = """
+                    Lists every price override sitting in PENDING_APPROVAL — the manager approval work queue.
+                    Use this tool to fetch what needs a decision; use approvePriceOverride or rejectPriceOverride \
+                    to act on an entry, and searchPriceOverrides instead for historical or filtered queries.
+                    Preconditions: none beyond the order:price_override:approve permission.
+                    Required inputs: none; there are no parameters and no request body.
+                    Emits an ORDER_PRICE_OVERRIDE_LIST_PENDING audit event; no state changes.
+                    Returns 200 with a possibly empty list; there are no business error conditions beyond \
+                    authorization.
+                    """,
             tags = {"Price Overrides"})
     @ApiResponse(responseCode = "200", description = "Pending overrides retrieved")
     @GetMapping("/pending")

--- a/pos-order/src/main/java/com/positivity/order/internal/controller/RegisterSessionController.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/controller/RegisterSessionController.java
@@ -13,6 +13,8 @@ import com.positivity.order.service.model.CashMovementCommand;
 import com.positivity.order.service.model.OpenSessionCommand;
 import com.positivity.order.service.model.RegisterSessionSummary;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -49,13 +51,40 @@ public class RegisterSessionController {
     private final RegisterSessionService registerSessionService;
 
     @Operation(
-            summary = "Open a register session",
-            description = "Opens a new register session for the provided terminal, location, and clerk context.",
+            operationId = "openRegisterSession",
+            summary = "Open a Register Session",
+            description = """
+                    Opens an OPEN register (drawer) session on a terminal; sales orders created on the terminal \
+                    while it is open bind to it, and it supplies their location by default.
+                    Use this tool at the start of a drawer shift; do not use recordCashMovement, which requires a \
+                    session that is already open.
+                    Preconditions: the terminal must have no session in OPEN or CLOSING — one drawer per terminal.
+                    Required inputs: terminalId and openedByClerkId; openingFloat defaults to the terminal's \
+                    previous counted close (else zero) when omitted, and locationId defaults from the terminal's \
+                    previous session.
+                    Emits an ORDER_SESSION_OPEN event.
+                    Returns 201 with the new session, and 409 when the terminal already has an active session.
+                    """,
             tags = {"Register Sessions"})
     @PostMapping
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_OPEN + "')")
     @EmitEvent(id = "ORDER_SESSION_OPEN", apiVersion = "1")
-    public ResponseEntity<RegisterSessionResponse> openSession(@Valid @RequestBody OpenSessionRequest request) {
+    public ResponseEntity<RegisterSessionResponse> openSession(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The terminal, clerk, and optional opening-float context for the shift.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Morning open", value = """
+                                                                    {"terminalId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a60",
+                                                                     "openedByClerkId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a50",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a90",
+                                                                     "openingFloat":150.00}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    OpenSessionRequest request) {
         RegisterSessionSummary summary = registerSessionService.openSession(new OpenSessionCommand(
                 request.getTerminalId(),
                 request.getLocationId(),
@@ -65,8 +94,18 @@ public class RegisterSessionController {
     }
 
     @Operation(
-            summary = "Get a register session by id",
-            description = "Retrieves register session details and balances for the given session id.",
+            operationId = "getRegisterSession",
+            summary = "Get a Register Session",
+            description = """
+                    Returns a register session with its status, opening float, counted and theoretical cash, \
+                    over/short, and lifecycle timestamps.
+                    Use this tool when the session id is already known; use getCurrentRegisterSession instead to \
+                    resolve the active session from a terminal id.
+                    Preconditions: the session must exist.
+                    Required inputs: sessionId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no register session exists for the supplied id.
+                    """,
             tags = {"Register Sessions"})
     @GetMapping("/{sessionId}")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
@@ -75,8 +114,18 @@ public class RegisterSessionController {
     }
 
     @Operation(
-            summary = "Get the current open session for a terminal",
-            description = "Returns the OPEN (or CLOSING) session on the terminal, or 204 if none is open.",
+            operationId = "getCurrentRegisterSession",
+            summary = "Get the Current Session for a Terminal",
+            description = """
+                    Returns the active register session on a terminal, preferring an OPEN session and falling back \
+                    to one in CLOSING.
+                    Use this tool to resolve which drawer a terminal is on; use getRegisterSession instead when \
+                    the session id is already known.
+                    Preconditions: none — a terminal without an active session is a normal outcome.
+                    Required inputs: terminalId as a query parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the OPEN or CLOSING session, and 204 when the terminal has no active session.
+                    """,
             tags = {"Register Sessions"})
     @GetMapping("/current")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
@@ -89,14 +138,41 @@ public class RegisterSessionController {
     }
 
     @Operation(
-            summary = "Record a drawer cash movement",
-            description = "Records a cash in/out drawer movement against the specified register session.",
+            operationId = "recordCashMovement",
+            summary = "Record a Drawer Cash Movement",
+            description = """
+                    Records a PAID_IN or PAID_OUT cash movement against an OPEN register session; movements feed \
+                    the theoretical-cash calculation at close.
+                    Use this tool for non-sale drawer cash such as petty cash or bank drops; do not use \
+                    beginSessionClose, which records the final counted drawer instead.
+                    Preconditions: the session must exist and be OPEN — movements are rejected once closing has \
+                    begun.
+                    Required inputs: movementType (PAID_IN or PAID_OUT), a positive amount, reason, and clerkId.
+                    Emits an ORDER_SESSION_CASH_MOVEMENT event.
+                    Returns 201 with the recorded movement, 404 when the session does not exist, 409 when the \
+                    session is not OPEN, and 422 when the amount is not positive or the movement type is unknown.
+                    """,
             tags = {"Register Sessions"})
     @PostMapping("/{sessionId}/cash-movements")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_CASH_MOVEMENT + "')")
     @EmitEvent(id = "ORDER_SESSION_CASH_MOVEMENT", apiVersion = "1")
     public ResponseEntity<CashMovementResponse> recordCashMovement(
-            @PathVariable UUID sessionId, @Valid @RequestBody CashMovementRequest request) {
+            @PathVariable UUID sessionId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The cash movement: direction, positive amount, reason, and clerk.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Petty cash out", value = """
+                                                                    {"movementType":"PAID_OUT",
+                                                                     "amount":40.00,
+                                                                     "reason":"petty cash to office",
+                                                                     "clerkId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a50"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CashMovementRequest request) {
         CashMovementResponse response =
                 CashMovementResponse.from(registerSessionService.recordCashMovement(new CashMovementCommand(
                         sessionId,
@@ -108,8 +184,17 @@ public class RegisterSessionController {
     }
 
     @Operation(
-            summary = "List a session's cash movements",
-            description = "Lists all recorded cash movements for the specified register session.",
+            operationId = "listCashMovements",
+            summary = "List a Session's Cash Movements",
+            description = """
+                    Lists every recorded cash movement for a register session in the order they occurred.
+                    Use this tool to review drawer ins and outs; use getSessionXReport instead for the aggregated \
+                    mid-day figures that include tender totals and theoretical cash.
+                    Preconditions: the session must exist.
+                    Required inputs: sessionId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with a possibly empty list, and 404 when the session does not exist.
+                    """,
             tags = {"Register Sessions"})
     @GetMapping("/{sessionId}/cash-movements")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
@@ -120,24 +205,65 @@ public class RegisterSessionController {
     }
 
     @Operation(
-            summary = "Begin closing a register session",
-            description = "Records the counted cash and moves the session to CLOSING. Blocked while any of "
-                    + "its orders are in PENDING_PAYMENT.",
+            operationId = "beginSessionClose",
+            summary = "Begin Closing a Register Session",
+            description = """
+                    Records the physically counted drawer cash and moves the register session to CLOSING, freezing \
+                    the terminal against new orders.
+                    Use this tool to start the drawer count at end of shift; do not use confirmSessionClose, which \
+                    finalizes a session already in CLOSING.
+                    Preconditions: the session must exist, must not already be CLOSED, and none of its orders may \
+                    be in PENDING_PAYMENT.
+                    Required inputs: countedCash (zero or greater) in the body and sessionId (UUID) as a path \
+                    parameter.
+                    Emits an ORDER_SESSION_BEGIN_CLOSE event.
+                    Returns 200 with the CLOSING session, 404 when the session does not exist, and 409 when the \
+                    session is already closed or an order on the session is still awaiting payment.
+                    """,
             tags = {"Register Sessions"})
     @PostMapping("/{sessionId}/begin-close")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_CLOSE + "')")
     @EmitEvent(id = "ORDER_SESSION_BEGIN_CLOSE", apiVersion = "1")
     public ResponseEntity<RegisterSessionResponse> beginClose(
-            @PathVariable UUID sessionId, @Valid @RequestBody BeginCloseRequest request) {
+            @PathVariable UUID sessionId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The physically counted drawer cash at the start of the close.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Counted drawer",
+                                                            value = "{\"countedCash\":310.00}")))
+                    @Valid
+                    @RequestBody
+                    BeginCloseRequest request) {
         return ResponseEntity.ok(
                 RegisterSessionResponse.from(registerSessionService.beginClose(sessionId, request.getCountedCash())));
     }
 
     @Operation(
-            summary = "Confirm a register session close",
-            description = "Snapshots theoretical cash, computes over/short, and moves the session to CLOSED. "
-                    + "An over/short beyond the authorized difference limit requires "
-                    + "order:session:approve_variance.",
+            operationId = "confirmSessionClose",
+            summary = "Confirm a Register Session Close",
+            description = """
+                    Finalizes a CLOSING register session: snapshots theoretical cash (opening float plus net CASH \
+                    settlements plus signed cash movements), computes the over/short against the counted drawer, \
+                    and moves the session to CLOSED.
+                    Use this tool to finish the close after the count; do not use beginSessionClose, which records \
+                    the count and must run first.
+                    Preconditions: the session must be in CLOSING, and no order on the session may have re-entered \
+                    PENDING_PAYMENT since the count began.
+                    Required inputs: sessionId (UUID) as a path parameter; there is no request body — an \
+                    over/short beyond the authorized difference limit (default 5.00, configurable via \
+                    pos.order.session.authorized-difference-limit) additionally requires the \
+                    order:session:approve_variance permission.
+                    Emits an ORDER_SESSION_CONFIRM_CLOSE event and publishes a register-session-closed fact \
+                    carrying per-tender totals and the reconciliation figures.
+                    Returns 200 with the CLOSED session, 403 when the variance exceeds the limit without the \
+                    approval permission, 404 when the session does not exist, and 409 when the session is not in \
+                    CLOSING or an order is still awaiting payment.
+                    """,
             tags = {"Register Sessions"})
     @PostMapping("/{sessionId}/confirm-close")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_CLOSE + "')")
@@ -147,8 +273,19 @@ public class RegisterSessionController {
     }
 
     @Operation(
-            summary = "X-report (mid-day figures for an open session)",
-            description = "Returns an interim session report for an open or in-progress register session.",
+            operationId = "getSessionXReport",
+            summary = "X-Report for a Register Session",
+            description = """
+                    Returns an interim X-report for a register session: opening float, per-tender totals, cash \
+                    settlements, cash movements, theoretical cash, and over/short when a count has been recorded.
+                    Use this tool for mid-shift figures while the session is open; use getSessionZReport instead \
+                    for the end-of-session close summary.
+                    Preconditions: the session must exist; figures are computed live from the session's current \
+                    ledger.
+                    Required inputs: sessionId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only report projection.
+                    Returns 404 when no register session exists for the supplied id.
+                    """,
             tags = {"Register Sessions"})
     @GetMapping("/{sessionId}/x-report")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")
@@ -157,8 +294,19 @@ public class RegisterSessionController {
     }
 
     @Operation(
-            summary = "Z-report (close summary)",
-            description = "Returns the end-of-session close summary, including totals and variance metrics.",
+            operationId = "getSessionZReport",
+            summary = "Z-Report for a Register Session",
+            description = """
+                    Returns the Z-report close summary for a register session, including per-tender totals, cash \
+                    movements, theoretical cash, counted cash, and the over/short variance.
+                    Use this tool for the end-of-session summary after close; use getSessionXReport instead for \
+                    interim mid-shift figures.
+                    Preconditions: the session must exist; the report reflects the session's current ledger, so it \
+                    is authoritative once the session is CLOSED.
+                    Required inputs: sessionId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only report projection.
+                    Returns 404 when no register session exists for the supplied id.
+                    """,
             tags = {"Register Sessions"})
     @GetMapping("/{sessionId}/z-report")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_SESSION_VIEW + "')")

--- a/pos-order/src/main/java/com/positivity/order/internal/controller/ReturnOrderController.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/controller/ReturnOrderController.java
@@ -12,6 +12,8 @@ import com.positivity.order.service.model.CreateReturnCommand;
 import com.positivity.order.service.model.ReturnLineCommand;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -48,9 +50,31 @@ public class ReturnOrderController {
     private final ReturnOrderService returnOrderService;
 
     @Operation(
-            summary = "Create a return against a completed order",
-            description = "Idempotency-Key header supported: a replayed key returns the original return. Over-cap "
-                    + "requests return 422 listing each line's returnableQty.",
+            operationId = "createReturn",
+            summary = "Create a Return Against a Completed Order",
+            description = """
+                    Creates a return order against one COMPLETED sales order, capping each line at its un-refunded \
+                    remainder (row-locked so concurrent returns serialize) and computing a pro-rata, tax-included \
+                    refund per line.
+                    Use this tool to take goods back after a completed sale; do not use cancelOrder or voidOrder, \
+                    which abandon an order before completion, and check listReturnableLines first to see each \
+                    line's remaining returnable quantity.
+                    Preconditions: the original order must be COMPLETED, every line must be returnable (workorder \
+                    consumed lines without an imported returnable flag are not), and each sold line may appear at \
+                    most once in the request.
+                    Required inputs: originalOrderId (UUID), refundMethod (ORIGINAL_TENDER, STORE_CREDIT or \
+                    ON_ACCOUNT_CREDIT), and at least one line with originalOrderLineId, a positive returnQty, and \
+                    condition (RESTOCK, SCRAP or WARRANTY); reasonCode, per-line serialNumbers, and the \
+                    Idempotency-Key header (replays return the original return) are optional.
+                    Emits an ORDER_RETURN_CREATE event; a refund total above the approval threshold (default \
+                    250.00, configurable via pos.order.return.approval-threshold) parks the return at \
+                    PENDING_APPROVAL, otherwise it starts at RETURN_REQUESTED ready for processReturn.
+                    Returns 201 on creation (idempotent replays included), 404 when the original order does not \
+                    exist, 409 when the original order is not COMPLETED, and 422 when a line exceeds its \
+                    returnable remainder (each offending line's returnableQty is listed in fieldErrors), a \
+                    WARRANTY-condition line must route to pos-warranty, or the lines are duplicated, unknown, or \
+                    invalid.
+                    """,
             tags = {"Returns"})
     @PostMapping
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_CREATE + "')")
@@ -59,7 +83,24 @@ public class ReturnOrderController {
             @Parameter(description = "Client idempotency key; replays return the original return")
                     @RequestHeader(name = "Idempotency-Key", required = false)
                     String idempotencyKey,
-            @Valid @RequestBody CreateReturnRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The return: source order, refund method, and the lines coming back.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "Single-line restock return", value = """
+                                                                    {"originalOrderId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01",
+                                                                     "refundMethod":"ORIGINAL_TENDER",
+                                                                     "reasonCode":"DEFECTIVE",
+                                                                     "lines":[{"originalOrderLineId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02",
+                                                                               "returnQty":1,
+                                                                               "condition":"RESTOCK"}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CreateReturnRequest request) {
         List<ReturnLineCommand> lines = request.getLines().stream()
                 .map(ReturnOrderController::toLineCommand)
                 .toList();
@@ -73,8 +114,18 @@ public class ReturnOrderController {
     }
 
     @Operation(
-            summary = "Get a return by id",
-            description = "Fetches a return order by return order identifier.",
+            operationId = "getReturn",
+            summary = "Get a Return by Id",
+            description = """
+                    Returns a return order with its status, refund method and total, failure reason when present, \
+                    and per-line quantities and refunds.
+                    Use this tool when the return order id is already known; use listReturns instead to find every \
+                    return created from an original order.
+                    Preconditions: the return order must exist.
+                    Required inputs: returnOrderId (UUID) as a path parameter; there is no request body.
+                    Emits an ORDER_RETURN_GET audit event; no state changes — this is a read-only projection.
+                    Returns 404 when no return order exists for the supplied id.
+                    """,
             tags = {"Returns"})
     @GetMapping("/{returnOrderId}")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_VIEW + "')")
@@ -84,8 +135,19 @@ public class ReturnOrderController {
     }
 
     @Operation(
-            summary = "List returns for an original order",
-            description = "Lists return orders created from the specified original order.",
+            operationId = "listReturns",
+            summary = "List Returns for an Original Order",
+            description = """
+                    Lists every return order created from one original sales order, newest first.
+                    Use this tool to review a sale's return history; use getReturn instead when the return order \
+                    id is known, or listReturnableLines to see what can still come back.
+                    Preconditions: none — an original order with no returns simply yields an empty list, and the \
+                    original order's existence is not checked.
+                    Required inputs: originalOrderId (UUID) as a query parameter; there is no request body.
+                    Emits an ORDER_RETURN_LIST audit event; no state changes — this is a read-only projection.
+                    Returns 200 with a possibly empty list; there are no business error conditions beyond \
+                    authorization.
+                    """,
             tags = {"Returns"})
     @GetMapping
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_VIEW + "')")
@@ -97,8 +159,20 @@ public class ReturnOrderController {
     }
 
     @Operation(
-            summary = "Per-line returnable quantities for a completed order",
-            description = "Returns each completed-order line with its currently returnable quantity.",
+            operationId = "listReturnableLines",
+            summary = "List Returnable Lines for an Order",
+            description = """
+                    Returns each line of a COMPLETED order with its sold quantity, already-returned quantity, \
+                    remaining returnable quantity, and returnable flag.
+                    Use this tool before createReturn to size a valid return; do not use listReturns, which lists \
+                    return orders already created rather than remaining capacity.
+                    Preconditions: the order must exist and be COMPLETED; workorder-consumed lines without an \
+                    imported returnable flag report zero returnable quantity.
+                    Required inputs: orderId (UUID) as a query parameter; there is no request body.
+                    Emits an ORDER_RETURN_RETURNABLE audit event; no state changes — this is a read-only \
+                    projection.
+                    Returns 404 when the order does not exist, and 409 when the order is not COMPLETED.
+                    """,
             tags = {"Returns"})
     @GetMapping("/returnable")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_VIEW + "')")
@@ -110,8 +184,21 @@ public class ReturnOrderController {
     }
 
     @Operation(
-            summary = "Approve a pending return",
-            description = "Approves a pending return so it can continue through the return workflow.",
+            operationId = "approveReturn",
+            summary = "Approve a Pending Return",
+            description = """
+                    Approves a PENDING_APPROVAL return, stamping the approver and moving it to RETURN_REQUESTED so \
+                    the refund saga can run.
+                    Use this tool for returns whose refund total exceeded the approval threshold; do not use \
+                    processReturn, which executes the refund and only accepts a return already in \
+                    RETURN_REQUESTED.
+                    Preconditions: the return order must exist and be in PENDING_APPROVAL.
+                    Required inputs: returnOrderId (UUID) as a path parameter; there is no request body — the \
+                    approver is taken from the security context.
+                    Emits an ORDER_RETURN_APPROVE event; no refund or stock movement happens yet.
+                    Returns 404 when the return does not exist, and 409 when the return is not in \
+                    PENDING_APPROVAL.
+                    """,
             tags = {"Returns"})
     @PostMapping("/{returnOrderId}/approve")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_APPROVE + "')")
@@ -121,22 +208,63 @@ public class ReturnOrderController {
     }
 
     @Operation(
-            summary = "Reject a pending return",
-            description = "Rejects a pending return with a provided rejection reason.",
+            operationId = "rejectReturn",
+            summary = "Reject a Pending Return",
+            description = """
+                    Rejects a PENDING_APPROVAL return with a recorded reason, moving it to the terminal REJECTED \
+                    state and releasing its quantities back to the per-line returnable cap.
+                    Use this tool to decline an over-threshold return; do not use approveReturn, which releases it \
+                    into the refund saga instead.
+                    Preconditions: the return order must exist and be in PENDING_APPROVAL.
+                    Required inputs: returnOrderId (UUID) as a path parameter and reason in the body.
+                    Emits an ORDER_RETURN_REJECT event; no refund is issued and no stock moves.
+                    Returns 404 when the return does not exist, and 409 when the return is not in \
+                    PENDING_APPROVAL.
+                    """,
             tags = {"Returns"})
     @PostMapping("/{returnOrderId}/reject")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_APPROVE + "')")
     @EmitEvent(id = "ORDER_RETURN_REJECT", apiVersion = "1")
     public ResponseEntity<ReturnOrderResponse> rejectReturn(
-            @PathVariable UUID returnOrderId, @Valid @RequestBody RejectReturnRequest request) {
+            @PathVariable UUID returnOrderId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The business reason the return is being declined.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Rejection",
+                                                            value =
+                                                                    "{\"reason\":\"Refund exceeds policy for this item\"}")))
+                    @Valid
+                    @RequestBody
+                    RejectReturnRequest request) {
         return ResponseEntity.ok(
                 ReturnOrderResponse.from(returnOrderService.rejectReturn(returnOrderId, request.getReason())));
     }
 
     @Operation(
-            summary = "Run the return orchestration saga (refund + restock signal)",
-            description = "From RETURN_REQUESTED: issues the refund and emits order.order.returned. A refund "
-                    + "failure parks the return at REFUND_FAILED before any stock movement.",
+            operationId = "processReturn",
+            summary = "Run the Return Refund Saga",
+            description = """
+                    Runs the return orchestration saga from RETURN_REQUESTED: issues the refund (ORIGINAL_TENDER \
+                    reverses the original order's settled payments through pos-invoice up to the refund total; \
+                    STORE_CREDIT and ON_ACCOUNT_CREDIT record the credit intent and require a customer on the \
+                    return), then completes the return.
+                    Use this tool to execute an approved or under-threshold return; do not use retryReturn, which \
+                    only re-drives a return already parked at REFUND_FAILED.
+                    Preconditions: the return must be in RETURN_REQUESTED (an already COMPLETED return is an \
+                    idempotent no-op), and an ORIGINAL_TENDER refund needs an invoice and sufficient settled \
+                    tender on the original order.
+                    Required inputs: returnOrderId (UUID) as a path parameter; there is no request body.
+                    Emits an ORDER_RETURN_PROCESS event and publishes an order.order.returned fact after \
+                    completion, which pos-inventory consumes to restock RESTOCK-condition lines (SCRAP lines are \
+                    skipped); a refund failure parks the return at REFUND_FAILED before any stock signal.
+                    Returns 200 when the saga completes (or the return was already COMPLETED), 404 when the return \
+                    does not exist, and 409 when the status is not RETURN_REQUESTED or the refund leg fails.
+                    """,
             tags = {"Returns"})
     @PostMapping("/{returnOrderId}/process")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_CREATE + "')")
@@ -146,8 +274,21 @@ public class ReturnOrderController {
     }
 
     @Operation(
-            summary = "Retry a return saga after a refund failure",
-            description = "Retries return processing for a return currently in a retryable failed state.",
+            operationId = "retryReturn",
+            summary = "Retry a Failed Return Refund",
+            description = """
+                    Re-runs the return refund saga for a return parked at REFUND_FAILED, using the same per-intent \
+                    idempotency so already-reversed payments are never refunded twice.
+                    Use this tool after fixing the cause of a refund failure; do not use processReturn, which only \
+                    accepts a return in RETURN_REQUESTED.
+                    Preconditions: the return must be in REFUND_FAILED; an already COMPLETED return is an \
+                    idempotent no-op.
+                    Required inputs: returnOrderId (UUID) as a path parameter; there is no request body.
+                    Emits an ORDER_RETURN_RETRY event and, on success, publishes the order.order.returned fact \
+                    that drives the pos-inventory restock of RESTOCK lines.
+                    Returns 200 when the retry completes (or the return was already COMPLETED), 404 when the \
+                    return does not exist, and 409 when the status is not REFUND_FAILED or the refund fails again.
+                    """,
             tags = {"Returns"})
     @PostMapping("/{returnOrderId}/retry")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_RETURN_CREATE + "')")

--- a/pos-order/src/main/java/com/positivity/order/internal/controller/SalesOrderController.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/controller/SalesOrderController.java
@@ -21,6 +21,8 @@ import com.positivity.order.service.model.SalesOrderLineSummary;
 import com.positivity.order.service.model.SalesOrderSummary;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -54,10 +56,25 @@ public class SalesOrderController {
     private final SalesOrderService salesOrderService;
 
     @Operation(
-            summary = "Create a sales order cart",
-            description = "Create a new sales order cart for a customer, terminal, and optional vehicle context. "
-                    + "Supports the Idempotency-Key header: a replayed key returns the original cart with 200 "
-                    + "instead of creating a duplicate; a replayed key with a different payload returns 409.",
+            operationId = "createCart",
+            summary = "Create a Sales Order Cart",
+            description = """
+                    Creates a DRAFT sales order cart bound to a clerk and terminal, with optional customer, vehicle, \
+                    and deposit-source context; a register session open on the terminal binds the cart to it and \
+                    supplies the location when locationId is omitted.
+                    Use this tool to start a new sale at the counter; do not use addCartItem, which adds line items \
+                    to a cart that already exists.
+                    Preconditions: the terminal must not have a register session in CLOSING, the customer and \
+                    vehicle must exist in CRM when supplied, and a location must be resolvable from the request or \
+                    the open session.
+                    Required inputs: clerkId and terminalId; customerId and vehicleId are optional UUID strings, \
+                    depositSourceType (ESTIMATE, WORKORDER or ORDER) and depositSourceId must be supplied together, \
+                    and the optional Idempotency-Key header makes creation replay-safe.
+                    Emits an ORDER_CART_CREATE event and records the initial DRAFT status-history row.
+                    Returns 201 on creation, 200 when a replayed Idempotency-Key returns the original cart, 409 when \
+                    the key was previously used with a different payload, and 422 when the customer or vehicle \
+                    cannot be validated, the location cannot be resolved, or the terminal's session is being closed.
+                    """,
             tags = {"Sales Orders"})
     @PostMapping("/carts")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_CREATE + "')")
@@ -66,7 +83,24 @@ public class SalesOrderController {
             @Parameter(description = "Client idempotency key; replays return the original cart")
                     @RequestHeader(name = "Idempotency-Key", required = false)
                     String idempotencyKey,
-            @Valid @RequestBody CreateCartRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Cart-creation context: who is selling, where, and for whom.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "Counter cart with customer", value = """
+                                                                    {"clerkId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a50",
+                                                                     "terminalId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a60",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a90",
+                                                                     "customerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a70",
+                                                                     "vehicleId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a80",
+                                                                     "label":"blue F-150 waiting on customer"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CreateCartRequest request) {
         CreateCartResult result = salesOrderService.createCart(new CreateCartCommand(
                 request.getClerkId(),
                 request.getTerminalId(),
@@ -83,9 +117,19 @@ public class SalesOrderController {
     }
 
     @Operation(
-            summary = "List sales order carts",
-            description = "List carts filtered by clerk, terminal, and/or status — the draft-parking/resume "
-                    + "surface. Line items are omitted from list results.",
+            operationId = "listCarts",
+            summary = "List Sales Order Carts",
+            description = """
+                    Lists sales order carts filtered by clerk, terminal, and status — the draft-parking and resume \
+                    surface; line items are omitted from list results.
+                    Use this tool when searching for carts to resume or review; use getOrder instead when the order \
+                    id is already known and full line detail is needed.
+                    Preconditions: none beyond an authenticated caller with order view permission.
+                    Required inputs: none — clerkId, terminalId, and status (a status name such as DRAFT) are \
+                    optional filters; page defaults to 0 and size defaults to 20, capped at 100.
+                    Emits an ORDER_CART_LIST audit event; no order state changes.
+                    Returns 200 with a possibly empty page, and 422 when status is not a valid order status name.
+                    """,
             tags = {"Sales Orders"})
     @GetMapping("/carts")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_VIEW + "')")
@@ -104,17 +148,49 @@ public class SalesOrderController {
     }
 
     @Operation(
-            summary = "Add an item to a sales order cart",
-            description =
-                    "Add a line item to an existing sales order cart using SKU, quantity, and optional pricing context."
-                            + " A client-supplied lineUuid makes the call replay-safe: a replay with a known lineUuid"
-                            + " updates the existing line instead of duplicating it.",
+            operationId = "addCartItem",
+            summary = "Add an Item to a Cart",
+            description = """
+                    Adds a line item to a DRAFT sales order cart, pricing it through the pricing service unless a \
+                    permissioned manual price is supplied, and marking the line AVAILABLE or BACKORDER from an \
+                    inventory availability check.
+                    Use this tool to put a SKU on an existing cart; do not use updateCartItemQuantity, which only \
+                    changes the quantity of a line already on the cart.
+                    Preconditions: the order must exist and be DRAFT, and a manual price requires the \
+                    order:line:enter_manual_price permission.
+                    Required inputs: itemSku and quantity (minimum 1); manualPrice, reasonCode, notes, and \
+                    serialNumbers (never more than quantity) are optional, and a client-supplied lineUuid makes the \
+                    call replay-safe — a replay with a known lineUuid updates that line's quantity instead of \
+                    duplicating it.
+                    Emits an ORDER_CART_ITEM_ADD event, recomputes order totals, and marks tax stale.
+                    Returns 400 when the SKU is unknown, 404 when the order does not exist, 409 when the order is \
+                    not DRAFT or the lineUuid was previously used for a different SKU, and 422 when pricing is \
+                    unavailable or serialNumbers exceed the quantity.
+                    """,
             tags = {"Sales Orders"})
     @PostMapping("/carts/{orderId}/items")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_LINE_CREATE + "')")
     @EmitEvent(id = "ORDER_CART_ITEM_ADD", apiVersion = "1")
     public ResponseEntity<SalesOrderLineResponse> addItem(
-            @PathVariable UUID orderId, @Valid @RequestBody AddItemRequest request) {
+            @PathVariable UUID orderId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The line item to add: SKU, quantity, and optional pricing context.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Priced line with replay identity",
+                                                            value = """
+                                                                    {"itemSku":"SKU-OIL-5W30-1L",
+                                                                     "quantity":2,
+                                                                     "lineUuid":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4aaa",
+                                                                     "customerNote":"Front wipers only"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    AddItemRequest request) {
         SalesOrderLineSummary line = salesOrderService.addItem(
                 orderId,
                 new AddItemCommand(
@@ -130,21 +206,52 @@ public class SalesOrderController {
     }
 
     @Operation(
-            summary = "Update a sales order cart item quantity",
-            description = "Update the quantity for an existing sales order line item in a cart.",
+            operationId = "updateCartItemQuantity",
+            summary = "Update a Cart Item Quantity",
+            description = """
+                    Updates the quantity of an existing line on a DRAFT sales order cart and recomputes order totals.
+                    Use this tool to change how many units a line sells; do not use removeCartItem, which deletes \
+                    the line entirely, and do not use addCartItem, which creates a new line.
+                    Preconditions: the order must exist and be DRAFT, and the line must exist on that order.
+                    Required inputs: orderId and lineId as path UUIDs, and quantity (minimum 1) in the body.
+                    Emits an ORDER_CART_ITEM_UPDATE event, recomputes order totals, and marks tax stale.
+                    Returns 404 when the order or line does not exist, and 409 when the order is not DRAFT.
+                    """,
             tags = {"Sales Orders"})
     @PutMapping("/carts/{orderId}/items/{lineId}")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_LINE_EDIT + "')")
     @EmitEvent(id = "ORDER_CART_ITEM_UPDATE", apiVersion = "1")
     public ResponseEntity<SalesOrderLineResponse> updateItemQuantity(
-            @PathVariable UUID orderId, @PathVariable UUID lineId, @Valid @RequestBody UpdateItemRequest request) {
+            @PathVariable UUID orderId,
+            @PathVariable UUID lineId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The new quantity for the line.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "Set quantity", value = "{\"quantity\":3}")))
+                    @Valid
+                    @RequestBody
+                    UpdateItemRequest request) {
         SalesOrderLineSummary line = salesOrderService.updateItemQuantity(orderId, lineId, request.getQuantity());
         return ResponseEntity.ok(toLineResponse(line));
     }
 
     @Operation(
-            summary = "Remove an item from a sales order cart",
-            description = "Remove a line item from an existing sales order cart.",
+            operationId = "removeCartItem",
+            summary = "Remove an Item from a Cart",
+            description = """
+                    Removes a line item from a DRAFT sales order cart and recomputes the remaining totals.
+                    Use this tool to take a line off the sale entirely; do not use updateCartItemQuantity, which \
+                    keeps the line and changes its quantity.
+                    Preconditions: the order must exist and be DRAFT; a lineId that is not on the order is silently \
+                    ignored rather than rejected.
+                    Required inputs: orderId and lineId as path UUIDs; there is no request body.
+                    Emits an ORDER_CART_ITEM_REMOVE event, recomputes order totals, and marks tax stale.
+                    Returns 204 on success, 404 when the order does not exist, and 409 when the order is not DRAFT.
+                    """,
             tags = {"Sales Orders"})
     @DeleteMapping("/carts/{orderId}/items/{lineId}")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_LINE_DELETE + "')")
@@ -155,8 +262,18 @@ public class SalesOrderController {
     }
 
     @Operation(
-            summary = "Get a sales order by ID",
-            description = "Retrieve a sales order cart and its current line items by identifier.",
+            operationId = "getOrder",
+            summary = "Get a Sales Order by Id",
+            description = """
+                    Returns a sales order with its current line items, totals, status, invoice references, and \
+                    payment balances.
+                    Use this tool when the order id is already known; use listCarts instead to search by clerk, \
+                    terminal or status.
+                    Preconditions: the order must exist.
+                    Required inputs: orderId (UUID) as a path parameter; there is no request body and no filtering.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no sales order exists for the supplied id.
+                    """,
             tags = {"Sales Orders"})
     @GetMapping("/carts/{orderId}")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_VIEW + "')")
@@ -165,23 +282,56 @@ public class SalesOrderController {
     }
 
     @Operation(
-            summary = "Apply an order-level discount",
-            description = "Apply or replace the order-level discount (PERCENT or AMOUNT), allocated pro-rata"
-                    + " across lines. DRAFT orders only.",
+            operationId = "applyOrderDiscount",
+            summary = "Apply an Order-Level Discount",
+            description = """
+                    Applies or replaces the single order-level discount on a DRAFT cart, allocated pro-rata across \
+                    lines when totals are recomputed.
+                    Use this tool for a whole-order concession; do not use applyPriceOverride, which changes one \
+                    line's unit price through the price-override approval workflow.
+                    Preconditions: the order must exist and be DRAFT.
+                    Required inputs: type (PERCENT or AMOUNT) and a positive value — a PERCENT value must not \
+                    exceed 100; reasonCode is optional.
+                    Emits an ORDER_CART_DISCOUNT_APPLY event, recomputes order totals, and marks tax stale.
+                    Returns 404 when the order does not exist, 409 when the order is not DRAFT, and 422 when the \
+                    type or value is invalid.
+                    """,
             tags = {"Sales Orders"})
     @PutMapping("/carts/{orderId}/discount")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_DISCOUNT + "')")
     @EmitEvent(id = "ORDER_CART_DISCOUNT_APPLY", apiVersion = "1")
     public ResponseEntity<SalesOrderResponse> applyOrderDiscount(
-            @PathVariable UUID orderId, @Valid @RequestBody OrderDiscountRequest request) {
+            @PathVariable UUID orderId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The order-level discount to set, replacing any existing one.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Ten percent goodwill", value = """
+                                                                    {"type":"PERCENT","value":10,
+                                                                     "reasonCode":"GOODWILL_ADJUSTMENT"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    OrderDiscountRequest request) {
         SalesOrderSummary updated = salesOrderService.applyOrderDiscount(
                 orderId, new OrderDiscountCommand(request.getType(), request.getValue(), request.getReasonCode()));
         return ResponseEntity.ok(toResponse(updated));
     }
 
     @Operation(
-            summary = "Remove the order-level discount",
-            description = "Clear any order-level discount and recompute totals. DRAFT orders only.",
+            operationId = "clearOrderDiscount",
+            summary = "Remove the Order-Level Discount",
+            description = """
+                    Clears any order-level discount from a DRAFT cart and recomputes totals.
+                    Use this tool to withdraw a whole-order concession; do not use applyOrderDiscount, which sets \
+                    or replaces the discount.
+                    Preconditions: the order must exist and be DRAFT; clearing a cart that has no discount succeeds.
+                    Required inputs: orderId (UUID) as a path parameter; there is no request body.
+                    Emits an ORDER_CART_DISCOUNT_REMOVE event, recomputes order totals, and marks tax stale.
+                    Returns 404 when the order does not exist, and 409 when the order is not DRAFT.
+                    """,
             tags = {"Sales Orders"})
     @DeleteMapping("/carts/{orderId}/discount")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_DISCOUNT + "')")
@@ -191,10 +341,24 @@ public class SalesOrderController {
     }
 
     @Operation(
-            summary = "Convert a cart to a counter quote",
-            description = "Final reprice + tax computation, then DRAFT → QUOTED with a validity horizon."
-                    + " Counter quotes only: workorder-linked orders are quoted via pos-workorder estimates"
-                    + " and are rejected here (spec Q3).",
+            operationId = "quoteCart",
+            summary = "Convert a Cart to a Counter Quote",
+            description = """
+                    Converts a DRAFT counter cart to QUOTED by running a final reprice and authoritative tax \
+                    computation and stamping a validity horizon (default P7D, configurable via \
+                    pos.order.quote.validity).
+                    Use this tool to hand the customer a priced, resumable counter quote; do not use \
+                    checkoutOrder, which freezes the cart for payment, and note that workorder-linked orders are \
+                    quoted via pos-workorder estimates and are rejected here.
+                    Preconditions: the order must be DRAFT with at least one line, must not reference a workorder \
+                    directly or through imported lines, and pricing must be reachable for every non-manual, \
+                    non-source line.
+                    Required inputs: orderId (UUID) as a path parameter; there is no request body.
+                    Emits an ORDER_CART_QUOTE event.
+                    Returns 404 when the order does not exist, 409 when the status does not allow the transition, \
+                    422 when the cart is empty, workorder-linked, or pricing is unavailable, and 503 when the tax \
+                    service cannot be reached.
+                    """,
             tags = {"Sales Orders"})
     @PostMapping("/carts/{orderId}/quote")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_QUOTE + "')")
@@ -204,8 +368,19 @@ public class SalesOrderController {
     }
 
     @Operation(
-            summary = "Reopen a counter quote",
-            description = "QUOTED → DRAFT: clears the validity horizon, best-effort reprices, and marks tax stale.",
+            operationId = "reopenQuote",
+            summary = "Reopen a Counter Quote",
+            description = """
+                    Reopens a QUOTED counter quote back to DRAFT, clearing the validity horizon so the cart can be \
+                    edited again.
+                    Use this tool to resume editing a quoted cart; do not use quoteCart, which moves the cart in \
+                    the opposite direction from DRAFT to QUOTED.
+                    Preconditions: the order must be QUOTED.
+                    Required inputs: orderId (UUID) as a path parameter; there is no request body.
+                    Emits an ORDER_CART_QUOTE_REOPEN event and best-effort reprices the lines — an unavailable \
+                    pricing service keeps the old prices, and totals are recomputed with tax marked stale.
+                    Returns 404 when the order does not exist, and 409 when the order is not QUOTED.
+                    """,
             tags = {"Sales Orders"})
     @PostMapping("/carts/{orderId}/quote/reopen")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_QUOTE + "')")
@@ -215,12 +390,29 @@ public class SalesOrderController {
     }
 
     @Operation(
-            summary = "Check out a sales order",
-            description = "Freeze the cart and take it to PENDING_PAYMENT: validates lines/customer/availability, "
-                    + "performs the final reprice and tax computation, and creates the fronting invoice at "
-                    + "pos-invoice. The Idempotency-Key header is required; a replayed key returns the checked-out "
-                    + "order with 200. Settlement completion is asynchronous — the order completes when payment "
-                    + "events settle the balance to zero.",
+            operationId = "checkoutOrder",
+            summary = "Check Out a Sales Order",
+            description = """
+                    Freezes a DRAFT or QUOTED cart into PENDING_PAYMENT: revalidates availability and serial \
+                    capture, runs the final reprice and tax computation, and synchronously creates the fronting \
+                    invoice at pos-invoice, rolling the whole checkout back if invoice creation fails.
+                    Use this tool when the customer is ready to pay; do not use quoteCart, which produces a \
+                    resumable quote, and do not use voidOrder, which abandons an order already in PENDING_PAYMENT.
+                    Preconditions: the cart must be non-empty with customer validation not PENDING, every line must \
+                    have sufficient inventory, serial-tracked lines must carry one serial per unit (lot-tracked at \
+                    least one), and ON_ACCOUNT additionally requires the order:order:charge_on_account permission \
+                    and a VALIDATED commercial customer with payment terms and no credit hold.
+                    Required inputs: the Idempotency-Key header; the body is optional with tenderType DEFAULT or \
+                    ON_ACCOUNT — DEFAULT settles asynchronously via payment events that complete the order when \
+                    the balance reaches zero, while ON_ACCOUNT settles against the AR invoice and completes the \
+                    order immediately.
+                    Emits an ORDER_CHECKOUT event; an ON_ACCOUNT checkout also records a settled ON_ACCOUNT ledger \
+                    entry and publishes an order-completed fact.
+                    Returns 201 on checkout, 200 when the same Idempotency-Key replays the checked-out order, 409 \
+                    when the key belongs to a different order or the status does not allow checkout, 422 when the \
+                    cart is empty, customer validation is pending, availability or serial capture is insufficient, \
+                    or on-account eligibility fails, and 503 when the tax or invoicing service is unreachable.
+                    """,
             tags = {"Sales Orders"})
     @PostMapping("/{orderId}/checkout")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_CHECKOUT + "')")
@@ -230,7 +422,18 @@ public class SalesOrderController {
             @Parameter(description = "Required checkout idempotency key; replays return the original result")
                     @RequestHeader(name = "Idempotency-Key")
                     String idempotencyKey,
-            @RequestBody(required = false) CheckoutRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Optional checkout options; omit the body entirely for default tender.",
+                            required = false,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "On-account tender",
+                                                            value = "{\"tenderType\":\"ON_ACCOUNT\"}")))
+                    @RequestBody(required = false)
+                    CheckoutRequest request) {
         CheckoutResult result =
                 salesOrderService.checkout(orderId, idempotencyKey, request == null ? null : request.getTenderType());
         HttpStatus status = result.replay() ? HttpStatus.OK : HttpStatus.CREATED;
@@ -238,30 +441,80 @@ public class SalesOrderController {
     }
 
     @Operation(
-            summary = "Void an unsettled order",
-            description = "Terminal void of a PENDING_PAYMENT order before any settlement: cancels the fronting "
-                    + "pos-invoice invoice and transitions the order to VOIDED. Rejected with 409 when settled "
-                    + "payments exist (use the cancellation flow) or from any other status (drafts are "
-                    + "cancelled, not voided).",
+            operationId = "voidOrder",
+            summary = "Void an Unsettled Order",
+            description = """
+                    Voids a PENDING_PAYMENT order before any settlement: cancels the fronting pos-invoice invoice \
+                    and transitions the order to VOIDED, rolling the void back if the invoice cancel fails.
+                    Use this tool to abandon a checked-out order that has taken no money; do not use cancelOrder, \
+                    which runs the cancellation saga for DRAFT and QUOTED orders and reverses settled payments.
+                    Preconditions: the order must be PENDING_PAYMENT with no settled payment records; voiding an \
+                    already VOIDED order is an idempotent no-op.
+                    Required inputs: orderId (UUID) as a path parameter; the body is optional and carries only a \
+                    free-text reason.
+                    Emits an ORDER_VOID event.
+                    Returns 200 on success or an already-voided no-op, 404 when the order does not exist, 409 when \
+                    settled payments exist (route through cancelOrder) or the status is not PENDING_PAYMENT, and \
+                    503 when the invoicing service is unreachable.
+                    """,
             tags = {"Sales Orders"})
     @PostMapping("/{orderId}/void")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_VOID + "')")
     @EmitEvent(id = "ORDER_VOID", apiVersion = "1")
     public ResponseEntity<SalesOrderResponse> voidOrder(
-            @PathVariable UUID orderId, @RequestBody(required = false) VoidOrderRequest request) {
+            @PathVariable UUID orderId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Optional void context; the body may be omitted entirely.",
+                            required = false,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Void with reason",
+                                                            value =
+                                                                    "{\"reason\":\"Customer walked away before payment\"}")))
+                    @RequestBody(required = false)
+                    VoidOrderRequest request) {
         SalesOrderSummary voided = salesOrderService.voidOrder(orderId, request == null ? null : request.getReason());
         return ResponseEntity.ok(toResponse(voided));
     }
 
     @Operation(
-            summary = "Link a source to a sales order",
-            description = "Associate an external source reference with an existing sales order cart.",
+            operationId = "linkOrderSource",
+            summary = "Link a Source Document to an Order",
+            description = """
+                    Imports the line items of a source document (an ESTIMATE or WORKORDER) into a DRAFT cart, \
+                    merging into same-SKU same-price lines where possible; imported source prices are contractual \
+                    and are never repriced.
+                    Use this tool to pull approved estimate or workorder lines onto a sale; do not use addCartItem, \
+                    which adds individually priced counter lines.
+                    Preconditions: the order must be DRAFT, a WORKORDER source requires a customer already on the \
+                    cart, and source lines already linked to the cart are skipped, making the call replay-safe.
+                    Required inputs: sourceType (ESTIMATE or WORKORDER) and sourceId, both in the body.
+                    Emits an ORDER_LINK_SOURCE event, recomputes order totals, and marks tax stale.
+                    Returns 404 when the order does not exist, 409 when the order is not DRAFT, and 422 when the \
+                    sourceType is unknown or a WORKORDER link is attempted without a customer on the cart.
+                    """,
             tags = {"Sales Orders"})
     @PatchMapping("/carts/{orderId}/source")
     @PreAuthorize("hasAuthority('" + OrderPermissions.ORDER_EDIT + "')")
     @EmitEvent(id = "ORDER_LINK_SOURCE", apiVersion = "1")
     public ResponseEntity<SalesOrderResponse> linkSource(
-            @PathVariable UUID orderId, @Valid @RequestBody LinkSourceRequest request) {
+            @PathVariable UUID orderId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The source document whose lines are imported into the cart.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Workorder link", value = """
+                                                                    {"sourceType":"WORKORDER",
+                                                                     "sourceId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    LinkSourceRequest request) {
         SalesOrderSummary updated =
                 salesOrderService.linkSource(orderId, request.getSourceType(), request.getSourceId());
         return ResponseEntity.ok(toResponse(updated));

--- a/pos-people-contact/openapi.yaml
+++ b/pos-people-contact/openapi.yaml
@@ -23,8 +23,20 @@ paths:
     get:
       tags:
       - People API
-      summary: Get person by ID
-      description: Retrieve a person by their unique ID.
+      summary: Get a Person by Unique ID
+      description: 'Returns a single person record by its UUID, including emails, work phone numbers and any linked username.
+
+        Use this tool when the person id is already known; use listPeople instead when searching by name or email, and getCurrentPerson when the target is the authenticated caller.
+
+        Preconditions: the person record must exist in the identity directory.
+
+        Required inputs: personId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no person exists for the supplied id.
+
+        '
       operationId: getPersonById
       parameters:
       - name: personId
@@ -56,8 +68,20 @@ paths:
     put:
       tags:
       - People API
-      summary: Update an existing person
-      description: Update the details of an existing person.
+      summary: Update an Existing Person Record
+      description: 'Updates an existing person''s identity fields, fully replacing names, emails and work phone numbers with the submitted values.
+
+        Use this tool to correct or complete a known person''s identity data; do not use replaceContactPoints, which manages the typed contact-point set, and do not use createPerson for records that do not exist yet.
+
+        Preconditions: the person record must already exist for the supplied id.
+
+        Required inputs: personId (UUID) as a path parameter plus a full person body with non-blank firstName and lastName; omitting primaryEmail, secondaryEmail or phoneNumbers erases the stored values, and username is ignored because it is owned by pos-security.
+
+        Emits a PEOPLE_CONTACT_PERSON_UPDATE event and queues a person.updated identity fact on the transactional outbox.
+
+        Returns 200 with the updated person, 404 when no person exists for the id, and 400 when firstName or lastName is blank.
+
+        '
       operationId: updatePerson
       parameters:
       - name: personId
@@ -69,10 +93,21 @@ paths:
           format: uuid
         example: 123e4567-e89b-12d3-a456-426614174000
       requestBody:
+        description: Full replacement identity snapshot for the person.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/Person'
+            examples:
+              Updated person:
+                description: Updated person
+                value:
+                  firstName: Jane
+                  lastName: Smith-Jones
+                  primaryEmail: jane.smith@example.com
+                  secondaryEmail: jane.alt@example.com
+                  phoneNumbers:
+                  - '+15551234567'
         required: true
       responses:
         '200':
@@ -95,8 +130,20 @@ paths:
     delete:
       tags:
       - People API
-      summary: Delete a person
-      description: Delete a person by their unique ID.
+      summary: Delete a Person Identity Record
+      description: 'Deletes a person record and, in the same transaction, its contact points and postal address.
+
+        Use this tool to permanently remove an identity record; do not use unlinkUserFromPerson, which only removes a user link and leaves the person in place.
+
+        Preconditions: the person must exist and must have no user-person links; linked users must be removed first with unlinkUserFromPerson.
+
+        Required inputs: personId (UUID) as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_PERSON_DELETE event and queues a person.deleted fact on the transactional outbox.
+
+        Returns 204 on success, 404 when the person does not exist, and 409 when one or more users are still linked to the person.
+
+        '
       operationId: deletePerson
       parameters:
       - name: personId
@@ -116,6 +163,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
+        '409':
+          description: Person still has linked users; unlink them first.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - people-contact:person:delete
@@ -125,9 +178,21 @@ paths:
     get:
       tags:
       - Postal Address API
-      summary: Get a person's postal address
-      description: Returns the person's structured postal address, or 404 when none is on file.
-      operationId: getPersonAddress
+      summary: Get a Person's Postal Address
+      description: 'Returns the single structured postal address on file for a person; pos-people-contact is the postal-address authority for person parties (FI-4).
+
+        Use this tool when reading a person''s mailing address; use getOrganizationPostalAddress instead for CRM organization parties.
+
+        Preconditions: an address must already have been stored for the person with putPersonPostalAddress.
+
+        Required inputs: personId (UUID) as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_PERSON_ADDRESS_GET audit event; no state changes.
+
+        Returns 404 when no address is on file for the person.
+
+        '
+      operationId: getPersonPostalAddress
       parameters:
       - name: personId
         in: path
@@ -157,9 +222,21 @@ paths:
     put:
       tags:
       - Postal Address API
-      summary: Create or replace a person's postal address
-      description: Stores the structured, validated address. Only line1 and an ISO 3166-1 alpha-2 countryCode are required — the shape is country-agnostic (region is free text, postalCode optional) so it works for any deployment locale.
-      operationId: putPersonAddress
+      summary: Create or Replace Person Postal Address
+      description: 'Creates or replaces the single structured postal address for a person; the shape is country-agnostic, with free-text region and an optional postalCode.
+
+        Use this tool for person mailing addresses; use putOrganizationPostalAddress instead for CRM organization parties, and do not use replaceContactPoints, which manages email and phone channels.
+
+        Preconditions: the person record must exist; any previously stored address is overwritten in place.
+
+        Required inputs: line1 and an ISO 3166-1 alpha-2 countryCode (stored upper-case); line2, city, region and postalCode are optional free text, trimmed, with blanks stored as null.
+
+        Emits a PEOPLE_CONTACT_PERSON_ADDRESS_PUT event and queues a person.updated identity fact carrying the new address.
+
+        Returns 200 with the stored address, 404 when the person does not exist, and 422 when line1 is blank or countryCode is not a valid ISO 3166-1 alpha-2 code.
+
+        '
+      operationId: putPersonPostalAddress
       parameters:
       - name: personId
         in: path
@@ -169,10 +246,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Country-agnostic structured postal address that replaces any address already on file for the person.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PostalAddressDto'
+            examples:
+              Japanese address:
+                description: Japanese address
+                value:
+                  line1: 1-2-3 Ginza
+                  line2: Chuo-ku
+                  city: Tokyo
+                  region: Tokyo
+                  postalCode: 104-0061
+                  countryCode: JP
         required: true
       responses:
         '200':
@@ -187,6 +275,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
+        '422':
+          description: line1 missing or countryCode not a valid ISO 3166-1 alpha-2 code.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - people-contact:person:edit
@@ -195,9 +289,21 @@ paths:
     delete:
       tags:
       - Postal Address API
-      summary: Delete a person's postal address
-      description: Removes the person's postal address; succeeds even when none is on file.
-      operationId: deletePersonAddress
+      summary: Delete a Person's Postal Address
+      description: 'Removes the postal address on file for a person; the operation is idempotent and succeeds when none exists.
+
+        Use this tool to clear a person''s mailing address; do not use deletePerson, which removes the entire identity record.
+
+        Preconditions: none; a missing address is treated as already deleted.
+
+        Required inputs: personId (UUID) as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_PERSON_ADDRESS_DELETE event, and queues a person.updated identity fact only when an address actually existed.
+
+        Returns 204 whether or not an address was on file.
+
+        '
+      operationId: deletePersonPostalAddress
       parameters:
       - name: personId
         in: path
@@ -218,8 +324,20 @@ paths:
     put:
       tags:
       - People API
-      summary: Replace a person's contact points
-      description: Replaces all typed contact points (email/phone) for a person. pos-people-contact is the source of truth for contacts (ADR-0015).
+      summary: Replace a Person's Contact Points
+      description: 'Replaces the full set of typed contact points for one person; pos-people-contact is the source of truth for contact channels (ADR-0015).
+
+        Use this tool to overwrite a person''s contact channels wholesale; do not use updatePerson, which replaces names, primaryEmail, secondaryEmail and phoneNumbers as flat identity fields rather than the typed contact-point set.
+
+        Preconditions: the person should exist; the id is not validated here, so writes for an unknown person are stored without error.
+
+        Required inputs: a JSON array of contact points, each with contactType (EMAIL, PHONE_MOBILE, PHONE_HOME or PHONE_WORK), value, and primary; entries missing contactType or value are silently dropped, and an empty array clears all contact points.
+
+        Emits a people-contact person.updated identity fact through the transactional outbox when the person exists; prior contact points are deleted in the same transaction.
+
+        Returns 204 on success, including when the array is empty or the person id is unknown.
+
+        '
       operationId: replaceContactPoints
       parameters:
       - name: personId
@@ -230,12 +348,23 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Complete replacement set of typed contact points for the person.
         content:
           application/json:
             schema:
               type: array
               items:
                 $ref: '#/components/schemas/ContactPointDto'
+            examples:
+              Email and mobile phone:
+                description: Email and mobile phone
+                value:
+                - contactType: EMAIL
+                  value: jane.smith@example.com
+                  primary: true
+                - contactType: PHONE_MOBILE
+                  value: '+15551234567'
+                  primary: true
         required: true
       responses:
         '204':
@@ -249,9 +378,21 @@ paths:
     get:
       tags:
       - Postal Address API
-      summary: Get an organization's postal address
-      description: Returns the organization party's structured postal address, or 404 when none is on file. The organization id is the party UUID owned by the CRM module.
-      operationId: getOrganizationAddress
+      summary: Get an Organization's Postal Address
+      description: 'Returns the structured postal address on file for a CRM organization party; the organization id is an external pos-customer party reference stored verbatim.
+
+        Use this tool when reading an organization''s mailing address; use getPersonPostalAddress instead for person parties.
+
+        Preconditions: an address must already have been stored for the organization with putOrganizationPostalAddress.
+
+        Required inputs: organizationId (the pos-customer commercial party UUID) as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_ORG_ADDRESS_GET audit event; no state changes.
+
+        Returns 404 when no address is on file for the organization.
+
+        '
+      operationId: getOrganizationPostalAddress
       parameters:
       - name: organizationId
         in: path
@@ -281,9 +422,21 @@ paths:
     put:
       tags:
       - Postal Address API
-      summary: Create or replace an organization's postal address
-      description: Stores the structured, validated address for an organization party. The id is an external party reference (pos-customer commercial party) stored verbatim.
-      operationId: putOrganizationAddress
+      summary: Create or Replace Organization Postal Address
+      description: 'Creates or replaces the single structured postal address for a CRM organization party.
+
+        Use this tool for organization mailing addresses; use putPersonPostalAddress instead for person parties.
+
+        Preconditions: none in this module; the organization id is an external pos-customer party reference stored verbatim without an existence check.
+
+        Required inputs: organizationId (UUID) as a path parameter, plus line1 and an ISO 3166-1 alpha-2 countryCode in the body; line2, city, region and postalCode are optional free text.
+
+        Emits a PEOPLE_CONTACT_ORG_ADDRESS_PUT event and an organization-address-updated fact for downstream consumers.
+
+        Returns 200 with the stored address, and 422 when line1 is blank or countryCode is not a valid ISO 3166-1 alpha-2 code.
+
+        '
+      operationId: putOrganizationPostalAddress
       parameters:
       - name: organizationId
         in: path
@@ -293,10 +446,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Country-agnostic structured postal address that replaces any address already on file for the organization party.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PostalAddressDto'
+            examples:
+              US business address:
+                description: US business address
+                value:
+                  line1: 400 Commerce Way
+                  line2: Suite 210
+                  city: Austin
+                  region: TX
+                  postalCode: '78701'
+                  countryCode: US
         required: true
       responses:
         '200':
@@ -305,6 +469,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PostalAddressDto'
+        '422':
+          description: line1 missing or countryCode not a valid ISO 3166-1 alpha-2 code.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearerAuth:
         - people-contact:organization:edit
@@ -313,9 +483,21 @@ paths:
     delete:
       tags:
       - Postal Address API
-      summary: Delete an organization's postal address
-      description: Removes the organization party's postal address; succeeds even when none is on file.
-      operationId: deleteOrganizationAddress
+      summary: Delete an Organization's Postal Address
+      description: 'Removes the postal address on file for a CRM organization party; the operation is idempotent and succeeds when none exists.
+
+        Use this tool to clear an organization''s mailing address; use deletePersonPostalAddress instead for person parties.
+
+        Preconditions: none; a missing address is treated as already deleted.
+
+        Required inputs: organizationId (UUID) as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_ORG_ADDRESS_DELETE event, and an organization-address-removed fact is published only when an address actually existed.
+
+        Returns 204 whether or not an address was on file.
+
+        '
+      operationId: deleteOrganizationPostalAddress
       parameters:
       - name: organizationId
         in: path
@@ -336,9 +518,21 @@ paths:
     get:
       tags:
       - People API
-      summary: Get all people
-      description: Retrieve people with an optional text filter. Employment filtering lives in pos-people (ADR-0044 §6) and is not available on the identity directory.
-      operationId: getAllPeople
+      summary: List People in Identity Directory
+      description: 'Lists person records in the identity directory, optionally narrowed by a free-text filter, with each result carrying emails, work phone numbers and any linked username.
+
+        Use this tool when browsing or searching people by name or email; do not use resolvePerson, which performs weighted duplicate matching and may create a new person as a side effect.
+
+        Preconditions: none; an empty directory simply yields an empty list.
+
+        Required inputs: none; q is an optional case-insensitive filter matched against firstName, lastName and primaryEmail, and employment attributes cannot be filtered here because they live in pos-people (ADR-0044 §6).
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the matching people, possibly an empty list when nothing matches the filter.
+
+        '
+      operationId: listPeople
       parameters:
       - name: q
         in: query
@@ -363,14 +557,36 @@ paths:
     post:
       tags:
       - People API
-      summary: Create a new person
-      description: Add a new person to the system.
+      summary: Create a New Person Record
+      description: 'Creates a new person identity record; emails and phone numbers are persisted as contact points owned by this module.
+
+        Use this tool when the person is known to be new; do not use resolvePerson, which should be preferred when a matching person may already exist, and do not use linkUserToPerson, which only associates an existing person with a security user.
+
+        Preconditions: none; duplicate names or emails are not rejected, so deduplication is the caller''s responsibility (or use resolvePerson).
+
+        Required inputs: firstName and lastName (non-blank); primaryEmail, secondaryEmail and phoneNumbers are optional, and username is ignored because usernames are owned by pos-security and linked separately.
+
+        Emits a PEOPLE_CONTACT_PERSON_CREATE event and queues a person.updated identity fact on the transactional outbox.
+
+        Returns 201 with the persisted person, and 400 when firstName or lastName is blank.
+
+        '
       operationId: createPerson
       requestBody:
+        description: Identity fields of the person to create; contact data is stored as contact points.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/Person'
+            examples:
+              New person:
+                description: New person
+                value:
+                  firstName: Jane
+                  lastName: Smith
+                  primaryEmail: jane.smith@example.com
+                  phoneNumbers:
+                  - '+15551234567'
         required: true
       responses:
         '201':
@@ -388,9 +604,21 @@ paths:
     get:
       tags:
       - People - Access Control
-      summary: Get role assignments
-      description: Retrieve role assignments for a person with optional history and date filtering
-      operationId: getAssignments
+      summary: List a Person's Role Assignments
+      description: 'Lists the role assignments a person holds in pos-security, resolved through the person''s active user-person link.
+
+        Use this tool to inspect the access a person already has; do not use listAssignableRoles, which returns the catalog of roles available for assignment.
+
+        Preconditions: the person must have an active user-person link, and the linked username must resolve to a pos-security user.
+
+        Required inputs: personUuid (UUID) as a path parameter; includeHistory defaults to false and adds ended assignments when true, and endDate (ISO date-time) optionally evaluates assignments as of that moment.
+
+        Emits a PEOPLE_CONTACT_ACCESS_ASSIGNMENTS_LIST audit event; no state changes.
+
+        Returns 404 when the person has no user link or the linked username has no security user.
+
+        '
+      operationId: listRoleAssignments
       parameters:
       - name: personUuid
         in: path
@@ -426,9 +654,21 @@ paths:
     post:
       tags:
       - People - Access Control
-      summary: Assign role to person
-      description: Assign a role to a person with optional location scope and date range
-      operationId: createAssignment
+      summary: Assign a Role to a Person
+      description: 'Assigns a role to a person by delegating to pos-security through the person''s linked user account, optionally scoped to one location and bounded by a date window.
+
+        Use this tool to grant access; do not use revokeRoleAssignment, which ends an assignment that already exists.
+
+        Preconditions: the person must have an active user-person link resolving to a pos-security user, and the roleCode must exist in pos-security.
+
+        Required inputs: personUuid (UUID) as a path parameter and roleCode in the body; locationId (UUID) scopes the role to one location when supplied, and optional startDate/endDate bound the assignment, with endDate required to be on or after startDate.
+
+        Emits a PEOPLE_CONTACT_ACCESS_ASSIGNMENT_CREATE event; the assignment record itself is created and owned by pos-security.
+
+        Returns 201 with the created assignment, 400 when roleCode is blank or endDate precedes startDate, and 404 when the person''s user link, the security user, or the role cannot be resolved.
+
+        '
+      operationId: assignRoleToPerson
       parameters:
       - name: personUuid
         in: path
@@ -437,10 +677,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Role code plus optional location scope and effective date window.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PersonRoleAssignmentRequest'
+            examples:
+              Location-scoped technician role:
+                description: Location-scoped technician role
+                value:
+                  roleCode: TECHNICIAN
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  startDate: 2026-09-01 00:00:00
+                  endDate: 2026-12-31 23:59:59
         required: true
       responses:
         '201':
@@ -470,14 +719,35 @@ paths:
     post:
       tags:
       - User-Person Linking API
-      summary: Link user to person
-      description: Create a link between an authentication user and a person record
+      summary: Link User to Person Record
+      description: 'Links a security user account to a person record, optionally recording a linkType and notes; the link is what lets a login act as that person.
+
+        Use this tool when associating a user with a person, for example during onboarding; do not use createUserPersonLink, which is the minimal admin variant without linkType or notes, and do not use createPerson, which creates the identity record itself.
+
+        Preconditions: the person must exist, and the username must not already be linked to a different person; one username maps to at most one person.
+
+        Required inputs: username and personId (UUID); linkType defaults to PRIMARY and notes is optional.
+
+        Emits a PEOPLE_CONTACT_USER_LINK_CREATE event and queues a link-updated fact on the transactional outbox.
+
+        Returns 201 when the link is created, 200 when the identical link already exists (the call is idempotent), 404 when the person does not exist, and 409 when the username is already linked to a different person.
+
+        '
       operationId: linkUserToPerson
       requestBody:
+        description: User-person pair to link, with optional link classification and notes.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LinkUserToPersonRequest'
+            examples:
+              Onboarding link:
+                description: Onboarding link
+                value:
+                  username: marcus.webb
+                  personId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  linkType: PRIMARY
+                  notes: Linked during onboarding
         required: true
       responses:
         '201':
@@ -519,14 +789,33 @@ paths:
     post:
       tags:
       - User-Person Linking API
-      summary: Create user-person link (admin)
-      description: Create a link between an authentication user and a person record
+      summary: Create User Person Link as Admin
+      description: 'Creates a user-person link from the minimal administrative payload of username and personId only; the link is stored with linkType PRIMARY.
+
+        Use this tool for administrative linking when linkType and notes are not needed; do not use linkUserToPerson, which accepts the same pair plus an explicit linkType and notes.
+
+        Preconditions: the person must exist, and the username must not already be linked to a different person; one username maps to at most one person.
+
+        Required inputs: username and personId (UUID); both are mandatory and there are no other fields.
+
+        Emits a PEOPLE_CONTACT_USER_LINK_CREATE event and queues a link-updated fact on the transactional outbox.
+
+        Returns 201 when the link is created, 200 when the identical link already exists (the call is idempotent), 404 when the person does not exist, and 409 when the username is already linked to a different person.
+
+        '
       operationId: createUserPersonLink
       requestBody:
+        description: Minimal user-person pair to link; the link is stored as PRIMARY.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateUserLinkRequest'
+            examples:
+              Admin link:
+                description: Admin link
+                value:
+                  username: marcus.webb
+                  personId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
         required: true
       responses:
         '201':
@@ -568,14 +857,36 @@ paths:
     post:
       tags:
       - People API
-      summary: Resolve person
-      description: Find best matching person by score or create a new person
+      summary: Resolve or Create Matching Person
+      description: 'Finds the best-matching existing person using weighted scoring (email 60, phone 25, lastName 10, firstName 5) and creates a new person when no candidate reaches the threshold.
+
+        Use this tool to deduplicate at intake before creating people; do not use createPerson, which always inserts a new record without any matching.
+
+        Preconditions: none; inputs are normalized before scoring (email lowercased, phone reduced to digits, names trimmed).
+
+        Required inputs: at least one of email, phone, lastName or firstName; threshold is optional and defaults to the configured pos.people-contact.matching.threshold value (30 unless overridden).
+
+        Emits a PEOPLE_CONTACT_PERSON_RESOLVE event; when no match reaches the threshold a new person is created and a person.updated identity fact is queued on the outbox.
+
+        Returns 200 with matchedExisting true, the score and the matchedBy reasons when a candidate wins, 200 with matchedExisting false when a new person was created, and 400 when all four matching inputs are absent or blank.
+
+        '
       operationId: resolvePerson
       requestBody:
+        description: Weighted matching criteria used to find or create the person.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ResolvePersonRequest'
+            examples:
+              Match by email and name:
+                description: Match by email and name
+                value:
+                  email: jane.smith@example.com
+                  phone: '+15551234567'
+                  lastName: Smith
+                  firstName: Jane
+                  threshold: 30
         required: true
       responses:
         '200':
@@ -593,18 +904,36 @@ paths:
     post:
       tags:
       - People API
-      summary: Get people by IDs
-      description: Batch-resolve persons by id in one request. Unknown ids are omitted; the result may be smaller than the request. Used for cross-service identity reads (ADR-0015).
+      summary: Batch Resolve People by IDs
+      description: 'Batch-resolves person records by id in one request, attaching typed contact points and linked usernames to each result.
+
+        Use this tool for cross-service identity reads that need several people at once (ADR-0015); use getPersonById instead for a single known id.
+
+        Preconditions: none; unknown ids are silently omitted, so the result may be smaller than the request.
+
+        Required inputs: a JSON array of person UUIDs as the request body; an empty array yields an empty list.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the resolved people; ids that do not exist are dropped rather than reported as errors.
+
+        '
       operationId: getPeopleByIds
       requestBody:
+        description: JSON array of person UUIDs to resolve in one batch.
         content:
           application/json:
             schema:
               type: array
-              description: Person ids to resolve
               items:
                 type: string
                 format: uuid
+            examples:
+              Two ids:
+                description: Two ids
+                value:
+                - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '200':
@@ -624,9 +953,21 @@ paths:
     get:
       tags:
       - People - Access Control
-      summary: Get available roles
-      description: Retrieve list of roles that can be assigned to people
-      operationId: getRoles
+      summary: List Roles Assignable to Person
+      description: 'Lists the role catalog a person could be assigned, combining LOCATION-scoped and GLOBAL-scoped roles fetched live from pos-security.
+
+        Use this tool to populate a role picker before calling assignRoleToPerson; do not use listRoleAssignments, which returns the roles the person already holds.
+
+        Preconditions: the person record must exist; the roles themselves are owned by pos-security, and no user-person link is needed for this listing.
+
+        Required inputs: personUuid (UUID) as a path parameter; there is no request body and no filtering.
+
+        Emits a PEOPLE_CONTACT_ACCESS_ROLES_LIST audit event; no state changes.
+
+        Returns 404 when the person does not exist, and propagates the pos-security status code when the role listing call fails there.
+
+        '
+      operationId: listAssignableRoles
       parameters:
       - name: personUuid
         in: path
@@ -652,9 +993,21 @@ paths:
     get:
       tags:
       - User-Person Linking API
-      summary: Get users linked to person
-      description: Retrieve all usernames linked to a person record
-      operationId: getUsernamesByPersonId
+      summary: List Usernames Linked to Person
+      description: 'Lists every username linked to a person record as a flat array of strings.
+
+        Use this tool to see which logins can act as a person; use getLinksByPersonId instead when the full link records with linkType, notes and audit fields are needed.
+
+        Preconditions: the person record must exist; a person with no links yields an empty list.
+
+        Required inputs: personId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the person does not exist.
+
+        '
+      operationId: listUsernamesForPerson
       parameters:
       - name: personId
         in: path
@@ -689,8 +1042,20 @@ paths:
     get:
       tags:
       - User-Person Linking API
-      summary: Get person by username
-      description: Retrieve the person record linked to a user
+      summary: Get Person Linked to Username
+      description: 'Returns the person record linked to a username, including emails, work phone numbers and the username itself.
+
+        Use this tool to translate a login identity into its person record; use getCurrentPerson instead when the target is the authenticated caller, and getLinksByPersonId to go from a person to its links.
+
+        Preconditions: a user-person link must exist for the username, and the linked person record must still exist.
+
+        Required inputs: username as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no link exists for the username or the linked person record is missing.
+
+        '
       operationId: getPersonByUsername
       parameters:
       - name: username
@@ -721,8 +1086,20 @@ paths:
     get:
       tags:
       - User-Person Linking API
-      summary: Get links by person ID
-      description: Retrieve user-person links for person
+      summary: Get User Links for Person
+      description: 'Returns the full user-person link records for a person, including linkType, notes, creator and creation time.
+
+        Use this tool when link metadata is needed; use listUsernamesForPerson instead when only the usernames matter, and getPersonByUsername to go from a username to its person.
+
+        Preconditions: the person record must exist; a person with no links yields an empty list.
+
+        Required inputs: personId (UUID) as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_USER_LINK_GET audit event; no state changes.
+
+        Returns 404 when the person does not exist.
+
+        '
       operationId: getLinksByPersonId
       parameters:
       - name: personId
@@ -756,8 +1133,20 @@ paths:
     get:
       tags:
       - People API
-      summary: Get current user's person record
-      description: Resolve the authenticated user to their linked person record. Returns 404 when the user has no person link or the linked person no longer exists.
+      summary: Get Current User's Person Record
+      description: 'Resolves the authenticated caller''s username to its linked person record and returns the identity snapshot with emails, work phone numbers and username.
+
+        Use this tool when the caller needs their own person record without knowing a person id; do not use getPersonById, which requires a known person UUID and can read any person.
+
+        Preconditions: an active user-person link must exist for the authenticated username, and the linked person record must still exist.
+
+        Required inputs: none; identity comes entirely from the authenticated security context.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the caller has no user-person link or the linked person no longer exists, and 401 when the authenticated context carries no username.
+
+        '
       operationId: getCurrentPerson
       responses:
         '200':
@@ -781,9 +1170,21 @@ paths:
     delete:
       tags:
       - People - Access Control
-      summary: Revoke role assignment
-      description: Revoke a role assignment from a person
-      operationId: revokeAssignment
+      summary: Revoke Role Assignment from Person
+      description: 'Revokes one of a person''s role assignments by delegating to pos-security through the person''s linked user account.
+
+        Use this tool to end access granted with assignRoleToPerson; do not use unlinkUserFromPerson, which severs the whole user-person link rather than a single role.
+
+        Preconditions: the person must have an active user-person link resolving to a pos-security user, and an assignment for the roleCode must exist there.
+
+        Required inputs: personUuid (UUID) and roleCode as path parameters; endDate (ISO date-time) optionally ends the assignment at that moment instead of immediately.
+
+        Emits a PEOPLE_CONTACT_ACCESS_ASSIGNMENT_REVOKE event; the assignment state change is recorded in pos-security.
+
+        Returns 204 on success, and 404 when the person has no user link, the security user cannot be resolved, or pos-security has no matching assignment.
+
+        '
+      operationId: revokeRoleAssignment
       parameters:
       - name: personUuid
         in: path
@@ -826,8 +1227,20 @@ paths:
     delete:
       tags:
       - User-Person Linking API
-      summary: Unlink user from person
-      description: Remove the link between a user and person
+      summary: Unlink User from Person Record
+      description: 'Removes the link between a security user and its person record, leaving both the user account and the person untouched.
+
+        Use this tool to sever a login from an identity, including before deletePerson on a person that still has linked users; do not use revokeRoleAssignment, which removes a single role rather than the whole link.
+
+        Preconditions: a user-person link must exist for the username.
+
+        Required inputs: username as a path parameter; there is no request body.
+
+        Emits a PEOPLE_CONTACT_USER_PERSON_LINK_DELETE event and queues a link-removed fact on the transactional outbox.
+
+        Returns 204 on success, and 404 when no link exists for the username.
+
+        '
       operationId: unlinkUserFromPerson
       parameters:
       - name: username
@@ -875,7 +1288,6 @@ components:
       - value
     Person:
       type: object
-      description: Person object to be created
       properties:
         id:
           type: string
@@ -1118,7 +1530,7 @@ components:
       - username
     ResolvePersonRequest:
       type: object
-      description: Resolve criteria
+      description: Resolve person request with weighted matching inputs
       properties:
         email:
           type: string

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PersonAccessController.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PersonAccessController.java
@@ -7,6 +7,7 @@ import com.positivity.peoplecontact.internal.dto.PersonRoleAssignmentRequest;
 import com.positivity.peoplecontact.service.PeopleAccessControlService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -42,7 +43,19 @@ public class PersonAccessController {
 
     @GetMapping("/{personUuid}/access/roles")
     @EmitEvent(id = "PEOPLE_CONTACT_ACCESS_ROLES_LIST", apiVersion = "1")
-    @Operation(summary = "Get available roles", description = "Retrieve list of roles that can be assigned to people")
+    @Operation(operationId = "listAssignableRoles", summary = "List Roles Assignable to Person", description = """
+                    Lists the role catalog a person could be assigned, combining LOCATION-scoped and \
+                    GLOBAL-scoped roles fetched live from pos-security.
+                    Use this tool to populate a role picker before calling assignRoleToPerson; do not use \
+                    listRoleAssignments, which returns the roles the person already holds.
+                    Preconditions: the person record must exist; the roles themselves are owned by pos-security, \
+                    and no user-person link is needed for this listing.
+                    Required inputs: personUuid (UUID) as a path parameter; there is no request body and no \
+                    filtering.
+                    Emits a PEOPLE_CONTACT_ACCESS_ROLES_LIST audit event; no state changes.
+                    Returns 404 when the person does not exist, and propagates the pos-security status code when \
+                    the role listing call fails there.
+                    """)
     @ApiResponse(responseCode = "200", description = "Roles retrieved successfully")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -54,9 +67,19 @@ public class PersonAccessController {
 
     @GetMapping("/{personUuid}/access/assignments")
     @EmitEvent(id = "PEOPLE_CONTACT_ACCESS_ASSIGNMENTS_LIST", apiVersion = "1")
-    @Operation(
-            summary = "Get role assignments",
-            description = "Retrieve role assignments for a person with optional history and date filtering")
+    @Operation(operationId = "listRoleAssignments", summary = "List a Person's Role Assignments", description = """
+                    Lists the role assignments a person holds in pos-security, resolved through the person's \
+                    active user-person link.
+                    Use this tool to inspect the access a person already has; do not use listAssignableRoles, \
+                    which returns the catalog of roles available for assignment.
+                    Preconditions: the person must have an active user-person link, and the linked username must \
+                    resolve to a pos-security user.
+                    Required inputs: personUuid (UUID) as a path parameter; includeHistory defaults to false and \
+                    adds ended assignments when true, and endDate (ISO date-time) optionally evaluates \
+                    assignments as of that moment.
+                    Emits a PEOPLE_CONTACT_ACCESS_ASSIGNMENTS_LIST audit event; no state changes.
+                    Returns 404 when the person has no user link or the linked username has no security user.
+                    """)
     @ApiResponse(responseCode = "200", description = "Assignments retrieved successfully")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -72,9 +95,22 @@ public class PersonAccessController {
 
     @PostMapping("/{personUuid}/access/assignments")
     @EmitEvent(id = "PEOPLE_CONTACT_ACCESS_ASSIGNMENT_CREATE", apiVersion = "1")
-    @Operation(
-            summary = "Assign role to person",
-            description = "Assign a role to a person with optional location scope and date range")
+    @Operation(operationId = "assignRoleToPerson", summary = "Assign a Role to a Person", description = """
+                    Assigns a role to a person by delegating to pos-security through the person's linked user \
+                    account, optionally scoped to one location and bounded by a date window.
+                    Use this tool to grant access; do not use revokeRoleAssignment, which ends an assignment \
+                    that already exists.
+                    Preconditions: the person must have an active user-person link resolving to a pos-security \
+                    user, and the roleCode must exist in pos-security.
+                    Required inputs: personUuid (UUID) as a path parameter and roleCode in the body; locationId \
+                    (UUID) scopes the role to one location when supplied, and optional startDate/endDate bound \
+                    the assignment, with endDate required to be on or after startDate.
+                    Emits a PEOPLE_CONTACT_ACCESS_ASSIGNMENT_CREATE event; the assignment record itself is \
+                    created and owned by pos-security.
+                    Returns 201 with the created assignment, 400 when roleCode is blank or endDate precedes \
+                    startDate, and 404 when the person's user link, the security user, or the role cannot be \
+                    resolved.
+                    """)
     @ApiResponses(
             value = {
                 @ApiResponse(
@@ -101,7 +137,25 @@ public class PersonAccessController {
             scopes = {"people-contact:role:assign"})
     @PreAuthorize("hasAuthority('people-contact:role:assign')")
     public ResponseEntity<UserRoleDto> createAssignment(
-            @PathVariable UUID personUuid, @Valid @RequestBody PersonRoleAssignmentRequest request) {
+            @PathVariable UUID personUuid,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Role code plus optional location scope and effective date window.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Location-scoped technician role",
+                                                            value = """
+                                                                    {"roleCode":"TECHNICIAN",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "startDate":"2026-09-01T00:00:00",
+                                                                     "endDate":"2026-12-31T23:59:59"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    PersonRoleAssignmentRequest request) {
         if (request.getRoleCode() == null || request.getRoleCode().isBlank()) {
             throw new IllegalArgumentException("roleCode is required");
         }
@@ -116,7 +170,20 @@ public class PersonAccessController {
 
     @DeleteMapping("/{personUuid}/access/assignments/{roleCode}")
     @EmitEvent(id = "PEOPLE_CONTACT_ACCESS_ASSIGNMENT_REVOKE", apiVersion = "1")
-    @Operation(summary = "Revoke role assignment", description = "Revoke a role assignment from a person")
+    @Operation(operationId = "revokeRoleAssignment", summary = "Revoke Role Assignment from Person", description = """
+                    Revokes one of a person's role assignments by delegating to pos-security through the \
+                    person's linked user account.
+                    Use this tool to end access granted with assignRoleToPerson; do not use \
+                    unlinkUserFromPerson, which severs the whole user-person link rather than a single role.
+                    Preconditions: the person must have an active user-person link resolving to a pos-security \
+                    user, and an assignment for the roleCode must exist there.
+                    Required inputs: personUuid (UUID) and roleCode as path parameters; endDate (ISO date-time) \
+                    optionally ends the assignment at that moment instead of immediately.
+                    Emits a PEOPLE_CONTACT_ACCESS_ASSIGNMENT_REVOKE event; the assignment state change is \
+                    recorded in pos-security.
+                    Returns 204 on success, and 404 when the person has no user link, the security user cannot \
+                    be resolved, or pos-security has no matching assignment.
+                    """)
     @ApiResponse(responseCode = "204", description = "Role assignment revoked successfully")
     @ApiResponse(
             responseCode = "400",

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PersonController.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PersonController.java
@@ -9,6 +9,7 @@ import com.positivity.peoplecontact.service.UserPersonTranslationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,10 +43,18 @@ public class PersonController {
 
     private final UserPersonTranslationService userPersonTranslationService;
 
-    @Operation(
-            summary = "Get current user's person record",
-            description = "Resolve the authenticated user to their linked person record. Returns 404 when the user"
-                    + " has no person link or the linked person no longer exists.")
+    @Operation(operationId = "getCurrentPerson", summary = "Get Current User's Person Record", description = """
+                    Resolves the authenticated caller's username to its linked person record and returns the \
+                    identity snapshot with emails, work phone numbers and username.
+                    Use this tool when the caller needs their own person record without knowing a person id; do \
+                    not use getPersonById, which requires a known person UUID and can read any person.
+                    Preconditions: an active user-person link must exist for the authenticated username, and the \
+                    linked person record must still exist.
+                    Required inputs: none; identity comes entirely from the authenticated security context.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when the caller has no user-person link or the linked person no longer exists, \
+                    and 401 when the authenticated context carries no username.
+                    """)
     @ApiResponse(responseCode = "200", description = "Person found and returned.")
     @ApiResponse(
             responseCode = "404",
@@ -66,10 +75,18 @@ public class PersonController {
                 .orElseThrow(() -> new EntityNotFoundException("No person found for id: " + personId));
     }
 
-    @Operation(
-            summary = "Get all people",
-            description = "Retrieve people with an optional text filter. Employment filtering lives in pos-people"
-                    + " (ADR-0044 §6) and is not available on the identity directory.")
+    @Operation(operationId = "listPeople", summary = "List People in Identity Directory", description = """
+                    Lists person records in the identity directory, optionally narrowed by a free-text filter, \
+                    with each result carrying emails, work phone numbers and any linked username.
+                    Use this tool when browsing or searching people by name or email; do not use resolvePerson, \
+                    which performs weighted duplicate matching and may create a new person as a side effect.
+                    Preconditions: none; an empty directory simply yields an empty list.
+                    Required inputs: none; q is an optional case-insensitive filter matched against firstName, \
+                    lastName and primaryEmail, and employment attributes cannot be filtered here because they \
+                    live in pos-people (ADR-0044 §6).
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the matching people, possibly an empty list when nothing matches the filter.
+                    """)
     @Parameter(name = "q", description = "Case-insensitive text search on firstName, lastName, primaryEmail.")
     @ApiResponse(responseCode = "200", description = "List of people returned successfully.")
     @GetMapping
@@ -81,7 +98,16 @@ public class PersonController {
         return personService.getAllPeople(q);
     }
 
-    @Operation(summary = "Get person by ID", description = "Retrieve a person by their unique ID.")
+    @Operation(operationId = "getPersonById", summary = "Get a Person by Unique ID", description = """
+                    Returns a single person record by its UUID, including emails, work phone numbers and any \
+                    linked username.
+                    Use this tool when the person id is already known; use listPeople instead when searching by \
+                    name or email, and getCurrentPerson when the target is the authenticated caller.
+                    Preconditions: the person record must exist in the identity directory.
+                    Required inputs: personId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no person exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Person found and returned.")
     @ApiResponse(
             responseCode = "404",
@@ -105,25 +131,56 @@ public class PersonController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @Operation(
-            summary = "Get people by IDs",
-            description = "Batch-resolve persons by id in one request. Unknown ids are omitted; the result may be"
-                    + " smaller than the request. Used for cross-service identity reads (ADR-0015).")
+    @Operation(operationId = "getPeopleByIds", summary = "Batch Resolve People by IDs", description = """
+                    Batch-resolves person records by id in one request, attaching typed contact points and linked \
+                    usernames to each result.
+                    Use this tool for cross-service identity reads that need several people at once (ADR-0015); \
+                    use getPersonById instead for a single known id.
+                    Preconditions: none; unknown ids are silently omitted, so the result may be smaller than the \
+                    request.
+                    Required inputs: a JSON array of person UUIDs as the request body; an empty array yields an \
+                    empty list.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the resolved people; ids that do not exist are dropped rather than reported \
+                    as errors.
+                    """)
     @ApiResponse(responseCode = "200", description = "Persons resolved.")
     @PostMapping("/by-ids")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"people-contact:person:view"})
     @PreAuthorize("hasAuthority('people-contact:person:view')")
-    public List<Person> getPeopleByIds(@Parameter(description = "Person ids to resolve") @RequestBody List<UUID> ids) {
+    public List<Person> getPeopleByIds(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "JSON array of person UUIDs to resolve in one batch.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Two ids", value = """
+                                                                    ["018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"]
+                                                                    """)))
+                    @RequestBody
+                    List<UUID> ids) {
         return personService.getPeopleByIds(ids);
     }
 
-    @Operation(
-            summary = "Replace a person's contact points",
-            description =
-                    "Replaces all typed contact points (email/phone) for a person. pos-people-contact is the source of"
-                            + " truth for contacts (ADR-0015).")
+    @Operation(operationId = "replaceContactPoints", summary = "Replace a Person's Contact Points", description = """
+                    Replaces the full set of typed contact points for one person; pos-people-contact is the \
+                    source of truth for contact channels (ADR-0015).
+                    Use this tool to overwrite a person's contact channels wholesale; do not use updatePerson, \
+                    which replaces names, primaryEmail, secondaryEmail and phoneNumbers as flat identity fields \
+                    rather than the typed contact-point set.
+                    Preconditions: the person should exist; the id is not validated here, so writes for an \
+                    unknown person are stored without error.
+                    Required inputs: a JSON array of contact points, each with contactType (EMAIL, PHONE_MOBILE, \
+                    PHONE_HOME or PHONE_WORK), value, and primary; entries missing contactType or value are \
+                    silently dropped, and an empty array clears all contact points.
+                    Emits a people-contact person.updated identity fact through the transactional outbox when \
+                    the person exists; prior contact points are deleted in the same transaction.
+                    Returns 204 on success, including when the array is empty or the person id is unknown.
+                    """)
     @ApiResponse(responseCode = "204", description = "Contact points replaced.")
     @PutMapping("/{personId}/contact-points")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -132,12 +189,41 @@ public class PersonController {
     @PreAuthorize("hasAuthority('people-contact:person:edit')")
     public ResponseEntity<Void> replaceContactPoints(
             @Parameter(description = "Person id") @PathVariable UUID personId,
-            @RequestBody List<Person.ContactPointDto> contactPoints) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Complete replacement set of typed contact points for the person.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Email and mobile phone", value = """
+                                                                    [{"contactType":"EMAIL",
+                                                                      "value":"jane.smith@example.com",
+                                                                      "primary":true},
+                                                                     {"contactType":"PHONE_MOBILE",
+                                                                      "value":"+15551234567",
+                                                                      "primary":true}]
+                                                                    """)))
+                    @RequestBody
+                    List<Person.ContactPointDto> contactPoints) {
         personService.replaceContactPoints(personId, contactPoints);
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Create a new person", description = "Add a new person to the system.")
+    @Operation(operationId = "createPerson", summary = "Create a New Person Record", description = """
+                    Creates a new person identity record; emails and phone numbers are persisted as contact \
+                    points owned by this module.
+                    Use this tool when the person is known to be new; do not use resolvePerson, which should be \
+                    preferred when a matching person may already exist, and do not use linkUserToPerson, which \
+                    only associates an existing person with a security user.
+                    Preconditions: none; duplicate names or emails are not rejected, so deduplication is the \
+                    caller's responsibility (or use resolvePerson).
+                    Required inputs: firstName and lastName (non-blank); primaryEmail, secondaryEmail and \
+                    phoneNumbers are optional, and username is ignored because usernames are owned by \
+                    pos-security and linked separately.
+                    Emits a PEOPLE_CONTACT_PERSON_CREATE event and queues a person.updated identity fact on the \
+                    transactional outbox.
+                    Returns 201 with the persisted person, and 400 when firstName or lastName is blank.
+                    """)
     @ApiResponse(responseCode = "201", description = "Person created successfully.")
     @EmitEvent(id = "PEOPLE_CONTACT_PERSON_CREATE", apiVersion = "1")
     @PostMapping
@@ -146,12 +232,42 @@ public class PersonController {
             scopes = {"people-contact:person:create"})
     @PreAuthorize("hasAuthority('people-contact:person:create')")
     public ResponseEntity<Person> createPerson(
-            @Parameter(description = "Person object to be created") @Valid @RequestBody Person person) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Identity fields of the person to create; contact data is stored as"
+                                    + " contact points.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "New person", value = """
+                                                                    {"firstName":"Jane",
+                                                                     "lastName":"Smith",
+                                                                     "primaryEmail":"jane.smith@example.com",
+                                                                     "phoneNumbers":["+15551234567"]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    Person person) {
         Person saved = personService.savePerson(person);
         return ResponseEntity.status(201).body(saved);
     }
 
-    @Operation(summary = "Resolve person", description = "Find best matching person by score or create a new person")
+    @Operation(operationId = "resolvePerson", summary = "Resolve or Create Matching Person", description = """
+                    Finds the best-matching existing person using weighted scoring (email 60, phone 25, lastName \
+                    10, firstName 5) and creates a new person when no candidate reaches the threshold.
+                    Use this tool to deduplicate at intake before creating people; do not use createPerson, \
+                    which always inserts a new record without any matching.
+                    Preconditions: none; inputs are normalized before scoring (email lowercased, phone reduced \
+                    to digits, names trimmed).
+                    Required inputs: at least one of email, phone, lastName or firstName; threshold is optional \
+                    and defaults to the configured pos.people-contact.matching.threshold value (30 unless \
+                    overridden).
+                    Emits a PEOPLE_CONTACT_PERSON_RESOLVE event; when no match reaches the threshold a new \
+                    person is created and a person.updated identity fact is queued on the outbox.
+                    Returns 200 with matchedExisting true, the score and the matchedBy reasons when a candidate \
+                    wins, 200 with matchedExisting false when a new person was created, and 400 when all four \
+                    matching inputs are absent or blank.
+                    """)
     @ApiResponse(responseCode = "200", description = "Person resolved successfully.")
     @EmitEvent(id = "PEOPLE_CONTACT_PERSON_RESOLVE", apiVersion = "1")
     @PostMapping("/resolve")
@@ -160,12 +276,41 @@ public class PersonController {
             scopes = {"people-contact:person:create"})
     @PreAuthorize("hasAuthority('people-contact:person:create')")
     public ResponseEntity<ResolvePersonResponse> resolvePerson(
-            @Parameter(description = "Resolve criteria") @Valid @RequestBody ResolvePersonRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Weighted matching criteria used to find or create the person.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Match by email and name", value = """
+                                                                    {"email":"jane.smith@example.com",
+                                                                     "phone":"+15551234567",
+                                                                     "lastName":"Smith",
+                                                                     "firstName":"Jane",
+                                                                     "threshold":30}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    ResolvePersonRequest request) {
         ResolvePersonResponse resolved = personService.resolvePerson(request);
         return ResponseEntity.ok(resolved);
     }
 
-    @Operation(summary = "Update an existing person", description = "Update the details of an existing person.")
+    @Operation(operationId = "updatePerson", summary = "Update an Existing Person Record", description = """
+                    Updates an existing person's identity fields, fully replacing names, emails and work phone \
+                    numbers with the submitted values.
+                    Use this tool to correct or complete a known person's identity data; do not use \
+                    replaceContactPoints, which manages the typed contact-point set, and do not use createPerson \
+                    for records that do not exist yet.
+                    Preconditions: the person record must already exist for the supplied id.
+                    Required inputs: personId (UUID) as a path parameter plus a full person body with non-blank \
+                    firstName and lastName; omitting primaryEmail, secondaryEmail or phoneNumbers erases the \
+                    stored values, and username is ignored because it is owned by pos-security.
+                    Emits a PEOPLE_CONTACT_PERSON_UPDATE event and queues a person.updated identity fact on the \
+                    transactional outbox.
+                    Returns 200 with the updated person, 404 when no person exists for the id, and 400 when \
+                    firstName or lastName is blank.
+                    """)
     @ApiResponse(responseCode = "200", description = "Person updated successfully.")
     @ApiResponse(
             responseCode = "404",
@@ -184,7 +329,22 @@ public class PersonController {
             @Parameter(description = "ID of the person to update", example = "123e4567-e89b-12d3-a456-426614174000")
                     @PathVariable
                     UUID personId,
-            @Parameter(description = "Updated person object") @Valid @RequestBody Person person) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement identity snapshot for the person.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Updated person", value = """
+                                                                    {"firstName":"Jane",
+                                                                     "lastName":"Smith-Jones",
+                                                                     "primaryEmail":"jane.smith@example.com",
+                                                                     "secondaryEmail":"jane.alt@example.com",
+                                                                     "phoneNumbers":["+15551234567"]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    Person person) {
         if (personService.getPersonById(personId).isEmpty()) {
             return ResponseEntity.notFound().build();
         }
@@ -193,11 +353,29 @@ public class PersonController {
         return ResponseEntity.ok(updated);
     }
 
-    @Operation(summary = "Delete a person", description = "Delete a person by their unique ID.")
+    @Operation(operationId = "deletePerson", summary = "Delete a Person Identity Record", description = """
+                    Deletes a person record and, in the same transaction, its contact points and postal address.
+                    Use this tool to permanently remove an identity record; do not use unlinkUserFromPerson, \
+                    which only removes a user link and leaves the person in place.
+                    Preconditions: the person must exist and must have no user-person links; linked users must \
+                    be removed first with unlinkUserFromPerson.
+                    Required inputs: personId (UUID) as a path parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_PERSON_DELETE event and queues a person.deleted fact on the \
+                    transactional outbox.
+                    Returns 204 on success, 404 when the person does not exist, and 409 when one or more users \
+                    are still linked to the person.
+                    """)
     @ApiResponse(responseCode = "204", description = "Person deleted successfully.")
     @ApiResponse(
             responseCode = "404",
             description = "Person not found.",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Person still has linked users; unlink them first.",
             content =
                     @Content(
                             mediaType = "application/problem+json",

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PostalAddressController.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/PostalAddressController.java
@@ -7,6 +7,7 @@ import com.positivity.peoplecontact.service.PostalAddressService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -35,9 +36,17 @@ public class PostalAddressController {
 
     private final PostalAddressService postalAddressService;
 
-    @Operation(
-            summary = "Get a person's postal address",
-            description = "Returns the person's structured postal address, or 404 when none is on file.")
+    @Operation(operationId = "getPersonPostalAddress", summary = "Get a Person's Postal Address", description = """
+                    Returns the single structured postal address on file for a person; pos-people-contact is the \
+                    postal-address authority for person parties (FI-4).
+                    Use this tool when reading a person's mailing address; use getOrganizationPostalAddress \
+                    instead for CRM organization parties.
+                    Preconditions: an address must already have been stored for the person with \
+                    putPersonPostalAddress.
+                    Required inputs: personId (UUID) as a path parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_PERSON_ADDRESS_GET audit event; no state changes.
+                    Returns 404 when no address is on file for the person.
+                    """)
     @ApiResponse(responseCode = "200", description = "Address found and returned.")
     @ApiResponse(
             responseCode = "404",
@@ -61,14 +70,34 @@ public class PostalAddressController {
     }
 
     @Operation(
-            summary = "Create or replace a person's postal address",
-            description = "Stores the structured, validated address. Only line1 and an ISO 3166-1 alpha-2"
-                    + " countryCode are required — the shape is country-agnostic (region is free text,"
-                    + " postalCode optional) so it works for any deployment locale.")
+            operationId = "putPersonPostalAddress",
+            summary = "Create or Replace Person Postal Address",
+            description = """
+                    Creates or replaces the single structured postal address for a person; the shape is \
+                    country-agnostic, with free-text region and an optional postalCode.
+                    Use this tool for person mailing addresses; use putOrganizationPostalAddress instead for CRM \
+                    organization parties, and do not use replaceContactPoints, which manages email and phone \
+                    channels.
+                    Preconditions: the person record must exist; any previously stored address is overwritten in \
+                    place.
+                    Required inputs: line1 and an ISO 3166-1 alpha-2 countryCode (stored upper-case); line2, \
+                    city, region and postalCode are optional free text, trimmed, with blanks stored as null.
+                    Emits a PEOPLE_CONTACT_PERSON_ADDRESS_PUT event and queues a person.updated identity fact \
+                    carrying the new address.
+                    Returns 200 with the stored address, 404 when the person does not exist, and 422 when line1 \
+                    is blank or countryCode is not a valid ISO 3166-1 alpha-2 code.
+                    """)
     @ApiResponse(responseCode = "200", description = "Address stored.")
     @ApiResponse(
             responseCode = "404",
             description = "Person not found.",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "line1 missing or countryCode not a valid ISO 3166-1 alpha-2 code.",
             content =
                     @Content(
                             mediaType = "application/problem+json",
@@ -81,13 +110,41 @@ public class PostalAddressController {
     @PreAuthorize("hasAuthority('people-contact:person:edit')")
     public ResponseEntity<PostalAddressDto> putPersonAddress(
             @Parameter(description = "Person id") @PathVariable UUID personId,
-            @Valid @RequestBody PostalAddressDto address) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Country-agnostic structured postal address that replaces any address"
+                                    + " already on file for the person.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Japanese address", value = """
+                                                                    {"line1":"1-2-3 Ginza",
+                                                                     "line2":"Chuo-ku",
+                                                                     "city":"Tokyo",
+                                                                     "region":"Tokyo",
+                                                                     "postalCode":"104-0061",
+                                                                     "countryCode":"JP"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    PostalAddressDto address) {
         return ResponseEntity.ok(postalAddressService.putAddress(PartyType.PERSON, personId, address));
     }
 
     @Operation(
-            summary = "Delete a person's postal address",
-            description = "Removes the person's postal address; succeeds even when none is on file.")
+            operationId = "deletePersonPostalAddress",
+            summary = "Delete a Person's Postal Address",
+            description = """
+                    Removes the postal address on file for a person; the operation is idempotent and succeeds \
+                    when none exists.
+                    Use this tool to clear a person's mailing address; do not use deletePerson, which removes \
+                    the entire identity record.
+                    Preconditions: none; a missing address is treated as already deleted.
+                    Required inputs: personId (UUID) as a path parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_PERSON_ADDRESS_DELETE event, and queues a person.updated identity \
+                    fact only when an address actually existed.
+                    Returns 204 whether or not an address was on file.
+                    """)
     @ApiResponse(responseCode = "204", description = "Address removed (or none existed).")
     @EmitEvent(id = "PEOPLE_CONTACT_PERSON_ADDRESS_DELETE", apiVersion = "1")
     @DeleteMapping("/v1/people/{personId}/postal-address")
@@ -101,9 +158,20 @@ public class PostalAddressController {
     }
 
     @Operation(
-            summary = "Get an organization's postal address",
-            description = "Returns the organization party's structured postal address, or 404 when none is on"
-                    + " file. The organization id is the party UUID owned by the CRM module.")
+            operationId = "getOrganizationPostalAddress",
+            summary = "Get an Organization's Postal Address",
+            description = """
+                    Returns the structured postal address on file for a CRM organization party; the organization \
+                    id is an external pos-customer party reference stored verbatim.
+                    Use this tool when reading an organization's mailing address; use getPersonPostalAddress \
+                    instead for person parties.
+                    Preconditions: an address must already have been stored for the organization with \
+                    putOrganizationPostalAddress.
+                    Required inputs: organizationId (the pos-customer commercial party UUID) as a path \
+                    parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_ORG_ADDRESS_GET audit event; no state changes.
+                    Returns 404 when no address is on file for the organization.
+                    """)
     @ApiResponse(responseCode = "200", description = "Address found and returned.")
     @ApiResponse(
             responseCode = "404",
@@ -127,10 +195,29 @@ public class PostalAddressController {
     }
 
     @Operation(
-            summary = "Create or replace an organization's postal address",
-            description = "Stores the structured, validated address for an organization party. The id is an"
-                    + " external party reference (pos-customer commercial party) stored verbatim.")
+            operationId = "putOrganizationPostalAddress",
+            summary = "Create or Replace Organization Postal Address",
+            description = """
+                    Creates or replaces the single structured postal address for a CRM organization party.
+                    Use this tool for organization mailing addresses; use putPersonPostalAddress instead for \
+                    person parties.
+                    Preconditions: none in this module; the organization id is an external pos-customer party \
+                    reference stored verbatim without an existence check.
+                    Required inputs: organizationId (UUID) as a path parameter, plus line1 and an ISO 3166-1 \
+                    alpha-2 countryCode in the body; line2, city, region and postalCode are optional free text.
+                    Emits a PEOPLE_CONTACT_ORG_ADDRESS_PUT event and an organization-address-updated fact for \
+                    downstream consumers.
+                    Returns 200 with the stored address, and 422 when line1 is blank or countryCode is not a \
+                    valid ISO 3166-1 alpha-2 code.
+                    """)
     @ApiResponse(responseCode = "200", description = "Address stored.")
+    @ApiResponse(
+            responseCode = "422",
+            description = "line1 missing or countryCode not a valid ISO 3166-1 alpha-2 code.",
+            content =
+                    @Content(
+                            mediaType = "application/problem+json",
+                            schema = @Schema(implementation = ProblemDetail.class)))
     @EmitEvent(id = "PEOPLE_CONTACT_ORG_ADDRESS_PUT", apiVersion = "1")
     @PutMapping("/v1/organizations/{organizationId}/postal-address")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -139,13 +226,41 @@ public class PostalAddressController {
     @PreAuthorize("hasAuthority('people-contact:organization:edit')")
     public ResponseEntity<PostalAddressDto> putOrganizationAddress(
             @Parameter(description = "Organization party id") @PathVariable UUID organizationId,
-            @Valid @RequestBody PostalAddressDto address) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Country-agnostic structured postal address that replaces any address"
+                                    + " already on file for the organization party.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "US business address", value = """
+                                                                    {"line1":"400 Commerce Way",
+                                                                     "line2":"Suite 210",
+                                                                     "city":"Austin",
+                                                                     "region":"TX",
+                                                                     "postalCode":"78701",
+                                                                     "countryCode":"US"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    PostalAddressDto address) {
         return ResponseEntity.ok(postalAddressService.putAddress(PartyType.ORGANIZATION, organizationId, address));
     }
 
     @Operation(
-            summary = "Delete an organization's postal address",
-            description = "Removes the organization party's postal address; succeeds even when none is on file.")
+            operationId = "deleteOrganizationPostalAddress",
+            summary = "Delete an Organization's Postal Address",
+            description = """
+                    Removes the postal address on file for a CRM organization party; the operation is idempotent \
+                    and succeeds when none exists.
+                    Use this tool to clear an organization's mailing address; use deletePersonPostalAddress \
+                    instead for person parties.
+                    Preconditions: none; a missing address is treated as already deleted.
+                    Required inputs: organizationId (UUID) as a path parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_ORG_ADDRESS_DELETE event, and an organization-address-removed fact \
+                    is published only when an address actually existed.
+                    Returns 204 whether or not an address was on file.
+                    """)
     @ApiResponse(responseCode = "204", description = "Address removed (or none existed).")
     @EmitEvent(id = "PEOPLE_CONTACT_ORG_ADDRESS_DELETE", apiVersion = "1")
     @DeleteMapping("/v1/organizations/{organizationId}/postal-address")

--- a/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/UserPersonLinkController.java
+++ b/pos-people-contact/src/main/java/com/positivity/peoplecontact/internal/controller/UserPersonLinkController.java
@@ -9,6 +9,7 @@ import com.positivity.peoplecontact.service.UserPersonLinkService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,9 +32,22 @@ public class UserPersonLinkController {
 
     @PostMapping("/users/link")
     @EmitEvent(id = "PEOPLE_CONTACT_USER_LINK_CREATE", apiVersion = "1")
-    @Operation(
-            summary = "Link user to person",
-            description = "Create a link between an authentication user and a person record")
+    @Operation(operationId = "linkUserToPerson", summary = "Link User to Person Record", description = """
+                    Links a security user account to a person record, optionally recording a linkType and notes; \
+                    the link is what lets a login act as that person.
+                    Use this tool when associating a user with a person, for example during onboarding; do not \
+                    use createUserPersonLink, which is the minimal admin variant without linkType or notes, and \
+                    do not use createPerson, which creates the identity record itself.
+                    Preconditions: the person must exist, and the username must not already be linked to a \
+                    different person; one username maps to at most one person.
+                    Required inputs: username and personId (UUID); linkType defaults to PRIMARY and notes is \
+                    optional.
+                    Emits a PEOPLE_CONTACT_USER_LINK_CREATE event and queues a link-updated fact on the \
+                    transactional outbox.
+                    Returns 201 when the link is created, 200 when the identical link already exists (the call \
+                    is idempotent), 404 when the person does not exist, and 409 when the username is already \
+                    linked to a different person.
+                    """)
     @ApiResponse(
             responseCode = "201",
             description = "Link created successfully",
@@ -50,7 +64,21 @@ public class UserPersonLinkController {
             scopes = {"people-contact:userLink:write"})
     @PreAuthorize("hasAuthority('people-contact:userLink:write')")
     public ResponseEntity<UserPersonLinkResponse> linkUserToPerson(
-            @Valid @RequestBody LinkUserToPersonRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "User-person pair to link, with optional link classification and notes.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Onboarding link", value = """
+                                                                    {"username":"marcus.webb",
+                                                                     "personId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "linkType":"PRIMARY",
+                                                                     "notes":"Linked during onboarding"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    LinkUserToPersonRequest request) {
 
         boolean alreadyLinked =
                 linkService.linkExistsByUsernameAndPersonId(request.getUsername(), request.getPersonId());
@@ -63,9 +91,21 @@ public class UserPersonLinkController {
 
     @PostMapping("/user-links")
     @EmitEvent(id = "PEOPLE_CONTACT_USER_LINK_CREATE", apiVersion = "1")
-    @Operation(
-            summary = "Create user-person link (admin)",
-            description = "Create a link between an authentication user and a person record")
+    @Operation(operationId = "createUserPersonLink", summary = "Create User Person Link as Admin", description = """
+                    Creates a user-person link from the minimal administrative payload of username and personId \
+                    only; the link is stored with linkType PRIMARY.
+                    Use this tool for administrative linking when linkType and notes are not needed; do not use \
+                    linkUserToPerson, which accepts the same pair plus an explicit linkType and notes.
+                    Preconditions: the person must exist, and the username must not already be linked to a \
+                    different person; one username maps to at most one person.
+                    Required inputs: username and personId (UUID); both are mandatory and there are no other \
+                    fields.
+                    Emits a PEOPLE_CONTACT_USER_LINK_CREATE event and queues a link-updated fact on the \
+                    transactional outbox.
+                    Returns 201 when the link is created, 200 when the identical link already exists (the call \
+                    is idempotent), 404 when the person does not exist, and 409 when the username is already \
+                    linked to a different person.
+                    """)
     @ApiResponse(
             responseCode = "201",
             description = "Link created successfully",
@@ -82,7 +122,19 @@ public class UserPersonLinkController {
             scopes = {"people-contact:userLink:write"})
     @PreAuthorize("hasAuthority('people-contact:userLink:write')")
     public ResponseEntity<UserPersonLinkResponse> createUserPersonLink(
-            @Valid @RequestBody CreateUserLinkRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Minimal user-person pair to link; the link is stored as PRIMARY.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Admin link", value = """
+                                                                    {"username":"marcus.webb",
+                                                                     "personId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CreateUserLinkRequest request) {
         boolean alreadyLinked =
                 linkService.linkExistsByUsernameAndPersonId(request.getUsername(), request.getPersonId());
         UserPersonLinkResponse response = linkService.createUserLink(request.getUsername(), request.getPersonId());
@@ -93,7 +145,18 @@ public class UserPersonLinkController {
 
     @DeleteMapping("/users/{username}/link")
     @EmitEvent(id = "PEOPLE_CONTACT_USER_PERSON_LINK_DELETE", apiVersion = "1")
-    @Operation(summary = "Unlink user from person", description = "Remove the link between a user and person")
+    @Operation(operationId = "unlinkUserFromPerson", summary = "Unlink User from Person Record", description = """
+                    Removes the link between a security user and its person record, leaving both the user \
+                    account and the person untouched.
+                    Use this tool to sever a login from an identity, including before deletePerson on a person \
+                    that still has linked users; do not use revokeRoleAssignment, which removes a single role \
+                    rather than the whole link.
+                    Preconditions: a user-person link must exist for the username.
+                    Required inputs: username as a path parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_USER_PERSON_LINK_DELETE event and queues a link-removed fact on the \
+                    transactional outbox.
+                    Returns 204 on success, and 404 when no link exists for the username.
+                    """)
     @ApiResponse(responseCode = "204", description = "Link deleted successfully")
     @ApiResponse(responseCode = "404", description = "Link not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -108,7 +171,18 @@ public class UserPersonLinkController {
     }
 
     @GetMapping("/users/{username}/person")
-    @Operation(summary = "Get person by username", description = "Retrieve the person record linked to a user")
+    @Operation(operationId = "getPersonByUsername", summary = "Get Person Linked to Username", description = """
+                    Returns the person record linked to a username, including emails, work phone numbers and the \
+                    username itself.
+                    Use this tool to translate a login identity into its person record; use getCurrentPerson \
+                    instead when the target is the authenticated caller, and getLinksByPersonId to go from a \
+                    person to its links.
+                    Preconditions: a user-person link must exist for the username, and the linked person record \
+                    must still exist.
+                    Required inputs: username as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no link exists for the username or the linked person record is missing.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Person found",
@@ -126,7 +200,15 @@ public class UserPersonLinkController {
     }
 
     @GetMapping("/{personId}/users")
-    @Operation(summary = "Get users linked to person", description = "Retrieve all usernames linked to a person record")
+    @Operation(operationId = "listUsernamesForPerson", summary = "List Usernames Linked to Person", description = """
+                    Lists every username linked to a person record as a flat array of strings.
+                    Use this tool to see which logins can act as a person; use getLinksByPersonId instead when \
+                    the full link records with linkType, notes and audit fields are needed.
+                    Preconditions: the person record must exist; a person with no links yields an empty list.
+                    Required inputs: personId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when the person does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Usernames returned")
     @ApiResponse(responseCode = "404", description = "Person not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -142,7 +224,16 @@ public class UserPersonLinkController {
 
     @GetMapping("/user-links/{personId}")
     @EmitEvent(id = "PEOPLE_CONTACT_USER_LINK_GET", apiVersion = "1")
-    @Operation(summary = "Get links by person ID", description = "Retrieve user-person links for person")
+    @Operation(operationId = "getLinksByPersonId", summary = "Get User Links for Person", description = """
+                    Returns the full user-person link records for a person, including linkType, notes, creator \
+                    and creation time.
+                    Use this tool when link metadata is needed; use listUsernamesForPerson instead when only the \
+                    usernames matter, and getPersonByUsername to go from a username to its person.
+                    Preconditions: the person record must exist; a person with no links yields an empty list.
+                    Required inputs: personId (UUID) as a path parameter; there is no request body.
+                    Emits a PEOPLE_CONTACT_USER_LINK_GET audit event; no state changes.
+                    Returns 404 when the person does not exist.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Links found",

--- a/pos-people/openapi.yaml
+++ b/pos-people/openapi.yaml
@@ -41,9 +41,21 @@ paths:
     get:
       tags:
       - People - Staffing Assignments
-      summary: Get assignment by ID
-      description: Retrieves a single staffing assignment by its unique ID.
-      operationId: getAssignment
+      summary: Get Staffing Assignment By Id
+      description: 'Returns a single staffing assignment by its unique assignment id.
+
+        Use this tool when the assignment id is already known; use listStaffingAssignments instead to discover a person''s assignments.
+
+        Preconditions: the assignment must exist; both ACTIVE and ENDED assignments are returned.
+
+        Required inputs: assignmentId (UUID) path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no assignment exists for the supplied id.
+
+        '
+      operationId: getStaffingAssignment
       parameters:
       - name: assignmentId
         in: path
@@ -72,9 +84,21 @@ paths:
     put:
       tags:
       - People - Staffing Assignments
-      summary: Update staffing assignment
-      description: Updates an existing staffing assignment, including role, dates, and primary flag.
-      operationId: updateAssignment
+      summary: Update An Existing Staffing Assignment
+      description: 'Replaces a staffing assignment''s person, location, role, primary flag, and effective dates.
+
+        Use this tool to correct or reshape an existing assignment; do not use endStaffingAssignment, which only closes an assignment, and do not use createStaffingAssignment for a new one.
+
+        Preconditions: the assignment must exist, the person must exist with an ACTIVE employee record, the location must be active, and no other assignment for the same person, location, and role may overlap the effective dates.
+
+        Required inputs: assignmentId (UUID) path parameter plus the full body (personId, locationId, role, isPrimary, effectiveFrom); this is a full replacement, not a patch.
+
+        Emits a PEOPLE_STAFFING_ASSIGNMENT_UPDATE event and publishes a staffing-assignment fact; setting isPrimary true demotes and ends any other overlapping primary assignment.
+
+        Returns 404 when the assignment, person, employee record, or active location cannot be resolved, 409 when another assignment overlaps for the person, location, and role, and 400 when the person''s employee status is not ACTIVE.
+
+        '
+      operationId: updateStaffingAssignment
       parameters:
       - name: assignmentId
         in: path
@@ -83,10 +107,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Full replacement values for the assignment's person, location, role, primary flag, and effective dates.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateStaffingAssignmentRequest'
+            examples:
+              Extend assignment end date:
+                description: Extend assignment end date
+                value:
+                  personId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  role: TECHNICIAN
+                  isPrimary: true
+                  effectiveFrom: 2026-02-16
+                  effectiveTo: 2026-12-31
         required: true
       responses:
         '200':
@@ -121,9 +156,21 @@ paths:
     delete:
       tags:
       - People - Staffing Assignments
-      summary: End (soft-delete) an assignment
-      description: Ends an active staffing assignment without physically deleting the record.
-      operationId: endAssignment
+      summary: End An Active Staffing Assignment
+      description: 'Ends a staffing assignment by setting its status to ENDED without physically deleting the row.
+
+        Use this tool when a person stops working at a location; do not use disableEmployee, which offboards the whole employee, and do not use updateStaffingAssignment to shorten dates manually.
+
+        Preconditions: the assignment must exist; ending an already ENDED assignment is accepted and republishes the fact.
+
+        Required inputs: assignmentId (UUID) path parameter; there is no request body.
+
+        Emits a PEOPLE_STAFFING_ASSIGNMENT_END event and publishes a staffing-assignment fact; a null effectiveTo is stamped with today''s date.
+
+        Returns 204 on success, and 404 when no assignment exists for the supplied id.
+
+        '
+      operationId: endStaffingAssignment
       parameters:
       - name: assignmentId
         in: path
@@ -145,8 +192,20 @@ paths:
     get:
       tags:
       - Employee API
-      summary: Get employee profile
-      description: Retrieves an employee profile by employee ID.
+      summary: Get Employee Profile By Person Id
+      description: 'Returns the full employee profile for a person id, merging identity fields from the pos-people-contact replica with local employment fields.
+
+        Use this tool when the person id is already known; use getEmployeeByNumber instead to resolve a human-entered employee number.
+
+        Preconditions: an employee row or identity-replica row must exist for the id; identity fields may briefly be null right after creation while the replica catches up.
+
+        Required inputs: employeeId (UUID) path parameter, which is the person id; there is no request body.
+
+        Emits a PEOPLE_EMPLOYEE_GET audit event but changes no state; this is a read-only projection.
+
+        Returns 404 when neither an employee record nor a person replica row exists for the id.
+
+        '
       operationId: getEmployee
       parameters:
       - name: employeeId
@@ -176,8 +235,20 @@ paths:
     put:
       tags:
       - Employee API
-      summary: Update employee profile
-      description: Updates an existing employee profile using the provided employee ID.
+      summary: Update An Existing Employee Profile
+      description: 'Updates an existing employee profile by person id, replacing employment attributes locally and forwarding identity attributes to pos-people-contact as an upsert command.
+
+        Use this tool when correcting or changing an existing employee''s details; do not use createEmployee, which registers a new person, and do not use disableEmployee, which is the offboarding transition.
+
+        Preconditions: an employee row or identity-replica row must exist for the supplied employeeId, which is the person id at this API surface.
+
+        Required inputs: employeeId (UUID) path parameter plus the full profile (firstName, lastName, employeeNumber, status, hireDate); this is a full replacement, not a patch, and duplicatePolicy defaults to STRICT.
+
+        Emits a PEOPLE_EMPLOYEE_UPDATE event and publishes a people.employee.updated fact; a status change also stamps statusEffectiveAt.
+
+        Returns 404 when no employee or person exists for the id, 409 when another employee already uses the employee number, email, or phone under STRICT policy, and 422 when terminationDate is before hireDate.
+
+        '
       operationId: updateEmployee
       parameters:
       - name: employeeId
@@ -187,10 +258,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Full replacement employee profile; identity fields are re-sent to pos-people-contact as an upsert command.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateEmployeeRequest'
+            examples:
+              Status change to leave:
+                description: Status change to leave
+                value:
+                  firstName: Jane
+                  lastName: Smith
+                  employeeNumber: EMP-0001
+                  status: ON_LEAVE
+                  hireDate: 2026-01-15
+                  duplicatePolicy: BALANCED
         required: true
       responses:
         '200':
@@ -232,8 +314,20 @@ paths:
     post:
       tags:
       - Work Sessions API
-      summary: Submit work session
-      description: Submit an ended work session with its billable and break totals for approval.
+      summary: Submit An Ended Work Session
+      description: 'Submits an ENDED work session for approval, recording billable and break minute totals and marking the session SUBMITTED.
+
+        Use this tool after stopWorkSession has ended the session; do not use approveTimeEntriesBatch, which decides time entries, not work sessions.
+
+        Preconditions: the session must exist and be in ENDED status; ACTIVE or already SUBMITTED sessions are rejected.
+
+        Required inputs: the work session id (UUID) path parameter and a body with billableMinutes and breakMinutes (both zero or greater) and submittedAt (ISO-8601 instant).
+
+        Emits a PEOPLE_WORK_SESSION_SUBMIT event.
+
+        Returns 404 when the session does not exist, and 409 when the session is not in ENDED status.
+
+        '
       operationId: submitWorkSession
       parameters:
       - name: id
@@ -245,10 +339,18 @@ paths:
           format: uuid
         example: 7b1f5a9d-0c2b-4c6d-9a5a-5f8e7c3a9b1c
       requestBody:
+        description: Billable and break minute totals plus the submission timestamp for the ended session.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/WorkSessionSubmitRequest'
+            examples:
+              Full day with lunch break:
+                description: Full day with lunch break
+                value:
+                  billableMinutes: 480
+                  breakMinutes: 30
+                  submittedAt: 2026-02-16 17:00:00+00:00
         required: true
       responses:
         '200':
@@ -277,8 +379,20 @@ paths:
     post:
       tags:
       - Work Sessions API
-      summary: Stop work session break
-      description: End a break within a work session.
+      summary: Stop The Open Work Session Break
+      description: 'Ends the open break on a work session, stamping the end time from the server clock.
+
+        Use this tool when a person returns from a break; do not use stopWorkSession, which ends the session and auto-closes any open break itself.
+
+        Preconditions: the session must have an open break with no recorded end time.
+
+        Required inputs: the work session id (UUID) as the path parameter; there is no request body.
+
+        Emits a PEOPLE_WORK_SESSION_BREAK_STOP event.
+
+        Returns 409 when no open break exists for the session, including when the session id itself is unknown.
+
+        '
       operationId: stopWorkSessionBreak
       parameters:
       - name: id
@@ -310,8 +424,20 @@ paths:
     post:
       tags:
       - Work Sessions API
-      summary: Start work session break
-      description: Start a break within an active work session.
+      summary: Start A Break In Work Session
+      description: 'Starts a break inside an active work session, stamping the start time from the server clock.
+
+        Use this tool when a person pauses work; do not use stopWorkSession, which ends the whole session rather than pausing it.
+
+        Preconditions: the session must exist and still be open, and no break may already be open on it.
+
+        Required inputs: the work session id (UUID) as the path parameter; there is no request body.
+
+        Emits a PEOPLE_WORK_SESSION_BREAK_START event.
+
+        Returns 404 when no open session exists for the id, and 409 when a break is already open, including under concurrent break-start races.
+
+        '
       operationId: startWorkSessionBreak
       parameters:
       - name: id
@@ -343,14 +469,32 @@ paths:
     post:
       tags:
       - Work Sessions API
-      summary: Stop work session
-      description: Stop an active work session.
+      summary: Stop An Active Work Session
+      description: 'Stops a person''s open work session, setting status ENDED and closing any break still open at the same timestamp.
+
+        Use this tool when a person clocks out; do not use submitWorkSession, which sends an already ENDED session for approval.
+
+        Preconditions: the person must have an open session; sessions are keyed by person here, not by session id.
+
+        Required inputs: personId (UUID) in the body; the body''s actor field is ignored in favour of the authenticated username.
+
+        Emits a PEOPLE_WORK_SESSION_STOP event.
+
+        Returns 404 when no active session exists for the person.
+
+        '
       operationId: stopWorkSession
       requestBody:
+        description: Identifies the person clocking out; the open session is found by person id, not session id.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/WorkSessionRequest'
+            examples:
+              Clock out:
+                description: Clock out
+                value:
+                  personId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
         required: true
       responses:
         '200':
@@ -367,14 +511,32 @@ paths:
     post:
       tags:
       - Work Sessions API
-      summary: Start work session
-      description: Create/start a work session for a person.
+      summary: Start A Work Session For Person
+      description: 'Starts a new ACTIVE work session for a person, stamping the start time from the server clock and the actor from the security context.
+
+        Use this tool when a person clocks in for the day; do not use startWorkSessionBreak, which pauses an already running session.
+
+        Preconditions: the person must exist in the identity replica, and the person must have no session that is still open.
+
+        Required inputs: personId (UUID) in the body; the body''s actor field is ignored, because the recorded actor is always the authenticated username.
+
+        Emits a PEOPLE_WORK_SESSION_START event.
+
+        Returns 404 when the person is unknown, and 409 when an active session already exists for the person, including under concurrent start races.
+
+        '
       operationId: startWorkSession
       requestBody:
+        description: Identifies the person clocking in; the actor field is ignored in favour of the authenticated username.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/WorkSessionRequest'
+            examples:
+              Clock in:
+                description: Clock in
+                value:
+                  personId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
         required: true
       responses:
         '200':
@@ -391,9 +553,21 @@ paths:
     post:
       tags:
       - Timekeeping Approval API
-      summary: Reject all pending timekeeping entries for a person in a period
-      description: Bulk-rejects all PENDING_APPROVAL timekeeping entries for the given employee in the given period.
-      operationId: rejectPeriod
+      summary: Reject All Pending Entries In Period
+      description: 'Bulk-rejects every PENDING_APPROVAL timekeeping entry for a person within a pay period, storing the reason on each entry as its correctionReason.
+
+        Use this tool to send a whole period back for correction; do not use rejectTimeEntriesBatch, which rejects individually selected time entries.
+
+        Preconditions: the time period must exist; only entries currently in PENDING_APPROVAL are touched.
+
+        Required inputs: timePeriodId (UUID) and personId (UUID) path parameters and a body with a non-blank reason.
+
+        No events are emitted; entries are flipped to REJECTED in place and the response reports the processed count.
+
+        Returns 400 when reason is blank, and 404 when the time period does not exist.
+
+        '
+      operationId: rejectTimePeriod
       parameters:
       - name: timePeriodId
         in: path
@@ -408,10 +582,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Rejection justification applied as the correctionReason on every pending entry in the period.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RejectTimePeriodRequest'
+            examples:
+              Missing breaks:
+                description: Missing breaks
+                value:
+                  reason: Missing break entries for two shifts
         required: true
       responses:
         '200':
@@ -441,9 +621,21 @@ paths:
     post:
       tags:
       - Timekeeping Approval API
-      summary: Approve all pending timekeeping entries for a person in a period
-      description: Bulk-approves all PENDING_APPROVAL timekeeping entries for the given employee in the given period.
-      operationId: approvePeriod
+      summary: Approve All Pending Entries In Period
+      description: 'Bulk-approves every PENDING_APPROVAL timekeeping entry for a person within a pay period''s date range.
+
+        Use this tool for pay-period sign-off; do not use approveTimeEntriesBatch, which decides individually selected time entries instead of a whole period.
+
+        Preconditions: the time period must exist; only entries currently in PENDING_APPROVAL are touched, so already decided entries are left as they are.
+
+        Required inputs: timePeriodId (UUID) and personId (UUID) path parameters; there is no request body.
+
+        No events are emitted; entries are flipped to APPROVED in place and the response reports the processed count.
+
+        Returns 200 with processedCount 0 when nothing was pending, and 404 when the time period does not exist.
+
+        '
+      operationId: approveTimePeriod
       parameters:
       - name: timePeriodId
         in: path
@@ -479,9 +671,21 @@ paths:
     post:
       tags:
       - Time Entry Approval API
-      summary: Batch reject time entries
-      description: Reject multiple time entries. rejectionReason is required for each decision.
-      operationId: rejectTimeEntries
+      summary: Batch Reject Submitted Time Entries
+      description: 'Rejects a batch of time entries, marking each SUBMITTED or PENDING_APPROVAL entry REJECTED with the supplied reason stored on the entry.
+
+        Use this tool to send individually selected entries back with a reason; do not use approveTimeEntriesBatch, which approves them, and do not use rejectTimePeriod, which rejects a whole pay period per person.
+
+        Preconditions: each entry must exist and be in SUBMITTED or PENDING_APPROVAL status, and the caller needs the people:timeEntry:reject authority for individual entries to succeed.
+
+        Required inputs: decisions, a non-empty list where every element carries timeEntryId and a non-blank rejectionReason; one missing reason fails the entire request before any entry is touched.
+
+        Emits a PEOPLE_TIME_ENTRY_REJECT event and writes an audit row per decision.
+
+        Returns 200 with a per-entry result list (failure codes NOT_FOUND, ENTRY_NOT_PENDING, FORBIDDEN), and 400 when any decision lacks a rejectionReason.
+
+        '
+      operationId: rejectTimeEntriesBatch
       parameters:
       - name: X-Correlation-Id
         in: header
@@ -489,10 +693,18 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Batch of rejection decisions; every element must carry a non-blank rejectionReason.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/TimeEntryDecisionBatchRequest'
+            examples:
+              Reject one entry:
+                description: Reject one entry
+                value:
+                  decisions:
+                  - timeEntryId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                    rejectionReason: Incomplete work details
         required: true
       responses:
         '200':
@@ -516,9 +728,21 @@ paths:
     post:
       tags:
       - Time Entry Approval API
-      summary: Batch approve time entries
-      description: Approve multiple time entries. pos-people is authoritative for approval execution.
-      operationId: approveTimeEntries
+      summary: Batch Approve Submitted Time Entries
+      description: 'Approves a batch of time entries, marking each SUBMITTED or PENDING_APPROVAL entry APPROVED and stamping the approver and approval time; pos-people is authoritative for approval execution.
+
+        Use this tool for supervisor approval of individually selected time entries; do not use rejectTimeEntriesBatch, which rejects them, and do not use approveTimePeriod, which approves a whole pay period per person.
+
+        Preconditions: each entry must exist and be in SUBMITTED or PENDING_APPROVAL status, and the caller needs the people:timeEntry:approve authority for individual entries to succeed.
+
+        Required inputs: decisions, a non-empty list of objects each carrying timeEntryId (UUID string); an optional X-Correlation-Id header is recorded in the audit trail.
+
+        Emits a PEOPLE_TIME_ENTRY_APPROVE event and writes an audit row per decision.
+
+        Returns 200 with a per-entry result list (failure codes NOT_FOUND, ENTRY_NOT_PENDING, FORBIDDEN) rather than failing the whole batch, and 400 when the decisions list is missing or empty.
+
+        '
+      operationId: approveTimeEntriesBatch
       parameters:
       - name: X-Correlation-Id
         in: header
@@ -526,10 +750,18 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Batch of approval decisions, one element per time entry to approve; rejectionReason is ignored here.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/TimeEntryDecisionBatchRequest'
+            examples:
+              Approve two entries:
+                description: Approve two entries
+                value:
+                  decisions:
+                  - timeEntryId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  - timeEntryId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '200':
@@ -553,14 +785,35 @@ paths:
     post:
       tags:
       - People TimeEntries
-      summary: Create a time entry adjustment
-      description: Submit a request to adjust a time entry. The adjustment will be in PENDING status until approved.
-      operationId: createAdjustment
+      summary: Create A Pending Time Entry Adjustment
+      description: 'Creates a PENDING adjustment against a time entry, proposing either replacement start and end timestamps or a signed minutes delta.
+
+        Use this tool when a recorded time entry needs correction before approval; do not use approveTimeEntryAdjustment, which decides an already proposed adjustment.
+
+        Preconditions: the time entry must exist and be in PENDING_APPROVAL status; entries already approved or rejected cannot be adjusted.
+
+        Required inputs: timeEntryId (UUID), reasonCode, and exactly one of the pair proposedStartAt plus proposedEndAt (ISO-8601 offset timestamps) or minutesDelta (positive adds, negative subtracts); notes and createdBy are optional.
+
+        Emits a PEOPLE_TIME_ENTRY_ADJUSTMENT_CREATE event; the time entry itself is not modified until the adjustment is approved.
+
+        Returns 404 when the time entry does not exist, 409 when the entry is not in PENDING_APPROVAL status, and 400 when reasonCode is missing or the proposed-times versus minutesDelta rule is violated.
+
+        '
+      operationId: createTimeEntryAdjustment
       requestBody:
+        description: 'Proposed correction for one time entry: replacement start/end timestamps or a signed minutes delta, with a reason code.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/TimeEntryAdjustmentRequest'
+            examples:
+              Subtract a missed break:
+                description: Subtract a missed break
+                value:
+                  timeEntryId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  reasonCode: MISSED_BREAK
+                  notes: Employee forgot to log lunch break
+                  minutesDelta: -30
         required: true
       responses:
         '201':
@@ -596,9 +849,21 @@ paths:
     post:
       tags:
       - People TimeEntries
-      summary: Approve a time entry adjustment
-      description: Approve a pending time entry adjustment. Requires approval permissions.
-      operationId: approveAdjustment
+      summary: Approve A Pending Time Entry Adjustment
+      description: 'Approves a time entry adjustment, stamping the deciding user and decision time and writing an ADJUSTMENT_APPROVED audit row.
+
+        Use this tool to accept a proposed correction; do not use approveTimeEntriesBatch, which approves the time entries themselves rather than adjustments.
+
+        Preconditions: the adjustment must exist; no status gate is enforced, so re-approving an already decided adjustment overwrites the previous decision.
+
+        Required inputs: adjustmentId (UUID) path parameter; an optional X-Correlation-Id header is carried into the audit trail.
+
+        Emits a PEOPLE_TIME_ENTRY_ADJUSTMENT_APPROVE event; the underlying time entry''s own timestamps are not recalculated by this call.
+
+        Returns 404 when no adjustment exists for the supplied id.
+
+        '
+      operationId: approveTimeEntryAdjustment
       parameters:
       - name: adjustmentId
         in: path
@@ -639,9 +904,21 @@ paths:
     get:
       tags:
       - People - Staffing Assignments
-      summary: List assignments for person
-      description: Returns all staffing assignments for the specified person.
-      operationId: getAssignments
+      summary: List Staffing Assignments For A Person
+      description: 'Lists every staffing assignment for a person, including ENDED ones, across all locations and roles.
+
+        Use this tool for assignment history and administration; use listPersonLocations instead when only the assignments active today are wanted.
+
+        Preconditions: none beyond authentication; an unknown personId simply yields no rows.
+
+        Required inputs: personId (UUID) as a query parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty list when the person has no assignments.
+
+        '
+      operationId: listStaffingAssignments
       parameters:
       - name: personId
         in: query
@@ -666,14 +943,36 @@ paths:
     post:
       tags:
       - People - Staffing Assignments
-      summary: Create staffing assignment
-      description: Link a person to a location with role, effective dates, and primary flag.
-      operationId: createAssignment
+      summary: Create Person To Location Staffing Assignment
+      description: 'Creates a staffing assignment linking a person to a location with a role, effective dates, and a primary flag.
+
+        Use this tool when a person starts working at a location; do not use updateStaffingAssignment, which modifies an existing assignment by id.
+
+        Preconditions: the person must exist in the identity replica with an ACTIVE employee record, the location must be active, and no assignment for the same person, location, and role may overlap the effective dates.
+
+        Required inputs: personId (UUID), locationId (UUID), role, isPrimary, and effectiveFrom (yyyy-MM-dd); effectiveTo is optional and open-ended when null.
+
+        Emits a PEOPLE_STAFFING_ASSIGNMENT_CREATE event and publishes a staffing-assignment fact; a new primary demotes and ends any overlapping existing primary, and a person''s first active assignment is forced primary regardless of the flag.
+
+        Returns 409 when an overlapping assignment exists for the person, location, and role, 404 when the person, employee record, or active location cannot be resolved, and 400 when the person''s employee status is not ACTIVE.
+
+        '
+      operationId: createStaffingAssignment
       requestBody:
+        description: Staffing assignment to create, binding one person to one location for a role over an effective date range.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateStaffingAssignmentRequest'
+            examples:
+              Primary technician assignment:
+                description: Primary technician assignment
+                value:
+                  personId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  role: TECHNICIAN
+                  isPrimary: true
+                  effectiveFrom: 2026-02-16
         required: true
       responses:
         '201':
@@ -709,9 +1008,21 @@ paths:
     get:
       tags:
       - People - Exceptions
-      summary: List exceptions, optional filter by employeeId
-      description: Retrieve all exceptions or filter by a specific employee ID.
-      operationId: listByEmployee
+      summary: List Time Entry Exceptions By Employee
+      description: 'Lists time entry exceptions, either all of them or those recorded for one employee.
+
+        Use this tool to review open and historical exceptions; use createTimeEntryException instead to record a new one.
+
+        Preconditions: none; when employeeId is omitted every exception in the system is returned without pagination.
+
+        Required inputs: none; employeeId (string) is an optional filter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty list when nothing matches.
+
+        '
+      operationId: listTimeEntryExceptions
       parameters:
       - name: employeeId
         in: query
@@ -735,14 +1046,37 @@ paths:
     post:
       tags:
       - People - Exceptions
-      summary: Create a time entry exception
-      description: Create a new time entry exception record with validation of required fields.
-      operationId: createException
+      summary: Create A Time Entry Exception
+      description: 'Records a timekeeping exception in OPEN status for an employee, such as a missed clock-out.
+
+        Use this tool when a timekeeping anomaly is detected; do not use resolveTimeEntryException or waiveTimeEntryException, which close an existing exception.
+
+        Preconditions: none are checked against other records; employeeId and timeEntryId are stored as given without referential validation.
+
+        Required inputs: employeeId and exceptionCode; severity accepts WARNING or BLOCKING and silently falls back to WARNING on any other value, and detectedAt defaults to the current server time.
+
+        Emits a PEOPLE_TIME_ENTRY_EXCEPTION_CREATE event; the exception starts in OPEN status.
+
+        Returns 200 with the new exceptionId, and 400 when the JSON payload is malformed.
+
+        '
+      operationId: createTimeEntryException
       requestBody:
+        description: Timekeeping anomaly to record against an employee, optionally tied to a specific time entry.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/TimeEntryExceptionRequest'
+            examples:
+              Missed clock-out:
+                description: Missed clock-out
+                value:
+                  employeeId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  exceptionCode: MISSED_CLOCK_OUT
+                  severity: BLOCKING
+                  timeEntryId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  resolutionNotes: Employee forgot to clock out at end of shift
+                  detectedAt: 2026-02-17 08:30:00-05:00
         required: true
       responses:
         '200':
@@ -766,9 +1100,21 @@ paths:
     post:
       tags:
       - People - Exceptions
-      summary: Waive an exception
-      description: Waive an exception with a reason. waiveReason is required.
-      operationId: waiveException
+      summary: Waive A Time Entry Exception
+      description: 'Marks a time entry exception as WAIVED with a mandatory reason, closing it without a correction.
+
+        Use this tool to deliberately dismiss an exception; use resolveTimeEntryException instead when the underlying issue was actually fixed.
+
+        Preconditions: the exception must exist and must not already be RESOLVED or WAIVED, which are terminal states.
+
+        Required inputs: exceptionId (UUID) path parameter and a body with a non-blank waiveReason, which is stored as the exception''s resolution notes.
+
+        Emits a PEOPLE_TIME_ENTRY_EXCEPTION_WAIVE event and writes an EXCEPTION_WAIVED audit row.
+
+        Returns 404 when the exception does not exist, and 400 when waiveReason is blank or the exception is already RESOLVED or WAIVED.
+
+        '
+      operationId: waiveTimeEntryException
       parameters:
       - name: exceptionId
         in: path
@@ -782,10 +1128,16 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Waiver justification; the reason is mandatory and becomes the exception's resolution notes.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/TimeEntryExceptionWaiveRequest'
+            examples:
+              Waive for device outage:
+                description: Waive for device outage
+                value:
+                  waiveReason: Known device outage; entry validated manually
         required: true
       responses:
         '200':
@@ -815,9 +1167,21 @@ paths:
     post:
       tags:
       - People - Exceptions
-      summary: Resolve an exception
-      description: Mark an exception as resolved with optional resolution notes.
-      operationId: resolveException
+      summary: Resolve A Time Entry Exception
+      description: 'Marks a time entry exception as RESOLVED with optional resolution notes, stamping the acting user and timestamp.
+
+        Use this tool when the underlying issue has been fixed; use waiveTimeEntryException instead to close it without a fix, or acknowledgeTimeEntryException to flag it as merely seen.
+
+        Preconditions: the exception must exist and must not already be RESOLVED or WAIVED, which are terminal states.
+
+        Required inputs: exceptionId (UUID) path parameter; the body is optional and may carry resolutionNotes.
+
+        Emits a PEOPLE_TIME_ENTRY_EXCEPTION_RESOLVE event and writes an EXCEPTION_RESOLVED audit row.
+
+        Returns 404 when the exception does not exist, and 400 when it is already RESOLVED or WAIVED.
+
+        '
+      operationId: resolveTimeEntryException
       parameters:
       - name: exceptionId
         in: path
@@ -831,10 +1195,16 @@ paths:
         schema:
           type: string
       requestBody:
+        description: Optional resolution details; when present, resolutionNotes replaces the notes stored on the exception.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/TimeEntryExceptionResolveRequest'
+            examples:
+              Resolution with notes:
+                description: Resolution with notes
+                value:
+                  resolutionNotes: Corrected the clock-out time manually
       responses:
         '200':
           description: Exception resolved successfully
@@ -857,9 +1227,21 @@ paths:
     post:
       tags:
       - People - Exceptions
-      summary: Acknowledge an exception
-      description: Mark an exception as acknowledged.
-      operationId: acknowledgeException
+      summary: Acknowledge An Open Time Entry Exception
+      description: 'Marks an OPEN time entry exception as ACKNOWLEDGED, stamping the acting user and timestamp.
+
+        Use this tool to signal an exception has been seen but not yet fixed; use resolveTimeEntryException or waiveTimeEntryException instead to close it.
+
+        Preconditions: the exception must exist and must not already be RESOLVED or WAIVED, which are terminal states.
+
+        Required inputs: exceptionId (UUID) path parameter; there is no request body, and an optional X-Correlation-Id header is carried into the audit trail.
+
+        Emits a PEOPLE_TIME_ENTRY_EXCEPTION_ACKNOWLEDGE event and writes an EXCEPTION_ACKNOWLEDGED audit row.
+
+        Returns 404 when the exception does not exist, and 400 when it is already RESOLVED or WAIVED.
+
+        '
+      operationId: acknowledgeTimeEntryException
       parameters:
       - name: exceptionId
         in: path
@@ -894,14 +1276,41 @@ paths:
     post:
       tags:
       - Employee API
-      summary: Create employee profile
-      description: Creates a new employee profile with identity, employment, and role-related attributes.
+      summary: Create A New Employee Profile
+      description: 'Creates an employee profile: employment attributes (employee number, status, hire date) are stored in the people domain, while identity attributes (names, contact info) are forwarded to pos-people-contact as an upsert command with a server-generated UUIDv7 person id.
+
+        Use this tool when hiring or registering a brand-new employee; do not use updateEmployee, which modifies an existing profile, and do not use createEmployeesBulk, which imports many records in one call.
+
+        Preconditions: no existing employee may match the employee number, primary email, or phone when duplicatePolicy is STRICT (the default); identity duplicate checks run against an eventually consistent replica.
+
+        Required inputs: firstName, lastName, employeeNumber, status (ACTIVE, ON_LEAVE, SUSPENDED, TERMINATED, DISABLED) and hireDate (yyyy-MM-dd); duplicatePolicy defaults to STRICT, and BALANCED accepts suspected duplicates while returning warnings in the response.
+
+        Emits a PEOPLE_EMPLOYEE_CREATE event, publishes a people.employee.updated fact, and sends a person upsert command to pos-people-contact; the response echoes the submitted identity fields because the replica may lag.
+
+        Returns 409 when a duplicate employee number, email, or phone is detected under STRICT policy, and 422 when terminationDate is before hireDate.
+
+        '
       operationId: createEmployee
       requestBody:
+        description: 'Employee profile to create: identity fields forwarded to pos-people-contact plus local employment attributes.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateEmployeeRequest'
+            examples:
+              New technician:
+                description: New technician
+                value:
+                  firstName: Jane
+                  lastName: Smith
+                  preferredName: Jane
+                  employeeNumber: EMP-0001
+                  status: ACTIVE
+                  hireDate: 2026-01-15
+                  contactInfo:
+                    primaryEmail: jane.smith@example.com
+                    primaryPhone: +1-555-123-4567
+                  duplicatePolicy: STRICT
         required: true
       responses:
         '201':
@@ -937,8 +1346,20 @@ paths:
     post:
       tags:
       - Employee API
-      summary: Disable employee profile
-      description: Disables an employee profile and records optional disable metadata.
+      summary: Disable Employee And Offboard Assignments
+      description: 'Disables an ACTIVE employee, setting status DISABLED with a fresh statusEffectiveAt, and applies the requested staffing-assignment offboarding policy.
+
+        Use this tool for offboarding; do not use updateEmployee to force the status field, which skips offboarding, and do not use endStaffingAssignment, which ends a single assignment only.
+
+        Preconditions: the employee must exist and be in ACTIVE status; ON_LEAVE or SUSPENDED employees are rejected, as are already DISABLED or TERMINATED ones.
+
+        Required inputs: employeeId (UUID) path parameter; the body is optional, assignmentPolicy defaults to IMMEDIATE, and assignmentEndDate applies only with GRACE_PERIOD.
+
+        Emits a PEOPLE_EMPLOYEE_DISABLE event and publishes a people.employee.updated fact; when the downstream assignment action fails, a retry is queued with a five-minute delay instead of failing the request.
+
+        Returns 404 when the employee does not exist, and 400 when the employee is not currently ACTIVE.
+
+        '
       operationId: disableEmployee
       parameters:
       - name: employeeId
@@ -948,10 +1369,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Optional offboarding metadata controlling how the employee's staffing assignments are terminated; omitting it applies the IMMEDIATE policy.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/DisableEmployeeRequestDto'
+            examples:
+              Grace-period offboarding:
+                description: Grace-period offboarding
+                value:
+                  disableReason: Voluntary resignation
+                  assignmentPolicy: GRACE_PERIOD
+                  assignmentEndDate: 2026-03-31
       responses:
         '200':
           description: Employee disabled
@@ -980,14 +1409,45 @@ paths:
     post:
       tags:
       - People Bulk Ingest API
-      summary: Bulk ingest records
-      description: Accepts a batch of domain records for bulk import. Returns per-record results.
-      operationId: bulkIngest
+      summary: Bulk Import Employee Records From Batch
+      description: 'Imports a batch of employee records, creating each one through the same path as createEmployee with status forced to ACTIVE.
+
+        Use this tool for initial loads or migrations of many employees; use createEmployee instead for a single hire, since per-record failures here are reported in the response body rather than as an HTTP error.
+
+        Preconditions: each record is checked under the STRICT duplicate policy, so an existing employee number, email, or phone fails that record.
+
+        Required inputs: jobId (UUID), locationId (UUID), and records, each with firstName, lastName, employeeNumber, and hireDate as a YYYY-MM-DD string.
+
+        Emits a PEOPLE_BULK_INGEST event, and each successfully created employee also publishes its identity upsert command and people.employee.updated fact.
+
+        Returns 200 even when individual records fail (inspect per-record success flags and errorCode PEOPLE_INGEST_FAILED), and 400 when the envelope itself is invalid or the records list is empty.
+
+        '
+      operationId: createEmployeesBulk
       requestBody:
+        description: 'Bulk ingest envelope: a job-scoped batch of person records to import as ACTIVE employees.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BulkIngestRequestPersonBulkIngestRecord'
+            examples:
+              Two-person batch:
+                description: Two-person batch
+                value:
+                  jobId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  operatorId: user-jdoe
+                  records:
+                  - firstName: Jane
+                    lastName: Smith
+                    employeeNumber: EMP-0001
+                    hireDate: 2026-01-15
+                    primaryEmail: jane.smith@example.com
+                  - firstName: John
+                    lastName: Doe
+                    employeeNumber: EMP-0002
+                    hireDate: 2026-02-01
+                    primaryPhone: +1-555-123-4567
         required: true
       responses:
         '200':
@@ -1011,9 +1471,21 @@ paths:
     get:
       tags:
       - People - Staffing Assignments
-      summary: List assignments for person (path variant)
-      description: Returns all staffing assignments for the person given in the path. Same contract as GET /v1/people/staffing/assignments?personId={personId}.
-      operationId: getAssignmentsByPath
+      summary: List Staffing Assignments By Person Path
+      description: 'Lists every staffing assignment for the person given in the path, including ENDED ones; the data is identical to listStaffingAssignments.
+
+        Use this tool when a path-style URL is preferred; use listStaffingAssignments instead for the query-parameter form, which returns the same rows.
+
+        Preconditions: none beyond authentication; an unknown personId simply yields no rows.
+
+        Required inputs: personId (UUID) path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty list when the person has no assignments.
+
+        '
+      operationId: listStaffingAssignmentsByPath
       parameters:
       - name: personId
         in: path
@@ -1039,8 +1511,20 @@ paths:
     get:
       tags:
       - People Availability API
-      summary: Get a person's primary location
-      description: Resolve a person's primary active location from their staffing assignments. Returns 404 when the person has no active assignment flagged as primary.
+      summary: Get Person Primary Location Assignment
+      description: 'Resolves a person''s primary active location from their staffing assignments as of today.
+
+        Use this tool for service-to-service location resolution by person id; use getMyPrimaryLocation instead for the authenticated caller.
+
+        Preconditions: the person must have an ACTIVE staffing assignment flagged primary whose effective dates cover today.
+
+        Required inputs: personId (UUID) path parameter; there is no request body.
+
+        Emits a PEOPLE_PERSON_PRIMARY_LOCATION_GET audit event but changes no state; this is a read-only projection.
+
+        Returns 404 when the person has no active assignment flagged as primary today.
+
+        '
       operationId: getPersonPrimaryLocation
       parameters:
       - name: personId
@@ -1072,9 +1556,21 @@ paths:
     get:
       tags:
       - People Availability API
-      summary: Get a person's active location assignments
-      description: List a person's staffing assignments that are active today, primary first. Returns an empty list when the person has no current location.
-      operationId: getPersonLocations
+      summary: List Person Active Location Assignments
+      description: 'Lists a given person''s staffing assignments that are active today, primary first.
+
+        Use this tool when acting on another person by id; use listMyLocations instead for the authenticated caller, and listStaffingAssignments for full history including ended assignments.
+
+        Preconditions: none beyond authentication; an unknown personId is not rejected.
+
+        Required inputs: personId (UUID) path parameter; there is no request body.
+
+        Emits a PEOPLE_PERSON_LOCATIONS_LIST audit event but changes no state; this is a read-only projection.
+
+        Returns 200 with an empty list when the person has no assignment active today, including when the personId is unknown.
+
+        '
+      operationId: listPersonLocations
       parameters:
       - name: personId
         in: path
@@ -1101,8 +1597,20 @@ paths:
     get:
       tags:
       - Timekeeping Approval API
-      summary: List timekeeping entries for a person in a period
-      description: Returns all timekeeping entries for the given person within the given time period's date range.
+      summary: List Timekeeping Entries For Person And Period
+      description: 'Lists a person''s timekeeping entries whose sessions fall entirely within the given pay period''s date range, evaluated in UTC.
+
+        Use this tool to review entries before deciding a period; use getTimePeriodApproval instead for just the status counts.
+
+        Preconditions: the time period must exist; sessions straddling the period boundary are excluded because both start and end must fall inside it.
+
+        Required inputs: personId (UUID) and timePeriodId (UUID) query parameters; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the time period does not exist.
+
+        '
       operationId: listTimekeepingEntries
       parameters:
       - name: personId
@@ -1143,8 +1651,20 @@ paths:
     get:
       tags:
       - Timekeeping Approval API
-      summary: List time periods
-      description: Returns all pay periods, optionally scoped to a tenant.
+      summary: List Pay Periods For Timekeeping Approval
+      description: 'Lists pay periods with their start and end dates and status, newest first when scoped to a tenant.
+
+        Use this tool to choose the period for approval screens; use listTimekeepingEntries instead for the entries inside a chosen period.
+
+        Preconditions: none; tenantId is an optional scope and omitting it returns all periods in repository order.
+
+        Required inputs: none; tenantId (UUID) is an optional query parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty list when no pay periods exist.
+
+        '
       operationId: listTimePeriods
       parameters:
       - name: tenantId
@@ -1171,8 +1691,20 @@ paths:
     get:
       tags:
       - Timekeeping Approval API
-      summary: Get approval summary for a person in a period
-      description: Returns the approval status counts and overall status for the given person in the given period.
+      summary: Get Time Period Approval Summary
+      description: 'Summarises a person''s timekeeping approval state for a pay period: total, pending, approved, and rejected counts plus an overall status.
+
+        Use this tool for a status badge or gate; use listTimekeepingEntries instead when the individual entries are needed.
+
+        Preconditions: the time period must exist; the overall status is PENDING_APPROVAL while any entry is pending, else REJECTED if any entry was rejected, else APPROVED.
+
+        Required inputs: personId (UUID) and timePeriodId (UUID) query parameters; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the time period does not exist.
+
+        '
       operationId: getTimePeriodApproval
       parameters:
       - name: personId
@@ -1209,9 +1741,21 @@ paths:
     get:
       tags:
       - Timekeeping Approval API
-      summary: List employees with timekeeping entries
-      description: Returns distinct employees who have at least one timekeeping entry.
-      operationId: listApprovalPeople
+      summary: List Employees With Timekeeping Entries
+      description: 'Lists the distinct employees that have at least one timekeeping entry, with display name and employee number.
+
+        Use this tool to build the person picker for pay-period approval; use listTimekeepingEntries instead for one person''s entries in a period.
+
+        Preconditions: none; display names come from the person identity replica, which is eventually consistent.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty list when no timekeeping entries exist.
+
+        '
+      operationId: listTimekeepingApprovalPeople
       responses:
         '200':
           description: List of employees
@@ -1230,9 +1774,21 @@ paths:
     get:
       tags:
       - People TimeEntries
-      summary: List adjustments for a time entry
-      description: Retrieve all adjustments associated with a specific time entry.
-      operationId: listForTimeEntry
+      summary: List Adjustments For A Time Entry
+      description: 'Lists all adjustments recorded against one time entry, in any status.
+
+        Use this tool to review an entry''s correction history; use createTimeEntryAdjustment instead to propose a new correction.
+
+        Preconditions: none; an unknown timeEntryId simply yields no rows.
+
+        Required inputs: timeEntryId (UUID) path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty list when the time entry has no adjustments.
+
+        '
+      operationId: listTimeEntryAdjustments
       parameters:
       - name: timeEntryId
         in: path
@@ -1258,8 +1814,20 @@ paths:
     get:
       tags:
       - People Reports API
-      summary: Get attendance and job time discrepancy report
-      description: Generates a per-technician, per-location, per-day discrepancy report based on attendance and approved job time totals.
+      summary: Get Attendance Versus Job Time Discrepancy Report
+      description: 'Generates a per-technician, per-location, per-day report comparing attendance minutes from time entries with job minutes from the workorder job-time replica.
+
+        Use this tool to spot technicians whose clocked attendance diverges from booked job time; use listApprovedTimeForExport instead for the raw approved rows consumed by accounting export.
+
+        Preconditions: attendance comes from local time entries and job minutes from the ext_workorder_job_time replica, so very recent workorder activity may not be reflected yet.
+
+        Required inputs: startDate and endDate (inclusive, yyyy-MM-dd) and timezone (IANA, used to bucket minutes into local days); locationId and technicianIds are optional filters, and flaggedOnly defaults to false.
+
+        Emits a REPORT_ATTENDANCE_VS_JOBTIME_GENERATED audit event but changes no state; rows are flagged when the absolute discrepancy exceeds the location''s configured threshold minutes.
+
+        Returns 400 when endDate is before startDate or timezone is not a valid IANA zone.
+
+        '
       operationId: getAttendanceDiscrepancyReport
       parameters:
       - name: startDate
@@ -1365,9 +1933,21 @@ paths:
     get:
       tags:
       - People Reports API
-      summary: Get approved time entries for accounting export
-      description: Returns People-domain approved time rows for a date range and one or more locations. This endpoint is the stable source-data read contract for accounting export workflows.
-      operationId: getApprovedTimeForExport
+      summary: List Approved Time For Accounting Export
+      description: 'Returns APPROVED time-entry rows with worked hours, approval metadata, and resolved employee and location names for a date range and one or more locations.
+
+        Use this tool as the stable source-data read for accounting time-export workflows; use getAttendanceDiscrepancyReport instead for variance analysis between attendance and job time.
+
+        Preconditions: every supplied locationId must resolve to an active location; rows missing approval or attendance timestamps are silently excluded.
+
+        Required inputs: startDate and endDate (inclusive, yyyy-MM-dd, evaluated in UTC) and one or more locationId query parameters.
+
+        Emits a PEOPLE_TIME_APPROVED_EXPORT_READ audit event but changes no state; this is a read-only projection sorted by entry date then time entry id.
+
+        Returns 400 when endDate is before startDate, when no locationId is supplied, or when a locationId is unknown or inactive.
+
+        '
+      operationId: listApprovedTimeForExport
       parameters:
       - name: startDate
         in: query
@@ -1451,9 +2031,21 @@ paths:
     get:
       tags:
       - People Availability API
-      summary: Get current user's primary location
-      description: Resolve the authenticated user's primary active location from their staffing assignments. Returns 404 when the user has no active assignment flagged as primary.
-      operationId: getCurrentUserPrimaryLocation
+      summary: Get Current User Primary Location
+      description: 'Resolves the authenticated caller''s primary active location from their staffing assignments as of today.
+
+        Use this tool when a UI or service needs the current user''s home location; use listMyLocations instead to see every active assignment, and getPersonPrimaryLocation for a different person.
+
+        Preconditions: the caller must be linked to a person, and that person must have an ACTIVE assignment flagged primary whose effective dates cover today.
+
+        Required inputs: none; identity comes from the bearer token and there are no parameters.
+
+        Emits a PEOPLE_PRIMARY_LOCATION_GET audit event but changes no state; this is a read-only projection.
+
+        Returns 404 when the caller has no person link or no active assignment flagged as primary today.
+
+        '
+      operationId: getMyPrimaryLocation
       responses:
         '200':
           description: Primary location resolved successfully.
@@ -1476,9 +2068,21 @@ paths:
     get:
       tags:
       - People Availability API
-      summary: Get current user's active location assignments
-      description: List the authenticated user's staffing assignments that are active today, primary first. Returns an empty list when the user has no current location.
-      operationId: getCurrentUserLocations
+      summary: List Current User Active Location Assignments
+      description: 'Lists the authenticated caller''s staffing assignments that are active today, primary first.
+
+        Use this tool to populate a location switcher for the current user; use getMyPrimaryLocation instead when only the single primary location is needed.
+
+        Preconditions: the caller must be linked to a person in the user-link replica; the link data is event-fed and can lag the link authority.
+
+        Required inputs: none; identity comes from the bearer token and there are no parameters.
+
+        Emits a PEOPLE_ME_LOCATIONS_LIST audit event but changes no state; this is a read-only projection.
+
+        Returns 200 with an empty list when the person has no assignment active today, 404 when no person is linked to the current user, and 401 when the security context carries no username.
+
+        '
+      operationId: listMyLocations
       responses:
         '200':
           description: Active location assignments returned successfully.
@@ -1503,9 +2107,21 @@ paths:
     get:
       tags:
       - Employee API
-      summary: Resolve employee by employee number
-      description: Resolves an employee number to a slim identity projection (person id + employment status). Used for service-to-service approver resolution, such as manager-approval-by-employee-number.
-      operationId: resolveByNumber
+      summary: Resolve Employee By Employee Number
+      description: 'Resolves an employee number to a slim identity projection containing the person id, employee number, employment status, and an active flag.
+
+        Use this tool for service-to-service approver resolution such as manager-approval-by-employee-number; use getEmployee instead when the full profile with names and contact info is needed.
+
+        Preconditions: an employee record with the given employee number must exist; matching is case-insensitive.
+
+        Required inputs: employeeNumber (string) path parameter; there is no request body and no pagination.
+
+        No events are emitted and no state changes; this is a read-only lookup.
+
+        Returns 404 when no employee carries the supplied employee number.
+
+        '
+      operationId: getEmployeeByNumber
       parameters:
       - name: employeeNumber
         in: path
@@ -1534,9 +2150,21 @@ paths:
     get:
       tags:
       - People Compliance API
-      summary: List active users linked to inactive persons
-      description: 'Compliance check (ADR-0015 §4): returns every ACTIVE user-person link whose linked person is in an inactive employment status (SUSPENDED, TERMINATED, DISABLED). Each row is a user that should have been disabled when the person was disabled/archived. Returns an empty list when none. Link facts come from the people-contact replica, so results can trail the link authority by the event-propagation delay.'
-      operationId: findActiveUsersForInactivePersons
+      summary: List Active Users Linked To Inactive Persons
+      description: 'Reports every ACTIVE user-person link whose linked person is in an inactive employment status (SUSPENDED, TERMINATED, or DISABLED), per ADR-0015 section 4; each row is a user that should have been disabled during offboarding.
+
+        Use this tool for periodic identity-compliance audits; do not use disableEmployee here, which performs the offboarding itself rather than reporting on it.
+
+        Preconditions: none; link facts come from the people-contact replica, so results can trail the link authority by the event-propagation delay.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        Emits a REPORT_INACTIVE_PERSON_ACTIVE_USER_GENERATED audit event but changes no state; this is a read-only report.
+
+        Returns 200 with an empty list when no offending links exist.
+
+        '
+      operationId: listInactivePersonActiveUsers
       responses:
         '200':
           description: Offending links returned (possibly empty)
@@ -1571,9 +2199,21 @@ paths:
     get:
       tags:
       - People Availability API
-      summary: Get people availability
-      description: Return availability with optional locationId and date filters.
-      operationId: getPeopleAvailability
+      summary: List People Availability For A Location
+      description: 'Lists people with staffing assignments active on a given date, joined with identity fields from the person replica, one row per assignment.
+
+        Use this tool to see who is available to work at a location on a date; use getPersonPrimaryLocation instead to resolve a single person''s home location.
+
+        Preconditions: when locationId is omitted the caller must be linked to a person with an active assignment, because the requester''s own location becomes the filter.
+
+        Required inputs: none are mandatory; locationId (UUID) defaults to the requester''s location and date (yyyy-MM-dd) defaults to today.
+
+        Emits a PEOPLE_AVAILABILITY_LIST audit event but changes no state; this is a read-only projection.
+
+        Returns 404 when locationId is omitted and the requester has no active location assignment or no person link.
+
+        '
+      operationId: listPeopleAvailability
       parameters:
       - name: locationId
         in: query
@@ -1920,18 +2560,20 @@ components:
       - status
     WorkSessionSubmitRequest:
       type: object
-      description: Work session submit request body
+      description: Request to submit a completed work session for review
       properties:
         billableMinutes:
           type: integer
           format: int32
           description: Total billable minutes for the session
           example: 480
+          minimum: 0
         breakMinutes:
           type: integer
           format: int32
           description: Total break minutes for the session
           example: 30
+          minimum: 0
         submittedAt:
           type: string
           format: date-time
@@ -2012,7 +2654,7 @@ components:
       - startedAt
     WorkSessionRequest:
       type: object
-      description: Work session start request body
+      description: Request to start or act on a work session for a person
       properties:
         personId:
           type: string

--- a/pos-people/openapi.yaml
+++ b/pos-people/openapi.yaml
@@ -410,8 +410,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BreakDto'
-        '404':
-          description: Work session or break not found.
+        '409':
+          description: No open break exists for the session, including when the session id itself is unknown.
           content:
             application/json:
               schema:

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/EmployeeController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/EmployeeController.java
@@ -8,6 +8,8 @@ import com.positivity.people.internal.dto.EmployeeProfileDto;
 import com.positivity.people.internal.dto.UpdateEmployeeRequest;
 import com.positivity.people.service.EmployeeService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -35,9 +37,25 @@ public class EmployeeController {
 
     @PostMapping
     @EmitEvent(id = "PEOPLE_EMPLOYEE_CREATE", apiVersion = "1")
-    @Operation(
-            summary = "Create employee profile",
-            description = "Creates a new employee profile with identity, employment, and role-related attributes.")
+    @Operation(operationId = "createEmployee", summary = "Create A New Employee Profile", description = """
+                    Creates an employee profile: employment attributes (employee number, status, hire date) are stored \
+                    in the people domain, while identity attributes (names, contact info) are forwarded to \
+                    pos-people-contact as an upsert command with a server-generated UUIDv7 person id.
+                    Use this tool when hiring or registering a brand-new employee; do not use updateEmployee, which \
+                    modifies an existing profile, and do not use createEmployeesBulk, which imports many records in \
+                    one call.
+                    Preconditions: no existing employee may match the employee number, primary email, or phone when \
+                    duplicatePolicy is STRICT (the default); identity duplicate checks run against an eventually \
+                    consistent replica.
+                    Required inputs: firstName, lastName, employeeNumber, status (ACTIVE, ON_LEAVE, SUSPENDED, \
+                    TERMINATED, DISABLED) and hireDate (yyyy-MM-dd); duplicatePolicy defaults to STRICT, and BALANCED \
+                    accepts suspected duplicates while returning warnings in the response.
+                    Emits a PEOPLE_EMPLOYEE_CREATE event, publishes a people.employee.updated fact, and sends a person \
+                    upsert command to pos-people-contact; the response echoes the submitted identity fields because \
+                    the replica may lag.
+                    Returns 409 when a duplicate employee number, email, or phone is detected under STRICT policy, \
+                    and 422 when terminationDate is before hireDate.
+                    """)
     @ApiResponse(responseCode = "201", description = "Employee created")
     @ApiResponse(responseCode = "400", description = "Invalid request")
     @ApiResponse(responseCode = "409", description = "Duplicate employee")
@@ -47,15 +65,49 @@ public class EmployeeController {
             scopes = {"people:employee:create"})
     @PreAuthorize("hasAuthority('people:employee:create')")
     public ResponseEntity<EmployeeProfileDto> createEmployee(
-            @Valid @RequestBody @NonNull CreateEmployeeRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Employee profile to create: identity fields forwarded to pos-people-contact plus"
+                                            + " local employment attributes.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "New technician", value = """
+                                                                    {"firstName":"Jane","lastName":"Smith",
+                                                                     "preferredName":"Jane",
+                                                                     "employeeNumber":"EMP-0001",
+                                                                     "status":"ACTIVE","hireDate":"2026-01-15",
+                                                                     "contactInfo":{"primaryEmail":"jane.smith@example.com",
+                                                                       "primaryPhone":"+1-555-123-4567"},
+                                                                     "duplicatePolicy":"STRICT"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    CreateEmployeeRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(employeeService.createEmployee(request));
     }
 
     @PutMapping("/{employeeId}")
     @EmitEvent(id = "PEOPLE_EMPLOYEE_UPDATE", apiVersion = "1")
-    @Operation(
-            summary = "Update employee profile",
-            description = "Updates an existing employee profile using the provided employee ID.")
+    @Operation(operationId = "updateEmployee", summary = "Update An Existing Employee Profile", description = """
+                    Updates an existing employee profile by person id, replacing employment attributes locally and \
+                    forwarding identity attributes to pos-people-contact as an upsert command.
+                    Use this tool when correcting or changing an existing employee's details; do not use \
+                    createEmployee, which registers a new person, and do not use disableEmployee, which is the \
+                    offboarding transition.
+                    Preconditions: an employee row or identity-replica row must exist for the supplied employeeId, \
+                    which is the person id at this API surface.
+                    Required inputs: employeeId (UUID) path parameter plus the full profile (firstName, lastName, \
+                    employeeNumber, status, hireDate); this is a full replacement, not a patch, and duplicatePolicy \
+                    defaults to STRICT.
+                    Emits a PEOPLE_EMPLOYEE_UPDATE event and publishes a people.employee.updated fact; a status \
+                    change also stamps statusEffectiveAt.
+                    Returns 404 when no employee or person exists for the id, 409 when another employee already uses \
+                    the employee number, email, or phone under STRICT policy, and 422 when terminationDate is before \
+                    hireDate.
+                    """)
     @ApiResponse(responseCode = "200", description = "Employee updated")
     @ApiResponse(responseCode = "400", description = "Invalid request")
     @ApiResponse(responseCode = "404", description = "Employee not found")
@@ -66,13 +118,41 @@ public class EmployeeController {
             scopes = {"people:employee:edit"})
     @PreAuthorize("hasAuthority('people:employee:edit')")
     public ResponseEntity<EmployeeProfileDto> updateEmployee(
-            @PathVariable UUID employeeId, @Valid @RequestBody @NonNull UpdateEmployeeRequest request) {
+            @PathVariable UUID employeeId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement employee profile; identity fields are re-sent to"
+                                    + " pos-people-contact as an upsert command.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Status change to leave", value = """
+                                                                    {"firstName":"Jane","lastName":"Smith",
+                                                                     "employeeNumber":"EMP-0001",
+                                                                     "status":"ON_LEAVE","hireDate":"2026-01-15",
+                                                                     "duplicatePolicy":"BALANCED"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    UpdateEmployeeRequest request) {
         return ResponseEntity.ok(employeeService.updateEmployee(employeeId, request));
     }
 
     @GetMapping("/{employeeId}")
     @EmitEvent(id = "PEOPLE_EMPLOYEE_GET", apiVersion = "1")
-    @Operation(summary = "Get employee profile", description = "Retrieves an employee profile by employee ID.")
+    @Operation(operationId = "getEmployee", summary = "Get Employee Profile By Person Id", description = """
+                    Returns the full employee profile for a person id, merging identity fields from the \
+                    pos-people-contact replica with local employment fields.
+                    Use this tool when the person id is already known; use getEmployeeByNumber instead to resolve a \
+                    human-entered employee number.
+                    Preconditions: an employee row or identity-replica row must exist for the id; identity fields may \
+                    briefly be null right after creation while the replica catches up.
+                    Required inputs: employeeId (UUID) path parameter, which is the person id; there is no request \
+                    body.
+                    Emits a PEOPLE_EMPLOYEE_GET audit event but changes no state; this is a read-only projection.
+                    Returns 404 when neither an employee record nor a person replica row exists for the id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Employee found")
     @ApiResponse(responseCode = "404", description = "Employee not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -84,10 +164,19 @@ public class EmployeeController {
     }
 
     @GetMapping("/by-number/{employeeNumber}")
-    @Operation(
-            summary = "Resolve employee by employee number",
-            description = "Resolves an employee number to a slim identity projection (person id + employment status)."
-                    + " Used for service-to-service approver resolution, such as manager-approval-by-employee-number.")
+    @Operation(operationId = "getEmployeeByNumber", summary = "Resolve Employee By Employee Number", description = """
+                    Resolves an employee number to a slim identity projection containing the person id, employee \
+                    number, employment status, and an active flag.
+                    Use this tool for service-to-service approver resolution such as \
+                    manager-approval-by-employee-number; use getEmployee instead when the full profile with names and \
+                    contact info is needed.
+                    Preconditions: an employee record with the given employee number must exist; matching is \
+                    case-insensitive.
+                    Required inputs: employeeNumber (string) path parameter; there is no request body and no \
+                    pagination.
+                    No events are emitted and no state changes; this is a read-only lookup.
+                    Returns 404 when no employee carries the supplied employee number.
+                    """)
     @ApiResponse(responseCode = "200", description = "Employee resolved")
     @ApiResponse(responseCode = "404", description = "No employee with that number")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -104,8 +193,22 @@ public class EmployeeController {
     @PostMapping("/{employeeId}/disable")
     @EmitEvent(id = "PEOPLE_EMPLOYEE_DISABLE", apiVersion = "1")
     @Operation(
-            summary = "Disable employee profile",
-            description = "Disables an employee profile and records optional disable metadata.")
+            operationId = "disableEmployee",
+            summary = "Disable Employee And Offboard Assignments",
+            description = """
+                    Disables an ACTIVE employee, setting status DISABLED with a fresh statusEffectiveAt, and applies \
+                    the requested staffing-assignment offboarding policy.
+                    Use this tool for offboarding; do not use updateEmployee to force the status field, which skips \
+                    offboarding, and do not use endStaffingAssignment, which ends a single assignment only.
+                    Preconditions: the employee must exist and be in ACTIVE status; ON_LEAVE or SUSPENDED employees \
+                    are rejected, as are already DISABLED or TERMINATED ones.
+                    Required inputs: employeeId (UUID) path parameter; the body is optional, assignmentPolicy \
+                    defaults to IMMEDIATE, and assignmentEndDate applies only with GRACE_PERIOD.
+                    Emits a PEOPLE_EMPLOYEE_DISABLE event and publishes a people.employee.updated fact; when the \
+                    downstream assignment action fails, a retry is queued with a five-minute delay instead of \
+                    failing the request.
+                    Returns 404 when the employee does not exist, and 400 when the employee is not currently ACTIVE.
+                    """)
     @ApiResponse(responseCode = "200", description = "Employee disabled")
     @ApiResponse(responseCode = "400", description = "Employee cannot be disabled")
     @ApiResponse(responseCode = "404", description = "Employee not found")
@@ -114,7 +217,21 @@ public class EmployeeController {
             scopes = {"people:employee:deactivate"})
     @PreAuthorize("hasAuthority('people:employee:deactivate')")
     public ResponseEntity<EmployeeProfileDto> disableEmployee(
-            @PathVariable UUID employeeId, @RequestBody(required = false) DisableEmployeeRequestDto request) {
+            @PathVariable UUID employeeId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Optional offboarding metadata controlling how the employee's staffing"
+                                    + " assignments are terminated; omitting it applies the IMMEDIATE policy.",
+                            required = false,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Grace-period offboarding", value = """
+                                                                    {"disableReason":"Voluntary resignation",
+                                                                     "assignmentPolicy":"GRACE_PERIOD",
+                                                                     "assignmentEndDate":"2026-03-31"}
+                                                                    """)))
+                    @RequestBody(required = false)
+                    DisableEmployeeRequestDto request) {
         DisableEmployeeRequestDto resolved = request != null ? request : new DisableEmployeeRequestDto();
         return ResponseEntity.ok(employeeService.disableEmployee(employeeId, resolved));
     }

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/PeopleAvailabilityController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/PeopleAvailabilityController.java
@@ -42,8 +42,22 @@ public class PeopleAvailabilityController {
     private final UserPersonTranslationService userPersonTranslationService;
 
     @Operation(
-            summary = "Get people availability",
-            description = "Return availability with optional locationId and date filters.")
+            operationId = "listPeopleAvailability",
+            summary = "List People Availability For A Location",
+            description = """
+                    Lists people with staffing assignments active on a given date, joined with identity fields from \
+                    the person replica, one row per assignment.
+                    Use this tool to see who is available to work at a location on a date; use \
+                    getPersonPrimaryLocation instead to resolve a single person's home location.
+                    Preconditions: when locationId is omitted the caller must be linked to a person with an active \
+                    assignment, because the requester's own location becomes the filter.
+                    Required inputs: none are mandatory; locationId (UUID) defaults to the requester's location and \
+                    date (yyyy-MM-dd) defaults to today.
+                    Emits a PEOPLE_AVAILABILITY_LIST audit event but changes no state; this is a read-only \
+                    projection.
+                    Returns 404 when locationId is omitted and the requester has no active location assignment or no \
+                    person link.
+                    """)
     @ApiResponse(responseCode = "200", description = "Availability data returned successfully.")
     @GetMapping("/availability")
     @EmitEvent(id = "PEOPLE_AVAILABILITY_LIST", apiVersion = "1")
@@ -63,10 +77,18 @@ public class PeopleAvailabilityController {
         return ResponseEntity.ok(peopleAvailabilityService.getPeopleAvailability(locationId, date));
     }
 
-    @Operation(
-            summary = "Get current user's primary location",
-            description = "Resolve the authenticated user's primary active location from their staffing assignments. "
-                    + "Returns 404 when the user has no active assignment flagged as primary.")
+    @Operation(operationId = "getMyPrimaryLocation", summary = "Get Current User Primary Location", description = """
+                    Resolves the authenticated caller's primary active location from their staffing assignments as \
+                    of today.
+                    Use this tool when a UI or service needs the current user's home location; use listMyLocations \
+                    instead to see every active assignment, and getPersonPrimaryLocation for a different person.
+                    Preconditions: the caller must be linked to a person, and that person must have an ACTIVE \
+                    assignment flagged primary whose effective dates cover today.
+                    Required inputs: none; identity comes from the bearer token and there are no parameters.
+                    Emits a PEOPLE_PRIMARY_LOCATION_GET audit event but changes no state; this is a read-only \
+                    projection.
+                    Returns 404 when the caller has no person link or no active assignment flagged as primary today.
+                    """)
     @ApiResponse(responseCode = "200", description = "Primary location resolved successfully.")
     @ApiResponse(
             responseCode = "404",
@@ -89,9 +111,20 @@ public class PeopleAvailabilityController {
     }
 
     @Operation(
-            summary = "Get current user's active location assignments",
-            description = "List the authenticated user's staffing assignments that are active today, primary first."
-                    + " Returns an empty list when the user has no current location.")
+            operationId = "listMyLocations",
+            summary = "List Current User Active Location Assignments",
+            description = """
+                    Lists the authenticated caller's staffing assignments that are active today, primary first.
+                    Use this tool to populate a location switcher for the current user; use getMyPrimaryLocation \
+                    instead when only the single primary location is needed.
+                    Preconditions: the caller must be linked to a person in the user-link replica; the link data is \
+                    event-fed and can lag the link authority.
+                    Required inputs: none; identity comes from the bearer token and there are no parameters.
+                    Emits a PEOPLE_ME_LOCATIONS_LIST audit event but changes no state; this is a read-only \
+                    projection.
+                    Returns 200 with an empty list when the person has no assignment active today, 404 when no \
+                    person is linked to the current user, and 401 when the security context carries no username.
+                    """)
     @ApiResponse(responseCode = "200", description = "Active location assignments returned successfully.")
     @ApiResponse(
             responseCode = "404",
@@ -112,9 +145,19 @@ public class PeopleAvailabilityController {
     }
 
     @Operation(
-            summary = "Get a person's active location assignments",
-            description = "List a person's staffing assignments that are active today, primary first. Returns an"
-                    + " empty list when the person has no current location.")
+            operationId = "listPersonLocations",
+            summary = "List Person Active Location Assignments",
+            description = """
+                    Lists a given person's staffing assignments that are active today, primary first.
+                    Use this tool when acting on another person by id; use listMyLocations instead for the \
+                    authenticated caller, and listStaffingAssignments for full history including ended assignments.
+                    Preconditions: none beyond authentication; an unknown personId is not rejected.
+                    Required inputs: personId (UUID) path parameter; there is no request body.
+                    Emits a PEOPLE_PERSON_LOCATIONS_LIST audit event but changes no state; this is a read-only \
+                    projection.
+                    Returns 200 with an empty list when the person has no assignment active today, including when \
+                    the personId is unknown.
+                    """)
     @ApiResponse(responseCode = "200", description = "Active location assignments returned successfully.")
     @GetMapping("/{personId}/locations")
     @EmitEvent(id = "PEOPLE_PERSON_LOCATIONS_LIST", apiVersion = "1")
@@ -128,9 +171,19 @@ public class PeopleAvailabilityController {
     }
 
     @Operation(
-            summary = "Get a person's primary location",
-            description = "Resolve a person's primary active location from their staffing assignments. Returns 404"
-                    + " when the person has no active assignment flagged as primary.")
+            operationId = "getPersonPrimaryLocation",
+            summary = "Get Person Primary Location Assignment",
+            description = """
+                    Resolves a person's primary active location from their staffing assignments as of today.
+                    Use this tool for service-to-service location resolution by person id; use getMyPrimaryLocation \
+                    instead for the authenticated caller.
+                    Preconditions: the person must have an ACTIVE staffing assignment flagged primary whose effective \
+                    dates cover today.
+                    Required inputs: personId (UUID) path parameter; there is no request body.
+                    Emits a PEOPLE_PERSON_PRIMARY_LOCATION_GET audit event but changes no state; this is a read-only \
+                    projection.
+                    Returns 404 when the person has no active assignment flagged as primary today.
+                    """)
     @ApiResponse(responseCode = "200", description = "Primary location resolved successfully.")
     @ApiResponse(
             responseCode = "404",

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/PeopleComplianceController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/PeopleComplianceController.java
@@ -26,12 +26,21 @@ public class PeopleComplianceController {
     private final PeopleComplianceService complianceService;
 
     @Operation(
-            summary = "List active users linked to inactive persons",
-            description = "Compliance check (ADR-0015 §4): returns every ACTIVE user-person link whose linked person"
-                    + " is in an inactive employment status (SUSPENDED, TERMINATED, DISABLED). Each row is a user"
-                    + " that should have been disabled when the person was disabled/archived. Returns an empty list"
-                    + " when none. Link facts come from the people-contact replica, so results can trail the link"
-                    + " authority by the event-propagation delay.")
+            operationId = "listInactivePersonActiveUsers",
+            summary = "List Active Users Linked To Inactive Persons",
+            description = """
+                    Reports every ACTIVE user-person link whose linked person is in an inactive employment status \
+                    (SUSPENDED, TERMINATED, or DISABLED), per ADR-0015 section 4; each row is a user that should \
+                    have been disabled during offboarding.
+                    Use this tool for periodic identity-compliance audits; do not use disableEmployee here, which \
+                    performs the offboarding itself rather than reporting on it.
+                    Preconditions: none; link facts come from the people-contact replica, so results can trail the \
+                    link authority by the event-propagation delay.
+                    Required inputs: none; there are no parameters and no request body.
+                    Emits a REPORT_INACTIVE_PERSON_ACTIVE_USER_GENERATED audit event but changes no state; this is a \
+                    read-only report.
+                    Returns 200 with an empty list when no offending links exist.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Offending links returned (possibly empty)",

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/PeopleReportsController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/PeopleReportsController.java
@@ -30,9 +30,22 @@ public class PeopleReportsController {
     private final PeopleReportsService peopleReportsService;
 
     @Operation(
-            summary = "Get attendance and job time discrepancy report",
-            description =
-                    "Generates a per-technician, per-location, per-day discrepancy report based on attendance and approved job time totals.")
+            operationId = "getAttendanceDiscrepancyReport",
+            summary = "Get Attendance Versus Job Time Discrepancy Report",
+            description = """
+                    Generates a per-technician, per-location, per-day report comparing attendance minutes from time \
+                    entries with job minutes from the workorder job-time replica.
+                    Use this tool to spot technicians whose clocked attendance diverges from booked job time; use \
+                    listApprovedTimeForExport instead for the raw approved rows consumed by accounting export.
+                    Preconditions: attendance comes from local time entries and job minutes from the \
+                    ext_workorder_job_time replica, so very recent workorder activity may not be reflected yet.
+                    Required inputs: startDate and endDate (inclusive, yyyy-MM-dd) and timezone (IANA, used to bucket \
+                    minutes into local days); locationId and technicianIds are optional filters, and flaggedOnly \
+                    defaults to false.
+                    Emits a REPORT_ATTENDANCE_VS_JOBTIME_GENERATED audit event but changes no state; rows are \
+                    flagged when the absolute discrepancy exceeds the location's configured threshold minutes.
+                    Returns 400 when endDate is before startDate or timezone is not a valid IANA zone.
+                    """)
     @ApiResponse(responseCode = "200", description = "Report generated successfully.")
     @ApiResponse(responseCode = "400", description = "Invalid parameters")
     @ApiResponse(responseCode = "403", description = "Forbidden")
@@ -65,9 +78,22 @@ public class PeopleReportsController {
     }
 
     @Operation(
-            summary = "Get approved time entries for accounting export",
-            description = "Returns People-domain approved time rows for a date range and one or more locations. "
-                    + "This endpoint is the stable source-data read contract for accounting export workflows.")
+            operationId = "listApprovedTimeForExport",
+            summary = "List Approved Time For Accounting Export",
+            description = """
+                    Returns APPROVED time-entry rows with worked hours, approval metadata, and resolved employee and \
+                    location names for a date range and one or more locations.
+                    Use this tool as the stable source-data read for accounting time-export workflows; use \
+                    getAttendanceDiscrepancyReport instead for variance analysis between attendance and job time.
+                    Preconditions: every supplied locationId must resolve to an active location; rows missing \
+                    approval or attendance timestamps are silently excluded.
+                    Required inputs: startDate and endDate (inclusive, yyyy-MM-dd, evaluated in UTC) and one or more \
+                    locationId query parameters.
+                    Emits a PEOPLE_TIME_APPROVED_EXPORT_READ audit event but changes no state; this is a read-only \
+                    projection sorted by entry date then time entry id.
+                    Returns 400 when endDate is before startDate, when no locationId is supplied, or when a \
+                    locationId is unknown or inactive.
+                    """)
     @ApiResponse(responseCode = "200", description = "Approved time rows retrieved successfully")
     @ApiResponse(responseCode = "400", description = "Invalid parameters")
     @ApiResponse(responseCode = "403", description = "Forbidden")

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/PersonBulkIngestController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/PersonBulkIngestController.java
@@ -10,6 +10,9 @@ import com.positivity.people.internal.dto.EmployeeContactInfoDto;
 import com.positivity.people.internal.dto.PersonBulkIngestRecord;
 import com.positivity.people.internal.enums.EmployeeStatus;
 import com.positivity.people.service.EmployeeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
@@ -44,8 +47,48 @@ public class PersonBulkIngestController extends AbstractBulkIngestController<Per
     @PostMapping("/bulk-ingest")
     @PreAuthorize("hasAuthority('people:employee:create')")
     @EmitEvent(id = "PEOPLE_BULK_INGEST", apiVersion = "1")
+    @Operation(
+            operationId = "createEmployeesBulk",
+            summary = "Bulk Import Employee Records From Batch",
+            description = """
+                    Imports a batch of employee records, creating each one through the same path as createEmployee \
+                    with status forced to ACTIVE.
+                    Use this tool for initial loads or migrations of many employees; use createEmployee instead for \
+                    a single hire, since per-record failures here are reported in the response body rather than as \
+                    an HTTP error.
+                    Preconditions: each record is checked under the STRICT duplicate policy, so an existing employee \
+                    number, email, or phone fails that record.
+                    Required inputs: jobId (UUID), locationId (UUID), and records, each with firstName, lastName, \
+                    employeeNumber, and hireDate as a YYYY-MM-DD string.
+                    Emits a PEOPLE_BULK_INGEST event, and each successfully created employee also publishes its \
+                    identity upsert command and people.employee.updated fact.
+                    Returns 200 even when individual records fail (inspect per-record success flags and errorCode \
+                    PEOPLE_INGEST_FAILED), and 400 when the envelope itself is invalid or the records list is empty.
+                    """)
     public ResponseEntity<BulkIngestResponse> bulkIngest(
-            @Valid @RequestBody @NonNull BulkIngestRequest<PersonBulkIngestRecord> request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Bulk ingest envelope: a job-scoped batch of person records to import as"
+                                    + " ACTIVE employees.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Two-person batch", value = """
+                                                                    {"jobId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "operatorId":"user-jdoe",
+                                                                     "records":[
+                                                                       {"firstName":"Jane","lastName":"Smith",
+                                                                        "employeeNumber":"EMP-0001","hireDate":"2026-01-15",
+                                                                        "primaryEmail":"jane.smith@example.com"},
+                                                                       {"firstName":"John","lastName":"Doe",
+                                                                        "employeeNumber":"EMP-0002","hireDate":"2026-02-01",
+                                                                        "primaryPhone":"+1-555-123-4567"}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BulkIngestRequest<PersonBulkIngestRecord> request) {
         return super.bulkIngest(request);
     }
 

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/StaffingAssignmentController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/StaffingAssignmentController.java
@@ -6,6 +6,8 @@ import com.positivity.people.internal.dto.StaffingAssignmentResponse;
 import com.positivity.people.internal.dto.UpdateStaffingAssignmentRequest;
 import com.positivity.people.service.StaffingAssignmentService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -40,8 +42,25 @@ public class StaffingAssignmentController {
     private final StaffingAssignmentService staffingAssignmentService;
 
     @Operation(
-            summary = "Create staffing assignment",
-            description = "Link a person to a location with role, effective dates, and primary flag.")
+            operationId = "createStaffingAssignment",
+            summary = "Create Person To Location Staffing Assignment",
+            description = """
+                    Creates a staffing assignment linking a person to a location with a role, effective dates, and a \
+                    primary flag.
+                    Use this tool when a person starts working at a location; do not use updateStaffingAssignment, \
+                    which modifies an existing assignment by id.
+                    Preconditions: the person must exist in the identity replica with an ACTIVE employee record, the \
+                    location must be active, and no assignment for the same person, location, and role may overlap \
+                    the effective dates.
+                    Required inputs: personId (UUID), locationId (UUID), role, isPrimary, and effectiveFrom \
+                    (yyyy-MM-dd); effectiveTo is optional and open-ended when null.
+                    Emits a PEOPLE_STAFFING_ASSIGNMENT_CREATE event and publishes a staffing-assignment fact; a new \
+                    primary demotes and ends any overlapping existing primary, and a person's first active \
+                    assignment is forced primary regardless of the flag.
+                    Returns 409 when an overlapping assignment exists for the person, location, and role, 404 when \
+                    the person, employee record, or active location cannot be resolved, and 400 when the person's \
+                    employee status is not ACTIVE.
+                    """)
     @ApiResponse(responseCode = "201", description = "Assignment created.")
     @ApiResponse(responseCode = "400", description = "Validation error.")
     @ApiResponse(responseCode = "404", description = "Location or person not found.")
@@ -53,7 +72,26 @@ public class StaffingAssignmentController {
             scopes = {"people:employee:edit"})
     @PreAuthorize("hasAuthority('people:employee:edit')")
     public ResponseEntity<StaffingAssignmentResponse> createAssignment(
-            @Valid @RequestBody @NonNull CreateStaffingAssignmentRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Staffing assignment to create, binding one person to one location for a"
+                                    + " role over an effective date range.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Primary technician assignment",
+                                                            value = """
+                                                                    {"personId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "role":"TECHNICIAN","isPrimary":true,
+                                                                     "effectiveFrom":"2026-02-16"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    CreateStaffingAssignmentRequest request,
             @AuthenticationPrincipal String actor) {
         StaffingAssignmentResponse response =
                 staffingAssignmentService.create(request, actor != null ? actor : "system");
@@ -61,8 +99,18 @@ public class StaffingAssignmentController {
     }
 
     @Operation(
-            summary = "List assignments for person",
-            description = "Returns all staffing assignments for the specified person.")
+            operationId = "listStaffingAssignments",
+            summary = "List Staffing Assignments For A Person",
+            description = """
+                    Lists every staffing assignment for a person, including ENDED ones, across all locations and \
+                    roles.
+                    Use this tool for assignment history and administration; use listPersonLocations instead when \
+                    only the assignments active today are wanted.
+                    Preconditions: none beyond authentication; an unknown personId simply yields no rows.
+                    Required inputs: personId (UUID) as a query parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty list when the person has no assignments.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of assignments.")
     @GetMapping(ASSIGNMENTS)
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -74,9 +122,18 @@ public class StaffingAssignmentController {
     }
 
     @Operation(
-            summary = "List assignments for person (path variant)",
-            description = "Returns all staffing assignments for the person given in the path. Same contract as"
-                    + " GET /v1/people/staffing/assignments?personId={personId}.")
+            operationId = "listStaffingAssignmentsByPath",
+            summary = "List Staffing Assignments By Person Path",
+            description = """
+                    Lists every staffing assignment for the person given in the path, including ENDED ones; the data \
+                    is identical to listStaffingAssignments.
+                    Use this tool when a path-style URL is preferred; use listStaffingAssignments instead for the \
+                    query-parameter form, which returns the same rows.
+                    Preconditions: none beyond authentication; an unknown personId simply yields no rows.
+                    Required inputs: personId (UUID) path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty list when the person has no assignments.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of assignments.")
     @GetMapping("/{personId}/staffing/assignments")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -87,9 +144,15 @@ public class StaffingAssignmentController {
         return staffingAssignmentService.findByPersonId(personId);
     }
 
-    @Operation(
-            summary = "Get assignment by ID",
-            description = "Retrieves a single staffing assignment by its unique ID.")
+    @Operation(operationId = "getStaffingAssignment", summary = "Get Staffing Assignment By Id", description = """
+                    Returns a single staffing assignment by its unique assignment id.
+                    Use this tool when the assignment id is already known; use listStaffingAssignments instead to \
+                    discover a person's assignments.
+                    Preconditions: the assignment must exist; both ACTIVE and ENDED assignments are returned.
+                    Required inputs: assignmentId (UUID) path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no assignment exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Assignment found.")
     @ApiResponse(responseCode = "404", description = "Assignment not found.")
     @GetMapping(ASSIGNMENTS + "/{assignmentId}")
@@ -105,8 +168,23 @@ public class StaffingAssignmentController {
     }
 
     @Operation(
-            summary = "Update staffing assignment",
-            description = "Updates an existing staffing assignment, including role, dates, and primary flag.")
+            operationId = "updateStaffingAssignment",
+            summary = "Update An Existing Staffing Assignment",
+            description = """
+                    Replaces a staffing assignment's person, location, role, primary flag, and effective dates.
+                    Use this tool to correct or reshape an existing assignment; do not use endStaffingAssignment, \
+                    which only closes an assignment, and do not use createStaffingAssignment for a new one.
+                    Preconditions: the assignment must exist, the person must exist with an ACTIVE employee record, \
+                    the location must be active, and no other assignment for the same person, location, and role may \
+                    overlap the effective dates.
+                    Required inputs: assignmentId (UUID) path parameter plus the full body (personId, locationId, \
+                    role, isPrimary, effectiveFrom); this is a full replacement, not a patch.
+                    Emits a PEOPLE_STAFFING_ASSIGNMENT_UPDATE event and publishes a staffing-assignment fact; \
+                    setting isPrimary true demotes and ends any other overlapping primary assignment.
+                    Returns 404 when the assignment, person, employee record, or active location cannot be resolved, \
+                    409 when another assignment overlaps for the person, location, and role, and 400 when the \
+                    person's employee status is not ACTIVE.
+                    """)
     @ApiResponse(responseCode = "200", description = "Assignment updated.")
     @ApiResponse(responseCode = "400", description = "Validation error.")
     @ApiResponse(responseCode = "404", description = "Assignment not found.")
@@ -119,7 +197,25 @@ public class StaffingAssignmentController {
     @PreAuthorize("hasAuthority('people:employee:edit')")
     public ResponseEntity<StaffingAssignmentResponse> updateAssignment(
             @PathVariable @NonNull UUID assignmentId,
-            @Valid @RequestBody @NonNull UpdateStaffingAssignmentRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement values for the assignment's person, location, role,"
+                                    + " primary flag, and effective dates.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "Extend assignment end date", value = """
+                                                                    {"personId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "role":"TECHNICIAN","isPrimary":true,
+                                                                     "effectiveFrom":"2026-02-16",
+                                                                     "effectiveTo":"2026-12-31"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    UpdateStaffingAssignmentRequest request,
             @AuthenticationPrincipal String actor) {
         return staffingAssignmentService
                 .update(assignmentId, request, actor != null ? actor : "system")
@@ -127,9 +223,17 @@ public class StaffingAssignmentController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @Operation(
-            summary = "End (soft-delete) an assignment",
-            description = "Ends an active staffing assignment without physically deleting the record.")
+    @Operation(operationId = "endStaffingAssignment", summary = "End An Active Staffing Assignment", description = """
+                    Ends a staffing assignment by setting its status to ENDED without physically deleting the row.
+                    Use this tool when a person stops working at a location; do not use disableEmployee, which \
+                    offboards the whole employee, and do not use updateStaffingAssignment to shorten dates manually.
+                    Preconditions: the assignment must exist; ending an already ENDED assignment is accepted and \
+                    republishes the fact.
+                    Required inputs: assignmentId (UUID) path parameter; there is no request body.
+                    Emits a PEOPLE_STAFFING_ASSIGNMENT_END event and publishes a staffing-assignment fact; a null \
+                    effectiveTo is stamped with today's date.
+                    Returns 204 on success, and 404 when no assignment exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "204", description = "Assignment ended.")
     @ApiResponse(responseCode = "404", description = "Assignment not found.")
     @EmitEvent(id = "PEOPLE_STAFFING_ASSIGNMENT_END", apiVersion = "1")

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/TimeEntryAdjustmentController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/TimeEntryAdjustmentController.java
@@ -7,6 +7,8 @@ import com.positivity.people.internal.dto.TimeEntryAdjustmentResponse;
 import com.positivity.people.service.TimeEntryAdjustmentService;
 import com.positivity.security.common.SecurityContextHelper;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -33,9 +35,24 @@ public class TimeEntryAdjustmentController {
     private final TimeEntryAdjustmentService adjustmentService;
 
     @Operation(
-            summary = "Create a time entry adjustment",
-            description =
-                    "Submit a request to adjust a time entry. The adjustment will be in PENDING status until approved.")
+            operationId = "createTimeEntryAdjustment",
+            summary = "Create A Pending Time Entry Adjustment",
+            description = """
+                    Creates a PENDING adjustment against a time entry, proposing either replacement start and end \
+                    timestamps or a signed minutes delta.
+                    Use this tool when a recorded time entry needs correction before approval; do not use \
+                    approveTimeEntryAdjustment, which decides an already proposed adjustment.
+                    Preconditions: the time entry must exist and be in PENDING_APPROVAL status; entries already \
+                    approved or rejected cannot be adjusted.
+                    Required inputs: timeEntryId (UUID), reasonCode, and exactly one of the pair proposedStartAt \
+                    plus proposedEndAt (ISO-8601 offset timestamps) or minutesDelta (positive adds, negative \
+                    subtracts); notes and createdBy are optional.
+                    Emits a PEOPLE_TIME_ENTRY_ADJUSTMENT_CREATE event; the time entry itself is not modified until \
+                    the adjustment is approved.
+                    Returns 404 when the time entry does not exist, 409 when the entry is not in PENDING_APPROVAL \
+                    status, and 400 when reasonCode is missing or the proposed-times versus minutesDelta rule is \
+                    violated.
+                    """)
     @ApiResponse(responseCode = "201", description = "Adjustment created")
     @ApiResponse(responseCode = "400", description = "Invalid request")
     @ApiResponse(responseCode = "404", description = "Time entry not found")
@@ -47,14 +64,38 @@ public class TimeEntryAdjustmentController {
             scopes = {"people:timeAdjustment:create"})
     @PreAuthorize("hasAuthority('people:timeAdjustment:create')")
     public ResponseEntity<TimeEntryAdjustmentResponse> createAdjustment(
-            @Valid @RequestBody TimeEntryAdjustmentRequest req) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Proposed correction for one time entry: replacement start/end timestamps"
+                                    + " or a signed minutes delta, with a reason code.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Subtract a missed break", value = """
+                                                                    {"timeEntryId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "reasonCode":"MISSED_BREAK",
+                                                                     "notes":"Employee forgot to log lunch break",
+                                                                     "minutesDelta":-30}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    TimeEntryAdjustmentRequest req) {
         TimeEntryAdjustmentResponse resp = adjustmentService.createAdjustment(req);
         return ResponseEntity.status(HttpStatus.CREATED).body(resp);
     }
 
     @Operation(
-            summary = "List adjustments for a time entry",
-            description = "Retrieve all adjustments associated with a specific time entry.")
+            operationId = "listTimeEntryAdjustments",
+            summary = "List Adjustments For A Time Entry",
+            description = """
+                    Lists all adjustments recorded against one time entry, in any status.
+                    Use this tool to review an entry's correction history; use createTimeEntryAdjustment instead to \
+                    propose a new correction.
+                    Preconditions: none; an unknown timeEntryId simply yields no rows.
+                    Required inputs: timeEntryId (UUID) path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty list when the time entry has no adjustments.
+                    """)
     @ApiResponse(responseCode = "200", description = "List returned")
     @GetMapping(value = "/{timeEntryId}/adjustments", produces = "application/json")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -67,8 +108,21 @@ public class TimeEntryAdjustmentController {
     }
 
     @Operation(
-            summary = "Approve a time entry adjustment",
-            description = "Approve a pending time entry adjustment. Requires approval permissions.")
+            operationId = "approveTimeEntryAdjustment",
+            summary = "Approve A Pending Time Entry Adjustment",
+            description = """
+                    Approves a time entry adjustment, stamping the deciding user and decision time and writing an \
+                    ADJUSTMENT_APPROVED audit row.
+                    Use this tool to accept a proposed correction; do not use approveTimeEntriesBatch, which \
+                    approves the time entries themselves rather than adjustments.
+                    Preconditions: the adjustment must exist; no status gate is enforced, so re-approving an already \
+                    decided adjustment overwrites the previous decision.
+                    Required inputs: adjustmentId (UUID) path parameter; an optional X-Correlation-Id header is \
+                    carried into the audit trail.
+                    Emits a PEOPLE_TIME_ENTRY_ADJUSTMENT_APPROVE event; the underlying time entry's own timestamps \
+                    are not recalculated by this call.
+                    Returns 404 when no adjustment exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Adjustment approved successfully")
     @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions")
     @ApiResponse(responseCode = "404", description = "Adjustment not found")

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/TimeEntryApprovalController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/TimeEntryApprovalController.java
@@ -5,6 +5,8 @@ import com.positivity.people.internal.dto.TimeEntryDecisionBatchRequest;
 import com.positivity.people.internal.dto.TimeEntryDecisionResponse;
 import com.positivity.people.internal.dto.TimeEntryDecisionResult;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -27,8 +29,22 @@ public class TimeEntryApprovalController {
     private final com.positivity.people.service.TimeEntryService timeEntryService;
 
     @Operation(
-            summary = "Batch approve time entries",
-            description = "Approve multiple time entries. pos-people is authoritative for approval execution.")
+            operationId = "approveTimeEntriesBatch",
+            summary = "Batch Approve Submitted Time Entries",
+            description = """
+                    Approves a batch of time entries, marking each SUBMITTED or PENDING_APPROVAL entry APPROVED and \
+                    stamping the approver and approval time; pos-people is authoritative for approval execution.
+                    Use this tool for supervisor approval of individually selected time entries; do not use \
+                    rejectTimeEntriesBatch, which rejects them, and do not use approveTimePeriod, which approves a \
+                    whole pay period per person.
+                    Preconditions: each entry must exist and be in SUBMITTED or PENDING_APPROVAL status, and the \
+                    caller needs the people:timeEntry:approve authority for individual entries to succeed.
+                    Required inputs: decisions, a non-empty list of objects each carrying timeEntryId (UUID string); \
+                    an optional X-Correlation-Id header is recorded in the audit trail.
+                    Emits a PEOPLE_TIME_ENTRY_APPROVE event and writes an audit row per decision.
+                    Returns 200 with a per-entry result list (failure codes NOT_FOUND, ENTRY_NOT_PENDING, FORBIDDEN) \
+                    rather than failing the whole batch, and 400 when the decisions list is missing or empty.
+                    """)
     @ApiResponse(responseCode = "200", description = "Time entries approved successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request - decisions required")
     @EmitEvent(id = "PEOPLE_TIME_ENTRY_APPROVE", apiVersion = "1")
@@ -38,7 +54,21 @@ public class TimeEntryApprovalController {
             scopes = {"people:timeEntry:approve"})
     @PreAuthorize("hasAuthority('people:timeEntry:approve')")
     public ResponseEntity<Object> approveTimeEntries(
-            @RequestBody @Valid TimeEntryDecisionBatchRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Batch of approval decisions, one element per time entry to approve; rejectionReason is ignored here.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Approve two entries", value = """
+                                                                    {"decisions":[
+                                                                      {"timeEntryId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"},
+                                                                      {"timeEntryId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"}]}
+                                                                    """)))
+                    @RequestBody
+                    @Valid
+                    TimeEntryDecisionBatchRequest request,
             @RequestHeader(value = "X-Correlation-Id", required = false) String correlationId) {
 
         List<String> ids = request.getDecisions().stream()
@@ -52,8 +82,23 @@ public class TimeEntryApprovalController {
     }
 
     @Operation(
-            summary = "Batch reject time entries",
-            description = "Reject multiple time entries. rejectionReason is required for each decision.")
+            operationId = "rejectTimeEntriesBatch",
+            summary = "Batch Reject Submitted Time Entries",
+            description = """
+                    Rejects a batch of time entries, marking each SUBMITTED or PENDING_APPROVAL entry REJECTED with \
+                    the supplied reason stored on the entry.
+                    Use this tool to send individually selected entries back with a reason; do not use \
+                    approveTimeEntriesBatch, which approves them, and do not use rejectTimePeriod, which rejects a \
+                    whole pay period per person.
+                    Preconditions: each entry must exist and be in SUBMITTED or PENDING_APPROVAL status, and the \
+                    caller needs the people:timeEntry:reject authority for individual entries to succeed.
+                    Required inputs: decisions, a non-empty list where every element carries timeEntryId and a \
+                    non-blank rejectionReason; one missing reason fails the entire request before any entry is \
+                    touched.
+                    Emits a PEOPLE_TIME_ENTRY_REJECT event and writes an audit row per decision.
+                    Returns 200 with a per-entry result list (failure codes NOT_FOUND, ENTRY_NOT_PENDING, \
+                    FORBIDDEN), and 400 when any decision lacks a rejectionReason.
+                    """)
     @ApiResponse(responseCode = "200", description = "Time entries rejected successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request - rejectionReason required for all decisions")
     @EmitEvent(id = "PEOPLE_TIME_ENTRY_REJECT", apiVersion = "1")
@@ -63,7 +108,21 @@ public class TimeEntryApprovalController {
             scopes = {"people:timeEntry:reject"})
     @PreAuthorize("hasAuthority('people:timeEntry:reject')")
     public ResponseEntity<Object> rejectTimeEntries(
-            @RequestBody @Valid TimeEntryDecisionBatchRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Batch of rejection decisions; every element must carry a non-blank rejectionReason.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Reject one entry", value = """
+                                                                    {"decisions":[
+                                                                      {"timeEntryId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                       "rejectionReason":"Incomplete work details"}]}
+                                                                    """)))
+                    @RequestBody
+                    @Valid
+                    TimeEntryDecisionBatchRequest request,
             @RequestHeader(value = "X-Correlation-Id", required = false) String correlationId) {
 
         // Extract rejection reasons map and pass to service

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/TimeEntryExceptionController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/TimeEntryExceptionController.java
@@ -8,6 +8,8 @@ import com.positivity.people.internal.dto.TimeEntryExceptionResponse;
 import com.positivity.people.internal.dto.TimeEntryExceptionWaiveRequest;
 import com.positivity.people.service.TimeEntryExceptionService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -25,9 +27,17 @@ public class TimeEntryExceptionController {
 
     private final TimeEntryExceptionService exceptionService;
 
-    @Operation(
-            summary = "Create a time entry exception",
-            description = "Create a new time entry exception record with validation of required fields.")
+    @Operation(operationId = "createTimeEntryException", summary = "Create A Time Entry Exception", description = """
+                    Records a timekeeping exception in OPEN status for an employee, such as a missed clock-out.
+                    Use this tool when a timekeeping anomaly is detected; do not use resolveTimeEntryException or \
+                    waiveTimeEntryException, which close an existing exception.
+                    Preconditions: none are checked against other records; employeeId and timeEntryId are stored as \
+                    given without referential validation.
+                    Required inputs: employeeId and exceptionCode; severity accepts WARNING or BLOCKING and silently \
+                    falls back to WARNING on any other value, and detectedAt defaults to the current server time.
+                    Emits a PEOPLE_TIME_ENTRY_EXCEPTION_CREATE event; the exception starts in OPEN status.
+                    Returns 200 with the new exceptionId, and 400 when the JSON payload is malformed.
+                    """)
     @ApiResponse(responseCode = "200", description = "Exception created")
     @ApiResponse(responseCode = "400", description = "Invalid request")
     @EmitEvent(id = "PEOPLE_TIME_ENTRY_EXCEPTION_CREATE", apiVersion = "1")
@@ -37,14 +47,41 @@ public class TimeEntryExceptionController {
             scopes = {"people:timeException:create"})
     @PreAuthorize("hasAuthority('people:timeException:create')")
     public ResponseEntity<TimeEntryExceptionResponse> createException(
-            @Valid @RequestBody TimeEntryExceptionRequest req) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Timekeeping anomaly to record against an employee, optionally tied to a"
+                                    + " specific time entry.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Missed clock-out", value = """
+                                                                    {"employeeId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "exceptionCode":"MISSED_CLOCK_OUT",
+                                                                     "severity":"BLOCKING",
+                                                                     "timeEntryId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "resolutionNotes":"Employee forgot to clock out at end of shift",
+                                                                     "detectedAt":"2026-02-17T08:30:00-05:00"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    TimeEntryExceptionRequest req) {
         TimeEntryExceptionResponse resp = exceptionService.createException(req);
         return ResponseEntity.ok(resp);
     }
 
     @Operation(
-            summary = "List exceptions, optional filter by employeeId",
-            description = "Retrieve all exceptions or filter by a specific employee ID.")
+            operationId = "listTimeEntryExceptions",
+            summary = "List Time Entry Exceptions By Employee",
+            description = """
+                    Lists time entry exceptions, either all of them or those recorded for one employee.
+                    Use this tool to review open and historical exceptions; use createTimeEntryException instead to \
+                    record a new one.
+                    Preconditions: none; when employeeId is omitted every exception in the system is returned \
+                    without pagination.
+                    Required inputs: none; employeeId (string) is an optional filter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty list when nothing matches.
+                    """)
     @ApiResponse(responseCode = "200", description = "List returned")
     @GetMapping(produces = "application/json")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -56,7 +93,21 @@ public class TimeEntryExceptionController {
         return ResponseEntity.ok(list);
     }
 
-    @Operation(summary = "Acknowledge an exception", description = "Mark an exception as acknowledged.")
+    @Operation(
+            operationId = "acknowledgeTimeEntryException",
+            summary = "Acknowledge An Open Time Entry Exception",
+            description = """
+                    Marks an OPEN time entry exception as ACKNOWLEDGED, stamping the acting user and timestamp.
+                    Use this tool to signal an exception has been seen but not yet fixed; use \
+                    resolveTimeEntryException or waiveTimeEntryException instead to close it.
+                    Preconditions: the exception must exist and must not already be RESOLVED or WAIVED, which are \
+                    terminal states.
+                    Required inputs: exceptionId (UUID) path parameter; there is no request body, and an optional \
+                    X-Correlation-Id header is carried into the audit trail.
+                    Emits a PEOPLE_TIME_ENTRY_EXCEPTION_ACKNOWLEDGE event and writes an EXCEPTION_ACKNOWLEDGED \
+                    audit row.
+                    Returns 404 when the exception does not exist, and 400 when it is already RESOLVED or WAIVED.
+                    """)
     @ApiResponse(responseCode = "200", description = "Exception acknowledged successfully")
     @ApiResponse(responseCode = "404", description = "Exception not found")
     @EmitEvent(id = "PEOPLE_TIME_ENTRY_EXCEPTION_ACKNOWLEDGE", apiVersion = "1")
@@ -73,9 +124,18 @@ public class TimeEntryExceptionController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(
-            summary = "Resolve an exception",
-            description = "Mark an exception as resolved with optional resolution notes.")
+    @Operation(operationId = "resolveTimeEntryException", summary = "Resolve A Time Entry Exception", description = """
+                    Marks a time entry exception as RESOLVED with optional resolution notes, stamping the acting \
+                    user and timestamp.
+                    Use this tool when the underlying issue has been fixed; use waiveTimeEntryException instead to \
+                    close it without a fix, or acknowledgeTimeEntryException to flag it as merely seen.
+                    Preconditions: the exception must exist and must not already be RESOLVED or WAIVED, which are \
+                    terminal states.
+                    Required inputs: exceptionId (UUID) path parameter; the body is optional and may carry \
+                    resolutionNotes.
+                    Emits a PEOPLE_TIME_ENTRY_EXCEPTION_RESOLVE event and writes an EXCEPTION_RESOLVED audit row.
+                    Returns 404 when the exception does not exist, and 400 when it is already RESOLVED or WAIVED.
+                    """)
     @ApiResponse(responseCode = "200", description = "Exception resolved successfully")
     @ApiResponse(responseCode = "404", description = "Exception not found")
     @EmitEvent(id = "PEOPLE_TIME_ENTRY_EXCEPTION_RESOLVE", apiVersion = "1")
@@ -86,7 +146,19 @@ public class TimeEntryExceptionController {
     @PreAuthorize("hasAuthority('people:timeException:resolve')")
     public ResponseEntity<Object> resolveException(
             @PathVariable java.util.UUID exceptionId,
-            @Valid @RequestBody(required = false) TimeEntryExceptionResolveRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Optional resolution details; when present, resolutionNotes replaces the"
+                                    + " notes stored on the exception.",
+                            required = false,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Resolution with notes", value = """
+                                                                    {"resolutionNotes":"Corrected the clock-out time manually"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody(required = false)
+                    TimeEntryExceptionResolveRequest request,
             @RequestHeader(value = "X-Correlation-Id", required = false) String correlationId) {
         String notes = request != null ? request.getResolutionNotes() : null;
         exceptionService.actionException(
@@ -94,9 +166,18 @@ public class TimeEntryExceptionController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(
-            summary = "Waive an exception",
-            description = "Waive an exception with a reason. waiveReason is required.")
+    @Operation(operationId = "waiveTimeEntryException", summary = "Waive A Time Entry Exception", description = """
+                    Marks a time entry exception as WAIVED with a mandatory reason, closing it without a correction.
+                    Use this tool to deliberately dismiss an exception; use resolveTimeEntryException instead when \
+                    the underlying issue was actually fixed.
+                    Preconditions: the exception must exist and must not already be RESOLVED or WAIVED, which are \
+                    terminal states.
+                    Required inputs: exceptionId (UUID) path parameter and a body with a non-blank waiveReason, \
+                    which is stored as the exception's resolution notes.
+                    Emits a PEOPLE_TIME_ENTRY_EXCEPTION_WAIVE event and writes an EXCEPTION_WAIVED audit row.
+                    Returns 404 when the exception does not exist, and 400 when waiveReason is blank or the \
+                    exception is already RESOLVED or WAIVED.
+                    """)
     @ApiResponse(responseCode = "200", description = "Exception waived successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request - waiveReason is required")
     @ApiResponse(responseCode = "404", description = "Exception not found")
@@ -108,7 +189,19 @@ public class TimeEntryExceptionController {
     @PreAuthorize("hasAuthority('people:timeException:resolve')")
     public ResponseEntity<Object> waiveException(
             @PathVariable java.util.UUID exceptionId,
-            @Valid @RequestBody TimeEntryExceptionWaiveRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Waiver justification; the reason is mandatory and becomes the exception's"
+                                    + " resolution notes.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Waive for device outage", value = """
+                                                                    {"waiveReason":"Known device outage; entry validated manually"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    TimeEntryExceptionWaiveRequest request,
             @RequestHeader(value = "X-Correlation-Id", required = false) String correlationId) {
         exceptionService.actionException(
                 exceptionId,

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/TimekeepingApprovalController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/TimekeepingApprovalController.java
@@ -8,6 +8,8 @@ import com.positivity.people.internal.dto.TimePeriodDto;
 import com.positivity.people.internal.dto.TimekeepingEntryDto;
 import com.positivity.people.service.TimekeepingApprovalService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -34,8 +36,19 @@ public class TimekeepingApprovalController {
 
     @GetMapping("/approvals/people")
     @Operation(
-            summary = "List employees with timekeeping entries",
-            description = "Returns distinct employees who have at least one timekeeping entry.")
+            operationId = "listTimekeepingApprovalPeople",
+            summary = "List Employees With Timekeeping Entries",
+            description = """
+                    Lists the distinct employees that have at least one timekeeping entry, with display name and \
+                    employee number.
+                    Use this tool to build the person picker for pay-period approval; use listTimekeepingEntries \
+                    instead for one person's entries in a period.
+                    Preconditions: none; display names come from the person identity replica, which is eventually \
+                    consistent.
+                    Required inputs: none; there are no parameters and no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty list when no timekeeping entries exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of employees")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -46,7 +59,20 @@ public class TimekeepingApprovalController {
     }
 
     @GetMapping("/time-periods")
-    @Operation(summary = "List time periods", description = "Returns all pay periods, optionally scoped to a tenant.")
+    @Operation(
+            operationId = "listTimePeriods",
+            summary = "List Pay Periods For Timekeeping Approval",
+            description = """
+                    Lists pay periods with their start and end dates and status, newest first when scoped to a \
+                    tenant.
+                    Use this tool to choose the period for approval screens; use listTimekeepingEntries instead for \
+                    the entries inside a chosen period.
+                    Preconditions: none; tenantId is an optional scope and omitting it returns all periods in \
+                    repository order.
+                    Required inputs: none; tenantId (UUID) is an optional query parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty list when no pay periods exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of time periods")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -58,9 +84,20 @@ public class TimekeepingApprovalController {
 
     @GetMapping("/timekeeping-entries")
     @Operation(
-            summary = "List timekeeping entries for a person in a period",
-            description =
-                    "Returns all timekeeping entries for the given person within the given time period's date range.")
+            operationId = "listTimekeepingEntries",
+            summary = "List Timekeeping Entries For Person And Period",
+            description = """
+                    Lists a person's timekeeping entries whose sessions fall entirely within the given pay period's \
+                    date range, evaluated in UTC.
+                    Use this tool to review entries before deciding a period; use getTimePeriodApproval instead for \
+                    just the status counts.
+                    Preconditions: the time period must exist; sessions straddling the period boundary are excluded \
+                    because both start and end must fall inside it.
+                    Required inputs: personId (UUID) and timePeriodId (UUID) query parameters; there is no request \
+                    body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when the time period does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of timekeeping entries")
     @ApiResponse(responseCode = "404", description = "Time period not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -73,10 +110,18 @@ public class TimekeepingApprovalController {
     }
 
     @GetMapping("/time-period-approvals")
-    @Operation(
-            summary = "Get approval summary for a person in a period",
-            description =
-                    "Returns the approval status counts and overall status for the given person in the given period.")
+    @Operation(operationId = "getTimePeriodApproval", summary = "Get Time Period Approval Summary", description = """
+                    Summarises a person's timekeeping approval state for a pay period: total, pending, approved, and \
+                    rejected counts plus an overall status.
+                    Use this tool for a status badge or gate; use listTimekeepingEntries instead when the individual \
+                    entries are needed.
+                    Preconditions: the time period must exist; the overall status is PENDING_APPROVAL while any \
+                    entry is pending, else REJECTED if any entry was rejected, else APPROVED.
+                    Required inputs: personId (UUID) and timePeriodId (UUID) query parameters; there is no request \
+                    body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when the time period does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Approval summary")
     @ApiResponse(responseCode = "404", description = "Time period not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -89,10 +134,20 @@ public class TimekeepingApprovalController {
     }
 
     @PostMapping("/time-periods/{timePeriodId}/people/{personId}/approve")
-    @Operation(
-            summary = "Approve all pending timekeeping entries for a person in a period",
-            description =
-                    "Bulk-approves all PENDING_APPROVAL timekeeping entries for the given employee in the given period.")
+    @Operation(operationId = "approveTimePeriod", summary = "Approve All Pending Entries In Period", description = """
+                    Bulk-approves every PENDING_APPROVAL timekeeping entry for a person within a pay period's date \
+                    range.
+                    Use this tool for pay-period sign-off; do not use approveTimeEntriesBatch, which decides \
+                    individually selected time entries instead of a whole period.
+                    Preconditions: the time period must exist; only entries currently in PENDING_APPROVAL are \
+                    touched, so already decided entries are left as they are.
+                    Required inputs: timePeriodId (UUID) and personId (UUID) path parameters; there is no request \
+                    body.
+                    No events are emitted; entries are flipped to APPROVED in place and the response reports the \
+                    processed count.
+                    Returns 200 with processedCount 0 when nothing was pending, and 404 when the time period does \
+                    not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Entries approved")
     @ApiResponse(responseCode = "404", description = "Time period not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -105,10 +160,19 @@ public class TimekeepingApprovalController {
     }
 
     @PostMapping("/time-periods/{timePeriodId}/people/{personId}/reject")
-    @Operation(
-            summary = "Reject all pending timekeeping entries for a person in a period",
-            description =
-                    "Bulk-rejects all PENDING_APPROVAL timekeeping entries for the given employee in the given period.")
+    @Operation(operationId = "rejectTimePeriod", summary = "Reject All Pending Entries In Period", description = """
+                    Bulk-rejects every PENDING_APPROVAL timekeeping entry for a person within a pay period, storing \
+                    the reason on each entry as its correctionReason.
+                    Use this tool to send a whole period back for correction; do not use rejectTimeEntriesBatch, \
+                    which rejects individually selected time entries.
+                    Preconditions: the time period must exist; only entries currently in PENDING_APPROVAL are \
+                    touched.
+                    Required inputs: timePeriodId (UUID) and personId (UUID) path parameters and a body with a \
+                    non-blank reason.
+                    No events are emitted; entries are flipped to REJECTED in place and the response reports the \
+                    processed count.
+                    Returns 400 when reason is blank, and 404 when the time period does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Entries rejected")
     @ApiResponse(responseCode = "400", description = "Reason is required")
     @ApiResponse(responseCode = "404", description = "Time period not found")
@@ -119,7 +183,19 @@ public class TimekeepingApprovalController {
     public ResponseEntity<TimePeriodDecisionResponse> rejectPeriod(
             @PathVariable UUID timePeriodId,
             @PathVariable UUID personId,
-            @RequestBody @Valid RejectTimePeriodRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Rejection justification applied as the correctionReason on every pending"
+                                    + " entry in the period.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Missing breaks", value = """
+                                                                    {"reason":"Missing break entries for two shifts"}
+                                                                    """)))
+                    @RequestBody
+                    @Valid
+                    RejectTimePeriodRequest request) {
         return ResponseEntity.ok(timekeepingApprovalService.rejectPeriod(timePeriodId, personId, request.getReason()));
     }
 }

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/WorkSessionController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/WorkSessionController.java
@@ -140,7 +140,9 @@ public class WorkSessionController {
                     unknown.
                     """)
     @ApiResponse(responseCode = "200", description = "Break stopped successfully.")
-    @ApiResponse(responseCode = "404", description = "Work session or break not found.")
+    @ApiResponse(
+            responseCode = "409",
+            description = "No open break exists for the session, including when the session id itself is unknown.")
     @EmitEvent(id = "PEOPLE_WORK_SESSION_BREAK_STOP", apiVersion = "1")
     @PostMapping("/{id}/breaks/stop")
     @PreAuthorize("isAuthenticated()")

--- a/pos-people/src/main/java/com/positivity/people/internal/controller/WorkSessionController.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/WorkSessionController.java
@@ -8,6 +8,8 @@ import com.positivity.people.internal.dto.WorkSessionSubmitRequest;
 import com.positivity.people.service.WorkSessionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -29,33 +31,89 @@ public class WorkSessionController {
 
     private final WorkSessionService workSessionService;
 
-    @Operation(summary = "Start work session", description = "Create/start a work session for a person.")
+    @Operation(operationId = "startWorkSession", summary = "Start A Work Session For Person", description = """
+                    Starts a new ACTIVE work session for a person, stamping the start time from the server clock and \
+                    the actor from the security context.
+                    Use this tool when a person clocks in for the day; do not use startWorkSessionBreak, which \
+                    pauses an already running session.
+                    Preconditions: the person must exist in the identity replica, and the person must have no \
+                    session that is still open.
+                    Required inputs: personId (UUID) in the body; the body's actor field is ignored, because the \
+                    recorded actor is always the authenticated username.
+                    Emits a PEOPLE_WORK_SESSION_START event.
+                    Returns 404 when the person is unknown, and 409 when an active session already exists for the \
+                    person, including under concurrent start races.
+                    """)
     @ApiResponse(responseCode = "200", description = "Work session started successfully.")
     @EmitEvent(id = "PEOPLE_WORK_SESSION_START", apiVersion = "1")
     @PostMapping("/start")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<WorkSessionDto> startWorkSession(
-            @Parameter(description = "Work session start request body") @Valid @RequestBody @NonNull
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Identifies the person clocking in; the actor field is ignored in favour of"
+                                    + " the authenticated username.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Clock in", value = """
+                                                                    {"personId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
                     WorkSessionRequest request) {
         log.info("Starting work session for personId(mask)={}", maskForLog(request.getPersonId()));
         WorkSessionDto response = workSessionService.startSession(request.getPersonId());
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "Stop work session", description = "Stop an active work session.")
+    @Operation(operationId = "stopWorkSession", summary = "Stop An Active Work Session", description = """
+                    Stops a person's open work session, setting status ENDED and closing any break still open at the \
+                    same timestamp.
+                    Use this tool when a person clocks out; do not use submitWorkSession, which sends an already \
+                    ENDED session for approval.
+                    Preconditions: the person must have an open session; sessions are keyed by person here, not by \
+                    session id.
+                    Required inputs: personId (UUID) in the body; the body's actor field is ignored in favour of the \
+                    authenticated username.
+                    Emits a PEOPLE_WORK_SESSION_STOP event.
+                    Returns 404 when no active session exists for the person.
+                    """)
     @ApiResponse(responseCode = "200", description = "Work session stopped successfully.")
     @EmitEvent(id = "PEOPLE_WORK_SESSION_STOP", apiVersion = "1")
     @PostMapping("/stop")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<WorkSessionDto> stopWorkSession(
-            @Parameter(description = "Work session stop request body") @Valid @RequestBody @NonNull
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Identifies the person clocking out; the open session is found by person"
+                                    + " id, not session id.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Clock out", value = """
+                                                                    {"personId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
                     WorkSessionRequest request) {
         log.info("Stopping work session for personId(mask)={}", maskForLog(request.getPersonId()));
         WorkSessionDto response = workSessionService.stopSession(request.getPersonId());
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "Start work session break", description = "Start a break within an active work session.")
+    @Operation(operationId = "startWorkSessionBreak", summary = "Start A Break In Work Session", description = """
+                    Starts a break inside an active work session, stamping the start time from the server clock.
+                    Use this tool when a person pauses work; do not use stopWorkSession, which ends the whole \
+                    session rather than pausing it.
+                    Preconditions: the session must exist and still be open, and no break may already be open on it.
+                    Required inputs: the work session id (UUID) as the path parameter; there is no request body.
+                    Emits a PEOPLE_WORK_SESSION_BREAK_START event.
+                    Returns 404 when no open session exists for the id, and 409 when a break is already open, \
+                    including under concurrent break-start races.
+                    """)
     @ApiResponse(responseCode = "200", description = "Break started successfully.")
     @ApiResponse(responseCode = "404", description = "Work session not found.")
     @EmitEvent(id = "PEOPLE_WORK_SESSION_BREAK_START", apiVersion = "1")
@@ -71,7 +129,16 @@ public class WorkSessionController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "Stop work session break", description = "End a break within a work session.")
+    @Operation(operationId = "stopWorkSessionBreak", summary = "Stop The Open Work Session Break", description = """
+                    Ends the open break on a work session, stamping the end time from the server clock.
+                    Use this tool when a person returns from a break; do not use stopWorkSession, which ends the \
+                    session and auto-closes any open break itself.
+                    Preconditions: the session must have an open break with no recorded end time.
+                    Required inputs: the work session id (UUID) as the path parameter; there is no request body.
+                    Emits a PEOPLE_WORK_SESSION_BREAK_STOP event.
+                    Returns 409 when no open break exists for the session, including when the session id itself is \
+                    unknown.
+                    """)
     @ApiResponse(responseCode = "200", description = "Break stopped successfully.")
     @ApiResponse(responseCode = "404", description = "Work session or break not found.")
     @EmitEvent(id = "PEOPLE_WORK_SESSION_BREAK_STOP", apiVersion = "1")
@@ -87,9 +154,18 @@ public class WorkSessionController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(
-            summary = "Submit work session",
-            description = "Submit an ended work session with its billable and break totals for approval.")
+    @Operation(operationId = "submitWorkSession", summary = "Submit An Ended Work Session", description = """
+                    Submits an ENDED work session for approval, recording billable and break minute totals and \
+                    marking the session SUBMITTED.
+                    Use this tool after stopWorkSession has ended the session; do not use approveTimeEntriesBatch, \
+                    which decides time entries, not work sessions.
+                    Preconditions: the session must exist and be in ENDED status; ACTIVE or already SUBMITTED \
+                    sessions are rejected.
+                    Required inputs: the work session id (UUID) path parameter and a body with billableMinutes and \
+                    breakMinutes (both zero or greater) and submittedAt (ISO-8601 instant).
+                    Emits a PEOPLE_WORK_SESSION_SUBMIT event.
+                    Returns 404 when the session does not exist, and 409 when the session is not in ENDED status.
+                    """)
     @ApiResponse(responseCode = "200", description = "Work session submitted successfully.")
     @ApiResponse(responseCode = "404", description = "Work session not found.")
     @ApiResponse(responseCode = "409", description = "Work session is not in a submittable state.")
@@ -101,7 +177,20 @@ public class WorkSessionController {
                     @PathVariable
                     @NonNull
                     UUID id,
-            @Parameter(description = "Work session submit request body") @Valid @RequestBody @NonNull
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Billable and break minute totals plus the submission timestamp for the"
+                                    + " ended session.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Full day with lunch break", value = """
+                                                                    {"billableMinutes":480,"breakMinutes":30,
+                                                                     "submittedAt":"2026-02-16T17:00:00Z"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
                     WorkSessionSubmitRequest request) {
         log.info("Submitting work session ID(mask): {}", maskForLog(id));
         WorkSessionDto response = workSessionService.submitSession(id, request);

--- a/pos-price/openapi.yaml
+++ b/pos-price/openapi.yaml
@@ -31,14 +31,40 @@ paths:
     post:
       tags:
       - Promotion Offers
-      summary: Create promotion offer
-      description: Creates a new promotion offer with code, lifecycle settings, and discount policy.
-      operationId: createOffer
+      summary: Create Promotion Offer
+      description: 'Creates a promotion offer in DRAFT status with a unique promo code, a validity window, and a discount policy.
+
+        Use this tool to define a new promotion; do not use activatePromotionOffer, which only transitions an existing offer to ACTIVE, and note that a DRAFT offer cannot be applied until activated.
+
+        Preconditions: no offer may already exist with the same promoCode, and startDate must not be after endDate.
+
+        Required inputs: promoCode (max 64 characters), name, discountType (PERCENT_LABOR, PERCENT_PARTS, or FIXED_INVOICE), discountValue (minimum 0.01, two decimal places), startDate, and endDate; usageLimit and storeCode are optional and default to unlimited usage and no store scoping.
+
+        Emits a PROMOTION_OFFER_CREATE event and persists the offer with status DRAFT and a zero usage count.
+
+        Returns 409 when the promoCode already exists, and 422 when startDate is after endDate.
+
+        '
+      operationId: createPromotionOffer
       requestBody:
+        description: 'Promotion offer definition: promo code, discount policy, and validity window.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreatePromotionOfferRequest'
+            examples:
+              Percent labor promotion:
+                description: Percent labor promotion
+                value:
+                  promoCode: SUMMER20
+                  name: Summer Labor Discount
+                  description: 20% off labor for seasonal service
+                  discountType: PERCENT_LABOR
+                  discountValue: 20.0
+                  startDate: 2026-06-01
+                  endDate: 2026-08-31
+                  usageLimit: 100
+                  storeCode: NYC-001
         required: true
       responses:
         '201':
@@ -59,6 +85,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PromotionOfferResponse'
+        '422':
+          description: startDate is after endDate.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromotionOfferResponse'
         '403':
           description: Forbidden.
           content:
@@ -74,9 +106,21 @@ paths:
     get:
       tags:
       - Promotion Eligibility Rules
-      summary: List eligibility rules for promotion offer
-      description: Returns all eligibility rules configured for the specified promotion offer.
-      operationId: getRules
+      summary: List Eligibility Rules For Promotion Offer
+      description: 'Lists every eligibility rule currently attached to the promotion offer identified by promotionId.
+
+        Use this tool to inspect a promotion''s audience constraints before editing them; use evaluatePromotionEligibility instead to test whether a concrete account, vehicle, or campaign context passes those rules.
+
+        Preconditions: none beyond the pricing:promotion:view authority; an unknown promotionId is not rejected.
+
+        Required inputs: promotionId (UUID) as a path parameter; there is no request body, filtering, or paging.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty array both when the promotion has no rules and when the promotionId matches no offer, so this operation cannot verify that a promotion exists.
+
+        '
+      operationId: listPromotionEligibilityRules
       parameters:
       - name: promotionId
         in: path
@@ -87,14 +131,6 @@ paths:
       responses:
         '200':
           description: Eligibility rules returned.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/EligibilityRuleResponse'
-        '404':
-          description: Promotion offer not found.
           content:
             application/json:
               schema:
@@ -117,9 +153,21 @@ paths:
     post:
       tags:
       - Promotion Eligibility Rules
-      summary: Add eligibility rule to promotion offer
-      description: Creates and attaches a new eligibility rule to the specified promotion offer.
-      operationId: addRule
+      summary: Add Eligibility Rule To Promotion Offer
+      description: 'Creates an eligibility rule and attaches it to the promotion offer identified by promotionId, constraining who may receive the promotion.
+
+        Use this tool when a promotion must be limited by account list, fleet size, vehicle tag, audience type, or campaign code; do not use evaluatePromotionEligibility, which tests a context against the existing rules without changing them.
+
+        Preconditions: the promotion offer must exist; rules may be added regardless of the offer''s status.
+
+        Required inputs: conditionType (ACCOUNT_ID_LIST, VEHICLE_TAG, ACCOUNT_FLEET_SIZE, AUDIENCE_TYPE, or CAMPAIGN_CODE), an operator supported by that type (IN, NOT_IN, EQUALS, GREATER_THAN_OR_EQUAL_TO), and value (max 255 characters; comma-separated for list types); ruleCombination is optional and defaults to AND, and at evaluation time the first rule''s combination governs all rules.
+
+        Emits a PROMOTION_RULE_CREATE event and the rule takes effect on the next eligibility evaluation.
+
+        Returns 404 when the promotion offer does not exist, and 400 when conditionType, operator, or value is missing or invalid.
+
+        '
+      operationId: createPromotionEligibilityRule
       parameters:
       - name: promotionId
         in: path
@@ -128,10 +176,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: 'Eligibility rule definition: the condition, operator, and comparison value to attach.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AddEligibilityRuleRequest'
+            examples:
+              Fleet size rule:
+                description: Fleet size rule
+                value:
+                  conditionType: ACCOUNT_FLEET_SIZE
+                  operator: GREATER_THAN_OR_EQUAL_TO
+                  value: '25'
+                  ruleCombination: AND
         required: true
       responses:
         '201':
@@ -167,9 +224,21 @@ paths:
     post:
       tags:
       - Promotion Eligibility Rules
-      summary: Evaluate promotion eligibility
-      description: Evaluates whether a promotion offer is eligible for the provided evaluation context.
-      operationId: evaluateEligibility
+      summary: Evaluate Promotion Eligibility
+      description: 'Evaluates whether the supplied account, vehicle, audience, and campaign context passes the eligibility rules attached to a promotion offer, returning an eligible flag and a reason code.
+
+        Use this tool to pre-check eligibility without consuming promotion usage; do not use applyPromotionOffer, which applies the discount and increments the offer''s usage count.
+
+        Preconditions: the first rule''s ruleCombination governs the evaluation (AND requires every rule to pass, OR requires any one); a promotion with no rules, or an unknown promotionId, evaluates to eligible because only the stored rules are consulted.
+
+        Required inputs: a context body whose fields are all optional; accountId and vehicleId (UUIDs), audienceType (compared case-insensitively), and campaignCode, where omitting a field that a rule needs fails that rule with a missing-context reason code such as MISSING_ACCOUNT_CONTEXT.
+
+        Emits a PROMOTION_RULE_EVALUATE event; no promotion state or usage count changes.
+
+        Returns 200 with eligible true or false and a reason code such as ELIGIBLE, ACCOUNT_NOT_IN_LIST, FLEET_SIZE_TOO_SMALL, or VEHICLE_TAG_NOT_PRESENT; 400 occurs only for an unparseable body.
+
+        '
+      operationId: evaluatePromotionEligibility
       parameters:
       - name: promotionId
         in: path
@@ -178,10 +247,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Account, vehicle, audience, and campaign context the promotion's rules are evaluated against.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/EligibilityContext'
+            examples:
+              Fleet account context:
+                description: Fleet account context
+                value:
+                  accountId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  vehicleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  audienceType: COMMERCIAL
+                  campaignCode: SPRING-FLEET-2026
         required: true
       responses:
         '200':
@@ -192,12 +270,6 @@ paths:
                 $ref: '#/components/schemas/EligibilityDecisionResponse'
         '400':
           description: Invalid evaluation request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EligibilityDecisionResponse'
-        '404':
-          description: Promotion offer not found.
           content:
             application/json:
               schema:
@@ -217,14 +289,42 @@ paths:
     post:
       tags:
       - Promotion Offers
-      summary: Apply promotion offer during estimate pricing
-      description: Applies a promotion offer to pricing inputs and returns resulting discount and adjusted totals.
-      operationId: applyPromotion
+      summary: Apply Promotion Offer During Estimate Pricing
+      description: 'Applies a promotion code to an estimate''s pricing context and returns the discount adjustment and the adjusted total.
+
+        Use this tool at estimate time to price in a promotion; use evaluatePromotionEligibility instead for a dry-run check, because this operation consumes one usage against the offer''s usageLimit.
+
+        Preconditions: the offer must be ACTIVE, the current date must fall within startDate and endDate, the context must pass the offer''s eligibility rules, the usage limit must not be exhausted, and no promo code may already be applied because only one promotion is allowed per estimate.
+
+        Required inputs: promotionCode and estimateContext with estimateId, customerId, subtotal, and at least one line item; PERCENT_LABOR and PERCENT_PARTS both currently discount the full subtotal by the percentage, while FIXED_INVOICE subtracts the fixed discountValue.
+
+        Emits a PROMOTION_OFFER_APPLY event and atomically increments the offer''s usage count.
+
+        Returns 400 with code PROMO_NOT_FOUND when the code is unknown, PROMO_NOT_APPLICABLE when the offer is inactive, outside its date range, ineligible for the context, or over its usage limit, and PROMO_MULTIPLE_NOT_ALLOWED when the estimate already carries an applied promo code.
+
+        '
+      operationId: applyPromotionOffer
       requestBody:
+        description: Promotion code plus the estimate context (customer, line items, subtotal) it is applied against.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ApplyPromotionRequest'
+            examples:
+              Apply to estimate:
+                description: Apply to estimate
+                value:
+                  promotionCode: SUMMER20
+                  estimateContext:
+                    estimateId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                    customerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
+                    vehicleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03
+                    lineItems:
+                    - sku: P001
+                      quantity: 1
+                      unitPrice: 500.0
+                    subtotal: 500.0
+                    appliedPromoCodes: []
         required: true
       responses:
         '200':
@@ -234,13 +334,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApplyPromotionResponse'
         '400':
-          description: Invalid promotion application request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApplyPromotionResponse'
-        '404':
-          description: Promotion offer not found or not eligible.
+          description: Invalid request, unknown promo code, promotion not applicable, or promotion already applied.
           content:
             application/json:
               schema:
@@ -260,14 +354,38 @@ paths:
     post:
       tags:
       - Price Restrictions
-      summary: Override price restrictions
-      description: Issues an override for price restrictions. Requires pricing:restriction:override authority.
-      operationId: overrideRestrictions
+      summary: Override Price Restrictions
+      description: 'Issues an audited, time-boxed override of a sale-restriction rule for a specific transaction and product.
+
+        Use this tool after evaluatePriceRestrictions returns ALLOW_WITH_OVERRIDE; do not use deactivateRestrictionRule, which retires the rule for everyone instead of exempting one transaction.
+
+        Preconditions: the referenced restriction rule must exist; the rule''s overrideable flag is not re-checked here, so callers must honour a BLOCK decision from evaluation rather than overriding it.
+
+        Required inputs: ruleId, transactionId, and productId (UUIDs), overrideContext (BROWSE, QUOTE, CHECKOUT, INVOICE_FINALIZE, or COMMIT_SALE), and reasonCode; notes and approvedBy are optional.
+
+        Emits a PRICE_RESTRICTIONS_OVERRIDE event and persists an ISSUED audit record capturing the actor and the rule''s policyVersion; the returned overrideId expires 24 hours after issue.
+
+        Returns 404 when the referenced restriction rule does not exist.
+
+        '
+      operationId: overridePriceRestriction
       requestBody:
+        description: Override justification tying a restriction rule to the transaction and product it is waived for.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RestrictionOverrideRequest'
+            examples:
+              Manager-approved override:
+                description: Manager-approved override
+                value:
+                  ruleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4c01
+                  transactionId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4c02
+                  productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01
+                  overrideContext: CHECKOUT
+                  reasonCode: MANAGER_APPROVAL
+                  notes: Customer is a licensed reseller
+                  approvedBy: user-001
         required: true
       responses:
         '200':
@@ -294,6 +412,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RestrictionOverrideResponse'
+        '404':
+          description: Restriction rule not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RestrictionOverrideResponse'
       security:
       - bearerAuth:
         - pricing:restriction:override
@@ -303,14 +427,36 @@ paths:
     post:
       tags:
       - Price Restrictions
-      summary: Evaluate price restrictions
-      description: Evaluates whether products are subject to restrictions in the given context.
-      operationId: evaluateRestrictions
+      summary: Evaluate Price Restrictions
+      description: 'Evaluates each submitted product and context entry against active sale-restriction rules and returns a per-item decision of ALLOW, BLOCK, ALLOW_WITH_OVERRIDE, or RESTRICTION_UNKNOWN.
+
+        Use this tool before quoting or selling a product to learn whether the sale is blocked or needs an override; do not use overridePriceRestriction, which records the override itself after a decision of ALLOW_WITH_OVERRIDE.
+
+        Preconditions: none; items with no matching active rule resolve to ALLOW.
+
+        Required inputs: items (at least one), each with productId (UUID), locationTag, serviceTag, and context (BROWSE, QUOTE, CHECKOUT, INVOICE_FINALIZE, or COMMIT_SALE); any matching rule with overrideable false forces BLOCK, otherwise matching rules yield ALLOW_WITH_OVERRIDE with the matched ruleIds.
+
+        Emits a PRICE_RESTRICTIONS_EVALUATE event; the evaluation itself is read-only and each item is bounded by an 800 ms timeout.
+
+        Returns 503 when evaluation fails or times out for an item in a commit-path context (CHECKOUT, INVOICE_FINALIZE, COMMIT_SALE), while the same failure on BROWSE or QUOTE degrades that item to a RESTRICTION_UNKNOWN decision instead of an error.
+
+        '
+      operationId: evaluatePriceRestrictions
       requestBody:
+        description: Batch of product/location/service/context entries to test against the active restriction rules.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RestrictionEvaluationRequest'
+            examples:
+              Checkout evaluation:
+                description: Checkout evaluation
+                value:
+                  items:
+                  - productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01
+                    locationTag: RETAIL_STORE
+                    serviceTag: POS_SALE
+                    context: CHECKOUT
         required: true
       responses:
         '200':
@@ -345,9 +491,21 @@ paths:
     get:
       tags:
       - Restriction Rules
-      summary: List all active restriction rules
-      description: Returns all currently active price restriction rules that can affect pricing decisions.
-      operationId: listRules
+      summary: List All Active Restriction Rules
+      description: 'Lists every currently active sale-restriction rule that can affect pricing and sale decisions.
+
+        Use this tool to review the standing restriction policy; use getRestrictionRuleById instead to fetch one rule, including deactivated rules, which this listing omits.
+
+        Preconditions: none beyond an authenticated caller.
+
+        Required inputs: none; there is no request body, filtering, or paging.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty array when no active restriction rules exist.
+
+        '
+      operationId: listRestrictionRules
       responses:
         '200':
           description: List of restriction rules.
@@ -372,14 +530,38 @@ paths:
     post:
       tags:
       - Restriction Rules
-      summary: Create a restriction rule
-      description: Creates a price restriction rule for a product, location tag, and service tag combination.
-      operationId: createRule
+      summary: Create A Restriction Rule
+      description: 'Creates an active sale-restriction rule that blocks or gates a product for a location tag and service tag combination.
+
+        Use this tool to configure a standing restriction policy; do not use overridePriceRestriction, which grants a one-time transaction exemption from an existing rule.
+
+        Preconditions: none are checked beyond authorization; duplicate rules for the same product and tag combination are not rejected, so each call appends a new rule.
+
+        Required inputs: productId (UUID), locationTag (ALL_LOCATIONS, RETAIL_STORE, WAREHOUSE, MOBILE_SERVICE, FRANCHISE, or TEST_LOCATION), serviceTag (POS_SALE, WORKORDER, ESTIMATE, INVOICE, or DELIVERY), effectiveFrom (date), and overrideable; effectiveTo is optional, and policyVersion defaults to 1 when omitted.
+
+        Emits a PRICE_RESTRICTION_RULE_CREATE event and the rule participates in evaluation immediately; a rule with overrideable false forces a BLOCK decision that cannot be overridden.
+
+        Returns 201 with the stored rule, and 400 when a required field is missing or a tag is not a valid enum value.
+
+        '
+      operationId: createRestrictionRule
       requestBody:
+        description: Restriction rule definition scoping a product restriction to location and service tags.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateRestrictionRuleRequest'
+            examples:
+              Overrideable retail restriction:
+                description: Overrideable retail restriction
+                value:
+                  productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01
+                  locationTag: RETAIL_STORE
+                  serviceTag: POS_SALE
+                  effectiveFrom: 2026-03-01
+                  effectiveTo: 2026-12-31
+                  policyVersion: 3
+                  overrideable: true
         required: true
       responses:
         '201':
@@ -415,14 +597,37 @@ paths:
     post:
       tags:
       - Price Quotes
-      summary: Calculate contextual price quote
-      description: Calculates a contextual price quote using request inputs such as product, location, customer tier, and pricing context.
+      summary: Calculate Contextual Price Quote
+      description: 'Calculates a contextual unit and extended price for a product by resolving, in order, the base MSRP effective at the pricing instant, then an active location price override that replaces the running price, then a customer tier discount rate applied to the running price.
+
+        Use this tool to price a line for an estimate or cart; do not use applyPromotionOffer here, because promotions are layered onto the estimate separately, and use getPricingSnapshotById to re-read a previously captured price instead of recalculating.
+
+        Preconditions: a base price for the product and quote currency must be effective at the pricing instant; location overrides and tier rules are optional layers that apply only when active.
+
+        Required inputs: productId, locationId, and customerTierId (UUIDs) plus quantity (minimum 1); effectiveTimestamp defaults to the current time, and currency defaults to the configured pos.price.default-currency (USD unless overridden).
+
+        Emits a PRICE_QUOTE_CALCULATE event but writes no pricing state; the unit price is rounded half-even to two decimals, priceSource is MSRP_FALLBACK when only the base price applied and CALCULATED otherwise, and each resolution step is itemised in pricingBreakdown.
+
+        Returns 404 with code PRICE_BASE_UNAVAILABLE when no base price is effective for the product, currency, and instant.
+
+        '
       operationId: calculatePriceQuote
       requestBody:
+        description: Pricing context identifying the product, quantity, location, customer tier, and optional instant and currency.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PriceQuoteRequest'
+            examples:
+              Tiered quote:
+                description: Tiered quote
+                value:
+                  productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01
+                  quantity: 2
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b02
+                  customerTierId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b03
+                  effectiveTimestamp: 2026-03-05 21:15:00+00:00
+                  currency: USD
         required: true
       responses:
         '200':
@@ -457,14 +662,30 @@ paths:
     post:
       tags:
       - Price Normalization
-      summary: Normalize pricing
-      description: Normalize and standardize pricing data across the system.
+      summary: Normalize Pricing Data
+      description: 'Normalizes and standardizes pricing data across the system; this operation is a declared placeholder that is not yet implemented.
+
+        Use this tool only to probe for the future normalization capability; use calculatePriceQuote instead for any real pricing work, since no normalization logic exists yet.
+
+        Preconditions: none; any authenticated caller is accepted.
+
+        Required inputs: none are read; the optional JSON body is accepted but ignored.
+
+        Emits a PRICE_NORMALIZATION_NORMALIZE event even though no normalization is performed and no state changes.
+
+        Returns 501 unconditionally until the operation is implemented.
+
+        '
       operationId: normalizePricing
       requestBody:
+        description: Optional free-form normalization payload; currently ignored because the endpoint is unimplemented.
         content:
           application/json:
             schema:
               type: object
+            examples:
+              Empty payload:
+                description: Empty payload
       responses:
         '501':
           description: Not yet implemented.
@@ -492,24 +713,55 @@ paths:
     post:
       tags:
       - Price Bulk Ingest API
-      summary: Bulk ingest records
-      description: Accepts a batch of domain records for bulk import. Returns per-record results.
-      operationId: bulkIngest
+      summary: Bulk Import Base Price Records
+      description: 'Bulk-imports base price (MSRP) records, appending an effective-dated price window per product and currency.
+
+        Use this tool for batch price loads from an upstream catalog; use calculatePriceQuote instead to read the price effective at a pricing instant, since quoting resolves these windows.
+
+        Preconditions: each record''s effectiveFrom must start after the product''s current window begins; re-submitting the current open window''s unchanged price is idempotent and returns the existing id.
+
+        Required inputs: jobId and locationId (UUIDs) and records (at least one), each record carrying productId (UUID string), msrp (decimal string), currency (ISO 4217 code), and effectiveFrom as an ISO-8601 instant such as 2026-03-01T00:00:00Z; operatorId is optional.
+
+        Emits a PRICE_BULK_INGEST event; a new window closes the previous open window at its effectiveFrom and rows are processed independently, so one bad row does not abort the batch.
+
+        Returns 200 with per-row results even when rows fail, marking failed rows with errorCode PRICE_INGEST_FAILED (including overlapping-window conflicts and unparseable values), and 400 when the batch envelope itself is invalid.
+
+        '
+      operationId: bulkIngestBasePrices
       requestBody:
+        description: Batch envelope of base-price records to ingest, scoped to a job and location.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BulkIngestRequestBasePriceBulkIngestRecord'
+            examples:
+              Single price window:
+                description: Single price window
+                value:
+                  jobId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d01
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d02
+                  operatorId: user-jdoe
+                  records:
+                  - productId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01
+                    msrp: '125.50'
+                    currency: USD
+                    effectiveFrom: 2026-03-01 00:00:00+00:00
         required: true
       responses:
         '200':
-          description: Batch processed (check per-record success/failure in response)
+          description: Batch processed; check per-record success and failure results.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BulkIngestResponse'
         '400':
-          description: Invalid request payload
+          description: Invalid batch envelope.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkIngestResponse'
+        '403':
+          description: Insufficient permissions.
           content:
             application/json:
               schema:
@@ -523,9 +775,21 @@ paths:
     patch:
       tags:
       - Promotion Offers
-      summary: Deactivate promotion offer
-      description: Deactivates a promotion offer so it is no longer eligible for application.
-      operationId: deactivateOffer
+      summary: Deactivate Promotion Offer
+      description: 'Transitions an ACTIVE promotion offer to INACTIVE so its promo code is no longer accepted by applyPromotionOffer.
+
+        Use this tool to withdraw a live offer while keeping its history and rules; do not use deletePromotionEligibilityRule, which removes a single audience rule rather than the offer.
+
+        Preconditions: the offer must exist and currently be ACTIVE; DRAFT, INACTIVE, and EXPIRED offers cannot be deactivated.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a PROMOTION_OFFER_DEACTIVATE event; the offer can later be re-enabled with activatePromotionOffer.
+
+        Returns 404 when the offer does not exist, and 422 when the offer is not currently ACTIVE.
+
+        '
+      operationId: deactivatePromotionOffer
       parameters:
       - name: id
         in: path
@@ -546,6 +810,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PromotionOfferResponse'
+        '422':
+          description: Promotion offer is not currently ACTIVE.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromotionOfferResponse'
         '403':
           description: Forbidden.
           content:
@@ -561,9 +831,21 @@ paths:
     patch:
       tags:
       - Promotion Offers
-      summary: Activate promotion offer
-      description: Activates a promotion offer so it becomes eligible for application.
-      operationId: activateOffer
+      summary: Activate Promotion Offer
+      description: 'Transitions a promotion offer to ACTIVE so applyPromotionOffer will accept its promo code within the validity window.
+
+        Use this tool to publish a DRAFT offer or re-enable an INACTIVE one; do not use createPromotionOffer, which creates a new offer that still starts in DRAFT.
+
+        Preconditions: the offer must exist, must not be EXPIRED, and its endDate must not already be in the past.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a PROMOTION_OFFER_ACTIVATE event and sets the status to ACTIVE immediately.
+
+        Returns 404 when the offer does not exist, and 422 when the offer is EXPIRED or its end date has already passed.
+
+        '
+      operationId: activatePromotionOffer
       parameters:
       - name: id
         in: path
@@ -584,7 +866,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PromotionOfferResponse'
-        '409':
+        '422':
           description: Promotion offer cannot be activated in current state.
           content:
             application/json:
@@ -605,9 +887,21 @@ paths:
     get:
       tags:
       - Promotion Offers
-      summary: Get promotion offer by ID
-      description: Retrieves a promotion offer using its unique identifier.
-      operationId: getOfferById
+      summary: Get Promotion Offer By ID
+      description: 'Returns the full promotion offer, including status, discount policy, validity window, and usage counters.
+
+        Use this tool when the promotion offer''s UUID is already known; use getPromotionOfferByCode instead when only the customer-facing promo code is available.
+
+        Preconditions: the promotion offer must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no promotion offer exists for the supplied id.
+
+        '
+      operationId: getPromotionOfferById
       parameters:
       - name: id
         in: path
@@ -643,9 +937,21 @@ paths:
     get:
       tags:
       - Promotion Offers
-      summary: Get promotion offer by code
-      description: Retrieves a promotion offer using its promotion code.
-      operationId: getOfferByCode
+      summary: Get Promotion Offer By Code
+      description: 'Returns the promotion offer that owns the supplied customer-facing promo code.
+
+        Use this tool when only the promo code from marketing material is known; use getPromotionOfferById instead when the offer''s UUID is available.
+
+        Preconditions: an offer with exactly that promoCode must exist; the lookup is an exact match on the code.
+
+        Required inputs: promoCode (max 64 characters) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no promotion offer exists for the supplied code.
+
+        '
+      operationId: getPromotionOfferByCode
       parameters:
       - name: promoCode
         in: path
@@ -680,9 +986,21 @@ paths:
     get:
       tags:
       - Pricing Snapshots
-      summary: Get pricing snapshot by ID
-      description: Retrieves an immutable pricing snapshot using its snapshot identifier.
-      operationId: getSnapshot
+      summary: Get Pricing Snapshot By ID
+      description: 'Returns an immutable pricing snapshot that captured the prices, applied rules, and policy version of a past pricing decision.
+
+        Use this tool to audit or re-display exactly what was priced at capture time; do not use calculatePriceQuote, which computes a fresh price that may differ from the recorded one.
+
+        Preconditions: a snapshot with the supplied id must have been persisted by an earlier pricing flow.
+
+        Required inputs: snapshotId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; snapshots are immutable and this is a read-only projection.
+
+        Returns 404 with code SNAPSHOT_NOT_FOUND when no snapshot exists for the supplied id.
+
+        '
+      operationId: getPricingSnapshotById
       parameters:
       - name: snapshotId
         in: path
@@ -717,9 +1035,21 @@ paths:
     get:
       tags:
       - Restriction Rules
-      summary: Get a restriction rule by ID
-      description: Returns the active or inactive restriction rule identified by the supplied rule ID.
-      operationId: getRuleById
+      summary: Get A Restriction Rule By ID
+      description: 'Returns a single sale-restriction rule, active or inactive, identified by its rule id.
+
+        Use this tool when the rule id is already known, typically from an evaluation result''s ruleIds; use listRestrictionRules instead to browse the active rule set.
+
+        Preconditions: the rule must exist; inactive rules remain readable through this operation.
+
+        Required inputs: ruleId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no restriction rule exists for the supplied id.
+
+        '
+      operationId: getRestrictionRuleById
       parameters:
       - name: ruleId
         in: path
@@ -753,9 +1083,21 @@ paths:
     delete:
       tags:
       - Restriction Rules
-      summary: Deactivate a restriction rule
-      description: Deactivates the specified restriction rule so it no longer participates in price restriction evaluation.
-      operationId: deactivateRule
+      summary: Deactivate A Restriction Rule
+      description: 'Deactivates a sale-restriction rule so it no longer participates in restriction evaluation.
+
+        Use this tool to retire a standing restriction for everyone; do not use overridePriceRestriction, which leaves the rule active and exempts only a single transaction.
+
+        Preconditions: the rule must exist and still be active; deactivation is not idempotent, so repeating it fails.
+
+        Required inputs: ruleId (UUID) as a path parameter; there is no request body.
+
+        Emits a PRICE_RESTRICTION_RULE_DEACTIVATE event, sets active to false, and stamps effectiveTo with the current date.
+
+        Returns 404 when no restriction rule exists for the supplied id; calling it on an already inactive rule produces a server error rather than a no-op.
+
+        '
+      operationId: deactivateRestrictionRule
       parameters:
       - name: ruleId
         in: path
@@ -797,9 +1139,21 @@ paths:
     delete:
       tags:
       - Promotion Eligibility Rules
-      summary: Delete eligibility rule
-      description: Deletes an eligibility rule from the specified promotion offer.
-      operationId: deleteRule
+      summary: Delete Promotion Eligibility Rule
+      description: 'Deletes a single eligibility rule from a promotion offer, widening the promotion''s audience from the next evaluation onward.
+
+        Use this tool to remove one constraint while keeping the offer and its other rules; do not use deactivatePromotionOffer, which withdraws the entire offer rather than one rule.
+
+        Preconditions: a rule with ruleId must exist and belong to the promotion identified by promotionId.
+
+        Required inputs: promotionId (UUID) and ruleId (UUID) as path parameters; there is no request body.
+
+        Emits a PROMOTION_RULE_DELETE event; the deletion is permanent and cannot be undone.
+
+        Returns 404 when no rule with ruleId exists under that promotion, including when the rule belongs to a different offer.
+
+        '
+      operationId: deletePromotionEligibilityRule
       parameters:
       - name: promotionId
         in: path

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/BasePriceBulkIngestController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/BasePriceBulkIngestController.java
@@ -7,6 +7,10 @@ import com.positivity.bulkingest.BulkIngestResult;
 import com.positivity.events.EmitEvent;
 import com.positivity.price.internal.dto.BasePriceBulkIngestRecord;
 import com.positivity.price.service.BasePriceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.math.BigDecimal;
@@ -37,12 +41,56 @@ public class BasePriceBulkIngestController extends AbstractBulkIngestController<
 
     private final BasePriceService basePriceService;
 
+    private static final String BULK_INGEST_EXAMPLE = """
+            {"jobId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d01",
+             "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d02",
+             "operatorId":"user-jdoe",
+             "records":[
+               {"productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01",
+                "msrp":"125.50",
+                "currency":"USD",
+                "effectiveFrom":"2026-03-01T00:00:00Z"}]}
+            """;
+
     @Override
     @PostMapping("/bulk-ingest")
     @PreAuthorize("hasAuthority('pricing:base_price:create')")
     @EmitEvent(id = "PRICE_BULK_INGEST", apiVersion = "1")
+    @Operation(operationId = "bulkIngestBasePrices", summary = "Bulk Import Base Price Records", description = """
+                    Bulk-imports base price (MSRP) records, appending an effective-dated price window per product and \
+                    currency.
+                    Use this tool for batch price loads from an upstream catalog; use calculatePriceQuote instead to \
+                    read the price effective at a pricing instant, since quoting resolves these windows.
+                    Preconditions: each record's effectiveFrom must start after the product's current window begins; \
+                    re-submitting the current open window's unchanged price is idempotent and returns the existing id.
+                    Required inputs: jobId and locationId (UUIDs) and records (at least one), each record carrying \
+                    productId (UUID string), msrp (decimal string), currency (ISO 4217 code), and effectiveFrom as an \
+                    ISO-8601 instant such as 2026-03-01T00:00:00Z; operatorId is optional.
+                    Emits a PRICE_BULK_INGEST event; a new window closes the previous open window at its effectiveFrom \
+                    and rows are processed independently, so one bad row does not abort the batch.
+                    Returns 200 with per-row results even when rows fail, marking failed rows with errorCode \
+                    PRICE_INGEST_FAILED (including overlapping-window conflicts and unparseable values), and 400 when \
+                    the batch envelope itself is invalid.
+                    """)
+    @ApiResponse(responseCode = "200", description = "Batch processed; check per-record success and failure results.")
+    @ApiResponse(responseCode = "400", description = "Invalid batch envelope.")
+    @ApiResponse(responseCode = "403", description = "Insufficient permissions.")
     public ResponseEntity<BulkIngestResponse> bulkIngest(
-            @Valid @RequestBody @NonNull BulkIngestRequest<BasePriceBulkIngestRecord> request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Batch envelope of base-price records to ingest, scoped to a job and location.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Single price window",
+                                                            value = BULK_INGEST_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BulkIngestRequest<BasePriceBulkIngestRecord> request) {
         return super.bulkIngest(request);
     }
 

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/PriceNormalizationController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/PriceNormalizationController.java
@@ -2,6 +2,8 @@ package com.positivity.price.internal.controller;
 
 import com.positivity.events.EmitEvent;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
@@ -22,14 +24,34 @@ public class PriceNormalizationController {
 
     private static final Logger log = LoggerFactory.getLogger(PriceNormalizationController.class);
 
-    @Operation(summary = "Normalize pricing", description = "Normalize and standardize pricing data across the system.")
+    @Operation(operationId = "normalizePricing", summary = "Normalize Pricing Data", description = """
+                    Normalizes and standardizes pricing data across the system; this operation is a declared \
+                    placeholder that is not yet implemented.
+                    Use this tool only to probe for the future normalization capability; use calculatePriceQuote \
+                    instead for any real pricing work, since no normalization logic exists yet.
+                    Preconditions: none; any authenticated caller is accepted.
+                    Required inputs: none are read; the optional JSON body is accepted but ignored.
+                    Emits a PRICE_NORMALIZATION_NORMALIZE event even though no normalization is performed and no state \
+                    changes.
+                    Returns 501 unconditionally until the operation is implemented.
+                    """)
     @ApiResponse(responseCode = "501", description = "Not yet implemented.")
     @ApiResponse(responseCode = "400", description = "Invalid request body.")
     @ApiResponse(responseCode = "500", description = "Internal server error.")
     @EmitEvent(id = "PRICE_NORMALIZATION_NORMALIZE", apiVersion = "1")
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/normalize")
-    public ResponseEntity<Object> normalizePricing(@RequestBody(required = false) Object requestBody) {
+    public ResponseEntity<Object> normalizePricing(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Optional free-form normalization payload; currently ignored because the endpoint is unimplemented.",
+                            required = false,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Empty payload", value = "{}")))
+                    @RequestBody(required = false)
+                    Object requestBody) {
         log.info("POST /v1/price/normalize");
         return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/PriceQuoteController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/PriceQuoteController.java
@@ -7,6 +7,7 @@ import com.positivity.price.service.PriceQuoteService;
 import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,10 +45,24 @@ public class PriceQuoteController {
     @PostMapping
     @EmitEvent(id = "PRICE_QUOTE_CALCULATE", apiVersion = "1")
     @PreAuthorize("isAuthenticated()")
-    @Operation(
-            summary = "Calculate contextual price quote",
-            description =
-                    "Calculates a contextual price quote using request inputs such as product, location, customer tier, and pricing context.")
+    @Operation(operationId = "calculatePriceQuote", summary = "Calculate Contextual Price Quote", description = """
+                    Calculates a contextual unit and extended price for a product by resolving, in order, the base \
+                    MSRP effective at the pricing instant, then an active location price override that replaces the \
+                    running price, then a customer tier discount rate applied to the running price.
+                    Use this tool to price a line for an estimate or cart; do not use applyPromotionOffer here, \
+                    because promotions are layered onto the estimate separately, and use getPricingSnapshotById to \
+                    re-read a previously captured price instead of recalculating.
+                    Preconditions: a base price for the product and quote currency must be effective at the pricing \
+                    instant; location overrides and tier rules are optional layers that apply only when active.
+                    Required inputs: productId, locationId, and customerTierId (UUIDs) plus quantity (minimum 1); \
+                    effectiveTimestamp defaults to the current time, and currency defaults to the configured \
+                    pos.price.default-currency (USD unless overridden).
+                    Emits a PRICE_QUOTE_CALCULATE event but writes no pricing state; the unit price is rounded \
+                    half-even to two decimals, priceSource is MSRP_FALLBACK when only the base price applied and \
+                    CALCULATED otherwise, and each resolution step is itemised in pricingBreakdown.
+                    Returns 404 with code PRICE_BASE_UNAVAILABLE when no base price is effective for the product, \
+                    currency, and instant.
+                    """)
     @ApiResponse(responseCode = "200", description = "Price quote calculated successfully.")
     @ApiResponse(
             responseCode = "400",
@@ -61,7 +76,25 @@ public class PriceQuoteController {
             responseCode = "404",
             description = "No base price effective for the product at the pricing instant (PRICE_BASE_UNAVAILABLE).",
             content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<PriceQuoteResponse> calculatePriceQuote(@Valid @RequestBody PriceQuoteRequest request) {
+    public ResponseEntity<PriceQuoteResponse> calculatePriceQuote(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Pricing context identifying the product, quantity, location, customer tier, and optional instant and currency.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Tiered quote", value = """
+                                                                    {"productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01",
+                                                                     "quantity":2,
+                                                                     "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b02",
+                                                                     "customerTierId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b03",
+                                                                     "effectiveTimestamp":"2026-03-05T21:15:00Z",
+                                                                     "currency":"USD"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    PriceQuoteRequest request) {
         return ResponseEntity.ok(priceQuoteService.calculatePrice(request));
     }
 }

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/PriceRestrictionsController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/PriceRestrictionsController.java
@@ -9,6 +9,8 @@ import com.positivity.price.internal.dto.RestrictionOverrideResponse;
 import com.positivity.price.service.RestrictionEvaluationService;
 import com.positivity.price.service.RestrictionOverrideService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -38,9 +40,23 @@ public class PriceRestrictionsController {
         this.overrideService = overrideService;
     }
 
-    @Operation(
-            summary = "Evaluate price restrictions",
-            description = "Evaluates whether products are subject to restrictions in the given context.")
+    @Operation(operationId = "evaluatePriceRestrictions", summary = "Evaluate Price Restrictions", description = """
+                    Evaluates each submitted product and context entry against active sale-restriction rules and \
+                    returns a per-item decision of ALLOW, BLOCK, ALLOW_WITH_OVERRIDE, or RESTRICTION_UNKNOWN.
+                    Use this tool before quoting or selling a product to learn whether the sale is blocked or needs an \
+                    override; do not use overridePriceRestriction, which records the override itself after a decision \
+                    of ALLOW_WITH_OVERRIDE.
+                    Preconditions: none; items with no matching active rule resolve to ALLOW.
+                    Required inputs: items (at least one), each with productId (UUID), locationTag, serviceTag, and \
+                    context (BROWSE, QUOTE, CHECKOUT, INVOICE_FINALIZE, or COMMIT_SALE); any matching rule with \
+                    overrideable false forces BLOCK, otherwise matching rules yield ALLOW_WITH_OVERRIDE with the \
+                    matched ruleIds.
+                    Emits a PRICE_RESTRICTIONS_EVALUATE event; the evaluation itself is read-only and each item is \
+                    bounded by an 800 ms timeout.
+                    Returns 503 when evaluation fails or times out for an item in a commit-path context (CHECKOUT, \
+                    INVOICE_FINALIZE, COMMIT_SALE), while the same failure on BROWSE or QUOTE degrades that item to a \
+                    RESTRICTION_UNKNOWN decision instead of an error.
+                    """)
     @ApiResponse(responseCode = "200", description = "Evaluation results per product.")
     @ApiResponse(responseCode = "400", description = "Invalid request body.")
     @ApiResponse(responseCode = "401", description = "Authentication required.")
@@ -50,20 +66,48 @@ public class PriceRestrictionsController {
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/restrictions:evaluate")
     public ResponseEntity<RestrictionEvaluationResponse> evaluateRestrictions(
-            @Valid @RequestBody RestrictionEvaluationRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Batch of product/location/service/context entries to test against the active restriction rules.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Checkout evaluation", value = """
+                                                                    {"items":[
+                                                                      {"productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01",
+                                                                       "locationTag":"RETAIL_STORE",
+                                                                       "serviceTag":"POS_SALE",
+                                                                       "context":"CHECKOUT"}]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    RestrictionEvaluationRequest request) {
         log.info(
                 "POST /v1/price/restrictions:evaluate items={}", request.items().size());
         List<RestrictionEvaluationResult> results = evaluationService.evaluate(request);
         return ResponseEntity.ok(new RestrictionEvaluationResponse(results));
     }
 
-    @Operation(
-            summary = "Override price restrictions",
-            description = "Issues an override for price restrictions. Requires pricing:restriction:override authority.")
+    @Operation(operationId = "overridePriceRestriction", summary = "Override Price Restrictions", description = """
+                    Issues an audited, time-boxed override of a sale-restriction rule for a specific transaction and \
+                    product.
+                    Use this tool after evaluatePriceRestrictions returns ALLOW_WITH_OVERRIDE; do not use \
+                    deactivateRestrictionRule, which retires the rule for everyone instead of exempting one \
+                    transaction.
+                    Preconditions: the referenced restriction rule must exist; the rule's overrideable flag is not \
+                    re-checked here, so callers must honour a BLOCK decision from evaluation rather than overriding it.
+                    Required inputs: ruleId, transactionId, and productId (UUIDs), overrideContext (BROWSE, QUOTE, \
+                    CHECKOUT, INVOICE_FINALIZE, or COMMIT_SALE), and reasonCode; notes and approvedBy are optional.
+                    Emits a PRICE_RESTRICTIONS_OVERRIDE event and persists an ISSUED audit record capturing the actor \
+                    and the rule's policyVersion; the returned overrideId expires 24 hours after issue.
+                    Returns 404 when the referenced restriction rule does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Override issued. Returns overrideId and expiresAt.")
     @ApiResponse(responseCode = "400", description = "Invalid request body.")
     @ApiResponse(responseCode = "401", description = "Authentication required.")
     @ApiResponse(responseCode = "403", description = "Insufficient permissions to override restrictions.")
+    @ApiResponse(responseCode = "404", description = "Restriction rule not found.")
     @EmitEvent(id = "PRICE_RESTRICTIONS_OVERRIDE", apiVersion = "1")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -71,7 +115,25 @@ public class PriceRestrictionsController {
     @PreAuthorize("hasAuthority('pricing:restriction:override')")
     @PostMapping("/restrictions:override")
     public ResponseEntity<RestrictionOverrideResponse> overrideRestrictions(
-            @Valid @RequestBody RestrictionOverrideRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Override justification tying a restriction rule to the transaction and product it is waived for.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Manager-approved override", value = """
+                                                                    {"ruleId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4c01",
+                                                                     "transactionId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4c02",
+                                                                     "productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01",
+                                                                     "overrideContext":"CHECKOUT",
+                                                                     "reasonCode":"MANAGER_APPROVAL",
+                                                                     "notes":"Customer is a licensed reseller",
+                                                                     "approvedBy":"user-001"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    RestrictionOverrideRequest request) {
         log.info("POST /v1/price/restrictions:override context={}", request.overrideContext());
         RestrictionOverrideResponse response = overrideService.createOverride(request);
         return ResponseEntity.ok(response);

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/PricingSnapshotController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/PricingSnapshotController.java
@@ -38,9 +38,17 @@ public class PricingSnapshotController {
      */
     @GetMapping("/{snapshotId}")
     @PreAuthorize("isAuthenticated()")
-    @Operation(
-            summary = "Get pricing snapshot by ID",
-            description = "Retrieves an immutable pricing snapshot using its snapshot identifier.")
+    @Operation(operationId = "getPricingSnapshotById", summary = "Get Pricing Snapshot By ID", description = """
+                    Returns an immutable pricing snapshot that captured the prices, applied rules, and policy version \
+                    of a past pricing decision.
+                    Use this tool to audit or re-display exactly what was priced at capture time; do not use \
+                    calculatePriceQuote, which computes a fresh price that may differ from the recorded one.
+                    Preconditions: a snapshot with the supplied id must have been persisted by an earlier pricing flow.
+                    Required inputs: snapshotId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; snapshots are immutable and this is a read-only \
+                    projection.
+                    Returns 404 with code SNAPSHOT_NOT_FOUND when no snapshot exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Pricing snapshot returned.")
     @ApiResponse(responseCode = "404", description = "Pricing snapshot not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/PromotionEligibilityRuleController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/PromotionEligibilityRuleController.java
@@ -8,6 +8,8 @@ import com.positivity.price.internal.dto.EligibilityRuleResponse;
 import com.positivity.price.internal.dto.PromotionEligibilityRuleMapper;
 import com.positivity.price.service.EligibilityEvaluationService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -45,14 +47,45 @@ public class PromotionEligibilityRuleController {
             scopes = {"pricing:promotion:manage"})
     @PreAuthorize("hasAuthority('pricing:promotion:manage')")
     @Operation(
-            summary = "Add eligibility rule to promotion offer",
-            description = "Creates and attaches a new eligibility rule to the specified promotion offer.")
+            operationId = "createPromotionEligibilityRule",
+            summary = "Add Eligibility Rule To Promotion Offer",
+            description = """
+                    Creates an eligibility rule and attaches it to the promotion offer identified by promotionId, \
+                    constraining who may receive the promotion.
+                    Use this tool when a promotion must be limited by account list, fleet size, vehicle tag, audience \
+                    type, or campaign code; do not use evaluatePromotionEligibility, which tests a context against the \
+                    existing rules without changing them.
+                    Preconditions: the promotion offer must exist; rules may be added regardless of the offer's status.
+                    Required inputs: conditionType (ACCOUNT_ID_LIST, VEHICLE_TAG, ACCOUNT_FLEET_SIZE, AUDIENCE_TYPE, or \
+                    CAMPAIGN_CODE), an operator supported by that type (IN, NOT_IN, EQUALS, GREATER_THAN_OR_EQUAL_TO), \
+                    and value (max 255 characters; comma-separated for list types); ruleCombination is optional and \
+                    defaults to AND, and at evaluation time the first rule's combination governs all rules.
+                    Emits a PROMOTION_RULE_CREATE event and the rule takes effect on the next eligibility evaluation.
+                    Returns 404 when the promotion offer does not exist, and 400 when conditionType, operator, or value \
+                    is missing or invalid.
+                    """)
     @ApiResponse(responseCode = "201", description = "Eligibility rule created.")
     @ApiResponse(responseCode = "400", description = "Invalid eligibility rule request.")
     @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
     public ResponseEntity<EligibilityRuleResponse> addRule(
-            @PathVariable("promotionId") UUID promotionId, @Valid @RequestBody AddEligibilityRuleRequest request) {
+            @PathVariable("promotionId") UUID promotionId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Eligibility rule definition: the condition, operator, and comparison value to attach.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Fleet size rule", value = """
+                                                                    {"conditionType":"ACCOUNT_FLEET_SIZE",
+                                                                     "operator":"GREATER_THAN_OR_EQUAL_TO",
+                                                                     "value":"25",
+                                                                     "ruleCombination":"AND"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    AddEligibilityRuleRequest request) {
         var rule = eligibilityEvaluationService.addRule(promotionId, request);
         var response = PromotionEligibilityRuleMapper.toResponse(rule);
         URI location = URI.create("/v1/promotions/offers/" + promotionId + "/rules/" + response.getRuleId());
@@ -65,10 +98,22 @@ public class PromotionEligibilityRuleController {
             scopes = {"pricing:promotion:view"})
     @PreAuthorize("hasAuthority('pricing:promotion:view')")
     @Operation(
-            summary = "List eligibility rules for promotion offer",
-            description = "Returns all eligibility rules configured for the specified promotion offer.")
+            operationId = "listPromotionEligibilityRules",
+            summary = "List Eligibility Rules For Promotion Offer",
+            description = """
+                    Lists every eligibility rule currently attached to the promotion offer identified by promotionId.
+                    Use this tool to inspect a promotion's audience constraints before editing them; use \
+                    evaluatePromotionEligibility instead to test whether a concrete account, vehicle, or campaign \
+                    context passes those rules.
+                    Preconditions: none beyond the pricing:promotion:view authority; an unknown promotionId is not \
+                    rejected.
+                    Required inputs: promotionId (UUID) as a path parameter; there is no request body, filtering, or \
+                    paging.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty array both when the promotion has no rules and when the promotionId \
+                    matches no offer, so this operation cannot verify that a promotion exists.
+                    """)
     @ApiResponse(responseCode = "200", description = "Eligibility rules returned.")
-    @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
     public ResponseEntity<List<EligibilityRuleResponse>> getRules(@PathVariable("promotionId") UUID promotionId) {
         List<EligibilityRuleResponse> responses = eligibilityEvaluationService.getRules(promotionId).stream()
@@ -84,8 +129,19 @@ public class PromotionEligibilityRuleController {
             scopes = {"pricing:promotion:manage"})
     @PreAuthorize("hasAuthority('pricing:promotion:manage')")
     @Operation(
-            summary = "Delete eligibility rule",
-            description = "Deletes an eligibility rule from the specified promotion offer.")
+            operationId = "deletePromotionEligibilityRule",
+            summary = "Delete Promotion Eligibility Rule",
+            description = """
+                    Deletes a single eligibility rule from a promotion offer, widening the promotion's audience from \
+                    the next evaluation onward.
+                    Use this tool to remove one constraint while keeping the offer and its other rules; do not use \
+                    deactivatePromotionOffer, which withdraws the entire offer rather than one rule.
+                    Preconditions: a rule with ruleId must exist and belong to the promotion identified by promotionId.
+                    Required inputs: promotionId (UUID) and ruleId (UUID) as path parameters; there is no request body.
+                    Emits a PROMOTION_RULE_DELETE event; the deletion is permanent and cannot be undone.
+                    Returns 404 when no rule with ruleId exists under that promotion, including when the rule belongs \
+                    to a different offer.
+                    """)
     @ApiResponse(responseCode = "204", description = "Eligibility rule deleted.")
     @ApiResponse(responseCode = "404", description = "Promotion offer or rule not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
@@ -102,14 +158,43 @@ public class PromotionEligibilityRuleController {
             scopes = {"pricing:promotion:apply"})
     @PreAuthorize("hasAuthority('pricing:promotion:apply')")
     @Operation(
-            summary = "Evaluate promotion eligibility",
-            description = "Evaluates whether a promotion offer is eligible for the provided evaluation context.")
+            operationId = "evaluatePromotionEligibility",
+            summary = "Evaluate Promotion Eligibility",
+            description = """
+                    Evaluates whether the supplied account, vehicle, audience, and campaign context passes the \
+                    eligibility rules attached to a promotion offer, returning an eligible flag and a reason code.
+                    Use this tool to pre-check eligibility without consuming promotion usage; do not use \
+                    applyPromotionOffer, which applies the discount and increments the offer's usage count.
+                    Preconditions: the first rule's ruleCombination governs the evaluation (AND requires every rule to \
+                    pass, OR requires any one); a promotion with no rules, or an unknown promotionId, evaluates to \
+                    eligible because only the stored rules are consulted.
+                    Required inputs: a context body whose fields are all optional; accountId and vehicleId (UUIDs), \
+                    audienceType (compared case-insensitively), and campaignCode, where omitting a field that a rule \
+                    needs fails that rule with a missing-context reason code such as MISSING_ACCOUNT_CONTEXT.
+                    Emits a PROMOTION_RULE_EVALUATE event; no promotion state or usage count changes.
+                    Returns 200 with eligible true or false and a reason code such as ELIGIBLE, ACCOUNT_NOT_IN_LIST, \
+                    FLEET_SIZE_TOO_SMALL, or VEHICLE_TAG_NOT_PRESENT; 400 occurs only for an unparseable body.
+                    """)
     @ApiResponse(responseCode = "200", description = "Eligibility evaluation result returned.")
     @ApiResponse(responseCode = "400", description = "Invalid evaluation request.")
-    @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
     public ResponseEntity<EligibilityDecisionResponse> evaluateEligibility(
-            @PathVariable("promotionId") UUID promotionId, @RequestBody EligibilityContext context) {
+            @PathVariable("promotionId") UUID promotionId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Account, vehicle, audience, and campaign context the promotion's rules are evaluated against.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Fleet account context", value = """
+                                                                    {"accountId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "vehicleId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "audienceType":"COMMERCIAL",
+                                                                     "campaignCode":"SPRING-FLEET-2026"}
+                                                                    """)))
+                    @RequestBody
+                    EligibilityContext context) {
         var decision = eligibilityEvaluationService.evaluateEligibility(
                 promotionId,
                 context == null ? null : context.getAccountId(),

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/PromotionOfferController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/PromotionOfferController.java
@@ -8,6 +8,8 @@ import com.positivity.price.internal.dto.PromotionOfferMapper;
 import com.positivity.price.internal.dto.PromotionOfferResponse;
 import com.positivity.price.service.PromotionOfferService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -29,6 +31,17 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Promotion Offers", description = "Promotion offer lifecycle operations")
 public class PromotionOfferController {
 
+    private static final String APPLY_PROMOTION_EXAMPLE = """
+            {"promotionCode":"SUMMER20",
+             "estimateContext":{
+               "estimateId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01",
+               "customerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02",
+               "vehicleId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03",
+               "lineItems":[{"sku":"P001","quantity":1,"unitPrice":500.00}],
+               "subtotal":500.00,
+               "appliedPromoCodes":[]}}
+            """;
+
     private final PromotionOfferService promotionOfferService;
 
     public PromotionOfferController(PromotionOfferService promotionOfferService) {
@@ -41,14 +54,47 @@ public class PromotionOfferController {
             name = "bearerAuth",
             scopes = {"pricing:promotion:manage"})
     @PreAuthorize("hasAuthority('pricing:promotion:manage')")
-    @Operation(
-            summary = "Create promotion offer",
-            description = "Creates a new promotion offer with code, lifecycle settings, and discount policy.")
+    @Operation(operationId = "createPromotionOffer", summary = "Create Promotion Offer", description = """
+                    Creates a promotion offer in DRAFT status with a unique promo code, a validity window, and a \
+                    discount policy.
+                    Use this tool to define a new promotion; do not use activatePromotionOffer, which only transitions \
+                    an existing offer to ACTIVE, and note that a DRAFT offer cannot be applied until activated.
+                    Preconditions: no offer may already exist with the same promoCode, and startDate must not be after \
+                    endDate.
+                    Required inputs: promoCode (max 64 characters), name, discountType (PERCENT_LABOR, PERCENT_PARTS, \
+                    or FIXED_INVOICE), discountValue (minimum 0.01, two decimal places), startDate, and endDate; \
+                    usageLimit and storeCode are optional and default to unlimited usage and no store scoping.
+                    Emits a PROMOTION_OFFER_CREATE event and persists the offer with status DRAFT and a zero usage \
+                    count.
+                    Returns 409 when the promoCode already exists, and 422 when startDate is after endDate.
+                    """)
     @ApiResponse(responseCode = "201", description = "Promotion offer created.")
     @ApiResponse(responseCode = "400", description = "Invalid promotion offer request.")
     @ApiResponse(responseCode = "409", description = "Promotion code already exists.")
+    @ApiResponse(responseCode = "422", description = "startDate is after endDate.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
-    public ResponseEntity<PromotionOfferResponse> createOffer(@Valid @RequestBody CreatePromotionOfferRequest request) {
+    public ResponseEntity<PromotionOfferResponse> createOffer(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Promotion offer definition: promo code, discount policy, and validity window.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Percent labor promotion", value = """
+                                                                    {"promoCode":"SUMMER20",
+                                                                     "name":"Summer Labor Discount",
+                                                                     "description":"20% off labor for seasonal service",
+                                                                     "discountType":"PERCENT_LABOR",
+                                                                     "discountValue":20.00,
+                                                                     "startDate":"2026-06-01",
+                                                                     "endDate":"2026-08-31",
+                                                                     "usageLimit":100,
+                                                                     "storeCode":"NYC-001"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    CreatePromotionOfferRequest request) {
         var offer = promotionOfferService.createOffer(request);
         var response = PromotionOfferMapper.toResponse(offer);
         URI location = URI.create("/v1/promotions/offers/" + response.getPromotionOfferId());
@@ -60,9 +106,16 @@ public class PromotionOfferController {
             name = "bearerAuth",
             scopes = {"pricing:promotion:view"})
     @PreAuthorize("hasAuthority('pricing:promotion:view')")
-    @Operation(
-            summary = "Get promotion offer by ID",
-            description = "Retrieves a promotion offer using its unique identifier.")
+    @Operation(operationId = "getPromotionOfferById", summary = "Get Promotion Offer By ID", description = """
+                    Returns the full promotion offer, including status, discount policy, validity window, and usage \
+                    counters.
+                    Use this tool when the promotion offer's UUID is already known; use getPromotionOfferByCode instead \
+                    when only the customer-facing promo code is available.
+                    Preconditions: the promotion offer must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no promotion offer exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Promotion offer returned.")
     @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
@@ -76,9 +129,16 @@ public class PromotionOfferController {
             name = "bearerAuth",
             scopes = {"pricing:promotion:view"})
     @PreAuthorize("hasAuthority('pricing:promotion:view')")
-    @Operation(
-            summary = "Get promotion offer by code",
-            description = "Retrieves a promotion offer using its promotion code.")
+    @Operation(operationId = "getPromotionOfferByCode", summary = "Get Promotion Offer By Code", description = """
+                    Returns the promotion offer that owns the supplied customer-facing promo code.
+                    Use this tool when only the promo code from marketing material is known; use \
+                    getPromotionOfferById instead when the offer's UUID is available.
+                    Preconditions: an offer with exactly that promoCode must exist; the lookup is an exact match on \
+                    the code.
+                    Required inputs: promoCode (max 64 characters) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no promotion offer exists for the supplied code.
+                    """)
     @ApiResponse(responseCode = "200", description = "Promotion offer returned.")
     @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
@@ -93,12 +153,21 @@ public class PromotionOfferController {
             name = "bearerAuth",
             scopes = {"pricing:promotion:manage"})
     @PreAuthorize("hasAuthority('pricing:promotion:manage')")
-    @Operation(
-            summary = "Activate promotion offer",
-            description = "Activates a promotion offer so it becomes eligible for application.")
+    @Operation(operationId = "activatePromotionOffer", summary = "Activate Promotion Offer", description = """
+                    Transitions a promotion offer to ACTIVE so applyPromotionOffer will accept its promo code within \
+                    the validity window.
+                    Use this tool to publish a DRAFT offer or re-enable an INACTIVE one; do not use \
+                    createPromotionOffer, which creates a new offer that still starts in DRAFT.
+                    Preconditions: the offer must exist, must not be EXPIRED, and its endDate must not already be in \
+                    the past.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a PROMOTION_OFFER_ACTIVATE event and sets the status to ACTIVE immediately.
+                    Returns 404 when the offer does not exist, and 422 when the offer is EXPIRED or its end date has \
+                    already passed.
+                    """)
     @ApiResponse(responseCode = "200", description = "Promotion offer activated.")
     @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
-    @ApiResponse(responseCode = "409", description = "Promotion offer cannot be activated in current state.")
+    @ApiResponse(responseCode = "422", description = "Promotion offer cannot be activated in current state.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
     public ResponseEntity<PromotionOfferResponse> activateOffer(@PathVariable("id") UUID promotionOfferId) {
         var offer = promotionOfferService.activateOffer(promotionOfferId);
@@ -111,11 +180,21 @@ public class PromotionOfferController {
             name = "bearerAuth",
             scopes = {"pricing:promotion:manage"})
     @PreAuthorize("hasAuthority('pricing:promotion:manage')")
-    @Operation(
-            summary = "Deactivate promotion offer",
-            description = "Deactivates a promotion offer so it is no longer eligible for application.")
+    @Operation(operationId = "deactivatePromotionOffer", summary = "Deactivate Promotion Offer", description = """
+                    Transitions an ACTIVE promotion offer to INACTIVE so its promo code is no longer accepted by \
+                    applyPromotionOffer.
+                    Use this tool to withdraw a live offer while keeping its history and rules; do not use \
+                    deletePromotionEligibilityRule, which removes a single audience rule rather than the offer.
+                    Preconditions: the offer must exist and currently be ACTIVE; DRAFT, INACTIVE, and EXPIRED offers \
+                    cannot be deactivated.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a PROMOTION_OFFER_DEACTIVATE event; the offer can later be re-enabled with \
+                    activatePromotionOffer.
+                    Returns 404 when the offer does not exist, and 422 when the offer is not currently ACTIVE.
+                    """)
     @ApiResponse(responseCode = "200", description = "Promotion offer deactivated.")
     @ApiResponse(responseCode = "404", description = "Promotion offer not found.")
+    @ApiResponse(responseCode = "422", description = "Promotion offer is not currently ACTIVE.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
     public ResponseEntity<PromotionOfferResponse> deactivateOffer(@PathVariable("id") UUID promotionOfferId) {
         var offer = promotionOfferService.deactivateOffer(promotionOfferId);
@@ -129,14 +208,45 @@ public class PromotionOfferController {
             scopes = {"pricing:promotion:apply"})
     @PreAuthorize("hasAuthority('pricing:promotion:apply')")
     @Operation(
-            summary = "Apply promotion offer during estimate pricing",
-            description =
-                    "Applies a promotion offer to pricing inputs and returns resulting discount and adjusted totals.")
+            operationId = "applyPromotionOffer",
+            summary = "Apply Promotion Offer During Estimate Pricing",
+            description = """
+                    Applies a promotion code to an estimate's pricing context and returns the discount adjustment and \
+                    the adjusted total.
+                    Use this tool at estimate time to price in a promotion; use evaluatePromotionEligibility instead \
+                    for a dry-run check, because this operation consumes one usage against the offer's usageLimit.
+                    Preconditions: the offer must be ACTIVE, the current date must fall within startDate and endDate, \
+                    the context must pass the offer's eligibility rules, the usage limit must not be exhausted, and no \
+                    promo code may already be applied because only one promotion is allowed per estimate.
+                    Required inputs: promotionCode and estimateContext with estimateId, customerId, subtotal, and at \
+                    least one line item; PERCENT_LABOR and PERCENT_PARTS both currently discount the full subtotal by \
+                    the percentage, while FIXED_INVOICE subtracts the fixed discountValue.
+                    Emits a PROMOTION_OFFER_APPLY event and atomically increments the offer's usage count.
+                    Returns 400 with code PROMO_NOT_FOUND when the code is unknown, PROMO_NOT_APPLICABLE when the \
+                    offer is inactive, outside its date range, ineligible for the context, or over its usage limit, \
+                    and PROMO_MULTIPLE_NOT_ALLOWED when the estimate already carries an applied promo code.
+                    """)
     @ApiResponse(responseCode = "200", description = "Promotion offer applied.")
-    @ApiResponse(responseCode = "400", description = "Invalid promotion application request.")
-    @ApiResponse(responseCode = "404", description = "Promotion offer not found or not eligible.")
+    @ApiResponse(
+            responseCode = "400",
+            description =
+                    "Invalid request, unknown promo code, promotion not applicable, or promotion already applied.")
     @ApiResponse(responseCode = "403", description = "Forbidden.")
-    public ResponseEntity<ApplyPromotionResponse> applyPromotion(@RequestBody @Valid ApplyPromotionRequest request) {
+    public ResponseEntity<ApplyPromotionResponse> applyPromotion(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Promotion code plus the estimate context (customer, line items, subtotal) it is applied against.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Apply to estimate",
+                                                            value = APPLY_PROMOTION_EXAMPLE)))
+                    @RequestBody
+                    @Valid
+                    ApplyPromotionRequest request) {
         return ResponseEntity.ok(promotionOfferService.applyPromotion(request));
     }
 }

--- a/pos-price/src/main/java/com/positivity/price/internal/controller/RestrictionRuleController.java
+++ b/pos-price/src/main/java/com/positivity/price/internal/controller/RestrictionRuleController.java
@@ -5,6 +5,8 @@ import com.positivity.price.internal.dto.CreateRestrictionRuleRequest;
 import com.positivity.price.internal.dto.RestrictionRuleResponse;
 import com.positivity.price.service.RestrictionRuleService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -37,9 +39,22 @@ public class RestrictionRuleController {
         this.restrictionRuleService = restrictionRuleService;
     }
 
-    @Operation(
-            summary = "Create a restriction rule",
-            description = "Creates a price restriction rule for a product, location tag, and service tag combination.")
+    @Operation(operationId = "createRestrictionRule", summary = "Create A Restriction Rule", description = """
+                    Creates an active sale-restriction rule that blocks or gates a product for a location tag and \
+                    service tag combination.
+                    Use this tool to configure a standing restriction policy; do not use overridePriceRestriction, \
+                    which grants a one-time transaction exemption from an existing rule.
+                    Preconditions: none are checked beyond authorization; duplicate rules for the same product and tag \
+                    combination are not rejected, so each call appends a new rule.
+                    Required inputs: productId (UUID), locationTag (ALL_LOCATIONS, RETAIL_STORE, WAREHOUSE, \
+                    MOBILE_SERVICE, FRANCHISE, or TEST_LOCATION), serviceTag (POS_SALE, WORKORDER, ESTIMATE, INVOICE, \
+                    or DELIVERY), effectiveFrom (date), and overrideable; effectiveTo is optional, and policyVersion \
+                    defaults to 1 when omitted.
+                    Emits a PRICE_RESTRICTION_RULE_CREATE event and the rule participates in evaluation immediately; \
+                    a rule with overrideable false forces a BLOCK decision that cannot be overridden.
+                    Returns 201 with the stored rule, and 400 when a required field is missing or a tag is not a valid \
+                    enum value.
+                    """)
     @ApiResponse(responseCode = "201", description = "Restriction rule created.")
     @ApiResponse(responseCode = "400", description = "Invalid request.")
     @ApiResponse(responseCode = "401", description = "Authentication required.")
@@ -51,15 +66,43 @@ public class RestrictionRuleController {
     @PreAuthorize("hasAuthority('pricing:restriction:manage')")
     @PostMapping
     public ResponseEntity<@NonNull RestrictionRuleResponse> createRule(
-            @Valid @RequestBody @NonNull CreateRestrictionRuleRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description =
+                                    "Restriction rule definition scoping a product restriction to location and service tags.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Overrideable retail restriction",
+                                                            value = """
+                                                                    {"productId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01",
+                                                                     "locationTag":"RETAIL_STORE",
+                                                                     "serviceTag":"POS_SALE",
+                                                                     "effectiveFrom":"2026-03-01",
+                                                                     "effectiveTo":"2026-12-31",
+                                                                     "policyVersion":3,
+                                                                     "overrideable":true}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    CreateRestrictionRuleRequest request) {
         log.info("POST /v1/price/restrictions/rules productId={}", request.productId());
         RestrictionRuleResponse response = restrictionRuleService.createRule(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @Operation(
-            summary = "Get a restriction rule by ID",
-            description = "Returns the active or inactive restriction rule identified by the supplied rule ID.")
+    @Operation(operationId = "getRestrictionRuleById", summary = "Get A Restriction Rule By ID", description = """
+                    Returns a single sale-restriction rule, active or inactive, identified by its rule id.
+                    Use this tool when the rule id is already known, typically from an evaluation result's ruleIds; \
+                    use listRestrictionRules instead to browse the active rule set.
+                    Preconditions: the rule must exist; inactive rules remain readable through this operation.
+                    Required inputs: ruleId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no restriction rule exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Restriction rule found.")
     @ApiResponse(responseCode = "401", description = "Authentication required.")
     @ApiResponse(responseCode = "404", description = "Restriction rule not found.")
@@ -72,9 +115,15 @@ public class RestrictionRuleController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(
-            summary = "List all active restriction rules",
-            description = "Returns all currently active price restriction rules that can affect pricing decisions.")
+    @Operation(operationId = "listRestrictionRules", summary = "List All Active Restriction Rules", description = """
+                    Lists every currently active sale-restriction rule that can affect pricing and sale decisions.
+                    Use this tool to review the standing restriction policy; use getRestrictionRuleById instead to \
+                    fetch one rule, including deactivated rules, which this listing omits.
+                    Preconditions: none beyond an authenticated caller.
+                    Required inputs: none; there is no request body, filtering, or paging.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty array when no active restriction rules exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of restriction rules.")
     @ApiResponse(responseCode = "401", description = "Authentication required.")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
@@ -86,10 +135,18 @@ public class RestrictionRuleController {
         return ResponseEntity.ok(rules);
     }
 
-    @Operation(
-            summary = "Deactivate a restriction rule",
-            description =
-                    "Deactivates the specified restriction rule so it no longer participates in price restriction evaluation.")
+    @Operation(operationId = "deactivateRestrictionRule", summary = "Deactivate A Restriction Rule", description = """
+                    Deactivates a sale-restriction rule so it no longer participates in restriction evaluation.
+                    Use this tool to retire a standing restriction for everyone; do not use overridePriceRestriction, \
+                    which leaves the rule active and exempts only a single transaction.
+                    Preconditions: the rule must exist and still be active; deactivation is not idempotent, so \
+                    repeating it fails.
+                    Required inputs: ruleId (UUID) as a path parameter; there is no request body.
+                    Emits a PRICE_RESTRICTION_RULE_DEACTIVATE event, sets active to false, and stamps effectiveTo with \
+                    the current date.
+                    Returns 404 when no restriction rule exists for the supplied id; calling it on an already inactive \
+                    rule produces a server error rather than a no-op.
+                    """)
     @ApiResponse(responseCode = "200", description = "Restriction rule deactivated.")
     @ApiResponse(responseCode = "401", description = "Authentication required.")
     @ApiResponse(responseCode = "403", description = "Insufficient permissions.")

--- a/pos-security-service/.flattened-pom.xml
+++ b/pos-security-service/.flattened-pom.xml
@@ -18,6 +18,10 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+  <properties>
+    <jacoco.line.min>0.76</jacoco.line.min>
+    <jacoco.branch.min>0.66</jacoco.branch.min>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pos-security-service/openapi.yaml
+++ b/pos-security-service/openapi.yaml
@@ -39,9 +39,21 @@ paths:
     put:
       tags:
       - User API
-      summary: Assign roles to a user
-      description: Replaces or applies the requested role set for the specified user by username.
-      operationId: assignRoles
+      summary: Replace a User's Direct Role Set
+      description: 'Replaces a user''s directly attached role set with the supplied role names, looking the user up by username.
+
+        Use this tool for wholesale role replacement by username; do not use assignUserRole, which adds a single scoped role assignment by UUID without touching the direct set.
+
+        Preconditions: the caller must hold security:role:assign, the username must resolve to a user, and every named role must exist.
+
+        Required inputs: username as a path parameter and roles, an array of existing role names, in the body; the set replaces all current direct roles.
+
+        Emits a SECURITY_USER_ASSIGN_ROLES event.
+
+        Returns 400 with INVALID_REQUEST when the user or a named role cannot be found; the miss surfaces as 400 rather than 404.
+
+        '
+      operationId: assignUserRolesByUsername
       parameters:
       - name: username
         in: path
@@ -50,11 +62,18 @@ paths:
         schema:
           type: string
       requestBody:
+        description: The replacement set of role names for the user.
         content:
           application/json:
             schema:
               type: object
-              description: Payload containing the roles to assign
+            examples:
+              Replace roles:
+                description: Replace roles
+                value:
+                  roles:
+                  - SHOP_MGR
+                  - ACCOUNTING_CLERK
         required: true
       responses:
         '400':
@@ -106,9 +125,21 @@ paths:
     put:
       tags:
       - User Role Management
-      summary: Assign a role to a user
-      description: Creates an effective role assignment linking the specified user to the specified role.
-      operationId: assignRoleToUser
+      summary: Assign a Role to a User
+      description: 'Creates a GLOBAL-scoped role assignment linking a user to a role, effective immediately with no end date.
+
+        Use this tool for the common unscoped grant; do not use createRoleAssignment, which supports LOCATION scope and effective date windows, and do not use assignPrincipalRole, which targets the string-keyed RBAC principal matrix.
+
+        Preconditions: the caller must hold security:role:assign and both the user and role must exist; no overlap check is performed here, so repeated calls create duplicate assignments.
+
+        Required inputs: userId and roleId (UUIDs) as path parameters; there is no request body.
+
+        Emits a SECURITY_USER_ROLE_ASSIGN event and writes a RoleAssignedToUser audit record.
+
+        Returns 404 when the user or role does not exist.
+
+        '
+      operationId: assignUserRole
       parameters:
       - name: userId
         in: path
@@ -167,9 +198,21 @@ paths:
     delete:
       tags:
       - User Role Management
-      summary: Revoke a role from a user
-      description: Removes the effective assignment of the specified role from the specified user.
-      operationId: revokeRoleFromUser
+      summary: Revoke a Role From a User
+      description: 'Ends the first currently effective assignment of a role for a user by setting its end date to now, preserving the row for history.
+
+        Use this tool for the common immediate revocation; do not use revokeRoleAssignment, which targets a specific assignment id and supports past or future end dates.
+
+        Preconditions: the caller must hold security:role:assign, the user and role must exist, and at least one effective assignment must link them.
+
+        Required inputs: userId and roleId (UUIDs) as path parameters; there is no request body.
+
+        Emits a SECURITY_USER_ROLE_REVOKE event and writes a RoleRevokedFromUser audit record.
+
+        Returns 404 when the user or role does not exist, or when no active assignment links them.
+
+        '
+      operationId: revokeUserRole
       parameters:
       - name: userId
         in: path
@@ -229,8 +272,20 @@ paths:
     get:
       tags:
       - User API
-      summary: Get user by ID
-      description: Retrieve a user by their unique ID.
+      summary: Get a User Account by Id
+      description: 'Returns a single user account by UUID, including effective role names merged from direct roles and currently active role assignments.
+
+        Use this tool when the user id is known; use listUsers instead to browse accounts, and getUserAccountState for administrative lock and expiry flags.
+
+        Preconditions: the caller must hold security:user:view and the user must exist.
+
+        Required inputs: id (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no user exists for the supplied id.
+
+        '
       operationId: getUserById
       parameters:
       - name: id
@@ -290,8 +345,20 @@ paths:
     put:
       tags:
       - User API
-      summary: Update an existing user
-      description: Update the details of an existing user.
+      summary: Partially Update a User Account
+      description: 'Applies a partial update to a user account: username, password, and the direct role set are each replaced only when supplied.
+
+        Use this tool to change account fields; do not use assignUserRolesByUsername, which only replaces roles, and do not use the account-state endpoints such as disableUserAccount, which flip administrative flags.
+
+        Preconditions: the caller must hold security:user:edit, the user must exist, and any named role must already exist.
+
+        Required inputs: id (UUID) as a path parameter; username, password, and roles are all optional, and omitted or blank fields are left unchanged.
+
+        Emits a SECURITY_USER_UPDATE event; a supplied password is re-hashed before storage.
+
+        Returns 400 with INVALID_REQUEST when the user or a named role cannot be found; the miss surfaces as 400 rather than 404.
+
+        '
       operationId: updateUser
       parameters:
       - name: id
@@ -303,10 +370,18 @@ paths:
           format: uuid
         example: 123e4567-e89b-12d3-a456-426614174000
       requestBody:
+        description: The account fields to change; omitted fields are left untouched.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UserUpdateRequest'
+            examples:
+              Rename and reset roles:
+                description: Rename and reset roles
+                value:
+                  username: jane.doe
+                  roles:
+                  - SHOP_MGR
         required: true
       responses:
         '400':
@@ -357,8 +432,20 @@ paths:
     delete:
       tags:
       - User API
-      summary: Delete a user
-      description: Delete a user by their unique ID.
+      summary: Delete a User Account
+      description: 'Deletes a user account and queues removal of its user-person link so downstream projections follow the account out.
+
+        Use this tool to remove an account permanently; do not use disableUserAccount, which blocks sign-in reversibly and keeps the record.
+
+        Preconditions: the caller must hold security:user:delete; deleting an id that does not exist is a silent no-op.
+
+        Required inputs: id (UUID) as a path parameter.
+
+        Emits a SECURITY_USER_DELETE event and sends a UserPersonLinkRemoveRequested command to the people-contact domain in the same transaction.
+
+        Returns 204 in all cases, including when the user was already absent.
+
+        '
       operationId: deleteUser
       parameters:
       - name: id
@@ -415,9 +502,21 @@ paths:
     put:
       tags:
       - Role Management
-      summary: Assign permission to a role by key
-      description: Assigns the permission identified by path key to the specified role
-      operationId: assignPermissionToRole
+      summary: Assign a Registered Permission to a Role
+      description: 'Adds an already-registered permission, identified by its key in the path, to a role''s grant set.
+
+        Use this tool when the permission is known to be registered; do not use grantRolePermission, which auto-registers unknown keys, and do not use updateRolePermissions, which replaces the whole set.
+
+        Preconditions: the caller must hold security:role:edit, the role must exist, and the permission key must already be registered (modules register at startup via registerModulePermissions).
+
+        Required inputs: roleId (UUID) and permissionKey (domain:resource:action) as path parameters; there is no request body.
+
+        Emits a SECURITY_ROLE_PERMISSION_ASSIGN event.
+
+        Returns 404 when the role does not exist or the permission key has not been registered.
+
+        '
+      operationId: assignRolePermissionByKey
       parameters:
       - name: roleId
         in: path
@@ -475,9 +574,21 @@ paths:
     delete:
       tags:
       - Role Management
-      summary: Revoke permission from a role
-      description: Removes the specified permission from the role
-      operationId: revokePermissionFromRole
+      summary: Revoke a Permission From a Role
+      description: 'Removes a permission key from a role''s grant set.
+
+        Use this tool to take one permission away from a role; do not use deleteRole, which removes the role entirely, and do not use revokeRoleAssignment, which ends a user''s assignment instead.
+
+        Preconditions: the caller must hold security:role:edit and the role must exist; revoking a key the role does not hold is a silent no-op.
+
+        Required inputs: roleId (UUID) and permissionKey (domain:resource:action) as path parameters; there is no request body.
+
+        Emits a SECURITY_ROLE_PERMISSION_REVOKE event.
+
+        Returns 404 when the role does not exist; an unknown permission key still yields 204.
+
+        '
+      operationId: revokeRolePermission
       parameters:
       - name: roleId
         in: path
@@ -536,9 +647,21 @@ paths:
     put:
       tags:
       - Role Management
-      summary: Assign permission to a role by key
-      description: Assigns the permission identified by path key to the specified role
-      operationId: assignPermissionToRole_1
+      summary: Assign a Registered Permission to a Role
+      description: 'Adds an already-registered permission, identified by its key in the path, to a role''s grant set.
+
+        Use this tool when the permission is known to be registered; do not use grantRolePermission, which auto-registers unknown keys, and do not use updateRolePermissions, which replaces the whole set.
+
+        Preconditions: the caller must hold security:role:edit, the role must exist, and the permission key must already be registered (modules register at startup via registerModulePermissions).
+
+        Required inputs: roleId (UUID) and permissionKey (domain:resource:action) as path parameters; there is no request body.
+
+        Emits a SECURITY_ROLE_PERMISSION_ASSIGN event.
+
+        Returns 404 when the role does not exist or the permission key has not been registered.
+
+        '
+      operationId: assignRolePermissionByKey_1
       parameters:
       - name: roleId
         in: path
@@ -596,9 +719,21 @@ paths:
     delete:
       tags:
       - Role Management
-      summary: Revoke permission from a role
-      description: Removes the specified permission from the role
-      operationId: revokePermissionFromRole_1
+      summary: Revoke a Permission From a Role
+      description: 'Removes a permission key from a role''s grant set.
+
+        Use this tool to take one permission away from a role; do not use deleteRole, which removes the role entirely, and do not use revokeRoleAssignment, which ends a user''s assignment instead.
+
+        Preconditions: the caller must hold security:role:edit and the role must exist; revoking a key the role does not hold is a silent no-op.
+
+        Required inputs: roleId (UUID) and permissionKey (domain:resource:action) as path parameters; there is no request body.
+
+        Emits a SECURITY_ROLE_PERMISSION_REVOKE event.
+
+        Returns 404 when the role does not exist; an unknown permission key still yields 204.
+
+        '
+      operationId: revokeRolePermission_1
       parameters:
       - name: roleId
         in: path
@@ -657,9 +792,21 @@ paths:
     put:
       tags:
       - Role Management
-      summary: Grant permission to a role
-      description: Grants a single permission to the specified role and returns the updated role
-      operationId: grantPermissionToRole
+      summary: Grant a Permission to a Role
+      description: 'Grants a single permission key to a role, auto-registering the key in the permission registry when it is not yet known.
+
+        Use this tool for additive one-off grants; do not use updateRolePermissions, which replaces the role''s entire permission set, and do not use assignRolePermissionByKey, which requires the permission to be registered already.
+
+        Preconditions: the caller must hold security:role:edit and the role must exist; the permission key does not need to exist beforehand.
+
+        Required inputs: roleId (UUID) as a path parameter and permission (domain:resource:action) in the body; permissionKey is accepted as a field alias.
+
+        Emits a SECURITY_ROLE_PERMISSION_GRANT event and publishes an internal grant audit record, then returns the updated role.
+
+        Returns 400 when permission is missing or blank, and 404 when the role does not exist.
+
+        '
+      operationId: grantRolePermission
       parameters:
       - name: roleId
         in: path
@@ -668,10 +815,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The single permission key to grant to the role.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RolePermissionGrantRequest'
+            examples:
+              Grant one permission:
+                description: Grant one permission
+                value:
+                  permission: people:timekeeping:view
         required: true
       responses:
         '400':
@@ -723,9 +876,21 @@ paths:
     put:
       tags:
       - Role Management
-      summary: Grant permission to a role
-      description: Grants a single permission to the specified role and returns the updated role
-      operationId: grantPermissionToRole_1
+      summary: Grant a Permission to a Role
+      description: 'Grants a single permission key to a role, auto-registering the key in the permission registry when it is not yet known.
+
+        Use this tool for additive one-off grants; do not use updateRolePermissions, which replaces the role''s entire permission set, and do not use assignRolePermissionByKey, which requires the permission to be registered already.
+
+        Preconditions: the caller must hold security:role:edit and the role must exist; the permission key does not need to exist beforehand.
+
+        Required inputs: roleId (UUID) as a path parameter and permission (domain:resource:action) in the body; permissionKey is accepted as a field alias.
+
+        Emits a SECURITY_ROLE_PERMISSION_GRANT event and publishes an internal grant audit record, then returns the updated role.
+
+        Returns 400 when permission is missing or blank, and 404 when the role does not exist.
+
+        '
+      operationId: grantRolePermission_1
       parameters:
       - name: roleId
         in: path
@@ -734,10 +899,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The single permission key to grant to the role.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RolePermissionGrantRequest'
+            examples:
+              Grant one permission:
+                description: Grant one permission
+                value:
+                  permission: people:timekeeping:view
         required: true
       responses:
         '400':
@@ -789,14 +960,35 @@ paths:
     put:
       tags:
       - Role Management
-      summary: Update role permissions
-      description: Assigns a set of permissions to a role
+      summary: Replace a Role's Permission Set
+      description: 'Replaces a role''s entire permission set with the supplied list of permission names.
+
+        Use this tool for wholesale permission resets; do not use grantRolePermission or revokeRolePermission, which change one key at a time and preserve the rest.
+
+        Preconditions: the caller must hold security:role:edit, the role must exist, and every named permission must already be registered.
+
+        Required inputs: roleId (UUID) and permissionNames, a set of domain:resource:action strings; an empty set clears all grants.
+
+        Emits a SECURITY_ROLE_PERMISSIONS_UPDATE event and returns the updated role with its new permission set.
+
+        Returns 404 when the role or any named permission does not exist; nothing is applied on failure.
+
+        '
       operationId: updateRolePermissions
       requestBody:
+        description: The role and the replacement set of permission names it should hold.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RolePermissionsRequest'
+            examples:
+              Replace permission set:
+                description: Replace permission set
+                value:
+                  roleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  permissionNames:
+                  - people:timekeeping:view
+                  - people:timekeeping:edit
         required: true
       responses:
         '400':
@@ -848,14 +1040,35 @@ paths:
     put:
       tags:
       - Role Management
-      summary: Update role permissions
-      description: Assigns a set of permissions to a role
+      summary: Replace a Role's Permission Set
+      description: 'Replaces a role''s entire permission set with the supplied list of permission names.
+
+        Use this tool for wholesale permission resets; do not use grantRolePermission or revokeRolePermission, which change one key at a time and preserve the rest.
+
+        Preconditions: the caller must hold security:role:edit, the role must exist, and every named permission must already be registered.
+
+        Required inputs: roleId (UUID) and permissionNames, a set of domain:resource:action strings; an empty set clears all grants.
+
+        Emits a SECURITY_ROLE_PERMISSIONS_UPDATE event and returns the updated role with its new permission set.
+
+        Returns 404 when the role or any named permission does not exist; nothing is applied on failure.
+
+        '
       operationId: updateRolePermissions_1
       requestBody:
+        description: The role and the replacement set of permission names it should hold.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RolePermissionsRequest'
+            examples:
+              Replace permission set:
+                description: Replace permission set
+                value:
+                  roleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  permissionNames:
+                  - people:timekeeping:view
+                  - people:timekeeping:edit
         required: true
       responses:
         '400':
@@ -907,9 +1120,21 @@ paths:
     put:
       tags:
       - Audit
-      summary: Update audit events not allowed
-      description: Audit events are immutable and cannot be modified after creation.
-      operationId: updateNotAllowed
+      summary: Reject Audit Event Modification
+      description: 'Rejects every attempt to modify audit events, unconditionally answering 405 Method Not Allowed.
+
+        Use this tool never; audit events are write-once, so record a new fact with createAuditEvent instead of editing an existing one.
+
+        Preconditions: none that permit success; the operation fails by design for any path under the audit events resource.
+
+        Required inputs: none are honored; the request is rejected regardless of path or payload.
+
+        No events are emitted and no state changes; the endpoint exists only to make immutability explicit.
+
+        Returns 405 in all cases.
+
+        '
+      operationId: rejectAuditEventUpdate
       responses:
         '400':
           description: Bad Request
@@ -954,9 +1179,21 @@ paths:
     delete:
       tags:
       - Audit
-      summary: Delete audit events not allowed
-      description: Audit events are immutable and cannot be deleted once recorded.
-      operationId: deleteNotAllowed
+      summary: Reject Audit Event Deletion
+      description: 'Rejects every attempt to delete audit events, unconditionally answering 405 Method Not Allowed.
+
+        Use this tool never; audit events are write-once, so use createAuditEvent to record facts and searchAuditEvents to read them instead.
+
+        Preconditions: none that permit success; the operation fails by design for any path under the audit events resource.
+
+        Required inputs: none are honored; the request is rejected regardless of path or payload.
+
+        No events are emitted and no state changes; the endpoint exists only to make immutability explicit.
+
+        Returns 405 in all cases.
+
+        '
+      operationId: rejectAuditEventDelete
       responses:
         '400':
           description: Bad Request
@@ -1002,9 +1239,21 @@ paths:
     get:
       tags:
       - User API
-      summary: Get all users
-      description: Retrieve a list of all users.
-      operationId: getAllUsers
+      summary: List All User Accounts
+      description: 'Returns every user account with its id, username, effective role names, and linked personId.
+
+        Use this tool to enumerate accounts; use getUserById instead for one known user.
+
+        Preconditions: the caller must hold security:user:view.
+
+        Required inputs: none; there are no filters or paging parameters, so the full user table is returned.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty list when no users exist; there are no business error conditions.
+
+        '
+      operationId: listUsers
       responses:
         '400':
           description: Bad Request
@@ -1056,14 +1305,35 @@ paths:
     post:
       tags:
       - User API
-      summary: Create a new user
-      description: Creates a new user with username, password, and roles.
+      summary: Create a User With Roles
+      description: 'Creates a user account with a username, a hashed password, and a set of directly attached roles.
+
+        Use this tool for operator provisioning of accounts; do not use selfRegisterUser, the anonymous customer flow that fixes the role to SELF_SERVICE_CUSTOMER and runs identity resolution first.
+
+        Preconditions: the caller must hold security:user:create, the username must be unused, and every named role must already exist.
+
+        Required inputs: username, password, and roles, a non-empty array of existing role names.
+
+        Emits a SECURITY_USER_CREATE event; the password is hashed before storage.
+
+        Returns 400 when the username already exists or a named role is not found.
+
+        '
       operationId: createUser
       requestBody:
+        description: Username, password, and role names of the account to create.
         content:
           application/json:
             schema:
               type: object
+            examples:
+              New user:
+                description: New user
+                value:
+                  username: jane.doe
+                  password: Sup3rS3cret!
+                  roles:
+                  - SHOP_MGR
         required: true
       responses:
         '400':
@@ -1115,9 +1385,21 @@ paths:
     post:
       tags:
       - Admin Account-State API
-      summary: Unlock a user account
-      description: Removes the locked state from the specified user account so the user can authenticate again.
-      operationId: unlock
+      summary: Unlock a Locked User Account
+      description: 'Clears the lockout state on a user account, resetting the failed-attempt counter and lock timestamps so the user can authenticate again.
+
+        Use this tool after a lockout caused by repeated failed logins; do not use enableUserAccount, which reverses an administrative disable rather than a lockout.
+
+        Preconditions: the caller must hold security:user_account_state:manage and the user must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a SECURITY_USER_UNLOCK event; existing tokens are not revoked.
+
+        Returns 404 with USER_NOT_FOUND when the user does not exist.
+
+        '
+      operationId: unlockUserAccount
       parameters:
       - name: id
         in: path
@@ -1171,9 +1453,21 @@ paths:
     post:
       tags:
       - Admin Account-State API
-      summary: Expire user credentials
-      description: Expires the specified user's credentials so a credential reset or update is required before reuse.
-      operationId: expireCredentials
+      summary: Expire a User's Credentials
+      description: 'Marks a user''s credentials as expired, stamping the expiry time and immediately revoking every token so a credential reset is required before further use.
+
+        Use this tool to force a password rotation; do not use expireUserAccount, which expires the whole account rather than just its credentials.
+
+        Preconditions: the caller must hold security:user_account_state:manage and the user must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a SECURITY_USER_EXPIRE_CREDENTIALS event and revokes all of the user''s access and refresh tokens.
+
+        Returns 404 with USER_NOT_FOUND when the user does not exist.
+
+        '
+      operationId: expireUserCredentials
       parameters:
       - name: id
         in: path
@@ -1227,9 +1521,21 @@ paths:
     post:
       tags:
       - Admin Account-State API
-      summary: Expire a user account
-      description: Expires the specified user account so it is no longer considered valid for authentication.
-      operationId: expireAccount
+      summary: Expire a User Account
+      description: 'Marks a user account as expired, stamping the expiry time and immediately revoking every token issued to the user.
+
+        Use this tool to end an account''s validity, for example at offboarding; do not use disableUserAccount, which signals a reversible administrative block, or expireUserCredentials, which only forces a credential reset.
+
+        Preconditions: the caller must hold security:user_account_state:manage and the user must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a SECURITY_USER_EXPIRE_ACCOUNT event and revokes all of the user''s access and refresh tokens.
+
+        Returns 404 with USER_NOT_FOUND when the user does not exist.
+
+        '
+      operationId: expireUserAccount
       parameters:
       - name: id
         in: path
@@ -1283,9 +1589,21 @@ paths:
     post:
       tags:
       - Admin Account-State API
-      summary: Enable a user account
-      description: Marks the specified user account as enabled so it can be used for sign-in and access checks.
-      operationId: enable
+      summary: Enable a Disabled User Account
+      description: 'Marks a user account as enabled so it is again accepted for sign-in and access checks.
+
+        Use this tool to reverse disableUserAccount; do not use unlockUserAccount, which clears a failed-login lockout instead.
+
+        Preconditions: the caller must hold security:user_account_state:manage and the user must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a SECURITY_USER_ENABLE event; no tokens are issued or restored, so the user must sign in again.
+
+        Returns 404 with USER_NOT_FOUND when the user does not exist.
+
+        '
+      operationId: enableUserAccount
       parameters:
       - name: id
         in: path
@@ -1339,9 +1657,21 @@ paths:
     post:
       tags:
       - Admin Account-State API
-      summary: Disable a user account
-      description: Marks the specified user account as disabled to prevent further use until it is re-enabled.
-      operationId: disable
+      summary: Disable a User Account
+      description: 'Marks a user account as disabled, records the disabling actor and time, and immediately revokes every token issued to the user.
+
+        Use this tool for a reversible administrative block; do not use deleteUser, which removes the account, and do not use expireUserAccount, which marks the account expired instead.
+
+        Preconditions: the caller must hold security:user_account_state:manage and the user must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a SECURITY_USER_DISABLE event and revokes all of the user''s access and refresh tokens.
+
+        Returns 404 with USER_NOT_FOUND when the user does not exist.
+
+        '
+      operationId: disableUserAccount
       parameters:
       - name: id
         in: path
@@ -1395,14 +1725,38 @@ paths:
     post:
       tags:
       - Role Management
-      summary: Create role assignment
-      description: Assigns a role to a user with optional scope and effective dates
+      summary: Create a Scoped Role Assignment
+      description: 'Assigns a role to a user with a scope (GLOBAL or LOCATION) and an optional effective date window.
+
+        Use this tool when the assignment needs scope or dates; do not use assignUserRole, the simple path-parameter variant that always creates a GLOBAL assignment starting now.
+
+        Preconditions: the caller must hold security:role:assign, the user and role must exist, and no overlapping assignment may exist for the same role, scope, and (for LOCATION scope) location.
+
+        Required inputs: userId and roleId (UUIDs); scopeType defaults to GLOBAL, scopeLocationIds is required for LOCATION scope and forbidden for GLOBAL, and effectiveStartDate defaults to now with an open-ended effectiveEndDate.
+
+        Emits a SECURITY_ROLE_ASSIGNMENT_CREATE event.
+
+        Returns 400 when the scope and location combination is invalid, 404 when the user or role does not exist, and 409 with ROLE_ASSIGNMENT_CONFLICT when the date window overlaps an existing assignment.
+
+        '
       operationId: createRoleAssignment
       requestBody:
+        description: The user, role, scope, and effective window of the assignment to create.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RoleAssignmentRequest'
+            examples:
+              Location-scoped assignment:
+                description: Location-scoped assignment
+                value:
+                  userId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  roleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  scopeType: LOCATION
+                  scopeLocationIds:
+                  - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d
+                  effectiveStartDate: 2026-01-15 00:00:00
+                  effectiveEndDate: 2026-12-31 00:00:00
         required: true
       responses:
         '400':
@@ -1454,14 +1808,38 @@ paths:
     post:
       tags:
       - Role Management
-      summary: Create role assignment
-      description: Assigns a role to a user with optional scope and effective dates
+      summary: Create a Scoped Role Assignment
+      description: 'Assigns a role to a user with a scope (GLOBAL or LOCATION) and an optional effective date window.
+
+        Use this tool when the assignment needs scope or dates; do not use assignUserRole, the simple path-parameter variant that always creates a GLOBAL assignment starting now.
+
+        Preconditions: the caller must hold security:role:assign, the user and role must exist, and no overlapping assignment may exist for the same role, scope, and (for LOCATION scope) location.
+
+        Required inputs: userId and roleId (UUIDs); scopeType defaults to GLOBAL, scopeLocationIds is required for LOCATION scope and forbidden for GLOBAL, and effectiveStartDate defaults to now with an open-ended effectiveEndDate.
+
+        Emits a SECURITY_ROLE_ASSIGNMENT_CREATE event.
+
+        Returns 400 when the scope and location combination is invalid, 404 when the user or role does not exist, and 409 with ROLE_ASSIGNMENT_CONFLICT when the date window overlaps an existing assignment.
+
+        '
       operationId: createRoleAssignment_1
       requestBody:
+        description: The user, role, scope, and effective window of the assignment to create.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RoleAssignmentRequest'
+            examples:
+              Location-scoped assignment:
+                description: Location-scoped assignment
+                value:
+                  userId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  roleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  scopeType: LOCATION
+                  scopeLocationIds:
+                  - 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d
+                  effectiveStartDate: 2026-01-15 00:00:00
+                  effectiveEndDate: 2026-12-31 00:00:00
         required: true
       responses:
         '400':
@@ -1513,9 +1891,21 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Get all roles
-      description: Returns all roles in the system
-      operationId: getAllRoles
+      summary: List All Roles in the System
+      description: 'Returns every role in the system with its permission set and audit metadata.
+
+        Use this tool to enumerate roles; use getRoleById or getRoleByName instead for a single known role.
+
+        Preconditions: the caller must hold security:role:view.
+
+        Required inputs: none; there are no filters or paging parameters.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty list when no roles exist; there are no business error conditions.
+
+        '
+      operationId: listRoles
       responses:
         '400':
           description: Bad Request
@@ -1567,16 +1957,35 @@ paths:
     post:
       tags:
       - Role Management
-      summary: Create a new role
-      description: Creates a new role with the specified name and description
+      summary: Create a New Role
+      description: 'Creates a new role with the given name and optional description; the role starts with no permissions and no user assignments.
+
+        Use this tool to define a new role; do not use createRoleAssignment, which links an existing role to a user, and do not use updateRolePermissions, which changes an existing role''s grants.
+
+        Preconditions: the caller must hold security:role:create and no role with the same name (compared case-insensitively) may already exist.
+
+        Required inputs: name, non-blank; description is optional.
+
+        Emits a SECURITY_ROLE_CREATE event and records the creating actor and timestamp.
+
+        Returns 400 when name is missing or blank, and 409 with DUPLICATE_ROLE_NAME when the name is already taken regardless of case.
+
+        '
       operationId: createRole
       requestBody:
+        description: Name and optional description of the role to create.
         content:
           application/json:
             schema:
               type: object
               additionalProperties:
                 type: string
+            examples:
+              New role:
+                description: New role
+                value:
+                  name: SHOP_MGR
+                  description: Shop manager
         required: true
       responses:
         '400':
@@ -1628,9 +2037,21 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Get all roles
-      description: Returns all roles in the system
-      operationId: getAllRoles_1
+      summary: List All Roles in the System
+      description: 'Returns every role in the system with its permission set and audit metadata.
+
+        Use this tool to enumerate roles; use getRoleById or getRoleByName instead for a single known role.
+
+        Preconditions: the caller must hold security:role:view.
+
+        Required inputs: none; there are no filters or paging parameters.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty list when no roles exist; there are no business error conditions.
+
+        '
+      operationId: listRoles_1
       responses:
         '400':
           description: Bad Request
@@ -1682,16 +2103,35 @@ paths:
     post:
       tags:
       - Role Management
-      summary: Create a new role
-      description: Creates a new role with the specified name and description
+      summary: Create a New Role
+      description: 'Creates a new role with the given name and optional description; the role starts with no permissions and no user assignments.
+
+        Use this tool to define a new role; do not use createRoleAssignment, which links an existing role to a user, and do not use updateRolePermissions, which changes an existing role''s grants.
+
+        Preconditions: the caller must hold security:role:create and no role with the same name (compared case-insensitively) may already exist.
+
+        Required inputs: name, non-blank; description is optional.
+
+        Emits a SECURITY_ROLE_CREATE event and records the creating actor and timestamp.
+
+        Returns 400 when name is missing or blank, and 409 with DUPLICATE_ROLE_NAME when the name is already taken regardless of case.
+
+        '
       operationId: createRole_1
       requestBody:
+        description: Name and optional description of the role to create.
         content:
           application/json:
             schema:
               type: object
               additionalProperties:
                 type: string
+            examples:
+              New role:
+                description: New role
+                value:
+                  name: SHOP_MGR
+                  description: Shop manager
         required: true
       responses:
         '400':
@@ -1743,9 +2183,21 @@ paths:
     post:
       tags:
       - Principal Role Management
-      summary: Assign a role to a principal
-      description: Assigns the specified role to the specified principal identifier for RBAC matrix authorization.
-      operationId: assignRoleToPrincipal
+      summary: Assign a Role to a Principal
+      description: 'Links a free-form principal identifier to a role in the RBAC principal matrix consulted by getAuthorizationDecision.
+
+        Use this tool for matrix principals that are not user UUIDs; do not use assignUserRole, which creates a role assignment for a real user account.
+
+        Preconditions: the caller must hold security:role:assign and the role must exist; the principal is not validated against any store, and an existing identical link makes the call a no-op.
+
+        Required inputs: principalId (arbitrary string) and roleId (UUID) as path parameters; there is no request body.
+
+        Emits a SECURITY_PRINCIPAL_ROLE_ASSIGN event.
+
+        Returns 404 when the role does not exist; repeat assignments still return 200.
+
+        '
+      operationId: assignPrincipalRole
       parameters:
       - name: principalId
         in: path
@@ -1806,14 +2258,39 @@ paths:
     post:
       tags:
       - Permission Registry
-      summary: Register permissions (RBAC contract endpoint)
-      description: Registers or updates permissions using the RBAC contract payload and returns the resulting permission set.
+      summary: Register Permissions via RBAC Contract
+      description: 'Registers or updates permissions from an RBAC contract payload, upserting each named permission and returning the resulting permission list.
+
+        Use this tool for strict all-or-nothing permission upserts; do not use registerModulePermissions, the lenient startup manifest endpoint that skips invalid entries and reports per-entry counters instead of failing the request.
+
+        Preconditions: the caller must hold security:permission:register, and every permission name must match domain:resource:action (or the legacy domain:action form).
+
+        Required inputs: permissions, a list of name and description definitions; serviceName is optional here and defaults to pos-security-service as the registering service.
+
+        Emits a SECURITY_PERMISSION_REGISTER event; existing permissions with the same name are overwritten in place, including description and registering service.
+
+        Returns 400 when any permission key fails the format check, rejecting the entire request.
+
+        '
       operationId: registerPermissionsContract
       requestBody:
+        description: RBAC contract payload of permission definitions to upsert.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PermissionRegistrationRequest'
+            examples:
+              Contract registration:
+                description: Contract registration
+                value:
+                  domain: people
+                  serviceName: pos-people-service
+                  version: '1.0'
+                  permissions:
+                  - name: people:timekeeping:view
+                    description: View timekeeping records
+                  - name: people:timekeeping:edit
+                    description: Edit timekeeping records
         required: true
       responses:
         '400':
@@ -1867,14 +2344,39 @@ paths:
     post:
       tags:
       - Permission Registry
-      summary: Register permissions (RBAC contract endpoint)
-      description: Registers or updates permissions using the RBAC contract payload and returns the resulting permission set.
+      summary: Register Permissions via RBAC Contract
+      description: 'Registers or updates permissions from an RBAC contract payload, upserting each named permission and returning the resulting permission list.
+
+        Use this tool for strict all-or-nothing permission upserts; do not use registerModulePermissions, the lenient startup manifest endpoint that skips invalid entries and reports per-entry counters instead of failing the request.
+
+        Preconditions: the caller must hold security:permission:register, and every permission name must match domain:resource:action (or the legacy domain:action form).
+
+        Required inputs: permissions, a list of name and description definitions; serviceName is optional here and defaults to pos-security-service as the registering service.
+
+        Emits a SECURITY_PERMISSION_REGISTER event; existing permissions with the same name are overwritten in place, including description and registering service.
+
+        Returns 400 when any permission key fails the format check, rejecting the entire request.
+
+        '
       operationId: registerPermissionsContract_1
       requestBody:
+        description: RBAC contract payload of permission definitions to upsert.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PermissionRegistrationRequest'
+            examples:
+              Contract registration:
+                description: Contract registration
+                value:
+                  domain: people
+                  serviceName: pos-people-service
+                  version: '1.0'
+                  permissions:
+                  - name: people:timekeeping:view
+                    description: View timekeeping records
+                  - name: people:timekeeping:edit
+                    description: Edit timekeeping records
         required: true
       responses:
         '400':
@@ -1928,14 +2430,39 @@ paths:
     post:
       tags:
       - Permission Registry
-      summary: Register permissions from a service
-      description: Services call this endpoint to register their available permissions
-      operationId: registerPermissions
+      summary: Register Module Permission Manifest
+      description: 'Registers or updates a module''s permission manifest in the central registry; this is the endpoint every pos module''s permission-registry initializer calls at startup.
+
+        Use this tool for idempotent bulk manifest registration that tolerates partial failure; do not use registerPermissionsContract, which rejects the entire payload on the first invalid key.
+
+        Preconditions: the caller must hold security:permission:register (module initializers authenticate with an internal service token).
+
+        Required inputs: serviceName and a non-empty permissions list of name and description entries; names must match domain:resource:action, while domain and version are informational.
+
+        Emits a SECURITY_PERMISSION_REGISTER event; new names are inserted (with a bit index when the compiled catalog defines one), changed descriptions are updated, and unchanged or invalid entries are counted as skipped.
+
+        Returns 400 when serviceName is blank or permissions is empty, and 400 with success=false and a per-entry errors list when every entry failed; partial failures still return 200 with the errors listed in the response.
+
+        '
+      operationId: registerModulePermissions
       requestBody:
+        description: Permission manifest published by one domain service at startup.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PermissionRegistrationRequest'
+            examples:
+              Startup manifest:
+                description: Startup manifest
+                value:
+                  domain: people
+                  serviceName: pos-people-service
+                  version: '1.0'
+                  permissions:
+                  - name: people:timekeeping:view
+                    description: View timekeeping records
+                  - name: people:timekeeping:edit
+                    description: Edit timekeeping records
         required: true
       responses:
         '400':
@@ -1987,14 +2514,39 @@ paths:
     post:
       tags:
       - Permission Registry
-      summary: Register permissions from a service
-      description: Services call this endpoint to register their available permissions
-      operationId: registerPermissions_1
+      summary: Register Module Permission Manifest
+      description: 'Registers or updates a module''s permission manifest in the central registry; this is the endpoint every pos module''s permission-registry initializer calls at startup.
+
+        Use this tool for idempotent bulk manifest registration that tolerates partial failure; do not use registerPermissionsContract, which rejects the entire payload on the first invalid key.
+
+        Preconditions: the caller must hold security:permission:register (module initializers authenticate with an internal service token).
+
+        Required inputs: serviceName and a non-empty permissions list of name and description entries; names must match domain:resource:action, while domain and version are informational.
+
+        Emits a SECURITY_PERMISSION_REGISTER event; new names are inserted (with a bit index when the compiled catalog defines one), changed descriptions are updated, and unchanged or invalid entries are counted as skipped.
+
+        Returns 400 when serviceName is blank or permissions is empty, and 400 with success=false and a per-entry errors list when every entry failed; partial failures still return 200 with the errors listed in the response.
+
+        '
+      operationId: registerModulePermissions_1
       requestBody:
+        description: Permission manifest published by one domain service at startup.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PermissionRegistrationRequest'
+            examples:
+              Startup manifest:
+                description: Startup manifest
+                value:
+                  domain: people
+                  serviceName: pos-people-service
+                  version: '1.0'
+                  permissions:
+                  - name: people:timekeeping:view
+                    description: View timekeeping records
+                  - name: people:timekeeping:edit
+                    description: Edit timekeeping records
         required: true
       responses:
         '400':
@@ -2046,14 +2598,33 @@ paths:
     post:
       tags:
       - Permission Registry
-      summary: Decode perm_bits for diagnostics
-      description: Decodes a perm_bits Base64URL BitSet back to permission code strings. For debugging only.
-      operationId: decodePermissions
+      summary: Decode Permission Bits for Diagnostics
+      description: 'Decodes a Base64URL perm_bits bitset taken from an access token back into sorted permission code strings for diagnostics.
+
+        Use this tool to inspect what a token''s perm_bits claim grants; do not use getUserPermissions, which reads a user''s effective permissions from role assignments instead of from a token.
+
+        Preconditions: the caller must hold security:permission:view, and perm_ver must equal the catalog version currently compiled into the service (see getPermissionCatalogVersion).
+
+        Required inputs: perm_bits, the Base64URL-encoded BitSet string, and perm_ver, a positive integer catalog version.
+
+        Emits a SECURITY_PERMISSION_DECODE_EXECUTE event; no records are changed.
+
+        Returns 400 when perm_bits is blank, perm_ver is not positive, or perm_ver does not match the current catalog version.
+
+        '
+      operationId: decodePermissionBits
       requestBody:
+        description: Encoded permission bitset and the catalog version it was encoded with.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PermissionDecodeRequest'
+            examples:
+              Decode request:
+                description: Decode request
+                value:
+                  perm_bits: AQID
+                  perm_ver: 7
         required: true
       responses:
         '400':
@@ -2105,14 +2676,33 @@ paths:
     post:
       tags:
       - Permission Registry
-      summary: Decode perm_bits for diagnostics
-      description: Decodes a perm_bits Base64URL BitSet back to permission code strings. For debugging only.
-      operationId: decodePermissions_1
+      summary: Decode Permission Bits for Diagnostics
+      description: 'Decodes a Base64URL perm_bits bitset taken from an access token back into sorted permission code strings for diagnostics.
+
+        Use this tool to inspect what a token''s perm_bits claim grants; do not use getUserPermissions, which reads a user''s effective permissions from role assignments instead of from a token.
+
+        Preconditions: the caller must hold security:permission:view, and perm_ver must equal the catalog version currently compiled into the service (see getPermissionCatalogVersion).
+
+        Required inputs: perm_bits, the Base64URL-encoded BitSet string, and perm_ver, a positive integer catalog version.
+
+        Emits a SECURITY_PERMISSION_DECODE_EXECUTE event; no records are changed.
+
+        Returns 400 when perm_bits is blank, perm_ver is not positive, or perm_ver does not match the current catalog version.
+
+        '
+      operationId: decodePermissionBits_1
       requestBody:
+        description: Encoded permission bitset and the catalog version it was encoded with.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PermissionDecodeRequest'
+            examples:
+              Decode request:
+                description: Decode request
+                value:
+                  perm_bits: AQID
+                  perm_ver: 7
         required: true
       responses:
         '400':
@@ -2164,9 +2754,21 @@ paths:
     post:
       tags:
       - Self-Registration Review API
-      summary: Resolve a self-registration review case
-      description: Marks a blocked self-registration case as resolved after recovery or manual review.
-      operationId: resolveCase
+      summary: Resolve a Self-Registration Review Case
+      description: 'Marks a blocked self-registration case RESOLVED, recording the resolving operator, timestamp, and resolution notes.
+
+        Use this tool after the underlying recovery or identity review is finished; do not use it to recover the account itself, which is done first with account-state endpoints such as enableUserAccount.
+
+        Preconditions: the caller must hold security:user_account_state:manage and be authenticated (the resolver is taken from the request principal); the case must exist, and re-resolving an already RESOLVED case overwrites the resolution fields.
+
+        Required inputs: caseId (UUID) as a path parameter and resolutionNotes, non-blank, in the body.
+
+        Emits a SECURITY_SELF_REGISTRATION_REVIEW_RESOLVE event.
+
+        Returns 404 when no review case exists for the supplied id.
+
+        '
+      operationId: resolveSelfRegistrationReviewCase
       parameters:
       - name: caseId
         in: path
@@ -2175,10 +2777,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: The resolution note recorded against the case.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ResolveSelfRegistrationReviewCaseRequest'
+            examples:
+              Case resolution:
+                description: Case resolution
+                value:
+                  resolutionNotes: Recovered existing disabled account and asked user to sign in.
         required: true
       responses:
         '400':
@@ -2230,14 +2838,35 @@ paths:
     post:
       tags:
       - JWT API
-      summary: Issue privileged JWT token pair (access + refresh)
-      description: Privileged internal endpoint that issues both access token (1-hour) and refresh token (7-day). Requires authority security:token:issue_internal. See BACKEND_CONTRACT_GUIDE.md §Token Pair Endpoint for full specification.
-      operationId: generateTokenPair
+      summary: Issue Privileged JWT Token Pair
+      description: 'Issues a JWT access token (1-hour) and refresh token (7-day) for an existing user''s username on behalf of a trusted internal caller, embedding uid, roles, perm_bits, and perm_ver claims.
+
+        Use this tool when an internal caller needs a refreshable session for an existing user; do not use issueInternalToken, which returns only a single access token, and do not use loginUser, which requires the user''s password.
+
+        Preconditions: the caller must hold security:token:issue_internal, and a user must already exist for the subject username.
+
+        Required inputs: subject, an existing username, and at least one role name in roles; roles are expanded to authorities and encoded into the perm_bits bitset claim.
+
+        Emits a SECURITY_AUTH_TOKEN_PAIR event and persists the pair so validateToken and refreshTokenPair recognize it.
+
+        Returns 400 when the subject is blank, no user exists for the subject, or the role set is empty.
+
+        '
+      operationId: issueTokenPair
       requestBody:
+        description: Subject and role names to embed in the issued access and refresh tokens.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/TokenPairRequest'
+            examples:
+              Token pair request:
+                description: Token pair request
+                value:
+                  subject: jane.doe
+                  roles:
+                  - SHOP_MGR
+                  - ACCOUNTING_CLERK
         required: true
       responses:
         '400':
@@ -2289,14 +2918,37 @@ paths:
     post:
       tags:
       - Auth API
-      summary: Self-register a new user
-      description: Creates a low-privilege customer account after resolving or creating a linked person record. Successful registration requires a follow-up login and does not issue tokens immediately. Conflict responses include operator guidance for recovery, linked-account, and CRM identity-review cases.
-      operationId: selfRegister
+      summary: Self-Register a New Customer Account
+      description: 'Creates a low-privilege SELF_SERVICE_CUSTOMER account for an anonymous person, resolving or creating a linked person record before any account row is written.
+
+        Use this tool when a customer registers themselves; do not use createUser, the operator-facing endpoint that provisions accounts with arbitrary roles and no identity resolution.
+
+        Preconditions: no active user may exist for the requested or email-derived username, the resolved person must not already have an active linked user, and CRM identity signals must not require manual review.
+
+        Required inputs: email, password, firstName, and lastName; username is optional and defaults to the email local part, phone and idpSubject are optional, and idempotencyKey optionally replays a completed attempt instead of duplicating it.
+
+        Emits a SECURITY_AUTH_SELF_REGISTER event, creates the user, and queues an asynchronous user-person link command, so the response reports linkStatus PENDING and issuedTokens false; a follow-up loginUser call is required to obtain tokens.
+
+        Returns 409 with code USER_ALREADY_EXISTS, ACCOUNT_RECOVERY_REQUIRED, PERSON_ALREADY_HAS_ACTIVE_USER, CRM_PERSON_CONFLICT, or IDEMPOTENCY_KEY_REUSED; recovery and identity conflicts also open a review case and return its id as referenceId with nextAction and supportAction guidance.
+
+        '
+      operationId: selfRegisterUser
       requestBody:
+        description: Identity and credential details of the person registering themselves.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SelfRegistrationRequest'
+            examples:
+              Customer self-registration:
+                description: Customer self-registration
+                value:
+                  email: jane.smith@example.com
+                  password: Sup3rS3cret!
+                  firstName: Jane
+                  lastName: Smith
+                  phone: '+15551234567'
+                  idempotencyKey: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
         required: true
       responses:
         '400':
@@ -2345,14 +2997,32 @@ paths:
     post:
       tags:
       - JWT API
-      summary: Refresh access token using refresh token
-      description: Exchange a valid refresh token for a new access token and refresh token. Old tokens are immediately revoked. See BACKEND_CONTRACT_GUIDE.md §Refresh Endpoint for full specification.
-      operationId: refreshAccessToken
+      summary: Refresh Access Token With Rotation
+      description: 'Exchanges a valid refresh token for a new access and refresh token pair, revoking the old pair in the same call (token rotation).
+
+        Use this tool when an access token nears expiry and the client still holds a refresh token; do not use loginUser, which requires credentials, and do not use validateToken, which only checks a token without renewing it.
+
+        Preconditions: the refresh token must be unexpired, unrevoked, present in the token store, and its user must still exist with at least one role.
+
+        Required inputs: refreshToken, the exact refresh token string previously issued.
+
+        Emits a SECURITY_AUTH_REFRESH event, revokes the old access and refresh token JTIs in Redis, deletes the stored pair, and persists the replacement pair.
+
+        Returns 400 when the refresh token is invalid, expired, revoked, or unknown, or the user has no roles, 401 with INVALID_REFRESH_TOKEN when the referenced user no longer exists, and 409 when concurrent refreshes race on the same token.
+
+        '
+      operationId: refreshTokenPair
       requestBody:
+        description: The refresh token being exchanged for a new token pair.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RefreshTokenRequest'
+            examples:
+              Refresh request:
+                description: Refresh request
+                value:
+                  refreshToken: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwMThmMGExYi0yYzNkLTdlNGYtOGE5Yi0wYzFkMmUzZjRhNWIifQ.sig
         required: true
       responses:
         '400':
@@ -2401,14 +3071,33 @@ paths:
     post:
       tags:
       - Auth API
-      summary: User login
-      description: Authenticates a user with username and password and returns a JWT token pair.
-      operationId: login
+      summary: Authenticate User and Issue Tokens
+      description: 'Authenticates a user with username and password and returns a JWT access token (1-hour) and refresh token (7-day) carrying uid, roles, perm_bits, and perm_ver claims.
+
+        Use this tool when a person signs in with credentials; do not use refreshTokenPair, which exchanges an existing refresh token, and do not use issueInternalToken, which mints tokens for trusted internal callers without a password.
+
+        Preconditions: the user account must exist, be enabled, non-expired, hold unexpired credentials, and not be inside an active failed-login lockout window.
+
+        Required inputs: username and password, both non-blank.
+
+        Emits a SECURITY_AUTH_LOGIN event, resets the failed-attempt counter on success, and persists the issued token pair for later validation and revocation.
+
+        Returns 401 with code ACCOUNT_LOCKED while the lockout window is active, INVALID_CREDENTIALS on a bad password, and ACCOUNT_DISABLED, ACCOUNT_EXPIRED, or CREDENTIALS_EXPIRED for the matching account states.
+
+        '
+      operationId: loginUser
       requestBody:
+        description: Credentials of the user signing in.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/LoginRequest'
+            examples:
+              Credential login:
+                description: Credential login
+                value:
+                  username: jane.doe
+                  password: Sup3rS3cret!
         required: true
       responses:
         '400':
@@ -2457,14 +3146,34 @@ paths:
     post:
       tags:
       - JWT API
-      summary: Issue internal JWT access token
-      description: Internal endpoint to issue a JWT access token (1-hour expiration). See BACKEND_CONTRACT_GUIDE.md §Login Endpoint for full specification.
+      summary: Issue Internal JWT Access Token
+      description: 'Issues a single JWT access token (1-hour expiry) for an existing user''s username on behalf of a trusted internal caller, without checking a password.
+
+        Use this tool for internal service-to-service token minting when only an access token is needed; do not use issueTokenPair, which also returns a 7-day refresh token, and do not use loginUser, which authenticates with credentials.
+
+        Preconditions: the caller must hold security:token:issue_internal, and a user must already exist for the subject username.
+
+        Required inputs: subject, an existing username; roles is nominally optional, but an empty effective role set is rejected, so supply at least one role name.
+
+        Emits a SECURITY_AUTH_INTERNAL_TOKEN_ISSUE event and persists the issued token so validateToken and revokeToken recognize it.
+
+        Returns 400 when the subject is blank, no user exists for the subject, or the role set is empty.
+
+        '
       operationId: issueInternalToken
       requestBody:
+        description: Subject and role names to embed in the internally issued access token.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/InternalTokenRequest'
+            examples:
+              Internal token request:
+                description: Internal token request
+                value:
+                  subject: svc.reporting
+                  roles:
+                  - SHOP_MGR
         required: true
       responses:
         '400':
@@ -2516,14 +3225,42 @@ paths:
     post:
       tags:
       - Audit
-      summary: Create pricing snapshot
-      description: Creates an immutable pricing snapshot record for later audit and traceability.
+      summary: Record an Immutable Pricing Snapshot
+      description: 'Records an immutable pricing snapshot with its ordered rule-evaluation trace and returns the generated snapshot id.
+
+        Use this tool to preserve how a price was computed for later audit; do not use createAuditEvent, which records generic entity-change events without a rule trace.
+
+        Preconditions: the caller must hold security:audit:create; the snapshot is write-once and cannot be modified afterwards.
+
+        Required inputs: quoteContext, finalPrice, and evaluationSteps, where every step needs ruleId, status, inputs, and outputs; evaluationSteps may be an empty list but not null.
+
+        Emits a SECURITY_AUDIT_PRICING_SNAPSHOT_CREATE event.
+
+        Returns 400 when quoteContext, finalPrice, evaluationSteps, or any per-step field is missing, or when a JSON field cannot be serialized.
+
+        '
       operationId: createPricingSnapshot
       requestBody:
+        description: The evaluated quote context, final price, and rule trace to preserve.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PricingSnapshotRequest'
+            examples:
+              Snapshot with one rule step:
+                description: Snapshot with one rule step
+                value:
+                  quoteContext:
+                    sku: BRAKE-PAD-001
+                    quantity: 2
+                  finalPrice: 129.99
+                  evaluationSteps:
+                  - ruleId: MSRP_BASE
+                    status: APPLIED
+                    inputs:
+                      listPrice: 149.99
+                    outputs:
+                      price: 129.99
         required: true
       responses:
         '400':
@@ -2574,14 +3311,35 @@ paths:
     post:
       tags:
       - Audit Exports
-      summary: Request audit export
-      description: Submits an asynchronous audit export job. Returns 202 Accepted with the created job reference.
+      summary: Request an Asynchronous Audit Export
+      description: 'Submits an asynchronous audit export job and answers 202 Accepted with the job id and an initial PENDING status.
+
+        Use this tool for bulk extraction of audit data as a file; use searchAuditEvents instead for interactive paged queries.
+
+        Preconditions: the caller must hold security:audit:export; jobs are currently held in an in-memory store, so they do not survive a service restart.
+
+        Required inputs: format (CSV or JSON) and deliveryMode (DOWNLOAD or WEBHOOK); filters is optional and scopes the export with the same criteria as searchAuditEvents.
+
+        Emits a SECURITY_AUDIT_EXPORT_REQUEST event; execution is deferred, so callers must poll getAuditExportJob for status and the eventual download URL.
+
+        Returns 400 when format or deliveryMode is missing or not a valid enum value.
+
+        '
       operationId: requestAuditExport
       requestBody:
+        description: Format, delivery mode, and optional filter scope of the export job.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AuditExportRequest'
+            examples:
+              CSV download export:
+                description: CSV download export
+                value:
+                  format: CSV
+                  deliveryMode: DOWNLOAD
+                  filters:
+                    eventType: PERMISSION_DENIED
         required: true
       responses:
         '400':
@@ -2632,8 +3390,20 @@ paths:
     get:
       tags:
       - Audit
-      summary: Search audit events
-      description: Searches audit events using rich filter criteria with pagination support.
+      summary: Search Audit Events With Filters
+      description: 'Searches audit events with pagination, filtering by time window, actor, event type, and aggregate identifier.
+
+        Use this tool to query the audit trail; use getAuditEvent instead when the event id is known, and requestAuditExport for bulk extraction as a file.
+
+        Preconditions: the caller must hold security:audit:view; when both bounds are given, fromDate must be strictly before toDate (fromDate inclusive, toDate exclusive).
+
+        Required inputs: none are mandatory; fromDate, toDate, actorId, eventType, and aggregateId are applied as filters, while workorderId, movementId, productId, sku, correlationId, reasonCode, pageToken, and locationIds are accepted for contract compatibility but not yet applied.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 400 when fromDate is not before toDate or a parameter fails type conversion.
+
+        '
       operationId: searchAuditEvents
       parameters:
       - name: fromDate
@@ -2782,14 +3552,38 @@ paths:
     post:
       tags:
       - Audit
-      summary: Create audit event
-      description: Creates an immutable audit event record and returns the generated event identifier.
-      operationId: createEvent
+      summary: Record an Immutable Audit Event
+      description: 'Records an immutable audit event and returns the generated event id and server timestamp.
+
+        Use this tool to persist a write-once audit fact; do not use createPricingSnapshot, which records a pricing rule trace, and note that updates and deletes of audit events are rejected with 405 by design.
+
+        Preconditions: the caller must hold security:audit:create; the actor is resolved server-side from the security context, so any actorId in the body is ignored.
+
+        Required inputs: eventType, entityId, entityType, oldValue, and newValue (empty strings are accepted, null is not); context is optional and stored as serialized JSON.
+
+        Emits a SECURITY_AUDIT_EVENT_CREATE event; the stored record can never be modified or deleted.
+
+        Returns 400 when any required field is missing or a value cannot be serialized to JSON.
+
+        '
+      operationId: createAuditEvent
       requestBody:
+        description: 'The audit fact to record: what changed, on which entity, from and to what.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AuditLogEventRequest'
+            examples:
+              Role change event:
+                description: Role change event
+                value:
+                  eventType: ROLE_ASSIGNED
+                  entityId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  entityType: USER
+                  oldValue: ''
+                  newValue: SHOP_MGR
+                  context:
+                    reason: onboarding
         required: true
       responses:
         '400':
@@ -2840,8 +3634,20 @@ paths:
     get:
       tags:
       - User Role Management
-      summary: Get user permissions
-      description: Returns all effective permissions for a user
+      summary: Get a User's Effective Permissions
+      description: 'Returns the union of permissions granted through a user''s currently effective role assignments.
+
+        Use this tool for a user''s flattened effective permission set; use listUserRoleAssignments instead to see the assignments and scopes behind it.
+
+        Preconditions: the caller must hold security:permission:view and the user must exist.
+
+        Required inputs: userId (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the user does not exist.
+
+        '
       operationId: getUserPermissions
       parameters:
       - name: userId
@@ -2903,9 +3709,21 @@ paths:
     get:
       tags:
       - Admin Account-State API
-      summary: Get user account state
-      description: Returns the current administrative account-state flags for the specified user.
-      operationId: getAccountState
+      summary: Get a User's Account-State Flags
+      description: 'Returns the administrative account-state flags for a user: enabled, lock, account-expiry, and credential-expiry state with their timestamps, disabling actor, and failed-attempt count.
+
+        Use this tool to diagnose why sign-in fails before choosing among unlockUserAccount, enableUserAccount, and the expiry endpoints; use getUserById instead for identity and role data.
+
+        Preconditions: the caller must hold security:user_account_state:view and the user must exist.
+
+        Required inputs: id (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 with USER_NOT_FOUND when the user does not exist.
+
+        '
+      operationId: getUserAccountState
       parameters:
       - name: id
         in: path
@@ -2963,8 +3781,20 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Get a role's default permissions
-      description: Returns the authority codes (ROLE_* plus domain permission codes) that the given role expands to, used by clients to prebuild per-role tool/permission caches.
+      summary: Get a Role's Default Authority Expansion
+      description: 'Returns the authority codes a role name expands to: the ROLE_ prefixed authority plus the domain permission codes hardwired for known roles.
+
+        Use this tool to prebuild per-role permission or tool caches, as pos-mcp-server does; do not use getUserPermissions, which reads a specific user''s database assignments instead of the static role expansion.
+
+        Preconditions: the caller must hold security:role:view; the role name does not need to exist in the database.
+
+        Required inputs: role name as a path parameter, for example SHOP_MGR.
+
+        No events are emitted and no state changes; this is a read-only expansion of the compiled role-authority map.
+
+        Returns 200 in all cases; an unrecognized role yields only its ROLE_ authority with no domain codes rather than an error.
+
+        '
       operationId: getRoleDefaultPermissions
       parameters:
       - name: role
@@ -3022,8 +3852,20 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Get a role's default permissions
-      description: Returns the authority codes (ROLE_* plus domain permission codes) that the given role expands to, used by clients to prebuild per-role tool/permission caches.
+      summary: Get a Role's Default Authority Expansion
+      description: 'Returns the authority codes a role name expands to: the ROLE_ prefixed authority plus the domain permission codes hardwired for known roles.
+
+        Use this tool to prebuild per-role permission or tool caches, as pos-mcp-server does; do not use getUserPermissions, which reads a specific user''s database assignments instead of the static role expansion.
+
+        Preconditions: the caller must hold security:role:view; the role name does not need to exist in the database.
+
+        Required inputs: role name as a path parameter, for example SHOP_MGR.
+
+        No events are emitted and no state changes; this is a read-only expansion of the compiled role-authority map.
+
+        Returns 200 in all cases; an unrecognized role yields only its ROLE_ authority with no domain codes rather than an error.
+
+        '
       operationId: getRoleDefaultPermissions_1
       parameters:
       - name: role
@@ -3081,8 +3923,20 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Get role by ID
-      description: Returns a specific role by its UUID
+      summary: Get a Single Role by UUID
+      description: 'Returns a single role looked up by its UUID, including its permission set and audit metadata.
+
+        Use this tool when the role id is known; use getRoleByName instead when only the name is available, and listRoles to browse.
+
+        Preconditions: the caller must hold security:role:view and the role must exist.
+
+        Required inputs: id (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no role exists for the supplied UUID.
+
+        '
       operationId: getRoleById
       parameters:
       - name: id
@@ -3140,8 +3994,20 @@ paths:
     delete:
       tags:
       - Role Management
-      summary: Delete a role
-      description: Deletes a role by UUID and removes its associations
+      summary: Delete a Role and Its Associations
+      description: 'Deletes a role by UUID, clearing its permission grants and deleting all of its role assignments in the same transaction.
+
+        Use this tool to retire a role entirely; do not use revokeRolePermission or revokeRoleAssignment, which remove a single grant or assignment and keep the role.
+
+        Preconditions: the caller must hold security:role:delete and the role must exist; users holding the role lose it immediately.
+
+        Required inputs: id (UUID) as a path parameter.
+
+        Emits a SECURITY_ROLE_DELETE event.
+
+        Returns 404 when the role does not exist.
+
+        '
       operationId: deleteRole
       parameters:
       - name: id
@@ -3196,8 +4062,20 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Get role by ID
-      description: Returns a specific role by its UUID
+      summary: Get a Single Role by UUID
+      description: 'Returns a single role looked up by its UUID, including its permission set and audit metadata.
+
+        Use this tool when the role id is known; use getRoleByName instead when only the name is available, and listRoles to browse.
+
+        Preconditions: the caller must hold security:role:view and the role must exist.
+
+        Required inputs: id (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no role exists for the supplied UUID.
+
+        '
       operationId: getRoleById_1
       parameters:
       - name: id
@@ -3255,8 +4133,20 @@ paths:
     delete:
       tags:
       - Role Management
-      summary: Delete a role
-      description: Deletes a role by UUID and removes its associations
+      summary: Delete a Role and Its Associations
+      description: 'Deletes a role by UUID, clearing its permission grants and deleting all of its role assignments in the same transaction.
+
+        Use this tool to retire a role entirely; do not use revokeRolePermission or revokeRoleAssignment, which remove a single grant or assignment and keep the role.
+
+        Preconditions: the caller must hold security:role:delete and the role must exist; users holding the role lose it immediately.
+
+        Required inputs: id (UUID) as a path parameter.
+
+        Emits a SECURITY_ROLE_DELETE event.
+
+        Returns 404 when the role does not exist.
+
+        '
       operationId: deleteRole_1
       parameters:
       - name: id
@@ -3311,9 +4201,21 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Get user permissions (legacy path)
-      description: Returns all permissions for a user from their role assignments
-      operationId: getUserPermissionsByUserId
+      summary: Get User Permissions at Legacy Path
+      description: 'Returns the union of permissions granted through a user''s currently effective role assignments, served at the legacy /permissions/user/{userId} path.
+
+        Use this tool only for legacy callers; use getUserPermissions instead, which returns the same data at the canonical /v1/users/{userId}/permissions path.
+
+        Preconditions: the caller must hold security:permission:view and the user must exist.
+
+        Required inputs: userId (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the user does not exist.
+
+        '
+      operationId: getUserPermissionsLegacy
       parameters:
       - name: userId
         in: path
@@ -3374,9 +4276,21 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Get user permissions (legacy path)
-      description: Returns all permissions for a user from their role assignments
-      operationId: getUserPermissionsByUserId_1
+      summary: Get User Permissions at Legacy Path
+      description: 'Returns the union of permissions granted through a user''s currently effective role assignments, served at the legacy /permissions/user/{userId} path.
+
+        Use this tool only for legacy callers; use getUserPermissions instead, which returns the same data at the canonical /v1/users/{userId}/permissions path.
+
+        Preconditions: the caller must hold security:permission:view and the user must exist.
+
+        Required inputs: userId (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the user does not exist.
+
+        '
+      operationId: getUserPermissionsLegacy_1
       parameters:
       - name: userId
         in: path
@@ -3437,8 +4351,20 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Check user permission
-      description: Checks if a user has a specific permission for a location
+      summary: Check One User Permission at a Location
+      description: 'Checks whether a user holds a specific permission through a currently effective role assignment whose scope covers the given location.
+
+        Use this tool for a point authorization probe by user UUID; use getAuthorizationDecision instead when the caller has a principal identifier from the RBAC matrix rather than a user id.
+
+        Preconditions: the caller must hold security:permission:view and the user must exist.
+
+        Required inputs: userId (UUID) and permission (domain:resource:action) as query parameters; locationId is optional and defaults to GLOBAL.
+
+        No events are emitted and no state changes; this is a read-only check.
+
+        Returns 200 with a plain boolean body, and 404 when the user does not exist.
+
+        '
       operationId: checkUserPermission
       parameters:
       - name: userId
@@ -3507,8 +4433,20 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Check user permission
-      description: Checks if a user has a specific permission for a location
+      summary: Check One User Permission at a Location
+      description: 'Checks whether a user holds a specific permission through a currently effective role assignment whose scope covers the given location.
+
+        Use this tool for a point authorization probe by user UUID; use getAuthorizationDecision instead when the caller has a principal identifier from the RBAC matrix rather than a user id.
+
+        Preconditions: the caller must hold security:permission:view and the user must exist.
+
+        Required inputs: userId (UUID) and permission (domain:resource:action) as query parameters; locationId is optional and defaults to GLOBAL.
+
+        No events are emitted and no state changes; this is a read-only check.
+
+        Returns 200 with a plain boolean body, and 404 when the user does not exist.
+
+        '
       operationId: checkUserPermission_1
       parameters:
       - name: userId
@@ -3577,8 +4515,20 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Get role by name
-      description: Returns a specific role by its name
+      summary: Get a Single Role by Name
+      description: 'Returns a single role looked up by its exact name, including its permission set.
+
+        Use this tool when only the role name is known; use getRoleById instead when the UUID is available, and listRoles to browse.
+
+        Preconditions: the caller must hold security:role:view and a role with that exact (case-sensitive) name must exist.
+
+        Required inputs: name as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 with ROLE_NOT_FOUND when no role has the supplied name.
+
+        '
       operationId: getRoleByName
       parameters:
       - name: name
@@ -3636,8 +4586,20 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Get role by name
-      description: Returns a specific role by its name
+      summary: Get a Single Role by Name
+      description: 'Returns a single role looked up by its exact name, including its permission set.
+
+        Use this tool when only the role name is known; use getRoleById instead when the UUID is available, and listRoles to browse.
+
+        Preconditions: the caller must hold security:role:view and a role with that exact (case-sensitive) name must exist.
+
+        Required inputs: name as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 with ROLE_NOT_FOUND when no role has the supplied name.
+
+        '
       operationId: getRoleByName_1
       parameters:
       - name: name
@@ -3695,9 +4657,21 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Get user role assignments
-      description: Returns currently effective assignments by default. Set includeHistory=true to return all assignments including expired/revoked
-      operationId: getUserRoleAssignments
+      summary: List a User's Role Assignments
+      description: 'Returns a user''s role assignments with their scope and effective window, limited to currently effective assignments by default.
+
+        Use this tool to inspect who holds which roles and in what scope; use getUserPermissions instead when only the flattened permission set matters.
+
+        Preconditions: the caller must hold security:role:view and the user must exist.
+
+        Required inputs: userId (UUID) as a path parameter; includeHistory defaults to false and, when true, also returns expired and revoked assignments.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the user does not exist.
+
+        '
+      operationId: listUserRoleAssignments
       parameters:
       - name: userId
         in: path
@@ -3767,9 +4741,21 @@ paths:
     get:
       tags:
       - Role Management
-      summary: Get user role assignments
-      description: Returns currently effective assignments by default. Set includeHistory=true to return all assignments including expired/revoked
-      operationId: getUserRoleAssignments_1
+      summary: List a User's Role Assignments
+      description: 'Returns a user''s role assignments with their scope and effective window, limited to currently effective assignments by default.
+
+        Use this tool to inspect who holds which roles and in what scope; use getUserPermissions instead when only the flattened permission set matters.
+
+        Preconditions: the caller must hold security:role:view and the user must exist.
+
+        Required inputs: userId (UUID) as a path parameter; includeHistory defaults to false and, when true, also returns expired and revoked assignments.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when the user does not exist.
+
+        '
+      operationId: listUserRoleAssignments_1
       parameters:
       - name: userId
         in: path
@@ -3839,8 +4825,20 @@ paths:
     get:
       tags:
       - Permission Registry
-      summary: Get permission by identifier
-      description: Returns a single registered permission by its UUID identifier.
+      summary: Get Permission by Identifier
+      description: 'Returns a single registered permission by its UUID identifier, including name, domain, description, and deprecation flag.
+
+        Use this tool when the permission id is already known; use listPermissions instead to search by domain or page through the registry.
+
+        Preconditions: the caller must hold security:permission:view and the permission must exist in the registry.
+
+        Required inputs: id (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no permission exists for the supplied id.
+
+        '
       operationId: getPermissionById
       parameters:
       - name: id
@@ -3899,8 +4897,20 @@ paths:
     get:
       tags:
       - Permission Registry
-      summary: Get permission by identifier
-      description: Returns a single registered permission by its UUID identifier.
+      summary: Get Permission by Identifier
+      description: 'Returns a single registered permission by its UUID identifier, including name, domain, description, and deprecation flag.
+
+        Use this tool when the permission id is already known; use listPermissions instead to search by domain or page through the registry.
+
+        Preconditions: the caller must hold security:permission:view and the permission must exist in the registry.
+
+        Required inputs: id (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no permission exists for the supplied id.
+
+        '
       operationId: getPermissionById_1
       parameters:
       - name: id
@@ -3959,8 +4969,20 @@ paths:
     get:
       tags:
       - Permission Registry
-      summary: Validate permission name format
-      description: Checks if a permission name follows the domain:resource:action format
+      summary: Validate Permission Name Format
+      description: 'Checks whether a permission name string matches the required domain:resource:action format (or the legacy two-segment domain:action form) without touching the database.
+
+        Use this tool to pre-validate a name before registration; use checkPermissionExists instead to test whether the name is actually registered.
+
+        Preconditions: the caller must hold security:permission:view.
+
+        Required inputs: permissionName as a path parameter; each segment must start with a letter and may contain letters, digits, underscores, and hyphens.
+
+        No events are emitted and no state changes; this is a pure format check.
+
+        Returns 200 with a plain boolean body; a malformed name yields false, never an error status.
+
+        '
       operationId: validatePermissionName
       parameters:
       - name: permissionName
@@ -4018,8 +5040,20 @@ paths:
     get:
       tags:
       - Permission Registry
-      summary: Validate permission name format
-      description: Checks if a permission name follows the domain:resource:action format
+      summary: Validate Permission Name Format
+      description: 'Checks whether a permission name string matches the required domain:resource:action format (or the legacy two-segment domain:action form) without touching the database.
+
+        Use this tool to pre-validate a name before registration; use checkPermissionExists instead to test whether the name is actually registered.
+
+        Preconditions: the caller must hold security:permission:view.
+
+        Required inputs: permissionName as a path parameter; each segment must start with a letter and may contain letters, digits, underscores, and hyphens.
+
+        No events are emitted and no state changes; this is a pure format check.
+
+        Returns 200 with a plain boolean body; a malformed name yields false, never an error status.
+
+        '
       operationId: validatePermissionName_1
       parameters:
       - name: permissionName
@@ -4077,9 +5111,21 @@ paths:
     get:
       tags:
       - Permission Registry
-      summary: Check if permission exists
-      description: Returns true if the permission is registered
-      operationId: permissionExists
+      summary: Check Whether a Permission Is Registered
+      description: 'Checks whether a permission with the given name is registered in the central registry.
+
+        Use this tool to test registration state; use validatePermissionName instead for a pure format check that ignores the database.
+
+        Preconditions: the caller must hold security:permission:view.
+
+        Required inputs: permissionName as a path parameter in domain:resource:action format.
+
+        No events are emitted and no state changes; this is a read-only existence check.
+
+        Returns 200 with a plain boolean body; an unregistered name yields false, never an error status.
+
+        '
+      operationId: checkPermissionExists
       parameters:
       - name: permissionName
         in: path
@@ -4136,9 +5182,21 @@ paths:
     get:
       tags:
       - Permission Registry
-      summary: Check if permission exists
-      description: Returns true if the permission is registered
-      operationId: permissionExists_1
+      summary: Check Whether a Permission Is Registered
+      description: 'Checks whether a permission with the given name is registered in the central registry.
+
+        Use this tool to test registration state; use validatePermissionName instead for a pure format check that ignores the database.
+
+        Preconditions: the caller must hold security:permission:view.
+
+        Required inputs: permissionName as a path parameter in domain:resource:action format.
+
+        No events are emitted and no state changes; this is a read-only existence check.
+
+        Returns 200 with a plain boolean body; an unregistered name yields false, never an error status.
+
+        '
+      operationId: checkPermissionExists_1
       parameters:
       - name: permissionName
         in: path
@@ -4195,9 +5253,21 @@ paths:
     get:
       tags:
       - Permission Registry
-      summary: Get permissions by domain
-      description: Returns all permissions for a specific domain/service
-      operationId: getPermissionsByDomain
+      summary: List Permissions for One Domain
+      description: 'Returns every registered permission for one domain as an unpaged list.
+
+        Use this tool when a complete domain snapshot is needed; use listPermissions instead when paging or when no domain filter applies.
+
+        Preconditions: the caller must hold security:permission:view.
+
+        Required inputs: domain as a path parameter, matching the first segment of the permission name (for example catalog in catalog:product:view).
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty list when the domain has no registered permissions; an unknown domain is not an error.
+
+        '
+      operationId: listPermissionsByDomain
       parameters:
       - name: domain
         in: path
@@ -4256,9 +5326,21 @@ paths:
     get:
       tags:
       - Permission Registry
-      summary: Get permissions by domain
-      description: Returns all permissions for a specific domain/service
-      operationId: getPermissionsByDomain_1
+      summary: List Permissions for One Domain
+      description: 'Returns every registered permission for one domain as an unpaged list.
+
+        Use this tool when a complete domain snapshot is needed; use listPermissions instead when paging or when no domain filter applies.
+
+        Preconditions: the caller must hold security:permission:view.
+
+        Required inputs: domain as a path parameter, matching the first segment of the permission name (for example catalog in catalog:product:view).
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty list when the domain has no registered permissions; an unknown domain is not an error.
+
+        '
+      operationId: listPermissionsByDomain_1
       parameters:
       - name: domain
         in: path
@@ -4317,9 +5399,21 @@ paths:
     get:
       tags:
       - Permission Registry
-      summary: Get current permission catalog version
-      description: Returns the active catalog version and total permission count. No authentication required.
-      operationId: getCatalogVersion
+      summary: Get Current Permission Catalog Version
+      description: 'Returns the permission catalog version compiled into this service build and the total number of permission codes in that catalog.
+
+        Use this tool to check whether a cached perm_bits decoding is stale before calling decodePermissionBits; do not use listPermissions, which pages the database registry rather than the compiled catalog.
+
+        Preconditions: none; the endpoint is public and requires no authentication.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection of the compiled PermissionCode catalog.
+
+        Returns 200 in all cases; there are no business error conditions.
+
+        '
+      operationId: getPermissionCatalogVersion
       responses:
         '400':
           description: Bad Request
@@ -4367,9 +5461,21 @@ paths:
     get:
       tags:
       - Permission Registry
-      summary: Get current permission catalog version
-      description: Returns the active catalog version and total permission count. No authentication required.
-      operationId: getCatalogVersion_1
+      summary: Get Current Permission Catalog Version
+      description: 'Returns the permission catalog version compiled into this service build and the total number of permission codes in that catalog.
+
+        Use this tool to check whether a cached perm_bits decoding is stale before calling decodePermissionBits; do not use listPermissions, which pages the database registry rather than the compiled catalog.
+
+        Preconditions: none; the endpoint is public and requires no authentication.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection of the compiled PermissionCode catalog.
+
+        Returns 200 in all cases; there are no business error conditions.
+
+        '
+      operationId: getPermissionCatalogVersion_1
       responses:
         '400':
           description: Bad Request
@@ -4417,8 +5523,20 @@ paths:
     get:
       tags:
       - Permission Registry
-      summary: List permissions
-      description: Returns a paged list of registered permissions, optionally filtered by domain.
+      summary: List Registered Permissions
+      description: 'Returns a paged list of registered permissions, optionally filtered to a single domain.
+
+        Use this tool to browse or search the permission registry; use getPermissionById instead when the UUID is already known, and getRoleDefaultPermissions to see what a role name expands to.
+
+        Preconditions: the caller must hold security:permission:view.
+
+        Required inputs: none are mandatory; domain is an optional filter, and page, size, and sort follow Spring pageable defaults (page 0, size 20).
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty page when nothing matches, and 400 when pagination parameters are malformed.
+
+        '
       operationId: listPermissions
       parameters:
       - name: domain
@@ -4478,8 +5596,20 @@ paths:
     get:
       tags:
       - Permission Registry
-      summary: List permissions
-      description: Returns a paged list of registered permissions, optionally filtered by domain.
+      summary: List Registered Permissions
+      description: 'Returns a paged list of registered permissions, optionally filtered to a single domain.
+
+        Use this tool to browse or search the permission registry; use getPermissionById instead when the UUID is already known, and getRoleDefaultPermissions to see what a role name expands to.
+
+        Preconditions: the caller must hold security:permission:view.
+
+        Required inputs: none are mandatory; domain is an optional filter, and page, size, and sort follow Spring pageable defaults (page 0, size 20).
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty page when nothing matches, and 400 when pagination parameters are malformed.
+
+        '
       operationId: listPermissions_1
       parameters:
       - name: domain
@@ -4539,9 +5669,21 @@ paths:
     get:
       tags:
       - Authorization
-      summary: Get authorization decision for a person
-      description: Returns allow or deny for the user backing the given personId and a permission key, evaluated against that user's assigned roles. Used to verify an off-session approver (e.g. a manager identified by employee number) holds a required permission.
-      operationId: getPersonDecision
+      summary: Get Authorization Decision for a Person
+      description: 'Returns an allow or deny decision for the user account linked to a personId, evaluated against that user''s directly assigned roles.
+
+        Use this tool to verify an off-session approver, such as a manager identified by employee number, holds a required permission; use getAuthorizationDecision instead for matrix principals.
+
+        Preconditions: the caller must hold security:authorization:decide; a user should be linked to the person via the user-person link projection.
+
+        Required inputs: personId (UUID) and permission (domain:resource:action) as query parameters.
+
+        No events are emitted and no state changes; this is a read-only evaluation.
+
+        Returns 200 with decision allow or deny; a person with no linked user or without the permission yields deny rather than an error.
+
+        '
+      operationId: getPersonAuthorizationDecision
       parameters:
       - name: personId
         in: query
@@ -4608,9 +5750,21 @@ paths:
     get:
       tags:
       - Authorization
-      summary: Get authorization decision
-      description: Returns allow or deny for a principal and permission key
-      operationId: getDecision
+      summary: Get Authorization Decision for a Principal
+      description: 'Returns an allow or deny decision for a principal identifier and permission key, evaluated against the principal-role matrix populated by assignPrincipalRole.
+
+        Use this tool for matrix-based checks keyed by principal string; use getPersonAuthorizationDecision instead when the caller has a personId, and checkUserPermission when it has a user UUID and location.
+
+        Preconditions: the caller must hold security:authorization:decide; the principal needs no prior registration.
+
+        Required inputs: principalId and permission (domain:resource:action) as query parameters.
+
+        No events are emitted and no state changes; this is a read-only evaluation.
+
+        Returns 200 with decision allow or deny; an unknown principal or permission yields deny rather than an error.
+
+        '
+      operationId: getAuthorizationDecision
       parameters:
       - name: principalId
         in: query
@@ -4676,9 +5830,21 @@ paths:
     get:
       tags:
       - Self-Registration Review API
-      summary: List self-registration review cases
-      description: Returns blocked self-registration cases for recovery or identity review.
-      operationId: listCases
+      summary: List Self-Registration Review Cases
+      description: 'Returns blocked self-registration review cases, newest first, optionally filtered by status and case type.
+
+        Use this tool to work the recovery and identity-review queue; use getSelfRegistrationReviewCase instead for one known case.
+
+        Preconditions: the caller must hold security:user_account_state:view.
+
+        Required inputs: none are mandatory; status filters on OPEN or RESOLVED and caseType on ACCOUNT_RECOVERY or IDENTITY_REVIEW.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with an empty list when nothing matches, and 400 when a filter value is not a valid enum constant.
+
+        '
+      operationId: listSelfRegistrationReviewCases
       parameters:
       - name: status
         in: query
@@ -4748,9 +5914,21 @@ paths:
     get:
       tags:
       - Self-Registration Review API
-      summary: Get a self-registration review case
-      description: Returns the details of a blocked self-registration case.
-      operationId: getCase
+      summary: Get One Self-Registration Review Case
+      description: 'Returns the full detail of one blocked self-registration case, including reason codes, CRM match summary, and any linked person or user ids.
+
+        Use this tool when the case id is known, typically from the referenceId of a 409 selfRegisterUser conflict; use listSelfRegistrationReviewCases instead to browse the queue.
+
+        Preconditions: the caller must hold security:user_account_state:view and the case must exist.
+
+        Required inputs: caseId (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no review case exists for the supplied id.
+
+        '
+      operationId: getSelfRegistrationReviewCase
       parameters:
       - name: caseId
         in: path
@@ -4808,8 +5986,20 @@ paths:
     get:
       tags:
       - JWT API
-      summary: Validate JWT token
-      description: Check if a JWT token is valid (signature, expiration, revocation)
+      summary: Validate a JWT Access Token
+      description: 'Checks whether a JWT access token is currently valid by verifying signature, issuer, audience, expiry, Redis revocation status, and presence in the token store.
+
+        Use this tool to test a token without side effects; do not use refreshTokenPair, which rotates tokens, and do not use revokeToken, which invalidates one.
+
+        Preconditions: none beyond possessing the token string; the endpoint is public.
+
+        Required inputs: token as a query parameter.
+
+        No events are emitted and no state changes; this is a read-only check.
+
+        Returns 200 in all cases with a valid flag, so callers must read valid=false rather than expect an error status when the token fails any check.
+
+        '
       operationId: validateToken
       parameters:
       - name: token
@@ -4864,9 +6054,21 @@ paths:
     get:
       tags:
       - JWT API
-      summary: Extract userId from JWT token
-      description: Get the stable user identifier from a JWT token
-      operationId: getUserId
+      summary: Extract User Id From JWT Token
+      description: 'Extracts the stable user identifier from a valid JWT token''s uid claim (falling back to the legacy userId claim) and returns it as a plain string body.
+
+        Use this tool to resolve the user UUID behind a token; use getTokenSubject instead when the username is what is needed.
+
+        Preconditions: the token must pass full validation, including revocation and token-store checks.
+
+        Required inputs: token as a query parameter.
+
+        No events are emitted and no state changes; this is a read-only claim extraction.
+
+        Returns 401 when the token is invalid, expired, revoked, or unknown to the token store.
+
+        '
+      operationId: getTokenUserId
       parameters:
       - name: token
         in: query
@@ -4922,9 +6124,21 @@ paths:
     get:
       tags:
       - JWT API
-      summary: Extract subject from JWT token
-      description: Get the subject (username) from a JWT token
-      operationId: getSubject
+      summary: Extract Subject From JWT Token
+      description: 'Extracts the subject claim, the username, from a valid JWT token and returns it as a plain string body.
+
+        Use this tool to resolve which user a token belongs to; use getTokenUserId instead for the stable UUID identifier, and getTokenRoles for the role claim.
+
+        Preconditions: the token must pass full validation, including revocation and token-store checks.
+
+        Required inputs: token as a query parameter.
+
+        No events are emitted and no state changes; this is a read-only claim extraction.
+
+        Returns 401 when the token is invalid, expired, revoked, or unknown to the token store.
+
+        '
+      operationId: getTokenSubject
       parameters:
       - name: token
         in: query
@@ -4980,9 +6194,21 @@ paths:
     get:
       tags:
       - JWT API
-      summary: Extract roles from JWT token
-      description: Get the roles claim from a JWT token
-      operationId: getRoles
+      summary: Extract Roles From JWT Token
+      description: 'Extracts the roles claim from a valid JWT token and returns the normalized role names.
+
+        Use this tool when a caller holds a token and needs its roles; use getTokenSubject instead for the username, and decodePermissionBits instead to expand the token''s perm_bits claim into permission codes.
+
+        Preconditions: the token must pass full validation, including revocation and token-store checks.
+
+        Required inputs: token as a query parameter.
+
+        No events are emitted and no state changes; this is a read-only claim extraction.
+
+        Returns 401 when the token is invalid, expired, revoked, or unknown to the token store.
+
+        '
+      operationId: getTokenRoles
       parameters:
       - name: token
         in: query
@@ -5041,8 +6267,20 @@ paths:
     get:
       tags:
       - Audit
-      summary: Get pricing snapshot
-      description: Returns an immutable pricing snapshot by its snapshot identifier.
+      summary: Get One Pricing Snapshot by Id
+      description: 'Returns an immutable pricing snapshot with its rule-evaluation steps ordered by rule id.
+
+        Use this tool when the snapshot id is known; use searchAuditEvents instead for general audit queries, since snapshots have no search endpoint.
+
+        Preconditions: the caller must hold security:audit:view and the snapshot must exist.
+
+        Required inputs: snapshotId (UUID) as a path parameter.
+
+        No events are emitted and no state changes; snapshots are read-only after creation.
+
+        Returns 400 with INVALID_REQUEST, not 404, when no snapshot exists for the supplied id; callers must treat that 400 as a miss.
+
+        '
       operationId: getPricingSnapshot
       parameters:
       - name: snapshotId
@@ -5100,8 +6338,20 @@ paths:
     get:
       tags:
       - Audit Exports
-      summary: Get audit export job status
-      description: Returns the current status of a previously submitted audit export job.
+      summary: Get Audit Export Job Status
+      description: 'Returns the current status of a previously submitted audit export job, including completion time, download URL, and error message when present.
+
+        Use this tool to poll a job created by requestAuditExport; do not resubmit the export while a job is still PENDING.
+
+        Preconditions: the caller must hold security:audit:export and the job must exist in the in-memory store, which is cleared on service restart.
+
+        Required inputs: jobId (UUID) as a path parameter.
+
+        No events are emitted and no state changes; this is a read-only status projection.
+
+        Returns 404 when the job id is unknown or the store was cleared by a restart.
+
+        '
       operationId: getAuditExportJob
       parameters:
       - name: jobId
@@ -5161,9 +6411,21 @@ paths:
     get:
       tags:
       - Audit
-      summary: Get audit event
-      description: Returns a previously recorded audit event by its event identifier.
-      operationId: getEvent
+      summary: Get One Audit Event by Id
+      description: 'Returns a previously recorded audit event by its event id.
+
+        Use this tool when the event id is known; use searchAuditEvents instead to filter by time window, actor, event type, or aggregate.
+
+        Preconditions: the caller must hold security:audit:view and the event must exist.
+
+        Required inputs: eventId (UUID) as a path parameter.
+
+        No events are emitted and no state changes; audit records are immutable.
+
+        Returns 404 when no audit event exists for the supplied id.
+
+        '
+      operationId: getAuditEvent
       parameters:
       - name: eventId
         in: path
@@ -5220,8 +6482,20 @@ paths:
     delete:
       tags:
       - Role Management
-      summary: Revoke role assignment
-      description: Revokes a role assignment by setting its end date. Supports past, present, or future dates. The system automatically records when the revocation was requested. Defaults to today when endDate is omitted
+      summary: Revoke a Role Assignment by Id
+      description: 'Revokes a role assignment by setting its effective end date, preserving the row for history.
+
+        Use this tool when the assignment id is known or a past or future end date is needed; do not use revokeUserRole, which finds the active assignment from userId and roleId and ends it now.
+
+        Preconditions: the caller must hold security:role:assign and the assignment must exist.
+
+        Required inputs: assignmentId (UUID) as a path parameter; endDate (ISO date-time) is optional and defaults to the current time, and the revocation timestamp is recorded automatically.
+
+        Emits a SECURITY_ROLE_ASSIGNMENT_REVOKE event.
+
+        Returns 400 when endDate is malformed, and 404 when the assignment does not exist.
+
+        '
       operationId: revokeRoleAssignment
       parameters:
       - name: assignmentId
@@ -5286,8 +6560,20 @@ paths:
     delete:
       tags:
       - Role Management
-      summary: Revoke role assignment
-      description: Revokes a role assignment by setting its end date. Supports past, present, or future dates. The system automatically records when the revocation was requested. Defaults to today when endDate is omitted
+      summary: Revoke a Role Assignment by Id
+      description: 'Revokes a role assignment by setting its effective end date, preserving the row for history.
+
+        Use this tool when the assignment id is known or a past or future end date is needed; do not use revokeUserRole, which finds the active assignment from userId and roleId and ends it now.
+
+        Preconditions: the caller must hold security:role:assign and the assignment must exist.
+
+        Required inputs: assignmentId (UUID) as a path parameter; endDate (ISO date-time) is optional and defaults to the current time, and the revocation timestamp is recorded automatically.
+
+        Emits a SECURITY_ROLE_ASSIGNMENT_REVOKE event.
+
+        Returns 400 when endDate is malformed, and 404 when the assignment does not exist.
+
+        '
       operationId: revokeRoleAssignment_1
       parameters:
       - name: assignmentId
@@ -5352,8 +6638,20 @@ paths:
     delete:
       tags:
       - JWT API
-      summary: Revoke JWT token
-      description: Revoke a JWT token immediately (Redis cache + database)
+      summary: Revoke a JWT Access Token
+      description: 'Revokes a JWT access token immediately by deleting its stored pair and adding its JTI to the Redis revocation cache until natural expiry.
+
+        Use this tool to invalidate one compromised or abandoned token; do not use disableUserAccount, which revokes every token for a user and blocks future sign-in.
+
+        Preconditions: an authenticated caller; the token should exist in the token store, though an unknown token is silently ignored.
+
+        Required inputs: token as a query parameter, the exact access token string to revoke.
+
+        Emits a SECURITY_AUTH_REVOKE event; revocation takes effect immediately for validateToken and downstream gateway checks.
+
+        Returns 204 in all cases, including when the token was not found, so revocation success cannot be inferred from the status code.
+
+        '
       operationId: revokeToken
       parameters:
       - name: token
@@ -5499,7 +6797,7 @@ components:
       - username
     UserUpdateRequest:
       type: object
-      description: Updated user object
+      description: Partial update of a user account; only supplied fields are applied
       properties:
         username:
           type: string
@@ -6521,12 +7819,12 @@ components:
     Page:
       type: object
       properties:
-        totalElements:
-          type: integer
-          format: int64
         totalPages:
           type: integer
           format: int32
+        totalElements:
+          type: integer
+          format: int64
         size:
           type: integer
           format: int32
@@ -6535,17 +7833,17 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
     PageableObject:
@@ -6708,12 +8006,12 @@ components:
     PageAuditLogEventDto:
       type: object
       properties:
-        totalElements:
-          type: integer
-          format: int64
         totalPages:
           type: integer
           format: int32
+        totalElements:
+          type: integer
+          format: int64
         size:
           type: integer
           format: int32
@@ -6724,17 +8022,17 @@ components:
         number:
           type: integer
           format: int32
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
         sort:
           $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
   securitySchemes:

--- a/pos-security-service/openapi.yaml
+++ b/pos-security-service/openapi.yaml
@@ -77,13 +77,13 @@ paths:
         required: true
       responses:
         '400':
-          description: Bad Request
+          description: User or named role not found (INVALID_REQUEST); the miss surfaces as 400, not 404.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
         '404':
-          description: User not found.
+          description: Not Found
           content:
             application/json:
               schema:
@@ -385,13 +385,13 @@ paths:
         required: true
       responses:
         '400':
-          description: Bad Request
+          description: User or named role not found (INVALID_REQUEST); the miss surfaces as 400, not 404.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
         '404':
-          description: User not found.
+          description: Not Found
           content:
             application/json:
               schema:

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AdminAccountStateController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AdminAccountStateController.java
@@ -24,10 +24,16 @@ public class AdminAccountStateController {
 
     private final AdminAccountStateService adminAccountStateService;
 
-    @Operation(
-            summary = "Unlock a user account",
-            description =
-                    "Removes the locked state from the specified user account so the user can authenticate again.")
+    @Operation(operationId = "unlockUserAccount", summary = "Unlock a Locked User Account", description = """
+                    Clears the lockout state on a user account, resetting the failed-attempt counter and lock \
+                    timestamps so the user can authenticate again.
+                    Use this tool after a lockout caused by repeated failed logins; do not use enableUserAccount, \
+                    which reverses an administrative disable rather than a lockout.
+                    Preconditions: the caller must hold security:user_account_state:manage and the user must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a SECURITY_USER_UNLOCK event; existing tokens are not revoked.
+                    Returns 404 with USER_NOT_FOUND when the user does not exist.
+                    """)
     @ApiResponse(responseCode = "204", description = "User account unlocked successfully")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -40,10 +46,16 @@ public class AdminAccountStateController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Enable a user account",
-            description =
-                    "Marks the specified user account as enabled so it can be used for sign-in and access checks.")
+    @Operation(operationId = "enableUserAccount", summary = "Enable a Disabled User Account", description = """
+                    Marks a user account as enabled so it is again accepted for sign-in and access checks.
+                    Use this tool to reverse disableUserAccount; do not use unlockUserAccount, which clears a \
+                    failed-login lockout instead.
+                    Preconditions: the caller must hold security:user_account_state:manage and the user must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a SECURITY_USER_ENABLE event; no tokens are issued or restored, so the user must sign in \
+                    again.
+                    Returns 404 with USER_NOT_FOUND when the user does not exist.
+                    """)
     @ApiResponse(responseCode = "204", description = "User account enabled successfully")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -56,9 +68,16 @@ public class AdminAccountStateController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Disable a user account",
-            description = "Marks the specified user account as disabled to prevent further use until it is re-enabled.")
+    @Operation(operationId = "disableUserAccount", summary = "Disable a User Account", description = """
+                    Marks a user account as disabled, records the disabling actor and time, and immediately revokes \
+                    every token issued to the user.
+                    Use this tool for a reversible administrative block; do not use deleteUser, which removes the \
+                    account, and do not use expireUserAccount, which marks the account expired instead.
+                    Preconditions: the caller must hold security:user_account_state:manage and the user must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a SECURITY_USER_DISABLE event and revokes all of the user's access and refresh tokens.
+                    Returns 404 with USER_NOT_FOUND when the user does not exist.
+                    """)
     @ApiResponse(responseCode = "204", description = "User account disabled successfully")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -71,9 +90,18 @@ public class AdminAccountStateController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Expire a user account",
-            description = "Expires the specified user account so it is no longer considered valid for authentication.")
+    @Operation(operationId = "expireUserAccount", summary = "Expire a User Account", description = """
+                    Marks a user account as expired, stamping the expiry time and immediately revoking every token \
+                    issued to the user.
+                    Use this tool to end an account's validity, for example at offboarding; do not use \
+                    disableUserAccount, which signals a reversible administrative block, or expireUserCredentials, \
+                    which only forces a credential reset.
+                    Preconditions: the caller must hold security:user_account_state:manage and the user must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a SECURITY_USER_EXPIRE_ACCOUNT event and revokes all of the user's access and refresh \
+                    tokens.
+                    Returns 404 with USER_NOT_FOUND when the user does not exist.
+                    """)
     @ApiResponse(responseCode = "204", description = "User account expired successfully")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -86,10 +114,17 @@ public class AdminAccountStateController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Expire user credentials",
-            description =
-                    "Expires the specified user's credentials so a credential reset or update is required before reuse.")
+    @Operation(operationId = "expireUserCredentials", summary = "Expire a User's Credentials", description = """
+                    Marks a user's credentials as expired, stamping the expiry time and immediately revoking every \
+                    token so a credential reset is required before further use.
+                    Use this tool to force a password rotation; do not use expireUserAccount, which expires the \
+                    whole account rather than just its credentials.
+                    Preconditions: the caller must hold security:user_account_state:manage and the user must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a SECURITY_USER_EXPIRE_CREDENTIALS event and revokes all of the user's access and refresh \
+                    tokens.
+                    Returns 404 with USER_NOT_FOUND when the user does not exist.
+                    """)
     @ApiResponse(responseCode = "204", description = "User credentials expired successfully")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -102,9 +137,16 @@ public class AdminAccountStateController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(
-            summary = "Get user account state",
-            description = "Returns the current administrative account-state flags for the specified user.")
+    @Operation(operationId = "getUserAccountState", summary = "Get a User's Account-State Flags", description = """
+                    Returns the administrative account-state flags for a user: enabled, lock, account-expiry, and \
+                    credential-expiry state with their timestamps, disabling actor, and failed-attempt count.
+                    Use this tool to diagnose why sign-in fails before choosing among unlockUserAccount, \
+                    enableUserAccount, and the expiry endpoints; use getUserById instead for identity and role data.
+                    Preconditions: the caller must hold security:user_account_state:view and the user must exist.
+                    Required inputs: id (UUID) as a path parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 with USER_NOT_FOUND when the user does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "User account state returned successfully")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuditController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuditController.java
@@ -14,6 +14,7 @@ import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -56,9 +57,18 @@ public class AuditController {
     @EmitEvent(id = "SECURITY_AUDIT_EVENT_CREATE", apiVersion = "1")
     @PostMapping("/events")
     @PreAuthorize("hasAuthority('security:audit:create')")
-    @Operation(
-            summary = "Create audit event",
-            description = "Creates an immutable audit event record and returns the generated event identifier.")
+    @Operation(operationId = "createAuditEvent", summary = "Record an Immutable Audit Event", description = """
+                    Records an immutable audit event and returns the generated event id and server timestamp.
+                    Use this tool to persist a write-once audit fact; do not use createPricingSnapshot, which \
+                    records a pricing rule trace, and note that updates and deletes of audit events are rejected \
+                    with 405 by design.
+                    Preconditions: the caller must hold security:audit:create; the actor is resolved server-side \
+                    from the security context, so any actorId in the body is ignored.
+                    Required inputs: eventType, entityId, entityType, oldValue, and newValue (empty strings are \
+                    accepted, null is not); context is optional and stored as serialized JSON.
+                    Emits a SECURITY_AUDIT_EVENT_CREATE event; the stored record can never be modified or deleted.
+                    Returns 400 when any required field is missing or a value cannot be serialized to JSON.
+                    """)
     @ApiResponse(
             responseCode = "201",
             description = "Audit event created",
@@ -71,7 +81,24 @@ public class AuditController {
             responseCode = "403",
             description = "Insufficient authority",
             content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<AuditEventCreatedResponse> createEvent(@RequestBody @NonNull AuditLogEventRequest request) {
+    public ResponseEntity<AuditEventCreatedResponse> createEvent(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The audit fact to record: what changed, on which entity, from and to what.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Role change event", value = """
+                                                                    {"eventType":"ROLE_ASSIGNED",
+                                                                     "entityId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "entityType":"USER",
+                                                                     "oldValue":"",
+                                                                     "newValue":"SHOP_MGR",
+                                                                     "context":{"reason":"onboarding"}}
+                                                                    """)))
+                    @RequestBody
+                    @NonNull
+                    AuditLogEventRequest request) {
         AuditLogEventDto created = auditEventService.createEvent(request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(AuditEventCreatedResponse.builder()
@@ -82,9 +109,15 @@ public class AuditController {
 
     @GetMapping("/events/{eventId}")
     @PreAuthorize("hasAuthority('security:audit:view')")
-    @Operation(
-            summary = "Get audit event",
-            description = "Returns a previously recorded audit event by its event identifier.")
+    @Operation(operationId = "getAuditEvent", summary = "Get One Audit Event by Id", description = """
+                    Returns a previously recorded audit event by its event id.
+                    Use this tool when the event id is known; use searchAuditEvents instead to filter by time \
+                    window, actor, event type, or aggregate.
+                    Preconditions: the caller must hold security:audit:view and the event must exist.
+                    Required inputs: eventId (UUID) as a path parameter.
+                    No events are emitted and no state changes; audit records are immutable.
+                    Returns 404 when no audit event exists for the supplied id.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Audit event returned successfully",
@@ -103,10 +136,19 @@ public class AuditController {
 
     @GetMapping("/events")
     @PreAuthorize("hasAuthority('security:audit:view')")
-    @Operation(
-            operationId = "searchAuditEvents",
-            summary = "Search audit events",
-            description = "Searches audit events using rich filter criteria with pagination support.")
+    @Operation(operationId = "searchAuditEvents", summary = "Search Audit Events With Filters", description = """
+                    Searches audit events with pagination, filtering by time window, actor, event type, and \
+                    aggregate identifier.
+                    Use this tool to query the audit trail; use getAuditEvent instead when the event id is known, \
+                    and requestAuditExport for bulk extraction as a file.
+                    Preconditions: the caller must hold security:audit:view; when both bounds are given, fromDate \
+                    must be strictly before toDate (fromDate inclusive, toDate exclusive).
+                    Required inputs: none are mandatory; fromDate, toDate, actorId, eventType, and aggregateId are \
+                    applied as filters, while workorderId, movementId, productId, sku, correlationId, reasonCode, \
+                    pageToken, and locationIds are accepted for contract compatibility but not yet applied.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 400 when fromDate is not before toDate or a parameter fails type conversion.
+                    """)
     @ApiResponse(responseCode = "200", description = "Audit events returned successfully")
     @ApiResponse(
             responseCode = "400",
@@ -180,9 +222,17 @@ public class AuditController {
 
     @DeleteMapping("/events/**")
     @PreAuthorize("hasAuthority('security:audit:create')")
-    @Operation(
-            summary = "Delete audit events not allowed",
-            description = "Audit events are immutable and cannot be deleted once recorded.")
+    @Operation(operationId = "rejectAuditEventDelete", summary = "Reject Audit Event Deletion", description = """
+                    Rejects every attempt to delete audit events, unconditionally answering 405 Method Not Allowed.
+                    Use this tool never; audit events are write-once, so use createAuditEvent to record facts and \
+                    searchAuditEvents to read them instead.
+                    Preconditions: none that permit success; the operation fails by design for any path under the \
+                    audit events resource.
+                    Required inputs: none are honored; the request is rejected regardless of path or payload.
+                    No events are emitted and no state changes; the endpoint exists only to make immutability \
+                    explicit.
+                    Returns 405 in all cases.
+                    """)
     @ApiResponse(responseCode = "405", description = "Method not allowed for immutable audit events")
     public ResponseEntity<Void> deleteNotAllowed() {
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).build();
@@ -190,9 +240,17 @@ public class AuditController {
 
     @PutMapping("/events/**")
     @PreAuthorize("hasAuthority('security:audit:create')")
-    @Operation(
-            summary = "Update audit events not allowed",
-            description = "Audit events are immutable and cannot be modified after creation.")
+    @Operation(operationId = "rejectAuditEventUpdate", summary = "Reject Audit Event Modification", description = """
+                    Rejects every attempt to modify audit events, unconditionally answering 405 Method Not Allowed.
+                    Use this tool never; audit events are write-once, so record a new fact with createAuditEvent \
+                    instead of editing an existing one.
+                    Preconditions: none that permit success; the operation fails by design for any path under the \
+                    audit events resource.
+                    Required inputs: none are honored; the request is rejected regardless of path or payload.
+                    No events are emitted and no state changes; the endpoint exists only to make immutability \
+                    explicit.
+                    Returns 405 in all cases.
+                    """)
     @ApiResponse(responseCode = "405", description = "Method not allowed for immutable audit events")
     public ResponseEntity<Void> updateNotAllowed() {
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).build();
@@ -202,15 +260,46 @@ public class AuditController {
     @PostMapping("/pricing-snapshots")
     @PreAuthorize("hasAuthority('security:audit:create')")
     @Operation(
-            summary = "Create pricing snapshot",
-            description = "Creates an immutable pricing snapshot record for later audit and traceability.")
+            operationId = "createPricingSnapshot",
+            summary = "Record an Immutable Pricing Snapshot",
+            description = """
+                    Records an immutable pricing snapshot with its ordered rule-evaluation trace and returns the \
+                    generated snapshot id.
+                    Use this tool to preserve how a price was computed for later audit; do not use \
+                    createAuditEvent, which records generic entity-change events without a rule trace.
+                    Preconditions: the caller must hold security:audit:create; the snapshot is write-once and \
+                    cannot be modified afterwards.
+                    Required inputs: quoteContext, finalPrice, and evaluationSteps, where every step needs ruleId, \
+                    status, inputs, and outputs; evaluationSteps may be an empty list but not null.
+                    Emits a SECURITY_AUDIT_PRICING_SNAPSHOT_CREATE event.
+                    Returns 400 when quoteContext, finalPrice, evaluationSteps, or any per-step field is missing, \
+                    or when a JSON field cannot be serialized.
+                    """)
     @ApiResponse(responseCode = "201", description = "Pricing snapshot created")
     @ApiResponse(
             responseCode = "400",
             description = "Invalid pricing snapshot payload",
             content = @Content(schema = @Schema(implementation = ApiError.class)))
     public ResponseEntity<PricingSnapshotCreatedResponse> createPricingSnapshot(
-            @RequestBody @NonNull PricingSnapshotRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The evaluated quote context, final price, and rule trace to preserve.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "Snapshot with one rule step", value = """
+                                                                    {"quoteContext":{"sku":"BRAKE-PAD-001","quantity":2},
+                                                                     "finalPrice":129.99,
+                                                                     "evaluationSteps":[
+                                                                       {"ruleId":"MSRP_BASE",
+                                                                        "status":"APPLIED",
+                                                                        "inputs":{"listPrice":149.99},
+                                                                        "outputs":{"price":129.99}}]}
+                                                                    """)))
+                    @RequestBody
+                    @NonNull
+                    PricingSnapshotRequest request) {
         PricingSnapshotDto created = pricingSnapshotService.createSnapshot(request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(PricingSnapshotCreatedResponse.builder()
@@ -220,9 +309,16 @@ public class AuditController {
 
     @GetMapping("/pricing-snapshots/{snapshotId}")
     @PreAuthorize("hasAuthority('security:audit:view')")
-    @Operation(
-            summary = "Get pricing snapshot",
-            description = "Returns an immutable pricing snapshot by its snapshot identifier.")
+    @Operation(operationId = "getPricingSnapshot", summary = "Get One Pricing Snapshot by Id", description = """
+                    Returns an immutable pricing snapshot with its rule-evaluation steps ordered by rule id.
+                    Use this tool when the snapshot id is known; use searchAuditEvents instead for general audit \
+                    queries, since snapshots have no search endpoint.
+                    Preconditions: the caller must hold security:audit:view and the snapshot must exist.
+                    Required inputs: snapshotId (UUID) as a path parameter.
+                    No events are emitted and no state changes; snapshots are read-only after creation.
+                    Returns 400 with INVALID_REQUEST, not 404, when no snapshot exists for the supplied id; callers \
+                    must treat that 400 as a miss.
+                    """)
     @ApiResponse(responseCode = "200", description = "Pricing snapshot returned successfully")
     @ApiResponse(
             responseCode = "404",

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuditExportController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuditExportController.java
@@ -8,6 +8,7 @@ import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -48,11 +49,19 @@ public class AuditExportController {
      * synchronous resource
      * creation (201); this deviation is intentional for async job endpoints.
      */
-    @Operation(
-            operationId = "requestAuditExport",
-            summary = "Request audit export",
-            description =
-                    "Submits an asynchronous audit export job. Returns 202 Accepted with the created job reference.")
+    @Operation(operationId = "requestAuditExport", summary = "Request an Asynchronous Audit Export", description = """
+                    Submits an asynchronous audit export job and answers 202 Accepted with the job id and an \
+                    initial PENDING status.
+                    Use this tool for bulk extraction of audit data as a file; use searchAuditEvents instead for \
+                    interactive paged queries.
+                    Preconditions: the caller must hold security:audit:export; jobs are currently held in an \
+                    in-memory store, so they do not survive a service restart.
+                    Required inputs: format (CSV or JSON) and deliveryMode (DOWNLOAD or WEBHOOK); filters is \
+                    optional and scopes the export with the same criteria as searchAuditEvents.
+                    Emits a SECURITY_AUDIT_EXPORT_REQUEST event; execution is deferred, so callers must poll \
+                    getAuditExportJob for status and the eventual download URL.
+                    Returns 400 when format or deliveryMode is missing or not a valid enum value.
+                    """)
     @ApiResponse(
             responseCode = "202",
             description = "Export job created",
@@ -66,17 +75,38 @@ public class AuditExportController {
             description = "Insufficient authority",
             content = @Content(schema = @Schema(implementation = ApiError.class)))
     public ResponseEntity<AuditExportJobResponse> requestAuditExport(
-            @RequestBody @Valid @NonNull AuditExportRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Format, delivery mode, and optional filter scope of the export job.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "CSV download export", value = """
+                                                                    {"format":"CSV",
+                                                                     "deliveryMode":"DOWNLOAD",
+                                                                     "filters":{"eventType":"PERMISSION_DENIED"}}
+                                                                    """)))
+                    @RequestBody
+                    @Valid
+                    @NonNull
+                    AuditExportRequest request) {
         AuditExportJobResponse response = auditExportService.requestExport(request);
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(response);
     }
 
     @GetMapping("/{jobId}")
     @PreAuthorize("hasAuthority('security:audit:export')")
-    @Operation(
-            operationId = "getAuditExportJob",
-            summary = "Get audit export job status",
-            description = "Returns the current status of a previously submitted audit export job.")
+    @Operation(operationId = "getAuditExportJob", summary = "Get Audit Export Job Status", description = """
+                    Returns the current status of a previously submitted audit export job, including completion \
+                    time, download URL, and error message when present.
+                    Use this tool to poll a job created by requestAuditExport; do not resubmit the export while a \
+                    job is still PENDING.
+                    Preconditions: the caller must hold security:audit:export and the job must exist in the \
+                    in-memory store, which is cleared on service restart.
+                    Required inputs: jobId (UUID) as a path parameter.
+                    No events are emitted and no state changes; this is a read-only status projection.
+                    Returns 404 when the job id is unknown or the store was cleared by a restart.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Export job status",

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuthController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuthController.java
@@ -10,6 +10,7 @@ import com.positivity.securityservice.service.SelfRegistrationService;
 import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,9 +41,21 @@ public class AuthController {
     private final AuthenticationService authenticationService;
     private final SelfRegistrationService selfRegistrationService;
 
-    @Operation(
-            summary = "User login",
-            description = "Authenticates a user with username and password and returns a JWT token pair.")
+    @Operation(operationId = "loginUser", summary = "Authenticate User and Issue Tokens", description = """
+                    Authenticates a user with username and password and returns a JWT access token (1-hour) and \
+                    refresh token (7-day) carrying uid, roles, perm_bits, and perm_ver claims.
+                    Use this tool when a person signs in with credentials; do not use refreshTokenPair, which \
+                    exchanges an existing refresh token, and do not use issueInternalToken, which mints tokens for \
+                    trusted internal callers without a password.
+                    Preconditions: the user account must exist, be enabled, non-expired, hold unexpired credentials, \
+                    and not be inside an active failed-login lockout window.
+                    Required inputs: username and password, both non-blank.
+                    Emits a SECURITY_AUTH_LOGIN event, resets the failed-attempt counter on success, and persists \
+                    the issued token pair for later validation and revocation.
+                    Returns 401 with code ACCOUNT_LOCKED while the lockout window is active, INVALID_CREDENTIALS on \
+                    a bad password, and ACCOUNT_DISABLED, ACCOUNT_EXPIRED, or CREDENTIALS_EXPIRED for the matching \
+                    account states.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Authentication successful",
@@ -53,14 +66,41 @@ public class AuthController {
     @EmitEvent(id = "SECURITY_AUTH_LOGIN", apiVersion = "1")
     @PostMapping("/login")
     @PreAuthorize("permitAll()")
-    public ResponseEntity<TokenPairResponse> login(@Valid @RequestBody LoginRequest request) {
+    public ResponseEntity<TokenPairResponse> login(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Credentials of the user signing in.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Credential login", value = """
+                                                                    {"username":"jane.doe","password":"Sup3rS3cret!"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    LoginRequest request) {
         return ResponseEntity.ok(authenticationService.login(request));
     }
 
-    @Operation(
-            summary = "Self-register a new user",
-            description =
-                    "Creates a low-privilege customer account after resolving or creating a linked person record. Successful registration requires a follow-up login and does not issue tokens immediately. Conflict responses include operator guidance for recovery, linked-account, and CRM identity-review cases.")
+    @Operation(operationId = "selfRegisterUser", summary = "Self-Register a New Customer Account", description = """
+                    Creates a low-privilege SELF_SERVICE_CUSTOMER account for an anonymous person, resolving or \
+                    creating a linked person record before any account row is written.
+                    Use this tool when a customer registers themselves; do not use createUser, the operator-facing \
+                    endpoint that provisions accounts with arbitrary roles and no identity resolution.
+                    Preconditions: no active user may exist for the requested or email-derived username, the \
+                    resolved person must not already have an active linked user, and CRM identity signals must not \
+                    require manual review.
+                    Required inputs: email, password, firstName, and lastName; username is optional and defaults to \
+                    the email local part, phone and idpSubject are optional, and idempotencyKey optionally replays a \
+                    completed attempt instead of duplicating it.
+                    Emits a SECURITY_AUTH_SELF_REGISTER event, creates the user, and queues an asynchronous \
+                    user-person link command, so the response reports linkStatus PENDING and issuedTokens false; a \
+                    follow-up loginUser call is required to obtain tokens.
+                    Returns 409 with code USER_ALREADY_EXISTS, ACCOUNT_RECOVERY_REQUIRED, \
+                    PERSON_ALREADY_HAS_ACTIVE_USER, CRM_PERSON_CONFLICT, or IDEMPOTENCY_KEY_REUSED; recovery and \
+                    identity conflicts also open a review case and return its id as referenceId with nextAction and \
+                    supportAction guidance.
+                    """)
     @ApiResponse(
             responseCode = "201",
             description = "Self-registration completed",
@@ -77,7 +117,25 @@ public class AuthController {
     @EmitEvent(id = "SECURITY_AUTH_SELF_REGISTER", apiVersion = "1")
     @PostMapping("/self-register")
     @PreAuthorize("permitAll()")
-    public ResponseEntity<SelfRegistrationResponse> selfRegister(@Valid @RequestBody SelfRegistrationRequest request) {
+    public ResponseEntity<SelfRegistrationResponse> selfRegister(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Identity and credential details of the person registering themselves.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "Customer self-registration", value = """
+                                                                    {"email":"jane.smith@example.com",
+                                                                     "password":"Sup3rS3cret!",
+                                                                     "firstName":"Jane",
+                                                                     "lastName":"Smith",
+                                                                     "phone":"+15551234567",
+                                                                     "idempotencyKey":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    SelfRegistrationRequest request) {
         return ResponseEntity.status(201).body(selfRegistrationService.selfRegister(request));
     }
 }

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuthorizationController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/AuthorizationController.java
@@ -34,8 +34,21 @@ public class AuthorizationController {
     @GetMapping("/authorization/decision")
     @PreAuthorize("hasAuthority('security:authorization:decide')")
     @Operation(
-            summary = "Get authorization decision",
-            description = "Returns allow or deny for a principal and permission key")
+            operationId = "getAuthorizationDecision",
+            summary = "Get Authorization Decision for a Principal",
+            description = """
+                    Returns an allow or deny decision for a principal identifier and permission key, evaluated \
+                    against the principal-role matrix populated by assignPrincipalRole.
+                    Use this tool for matrix-based checks keyed by principal string; use \
+                    getPersonAuthorizationDecision instead when the caller has a personId, and checkUserPermission \
+                    when it has a user UUID and location.
+                    Preconditions: the caller must hold security:authorization:decide; the principal needs no prior \
+                    registration.
+                    Required inputs: principalId and permission (domain:resource:action) as query parameters.
+                    No events are emitted and no state changes; this is a read-only evaluation.
+                    Returns 200 with decision allow or deny; an unknown principal or permission yields deny rather \
+                    than an error.
+                    """)
     @ApiResponse(responseCode = "200", description = "Authorization decision returned")
     @ApiResponse(responseCode = "403", description = "Forbidden: authorization decision permission required")
     public ResponseEntity<AuthorizationDecisionResponse> getDecision(
@@ -52,10 +65,20 @@ public class AuthorizationController {
     @GetMapping("/authorization/person-decision")
     @PreAuthorize("hasAuthority('security:authorization:decide')")
     @Operation(
-            summary = "Get authorization decision for a person",
-            description = "Returns allow or deny for the user backing the given personId and a permission key,"
-                    + " evaluated against that user's assigned roles. Used to verify an off-session approver"
-                    + " (e.g. a manager identified by employee number) holds a required permission.")
+            operationId = "getPersonAuthorizationDecision",
+            summary = "Get Authorization Decision for a Person",
+            description = """
+                    Returns an allow or deny decision for the user account linked to a personId, evaluated against \
+                    that user's directly assigned roles.
+                    Use this tool to verify an off-session approver, such as a manager identified by employee \
+                    number, holds a required permission; use getAuthorizationDecision instead for matrix principals.
+                    Preconditions: the caller must hold security:authorization:decide; a user should be linked to \
+                    the person via the user-person link projection.
+                    Required inputs: personId (UUID) and permission (domain:resource:action) as query parameters.
+                    No events are emitted and no state changes; this is a read-only evaluation.
+                    Returns 200 with decision allow or deny; a person with no linked user or without the permission \
+                    yields deny rather than an error.
+                    """)
     @ApiResponse(responseCode = "200", description = "Authorization decision returned")
     @ApiResponse(responseCode = "403", description = "Forbidden: authorization decision permission required")
     public ResponseEntity<AuthorizationDecisionResponse> getPersonDecision(

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/JwtController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/JwtController.java
@@ -11,6 +11,7 @@ import com.positivity.securityservice.service.UserService;
 import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -59,23 +60,23 @@ public class JwtController {
     /**
      * Issues a single JWT access token for internal trusted callers.
      *
-     * **Contract:**
-     * - Request: POST /v1/auth/internal/token with InternalTokenRequest body
-     * - Response: TokenResponse (single accessToken field)
-     * - Success: 200 OK
-     * - Errors: 400 (invalid request), 403 (forbidden), 500 (server error)
-     *
-     * **See BACKEND_CONTRACT_GUIDE.md: Login Endpoint (page 3)**
-     *
      * @param request token issuance request with subject and optional roles
      * @return token response containing access token
-     *
-     * @throws IllegalArgumentException if username is blank or roles are empty
      */
-    @Operation(
-            summary = "Issue internal JWT access token",
-            description = "Internal endpoint to issue a JWT access token (1-hour expiration). "
-                    + "See BACKEND_CONTRACT_GUIDE.md §Login Endpoint for full specification.")
+    @Operation(operationId = "issueInternalToken", summary = "Issue Internal JWT Access Token", description = """
+                    Issues a single JWT access token (1-hour expiry) for an existing user's username on behalf of a \
+                    trusted internal caller, without checking a password.
+                    Use this tool for internal service-to-service token minting when only an access token is \
+                    needed; do not use issueTokenPair, which also returns a 7-day refresh token, and do not use \
+                    loginUser, which authenticates with credentials.
+                    Preconditions: the caller must hold security:token:issue_internal, and a user must already \
+                    exist for the subject username.
+                    Required inputs: subject, an existing username; roles is nominally optional, but an empty \
+                    effective role set is rejected, so supply at least one role name.
+                    Emits a SECURITY_AUTH_INTERNAL_TOKEN_ISSUE event and persists the issued token so validateToken \
+                    and revokeToken recognize it.
+                    Returns 400 when the subject is blank, no user exists for the subject, or the role set is empty.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "JWT token issued successfully",
@@ -98,7 +99,19 @@ public class JwtController {
     @EmitEvent(id = "SECURITY_AUTH_INTERNAL_TOKEN_ISSUE", apiVersion = "1")
     @PreAuthorize("hasAuthority('security:token:issue_internal')")
     @PostMapping("/internal/token")
-    public ResponseEntity<TokenResponse> issueInternalToken(@Valid @RequestBody InternalTokenRequest request) {
+    public ResponseEntity<TokenResponse> issueInternalToken(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Subject and role names to embed in the internally issued access token.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Internal token request", value = """
+                                                                    {"subject":"svc.reporting","roles":["SHOP_MGR"]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    InternalTokenRequest request) {
         log.info(
                 "Internal token issuance request received: subject={}, rolesCount={}",
                 request.subject(),
@@ -120,30 +133,23 @@ public class JwtController {
     /**
      * Issues both access and refresh tokens.
      *
-     * **Contract:**
-     * - Request: POST /v1/auth/token-pair with TokenPairRequest body
-     * - Response: TokenPairResponse (accessToken + refreshToken)
-     * - Success: 200 OK
-     * - Errors: 400 (invalid request), 403 (insufficient permission), 500 (server
-     * error)
-     *
-     * **Token Lifetimes:**
-     * - accessToken: 1 hour (3600 seconds)
-     * - refreshToken: 7 days (604800 seconds)
-     *
-     * **See BACKEND_CONTRACT_GUIDE.md: Token Pair Endpoint (page 4)**
-     *
      * @param request token pair request with username and optional roles
      * @return token pair response containing both tokens
-     *
-     * @throws IllegalArgumentException if username is blank or roles are empty
      */
-    @Operation(
-            summary = "Issue privileged JWT token pair (access + refresh)",
-            description =
-                    "Privileged internal endpoint that issues both access token (1-hour) and refresh token (7-day). "
-                            + "Requires authority security:token:issue_internal. "
-                            + "See BACKEND_CONTRACT_GUIDE.md §Token Pair Endpoint for full specification.")
+    @Operation(operationId = "issueTokenPair", summary = "Issue Privileged JWT Token Pair", description = """
+                    Issues a JWT access token (1-hour) and refresh token (7-day) for an existing user's username on \
+                    behalf of a trusted internal caller, embedding uid, roles, perm_bits, and perm_ver claims.
+                    Use this tool when an internal caller needs a refreshable session for an existing user; do not \
+                    use issueInternalToken, which returns only a single access token, and do not use loginUser, \
+                    which requires the user's password.
+                    Preconditions: the caller must hold security:token:issue_internal, and a user must already \
+                    exist for the subject username.
+                    Required inputs: subject, an existing username, and at least one role name in roles; roles are \
+                    expanded to authorities and encoded into the perm_bits bitset claim.
+                    Emits a SECURITY_AUTH_TOKEN_PAIR event and persists the pair so validateToken and \
+                    refreshTokenPair recognize it.
+                    Returns 400 when the subject is blank, no user exists for the subject, or the role set is empty.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Token pair issued successfully",
@@ -166,7 +172,19 @@ public class JwtController {
     @EmitEvent(id = "SECURITY_AUTH_TOKEN_PAIR", apiVersion = "1")
     @PreAuthorize("hasAuthority('security:token:issue_internal')")
     @PostMapping("/token-pair")
-    public ResponseEntity<TokenPairResponse> generateTokenPair(@Valid @RequestBody TokenPairRequest request) {
+    public ResponseEntity<TokenPairResponse> generateTokenPair(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Subject and role names to embed in the issued access and refresh tokens.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Token pair request", value = """
+                                                                    {"subject":"jane.doe","roles":["SHOP_MGR","ACCOUNTING_CLERK"]}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    TokenPairRequest request) {
 
         log.info(
                 "Token pair request received: subject={}, rolesCount={}",
@@ -189,29 +207,24 @@ public class JwtController {
     /**
      * Refreshes the access token using a refresh token.
      *
-     * **Contract:**
-     * - Request: POST /v1/auth/refresh with RefreshTokenRequest body
-     * - Response: TokenPairResponse (new accessToken + refreshToken)
-     * - Success: 200 OK
-     * - Errors: 400 (invalid token), 409 (concurrency), 500 (server error)
-     *
-     * **Process:**
-     * 1. Validate refresh token (signature, expiration, revocation, DB presence)
-     * 2. Revoke old tokens (Redis + database)
-     * 3. Issue new token pair
-     *
-     * **See BACKEND_CONTRACT_GUIDE.md: Refresh Endpoint (page 4)**
-     *
      * @param request refresh token request
      * @return token pair response with new tokens
-     *
-     * @throws IllegalArgumentException if refresh token is invalid
      */
-    @Operation(
-            summary = "Refresh access token using refresh token",
-            description = "Exchange a valid refresh token for a new access token and refresh token. "
-                    + "Old tokens are immediately revoked. "
-                    + "See BACKEND_CONTRACT_GUIDE.md §Refresh Endpoint for full specification.")
+    @Operation(operationId = "refreshTokenPair", summary = "Refresh Access Token With Rotation", description = """
+                    Exchanges a valid refresh token for a new access and refresh token pair, revoking the old pair \
+                    in the same call (token rotation).
+                    Use this tool when an access token nears expiry and the client still holds a refresh token; do \
+                    not use loginUser, which requires credentials, and do not use validateToken, which only checks \
+                    a token without renewing it.
+                    Preconditions: the refresh token must be unexpired, unrevoked, present in the token store, and \
+                    its user must still exist with at least one role.
+                    Required inputs: refreshToken, the exact refresh token string previously issued.
+                    Emits a SECURITY_AUTH_REFRESH event, revokes the old access and refresh token JTIs in Redis, \
+                    deletes the stored pair, and persists the replacement pair.
+                    Returns 400 when the refresh token is invalid, expired, revoked, or unknown, or the user has no \
+                    roles, 401 with INVALID_REFRESH_TOKEN when the referenced user no longer exists, and 409 when \
+                    concurrent refreshes race on the same token.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "New token pair issued successfully",
@@ -231,7 +244,19 @@ public class JwtController {
     @EmitEvent(id = "SECURITY_AUTH_REFRESH", apiVersion = "1")
     @PreAuthorize("permitAll()")
     @PostMapping("/refresh")
-    public ResponseEntity<TokenPairResponse> refreshAccessToken(@Valid @RequestBody RefreshTokenRequest request) {
+    public ResponseEntity<TokenPairResponse> refreshAccessToken(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The refresh token being exchanged for a new token pair.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Refresh request", value = """
+                                                                    {"refreshToken":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwMThmMGExYi0yYzNkLTdlNGYtOGE5Yi0wYzFkMmUzZjRhNWIifQ.sig"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    RefreshTokenRequest request) {
 
         log.debug("Refresh token request received");
 
@@ -243,23 +268,20 @@ public class JwtController {
     /**
      * Validates a JWT token.
      *
-     * **Validation Checks:**
-     * 1. JWT signature (HMAC-SHA256)
-     * 2. Token expiration
-     * 3. Revocation status in Redis
-     * 4. Database presence
-     *
-     * **Contract:**
-     * - Request: GET /v1/auth/validate?token=...
-     * - Response: { valid: true/false }
-     * - Success: 200 OK
-     *
      * @param token JWT token to validate
      * @return validation result
      */
-    @Operation(
-            summary = "Validate JWT token",
-            description = "Check if a JWT token is valid (signature, expiration, revocation)")
+    @Operation(operationId = "validateToken", summary = "Validate a JWT Access Token", description = """
+                    Checks whether a JWT access token is currently valid by verifying signature, issuer, audience, \
+                    expiry, Redis revocation status, and presence in the token store.
+                    Use this tool to test a token without side effects; do not use refreshTokenPair, which rotates \
+                    tokens, and do not use revokeToken, which invalidates one.
+                    Preconditions: none beyond possessing the token string; the endpoint is public.
+                    Required inputs: token as a query parameter.
+                    No events are emitted and no state changes; this is a read-only check.
+                    Returns 200 in all cases with a valid flag, so callers must read valid=false rather than expect \
+                    an error status when the token fails any check.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Validation result returned",
@@ -274,20 +296,22 @@ public class JwtController {
     /**
      * Revokes a JWT token.
      *
-     * **Process:**
-     * 1. Extract JTI from token
-     * 2. Add JTI to Redis revocation cache with TTL
-     * 3. Delete token from database
-     *
-     * **Contract:**
-     * - Request: DELETE /v1/auth/revoke?token=...
-     * - Response: 204 No Content
-     * - Success: 204 No Content
-     *
      * @param token JWT token to revoke
      * @return 204 No Content
      */
-    @Operation(summary = "Revoke JWT token", description = "Revoke a JWT token immediately (Redis cache + database)")
+    @Operation(operationId = "revokeToken", summary = "Revoke a JWT Access Token", description = """
+                    Revokes a JWT access token immediately by deleting its stored pair and adding its JTI to the \
+                    Redis revocation cache until natural expiry.
+                    Use this tool to invalidate one compromised or abandoned token; do not use disableUserAccount, \
+                    which revokes every token for a user and blocks future sign-in.
+                    Preconditions: an authenticated caller; the token should exist in the token store, though an \
+                    unknown token is silently ignored.
+                    Required inputs: token as a query parameter, the exact access token string to revoke.
+                    Emits a SECURITY_AUTH_REVOKE event; revocation takes effect immediately for validateToken and \
+                    downstream gateway checks.
+                    Returns 204 in all cases, including when the token was not found, so revocation success cannot \
+                    be inferred from the status code.
+                    """)
     @ApiResponse(responseCode = "204", description = "Token revoked successfully")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
     @EmitEvent(id = "SECURITY_AUTH_REVOKE", apiVersion = "1")
@@ -305,7 +329,16 @@ public class JwtController {
      * @param token JWT token
      * @return set of roles or 401 if token invalid
      */
-    @Operation(summary = "Extract roles from JWT token", description = "Get the roles claim from a JWT token")
+    @Operation(operationId = "getTokenRoles", summary = "Extract Roles From JWT Token", description = """
+                    Extracts the roles claim from a valid JWT token and returns the normalized role names.
+                    Use this tool when a caller holds a token and needs its roles; use getTokenSubject instead for \
+                    the username, and decodePermissionBits instead to expand the token's perm_bits claim into \
+                    permission codes.
+                    Preconditions: the token must pass full validation, including revocation and token-store checks.
+                    Required inputs: token as a query parameter.
+                    No events are emitted and no state changes; this is a read-only claim extraction.
+                    Returns 401 when the token is invalid, expired, revoked, or unknown to the token store.
+                    """)
     @ApiResponse(responseCode = "200", description = "Roles extracted successfully")
     @ApiResponse(responseCode = "401", description = "Token invalid or expired")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
@@ -325,7 +358,16 @@ public class JwtController {
      * @param token JWT token
      * @return subject (username) or 401 if token invalid
      */
-    @Operation(summary = "Extract subject from JWT token", description = "Get the subject (username) from a JWT token")
+    @Operation(operationId = "getTokenSubject", summary = "Extract Subject From JWT Token", description = """
+                    Extracts the subject claim, the username, from a valid JWT token and returns it as a plain \
+                    string body.
+                    Use this tool to resolve which user a token belongs to; use getTokenUserId instead for the \
+                    stable UUID identifier, and getTokenRoles for the role claim.
+                    Preconditions: the token must pass full validation, including revocation and token-store checks.
+                    Required inputs: token as a query parameter.
+                    No events are emitted and no state changes; this is a read-only claim extraction.
+                    Returns 401 when the token is invalid, expired, revoked, or unknown to the token store.
+                    """)
     @ApiResponse(responseCode = "200", description = "Subject extracted successfully")
     @ApiResponse(responseCode = "401", description = "Token invalid or expired")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
@@ -345,9 +387,16 @@ public class JwtController {
      * @param token JWT token
      * @return userId or 401 if token invalid
      */
-    @Operation(
-            summary = "Extract userId from JWT token",
-            description = "Get the stable user identifier from a JWT token")
+    @Operation(operationId = "getTokenUserId", summary = "Extract User Id From JWT Token", description = """
+                    Extracts the stable user identifier from a valid JWT token's uid claim (falling back to the \
+                    legacy userId claim) and returns it as a plain string body.
+                    Use this tool to resolve the user UUID behind a token; use getTokenSubject instead when the \
+                    username is what is needed.
+                    Preconditions: the token must pass full validation, including revocation and token-store checks.
+                    Required inputs: token as a query parameter.
+                    No events are emitted and no state changes; this is a read-only claim extraction.
+                    Returns 401 when the token is invalid, expired, revoked, or unknown to the token store.
+                    """)
     @ApiResponse(responseCode = "200", description = "userId extracted successfully")
     @ApiResponse(responseCode = "401", description = "Token invalid or expired")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/PermissionController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/PermissionController.java
@@ -14,6 +14,7 @@ import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,6 +42,15 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Permission Registry", description = "Central permission registry for all services")
 public class PermissionController {
 
+    private static final String PERMISSION_MANIFEST_EXAMPLE = """
+            {"domain":"people",
+             "serviceName":"pos-people-service",
+             "version":"1.0",
+             "permissions":[
+               {"name":"people:timekeeping:view","description":"View timekeeping records"},
+               {"name":"people:timekeeping:edit","description":"Edit timekeeping records"}]}
+            """;
+
     private final PermissionRegistryService permissionRegistryService;
     private final PermissionService permissionService;
     private final PermissionCatalogVersionService permissionCatalogVersionService;
@@ -52,8 +62,20 @@ public class PermissionController {
     @GetMapping("/catalog-version")
     @PreAuthorize("permitAll()")
     @Operation(
-            summary = "Get current permission catalog version",
-            description = "Returns the active catalog version and total permission count. No authentication required.")
+            operationId = "getPermissionCatalogVersion",
+            summary = "Get Current Permission Catalog Version",
+            description = """
+                    Returns the permission catalog version compiled into this service build and the total number of \
+                    permission codes in that catalog.
+                    Use this tool to check whether a cached perm_bits decoding is stale before calling \
+                    decodePermissionBits; do not use listPermissions, which pages the database registry rather than \
+                    the compiled catalog.
+                    Preconditions: none; the endpoint is public and requires no authentication.
+                    Required inputs: none; there are no parameters and no request body.
+                    No events are emitted and no state changes; this is a read-only projection of the compiled \
+                    PermissionCode catalog.
+                    Returns 200 in all cases; there are no business error conditions.
+                    """)
     public ResponseEntity<CatalogVersionResponse> getCatalogVersion() {
         return ResponseEntity.ok(new CatalogVersionResponse(
                 permissionCatalogVersionService.getCatalogVersion(),
@@ -67,14 +89,39 @@ public class PermissionController {
     @EmitEvent(id = "SECURITY_PERMISSION_DECODE_EXECUTE", apiVersion = "1")
     @PostMapping("/decode")
     @Operation(
-            summary = "Decode perm_bits for diagnostics",
-            description = "Decodes a perm_bits Base64URL BitSet back to permission code strings. For debugging only.")
+            operationId = "decodePermissionBits",
+            summary = "Decode Permission Bits for Diagnostics",
+            description = """
+                    Decodes a Base64URL perm_bits bitset taken from an access token back into sorted permission \
+                    code strings for diagnostics.
+                    Use this tool to inspect what a token's perm_bits claim grants; do not use getUserPermissions, \
+                    which reads a user's effective permissions from role assignments instead of from a token.
+                    Preconditions: the caller must hold security:permission:view, and perm_ver must equal the \
+                    catalog version currently compiled into the service (see getPermissionCatalogVersion).
+                    Required inputs: perm_bits, the Base64URL-encoded BitSet string, and perm_ver, a positive \
+                    integer catalog version.
+                    Emits a SECURITY_PERMISSION_DECODE_EXECUTE event; no records are changed.
+                    Returns 400 when perm_bits is blank, perm_ver is not positive, or perm_ver does not match the \
+                    current catalog version.
+                    """)
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"security:permission:view"})
     @PreAuthorize("hasAuthority('security:permission:view')")
     public ResponseEntity<PermissionDecodeResponse> decodePermissions(
-            @RequestBody @Valid @NonNull PermissionDecodeRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Encoded permission bitset and the catalog version it was encoded with.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Decode request", value = """
+                                                                    {"perm_bits":"AQID","perm_ver":7}
+                                                                    """)))
+                    @RequestBody
+                    @Valid
+                    @NonNull
+                    PermissionDecodeRequest request) {
         if (!StringUtils.hasText(request.permBits())) {
             throw new IllegalArgumentException("perm_bits must be provided");
         }
@@ -92,15 +139,40 @@ public class PermissionController {
     @EmitEvent(id = "SECURITY_PERMISSION_REGISTER", apiVersion = "1")
     @PostMapping("/registerPermissions")
     @Operation(
-            summary = "Register permissions (RBAC contract endpoint)",
-            description =
-                    "Registers or updates permissions using the RBAC contract payload and returns the resulting permission set.")
+            operationId = "registerPermissionsContract",
+            summary = "Register Permissions via RBAC Contract",
+            description = """
+                    Registers or updates permissions from an RBAC contract payload, upserting each named permission \
+                    and returning the resulting permission list.
+                    Use this tool for strict all-or-nothing permission upserts; do not use \
+                    registerModulePermissions, the lenient startup manifest endpoint that skips invalid entries and \
+                    reports per-entry counters instead of failing the request.
+                    Preconditions: the caller must hold security:permission:register, and every permission name \
+                    must match domain:resource:action (or the legacy domain:action form).
+                    Required inputs: permissions, a list of name and description definitions; serviceName is \
+                    optional here and defaults to pos-security-service as the registering service.
+                    Emits a SECURITY_PERMISSION_REGISTER event; existing permissions with the same name are \
+                    overwritten in place, including description and registering service.
+                    Returns 400 when any permission key fails the format check, rejecting the entire request.
+                    """)
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"security:permission:register"})
     @PreAuthorize("hasAuthority('security:permission:register')")
     public ResponseEntity<List<PermissionDto>> registerPermissionsContract(
-            @RequestBody @NonNull PermissionRegistrationRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "RBAC contract payload of permission definitions to upsert.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Contract registration",
+                                                            value = PERMISSION_MANIFEST_EXAMPLE)))
+                    @RequestBody
+                    @NonNull
+                    PermissionRegistrationRequest request) {
         return ResponseEntity.ok(permissionService.registerPermissions(request));
     }
 
@@ -108,9 +180,17 @@ public class PermissionController {
      * Issue #42: Get a permission by UUID identifier.
      */
     @GetMapping("/{id}")
-    @Operation(
-            summary = "Get permission by identifier",
-            description = "Returns a single registered permission by its UUID identifier.")
+    @Operation(operationId = "getPermissionById", summary = "Get Permission by Identifier", description = """
+                    Returns a single registered permission by its UUID identifier, including name, domain, \
+                    description, and deprecation flag.
+                    Use this tool when the permission id is already known; use listPermissions instead to search by \
+                    domain or page through the registry.
+                    Preconditions: the caller must hold security:permission:view and the permission must exist in \
+                    the registry.
+                    Required inputs: id (UUID) as a path parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no permission exists for the supplied id.
+                    """)
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"security:permission:view"})
@@ -125,14 +205,41 @@ public class PermissionController {
     @EmitEvent(id = "SECURITY_PERMISSION_REGISTER", apiVersion = "1")
     @PostMapping("/register")
     @Operation(
-            summary = "Register permissions from a service",
-            description = "Services call this endpoint to register their available permissions")
+            operationId = "registerModulePermissions",
+            summary = "Register Module Permission Manifest",
+            description = """
+                    Registers or updates a module's permission manifest in the central registry; this is the \
+                    endpoint every pos module's permission-registry initializer calls at startup.
+                    Use this tool for idempotent bulk manifest registration that tolerates partial failure; do not \
+                    use registerPermissionsContract, which rejects the entire payload on the first invalid key.
+                    Preconditions: the caller must hold security:permission:register (module initializers \
+                    authenticate with an internal service token).
+                    Required inputs: serviceName and a non-empty permissions list of name and description entries; \
+                    names must match domain:resource:action, while domain and version are informational.
+                    Emits a SECURITY_PERMISSION_REGISTER event; new names are inserted (with a bit index when the \
+                    compiled catalog defines one), changed descriptions are updated, and unchanged or invalid \
+                    entries are counted as skipped.
+                    Returns 400 when serviceName is blank or permissions is empty, and 400 with success=false and a \
+                    per-entry errors list when every entry failed; partial failures still return 200 with the \
+                    errors listed in the response.
+                    """)
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"security:permission:register"})
     @PreAuthorize("hasAuthority('security:permission:register')")
     public ResponseEntity<PermissionRegistrationResponse> registerPermissions(
-            @RequestBody PermissionRegistrationRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Permission manifest published by one domain service at startup.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Startup manifest",
+                                                            value = PERMISSION_MANIFEST_EXAMPLE)))
+                    @RequestBody
+                    PermissionRegistrationRequest request) {
 
         log.info("Received permission registration request from service: {}", request.getServiceName());
 
@@ -146,10 +253,17 @@ public class PermissionController {
     }
 
     @GetMapping
-    @Operation(
-            operationId = "listPermissions",
-            summary = "List permissions",
-            description = "Returns a paged list of registered permissions, optionally filtered by domain.")
+    @Operation(operationId = "listPermissions", summary = "List Registered Permissions", description = """
+                    Returns a paged list of registered permissions, optionally filtered to a single domain.
+                    Use this tool to browse or search the permission registry; use getPermissionById instead when \
+                    the UUID is already known, and getRoleDefaultPermissions to see what a role name expands to.
+                    Preconditions: the caller must hold security:permission:view.
+                    Required inputs: none are mandatory; domain is an optional filter, and page, size, and sort \
+                    follow Spring pageable defaults (page 0, size 20).
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty page when nothing matches, and 400 when pagination parameters are \
+                    malformed.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Permissions returned",
@@ -180,9 +294,17 @@ public class PermissionController {
      */
     @GetMapping("/domain/{domain}")
     @PreAuthorize("hasAuthority('security:permission:view')")
-    @Operation(
-            summary = "Get permissions by domain",
-            description = "Returns all permissions for a specific domain/service")
+    @Operation(operationId = "listPermissionsByDomain", summary = "List Permissions for One Domain", description = """
+                    Returns every registered permission for one domain as an unpaged list.
+                    Use this tool when a complete domain snapshot is needed; use listPermissions instead when \
+                    paging or when no domain filter applies.
+                    Preconditions: the caller must hold security:permission:view.
+                    Required inputs: domain as a path parameter, matching the first segment of the permission name \
+                    (for example catalog in catalog:product:view).
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty list when the domain has no registered permissions; an unknown domain \
+                    is not an error.
+                    """)
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"security:permission:view"})
@@ -194,9 +316,17 @@ public class PermissionController {
      * Validate a permission name format
      */
     @GetMapping("/validate/{permissionName}")
-    @Operation(
-            summary = "Validate permission name format",
-            description = "Checks if a permission name follows the domain:resource:action format")
+    @Operation(operationId = "validatePermissionName", summary = "Validate Permission Name Format", description = """
+                    Checks whether a permission name string matches the required domain:resource:action format (or \
+                    the legacy two-segment domain:action form) without touching the database.
+                    Use this tool to pre-validate a name before registration; use checkPermissionExists instead to \
+                    test whether the name is actually registered.
+                    Preconditions: the caller must hold security:permission:view.
+                    Required inputs: permissionName as a path parameter; each segment must start with a letter and \
+                    may contain letters, digits, underscores, and hyphens.
+                    No events are emitted and no state changes; this is a pure format check.
+                    Returns 200 with a plain boolean body; a malformed name yields false, never an error status.
+                    """)
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"security:permission:view"})
@@ -210,7 +340,18 @@ public class PermissionController {
      * Check if a permission exists
      */
     @GetMapping("/exists/{permissionName}")
-    @Operation(summary = "Check if permission exists", description = "Returns true if the permission is registered")
+    @Operation(
+            operationId = "checkPermissionExists",
+            summary = "Check Whether a Permission Is Registered",
+            description = """
+                    Checks whether a permission with the given name is registered in the central registry.
+                    Use this tool to test registration state; use validatePermissionName instead for a pure format \
+                    check that ignores the database.
+                    Preconditions: the caller must hold security:permission:view.
+                    Required inputs: permissionName as a path parameter in domain:resource:action format.
+                    No events are emitted and no state changes; this is a read-only existence check.
+                    Returns 200 with a plain boolean body; an unregistered name yields false, never an error status.
+                    """)
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
             scopes = {"security:permission:view"})

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/PrincipalRoleController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/PrincipalRoleController.java
@@ -37,10 +37,18 @@ public class PrincipalRoleController {
     @EmitEvent(id = "SECURITY_PRINCIPAL_ROLE_ASSIGN", apiVersion = "1")
     @PostMapping("/{principalId}/roles/{roleId}")
     @PreAuthorize("hasAuthority('security:role:assign')")
-    @Operation(
-            summary = "Assign a role to a principal",
-            description =
-                    "Assigns the specified role to the specified principal identifier for RBAC matrix authorization.")
+    @Operation(operationId = "assignPrincipalRole", summary = "Assign a Role to a Principal", description = """
+                    Links a free-form principal identifier to a role in the RBAC principal matrix consulted by \
+                    getAuthorizationDecision.
+                    Use this tool for matrix principals that are not user UUIDs; do not use assignUserRole, which \
+                    creates a role assignment for a real user account.
+                    Preconditions: the caller must hold security:role:assign and the role must exist; the principal \
+                    is not validated against any store, and an existing identical link makes the call a no-op.
+                    Required inputs: principalId (arbitrary string) and roleId (UUID) as path parameters; there is \
+                    no request body.
+                    Emits a SECURITY_PRINCIPAL_ROLE_ASSIGN event.
+                    Returns 404 when the role does not exist; repeat assignments still return 200.
+                    """)
     @ApiResponse(responseCode = "200", description = "Role assigned to principal successfully")
     @ApiResponse(
             responseCode = "404",

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/RoleController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/RoleController.java
@@ -15,6 +15,7 @@ import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -59,9 +60,18 @@ public class RoleController {
             name = "bearerAuth",
             scopes = {"security:role:create"})
     @PreAuthorize("hasAuthority('security:role:create')")
-    @Operation(
-            summary = "Create a new role",
-            description = "Creates a new role with the specified name and description")
+    @Operation(operationId = "createRole", summary = "Create a New Role", description = """
+                    Creates a new role with the given name and optional description; the role starts with no \
+                    permissions and no user assignments.
+                    Use this tool to define a new role; do not use createRoleAssignment, which links an existing \
+                    role to a user, and do not use updateRolePermissions, which changes an existing role's grants.
+                    Preconditions: the caller must hold security:role:create and no role with the same name \
+                    (compared case-insensitively) may already exist.
+                    Required inputs: name, non-blank; description is optional.
+                    Emits a SECURITY_ROLE_CREATE event and records the creating actor and timestamp.
+                    Returns 400 when name is missing or blank, and 409 with DUPLICATE_ROLE_NAME when the name is \
+                    already taken regardless of case.
+                    """)
     @ApiResponse(responseCode = "201", description = "Role created")
     @ApiResponse(
             responseCode = "400",
@@ -71,7 +81,18 @@ public class RoleController {
             responseCode = "409",
             description = "Role name already exists",
             content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<RoleDto> createRole(@RequestBody Map<String, String> request) {
+    public ResponseEntity<RoleDto> createRole(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Name and optional description of the role to create.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "New role", value = """
+                                                                    {"name":"SHOP_MGR","description":"Shop manager"}
+                                                                    """)))
+                    @RequestBody
+                    Map<String, String> request) {
         String name = request.get("name");
         String description = request.get("description");
 
@@ -92,9 +113,20 @@ public class RoleController {
             name = "bearerAuth",
             scopes = {"security:role:edit"})
     @PreAuthorize("hasAuthority('security:role:edit')")
-    @Operation(
-            summary = "Grant permission to a role",
-            description = "Grants a single permission to the specified role and returns the updated role")
+    @Operation(operationId = "grantRolePermission", summary = "Grant a Permission to a Role", description = """
+                    Grants a single permission key to a role, auto-registering the key in the permission registry \
+                    when it is not yet known.
+                    Use this tool for additive one-off grants; do not use updateRolePermissions, which replaces the \
+                    role's entire permission set, and do not use assignRolePermissionByKey, which requires the \
+                    permission to be registered already.
+                    Preconditions: the caller must hold security:role:edit and the role must exist; the permission \
+                    key does not need to exist beforehand.
+                    Required inputs: roleId (UUID) as a path parameter and permission (domain:resource:action) in \
+                    the body; permissionKey is accepted as a field alias.
+                    Emits a SECURITY_ROLE_PERMISSION_GRANT event and publishes an internal grant audit record, then \
+                    returns the updated role.
+                    Returns 400 when permission is missing or blank, and 404 when the role does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Permission granted to role")
     @ApiResponse(
             responseCode = "400",
@@ -105,7 +137,18 @@ public class RoleController {
             description = "Role or permission not found",
             content = @Content(schema = @Schema(implementation = ApiError.class)))
     public ResponseEntity<RoleDto> grantPermissionToRole(
-            @NonNull @PathVariable UUID roleId, @RequestBody RolePermissionGrantRequest request) {
+            @NonNull @PathVariable UUID roleId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The single permission key to grant to the role.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Grant one permission", value = """
+                                                                    {"permission":"people:timekeeping:view"}
+                                                                    """)))
+                    @RequestBody
+                    RolePermissionGrantRequest request) {
         if (request == null
                 || request.getPermission() == null
                 || request.getPermission().isBlank()) {
@@ -123,9 +166,17 @@ public class RoleController {
             name = "bearerAuth",
             scopes = {"security:role:edit"})
     @PreAuthorize("hasAuthority('security:role:edit')")
-    @Operation(
-            summary = "Revoke permission from a role",
-            description = "Removes the specified permission from the role")
+    @Operation(operationId = "revokeRolePermission", summary = "Revoke a Permission From a Role", description = """
+                    Removes a permission key from a role's grant set.
+                    Use this tool to take one permission away from a role; do not use deleteRole, which removes the \
+                    role entirely, and do not use revokeRoleAssignment, which ends a user's assignment instead.
+                    Preconditions: the caller must hold security:role:edit and the role must exist; revoking a key \
+                    the role does not hold is a silent no-op.
+                    Required inputs: roleId (UUID) and permissionKey (domain:resource:action) as path parameters; \
+                    there is no request body.
+                    Emits a SECURITY_ROLE_PERMISSION_REVOKE event.
+                    Returns 404 when the role does not exist; an unknown permission key still yields 204.
+                    """)
     @ApiResponse(responseCode = "204", description = "Permission revoked from role")
     @ApiResponse(
             responseCode = "404",
@@ -147,8 +198,20 @@ public class RoleController {
             scopes = {"security:role:edit"})
     @PreAuthorize("hasAuthority('security:role:edit')")
     @Operation(
-            summary = "Assign permission to a role by key",
-            description = "Assigns the permission identified by path key to the specified role")
+            operationId = "assignRolePermissionByKey",
+            summary = "Assign a Registered Permission to a Role",
+            description = """
+                    Adds an already-registered permission, identified by its key in the path, to a role's grant set.
+                    Use this tool when the permission is known to be registered; do not use grantRolePermission, \
+                    which auto-registers unknown keys, and do not use updateRolePermissions, which replaces the \
+                    whole set.
+                    Preconditions: the caller must hold security:role:edit, the role must exist, and the permission \
+                    key must already be registered (modules register at startup via registerModulePermissions).
+                    Required inputs: roleId (UUID) and permissionKey (domain:resource:action) as path parameters; \
+                    there is no request body.
+                    Emits a SECURITY_ROLE_PERMISSION_ASSIGN event.
+                    Returns 404 when the role does not exist or the permission key has not been registered.
+                    """)
     @ApiResponse(responseCode = "204", description = "Permission assigned to role")
     @ApiResponse(
             responseCode = "404",
@@ -169,13 +232,36 @@ public class RoleController {
             name = "bearerAuth",
             scopes = {"security:role:edit"})
     @PreAuthorize("hasAuthority('security:role:edit')")
-    @Operation(summary = "Update role permissions", description = "Assigns a set of permissions to a role")
+    @Operation(operationId = "updateRolePermissions", summary = "Replace a Role's Permission Set", description = """
+                    Replaces a role's entire permission set with the supplied list of permission names.
+                    Use this tool for wholesale permission resets; do not use grantRolePermission or \
+                    revokeRolePermission, which change one key at a time and preserve the rest.
+                    Preconditions: the caller must hold security:role:edit, the role must exist, and every named \
+                    permission must already be registered.
+                    Required inputs: roleId (UUID) and permissionNames, a set of domain:resource:action strings; an \
+                    empty set clears all grants.
+                    Emits a SECURITY_ROLE_PERMISSIONS_UPDATE event and returns the updated role with its new \
+                    permission set.
+                    Returns 404 when the role or any named permission does not exist; nothing is applied on failure.
+                    """)
     @ApiResponse(responseCode = "200", description = "Role permissions updated")
     @ApiResponse(
             responseCode = "404",
             description = "Role or permission not found",
             content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<RoleDto> updateRolePermissions(@RequestBody RolePermissionsRequest request) {
+    public ResponseEntity<RoleDto> updateRolePermissions(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The role and the replacement set of permission names it should hold.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Replace permission set", value = """
+                                                                    {"roleId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "permissionNames":["people:timekeeping:view","people:timekeeping:edit"]}
+                                                                    """)))
+                    @RequestBody
+                    RolePermissionsRequest request) {
         RoleDto role = roleManagementService.updateRolePermissions(request);
         return ResponseEntity.ok(role);
     }
@@ -189,15 +275,44 @@ public class RoleController {
             name = "bearerAuth",
             scopes = {"security:role:assign"})
     @PreAuthorize("hasAuthority('security:role:assign')")
-    @Operation(
-            summary = "Create role assignment",
-            description = "Assigns a role to a user with optional scope and effective dates")
+    @Operation(operationId = "createRoleAssignment", summary = "Create a Scoped Role Assignment", description = """
+                    Assigns a role to a user with a scope (GLOBAL or LOCATION) and an optional effective date \
+                    window.
+                    Use this tool when the assignment needs scope or dates; do not use assignUserRole, the simple \
+                    path-parameter variant that always creates a GLOBAL assignment starting now.
+                    Preconditions: the caller must hold security:role:assign, the user and role must exist, and no \
+                    overlapping assignment may exist for the same role, scope, and (for LOCATION scope) location.
+                    Required inputs: userId and roleId (UUIDs); scopeType defaults to GLOBAL, scopeLocationIds is \
+                    required for LOCATION scope and forbidden for GLOBAL, and effectiveStartDate defaults to now \
+                    with an open-ended effectiveEndDate.
+                    Emits a SECURITY_ROLE_ASSIGNMENT_CREATE event.
+                    Returns 400 when the scope and location combination is invalid, 404 when the user or role does \
+                    not exist, and 409 with ROLE_ASSIGNMENT_CONFLICT when the date window overlaps an existing \
+                    assignment.
+                    """)
     @ApiResponse(responseCode = "201", description = "Role assignment created")
     @ApiResponse(
             responseCode = "404",
             description = "User or role not found",
             content = @Content(schema = @Schema(implementation = ApiError.class)))
-    public ResponseEntity<RoleAssignmentDto> createRoleAssignment(@RequestBody RoleAssignmentRequest request) {
+    public ResponseEntity<RoleAssignmentDto> createRoleAssignment(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The user, role, scope, and effective window of the assignment to create.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "Location-scoped assignment", value = """
+                                                                    {"userId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                                                                     "roleId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+                                                                     "scopeType":"LOCATION",
+                                                                     "scopeLocationIds":["018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d"],
+                                                                     "effectiveStartDate":"2026-01-15T00:00:00",
+                                                                     "effectiveEndDate":"2026-12-31T00:00:00"}
+                                                                    """)))
+                    @RequestBody
+                    RoleAssignmentRequest request) {
         RoleAssignmentDto assignment = roleManagementService.createRoleAssignment(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(assignment);
     }
@@ -210,10 +325,17 @@ public class RoleController {
             name = "bearerAuth",
             scopes = {"security:role:view"})
     @PreAuthorize("hasAuthority('security:role:view')")
-    @Operation(
-            summary = "Get user role assignments",
-            description =
-                    "Returns currently effective assignments by default. Set includeHistory=true to return all assignments including expired/revoked")
+    @Operation(operationId = "listUserRoleAssignments", summary = "List a User's Role Assignments", description = """
+                    Returns a user's role assignments with their scope and effective window, limited to currently \
+                    effective assignments by default.
+                    Use this tool to inspect who holds which roles and in what scope; use getUserPermissions \
+                    instead when only the flattened permission set matters.
+                    Preconditions: the caller must hold security:role:view and the user must exist.
+                    Required inputs: userId (UUID) as a path parameter; includeHistory defaults to false and, when \
+                    true, also returns expired and revoked assignments.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when the user does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Role assignments returned successfully")
     @ApiResponse(
             responseCode = "404",
@@ -238,8 +360,18 @@ public class RoleController {
             scopes = {"security:permission:view"})
     @PreAuthorize("hasAuthority('security:permission:view')")
     @Operation(
-            summary = "Get user permissions (legacy path)",
-            description = "Returns all permissions for a user from their role assignments")
+            operationId = "getUserPermissionsLegacy",
+            summary = "Get User Permissions at Legacy Path",
+            description = """
+                    Returns the union of permissions granted through a user's currently effective role assignments, \
+                    served at the legacy /permissions/user/{userId} path.
+                    Use this tool only for legacy callers; use getUserPermissions instead, which returns the same \
+                    data at the canonical /v1/users/{userId}/permissions path.
+                    Preconditions: the caller must hold security:permission:view and the user must exist.
+                    Required inputs: userId (UUID) as a path parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when the user does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "User permissions returned successfully")
     @ApiResponse(
             responseCode = "404",
@@ -262,9 +394,22 @@ public class RoleController {
             scopes = {"security:role:view"})
     @PreAuthorize("hasAuthority('security:role:view')")
     @Operation(
-            summary = "Get a role's default permissions",
-            description = "Returns the authority codes (ROLE_* plus domain permission codes) that the given role "
-                    + "expands to, used by clients to prebuild per-role tool/permission caches.")
+            operationId = "getRoleDefaultPermissions",
+            summary = "Get a Role's Default Authority Expansion",
+            description = """
+                    Returns the authority codes a role name expands to: the ROLE_ prefixed authority plus the \
+                    domain permission codes hardwired for known roles.
+                    Use this tool to prebuild per-role permission or tool caches, as pos-mcp-server does; do not \
+                    use getUserPermissions, which reads a specific user's database assignments instead of the \
+                    static role expansion.
+                    Preconditions: the caller must hold security:role:view; the role name does not need to exist in \
+                    the database.
+                    Required inputs: role name as a path parameter, for example SHOP_MGR.
+                    No events are emitted and no state changes; this is a read-only expansion of the compiled \
+                    role-authority map.
+                    Returns 200 in all cases; an unrecognized role yields only its ROLE_ authority with no domain \
+                    codes rather than an error.
+                    """)
     @ApiResponse(responseCode = "200", description = "Role default permissions returned")
     public ResponseEntity<RoleDefaultPermissionsResponse> getRoleDefaultPermissions(@PathVariable String role) {
         Set<String> authorities = roleAuthorityService.expandRolesToAuthorities(Set.of(role));
@@ -281,8 +426,19 @@ public class RoleController {
             scopes = {"security:permission:view"})
     @PreAuthorize("hasAuthority('security:permission:view')")
     @Operation(
-            summary = "Check user permission",
-            description = "Checks if a user has a specific permission for a location")
+            operationId = "checkUserPermission",
+            summary = "Check One User Permission at a Location",
+            description = """
+                    Checks whether a user holds a specific permission through a currently effective role assignment \
+                    whose scope covers the given location.
+                    Use this tool for a point authorization probe by user UUID; use getAuthorizationDecision \
+                    instead when the caller has a principal identifier from the RBAC matrix rather than a user id.
+                    Preconditions: the caller must hold security:permission:view and the user must exist.
+                    Required inputs: userId (UUID) and permission (domain:resource:action) as query parameters; \
+                    locationId is optional and defaults to GLOBAL.
+                    No events are emitted and no state changes; this is a read-only check.
+                    Returns 200 with a plain boolean body, and 404 when the user does not exist.
+                    """)
     @ApiResponse(responseCode = "200", description = "Permission check completed")
     @ApiResponse(
             responseCode = "404",
@@ -307,10 +463,16 @@ public class RoleController {
             name = "bearerAuth",
             scopes = {"security:role:assign"})
     @PreAuthorize("hasAuthority('security:role:assign')")
-    @Operation(
-            summary = "Revoke role assignment",
-            description =
-                    "Revokes a role assignment by setting its end date. Supports past, present, or future dates. The system automatically records when the revocation was requested. Defaults to today when endDate is omitted")
+    @Operation(operationId = "revokeRoleAssignment", summary = "Revoke a Role Assignment by Id", description = """
+                    Revokes a role assignment by setting its effective end date, preserving the row for history.
+                    Use this tool when the assignment id is known or a past or future end date is needed; do not \
+                    use revokeUserRole, which finds the active assignment from userId and roleId and ends it now.
+                    Preconditions: the caller must hold security:role:assign and the assignment must exist.
+                    Required inputs: assignmentId (UUID) as a path parameter; endDate (ISO date-time) is optional \
+                    and defaults to the current time, and the revocation timestamp is recorded automatically.
+                    Emits a SECURITY_ROLE_ASSIGNMENT_REVOKE event.
+                    Returns 400 when endDate is malformed, and 404 when the assignment does not exist.
+                    """)
     @ApiResponse(responseCode = "204", description = "Role assignment revoked")
     @ApiResponse(responseCode = "400", description = "Invalid endDate")
     @ApiResponse(responseCode = "404", description = "Role assignment not found")
@@ -338,7 +500,15 @@ public class RoleController {
             name = "bearerAuth",
             scopes = {"security:role:view"})
     @PreAuthorize("hasAuthority('security:role:view')")
-    @Operation(summary = "Get all roles", description = "Returns all roles in the system")
+    @Operation(operationId = "listRoles", summary = "List All Roles in the System", description = """
+                    Returns every role in the system with its permission set and audit metadata.
+                    Use this tool to enumerate roles; use getRoleById or getRoleByName instead for a single known \
+                    role.
+                    Preconditions: the caller must hold security:role:view.
+                    Required inputs: none; there are no filters or paging parameters.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty list when no roles exist; there are no business error conditions.
+                    """)
     @ApiResponse(responseCode = "200", description = "Roles returned successfully")
     public ResponseEntity<List<RoleDto>> getAllRoles() {
         return ResponseEntity.ok(roleManagementService.getAllRoles());
@@ -352,7 +522,16 @@ public class RoleController {
             name = "bearerAuth",
             scopes = {"security:role:view"})
     @PreAuthorize("hasAuthority('security:role:view')")
-    @Operation(summary = "Get role by name", description = "Returns a specific role by its name")
+    @Operation(operationId = "getRoleByName", summary = "Get a Single Role by Name", description = """
+                    Returns a single role looked up by its exact name, including its permission set.
+                    Use this tool when only the role name is known; use getRoleById instead when the UUID is \
+                    available, and listRoles to browse.
+                    Preconditions: the caller must hold security:role:view and a role with that exact \
+                    (case-sensitive) name must exist.
+                    Required inputs: name as a path parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 with ROLE_NOT_FOUND when no role has the supplied name.
+                    """)
     @ApiResponse(responseCode = "200", description = "Role returned successfully")
     @ApiResponse(
             responseCode = "404",
@@ -370,7 +549,15 @@ public class RoleController {
             name = "bearerAuth",
             scopes = {"security:role:view"})
     @PreAuthorize("hasAuthority('security:role:view')")
-    @Operation(summary = "Get role by ID", description = "Returns a specific role by its UUID")
+    @Operation(operationId = "getRoleById", summary = "Get a Single Role by UUID", description = """
+                    Returns a single role looked up by its UUID, including its permission set and audit metadata.
+                    Use this tool when the role id is known; use getRoleByName instead when only the name is \
+                    available, and listRoles to browse.
+                    Preconditions: the caller must hold security:role:view and the role must exist.
+                    Required inputs: id (UUID) as a path parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no role exists for the supplied UUID.
+                    """)
     @ApiResponse(responseCode = "200", description = "Role returned successfully")
     @ApiResponse(
             responseCode = "404",
@@ -392,7 +579,17 @@ public class RoleController {
             name = "bearerAuth",
             scopes = {"security:role:delete"})
     @PreAuthorize("hasAuthority('security:role:delete')")
-    @Operation(summary = "Delete a role", description = "Deletes a role by UUID and removes its associations")
+    @Operation(operationId = "deleteRole", summary = "Delete a Role and Its Associations", description = """
+                    Deletes a role by UUID, clearing its permission grants and deleting all of its role assignments \
+                    in the same transaction.
+                    Use this tool to retire a role entirely; do not use revokeRolePermission or \
+                    revokeRoleAssignment, which remove a single grant or assignment and keep the role.
+                    Preconditions: the caller must hold security:role:delete and the role must exist; users holding \
+                    the role lose it immediately.
+                    Required inputs: id (UUID) as a path parameter.
+                    Emits a SECURITY_ROLE_DELETE event.
+                    Returns 404 when the role does not exist.
+                    """)
     @ApiResponse(responseCode = "204", description = "Role deleted")
     @ApiResponse(
             responseCode = "404",

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/SelfRegistrationReviewController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/SelfRegistrationReviewController.java
@@ -7,6 +7,8 @@ import com.positivity.securityservice.internal.enums.SelfRegistrationCaseStatus;
 import com.positivity.securityservice.internal.enums.SelfRegistrationCaseType;
 import com.positivity.securityservice.service.SelfRegistrationReviewService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -37,8 +39,20 @@ public class SelfRegistrationReviewController {
 
     @GetMapping
     @Operation(
-            summary = "List self-registration review cases",
-            description = "Returns blocked self-registration cases for recovery or identity review.")
+            operationId = "listSelfRegistrationReviewCases",
+            summary = "List Self-Registration Review Cases",
+            description = """
+                    Returns blocked self-registration review cases, newest first, optionally filtered by status and \
+                    case type.
+                    Use this tool to work the recovery and identity-review queue; use \
+                    getSelfRegistrationReviewCase instead for one known case.
+                    Preconditions: the caller must hold security:user_account_state:view.
+                    Required inputs: none are mandatory; status filters on OPEN or RESOLVED and caseType on \
+                    ACCOUNT_RECOVERY or IDENTITY_REVIEW.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty list when nothing matches, and 400 when a filter value is not a valid \
+                    enum constant.
+                    """)
     @ApiResponse(responseCode = "200", description = "Review cases returned successfully")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -52,8 +66,18 @@ public class SelfRegistrationReviewController {
 
     @GetMapping("/{caseId}")
     @Operation(
-            summary = "Get a self-registration review case",
-            description = "Returns the details of a blocked self-registration case.")
+            operationId = "getSelfRegistrationReviewCase",
+            summary = "Get One Self-Registration Review Case",
+            description = """
+                    Returns the full detail of one blocked self-registration case, including reason codes, CRM \
+                    match summary, and any linked person or user ids.
+                    Use this tool when the case id is known, typically from the referenceId of a 409 \
+                    selfRegisterUser conflict; use listSelfRegistrationReviewCases instead to browse the queue.
+                    Preconditions: the caller must hold security:user_account_state:view and the case must exist.
+                    Required inputs: caseId (UUID) as a path parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no review case exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Review case returned successfully")
     @ApiResponse(responseCode = "404", description = "Review case not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -67,8 +91,21 @@ public class SelfRegistrationReviewController {
     @PostMapping("/{caseId}/resolve")
     @EmitEvent(id = "SECURITY_SELF_REGISTRATION_REVIEW_RESOLVE", apiVersion = "1")
     @Operation(
-            summary = "Resolve a self-registration review case",
-            description = "Marks a blocked self-registration case as resolved after recovery or manual review.")
+            operationId = "resolveSelfRegistrationReviewCase",
+            summary = "Resolve a Self-Registration Review Case",
+            description = """
+                    Marks a blocked self-registration case RESOLVED, recording the resolving operator, timestamp, \
+                    and resolution notes.
+                    Use this tool after the underlying recovery or identity review is finished; do not use it to \
+                    recover the account itself, which is done first with account-state endpoints such as \
+                    enableUserAccount.
+                    Preconditions: the caller must hold security:user_account_state:manage and be authenticated \
+                    (the resolver is taken from the request principal); the case must exist, and re-resolving an \
+                    already RESOLVED case overwrites the resolution fields.
+                    Required inputs: caseId (UUID) as a path parameter and resolutionNotes, non-blank, in the body.
+                    Emits a SECURITY_SELF_REGISTRATION_REVIEW_RESOLVE event.
+                    Returns 404 when no review case exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Review case resolved successfully")
     @ApiResponse(responseCode = "404", description = "Review case not found")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -77,7 +114,18 @@ public class SelfRegistrationReviewController {
     @PreAuthorize("hasAuthority('security:user_account_state:manage')")
     public ResponseEntity<SelfRegistrationReviewCaseResponse> resolveCase(
             @PathVariable UUID caseId,
-            @Valid @RequestBody ResolveSelfRegistrationReviewCaseRequest request,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The resolution note recorded against the case.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Case resolution", value = """
+                                                                    {"resolutionNotes":"Recovered existing disabled account and asked user to sign in."}
+                                                                    """)))
+                    @Valid
+                    @RequestBody
+                    ResolveSelfRegistrationReviewCaseRequest request,
             @NonNull Principal principal) {
         return ResponseEntity.ok(selfRegistrationReviewService.resolveCase(caseId, request, principal.getName()));
     }

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/UserController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/UserController.java
@@ -6,6 +6,8 @@ import com.positivity.securityservice.internal.dto.UserUpdateRequest;
 import com.positivity.securityservice.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -28,7 +30,17 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
     private final UserService userService;
 
-    @Operation(summary = "Create a new user", description = "Creates a new user with username, password, and roles.")
+    @Operation(operationId = "createUser", summary = "Create a User With Roles", description = """
+                    Creates a user account with a username, a hashed password, and a set of directly attached \
+                    roles.
+                    Use this tool for operator provisioning of accounts; do not use selfRegisterUser, the anonymous \
+                    customer flow that fixes the role to SELF_SERVICE_CUSTOMER and runs identity resolution first.
+                    Preconditions: the caller must hold security:user:create, the username must be unused, and \
+                    every named role must already exist.
+                    Required inputs: username, password, and roles, a non-empty array of existing role names.
+                    Emits a SECURITY_USER_CREATE event; the password is hashed before storage.
+                    Returns 400 when the username already exists or a named role is not found.
+                    """)
     @ApiResponse(responseCode = "201", description = "User created successfully.")
     @EmitEvent(id = "SECURITY_USER_CREATE", apiVersion = "1")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -36,7 +48,20 @@ public class UserController {
             scopes = {"security:user:create"})
     @PreAuthorize("hasAuthority('security:user:create')")
     @PostMapping
-    public ResponseEntity<UserDto> createUser(@RequestBody Map<String, Object> payload) {
+    public ResponseEntity<UserDto> createUser(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Username, password, and role names of the account to create.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "New user", value = """
+                                                                    {"username":"jane.doe",
+                                                                     "password":"Sup3rS3cret!",
+                                                                     "roles":["SHOP_MGR"]}
+                                                                    """)))
+                    @RequestBody
+                    Map<String, Object> payload) {
         String username = (String) payload.get("username");
         String password = (String) payload.get("password");
         List<?> rolesList = (List<?>) payload.get("roles");
@@ -45,7 +70,15 @@ public class UserController {
         return ResponseEntity.status(201).body(user);
     }
 
-    @Operation(summary = "Get all users", description = "Retrieve a list of all users.")
+    @Operation(operationId = "listUsers", summary = "List All User Accounts", description = """
+                    Returns every user account with its id, username, effective role names, and linked personId.
+                    Use this tool to enumerate accounts; use getUserById instead for one known user.
+                    Preconditions: the caller must hold security:user:view.
+                    Required inputs: none; there are no filters or paging parameters, so the full user table is \
+                    returned.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with an empty list when no users exist; there are no business error conditions.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of users returned successfully.")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -56,7 +89,16 @@ public class UserController {
         return userService.getAllUsers();
     }
 
-    @Operation(summary = "Get user by ID", description = "Retrieve a user by their unique ID.")
+    @Operation(operationId = "getUserById", summary = "Get a User Account by Id", description = """
+                    Returns a single user account by UUID, including effective role names merged from direct roles \
+                    and currently active role assignments.
+                    Use this tool when the user id is known; use listUsers instead to browse accounts, and \
+                    getUserAccountState for administrative lock and expiry flags.
+                    Preconditions: the caller must hold security:user:view and the user must exist.
+                    Required inputs: id (UUID) as a path parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no user exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "User found and returned.")
     @ApiResponse(responseCode = "404", description = "User not found.")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -73,7 +115,20 @@ public class UserController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @Operation(summary = "Update an existing user", description = "Update the details of an existing user.")
+    @Operation(operationId = "updateUser", summary = "Partially Update a User Account", description = """
+                    Applies a partial update to a user account: username, password, and the direct role set are \
+                    each replaced only when supplied.
+                    Use this tool to change account fields; do not use assignUserRolesByUsername, which only \
+                    replaces roles, and do not use the account-state endpoints such as disableUserAccount, which \
+                    flip administrative flags.
+                    Preconditions: the caller must hold security:user:edit, the user must exist, and any named role \
+                    must already exist.
+                    Required inputs: id (UUID) as a path parameter; username, password, and roles are all optional, \
+                    and omitted or blank fields are left unchanged.
+                    Emits a SECURITY_USER_UPDATE event; a supplied password is re-hashed before storage.
+                    Returns 400 with INVALID_REQUEST when the user or a named role cannot be found; the miss \
+                    surfaces as 400 rather than 404.
+                    """)
     @ApiResponse(responseCode = "200", description = "User updated successfully.")
     @ApiResponse(responseCode = "404", description = "User not found.")
     @EmitEvent(id = "SECURITY_USER_UPDATE", apiVersion = "1")
@@ -86,12 +141,33 @@ public class UserController {
             @Parameter(description = "ID of the user to update", example = "123e4567-e89b-12d3-a456-426614174000")
                     @PathVariable
                     UUID id,
-            @Parameter(description = "Updated user object") @RequestBody UserUpdateRequest user) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The account fields to change; omitted fields are left untouched.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Rename and reset roles", value = """
+                                                                    {"username":"jane.doe","roles":["SHOP_MGR"]}
+                                                                    """)))
+                    @RequestBody
+                    UserUpdateRequest user) {
         UserDto updatedUser = userService.updateUser(id, user);
         return ResponseEntity.ok(updatedUser);
     }
 
-    @Operation(summary = "Delete a user", description = "Delete a user by their unique ID.")
+    @Operation(operationId = "deleteUser", summary = "Delete a User Account", description = """
+                    Deletes a user account and queues removal of its user-person link so downstream projections \
+                    follow the account out.
+                    Use this tool to remove an account permanently; do not use disableUserAccount, which blocks \
+                    sign-in reversibly and keeps the record.
+                    Preconditions: the caller must hold security:user:delete; deleting an id that does not exist is \
+                    a silent no-op.
+                    Required inputs: id (UUID) as a path parameter.
+                    Emits a SECURITY_USER_DELETE event and sends a UserPersonLinkRemoveRequested command to the \
+                    people-contact domain in the same transaction.
+                    Returns 204 in all cases, including when the user was already absent.
+                    """)
     @ApiResponse(responseCode = "204", description = "User deleted successfully.")
     @ApiResponse(responseCode = "404", description = "User not found.")
     @EmitEvent(id = "SECURITY_USER_DELETE", apiVersion = "1")
@@ -109,8 +185,21 @@ public class UserController {
     }
 
     @Operation(
-            summary = "Assign roles to a user",
-            description = "Replaces or applies the requested role set for the specified user by username.")
+            operationId = "assignUserRolesByUsername",
+            summary = "Replace a User's Direct Role Set",
+            description = """
+                    Replaces a user's directly attached role set with the supplied role names, looking the user up \
+                    by username.
+                    Use this tool for wholesale role replacement by username; do not use assignUserRole, which adds \
+                    a single scoped role assignment by UUID without touching the direct set.
+                    Preconditions: the caller must hold security:role:assign, the username must resolve to a user, \
+                    and every named role must exist.
+                    Required inputs: username as a path parameter and roles, an array of existing role names, in \
+                    the body; the set replaces all current direct roles.
+                    Emits a SECURITY_USER_ASSIGN_ROLES event.
+                    Returns 400 with INVALID_REQUEST when the user or a named role cannot be found; the miss \
+                    surfaces as 400 rather than 404.
+                    """)
     @ApiResponse(responseCode = "200", description = "User roles updated successfully.")
     @ApiResponse(responseCode = "404", description = "User not found.")
     @EmitEvent(id = "SECURITY_USER_ASSIGN_ROLES", apiVersion = "1")
@@ -122,7 +211,16 @@ public class UserController {
     public ResponseEntity<UserDto> assignRoles(
             @Parameter(description = "Username of the user whose roles are being assigned") @PathVariable
                     String username,
-            @Parameter(description = "Payload containing the roles to assign") @RequestBody
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "The replacement set of role names for the user.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Replace roles", value = """
+                                                                    {"roles":["SHOP_MGR","ACCOUNTING_CLERK"]}
+                                                                    """)))
+                    @RequestBody
                     Map<String, Object> payload) {
         List<?> rolesList = (List<?>) payload.get("roles");
         Set<String> roles = rolesList.stream().map(Object::toString).collect(Collectors.toSet());

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/UserController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/UserController.java
@@ -130,7 +130,9 @@ public class UserController {
                     surfaces as 400 rather than 404.
                     """)
     @ApiResponse(responseCode = "200", description = "User updated successfully.")
-    @ApiResponse(responseCode = "404", description = "User not found.")
+    @ApiResponse(
+            responseCode = "400",
+            description = "User or named role not found (INVALID_REQUEST); the miss surfaces as 400, not 404.")
     @EmitEvent(id = "SECURITY_USER_UPDATE", apiVersion = "1")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
@@ -201,7 +203,9 @@ public class UserController {
                     surfaces as 400 rather than 404.
                     """)
     @ApiResponse(responseCode = "200", description = "User roles updated successfully.")
-    @ApiResponse(responseCode = "404", description = "User not found.")
+    @ApiResponse(
+            responseCode = "400",
+            description = "User or named role not found (INVALID_REQUEST); the miss surfaces as 400, not 404.")
     @EmitEvent(id = "SECURITY_USER_ASSIGN_ROLES", apiVersion = "1")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/UserRoleController.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/controller/UserRoleController.java
@@ -39,9 +39,18 @@ public class UserRoleController {
             name = "bearerAuth",
             scopes = {"security:role:assign"})
     @PreAuthorize("hasAuthority('security:role:assign')")
-    @Operation(
-            summary = "Assign a role to a user",
-            description = "Creates an effective role assignment linking the specified user to the specified role.")
+    @Operation(operationId = "assignUserRole", summary = "Assign a Role to a User", description = """
+                    Creates a GLOBAL-scoped role assignment linking a user to a role, effective immediately with no \
+                    end date.
+                    Use this tool for the common unscoped grant; do not use createRoleAssignment, which supports \
+                    LOCATION scope and effective date windows, and do not use assignPrincipalRole, which targets \
+                    the string-keyed RBAC principal matrix.
+                    Preconditions: the caller must hold security:role:assign and both the user and role must exist; \
+                    no overlap check is performed here, so repeated calls create duplicate assignments.
+                    Required inputs: userId and roleId (UUIDs) as path parameters; there is no request body.
+                    Emits a SECURITY_USER_ROLE_ASSIGN event and writes a RoleAssignedToUser audit record.
+                    Returns 404 when the user or role does not exist.
+                    """)
     public ResponseEntity<Void> assignRoleToUser(@PathVariable UUID userId, @PathVariable UUID roleId) {
         roleManagementService.assignRoleToUser(userId, roleId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -56,9 +65,17 @@ public class UserRoleController {
             name = "bearerAuth",
             scopes = {"security:role:assign"})
     @PreAuthorize("hasAuthority('security:role:assign')")
-    @Operation(
-            summary = "Revoke a role from a user",
-            description = "Removes the effective assignment of the specified role from the specified user.")
+    @Operation(operationId = "revokeUserRole", summary = "Revoke a Role From a User", description = """
+                    Ends the first currently effective assignment of a role for a user by setting its end date to \
+                    now, preserving the row for history.
+                    Use this tool for the common immediate revocation; do not use revokeRoleAssignment, which \
+                    targets a specific assignment id and supports past or future end dates.
+                    Preconditions: the caller must hold security:role:assign, the user and role must exist, and at \
+                    least one effective assignment must link them.
+                    Required inputs: userId and roleId (UUIDs) as path parameters; there is no request body.
+                    Emits a SECURITY_USER_ROLE_REVOKE event and writes a RoleRevokedFromUser audit record.
+                    Returns 404 when the user or role does not exist, or when no active assignment links them.
+                    """)
     public ResponseEntity<Void> revokeRoleFromUser(@PathVariable UUID userId, @PathVariable UUID roleId) {
         roleManagementService.revokeRoleFromUser(userId, roleId);
         return ResponseEntity.noContent().build();
@@ -72,7 +89,15 @@ public class UserRoleController {
             name = "bearerAuth",
             scopes = {"security:permission:view"})
     @PreAuthorize("hasAuthority('security:permission:view')")
-    @Operation(summary = "Get user permissions", description = "Returns all effective permissions for a user")
+    @Operation(operationId = "getUserPermissions", summary = "Get a User's Effective Permissions", description = """
+                    Returns the union of permissions granted through a user's currently effective role assignments.
+                    Use this tool for a user's flattened effective permission set; use listUserRoleAssignments \
+                    instead to see the assignments and scopes behind it.
+                    Preconditions: the caller must hold security:permission:view and the user must exist.
+                    Required inputs: userId (UUID) as a path parameter.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when the user does not exist.
+                    """)
     public ResponseEntity<Set<PermissionDto>> getUserPermissions(@PathVariable UUID userId) {
         return ResponseEntity.ok(roleManagementService.getUserPermissions(userId));
     }

--- a/pos-vehicle-inventory/openapi.yaml
+++ b/pos-vehicle-inventory/openapi.yaml
@@ -26,8 +26,20 @@ paths:
       tags:
       - Vehicle Preferences
       summary: Get vehicle care preferences
-      description: Retrieves the care preferences for a vehicle. Returns 404 if no preferences exist.
-      operationId: getPreferences
+      description: 'Returns the care-preference document for a vehicle, including the free-form preferences map, the structured service interval in months and any service notes.
+
+        Use this tool to read what a customer wants for vehicle care; do not use getVehicle, which returns the registry record itself and carries no preferences.
+
+        Preconditions: a preference document must already have been stored for the vehicle, because vehicles start with no preferences.
+
+        Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 with an empty body when no preference document exists for the vehicle.
+
+        '
+      operationId: getVehiclePreferences
       parameters:
       - name: vehicleId
         in: path
@@ -57,8 +69,20 @@ paths:
       tags:
       - Vehicle Preferences
       summary: Create or update vehicle care preferences
-      description: Upserts preferences for a vehicle. If preferences exist, replaces them entirely. Use PATCH for partial updates.
-      operationId: upsertPreferences
+      description: 'Creates or fully replaces the care-preference document for a vehicle, storing the preferences map and the structured service interval.
+
+        Use this tool to set preferences wholesale; use mergeVehiclePreferences instead for partial changes, because this operation replaces the entire map and a null serviceIntervalMonths clears the stored interval override.
+
+        Preconditions: the vehicle must exist in the registry; an existing preference document is replaced and a missing one is created.
+
+        Required inputs: preferences (a map, which may be empty but not null); serviceIntervalMonths is optional and must be between 1 and 120 months, a legacy serviceIntervalMonths key inside the map is promoted into the structured column, and serviceNotes, createdByUserId and updatedByUserId are optional.
+
+        Emits a VEHICLE_PREFERENCES_UPSERT event and queues a vehicle.care-preference.updated fact for CRM consumers.
+
+        Returns 200 with the saved document for both create and replace, 404 with a RESOURCE_NOT_FOUND ApiError when the vehicle does not exist, and 400 with a VALIDATION_ERROR ApiError when serviceIntervalMonths is outside 1 to 120.
+
+        '
+      operationId: upsertVehiclePreferences
       parameters:
       - name: vehicleId
         in: path
@@ -68,10 +92,22 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Complete care-preference document that replaces whatever is currently stored for the vehicle.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PreferencesUpsertDto'
+            examples:
+              Full preference document:
+                description: Full preference document
+                value:
+                  preferences:
+                    preferredOil: 5W-30
+                    tireRotationInterval: 5000
+                  serviceIntervalMonths: 6
+                  serviceNotes: Customer prefers synthetic oil only
+                  createdByUserId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  updatedByUserId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '200':
@@ -106,8 +142,20 @@ paths:
       tags:
       - Vehicle Preferences
       summary: Delete vehicle care preferences
-      description: Removes all preferences for a vehicle
-      operationId: deletePreferences
+      description: 'Removes the entire care-preference document for a vehicle when one exists.
+
+        Use this tool to clear all stored preferences at once; do not use mergeVehiclePreferences to blank individual keys when the intent is a full reset.
+
+        Preconditions: none; the operation is idempotent and a vehicle without preferences is left untouched.
+
+        Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+
+        Emits a VEHICLE_PREFERENCES_DELETE event, and queues a vehicle.care-preference.updated tombstone fact for CRM consumers only when a document was actually removed.
+
+        Returns 204 in all cases, including when no preference document exists, because deletion is idempotent.
+
+        '
+      operationId: deleteVehiclePreferences
       parameters:
       - name: vehicleId
         in: path
@@ -129,8 +177,20 @@ paths:
       tags:
       - Vehicle Preferences
       summary: Partially update vehicle care preferences
-      description: Merges provided preference fields into existing preferences without replacing the entire map
-      operationId: mergePreferences
+      description: 'Merges the supplied preference keys into a vehicle''s existing care-preference document without replacing the rest of the map.
+
+        Use this tool for partial changes such as one key or the interval alone; do not use upsertVehiclePreferences, which replaces the whole map and clears the interval when it is omitted.
+
+        Preconditions: a preference document must already exist for the vehicle, because this operation cannot create one.
+
+        Required inputs: no body field is individually mandatory; partialPreferences keys overwrite matching stored keys, serviceIntervalMonths must be between 1 and 120 months and leaves the stored value unchanged when null, and a legacy serviceIntervalMonths key inside the map is promoted into the structured column rather than kept in the blob.
+
+        Emits a VEHICLE_PREFERENCES_MERGE event and queues a vehicle.care-preference.updated fact for CRM consumers.
+
+        Returns 200 with the merged document, 404 with a RESOURCE_NOT_FOUND ApiError when no preference document exists for the vehicle, and 400 with a VALIDATION_ERROR ApiError when an interval value is out of range or not a whole number.
+
+        '
+      operationId: mergeVehiclePreferences
       parameters:
       - name: vehicleId
         in: path
@@ -140,10 +200,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Subset of preference fields to merge into the existing care-preference document.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PreferencesMergeDto'
+            examples:
+              Partial preference merge:
+                description: Partial preference merge
+                value:
+                  partialPreferences:
+                    tireRotationInterval: 7500
+                  serviceIntervalMonths: 6
+                  updatedByUserId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
         required: true
       responses:
         '200':
@@ -167,7 +236,19 @@ paths:
       tags:
       - Vehicle API
       summary: Get vehicle by ID
-      description: Retrieve a vehicle by its unique ID.
+      description: 'Returns a single vehicle from the legacy vehicle store by its UUID primary key.
+
+        Use this tool when the legacy vehicle id is already known; use getVehicleLegacyByVin instead when only the VIN is known, and do not use getVehicle, which reads the separate registry store.
+
+        Preconditions: the vehicle must exist in the legacy store; legacy deletes are hard deletes, so a deleted vehicle is gone rather than flagged inactive.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 with an empty body when no legacy vehicle exists for the supplied id.
+
+        '
       operationId: getVehicleLegacy
       parameters:
       - name: id
@@ -177,7 +258,7 @@ paths:
         schema:
           type: string
           format: uuid
-        example: 1
+        example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
       responses:
         '200':
           description: Vehicle found and returned.
@@ -199,7 +280,19 @@ paths:
       tags:
       - Vehicle API
       summary: Update vehicle by ID
-      description: Update an existing vehicle's details by its ID.
+      description: 'Replaces the core fields of an existing legacy vehicle identified by its UUID, applying make, model, year, VIN and vehicleType from the request.
+
+        Use this tool to correct a legacy record by id; use updateVehicleLegacyByVin instead when only the VIN is known, and do not use updateVehicle, which patches registry vehicles field by field.
+
+        Preconditions: the vehicle must already exist in the legacy store; the request is a full replacement of core fields rather than a partial patch.
+
+        Required inputs: id (UUID) as a path parameter plus make, model and year in the body (year between 1886 and the current year plus one); vin and vehicleType are optional.
+
+        Emits a VEHICLE_UPDATE event; no replica fact is published from the legacy surface.
+
+        Returns 404 with an empty body when the id is unknown, and 400 with a VALIDATION_ERROR ApiError when make, model or year is missing or invalid.
+
+        '
       operationId: updateVehicleLegacy
       parameters:
       - name: id
@@ -209,12 +302,22 @@ paths:
         schema:
           type: string
           format: uuid
-        example: 1
+        example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
       requestBody:
+        description: Full replacement values for the legacy vehicle's core fields.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/VehicleLegacyRequest'
+            examples:
+              Legacy vehicle:
+                description: Legacy vehicle
+                value:
+                  make: Honda
+                  model: Accord
+                  year: 2003
+                  vin: 1HGCM82633A004352
+                  vehicleType: CAR
         required: true
       responses:
         '200':
@@ -237,7 +340,19 @@ paths:
       tags:
       - Vehicle API
       summary: Delete vehicle by ID
-      description: Delete a vehicle from the inventory by its ID.
+      description: 'Permanently deletes a vehicle from the legacy vehicle store; the row is removed rather than deactivated.
+
+        Use this tool to purge a legacy record by id; do not use deleteVehicle, which soft-deactivates a registry vehicle and keeps it readable.
+
+        Preconditions: the vehicle must exist in the legacy store; deletion is not recoverable through this API.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a VEHICLE_DELETE event; no replica fact is published from the legacy surface.
+
+        Returns 204 on successful deletion, and 404 with an empty body when the id is unknown.
+
+        '
       operationId: deleteVehicleLegacy
       parameters:
       - name: id
@@ -247,7 +362,7 @@ paths:
         schema:
           type: string
           format: uuid
-        example: 1
+        example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
       responses:
         '204':
           description: Vehicle deleted successfully.
@@ -262,8 +377,20 @@ paths:
       tags:
       - Vehicle API
       summary: Get vehicle by VIN
-      description: Retrieve a vehicle by its VIN.
-      operationId: getVehicleByVIN
+      description: 'Returns a single vehicle from the legacy vehicle store by VIN, trimming the supplied value before the lookup.
+
+        Use this tool when only the VIN of a legacy record is known; use getVehicleLegacy instead when the id is known, and do not use getVehicleByVin, which reads the registry store with normalized VINs.
+
+        Preconditions: the vehicle must exist in the legacy store; the lookup is an exact match on the trimmed VIN, not a normalized or partial match.
+
+        Required inputs: vin as a non-blank path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 with an empty body when no legacy vehicle carries the VIN, and 400 with a VALIDATION_ERROR ApiError when the VIN is blank.
+
+        '
+      operationId: getVehicleLegacyByVin
       parameters:
       - name: vin
         in: path
@@ -293,8 +420,20 @@ paths:
       tags:
       - Vehicle API
       summary: Update vehicle by VIN
-      description: Update an existing vehicle's details by its VIN.
-      operationId: updateVehicleByVIN
+      description: 'Replaces the core fields of an existing legacy vehicle located by VIN, applying make, model, year and vehicleType from the request.
+
+        Use this tool to correct a legacy record when only the VIN is known; use updateVehicleLegacy instead when the id is known, and do not use updateVehicle, which patches registry vehicles.
+
+        Preconditions: a vehicle with the trimmed VIN must already exist in the legacy store; the request fully replaces core fields rather than patching them.
+
+        Required inputs: vin as a path parameter plus make, model and year in the body (year between 1886 and the current year plus one); vehicleType is optional.
+
+        Emits a VEHICLE_UPDATE event; no replica fact is published from the legacy surface.
+
+        Returns 404 with an empty body when no legacy vehicle carries the VIN, and 400 with a VALIDATION_ERROR ApiError when a required body field is missing or invalid.
+
+        '
+      operationId: updateVehicleLegacyByVin
       parameters:
       - name: vin
         in: path
@@ -304,10 +443,20 @@ paths:
           type: string
         example: 1HGCM82633A004352
       requestBody:
+        description: Full replacement values for the legacy vehicle's core fields.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/VehicleLegacyRequest'
+            examples:
+              Legacy vehicle:
+                description: Legacy vehicle
+                value:
+                  make: Honda
+                  model: Accord
+                  year: 2003
+                  vin: 1HGCM82633A004352
+                  vehicleType: CAR
         required: true
       responses:
         '200':
@@ -330,8 +479,20 @@ paths:
       tags:
       - Vehicle API
       summary: Delete vehicle by VIN
-      description: Delete a vehicle from the inventory by its VIN.
-      operationId: deleteVehicleByVIN
+      description: 'Permanently deletes a vehicle from the legacy vehicle store located by VIN; the row is removed rather than deactivated.
+
+        Use this tool to purge a legacy record when only the VIN is known; use deleteVehicleLegacy instead when the id is known, and do not use deleteVehicle, which soft-deactivates registry vehicles.
+
+        Preconditions: a vehicle with the trimmed VIN must exist in the legacy store; deletion is not recoverable through this API.
+
+        Required inputs: vin as a non-blank path parameter; there is no request body.
+
+        Emits a VEHICLE_DELETE event; no replica fact is published from the legacy surface.
+
+        Returns 204 on successful deletion, and 404 with an empty body when no legacy vehicle carries the VIN.
+
+        '
+      operationId: deleteVehicleLegacyByVin
       parameters:
       - name: vin
         in: path
@@ -354,7 +515,19 @@ paths:
       tags:
       - Vehicle Registry API
       summary: Get vehicle by ID
-      description: Retrieve a vehicle by its unique ID
+      description: 'Returns a single vehicle registry record by its vehicleId, whether the vehicle is active or deactivated.
+
+        Use this tool when the registry id is already known; use getVehicleByVin instead for VIN lookups, use searchVehicles for free-text discovery, and do not use getVehicleLegacy, which reads the legacy store.
+
+        Preconditions: the record must exist in the registry; deactivated vehicles are still returned, so callers must check the isActive flag.
+
+        Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 with an empty body when no registry record exists for the supplied vehicleId.
+
+        '
       operationId: getVehicle
       parameters:
       - name: vehicleId
@@ -385,7 +558,19 @@ paths:
       tags:
       - Vehicle Registry API
       summary: Update vehicle
-      description: Update an existing vehicle by ID
+      description: 'Applies a partial update to a vehicle registry record; only fields present in the body are changed, and the VIN itself cannot be modified here.
+
+        Use this tool to correct registry data or transfer ownership, since a new accountId moves the vehicle to that party and consumer replicas move their vehicle-party association from the emitted fact (ADR-0044); do not use updateVehicleLegacy, which fully replaces legacy records.
+
+        Preconditions: the record must exist in the registry; deactivated vehicles can still be updated.
+
+        Required inputs: vehicleId (UUID) as a path parameter and at least one body field among accountId, unitNumber, description, licensePlate, licensePlateJurisdiction, year, make, model and trim; a provided unitNumber or description must be non-blank, and year must be between 1886 and 2100.
+
+        Emits a VEHICLE_UPDATE event and queues a vehicle.vehicle.updated fact on the vehicle.events.v1 outbox for downstream replicas.
+
+        Returns 404 with a RESOURCE_NOT_FOUND ApiError when the vehicleId is unknown, and 400 with a VALIDATION_FAILED ApiError when no field is provided or a provided field violates its constraints.
+
+        '
       operationId: updateVehicle
       parameters:
       - name: vehicleId
@@ -396,10 +581,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Subset of mutable vehicle fields to change; omitted fields keep their stored values.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateVehicleRequest'
+            examples:
+              Partial update:
+                description: Partial update
+                value:
+                  description: 2003 Honda Accord EX Sedan, repainted
+                  licensePlate: XYZ7890
+                  licensePlateJurisdiction: TX
         required: true
       responses:
         '200':
@@ -428,7 +621,19 @@ paths:
       tags:
       - Vehicle Registry API
       summary: Delete vehicle
-      description: Deactivate a vehicle by ID
+      description: 'Deactivates a vehicle registry record by setting isActive to false; the row is retained and remains readable by id and by VIN.
+
+        Use this tool to retire a registry vehicle while preserving history and releasing its VIN for reuse by a future active vehicle; do not use deleteVehicleLegacy, which hard-deletes from the legacy store.
+
+        Preconditions: the record must exist in the registry; deactivating an already inactive vehicle is accepted and simply re-emits the replica fact.
+
+        Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+
+        Emits a VEHICLE_DELETE event and queues a vehicle.vehicle.updated fact with isActive false on the vehicle.events.v1 outbox, which tells downstream replicas to treat the vehicle as retired.
+
+        Returns 204 on successful deactivation, and 404 with a RESOURCE_NOT_FOUND ApiError when the vehicleId is unknown.
+
+        '
       operationId: deleteVehicle
       parameters:
       - name: vehicleId
@@ -452,8 +657,20 @@ paths:
       tags:
       - Vehicle Search
       summary: Search vehicles (query parameter)
-      description: Alternative search endpoint using query parameters. Useful for browser-based queries.
-      operationId: searchByQuery
+      description: 'Searches vehicle registry records using query parameters, applying the same ranking as searchVehicles with exact matches first, then prefix matches, then optional contains matches.
+
+        Use this tool for browser-friendly or link-style searches; use searchVehicles instead when the client can send a JSON body, and use getVehicleByVin when the full 17-character VIN is already known.
+
+        Preconditions: none beyond registry data existing; the match field is inferred from the query shape exactly as in searchVehicles.
+
+        Required inputs: q (non-blank, at least 3 characters, or 6 when VIN-shaped); limit defaults to 25 and is capped at 50, and enableContains defaults to false.
+
+        Emits a VEHICLE_SEARCH event; no vehicle state changes.
+
+        Returns 200 with ranked results plus totalCount and hasMore, and 400 with a VALIDATION_ERROR ApiError when q is empty or shorter than the minimum for its inferred type.
+
+        '
+      operationId: searchVehiclesByQuery
       parameters:
       - name: q
         in: query
@@ -497,13 +714,33 @@ paths:
       tags:
       - Vehicle Search
       summary: Search vehicles
-      description: 'Search for vehicles by VIN, license plate, unit number, or description. Results are ranked by relevance: exact match > prefix match > contains match.'
-      operationId: search
+      description: 'Searches vehicle registry records with a single free-text query, ranking exact matches ahead of prefix matches ahead of optional contains matches.
+
+        Use this tool for vehicle discovery from a JSON body; use searchVehiclesByQuery for the query-parameter variant, and use getVehicleByVin instead when the full 17-character VIN is already known.
+
+        Preconditions: none beyond registry data existing; the match field is inferred from the query shape, with six or more alphanumeric characters searched as a VIN (seventeen as an exact VIN), shorter queries searched against license plates, and the remainder searched against unit number plus description.
+
+        Required inputs: query (non-blank, at least 3 characters, or 6 when VIN-shaped); limit defaults to 25 and is capped at 50, enableContainsMatching defaults to false, and cursor is reserved and currently ignored.
+
+        Emits a VEHICLE_SEARCH event; no vehicle state changes.
+
+        Returns 200 with ranked results plus totalCount and hasMore, and 400 with a VALIDATION_ERROR ApiError when the query is empty or shorter than the minimum for its inferred type.
+
+        '
+      operationId: searchVehicles
       requestBody:
+        description: Free-text search criteria with an optional result limit and matching strategy flag.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SearchVehiclesRequest'
+            examples:
+              VIN prefix search:
+                description: VIN prefix search
+                value:
+                  query: 1HGCM8
+                  limit: 25
+                  enableContainsMatching: false
         required: true
       responses:
         '200':
@@ -526,24 +763,55 @@ paths:
     post:
       tags:
       - Vehicle Bulk Ingest API
-      summary: Bulk ingest records
-      description: Accepts a batch of domain records for bulk import. Returns per-record results.
-      operationId: bulkIngest
+      summary: Bulk ingest vehicle records
+      description: 'Ingests a batch of vehicle records into the registry, creating each row independently through the same validation as createVehicle and reporting a per-row outcome.
+
+        Use this tool for bulk loads such as fleet imports; do not use createVehicle, which registers one vehicle per call, and do not retry a whole batch blindly, because rows that already succeeded would then fail as duplicate VINs.
+
+        Preconditions: the caller must hold the vehicle-inventory:registry:create authority, and each row''s VIN must be valid and not already held by an active vehicle for that row to succeed.
+
+        Required inputs: jobId (UUID), locationId (UUID) and a non-empty records array whose entries require accountId (UUID), vin (17 characters), unitNumber and description; licensePlate, licensePlateJurisdiction, year, make, model and trim are optional per record, and operatorId is optional on the envelope.
+
+        Emits a VEHICLE_BULK_INGEST event, and every successfully created row also queues a vehicle.vehicle.updated fact on the vehicle.events.v1 outbox for downstream replicas.
+
+        Returns 200 with per-row results even when some rows fail, since row failures carry the VEHICLE_INGEST_FAILED error code instead of an error status, and 400 with a VALIDATION_FAILED ApiError when the envelope is missing jobId or locationId or the records array is empty.
+
+        '
+      operationId: bulkIngestVehicles
       requestBody:
+        description: Batch envelope carrying the ingest job, target location and the vehicle records to create.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BulkIngestRequestVehicleBulkIngestRecord'
+            examples:
+              Single-record batch:
+                description: Single-record batch
+                value:
+                  jobId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
+                  operatorId: user-jdoe
+                  records:
+                  - accountId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                    vin: 1HGCM82633A004352
+                    unitNumber: UNIT-1042
+                    description: 2003 Honda Accord EX Sedan
+                    licensePlate: ABC1234
+                    licensePlateJurisdiction: CA
+                    year: 2003
+                    make: Honda
+                    model: Accord
+                    trim: EX
         required: true
       responses:
         '200':
-          description: Batch processed (check per-record success/failure in response)
+          description: Batch processed; check per-record success and failure counts.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BulkIngestResponse'
         '400':
-          description: Invalid request payload
+          description: Invalid request envelope.
           content:
             application/json:
               schema:
@@ -558,8 +826,20 @@ paths:
       tags:
       - Vehicle API
       summary: Get all vehicles
-      description: Retrieve a list of all vehicles in the inventory.
-      operationId: getAllVehicles
+      description: 'Returns every vehicle in the legacy vehicle store as a flat list with no paging or filtering.
+
+        Use this tool to enumerate the legacy store; do not use searchVehicles, which queries the registry store, and prefer getVehicleLegacy when a specific id is already known.
+
+        Preconditions: none; an empty store simply yields an empty list.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 in all cases, including an empty JSON array when the store holds no vehicles.
+
+        '
+      operationId: listVehiclesLegacy
       responses:
         '200':
           description: List of vehicles returned successfully.
@@ -577,13 +857,35 @@ paths:
       tags:
       - Vehicle API
       summary: Create a new vehicle
-      description: Add a new vehicle to the inventory.
+      description: 'Creates a vehicle in the legacy vehicle store, persisting make, model, year and an optional VIN without enforcing VIN uniqueness.
+
+        Use this tool only when maintaining the legacy CRUD surface under /v1/vehicles-legacy; do not use it for registry vehicles, which createVehicle owns and which replicate to consumer services.
+
+        Preconditions: none beyond an authenticated caller; duplicate VINs are accepted because the legacy store has no uniqueness check.
+
+        Required inputs: make, model and year (year between 1886 and the current year plus one); vin is optional on this operation but must not be blank when present, and vehicleType is optional and limited to CAR, VAN, COMMERCIAL_TRUCK, PASSENGER_TRUCK or TRUCK.
+
+        Emits a VEHICLE_CREATE event; no replica fact is published, because the legacy store does not feed the vehicle.events.v1 stream.
+
+        Returns 200 with the stored vehicle, and 400 with a VALIDATION_ERROR ApiError when make, model or year is missing, year is out of range, vin is blank or vehicleType is unsupported.
+
+        '
       operationId: createVehicleLegacy
       requestBody:
+        description: Legacy vehicle to store, identified by its core make, model, year and optional VIN fields.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/VehicleLegacyRequest'
+            examples:
+              Legacy vehicle:
+                description: Legacy vehicle
+                value:
+                  make: Honda
+                  model: Accord
+                  year: 2003
+                  vin: 1HGCM82633A004352
+                  vehicleType: CAR
         required: true
       responses:
         '200':
@@ -601,13 +903,35 @@ paths:
       tags:
       - Vehicle API
       summary: Create vehicle by VIN
-      description: Add a new vehicle to the inventory using its VIN.
-      operationId: createVehicleByVIN
+      description: 'Creates a vehicle in the legacy vehicle store with the VIN treated as mandatory, trimming the supplied value before storing it.
+
+        Use this tool when the VIN is the identifying field for a legacy record; do not use createVehicleLegacy, which accepts a missing VIN, and do not use createVehicle, which writes the registry store.
+
+        Preconditions: none beyond an authenticated caller; the VIN is not checked for uniqueness or 17-character format by this legacy surface.
+
+        Required inputs: make, model, year and vin in the body (year between 1886 and the current year plus one); vehicleType is optional and limited to CAR, VAN, COMMERCIAL_TRUCK, PASSENGER_TRUCK or TRUCK.
+
+        Emits a VEHICLE_CREATE event; no replica fact is published from the legacy surface.
+
+        Returns 200 with the stored vehicle, and 400 with a VALIDATION_ERROR ApiError when make, model, year or vin is missing or invalid.
+
+        '
+      operationId: createVehicleLegacyByVin
       requestBody:
+        description: Legacy vehicle to store, with the VIN required as its identifying field.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/VehicleLegacyRequest'
+            examples:
+              Legacy vehicle:
+                description: Legacy vehicle
+                value:
+                  make: Honda
+                  model: Accord
+                  year: 2003
+                  vin: 1HGCM82633A004352
+                  vehicleType: CAR
         required: true
       responses:
         '200':
@@ -625,13 +949,40 @@ paths:
       tags:
       - Vehicle Registry API
       summary: Create vehicle
-      description: Create a new vehicle registry record
+      description: 'Creates an active vehicle registry record after validating and normalizing the VIN, which must be globally unique among active vehicles.
+
+        Use this tool to register a single vehicle whose changes replicate to consumer services; do not use bulkIngestVehicles, which loads batches with per-row results, and do not use createVehicleLegacy, which writes the unreplicated legacy store.
+
+        Preconditions: no active vehicle may already hold the same normalized VIN; a deactivated vehicle releases its VIN for reuse.
+
+        Required inputs: accountId (UUID) and vin (17 characters after separators are stripped, with letters I, O and Q rejected); unitNumber and description are optional and stored as empty strings when omitted, and licensePlate, licensePlateJurisdiction, year, make, model and trim are optional.
+
+        Emits a VEHICLE_CREATE event and queues a vehicle.vehicle.updated fact on the vehicle.events.v1 outbox for downstream replicas.
+
+        Returns 201 with the created record, and 400 with a VALIDATION_ERROR ApiError when the VIN is malformed or an active vehicle already holds the same normalized VIN; the duplicate-VIN case is reported as 400, not 409.
+
+        '
       operationId: createVehicle
       requestBody:
+        description: Registry vehicle to create, owned by one account and identified by a globally unique VIN.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateVehicleRequest'
+            examples:
+              Registry vehicle:
+                description: Registry vehicle
+                value:
+                  accountId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  vin: 1HGCM82633A004352
+                  unitNumber: UNIT-1042
+                  description: 2003 Honda Accord EX Sedan
+                  licensePlate: ABC1234
+                  licensePlateJurisdiction: CA
+                  year: 2003
+                  make: Honda
+                  model: Accord
+                  trim: EX
         required: true
       responses:
         '201':
@@ -655,7 +1006,19 @@ paths:
       tags:
       - Vehicle Registry API
       summary: Get vehicle by VIN
-      description: Retrieve a vehicle by VIN
+      description: 'Returns a single vehicle registry record by VIN, normalizing the supplied value by trimming, uppercasing and stripping separators before the lookup.
+
+        Use this tool when the full 17-character VIN is known; use searchVehicles instead for partial VIN prefixes, and do not use getVehicleLegacyByVin, which reads the legacy store.
+
+        Preconditions: a record with the normalized VIN must exist in the registry; active and deactivated vehicles are both returned.
+
+        Required inputs: vin as a path parameter, exactly 17 characters; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 with an empty body when no registry record carries the normalized VIN, and 400 with a VALIDATION_FAILED ApiError when the path VIN is not exactly 17 characters.
+
+        '
       operationId: getVehicleByVin
       parameters:
       - name: vin
@@ -781,7 +1144,7 @@ components:
       - version
     VehicleLegacyRequest:
       type: object
-      description: Vehicle object to be created
+      description: Legacy request payload for creating or updating a vehicle
       properties:
         id:
           type: string
@@ -866,7 +1229,7 @@ components:
       - year
     UpdateVehicleRequest:
       type: object
-      description: Vehicle update request
+      description: Request payload for partially updating mutable vehicle fields.
       properties:
         accountId:
           type: string
@@ -1264,7 +1627,7 @@ components:
       - success
     CreateVehicleRequest:
       type: object
-      description: Vehicle creation request
+      description: Request payload for creating a vehicle record.
       properties:
         accountId:
           type: string

--- a/pos-vehicle-inventory/openapi.yaml
+++ b/pos-vehicle-inventory/openapi.yaml
@@ -166,9 +166,7 @@ paths:
           format: uuid
       responses:
         '204':
-          description: Preferences deleted successfully
-        '404':
-          description: No preferences found to delete
+          description: Preferences deleted, or no preference document existed (idempotent delete)
       security:
       - bearerAuth: []
       x-required-permissions:

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleBulkIngestController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleBulkIngestController.java
@@ -8,6 +8,10 @@ import com.positivity.events.EmitEvent;
 import com.positivity.shared.dto.CreateVehicleRequest;
 import com.positivity.vehicle.internal.dto.VehicleBulkIngestRecord;
 import com.positivity.vehicle.service.VehicleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
@@ -33,14 +37,65 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Vehicle Bulk Ingest API", description = "Bulk import vehicle records")
 public class VehicleBulkIngestController extends AbstractBulkIngestController<VehicleBulkIngestRecord> {
 
+    private static final String BULK_INGEST_EXAMPLE = """
+            {"jobId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01",
+             "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02",
+             "operatorId":"user-jdoe",
+             "records":[
+               {"accountId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+                "vin":"1HGCM82633A004352",
+                "unitNumber":"UNIT-1042",
+                "description":"2003 Honda Accord EX Sedan",
+                "licensePlate":"ABC1234",
+                "licensePlateJurisdiction":"CA",
+                "year":2003,
+                "make":"Honda",
+                "model":"Accord",
+                "trim":"EX"}]}
+            """;
+
     private final VehicleService vehicleService;
 
+    @Operation(operationId = "bulkIngestVehicles", summary = "Bulk ingest vehicle records", description = """
+                    Ingests a batch of vehicle records into the registry, creating each row independently through \
+                    the same validation as createVehicle and reporting a per-row outcome.
+                    Use this tool for bulk loads such as fleet imports; do not use createVehicle, which registers \
+                    one vehicle per call, and do not retry a whole batch blindly, because rows that already \
+                    succeeded would then fail as duplicate VINs.
+                    Preconditions: the caller must hold the vehicle-inventory:registry:create authority, and each \
+                    row's VIN must be valid and not already held by an active vehicle for that row to succeed.
+                    Required inputs: jobId (UUID), locationId (UUID) and a non-empty records array whose entries \
+                    require accountId (UUID), vin (17 characters), unitNumber and description; licensePlate, \
+                    licensePlateJurisdiction, year, make, model and trim are optional per record, and operatorId \
+                    is optional on the envelope.
+                    Emits a VEHICLE_BULK_INGEST event, and every successfully created row also queues a \
+                    vehicle.vehicle.updated fact on the vehicle.events.v1 outbox for downstream replicas.
+                    Returns 200 with per-row results even when some rows fail, since row failures carry the \
+                    VEHICLE_INGEST_FAILED error code instead of an error status, and 400 with a VALIDATION_FAILED \
+                    ApiError when the envelope is missing jobId or locationId or the records array is empty.
+                    """)
+    @ApiResponse(responseCode = "200", description = "Batch processed; check per-record success and failure counts.")
+    @ApiResponse(responseCode = "400", description = "Invalid request envelope.")
     @Override
     @PostMapping("/bulk-ingest")
     @PreAuthorize("hasAuthority('vehicle-inventory:registry:create')")
     @EmitEvent(id = "VEHICLE_BULK_INGEST", apiVersion = "1")
     public ResponseEntity<BulkIngestResponse> bulkIngest(
-            @Valid @RequestBody @NonNull BulkIngestRequest<VehicleBulkIngestRecord> request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Batch envelope carrying the ingest job, target location and the vehicle"
+                                    + " records to create.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Single-record batch",
+                                                            value = BULK_INGEST_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    @NonNull
+                    BulkIngestRequest<VehicleBulkIngestRecord> request) {
         return super.bulkIngest(request);
     }
 

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleController.java
@@ -6,6 +6,8 @@ import com.positivity.vehicle.internal.dto.VehicleLegacyResponse;
 import com.positivity.vehicle.service.VehicleLegacyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -38,83 +40,199 @@ import org.springframework.web.bind.annotation.RestController;
 @PreAuthorize("isAuthenticated()")
 @RequestMapping("/v1/vehicles-legacy")
 public class VehicleController {
+
+    private static final String LEGACY_VEHICLE_EXAMPLE = """
+            {"make":"Honda",
+             "model":"Accord",
+             "year":2003,
+             "vin":"1HGCM82633A004352",
+             "vehicleType":"CAR"}
+            """;
+
     private final VehicleLegacyService vehicleLegacyService;
 
-    @Operation(
-            operationId = "createVehicleLegacy",
-            summary = "Create a new vehicle",
-            description = "Add a new vehicle to the inventory.")
+    @Operation(operationId = "createVehicleLegacy", summary = "Create a new vehicle", description = """
+                    Creates a vehicle in the legacy vehicle store, persisting make, model, year and an optional VIN \
+                    without enforcing VIN uniqueness.
+                    Use this tool only when maintaining the legacy CRUD surface under /v1/vehicles-legacy; do not use \
+                    it for registry vehicles, which createVehicle owns and which replicate to consumer services.
+                    Preconditions: none beyond an authenticated caller; duplicate VINs are accepted because the \
+                    legacy store has no uniqueness check.
+                    Required inputs: make, model and year (year between 1886 and the current year plus one); vin is \
+                    optional on this operation but must not be blank when present, and vehicleType is optional and \
+                    limited to CAR, VAN, COMMERCIAL_TRUCK, PASSENGER_TRUCK or TRUCK.
+                    Emits a VEHICLE_CREATE event; no replica fact is published, because the legacy store does not \
+                    feed the vehicle.events.v1 stream.
+                    Returns 200 with the stored vehicle, and 400 with a VALIDATION_ERROR ApiError when make, model \
+                    or year is missing, year is out of range, vin is blank or vehicleType is unsupported.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle created successfully.")
     @EmitEvent(id = "VEHICLE_CREATE", apiVersion = "1")
     @PostMapping
     public ResponseEntity<VehicleLegacyResponse> createVehicle(
-            @Parameter(description = "Vehicle object to be created") @RequestBody VehicleLegacyRequest vehicle) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Legacy vehicle to store, identified by its core make, model, year"
+                                    + " and optional VIN fields.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Legacy vehicle",
+                                                            value = LEGACY_VEHICLE_EXAMPLE)))
+                    @RequestBody
+                    VehicleLegacyRequest vehicle) {
         return ResponseEntity.ok(vehicleLegacyService.createVehicle(vehicle));
     }
 
-    @Operation(
-            operationId = "getVehicleLegacy",
-            summary = "Get vehicle by ID",
-            description = "Retrieve a vehicle by its unique ID.")
+    @Operation(operationId = "getVehicleLegacy", summary = "Get vehicle by ID", description = """
+                    Returns a single vehicle from the legacy vehicle store by its UUID primary key.
+                    Use this tool when the legacy vehicle id is already known; use getVehicleLegacyByVin instead \
+                    when only the VIN is known, and do not use getVehicle, which reads the separate registry store.
+                    Preconditions: the vehicle must exist in the legacy store; legacy deletes are hard deletes, so \
+                    a deleted vehicle is gone rather than flagged inactive.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 with an empty body when no legacy vehicle exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle found and returned.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @GetMapping("/{id}")
     public ResponseEntity<VehicleLegacyResponse> getVehicle(
-            @Parameter(description = "ID of the vehicle to retrieve", example = "1") @PathVariable UUID id) {
+            @Parameter(description = "ID of the vehicle to retrieve", example = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b")
+                    @PathVariable
+                    UUID id) {
         return vehicleLegacyService
                 .getVehicle(id)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @Operation(summary = "Get all vehicles", description = "Retrieve a list of all vehicles in the inventory.")
+    @Operation(operationId = "listVehiclesLegacy", summary = "Get all vehicles", description = """
+                    Returns every vehicle in the legacy vehicle store as a flat list with no paging or filtering.
+                    Use this tool to enumerate the legacy store; do not use searchVehicles, which queries the \
+                    registry store, and prefer getVehicleLegacy when a specific id is already known.
+                    Preconditions: none; an empty store simply yields an empty list.
+                    Required inputs: none; there are no parameters and no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 in all cases, including an empty JSON array when the store holds no vehicles.
+                    """)
     @ApiResponse(responseCode = "200", description = "List of vehicles returned successfully.")
     @GetMapping
     public List<VehicleLegacyResponse> getAllVehicles() {
         return vehicleLegacyService.getAllVehicles();
     }
 
-    @Operation(
-            operationId = "updateVehicleLegacy",
-            summary = "Update vehicle by ID",
-            description = "Update an existing vehicle's details by its ID.")
+    @Operation(operationId = "updateVehicleLegacy", summary = "Update vehicle by ID", description = """
+                    Replaces the core fields of an existing legacy vehicle identified by its UUID, applying make, \
+                    model, year, VIN and vehicleType from the request.
+                    Use this tool to correct a legacy record by id; use updateVehicleLegacyByVin instead when only \
+                    the VIN is known, and do not use updateVehicle, which patches registry vehicles field by field.
+                    Preconditions: the vehicle must already exist in the legacy store; the request is a full \
+                    replacement of core fields rather than a partial patch.
+                    Required inputs: id (UUID) as a path parameter plus make, model and year in the body (year \
+                    between 1886 and the current year plus one); vin and vehicleType are optional.
+                    Emits a VEHICLE_UPDATE event; no replica fact is published from the legacy surface.
+                    Returns 404 with an empty body when the id is unknown, and 400 with a VALIDATION_ERROR ApiError \
+                    when make, model or year is missing or invalid.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle updated successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @EmitEvent(id = "VEHICLE_UPDATE", apiVersion = "1")
     @PutMapping("/{id}")
     public ResponseEntity<VehicleLegacyResponse> updateVehicle(
-            @Parameter(description = "ID of the vehicle to update", example = "1") @PathVariable UUID id,
-            @Parameter(description = "Updated vehicle object") @RequestBody VehicleLegacyRequest updated) {
+            @Parameter(description = "ID of the vehicle to update", example = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b")
+                    @PathVariable
+                    UUID id,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement values for the legacy vehicle's core fields.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Legacy vehicle",
+                                                            value = LEGACY_VEHICLE_EXAMPLE)))
+                    @RequestBody
+                    VehicleLegacyRequest updated) {
         // ResponseEntity.of: 200 + body when present, 404 when empty (Sonar S6863).
         return ResponseEntity.of(vehicleLegacyService.updateVehicle(id, updated));
     }
 
-    @Operation(
-            operationId = "deleteVehicleLegacy",
-            summary = "Delete vehicle by ID",
-            description = "Delete a vehicle from the inventory by its ID.")
+    @Operation(operationId = "deleteVehicleLegacy", summary = "Delete vehicle by ID", description = """
+                    Permanently deletes a vehicle from the legacy vehicle store; the row is removed rather than \
+                    deactivated.
+                    Use this tool to purge a legacy record by id; do not use deleteVehicle, which soft-deactivates \
+                    a registry vehicle and keeps it readable.
+                    Preconditions: the vehicle must exist in the legacy store; deletion is not recoverable through \
+                    this API.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a VEHICLE_DELETE event; no replica fact is published from the legacy surface.
+                    Returns 204 on successful deletion, and 404 with an empty body when the id is unknown.
+                    """)
     @ApiResponse(responseCode = "204", description = "Vehicle deleted successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @EmitEvent(id = "VEHICLE_DELETE", apiVersion = "1")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteVehicle(
-            @Parameter(description = "ID of the vehicle to delete", example = "1") @PathVariable UUID id) {
+            @Parameter(description = "ID of the vehicle to delete", example = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b")
+                    @PathVariable
+                    UUID id) {
         if (!vehicleLegacyService.deleteVehicle(id)) {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Create vehicle by VIN", description = "Add a new vehicle to the inventory using its VIN.")
+    @Operation(operationId = "createVehicleLegacyByVin", summary = "Create vehicle by VIN", description = """
+                    Creates a vehicle in the legacy vehicle store with the VIN treated as mandatory, trimming the \
+                    supplied value before storing it.
+                    Use this tool when the VIN is the identifying field for a legacy record; do not use \
+                    createVehicleLegacy, which accepts a missing VIN, and do not use createVehicle, which writes \
+                    the registry store.
+                    Preconditions: none beyond an authenticated caller; the VIN is not checked for uniqueness or \
+                    17-character format by this legacy surface.
+                    Required inputs: make, model, year and vin in the body (year between 1886 and the current year \
+                    plus one); vehicleType is optional and limited to CAR, VAN, COMMERCIAL_TRUCK, PASSENGER_TRUCK \
+                    or TRUCK.
+                    Emits a VEHICLE_CREATE event; no replica fact is published from the legacy surface.
+                    Returns 200 with the stored vehicle, and 400 with a VALIDATION_ERROR ApiError when make, model, \
+                    year or vin is missing or invalid.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle created successfully.")
     @EmitEvent(id = "VEHICLE_CREATE", apiVersion = "1")
     @PostMapping("/vin")
     public ResponseEntity<VehicleLegacyResponse> createVehicleByVIN(
-            @Parameter(description = "Vehicle object to be created") @RequestBody VehicleLegacyRequest vehicle) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Legacy vehicle to store, with the VIN required as its identifying field.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Legacy vehicle",
+                                                            value = LEGACY_VEHICLE_EXAMPLE)))
+                    @RequestBody
+                    VehicleLegacyRequest vehicle) {
         return ResponseEntity.ok(vehicleLegacyService.createVehicleByVin(vehicle));
     }
 
-    @Operation(summary = "Get vehicle by VIN", description = "Retrieve a vehicle by its VIN.")
+    @Operation(operationId = "getVehicleLegacyByVin", summary = "Get vehicle by VIN", description = """
+                    Returns a single vehicle from the legacy vehicle store by VIN, trimming the supplied value \
+                    before the lookup.
+                    Use this tool when only the VIN of a legacy record is known; use getVehicleLegacy instead when \
+                    the id is known, and do not use getVehicleByVin, which reads the registry store with normalized \
+                    VINs.
+                    Preconditions: the vehicle must exist in the legacy store; the lookup is an exact match on the \
+                    trimmed VIN, not a normalized or partial match.
+                    Required inputs: vin as a non-blank path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 with an empty body when no legacy vehicle carries the VIN, and 400 with a \
+                    VALIDATION_ERROR ApiError when the VIN is blank.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle found and returned.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @GetMapping("/vin/{vin}")
@@ -125,7 +243,19 @@ public class VehicleController {
         return ResponseEntity.of(vehicleLegacyService.getVehicleByVin(vin));
     }
 
-    @Operation(summary = "Update vehicle by VIN", description = "Update an existing vehicle's details by its VIN.")
+    @Operation(operationId = "updateVehicleLegacyByVin", summary = "Update vehicle by VIN", description = """
+                    Replaces the core fields of an existing legacy vehicle located by VIN, applying make, model, \
+                    year and vehicleType from the request.
+                    Use this tool to correct a legacy record when only the VIN is known; use updateVehicleLegacy \
+                    instead when the id is known, and do not use updateVehicle, which patches registry vehicles.
+                    Preconditions: a vehicle with the trimmed VIN must already exist in the legacy store; the \
+                    request fully replaces core fields rather than patching them.
+                    Required inputs: vin as a path parameter plus make, model and year in the body (year between \
+                    1886 and the current year plus one); vehicleType is optional.
+                    Emits a VEHICLE_UPDATE event; no replica fact is published from the legacy surface.
+                    Returns 404 with an empty body when no legacy vehicle carries the VIN, and 400 with a \
+                    VALIDATION_ERROR ApiError when a required body field is missing or invalid.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle updated successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @EmitEvent(id = "VEHICLE_UPDATE", apiVersion = "1")
@@ -133,12 +263,35 @@ public class VehicleController {
     public ResponseEntity<VehicleLegacyResponse> updateVehicleByVIN(
             @Parameter(description = "VIN of the vehicle to update", example = "1HGCM82633A004352") @PathVariable
                     String vin,
-            @Parameter(description = "Updated vehicle object") @RequestBody VehicleLegacyRequest updated) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement values for the legacy vehicle's core fields.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Legacy vehicle",
+                                                            value = LEGACY_VEHICLE_EXAMPLE)))
+                    @RequestBody
+                    VehicleLegacyRequest updated) {
         // ResponseEntity.of: 200 + body when present, 404 when empty (Sonar S6863).
         return ResponseEntity.of(vehicleLegacyService.updateVehicleByVin(vin, updated));
     }
 
-    @Operation(summary = "Delete vehicle by VIN", description = "Delete a vehicle from the inventory by its VIN.")
+    @Operation(operationId = "deleteVehicleLegacyByVin", summary = "Delete vehicle by VIN", description = """
+                    Permanently deletes a vehicle from the legacy vehicle store located by VIN; the row is removed \
+                    rather than deactivated.
+                    Use this tool to purge a legacy record when only the VIN is known; use deleteVehicleLegacy \
+                    instead when the id is known, and do not use deleteVehicle, which soft-deactivates registry \
+                    vehicles.
+                    Preconditions: a vehicle with the trimmed VIN must exist in the legacy store; deletion is not \
+                    recoverable through this API.
+                    Required inputs: vin as a non-blank path parameter; there is no request body.
+                    Emits a VEHICLE_DELETE event; no replica fact is published from the legacy surface.
+                    Returns 204 on successful deletion, and 404 with an empty body when no legacy vehicle carries \
+                    the VIN.
+                    """)
     @ApiResponse(responseCode = "204", description = "Vehicle deleted successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @EmitEvent(id = "VEHICLE_DELETE", apiVersion = "1")

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehiclePreferencesController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehiclePreferencesController.java
@@ -8,6 +8,7 @@ import com.positivity.vehicle.service.VehiclePreferencesService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,11 +45,33 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/vehicles/{vehicleId}/preferences")
 public class VehiclePreferencesController {
 
+    private static final String UPSERT_EXAMPLE = """
+            {"preferences":{"preferredOil":"5W-30","tireRotationInterval":5000},
+             "serviceIntervalMonths":6,
+             "serviceNotes":"Customer prefers synthetic oil only",
+             "createdByUserId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+             "updatedByUserId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"}
+            """;
+
+    private static final String MERGE_EXAMPLE = """
+            {"partialPreferences":{"tireRotationInterval":7500},
+             "serviceIntervalMonths":6,
+             "updatedByUserId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c"}
+            """;
+
     private final VehiclePreferencesService preferencesService;
 
-    @Operation(
-            summary = "Get vehicle care preferences",
-            description = "Retrieves the care preferences for a vehicle. Returns 404 if no preferences exist.")
+    @Operation(operationId = "getVehiclePreferences", summary = "Get vehicle care preferences", description = """
+                    Returns the care-preference document for a vehicle, including the free-form preferences map, \
+                    the structured service interval in months and any service notes.
+                    Use this tool to read what a customer wants for vehicle care; do not use getVehicle, which \
+                    returns the registry record itself and carries no preferences.
+                    Preconditions: a preference document must already have been stored for the vehicle, because \
+                    vehicles start with no preferences.
+                    Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 with an empty body when no preference document exists for the vehicle.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Preferences found and returned",
@@ -67,9 +90,26 @@ public class VehiclePreferencesController {
     }
 
     @Operation(
+            operationId = "upsertVehiclePreferences",
             summary = "Create or update vehicle care preferences",
-            description =
-                    "Upserts preferences for a vehicle. If preferences exist, replaces them entirely. Use PATCH for partial updates.")
+            description = """
+                    Creates or fully replaces the care-preference document for a vehicle, storing the preferences \
+                    map and the structured service interval.
+                    Use this tool to set preferences wholesale; use mergeVehiclePreferences instead for partial \
+                    changes, because this operation replaces the entire map and a null serviceIntervalMonths \
+                    clears the stored interval override.
+                    Preconditions: the vehicle must exist in the registry; an existing preference document is \
+                    replaced and a missing one is created.
+                    Required inputs: preferences (a map, which may be empty but not null); serviceIntervalMonths \
+                    is optional and must be between 1 and 120 months, a legacy serviceIntervalMonths key inside \
+                    the map is promoted into the structured column, and serviceNotes, createdByUserId and \
+                    updatedByUserId are optional.
+                    Emits a VEHICLE_PREFERENCES_UPSERT event and queues a vehicle.care-preference.updated fact for \
+                    CRM consumers.
+                    Returns 200 with the saved document for both create and replace, 404 with a \
+                    RESOURCE_NOT_FOUND ApiError when the vehicle does not exist, and 400 with a VALIDATION_ERROR \
+                    ApiError when serviceIntervalMonths is outside 1 to 120.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Preferences updated successfully",
@@ -84,7 +124,20 @@ public class VehiclePreferencesController {
     @EmitEvent(id = "VEHICLE_PREFERENCES_UPSERT", apiVersion = "1")
     public ResponseEntity<VehicleCarePreferenceResponse> upsertPreferences(
             @Parameter(description = "Vehicle ID") @PathVariable UUID vehicleId,
-            @Valid @RequestBody PreferencesUpsertDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Complete care-preference document that replaces whatever is currently"
+                                    + " stored for the vehicle.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Full preference document",
+                                                            value = UPSERT_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    PreferencesUpsertDto request) {
 
         log.info(
                 "PUT /v1/vehicles/{}/preferences - keys={}",
@@ -104,9 +157,26 @@ public class VehiclePreferencesController {
     }
 
     @Operation(
+            operationId = "mergeVehiclePreferences",
             summary = "Partially update vehicle care preferences",
-            description =
-                    "Merges provided preference fields into existing preferences without replacing the entire map")
+            description = """
+                    Merges the supplied preference keys into a vehicle's existing care-preference document without \
+                    replacing the rest of the map.
+                    Use this tool for partial changes such as one key or the interval alone; do not use \
+                    upsertVehiclePreferences, which replaces the whole map and clears the interval when it is \
+                    omitted.
+                    Preconditions: a preference document must already exist for the vehicle, because this \
+                    operation cannot create one.
+                    Required inputs: no body field is individually mandatory; partialPreferences keys overwrite \
+                    matching stored keys, serviceIntervalMonths must be between 1 and 120 months and leaves the \
+                    stored value unchanged when null, and a legacy serviceIntervalMonths key inside the map is \
+                    promoted into the structured column rather than kept in the blob.
+                    Emits a VEHICLE_PREFERENCES_MERGE event and queues a vehicle.care-preference.updated fact for \
+                    CRM consumers.
+                    Returns 200 with the merged document, 404 with a RESOURCE_NOT_FOUND ApiError when no \
+                    preference document exists for the vehicle, and 400 with a VALIDATION_ERROR ApiError when an \
+                    interval value is out of range or not a whole number.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Preferences merged successfully",
@@ -116,7 +186,20 @@ public class VehiclePreferencesController {
     @EmitEvent(id = "VEHICLE_PREFERENCES_MERGE", apiVersion = "1")
     public ResponseEntity<VehicleCarePreferenceResponse> mergePreferences(
             @Parameter(description = "Vehicle ID") @PathVariable UUID vehicleId,
-            @Valid @RequestBody PreferencesMergeDto request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Subset of preference fields to merge into the existing care-preference"
+                                    + " document.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Partial preference merge",
+                                                            value = MERGE_EXAMPLE)))
+                    @Valid
+                    @RequestBody
+                    PreferencesMergeDto request) {
 
         // partialPreferences is optional: a PATCH may update only serviceIntervalMonths.
         Map<String, Object> partialPreferences =
@@ -128,7 +211,18 @@ public class VehiclePreferencesController {
         return ResponseEntity.ok(VehicleCarePreferenceMapper.toResponse(preference));
     }
 
-    @Operation(summary = "Delete vehicle care preferences", description = "Removes all preferences for a vehicle")
+    @Operation(operationId = "deleteVehiclePreferences", summary = "Delete vehicle care preferences", description = """
+                    Removes the entire care-preference document for a vehicle when one exists.
+                    Use this tool to clear all stored preferences at once; do not use mergeVehiclePreferences to \
+                    blank individual keys when the intent is a full reset.
+                    Preconditions: none; the operation is idempotent and a vehicle without preferences is left \
+                    untouched.
+                    Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+                    Emits a VEHICLE_PREFERENCES_DELETE event, and queues a vehicle.care-preference.updated \
+                    tombstone fact for CRM consumers only when a document was actually removed.
+                    Returns 204 in all cases, including when no preference document exists, because deletion is \
+                    idempotent.
+                    """)
     @ApiResponse(responseCode = "204", description = "Preferences deleted successfully")
     @ApiResponse(responseCode = "404", description = "No preferences found to delete")
     @DeleteMapping

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehiclePreferencesController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehiclePreferencesController.java
@@ -223,8 +223,9 @@ public class VehiclePreferencesController {
                     Returns 204 in all cases, including when no preference document exists, because deletion is \
                     idempotent.
                     """)
-    @ApiResponse(responseCode = "204", description = "Preferences deleted successfully")
-    @ApiResponse(responseCode = "404", description = "No preferences found to delete")
+    @ApiResponse(
+            responseCode = "204",
+            description = "Preferences deleted, or no preference document existed (idempotent delete)")
     @DeleteMapping
     @EmitEvent(id = "VEHICLE_PREFERENCES_DELETE", apiVersion = "1")
     public ResponseEntity<Void> deletePreferences(@Parameter(description = "Vehicle ID") @PathVariable UUID vehicleId) {

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleRegistryController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleRegistryController.java
@@ -7,6 +7,8 @@ import com.positivity.shared.dto.VehicleResponse;
 import com.positivity.vehicle.service.VehicleService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -45,21 +47,81 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/vehicle-registry")
 public class VehicleRegistryController {
 
+    private static final String CREATE_VEHICLE_EXAMPLE = """
+            {"accountId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+             "vin":"1HGCM82633A004352",
+             "unitNumber":"UNIT-1042",
+             "description":"2003 Honda Accord EX Sedan",
+             "licensePlate":"ABC1234",
+             "licensePlateJurisdiction":"CA",
+             "year":2003,
+             "make":"Honda",
+             "model":"Accord",
+             "trim":"EX"}
+            """;
+
+    private static final String UPDATE_VEHICLE_EXAMPLE = """
+            {"description":"2003 Honda Accord EX Sedan, repainted",
+             "licensePlate":"XYZ7890",
+             "licensePlateJurisdiction":"TX"}
+            """;
+
     private final VehicleService vehicleService;
 
-    @Operation(summary = "Create vehicle", description = "Create a new vehicle registry record")
+    @Operation(operationId = "createVehicle", summary = "Create vehicle", description = """
+                    Creates an active vehicle registry record after validating and normalizing the VIN, which must \
+                    be globally unique among active vehicles.
+                    Use this tool to register a single vehicle whose changes replicate to consumer services; do not \
+                    use bulkIngestVehicles, which loads batches with per-row results, and do not use \
+                    createVehicleLegacy, which writes the unreplicated legacy store.
+                    Preconditions: no active vehicle may already hold the same normalized VIN; a deactivated \
+                    vehicle releases its VIN for reuse.
+                    Required inputs: accountId (UUID) and vin (17 characters after separators are stripped, with \
+                    letters I, O and Q rejected); unitNumber and description are optional and stored as empty \
+                    strings when omitted, and licensePlate, licensePlateJurisdiction, year, make, model and trim \
+                    are optional.
+                    Emits a VEHICLE_CREATE event and queues a vehicle.vehicle.updated fact on the vehicle.events.v1 \
+                    outbox for downstream replicas.
+                    Returns 201 with the created record, and 400 with a VALIDATION_ERROR ApiError when the VIN is \
+                    malformed or an active vehicle already holds the same normalized VIN; the duplicate-VIN case is \
+                    reported as 400, not 409.
+                    """)
     @ApiResponse(responseCode = "201", description = "Vehicle created successfully.")
     @ApiResponse(responseCode = "400", description = "Invalid vehicle request.")
     @EmitEvent(id = "VEHICLE_CREATE", apiVersion = "1")
     @PostMapping
     public ResponseEntity<VehicleResponse> createVehicle(
-            @Parameter(description = "Vehicle creation request", required = true) @Valid @NotNull @RequestBody
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Registry vehicle to create, owned by one account and identified by a"
+                                    + " globally unique VIN.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Registry vehicle",
+                                                            value = CREATE_VEHICLE_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
                     CreateVehicleRequest request) {
         VehicleResponse response = vehicleService.createVehicle(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @Operation(summary = "Get vehicle by ID", description = "Retrieve a vehicle by its unique ID")
+    @Operation(operationId = "getVehicle", summary = "Get vehicle by ID", description = """
+                    Returns a single vehicle registry record by its vehicleId, whether the vehicle is active or \
+                    deactivated.
+                    Use this tool when the registry id is already known; use getVehicleByVin instead for VIN \
+                    lookups, use searchVehicles for free-text discovery, and do not use getVehicleLegacy, which \
+                    reads the legacy store.
+                    Preconditions: the record must exist in the registry; deactivated vehicles are still returned, \
+                    so callers must check the isActive flag.
+                    Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 with an empty body when no registry record exists for the supplied vehicleId.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle retrieved successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @GetMapping("/{vehicleId}")
@@ -71,7 +133,18 @@ public class VehicleRegistryController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @Operation(summary = "Get vehicle by VIN", description = "Retrieve a vehicle by VIN")
+    @Operation(operationId = "getVehicleByVin", summary = "Get vehicle by VIN", description = """
+                    Returns a single vehicle registry record by VIN, normalizing the supplied value by trimming, \
+                    uppercasing and stripping separators before the lookup.
+                    Use this tool when the full 17-character VIN is known; use searchVehicles instead for partial \
+                    VIN prefixes, and do not use getVehicleLegacyByVin, which reads the legacy store.
+                    Preconditions: a record with the normalized VIN must exist in the registry; active and \
+                    deactivated vehicles are both returned.
+                    Required inputs: vin as a path parameter, exactly 17 characters; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 with an empty body when no registry record carries the normalized VIN, and 400 \
+                    with a VALIDATION_FAILED ApiError when the path VIN is not exactly 17 characters.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle retrieved successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @GetMapping("/vin/{vin}")
@@ -84,7 +157,23 @@ public class VehicleRegistryController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @Operation(summary = "Update vehicle", description = "Update an existing vehicle by ID")
+    @Operation(operationId = "updateVehicle", summary = "Update vehicle", description = """
+                    Applies a partial update to a vehicle registry record; only fields present in the body are \
+                    changed, and the VIN itself cannot be modified here.
+                    Use this tool to correct registry data or transfer ownership, since a new accountId moves the \
+                    vehicle to that party and consumer replicas move their vehicle-party association from the \
+                    emitted fact (ADR-0044); do not use updateVehicleLegacy, which fully replaces legacy records.
+                    Preconditions: the record must exist in the registry; deactivated vehicles can still be updated.
+                    Required inputs: vehicleId (UUID) as a path parameter and at least one body field among \
+                    accountId, unitNumber, description, licensePlate, licensePlateJurisdiction, year, make, model \
+                    and trim; a provided unitNumber or description must be non-blank, and year must be between \
+                    1886 and 2100.
+                    Emits a VEHICLE_UPDATE event and queues a vehicle.vehicle.updated fact on the vehicle.events.v1 \
+                    outbox for downstream replicas.
+                    Returns 404 with a RESOURCE_NOT_FOUND ApiError when the vehicleId is unknown, and 400 with a \
+                    VALIDATION_FAILED ApiError when no field is provided or a provided field violates its \
+                    constraints.
+                    """)
     @ApiResponse(responseCode = "200", description = "Vehicle updated successfully.")
     @ApiResponse(responseCode = "400", description = "Invalid vehicle request.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
@@ -92,13 +181,39 @@ public class VehicleRegistryController {
     @PutMapping("/{vehicleId}")
     public ResponseEntity<VehicleResponse> updateVehicle(
             @Parameter(description = "Vehicle UUID", required = true) @PathVariable @NotNull UUID vehicleId,
-            @Parameter(description = "Vehicle update request", required = true) @Valid @NotNull @RequestBody
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Subset of mutable vehicle fields to change; omitted fields keep their"
+                                    + " stored values.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Partial update",
+                                                            value = UPDATE_VEHICLE_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
                     UpdateVehicleRequest request) {
         VehicleResponse response = vehicleService.updateVehicle(vehicleId, request);
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "Delete vehicle", description = "Deactivate a vehicle by ID")
+    @Operation(operationId = "deleteVehicle", summary = "Delete vehicle", description = """
+                    Deactivates a vehicle registry record by setting isActive to false; the row is retained and \
+                    remains readable by id and by VIN.
+                    Use this tool to retire a registry vehicle while preserving history and releasing its VIN for \
+                    reuse by a future active vehicle; do not use deleteVehicleLegacy, which hard-deletes from the \
+                    legacy store.
+                    Preconditions: the record must exist in the registry; deactivating an already inactive vehicle \
+                    is accepted and simply re-emits the replica fact.
+                    Required inputs: vehicleId (UUID) as a path parameter; there is no request body.
+                    Emits a VEHICLE_DELETE event and queues a vehicle.vehicle.updated fact with isActive false on \
+                    the vehicle.events.v1 outbox, which tells downstream replicas to treat the vehicle as retired.
+                    Returns 204 on successful deactivation, and 404 with a RESOURCE_NOT_FOUND ApiError when the \
+                    vehicleId is unknown.
+                    """)
     @ApiResponse(responseCode = "204", description = "Vehicle deleted successfully.")
     @ApiResponse(responseCode = "404", description = "Vehicle not found.")
     @EmitEvent(id = "VEHICLE_DELETE", apiVersion = "1")

--- a/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleSearchController.java
+++ b/pos-vehicle-inventory/src/main/java/com/positivity/vehicle/internal/controller/VehicleSearchController.java
@@ -7,6 +7,7 @@ import com.positivity.vehicle.service.VehicleSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -34,12 +35,31 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/vehicles/search")
 public class VehicleSearchController {
 
+    private static final String SEARCH_EXAMPLE = """
+            {"query":"1HGCM8",
+             "limit":25,
+             "enableContainsMatching":false}
+            """;
+
     private final VehicleSearchService searchService;
 
-    @Operation(
-            summary = "Search vehicles",
-            description = "Search for vehicles by VIN, license plate, unit number, or description. "
-                    + "Results are ranked by relevance: exact match > prefix match > contains match.")
+    @Operation(operationId = "searchVehicles", summary = "Search vehicles", description = """
+                    Searches vehicle registry records with a single free-text query, ranking exact matches ahead \
+                    of prefix matches ahead of optional contains matches.
+                    Use this tool for vehicle discovery from a JSON body; use searchVehiclesByQuery for the \
+                    query-parameter variant, and use getVehicleByVin instead when the full 17-character VIN is \
+                    already known.
+                    Preconditions: none beyond registry data existing; the match field is inferred from the query \
+                    shape, with six or more alphanumeric characters searched as a VIN (seventeen as an exact VIN), \
+                    shorter queries searched against license plates, and the remainder searched against unit \
+                    number plus description.
+                    Required inputs: query (non-blank, at least 3 characters, or 6 when VIN-shaped); limit \
+                    defaults to 25 and is capped at 50, enableContainsMatching defaults to false, and cursor is \
+                    reserved and currently ignored.
+                    Emits a VEHICLE_SEARCH event; no vehicle state changes.
+                    Returns 200 with ranked results plus totalCount and hasMore, and 400 with a VALIDATION_ERROR \
+                    ApiError when the query is empty or shorter than the minimum for its inferred type.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Search results returned",
@@ -47,7 +67,18 @@ public class VehicleSearchController {
     @ApiResponse(responseCode = "400", description = "Invalid search query")
     @PostMapping
     @EmitEvent(id = "VEHICLE_SEARCH", apiVersion = "1")
-    public ResponseEntity<SearchVehiclesResponse> search(@RequestBody SearchVehiclesRequest request) {
+    public ResponseEntity<SearchVehiclesResponse> search(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Free-text search criteria with an optional result limit and matching"
+                                    + " strategy flag.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(name = "VIN prefix search", value = SEARCH_EXAMPLE)))
+                    @RequestBody
+                    SearchVehiclesRequest request) {
 
         log.info(
                 "POST /v1/vehicles/search - query(mask)='{}', limit={}",
@@ -58,9 +89,20 @@ public class VehicleSearchController {
         return ResponseEntity.ok(results);
     }
 
-    @Operation(
-            summary = "Search vehicles (query parameter)",
-            description = "Alternative search endpoint using query parameters. Useful for browser-based queries.")
+    @Operation(operationId = "searchVehiclesByQuery", summary = "Search vehicles (query parameter)", description = """
+                    Searches vehicle registry records using query parameters, applying the same ranking as \
+                    searchVehicles with exact matches first, then prefix matches, then optional contains matches.
+                    Use this tool for browser-friendly or link-style searches; use searchVehicles instead when the \
+                    client can send a JSON body, and use getVehicleByVin when the full 17-character VIN is already \
+                    known.
+                    Preconditions: none beyond registry data existing; the match field is inferred from the query \
+                    shape exactly as in searchVehicles.
+                    Required inputs: q (non-blank, at least 3 characters, or 6 when VIN-shaped); limit defaults to \
+                    25 and is capped at 50, and enableContains defaults to false.
+                    Emits a VEHICLE_SEARCH event; no vehicle state changes.
+                    Returns 200 with ranked results plus totalCount and hasMore, and 400 with a VALIDATION_ERROR \
+                    ApiError when q is empty or shorter than the minimum for its inferred type.
+                    """)
     @ApiResponse(
             responseCode = "200",
             description = "Search results returned",

--- a/pos-warranty/openapi.yaml
+++ b/pos-warranty/openapi.yaml
@@ -30,7 +30,19 @@ paths:
       tags:
       - Warranty Registrations
       summary: Get registration
-      description: Retrieve a warranty registration by id
+      description: 'Returns one warranty registration — the sold/instantiated coverage binding a policy to a customer, and optionally to a vehicle and its originating invoice line.
+
+        Use this tool when the registration id is already known; use searchRegistrations instead to locate coverage by customer, vehicle, or status.
+
+        Preconditions: the registration must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no registration exists for the supplied id.
+
+        '
       operationId: getRegistration
       parameters:
       - name: id
@@ -61,7 +73,19 @@ paths:
       tags:
       - Warranty Registrations
       summary: Update registration
-      description: Full update of an existing warranty registration
+      description: 'Fully replaces an existing warranty registration''s fields, including the policy binding, source references, and coverage dates.
+
+        Use this tool to correct or expire sold coverage; do not use createRegistration, which records new coverage.
+
+        Preconditions: the registration and the referenced policy must exist; omitting status keeps the current value, while the other fields are rewritten from the request and null clears them.
+
+        Required inputs: id (UUID) as a path parameter, plus policyId, customerId, and purchaseDate; vehicleId, source invoice references, contractNumber, expiresAt, and status (ACTIVE, EXPIRED, CANCELLED, EXHAUSTED) are optional.
+
+        Emits a WARRANTY_REGISTRATION_UPDATE event.
+
+        Returns 404 when the registration or the referenced policy cannot be resolved.
+
+        '
       operationId: updateRegistration
       parameters:
       - name: id
@@ -72,10 +96,24 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Full replacement of the registration's fields (omitting status keeps the current value).
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RegistrationRequest'
+            examples:
+              Road-hazard registration:
+                description: Road-hazard registration
+                value:
+                  policyId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a30
+                  customerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                  vehicleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
+                  sourceInvoiceId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04
+                  sourceInvoiceLineId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a05
+                  contractNumber: RH-2026-88412
+                  purchaseDate: 2026-05-14
+                  expiresAt: 2029-05-14
+                  status: ACTIVE
         required: true
       responses:
         '200':
@@ -105,7 +143,19 @@ paths:
       tags:
       - Warranty Providers
       summary: Get provider
-      description: Retrieve a warranty provider by id
+      description: 'Returns one warranty provider, including its funding type, AP vendor link, and claim-submission contact details.
+
+        Use this tool when the provider id is already known; use listProviders instead to locate a provider by status or type.
+
+        Preconditions: the provider must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no provider exists for the supplied id.
+
+        '
       operationId: getProvider
       parameters:
       - name: id
@@ -136,7 +186,19 @@ paths:
       tags:
       - Warranty Providers
       summary: Update provider
-      description: Full update of an existing warranty provider
+      description: 'Fully replaces an existing warranty provider''s fields, including funding type, contact details, and the AP vendor link.
+
+        Use this tool to change provider data; do not use createProvider, which adds a new provider.
+
+        Preconditions: the provider must exist; omitting status keeps the current value, while every other field is rewritten from the request and null clears it.
+
+        Required inputs: id (UUID) as a path parameter, plus name and providerType; apVendorId, manufacturerId, claimSubmissionMethod, and the contact fields are optional.
+
+        Emits a WARRANTY_PROVIDER_UPDATE event.
+
+        Returns 404 when no provider exists for the supplied id.
+
+        '
       operationId: updateProvider
       parameters:
       - name: id
@@ -147,10 +209,25 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Full replacement of the provider's fields (omitting status keeps the current value).
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ProviderRequest'
+            examples:
+              Manufacturer provider:
+                description: Manufacturer provider
+                value:
+                  name: Michelin North America
+                  providerType: MANUFACTURER
+                  status: ACTIVE
+                  apVendorId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a20
+                  manufacturerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a11
+                  claimSubmissionMethod: Portal
+                  portalUrl: https://warranty.michelin.example.com
+                  contactName: Claims Desk
+                  contactPhone: +1-800-555-0100
+                  contactEmail: claims@michelin.example.com
         required: true
       responses:
         '200':
@@ -180,7 +257,19 @@ paths:
       tags:
       - Warranty Policies
       summary: Get policy
-      description: Retrieve a warranty policy by id
+      description: 'Returns one warranty policy with its full structured coverage terms, including proration method, caps, and evidence requirements.
+
+        Use this tool when the policy id is already known; use listPolicies or findApplicablePolicies instead to locate a policy.
+
+        Preconditions: the policy must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no policy exists for the supplied id.
+
+        '
       operationId: getPolicy
       parameters:
       - name: id
@@ -211,7 +300,19 @@ paths:
       tags:
       - Warranty Policies
       summary: Update policy
-      description: Full update of an existing warranty policy
+      description: 'Fully replaces an existing warranty policy''s structured coverage terms; every field is rewritten from the request, and omitted optional booleans reset to false.
+
+        Use this tool to change a coverage program; do not use createPolicy, which adds a new program — claims already decided keep their frozen proration inputs regardless of policy edits.
+
+        Preconditions: the policy and the referenced provider must exist, the appliesTo scope keys must be consistent with appliesToType, and effectiveTo must not precede effectiveFrom.
+
+        Required inputs: id (UUID) as a path parameter and the same full body as createPolicy — this is full-update semantics, so omitting an optional field clears it or resets its default.
+
+        Emits a WARRANTY_POLICY_UPDATE event.
+
+        Returns 404 when the policy or the referenced provider cannot be resolved, and 400 when the appliesTo scope keys or the effective window are inconsistent.
+
+        '
       operationId: updatePolicy
       parameters:
       - name: id
@@ -222,10 +323,30 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Full replacement of the policy's structured coverage terms (full-update semantics).
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PolicyRequest'
+            examples:
+              Manufacturer tread-depth policy:
+                description: Manufacturer tread-depth policy
+                value:
+                  providerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a10
+                  name: Michelin passenger replacement — workmanship & materials
+                  coverageType: MANUFACTURER_DEFECT
+                  appliesToType: MANUFACTURER
+                  appliesToManufacturerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a11
+                  effectiveFrom: 2025-01-01
+                  durationMonths: 72
+                  treadPullPointThirtySeconds: 2
+                  laborCovered: false
+                  prorationMethod: TREAD_DEPTH
+                  requiresPartReturn: true
+                  requiresPhotoEvidence: true
+                  transferable: false
+                  autoRegister: false
+                  termsText: Prorated on remaining tread down to the 2/32 pull point.
         required: true
       responses:
         '200':
@@ -255,7 +376,19 @@ paths:
       tags:
       - Warranty Part Returns
       summary: Update part return (RMA)
-      description: Advances the RMA (AWAITING_PART -> ON_HOLD -> SHIPPED -> RECEIVED_BY_VENDOR, or SCRAPPED/CLOSED per disposition) and/or updates RMA details
+      description: 'Advances a part return through its child state machine — AWAITING_PART to ON_HOLD to SHIPPED to RECEIVED_BY_VENDOR, or to SCRAPPED/CLOSED per disposition, where ON_HOLD may be skipped — and/or updates RMA details without a lifecycle move.
+
+        Use this tool for every change after creation; do not use createPartReturn, which opens a new RMA and rejects a line that already has one.
+
+        Preconditions: the part return must exist and not be terminal; moving to SHIPPED or RECEIVED_BY_VENDOR requires disposition RETURN_TO_VENDOR, and moving to SCRAPPED requires disposition SCRAP_AUTHORIZED (either already set or set in the same request).
+
+        Required inputs: part return id (UUID) as a path parameter; every body field is optional — omit status for a detail-only update, and shippedAt defaults to now when entering SHIPPED.
+
+        Emits a WARRANTY_PART_RETURN_UPDATE event, enqueues warranty.part-return.shipped when the return enters SHIPPED, and republishes the claim snapshot.
+
+        Returns 404 when the part return does not exist, and 409 when the transition is illegal, the disposition does not permit the target status, or the return is already terminal.
+
+        '
       operationId: updatePartReturn
       parameters:
       - name: id
@@ -266,10 +399,20 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Lifecycle move and/or RMA detail changes; all fields optional, omit status for a detail-only update.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PartReturnUpdateRequest'
+            examples:
+              Ship to vendor:
+                description: Ship to vendor
+                value:
+                  status: SHIPPED
+                  disposition: RETURN_TO_VENDOR
+                  carrier: UPS
+                  trackingNumber: 1Z999AA10123456784
+                  shippedAt: 2026-08-12 15:04:05+00:00
         required: true
       responses:
         '200':
@@ -299,7 +442,19 @@ paths:
       tags:
       - Warranty Claims
       summary: Get claim
-      description: Full detail incl. lines, settlements, reimbursements, part returns, history, notes
+      description: 'Returns the full warranty claim detail, including lines, settlements, reimbursements, part returns, status history, and notes.
+
+        Use this tool when the claim id is already known; use searchClaims instead to locate a claim by customer, vehicle, status, or claim code.
+
+        Preconditions: the claim must exist.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body and no filtering.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 404 when no claim exists for the supplied id.
+
+        '
       operationId: getClaim
       parameters:
       - name: id
@@ -330,7 +485,19 @@ paths:
       tags:
       - Warranty Claims
       summary: Update claim
-      description: Edit intake fields while DRAFT or INFO_NEEDED
+      description: 'Replaces the intake fields of a claim that is still DRAFT or INFO_NEEDED: origin references, sale date, registration, failure details, and location use full-update semantics where null clears the value, while claimType and photoEvidenceUrls change only when non-null.
+
+        Use this tool to correct intake data before adjudication; do not use decideClaim, which records the approve/deny decision, and manage lines through addClaimLine and removeClaimLine rather than this operation.
+
+        Preconditions: the claim must exist and be in DRAFT or INFO_NEEDED — every other status rejects edits.
+
+        Required inputs: id (UUID) as a path parameter and the update body; clearing both originWorkorderId and originInvoiceId re-flags the claim originUnverified.
+
+        Emits a WARRANTY_CLAIM_UPDATE event and republishes the claim snapshot.
+
+        Returns 404 when the claim does not exist, and 409 (WARRANTY_CLAIM_NOT_EDITABLE) when the claim is not DRAFT or INFO_NEEDED.
+
+        '
       operationId: updateClaim
       parameters:
       - name: id
@@ -341,10 +508,21 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Intake fields to replace on the claim; null clears origin, failure, and location fields, while claimType and photoEvidenceUrls apply only when non-null.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ClaimUpdateRequest'
+            examples:
+              Correct intake data:
+                description: Correct intake data
+                value:
+                  claimType: ROAD_HAZARD
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03
+                  originInvoiceId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04
+                  originSaleDate: 2025-11-02
+                  failureDescription: Sidewall puncture, right rear tire — updated after inspection
+                  failureDate: 2026-08-09
         required: true
       responses:
         '200':
@@ -374,7 +552,19 @@ paths:
       tags:
       - Warranty Reimbursements
       summary: Update vendor reimbursement
-      description: Records a vendor decision (APPROVED/PARTIALLY_APPROVED/DENIED), credit receipt, or write-off; only legal child-lifecycle transitions are accepted
+      description: 'Records the vendor''s resolution on a claim''s reimbursement: a decision (APPROVED, PARTIALLY_APPROVED, DENIED), the credit receipt (CREDIT_RECEIVED), or a write-off (WRITTEN_OFF).
+
+        Use this tool after the vendor responds; do not use submitReimbursement, which performs the initial NOT_SUBMITTED-to-SUBMITTED move.
+
+        Preconditions: the claim must have a reimbursement record and the move must be legal in the child state machine — SUBMITTED may resolve to APPROVED, PARTIALLY_APPROVED, or DENIED, approvals may then move to CREDIT_RECEIVED, and any non-terminal state may be WRITTEN_OFF; DENIED, CREDIT_RECEIVED, WRITTEN_OFF, and NOT_APPLICABLE are terminal and unblock claim close.
+
+        Required inputs: claim id (UUID) as a path parameter and a body with status; amountApproved is required for APPROVED and PARTIALLY_APPROVED, and creditReference typically accompanies CREDIT_RECEIVED.
+
+        Emits a WARRANTY_REIMBURSEMENT_UPDATE event and enqueues warranty.reimbursement.resolved for every resolution status so pos-accounting can match or stop expecting the vendor credit.
+
+        Returns 400 when the target status is outside the updatable set or amountApproved is missing, 404 when the claim or its reimbursement record does not exist, and 409 when the transition is illegal from the current status (nextAction lists the legal moves).
+
+        '
       operationId: updateReimbursement
       parameters:
       - name: id
@@ -385,10 +575,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: 'Vendor resolution: target status with the approved amount, credit reference, or notes that go with it.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ReimbursementUpdateRequest'
+            examples:
+              Vendor approved:
+                description: Vendor approved
+                value:
+                  status: APPROVED
+                  amountApproved: 130.0
+                  notes: Vendor approved at adjusted labor rate
         required: true
       responses:
         '200':
@@ -418,7 +616,19 @@ paths:
       tags:
       - Warranty Registrations
       summary: Search registrations
-      description: Optionally filter by customer, vehicle, and status
+      description: 'Searches sold-coverage registrations, optionally filtered by customer, vehicle, and lifecycle status.
+
+        Use this tool to find a customer''s road-hazard or extended-plan coverage; use getRegistration instead when the registration id is already known.
+
+        Preconditions: none — an empty list is returned when nothing matches.
+
+        Required inputs: customerId, vehicleId, and status (ACTIVE, EXPIRED, CANCELLED, EXHAUSTED) are all optional query parameters; with no filters every registration is returned.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the list, which is empty rather than 404 when nothing matches.
+
+        '
       operationId: searchRegistrations
       parameters:
       - name: customerId
@@ -463,13 +673,39 @@ paths:
       tags:
       - Warranty Registrations
       summary: Create registration
-      description: Record sold/instantiated coverage
+      description: 'Records sold/instantiated coverage — a registration binding a governing policy to a customer, and optionally to a vehicle and the originating invoice line.
+
+        Use this tool when coverage such as a road-hazard add-on or extended plan is sold; do not use createPolicy, which defines the reusable program a registration instantiates.
+
+        Preconditions: the governing policy must exist; policies flagged autoRegister create registrations automatically from invoiced sales, so manual creation covers the remaining cases.
+
+        Required inputs: policyId (UUID), customerId (UUID), and purchaseDate (ISO date); vehicleId, source invoice references, contractNumber, and expiresAt are optional, and status defaults to ACTIVE.
+
+        Emits a WARRANTY_REGISTRATION_CREATE event.
+
+        Returns 404 when the referenced policy cannot be resolved.
+
+        '
       operationId: createRegistration
       requestBody:
+        description: 'Sold coverage to record: governing policy, covered customer and vehicle, and the originating sale references.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/RegistrationRequest'
+            examples:
+              Road-hazard registration:
+                description: Road-hazard registration
+                value:
+                  policyId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a30
+                  customerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                  vehicleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
+                  sourceInvoiceId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04
+                  sourceInvoiceLineId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a05
+                  contractNumber: RH-2026-88412
+                  purchaseDate: 2026-05-14
+                  expiresAt: 2029-05-14
+                  status: ACTIVE
         required: true
       responses:
         '201':
@@ -499,7 +735,19 @@ paths:
       tags:
       - Warranty Providers
       summary: List providers
-      description: Optionally filter by status and/or provider type
+      description: 'Returns warranty providers, optionally filtered by lifecycle status and/or provider type.
+
+        Use this tool to browse who funds warranty programs; use getProvider instead when the provider id is already known.
+
+        Preconditions: none — an empty list is returned when nothing matches.
+
+        Required inputs: status (ACTIVE or INACTIVE) and providerType (MANUFACTURER, DISTRIBUTOR_PROGRAM, THIRD_PARTY_ADMIN, DEALER) are optional query parameters; when both are given the status filter is applied first and provider type filters the result.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the list, which is empty rather than 404 when no provider matches.
+
+        '
       operationId: listProviders
       parameters:
       - name: status
@@ -536,13 +784,40 @@ paths:
       tags:
       - Warranty Providers
       summary: Create provider
-      description: Create a new warranty provider
+      description: 'Creates a warranty provider — the party that funds a warranty program, from a manufacturer or third-party administrator to the dealer itself.
+
+        Use this tool to register a new payer before configuring its policies with createPolicy; do not use updateProvider, which rewrites an existing provider.
+
+        Preconditions: none — there is no duplicate-name check, so repeating the call creates a second provider.
+
+        Required inputs: name and providerType (MANUFACTURER, DISTRIBUTOR_PROGRAM, THIRD_PARTY_ADMIN, or DEALER — DEALER means self-funded, which later makes vendor reimbursement NOT_APPLICABLE); status defaults to ACTIVE, and apVendorId optionally links the pos-accounting vendor for credit matching.
+
+        Emits a WARRANTY_PROVIDER_CREATE event; no policies or claims are touched.
+
+        Returns 201 with the created provider on success.
+
+        '
       operationId: createProvider
       requestBody:
+        description: 'Warranty provider to create: funding type, lifecycle status, and claim-submission contact details.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ProviderRequest'
+            examples:
+              Manufacturer provider:
+                description: Manufacturer provider
+                value:
+                  name: Michelin North America
+                  providerType: MANUFACTURER
+                  status: ACTIVE
+                  apVendorId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a20
+                  manufacturerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a11
+                  claimSubmissionMethod: Portal
+                  portalUrl: https://warranty.michelin.example.com
+                  contactName: Claims Desk
+                  contactPhone: +1-800-555-0100
+                  contactEmail: claims@michelin.example.com
         required: true
       responses:
         '201':
@@ -566,7 +841,19 @@ paths:
       tags:
       - Warranty Policies
       summary: List policies
-      description: Optionally filter by provider and/or coverage type
+      description: 'Returns warranty policies, optionally filtered by owning provider and/or coverage type.
+
+        Use this tool to browse configured coverage programs; use findApplicablePolicies instead to resolve which policies cover a specific product on a specific sale date.
+
+        Preconditions: none — an empty list is returned when nothing matches.
+
+        Required inputs: providerId and coverageType are optional query parameters; when both are given the provider filter is applied first and coverage type filters the result.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the list, which is empty rather than 404 when no policy matches.
+
+        '
       operationId: listPolicies
       parameters:
       - name: providerId
@@ -604,13 +891,45 @@ paths:
       tags:
       - Warranty Policies
       summary: Create policy
-      description: Create a new warranty policy
+      description: 'Creates a warranty policy — one row of structured coverage terms owned by a provider, governing eligibility, proration, and evidence requirements for claims.
+
+        Use this tool to configure a new coverage program; do not use updatePolicy, which fully replaces an existing policy, and do not use createRegistration, which records coverage sold to one customer under a policy.
+
+        Preconditions: the owning provider must exist; the appliesTo scope must be internally consistent — PRODUCT_LIST needs a non-empty appliesToProductEntityIds, CATEGORY needs appliesToCategoryId, MANUFACTURER needs appliesToManufacturerId — and effectiveTo must not precede effectiveFrom.
+
+        Required inputs: providerId (UUID), name, coverageType, appliesToType, effectiveFrom (ISO date), and prorationMethod (NONE, TREAD_DEPTH, MILEAGE, or TIME); laborCovered, requiresPartReturn, requiresPhotoEvidence, transferable, and autoRegister all default to false.
+
+        Emits a WARRANTY_POLICY_CREATE event; no claims or registrations are touched.
+
+        Returns 404 when the referenced provider cannot be resolved, and 400 when the appliesTo scope keys or the effective window are inconsistent.
+
+        '
       operationId: createPolicy
       requestBody:
+        description: 'Structured coverage terms of the program: scope, effective window, limits, proration method, and evidence requirements.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PolicyRequest'
+            examples:
+              Manufacturer tread-depth policy:
+                description: Manufacturer tread-depth policy
+                value:
+                  providerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a10
+                  name: Michelin passenger replacement — workmanship & materials
+                  coverageType: MANUFACTURER_DEFECT
+                  appliesToType: MANUFACTURER
+                  appliesToManufacturerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a11
+                  effectiveFrom: 2025-01-01
+                  durationMonths: 72
+                  treadPullPointThirtySeconds: 2
+                  laborCovered: false
+                  prorationMethod: TREAD_DEPTH
+                  requiresPartReturn: true
+                  requiresPhotoEvidence: true
+                  transferable: false
+                  autoRegister: false
+                  termsText: Prorated on remaining tread down to the 2/32 pull point.
         required: true
       responses:
         '201':
@@ -640,7 +959,19 @@ paths:
       tags:
       - Warranty Claims
       summary: Search claims
-      description: Paged claim summaries; filter by customer, vehicle, status, claim code, location
+      description: 'Searches warranty claims and returns a page of claim summaries filtered by customer, vehicle, status, claim code, and location.
+
+        Use this tool to locate claims by criteria or to browse a worklist; do not use getClaim, which requires a known claim id and returns the full detail including lines, settlements, and history.
+
+        Preconditions: none — an empty page is returned when nothing matches.
+
+        Required inputs: every filter is optional; claimCode must be exact (for example WC-2026-000123) and short-circuits the other filters to at most one match, and paging defaults to size 20 sorted by createdAt descending.
+
+        Emits a WARRANTY_CLAIM_SEARCH audit event; no claim state changes, this is a read-only projection.
+
+        Returns 200 with the page, which is empty rather than 404 when no claim matches.
+
+        '
       operationId: searchClaims
       parameters:
       - name: customerId
@@ -706,13 +1037,51 @@ paths:
       tags:
       - Warranty Claims
       summary: Create draft claim
-      description: Creates a DRAFT claim; snapshots VIN/odometer
+      description: 'Creates a DRAFT warranty claim for a customer and vehicle, assigning the next WC-{yyyy}-{seq} claim code and freezing the VIN and odometer snapshot from the event-fed vehicle replica when the vehicle fact has already arrived; walk-ins with no locatable sale leave the origin fields null and the claim is flagged originUnverified.
+
+        Use this tool to open a brand-new claim at intake; do not use updateClaim, which edits an existing DRAFT or INFO_NEEDED claim, and use searchCandidateLines first to locate the origin sale lines.
+
+        Preconditions: none beyond a known customerId and vehicleId — the vehicle replica may still be empty (the claim is created with a null snapshot) and no origin sale reference is required.
+
+        Required inputs: claimType (MANUFACTURER_DEFECT, DEALER_WORKMANSHIP, ROAD_HAZARD, or EXTENDED_PLAN), customerId (UUID), and vehicleId (UUID); locationId, origin workorder/invoice ids, originSaleDate, registrationId, failure details, photoEvidenceUrls, and initial lines are optional, and each line''s quantity defaults to 1.
+
+        Emits a WARRANTY_CLAIM_CREATE event, records a DRAFT status-history row, and publishes the claim snapshot.
+
+        Returns 201 with the DRAFT claim; there is no duplicate check, so repeating the call creates a second claim.
+
+        '
       operationId: createClaim
       requestBody:
+        description: 'Draft-claim intake payload: customer, vehicle, claim type, and optional origin references, failure details, photos, and initial lines.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ClaimCreateRequest'
+            examples:
+              Road-hazard tire claim:
+                description: Road-hazard tire claim
+                value:
+                  claimType: ROAD_HAZARD
+                  customerId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01
+                  vehicleId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02
+                  locationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03
+                  originInvoiceId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04
+                  originSaleDate: 2025-11-02
+                  failureDescription: Sidewall puncture, right rear tire
+                  failureDate: 2026-08-10
+                  photoEvidenceUrls:
+                  - https://media.example.com/claims/tire-1.jpg
+                  lines:
+                  - sourceType: INVOICE_LINE
+                    sourceId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04
+                    sourceLineId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a05
+                    productEntityId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a06
+                    sku: MICH-DEF2-225-65R17
+                    description: Michelin Defender2 225/65R17
+                    quantity: 1
+                    originalUnitPrice: 189.99
+                    originalTreadDepth: 12
+                    measuredTreadDepth: 9
         required: true
       responses:
         '201':
@@ -736,7 +1105,19 @@ paths:
       tags:
       - Warranty Claims
       summary: Submit claim
-      description: 'Intake complete: runs eligibility, then DRAFT→SUBMITTED (or INFO_NEEDED→IN_REVIEW)'
+      description: 'Completes intake by running the eligibility evaluation and then moving the claim DRAFT to SUBMITTED, or INFO_NEEDED back to IN_REVIEW once the requested information is provided.
+
+        Use this tool when intake is finished; do not use decideClaim, which records the adjudication outcome, and do not use evaluateClaimEligibility, which recomputes the suggestion without any status change.
+
+        Preconditions: the claim must be DRAFT or INFO_NEEDED, must have at least one claim line, and must carry at least one photo when the winning policy requires photo evidence.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body — eligibility, policy selection, and per-line proration are computed server-side and persisted onto the claim.
+
+        Emits a WARRANTY_CLAIM_SUBMIT event and republishes the claim snapshot.
+
+        Returns 400 when the claim has no lines or the selected policy requires missing photo evidence, 404 when the claim does not exist, and 409 when the current status does not allow submit (nextAction lists the legal moves).
+
+        '
       operationId: submitClaim
       parameters:
       - name: id
@@ -780,7 +1161,19 @@ paths:
       tags:
       - Warranty Settlements
       summary: Execute a settlement
-      description: 'Executes one settlement on an APPROVED (or already SETTLED) claim: creates an invoice adjustment/refund via pos-invoice for credit/refund types, links a validated replacement workorder, or records NO_ACTION. The first successful settlement moves the claim to SETTLED.'
+      description: 'Executes one settlement on an APPROVED or already SETTLED claim: credit types (INVOICE_CREDIT, PRORATED_CREDIT, GOODWILL) create an invoice adjustment via pos-invoice, REFUND initiates a refund of a captured payment via pos-invoice, REPLACEMENT_WORKORDER links a workorder that staff already created through the normal flow, and NO_ACTION records that nothing is owed.
+
+        Use this tool when the clerk settles the customer; do not use decideClaim, which approves the claim first, and do not use submitReimbursement, which is the later vendor-recovery step that never blocks customer settlement.
+
+        Preconditions: the claim must be APPROVED or SETTLED (concurrent settlements of the same claim are serialized under a pessimistic lock), a replacement workorder must already exist in the event-fed workorder replica, and pos-invoice writes carry the settlement id as the idempotency key (externalReference).
+
+        Required inputs: claim id (UUID) and a body with settlementType, coveredAmount, and customerAmount (both zero or positive); replacementWorkorderId is required for REPLACEMENT_WORKORDER, invoiceId for the credit types, and invoiceId plus paymentId for REFUND.
+
+        Emits a WARRANTY_CLAIM_SETTLE event and enqueues warranty.claim.settled for pos-accounting; the first successful settlement moves the claim APPROVED to SETTLED, and a failed pos-invoice write keeps a durable FAILED settlement row for the reconciliation worklist.
+
+        Returns 400 when the type-specific reference id is missing, 404 when the claim does not exist, 409 when the claim is not settleable, 422 when the replacement workorder cannot be resolved, and 502 when the pos-invoice write fails (the settlement is recorded FAILED and staff retry with a fresh settlement after checking reconcileSettlements).
+
+        '
       operationId: createSettlement
       parameters:
       - name: id
@@ -791,10 +1184,20 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: 'Settlement to execute: how the customer is made whole, the covered and customer amounts, and the type-specific reference ids.'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SettlementCreateRequest'
+            examples:
+              Prorated credit:
+                description: Prorated credit
+                value:
+                  settlementType: PRORATED_CREDIT
+                  coveredAmount: 142.49
+                  customerAmount: 47.5
+                  invoiceId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04
+                  notes: Prorated at 75% remaining tread
         required: true
       responses:
         '201':
@@ -836,7 +1239,19 @@ paths:
       tags:
       - Warranty Reimbursements
       summary: Submit vendor reimbursement
-      description: Creates/updates the claim's single reimbursement NOT_SUBMITTED -> SUBMITTED; claim must be APPROVED or SETTLED and provider must not be dealer-funded
+      description: 'Submits the claim''s single vendor reimbursement to the warranty provider, creating the record if needed and moving it NOT_SUBMITTED to SUBMITTED.
+
+        Use this tool for the back-office recovery step after the customer is settled; do not use updateReimbursement, which records the vendor''s decision, credit receipt, or write-off on an already-submitted reimbursement.
+
+        Preconditions: the claim must be APPROVED or SETTLED (settle-customer-first), must have a provider assigned, the provider must not be DEALER-funded (self-funded programs are NOT_APPLICABLE), and the reimbursement must still be NOT_SUBMITTED — each claim has at most one.
+
+        Required inputs: claim id (UUID) as a path parameter and a body with amountRequested (positive decimal); vendorClaimReference and notes are optional.
+
+        Emits a WARRANTY_REIMBURSEMENT_SUBMIT event and enqueues warranty.reimbursement.submitted so pos-accounting can expect the vendor credit; the claim''s own status is never touched.
+
+        Returns 404 when the claim or its provider cannot be resolved, and 409 when the claim state disallows submission, no provider is assigned, the provider is dealer-funded, or the reimbursement was already submitted (including a concurrent submit).
+
+        '
       operationId: submitReimbursement
       parameters:
       - name: id
@@ -847,10 +1262,18 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Amount requested from the vendor with an optional vendor claim reference and back-office notes.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ReimbursementSubmitRequest'
+            examples:
+              Portal submission:
+                description: Portal submission
+                value:
+                  amountRequested: 145.5
+                  vendorClaimReference: MICH-CLM-99120
+                  notes: Submitted via provider portal
         required: true
       responses:
         '200':
@@ -880,8 +1303,20 @@ paths:
       tags:
       - Warranty Claims
       summary: Add photo
-      description: Attach a photo-evidence URL while DRAFT or INFO_NEEDED
-      operationId: addPhoto
+      description: 'Attaches one photo-evidence URL to a claim that is still DRAFT or INFO_NEEDED; a URL that is already attached is kept once, so the add is idempotent.
+
+        Use this tool to attach evidence the governing policy may require before submission; do not use removeClaimPhoto, which detaches a URL, and do not use updateClaim for single-photo changes because its photoEvidenceUrls field replaces the whole list.
+
+        Preconditions: the claim must exist and be in DRAFT or INFO_NEEDED.
+
+        Required inputs: id (UUID) as a path parameter and a body with url (max 2048 characters); the image itself is stored elsewhere — warranty keeps only the URL reference.
+
+        Emits a WARRANTY_CLAIM_UPDATE event and republishes the claim snapshot.
+
+        Returns 404 when the claim does not exist, and 409 when the claim is not editable in its current status.
+
+        '
+      operationId: addClaimPhoto
       parameters:
       - name: id
         in: path
@@ -891,10 +1326,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Photo-evidence URL to attach to the claim (URL-reference pattern; the image is hosted elsewhere).
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ClaimPhotoRequest'
+            examples:
+              Tire photo:
+                description: Tire photo
+                value:
+                  url: https://media.example.com/claims/wc-2026-000123/tire-1.jpg
         required: true
       responses:
         '200':
@@ -923,8 +1364,20 @@ paths:
       tags:
       - Warranty Claims
       summary: Remove photo
-      description: Detach a photo-evidence URL while DRAFT or INFO_NEEDED
-      operationId: removePhoto
+      description: 'Detaches one photo-evidence URL from a claim that is still DRAFT or INFO_NEEDED.
+
+        Use this tool to withdraw a wrongly attached photo; do not use addClaimPhoto, which attaches a URL, and do not use updateClaim for single-photo changes because its list field is full-replace.
+
+        Preconditions: the claim must exist, be in DRAFT or INFO_NEEDED, and the URL must currently be attached.
+
+        Required inputs: id (UUID) as a path parameter and url as a query parameter matching the attached URL exactly; there is no request body.
+
+        Emits a WARRANTY_CLAIM_UPDATE event and republishes the claim snapshot.
+
+        Returns 404 when the claim does not exist or the URL is not attached, and 409 when the claim is not editable in its current status.
+
+        '
+      operationId: removeClaimPhoto
       parameters:
       - name: id
         in: path
@@ -968,7 +1421,19 @@ paths:
       tags:
       - Warranty Part Returns
       summary: Create part return (RMA)
-      description: Opens the RMA lifecycle for one claim line (at most one per line); starts AWAITING_PART
+      description: 'Opens the defective-part RMA lifecycle for one claim line, creating a part return in AWAITING_PART with the chosen disposition.
+
+        Use this tool when the governing policy requires the part back or staff choose to hold or return it; do not use updatePartReturn, which advances or annotates an RMA that already exists — at most one part return is allowed per claim line.
+
+        Preconditions: the claim must exist and not be CANCELLED or CLOSED, the line must belong to the claim, and no part return may already exist for that line; no policy check gates creation because staff choice is always permitted.
+
+        Required inputs: claim id (UUID) as a path parameter and a body with claimLineId (UUID) and disposition (HOLD_FOR_INSPECTION, RETURN_TO_VENDOR, SCRAP_AUTHORIZED, or CUSTOMER_RETAINED); rmaNumber and holdLocationNote are optional.
+
+        Emits a WARRANTY_PART_RETURN_CREATE event, enqueues warranty.part-return.requested so pos-inventory can quarantine the defective unit, and republishes the claim snapshot.
+
+        Returns 404 when the claim or the line cannot be found, and 409 when the line already has a part return or the claim is terminal.
+
+        '
       operationId: createPartReturn
       parameters:
       - name: id
@@ -979,10 +1444,19 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Claim line whose defective part is being returned or held, with its disposition and optional RMA details.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/PartReturnCreateRequest'
+            examples:
+              Return to vendor:
+                description: Return to vendor
+                value:
+                  claimLineId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a07
+                  disposition: RETURN_TO_VENDOR
+                  rmaNumber: RMA-88231
+                  holdLocationNote: Hold shelf B3
         required: true
       responses:
         '201':
@@ -1012,8 +1486,20 @@ paths:
       tags:
       - Warranty Claims
       summary: Add note
-      description: Append a free-form staff note (any status)
-      operationId: addNote
+      description: 'Appends one free-form, append-only staff note to a warranty claim in any status.
+
+        Use this tool to record context that is not a status change; do not use decideClaim or updateClaim, which mutate the claim itself — notes are never editable or deletable once written.
+
+        Preconditions: the claim must exist; there is no status restriction.
+
+        Required inputs: id (UUID) as a path parameter and a body with note (non-blank, max 10000 characters).
+
+        Emits a WARRANTY_CLAIM_UPDATE event; the claim''s own fields and status are untouched.
+
+        Returns 201 with the full claim detail including the new note, and 404 when the claim does not exist.
+
+        '
+      operationId: addClaimNote
       parameters:
       - name: id
         in: path
@@ -1023,10 +1509,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Free-form staff note text to append to the claim's audit trail.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ClaimNoteRequest'
+            examples:
+              Staff note:
+                description: Staff note
+                value:
+                  note: Customer called; defective tire is on hold shelf B3
         required: true
       responses:
         '201':
@@ -1050,8 +1542,20 @@ paths:
       tags:
       - Warranty Claims
       summary: Add claim line
-      description: Add a failed part/service line while DRAFT or INFO_NEEDED
-      operationId: addLine
+      description: 'Adds one failed part or service line to a claim that is still DRAFT or INFO_NEEDED, snapshotting SKU, description, serial numbers, price, and tread depths at intake.
+
+        Use this tool to build the claim''s line list; do not use updateClaim, which edits header fields and cannot touch lines, and use removeClaimLine to take a line off.
+
+        Preconditions: the claim must exist and be in DRAFT or INFO_NEEDED.
+
+        Required inputs: id (UUID) as a path parameter and a line body with sourceType (INVOICE_LINE, WORKORDER_PART, WORKORDER_SERVICE, or MANUAL); sourceId and sourceLineId are null for MANUAL lines, quantity defaults to 1, and tread depths are integers in 32nds of an inch.
+
+        Emits a WARRANTY_CLAIM_UPDATE event and republishes the claim snapshot.
+
+        Returns 404 when the claim does not exist, and 409 when the claim is not editable in its current status.
+
+        '
+      operationId: addClaimLine
       parameters:
       - name: id
         in: path
@@ -1061,10 +1565,24 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: One failed part or service line with its source provenance and intake snapshots.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ClaimLineRequest'
+            examples:
+              Manual tire line:
+                description: Manual tire line
+                value:
+                  sourceType: MANUAL
+                  sku: MICH-DEF2-225-65R17
+                  description: Michelin Defender2 225/65R17
+                  serialNumber: SN-4471002
+                  dotNumber: DOT Y9RJ FPUU 2325
+                  quantity: 1
+                  originalUnitPrice: 189.99
+                  originalTreadDepth: 12
+                  measuredTreadDepth: 9
         required: true
       responses:
         '200':
@@ -1094,8 +1612,20 @@ paths:
       tags:
       - Warranty Claims
       summary: Re-run eligibility
-      description: Recompute the eligibility suggestion on demand (DRAFT, SUBMITTED, IN_REVIEW, or INFO_NEEDED only)
-      operationId: evaluateEligibility
+      description: 'Recomputes the eligibility suggestion — result, reasons, suggested outcome, policy selection, and per-line proration — on demand without changing the claim status.
+
+        Use this tool after intake data changes to refresh the suggestion; do not use submitClaim, which also runs eligibility but performs the lifecycle move, and do not use decideClaim, which records the human decision that may override the suggestion.
+
+        Preconditions: the claim must be DRAFT, SUBMITTED, IN_REVIEW, or INFO_NEEDED — once decided (APPROVED, DENIED, SETTLED) the persisted inputs are frozen audit evidence, and a DENIED claim regains recompute only through an appeal back to IN_REVIEW.
+
+        Required inputs: id (UUID) as a path parameter; there is no request body.
+
+        Emits a WARRANTY_CLAIM_UPDATE event and republishes the claim snapshot with the recomputed suggestion.
+
+        Returns 404 when the claim does not exist, and 409 when the claim is already decided or terminal.
+
+        '
+      operationId: evaluateClaimEligibility
       parameters:
       - name: id
         in: path
@@ -1132,7 +1662,19 @@ paths:
       tags:
       - Warranty Claims
       summary: Decide claim
-      description: APPROVE/DENY/REQUEST_INFO (implicitly begins review on a SUBMITTED claim); APPEAL reopens a DENIED claim. Deny, appeal, and suggestion overrides require a reason. Optional lineDecisions record per-line approved amounts/dispositions; amounts that differ from the computed request require an audited override reason
+      description: 'Records the human adjudication decision on a claim — APPROVE, DENY, or REQUEST_INFO, where a decision on a SUBMITTED claim implicitly begins review first — while APPEAL reopens a DENIED claim back to IN_REVIEW and clears the standing decision (the denial stays audited in the status history).
+
+        Use this tool to adjudicate; do not use submitClaim, which moves intake into adjudication, and do not use createSettlement, which executes the payout only after approval.
+
+        Preconditions: the claim must be SUBMITTED, IN_REVIEW, or DENIED (APPEAL only); DENY and APPEAL require a reason, and a decision contradicting the computed suggestion (approving an INELIGIBLE or denying an ELIGIBLE claim) also requires a reason and marks the claim overrodeSuggestion.
+
+        Required inputs: id (UUID) and a body with decision; optional lineDecisions (APPROVE/DENY only) set per-line amountApproved and lineDisposition, omitted lines default to the computed amountRequested on approve or to DENIED on deny, and an amountApproved differing from the computed amount requires an overrideReason that is audited as a claim note.
+
+        Emits a WARRANTY_CLAIM_DECIDE event and republishes the claim snapshot.
+
+        Returns 400 when a required reason or overrideReason is missing or lineDecisions accompany REQUEST_INFO, 404 when the claim or a referenced line does not exist, and 409 when the current status does not allow the move (nextAction lists the legal moves).
+
+        '
       operationId: decideClaim
       parameters:
       - name: id
@@ -1143,10 +1685,22 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Adjudication action with its reason and optional per-line approved amounts and dispositions.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ClaimDecisionRequest'
+            examples:
+              Approve with line override:
+                description: Approve with line override
+                value:
+                  decision: APPROVE
+                  reason: Covered failure verified against policy terms
+                  lineDecisions:
+                  - lineId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a07
+                    amountApproved: 142.49
+                    lineDisposition: PARTIALLY_APPROVED
+                    overrideReason: Prorated to 75% remaining tread per manual gauge reading
         required: true
       responses:
         '200':
@@ -1182,7 +1736,19 @@ paths:
       tags:
       - Warranty Claims
       summary: Close claim
-      description: Close from SETTLED or DENIED once every reimbursement and part return is terminal
+      description: 'Closes a warranty claim, moving SETTLED or DENIED to the terminal CLOSED status once every child record is terminal.
+
+        Use this tool to finish the back-office lifecycle after the customer journey is done; do not use cancelClaim, which abandons a claim before adjudication — open children block CLOSED but never SETTLED (settle-customer-first).
+
+        Preconditions: the claim must be SETTLED or DENIED; every vendor reimbursement must be terminal (CREDIT_RECEIVED, WRITTEN_OFF, NOT_APPLICABLE, or DENIED), every part return must be terminal (RECEIVED_BY_VENDOR, SCRAPPED, or CLOSED), and a SETTLED claim whose policy requires part return must have at least one part return on record.
+
+        Required inputs: id (UUID) as a path parameter; the body is optional and carries only a reason recorded in the status history.
+
+        Emits a WARRANTY_CLAIM_CLOSE event and republishes the claim snapshot.
+
+        Returns 404 when the claim does not exist, and 409 when the transition is illegal or open child records block closing (WARRANTY_CLAIM_CLOSE_BLOCKED, with nextAction describing what to resolve).
+
+        '
       operationId: closeClaim
       parameters:
       - name: id
@@ -1193,10 +1759,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Optional closure reason recorded in the claim status history.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ClaimActionRequest'
+            examples:
+              Close with reason:
+                description: Close with reason
+                value:
+                  reason: Vendor credit received; RMA received by vendor
       responses:
         '200':
           description: Claim closed.
@@ -1225,7 +1797,19 @@ paths:
       tags:
       - Warranty Claims
       summary: Cancel claim
-      description: Cancel from DRAFT, SUBMITTED, or INFO_NEEDED
+      description: 'Cancels a warranty claim, moving DRAFT, SUBMITTED, or INFO_NEEDED to the terminal CANCELLED status with an audited status-history row.
+
+        Use this tool when the customer or staff abandons the claim before adjudication completes; do not use closeClaim, which finishes a SETTLED or DENIED claim after its child records are terminal.
+
+        Preconditions: the claim must be DRAFT, SUBMITTED, or INFO_NEEDED — IN_REVIEW, APPROVED, DENIED, SETTLED, and terminal claims cannot be cancelled.
+
+        Required inputs: id (UUID) as a path parameter; the body is optional and carries only a reason recorded in the status history.
+
+        Emits a WARRANTY_CLAIM_CANCEL event and republishes the claim snapshot.
+
+        Returns 404 when the claim does not exist, and 409 when the current status does not allow cancellation (nextAction lists the legal moves).
+
+        '
       operationId: cancelClaim
       parameters:
       - name: id
@@ -1236,10 +1820,16 @@ paths:
           type: string
           format: uuid
       requestBody:
+        description: Optional cancellation reason recorded in the claim status history.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ClaimActionRequest'
+            examples:
+              Cancel with reason:
+                description: Cancel with reason
+                value:
+                  reason: Customer withdrew the claim
       responses:
         '200':
           description: Claim cancelled.
@@ -1268,7 +1858,19 @@ paths:
       tags:
       - Warranty Settlements
       summary: Reconcile FAILED settlements against pos-invoice
-      description: 'Read-only worklist (issue #922): every FAILED adjustment/refund settlement checked against pos-invoice by its externalReference (the settlement id). Rows with committedOnInvoice=true are the double-pay risk — pos-invoice committed the money write even though warranty recorded the settlement as FAILED. Rows with checkStatus=UNKNOWN could not be verified (pos-invoice unreachable) and should be re-checked.'
+      description: 'Builds the reconciliation worklist for FAILED invoice-writing settlements by asking pos-invoice whether each adjustment or refund actually committed, matched by externalReference (the settlement id).
+
+        Use this tool to detect double-pay risk after a settlement failure; do not retry with createSettlement until the row shows committedOnInvoice=false — committedOnInvoice=true means pos-invoice committed the money write even though warranty recorded the settlement as FAILED.
+
+        Preconditions: none — only settlements already recorded FAILED with an invoice-writing type appear, and pos-invoice is consulted live at request time.
+
+        Required inputs: none; there are no parameters and no request body.
+
+        Emits a WARRANTY_SETTLEMENT_RECONCILIATION audit event; no state changes, this is a read-only cross-service check.
+
+        Returns 200 with one row per FAILED settlement, where checkStatus UNKNOWN means pos-invoice was unreachable for that invoice and the worklist should be re-run before acting.
+
+        '
       operationId: reconcileSettlements
       responses:
         '200':
@@ -1288,7 +1890,19 @@ paths:
       tags:
       - Warranty Reimbursements
       summary: Reimbursement worklist
-      description: Back-office worklist of vendor reimbursements, filterable by status and provider
+      description: 'Returns the back-office worklist of vendor reimbursements across all claims, optionally filtered by status and provider.
+
+        Use this tool to work open vendor credits; use getClaim instead to see the reimbursement of one specific claim.
+
+        Preconditions: none — an empty list is returned when nothing matches.
+
+        Required inputs: status and providerId are optional query parameters and combine as AND when both are given; omitting both returns every reimbursement.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the list, which is empty rather than 404 when nothing matches.
+
+        '
       operationId: listReimbursements
       parameters:
       - name: status
@@ -1331,7 +1945,19 @@ paths:
       tags:
       - Warranty Policies
       summary: Find applicable policies
-      description: Policies in effect on the sale date whose appliesTo scope matches any provided key, ordered most-specific-first (PRODUCT > MANUFACTURER > CATEGORY > ALL)
+      description: 'Resolves the policies in effect on the original sale date whose appliesTo scope matches any provided catalog key, ordered most-specific-first (PRODUCT_LIST, then MANUFACTURER, then CATEGORY, then ALL).
+
+        Use this tool during intake or eligibility work to find the governing policy for a product; do not use listPolicies, which lists policies without effective-date or scope matching.
+
+        Preconditions: policies must exist with an effectiveFrom/effectiveTo window covering the sale date; ALL-scoped policies always match, while scoped policies match only when the corresponding key is provided and equal.
+
+        Required inputs: saleDate (ISO-8601 date) is required; productEntityId, manufacturerId, and categoryId are optional pos-catalog keys, and coverageType optionally restricts the result to one coverage type.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with matching policies most specific first (empty when none match), and 400 when saleDate is missing or malformed.
+
+        '
       operationId: findApplicablePolicies
       parameters:
       - name: productEntityId
@@ -1399,7 +2025,19 @@ paths:
       tags:
       - Warranty Part Returns
       summary: Part-return worklist
-      description: Hold-shelf / shipping worklist of part returns, filterable by status
+      description: 'Returns the hold-shelf and shipping worklist of part returns across all claims, optionally filtered by status.
+
+        Use this tool to drive the back-office RMA worklist; use getClaim instead to see the part returns of one specific claim.
+
+        Preconditions: none — an empty list is returned when nothing matches.
+
+        Required inputs: status is an optional query parameter (AWAITING_PART, ON_HOLD, SHIPPED, RECEIVED_BY_VENDOR, SCRAPPED, CLOSED); omitting it returns every part return.
+
+        No events are emitted and no state changes; this is a read-only projection.
+
+        Returns 200 with the list, which is empty rather than 404 when no part return matches.
+
+        '
       operationId: listPartReturns
       parameters:
       - name: status
@@ -1433,7 +2071,19 @@ paths:
       tags:
       - Warranty Claims
       summary: Search candidate origin lines
-      description: Cross-service search of invoices and workorders for origin-line matching (PRD §7 step 2)
+      description: 'Searches the event-fed invoice and workorder replicas for a customer''s historical sale lines that could be the origin of a warranty claim (PRD §7 step 2).
+
+        Use this tool during intake to match a failed part to its original sale before creating claim lines; do not use searchClaims, which searches existing warranty claims rather than origin sales.
+
+        Preconditions: the replicas are eventually consistent and each source degrades independently — a read failure on one source still returns the other''s results, and a very recent sale may not have arrived yet.
+
+        Required inputs: customerId (UUID) is required; vehicleId, sku, and productEntityId optionally narrow the match, workorder parts match by productEntityId directly while invoice and service lines match by description tokens, and fan-out is capped at 25 invoices and 25 workorders.
+
+        Emits a WARRANTY_CANDIDATE_LINE_SEARCH audit event; no state changes, this is a read-only cross-replica projection.
+
+        Returns 200 with candidate lines, which may be empty or partial — the clerk falls back to manual origin entry (originUnverified) when the sale cannot be located.
+
+        '
       operationId: searchCandidateLines
       parameters:
       - name: customerId
@@ -1481,8 +2131,20 @@ paths:
       tags:
       - Warranty Claims
       summary: Remove claim line
-      description: Remove a claim line while DRAFT or INFO_NEEDED
-      operationId: removeLine
+      description: 'Removes one line from a claim that is still DRAFT or INFO_NEEDED.
+
+        Use this tool to drop a mistakenly added line; do not use addClaimLine, which appends a line — there is no line-edit operation, so correcting a line means removing and re-adding it.
+
+        Preconditions: the claim must exist, be in DRAFT or INFO_NEEDED, and the line must belong to the claim.
+
+        Required inputs: id and lineId (UUIDs) as path parameters; there is no request body.
+
+        Emits a WARRANTY_CLAIM_UPDATE event and republishes the claim snapshot.
+
+        Returns 404 when the claim does not exist or the line is not on the claim, and 409 when the claim is not editable in its current status.
+
+        '
+      operationId: removeClaimLine
       parameters:
       - name: id
         in: path
@@ -1774,10 +2436,12 @@ components:
           type: integer
           format: int32
           description: Time limit in months from sale date; null = unlimited
+          minimum: 0
         mileageLimit:
           type: integer
           format: int32
           description: Miles from sale odometer; null = n/a
+          minimum: 0
         treadPullPointThirtySeconds:
           type: integer
           format: int32
@@ -2446,6 +3110,7 @@ components:
         amountApproved:
           type: number
           description: Amount the vendor approved (required for APPROVED / PARTIALLY_APPROVED)
+          minimum: 0
         creditReference:
           type: string
           description: Vendor credit/payment reference (typically with CREDIT_RECEIVED)
@@ -2660,9 +3325,11 @@ components:
         coveredAmount:
           type: number
           description: Amount coverage pays
+          minimum: 0
         customerAmount:
           type: number
           description: Amount the customer still owes (proration remainder, upcharge, fees)
+          minimum: 0
         replacementWorkorderId:
           type: string
           format: uuid
@@ -2751,6 +3418,7 @@ components:
         amountRequested:
           type: number
           description: Amount requested from the vendor
+          minimum: 0
         vendorClaimReference:
           type: string
           description: The vendor's own claim reference number, if already assigned
@@ -3004,12 +3672,12 @@ components:
     PageClaimSummaryResponse:
       type: object
       properties:
-        totalElements:
-          type: integer
-          format: int64
         totalPages:
           type: integer
           format: int32
+        totalElements:
+          type: integer
+          format: int64
         size:
           type: integer
           format: int32
@@ -3024,13 +3692,13 @@ components:
           $ref: '#/components/schemas/SortObject'
         pageable:
           $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
         first:
           type: boolean
         last:
           type: boolean
-        numberOfElements:
-          type: integer
-          format: int32
         empty:
           type: boolean
     PageableObject:
@@ -3039,16 +3707,16 @@ components:
         offset:
           type: integer
           format: int64
-        sort:
-          $ref: '#/components/schemas/SortObject'
-        paged:
-          type: boolean
         pageNumber:
           type: integer
           format: int32
         pageSize:
           type: integer
           format: int32
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        paged:
+          type: boolean
         unpaged:
           type: boolean
     SortObject:

--- a/pos-warranty/openapi.yaml
+++ b/pos-warranty/openapi.yaml
@@ -595,6 +595,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReimbursementResponse'
+        '400':
+          description: Target status outside the updatable set, or amountApproved missing when required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReimbursementResponse'
         '404':
           description: Claim or reimbursement not found.
           content:
@@ -3707,16 +3713,16 @@ components:
         offset:
           type: integer
           format: int64
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        paged:
+          type: boolean
         pageNumber:
           type: integer
           format: int32
         pageSize:
           type: integer
           format: int32
-        sort:
-          $ref: '#/components/schemas/SortObject'
-        paged:
-          type: boolean
         unpaged:
           type: boolean
     SortObject:

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/ClaimController.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/ClaimController.java
@@ -17,6 +17,8 @@ import com.positivity.warranty.internal.service.CandidateLineService;
 import com.positivity.warranty.internal.service.ClaimService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -58,24 +60,119 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/warranty/claims")
 public class ClaimController {
 
+    private static final String CLAIM_CREATE_EXAMPLE = """
+            {"claimType":"ROAD_HAZARD",
+             "customerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01",
+             "vehicleId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02",
+             "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03",
+             "originInvoiceId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04",
+             "originSaleDate":"2025-11-02",
+             "failureDescription":"Sidewall puncture, right rear tire",
+             "failureDate":"2026-08-10",
+             "photoEvidenceUrls":["https://media.example.com/claims/tire-1.jpg"],
+             "lines":[{"sourceType":"INVOICE_LINE",
+                       "sourceId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04",
+                       "sourceLineId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a05",
+                       "productEntityId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a06",
+                       "sku":"MICH-DEF2-225-65R17",
+                       "description":"Michelin Defender2 225/65R17",
+                       "quantity":1,
+                       "originalUnitPrice":189.99,
+                       "originalTreadDepth":12,
+                       "measuredTreadDepth":9}]}
+            """;
+
+    private static final String CLAIM_UPDATE_EXAMPLE = """
+            {"claimType":"ROAD_HAZARD",
+             "locationId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03",
+             "originInvoiceId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04",
+             "originSaleDate":"2025-11-02",
+             "failureDescription":"Sidewall puncture, right rear tire — updated after inspection",
+             "failureDate":"2026-08-09"}
+            """;
+
+    private static final String CLAIM_LINE_EXAMPLE = """
+            {"sourceType":"MANUAL",
+             "sku":"MICH-DEF2-225-65R17",
+             "description":"Michelin Defender2 225/65R17",
+             "serialNumber":"SN-4471002",
+             "dotNumber":"DOT Y9RJ FPUU 2325",
+             "quantity":1,
+             "originalUnitPrice":189.99,
+             "originalTreadDepth":12,
+             "measuredTreadDepth":9}
+            """;
+
+    private static final String CLAIM_DECISION_EXAMPLE = """
+            {"decision":"APPROVE",
+             "reason":"Covered failure verified against policy terms",
+             "lineDecisions":[{"lineId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a07",
+                               "amountApproved":142.49,
+                               "lineDisposition":"PARTIALLY_APPROVED",
+                               "overrideReason":"Prorated to 75% remaining tread per manual gauge reading"}]}
+            """;
+
     private final ClaimService claimService;
     private final CandidateLineService candidateLineService;
 
     // ------------------------------------------------------------------ intake / read
 
-    @Operation(summary = "Create draft claim", description = "Creates a DRAFT claim; snapshots VIN/odometer")
+    @Operation(operationId = "createClaim", summary = "Create draft claim", description = """
+                    Creates a DRAFT warranty claim for a customer and vehicle, assigning the next WC-{yyyy}-{seq} \
+                    claim code and freezing the VIN and odometer snapshot from the event-fed vehicle replica when \
+                    the vehicle fact has already arrived; walk-ins with no locatable sale leave the origin fields \
+                    null and the claim is flagged originUnverified.
+                    Use this tool to open a brand-new claim at intake; do not use updateClaim, which edits an \
+                    existing DRAFT or INFO_NEEDED claim, and use searchCandidateLines first to locate the origin \
+                    sale lines.
+                    Preconditions: none beyond a known customerId and vehicleId — the vehicle replica may still be \
+                    empty (the claim is created with a null snapshot) and no origin sale reference is required.
+                    Required inputs: claimType (MANUFACTURER_DEFECT, DEALER_WORKMANSHIP, ROAD_HAZARD, or \
+                    EXTENDED_PLAN), customerId (UUID), and vehicleId (UUID); locationId, origin \
+                    workorder/invoice ids, originSaleDate, registrationId, failure details, photoEvidenceUrls, and \
+                    initial lines are optional, and each line's quantity defaults to 1.
+                    Emits a WARRANTY_CLAIM_CREATE event, records a DRAFT status-history row, and publishes the \
+                    claim snapshot.
+                    Returns 201 with the DRAFT claim; there is no duplicate check, so repeating the call creates a \
+                    second claim.
+                    """)
     @ApiResponse(responseCode = "201", description = "Claim created.")
     @ApiResponse(responseCode = "400", description = "Invalid request.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.CLAIM_CREATE + "')")
     @EmitEvent(id = "WARRANTY_CLAIM_CREATE", apiVersion = "1")
     @PostMapping
-    public ResponseEntity<ClaimResponse> createClaim(@Valid @NotNull @RequestBody ClaimCreateRequest request) {
+    public ResponseEntity<ClaimResponse> createClaim(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Draft-claim intake payload: customer, vehicle, claim type, and optional"
+                                    + " origin references, failure details, photos, and initial lines.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Road-hazard tire claim",
+                                                            value = CLAIM_CREATE_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    ClaimCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(claimService.create(request));
     }
 
-    @Operation(
-            summary = "Search claims",
-            description = "Paged claim summaries; filter by customer, vehicle, status, claim code, location")
+    @Operation(operationId = "searchClaims", summary = "Search claims", description = """
+                    Searches warranty claims and returns a page of claim summaries filtered by customer, vehicle, \
+                    status, claim code, and location.
+                    Use this tool to locate claims by criteria or to browse a worklist; do not use getClaim, which \
+                    requires a known claim id and returns the full detail including lines, settlements, and history.
+                    Preconditions: none — an empty page is returned when nothing matches.
+                    Required inputs: every filter is optional; claimCode must be exact (for example WC-2026-000123) \
+                    and short-circuits the other filters to at most one match, and paging defaults to size 20 \
+                    sorted by createdAt descending.
+                    Emits a WARRANTY_CLAIM_SEARCH audit event; no claim state changes, this is a read-only \
+                    projection.
+                    Returns 200 with the page, which is empty rather than 404 when no claim matches.
+                    """)
     @ApiResponse(responseCode = "200", description = "Claims returned.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.CLAIM_VIEW + "')")
     @EmitEvent(id = "WARRANTY_CLAIM_SEARCH", apiVersion = "1")
@@ -91,9 +188,23 @@ public class ClaimController {
         return ResponseEntity.ok(claimService.search(customerId, vehicleId, status, claimCode, locationId, pageable));
     }
 
-    @Operation(
-            summary = "Search candidate origin lines",
-            description = "Cross-service search of invoices and workorders for origin-line matching (PRD §7 step 2)")
+    @Operation(operationId = "searchCandidateLines", summary = "Search candidate origin lines", description = """
+                    Searches the event-fed invoice and workorder replicas for a customer's historical sale lines \
+                    that could be the origin of a warranty claim (PRD §7 step 2).
+                    Use this tool during intake to match a failed part to its original sale before creating claim \
+                    lines; do not use searchClaims, which searches existing warranty claims rather than origin \
+                    sales.
+                    Preconditions: the replicas are eventually consistent and each source degrades independently — \
+                    a read failure on one source still returns the other's results, and a very recent sale may not \
+                    have arrived yet.
+                    Required inputs: customerId (UUID) is required; vehicleId, sku, and productEntityId optionally \
+                    narrow the match, workorder parts match by productEntityId directly while invoice and service \
+                    lines match by description tokens, and fan-out is capped at 25 invoices and 25 workorders.
+                    Emits a WARRANTY_CANDIDATE_LINE_SEARCH audit event; no state changes, this is a read-only \
+                    cross-replica projection.
+                    Returns 200 with candidate lines, which may be empty or partial — the clerk falls back to \
+                    manual origin entry (originUnverified) when the sale cannot be located.
+                    """)
     @ApiResponse(responseCode = "200", description = "Candidate lines returned.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.CLAIM_VIEW + "')")
     @EmitEvent(id = "WARRANTY_CANDIDATE_LINE_SEARCH", apiVersion = "1")
@@ -107,9 +218,16 @@ public class ClaimController {
         return ResponseEntity.ok(candidateLineService.findCandidateLines(customerId, vehicleId, sku, productEntityId));
     }
 
-    @Operation(
-            summary = "Get claim",
-            description = "Full detail incl. lines, settlements, reimbursements, part returns, history, notes")
+    @Operation(operationId = "getClaim", summary = "Get claim", description = """
+                    Returns the full warranty claim detail, including lines, settlements, reimbursements, part \
+                    returns, status history, and notes.
+                    Use this tool when the claim id is already known; use searchClaims instead to locate a claim \
+                    by customer, vehicle, status, or claim code.
+                    Preconditions: the claim must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body and no filtering.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no claim exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Claim returned.")
     @ApiResponse(responseCode = "404", description = "Claim not found.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.CLAIM_VIEW + "')")
@@ -121,7 +239,21 @@ public class ClaimController {
 
     // ------------------------------------------------------------------ edits (DRAFT / INFO_NEEDED)
 
-    @Operation(summary = "Update claim", description = "Edit intake fields while DRAFT or INFO_NEEDED")
+    @Operation(operationId = "updateClaim", summary = "Update claim", description = """
+                    Replaces the intake fields of a claim that is still DRAFT or INFO_NEEDED: origin references, \
+                    sale date, registration, failure details, and location use full-update semantics where null \
+                    clears the value, while claimType and photoEvidenceUrls change only when non-null.
+                    Use this tool to correct intake data before adjudication; do not use decideClaim, which \
+                    records the approve/deny decision, and manage lines through addClaimLine and removeClaimLine \
+                    rather than this operation.
+                    Preconditions: the claim must exist and be in DRAFT or INFO_NEEDED — every other status \
+                    rejects edits.
+                    Required inputs: id (UUID) as a path parameter and the update body; clearing both \
+                    originWorkorderId and originInvoiceId re-flags the claim originUnverified.
+                    Emits a WARRANTY_CLAIM_UPDATE event and republishes the claim snapshot.
+                    Returns 404 when the claim does not exist, and 409 (WARRANTY_CLAIM_NOT_EDITABLE) when the \
+                    claim is not DRAFT or INFO_NEEDED.
+                    """)
     @ApiResponse(responseCode = "200", description = "Claim updated.")
     @ApiResponse(responseCode = "404", description = "Claim not found.")
     @ApiResponse(responseCode = "409", description = "Claim is not editable in its current status.")
@@ -130,11 +262,38 @@ public class ClaimController {
     @PutMapping("/{id}")
     public ResponseEntity<ClaimResponse> updateClaim(
             @Parameter(description = "Claim UUID", required = true) @PathVariable @NotNull UUID id,
-            @Valid @NotNull @RequestBody ClaimUpdateRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Intake fields to replace on the claim; null clears origin, failure, and"
+                                    + " location fields, while claimType and photoEvidenceUrls apply only when"
+                                    + " non-null.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Correct intake data",
+                                                            value = CLAIM_UPDATE_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    ClaimUpdateRequest request) {
         return ResponseEntity.ok(claimService.update(id, request));
     }
 
-    @Operation(summary = "Add claim line", description = "Add a failed part/service line while DRAFT or INFO_NEEDED")
+    @Operation(operationId = "addClaimLine", summary = "Add claim line", description = """
+                    Adds one failed part or service line to a claim that is still DRAFT or INFO_NEEDED, \
+                    snapshotting SKU, description, serial numbers, price, and tread depths at intake.
+                    Use this tool to build the claim's line list; do not use updateClaim, which edits header \
+                    fields and cannot touch lines, and use removeClaimLine to take a line off.
+                    Preconditions: the claim must exist and be in DRAFT or INFO_NEEDED.
+                    Required inputs: id (UUID) as a path parameter and a line body with sourceType (INVOICE_LINE, \
+                    WORKORDER_PART, WORKORDER_SERVICE, or MANUAL); sourceId and sourceLineId are null for MANUAL \
+                    lines, quantity defaults to 1, and tread depths are integers in 32nds of an inch.
+                    Emits a WARRANTY_CLAIM_UPDATE event and republishes the claim snapshot.
+                    Returns 404 when the claim does not exist, and 409 when the claim is not editable in its \
+                    current status.
+                    """)
     @ApiResponse(responseCode = "200", description = "Line added.")
     @ApiResponse(responseCode = "404", description = "Claim not found.")
     @ApiResponse(responseCode = "409", description = "Claim is not editable in its current status.")
@@ -143,11 +302,35 @@ public class ClaimController {
     @PostMapping("/{id}/lines")
     public ResponseEntity<ClaimResponse> addLine(
             @Parameter(description = "Claim UUID", required = true) @PathVariable @NotNull UUID id,
-            @Valid @NotNull @RequestBody ClaimLineRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "One failed part or service line with its source provenance and intake"
+                                    + " snapshots.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Manual tire line",
+                                                            value = CLAIM_LINE_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    ClaimLineRequest request) {
         return ResponseEntity.ok(claimService.addLine(id, request));
     }
 
-    @Operation(summary = "Remove claim line", description = "Remove a claim line while DRAFT or INFO_NEEDED")
+    @Operation(operationId = "removeClaimLine", summary = "Remove claim line", description = """
+                    Removes one line from a claim that is still DRAFT or INFO_NEEDED.
+                    Use this tool to drop a mistakenly added line; do not use addClaimLine, which appends a line — \
+                    there is no line-edit operation, so correcting a line means removing and re-adding it.
+                    Preconditions: the claim must exist, be in DRAFT or INFO_NEEDED, and the line must belong to \
+                    the claim.
+                    Required inputs: id and lineId (UUIDs) as path parameters; there is no request body.
+                    Emits a WARRANTY_CLAIM_UPDATE event and republishes the claim snapshot.
+                    Returns 404 when the claim does not exist or the line is not on the claim, and 409 when the \
+                    claim is not editable in its current status.
+                    """)
     @ApiResponse(responseCode = "200", description = "Line removed.")
     @ApiResponse(responseCode = "404", description = "Claim or line not found.")
     @ApiResponse(responseCode = "409", description = "Claim is not editable in its current status.")
@@ -160,7 +343,19 @@ public class ClaimController {
         return ResponseEntity.ok(claimService.removeLine(id, lineId));
     }
 
-    @Operation(summary = "Add photo", description = "Attach a photo-evidence URL while DRAFT or INFO_NEEDED")
+    @Operation(operationId = "addClaimPhoto", summary = "Add photo", description = """
+                    Attaches one photo-evidence URL to a claim that is still DRAFT or INFO_NEEDED; a URL that is \
+                    already attached is kept once, so the add is idempotent.
+                    Use this tool to attach evidence the governing policy may require before submission; do not \
+                    use removeClaimPhoto, which detaches a URL, and do not use updateClaim for single-photo \
+                    changes because its photoEvidenceUrls field replaces the whole list.
+                    Preconditions: the claim must exist and be in DRAFT or INFO_NEEDED.
+                    Required inputs: id (UUID) as a path parameter and a body with url (max 2048 characters); the \
+                    image itself is stored elsewhere — warranty keeps only the URL reference.
+                    Emits a WARRANTY_CLAIM_UPDATE event and republishes the claim snapshot.
+                    Returns 404 when the claim does not exist, and 409 when the claim is not editable in its \
+                    current status.
+                    """)
     @ApiResponse(responseCode = "200", description = "Photo attached.")
     @ApiResponse(responseCode = "404", description = "Claim not found.")
     @ApiResponse(responseCode = "409", description = "Claim is not editable in its current status.")
@@ -169,11 +364,36 @@ public class ClaimController {
     @PostMapping("/{id}/photos")
     public ResponseEntity<ClaimResponse> addPhoto(
             @Parameter(description = "Claim UUID", required = true) @PathVariable @NotNull UUID id,
-            @Valid @NotNull @RequestBody ClaimPhotoRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Photo-evidence URL to attach to the claim (URL-reference pattern; the"
+                                    + " image is hosted elsewhere).",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Tire photo", value = """
+                                                                    {"url":"https://media.example.com/claims/wc-2026-000123/tire-1.jpg"}
+                                                                    """)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    ClaimPhotoRequest request) {
         return ResponseEntity.ok(claimService.addPhoto(id, request.url()));
     }
 
-    @Operation(summary = "Remove photo", description = "Detach a photo-evidence URL while DRAFT or INFO_NEEDED")
+    @Operation(operationId = "removeClaimPhoto", summary = "Remove photo", description = """
+                    Detaches one photo-evidence URL from a claim that is still DRAFT or INFO_NEEDED.
+                    Use this tool to withdraw a wrongly attached photo; do not use addClaimPhoto, which attaches a \
+                    URL, and do not use updateClaim for single-photo changes because its list field is \
+                    full-replace.
+                    Preconditions: the claim must exist, be in DRAFT or INFO_NEEDED, and the URL must currently be \
+                    attached.
+                    Required inputs: id (UUID) as a path parameter and url as a query parameter matching the \
+                    attached URL exactly; there is no request body.
+                    Emits a WARRANTY_CLAIM_UPDATE event and republishes the claim snapshot.
+                    Returns 404 when the claim does not exist or the URL is not attached, and 409 when the claim \
+                    is not editable in its current status.
+                    """)
     @ApiResponse(responseCode = "200", description = "Photo detached.")
     @ApiResponse(responseCode = "404", description = "Claim or photo not found.")
     @ApiResponse(responseCode = "409", description = "Claim is not editable in its current status.")
@@ -188,9 +408,21 @@ public class ClaimController {
 
     // ------------------------------------------------------------------ lifecycle
 
-    @Operation(
-            summary = "Submit claim",
-            description = "Intake complete: runs eligibility, then DRAFT→SUBMITTED (or INFO_NEEDED→IN_REVIEW)")
+    @Operation(operationId = "submitClaim", summary = "Submit claim", description = """
+                    Completes intake by running the eligibility evaluation and then moving the claim DRAFT to \
+                    SUBMITTED, or INFO_NEEDED back to IN_REVIEW once the requested information is provided.
+                    Use this tool when intake is finished; do not use decideClaim, which records the adjudication \
+                    outcome, and do not use evaluateClaimEligibility, which recomputes the suggestion without any \
+                    status change.
+                    Preconditions: the claim must be DRAFT or INFO_NEEDED, must have at least one claim line, and \
+                    must carry at least one photo when the winning policy requires photo evidence.
+                    Required inputs: id (UUID) as a path parameter; there is no request body — eligibility, policy \
+                    selection, and per-line proration are computed server-side and persisted onto the claim.
+                    Emits a WARRANTY_CLAIM_SUBMIT event and republishes the claim snapshot.
+                    Returns 400 when the claim has no lines or the selected policy requires missing photo \
+                    evidence, 404 when the claim does not exist, and 409 when the current status does not allow \
+                    submit (nextAction lists the legal moves).
+                    """)
     @ApiResponse(responseCode = "200", description = "Claim submitted.")
     @ApiResponse(responseCode = "400", description = "Intake incomplete (no lines, missing required photos).")
     @ApiResponse(responseCode = "404", description = "Claim not found.")
@@ -203,10 +435,21 @@ public class ClaimController {
         return ResponseEntity.ok(claimService.submit(id));
     }
 
-    @Operation(
-            summary = "Re-run eligibility",
-            description = "Recompute the eligibility suggestion on demand"
-                    + " (DRAFT, SUBMITTED, IN_REVIEW, or INFO_NEEDED only)")
+    @Operation(operationId = "evaluateClaimEligibility", summary = "Re-run eligibility", description = """
+                    Recomputes the eligibility suggestion — result, reasons, suggested outcome, policy selection, \
+                    and per-line proration — on demand without changing the claim status.
+                    Use this tool after intake data changes to refresh the suggestion; do not use submitClaim, \
+                    which also runs eligibility but performs the lifecycle move, and do not use decideClaim, which \
+                    records the human decision that may override the suggestion.
+                    Preconditions: the claim must be DRAFT, SUBMITTED, IN_REVIEW, or INFO_NEEDED — once decided \
+                    (APPROVED, DENIED, SETTLED) the persisted inputs are frozen audit evidence, and a DENIED claim \
+                    regains recompute only through an appeal back to IN_REVIEW.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    Emits a WARRANTY_CLAIM_UPDATE event and republishes the claim snapshot with the recomputed \
+                    suggestion.
+                    Returns 404 when the claim does not exist, and 409 when the claim is already decided or \
+                    terminal.
+                    """)
     @ApiResponse(responseCode = "200", description = "Eligibility recomputed.")
     @ApiResponse(responseCode = "404", description = "Claim not found.")
     @ApiResponse(responseCode = "409", description = "Claim already decided or terminal.")
@@ -218,12 +461,26 @@ public class ClaimController {
         return ResponseEntity.ok(claimService.evaluateEligibility(id));
     }
 
-    @Operation(
-            summary = "Decide claim",
-            description = "APPROVE/DENY/REQUEST_INFO (implicitly begins review on a SUBMITTED claim);"
-                    + " APPEAL reopens a DENIED claim. Deny, appeal, and suggestion overrides require a reason."
-                    + " Optional lineDecisions record per-line approved amounts/dispositions; amounts that"
-                    + " differ from the computed request require an audited override reason")
+    @Operation(operationId = "decideClaim", summary = "Decide claim", description = """
+                    Records the human adjudication decision on a claim — APPROVE, DENY, or REQUEST_INFO, where a \
+                    decision on a SUBMITTED claim implicitly begins review first — while APPEAL reopens a DENIED \
+                    claim back to IN_REVIEW and clears the standing decision (the denial stays audited in the \
+                    status history).
+                    Use this tool to adjudicate; do not use submitClaim, which moves intake into adjudication, and \
+                    do not use createSettlement, which executes the payout only after approval.
+                    Preconditions: the claim must be SUBMITTED, IN_REVIEW, or DENIED (APPEAL only); DENY and \
+                    APPEAL require a reason, and a decision contradicting the computed suggestion (approving an \
+                    INELIGIBLE or denying an ELIGIBLE claim) also requires a reason and marks the claim \
+                    overrodeSuggestion.
+                    Required inputs: id (UUID) and a body with decision; optional lineDecisions (APPROVE/DENY \
+                    only) set per-line amountApproved and lineDisposition, omitted lines default to the computed \
+                    amountRequested on approve or to DENIED on deny, and an amountApproved differing from the \
+                    computed amount requires an overrideReason that is audited as a claim note.
+                    Emits a WARRANTY_CLAIM_DECIDE event and republishes the claim snapshot.
+                    Returns 400 when a required reason or overrideReason is missing or lineDecisions accompany \
+                    REQUEST_INFO, 404 when the claim or a referenced line does not exist, and 409 when the current \
+                    status does not allow the move (nextAction lists the legal moves).
+                    """)
     @ApiResponse(responseCode = "200", description = "Decision applied.")
     @ApiResponse(responseCode = "400", description = "Missing required reason.")
     @ApiResponse(responseCode = "404", description = "Claim not found.")
@@ -233,11 +490,38 @@ public class ClaimController {
     @PostMapping("/{id}/decision")
     public ResponseEntity<ClaimResponse> decideClaim(
             @Parameter(description = "Claim UUID", required = true) @PathVariable @NotNull UUID id,
-            @Valid @NotNull @RequestBody ClaimDecisionRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Adjudication action with its reason and optional per-line approved"
+                                    + " amounts and dispositions.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Approve with line override",
+                                                            value = CLAIM_DECISION_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    ClaimDecisionRequest request) {
         return ResponseEntity.ok(claimService.decide(id, request));
     }
 
-    @Operation(summary = "Cancel claim", description = "Cancel from DRAFT, SUBMITTED, or INFO_NEEDED")
+    @Operation(operationId = "cancelClaim", summary = "Cancel claim", description = """
+                    Cancels a warranty claim, moving DRAFT, SUBMITTED, or INFO_NEEDED to the terminal CANCELLED \
+                    status with an audited status-history row.
+                    Use this tool when the customer or staff abandons the claim before adjudication completes; do \
+                    not use closeClaim, which finishes a SETTLED or DENIED claim after its child records are \
+                    terminal.
+                    Preconditions: the claim must be DRAFT, SUBMITTED, or INFO_NEEDED — IN_REVIEW, APPROVED, \
+                    DENIED, SETTLED, and terminal claims cannot be cancelled.
+                    Required inputs: id (UUID) as a path parameter; the body is optional and carries only a reason \
+                    recorded in the status history.
+                    Emits a WARRANTY_CLAIM_CANCEL event and republishes the claim snapshot.
+                    Returns 404 when the claim does not exist, and 409 when the current status does not allow \
+                    cancellation (nextAction lists the legal moves).
+                    """)
     @ApiResponse(responseCode = "200", description = "Claim cancelled.")
     @ApiResponse(responseCode = "404", description = "Claim not found.")
     @ApiResponse(responseCode = "409", description = "Illegal transition; nextAction lists legal moves.")
@@ -246,13 +530,38 @@ public class ClaimController {
     @PostMapping("/{id}/cancel")
     public ResponseEntity<ClaimResponse> cancelClaim(
             @Parameter(description = "Claim UUID", required = true) @PathVariable @NotNull UUID id,
-            @Valid @RequestBody(required = false) ClaimActionRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Optional cancellation reason recorded in the claim status history.",
+                            required = false,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Cancel with reason", value = """
+                                                                    {"reason":"Customer withdrew the claim"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody(required = false)
+                    ClaimActionRequest request) {
         return ResponseEntity.ok(claimService.cancel(id, request == null ? new ClaimActionRequest(null) : request));
     }
 
-    @Operation(
-            summary = "Close claim",
-            description = "Close from SETTLED or DENIED once every reimbursement and part return is terminal")
+    @Operation(operationId = "closeClaim", summary = "Close claim", description = """
+                    Closes a warranty claim, moving SETTLED or DENIED to the terminal CLOSED status once every \
+                    child record is terminal.
+                    Use this tool to finish the back-office lifecycle after the customer journey is done; do not \
+                    use cancelClaim, which abandons a claim before adjudication — open children block CLOSED but \
+                    never SETTLED (settle-customer-first).
+                    Preconditions: the claim must be SETTLED or DENIED; every vendor reimbursement must be \
+                    terminal (CREDIT_RECEIVED, WRITTEN_OFF, NOT_APPLICABLE, or DENIED), every part return must be \
+                    terminal (RECEIVED_BY_VENDOR, SCRAPPED, or CLOSED), and a SETTLED claim whose policy requires \
+                    part return must have at least one part return on record.
+                    Required inputs: id (UUID) as a path parameter; the body is optional and carries only a reason \
+                    recorded in the status history.
+                    Emits a WARRANTY_CLAIM_CLOSE event and republishes the claim snapshot.
+                    Returns 404 when the claim does not exist, and 409 when the transition is illegal or open \
+                    child records block closing (WARRANTY_CLAIM_CLOSE_BLOCKED, with nextAction describing what to \
+                    resolve).
+                    """)
     @ApiResponse(responseCode = "200", description = "Claim closed.")
     @ApiResponse(responseCode = "404", description = "Claim not found.")
     @ApiResponse(responseCode = "409", description = "Illegal transition or open child records; see nextAction.")
@@ -261,11 +570,33 @@ public class ClaimController {
     @PostMapping("/{id}/close")
     public ResponseEntity<ClaimResponse> closeClaim(
             @Parameter(description = "Claim UUID", required = true) @PathVariable @NotNull UUID id,
-            @Valid @RequestBody(required = false) ClaimActionRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Optional closure reason recorded in the claim status history.",
+                            required = false,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Close with reason", value = """
+                                                                    {"reason":"Vendor credit received; RMA received by vendor"}
+                                                                    """)))
+                    @Valid
+                    @RequestBody(required = false)
+                    ClaimActionRequest request) {
         return ResponseEntity.ok(claimService.close(id, request == null ? new ClaimActionRequest(null) : request));
     }
 
-    @Operation(summary = "Add note", description = "Append a free-form staff note (any status)")
+    @Operation(operationId = "addClaimNote", summary = "Add note", description = """
+                    Appends one free-form, append-only staff note to a warranty claim in any status.
+                    Use this tool to record context that is not a status change; do not use decideClaim or \
+                    updateClaim, which mutate the claim itself — notes are never editable or deletable once \
+                    written.
+                    Preconditions: the claim must exist; there is no status restriction.
+                    Required inputs: id (UUID) as a path parameter and a body with note (non-blank, max 10000 \
+                    characters).
+                    Emits a WARRANTY_CLAIM_UPDATE event; the claim's own fields and status are untouched.
+                    Returns 201 with the full claim detail including the new note, and 404 when the claim does not \
+                    exist.
+                    """)
     @ApiResponse(responseCode = "201", description = "Note appended.")
     @ApiResponse(responseCode = "404", description = "Claim not found.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.CLAIM_CREATE + "')")
@@ -273,7 +604,19 @@ public class ClaimController {
     @PostMapping("/{id}/notes")
     public ResponseEntity<ClaimResponse> addNote(
             @Parameter(description = "Claim UUID", required = true) @PathVariable @NotNull UUID id,
-            @Valid @NotNull @RequestBody ClaimNoteRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Free-form staff note text to append to the claim's audit trail.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Staff note", value = """
+                                                                    {"note":"Customer called; defective tire is on hold shelf B3"}
+                                                                    """)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    ClaimNoteRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(claimService.addNote(id, request));
     }
 }

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/PartReturnController.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/PartReturnController.java
@@ -9,6 +9,8 @@ import com.positivity.warranty.internal.security.WarrantyPermissions;
 import com.positivity.warranty.internal.service.PartReturnService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -46,9 +48,23 @@ public class PartReturnController {
 
     private final PartReturnService partReturnService;
 
-    @Operation(
-            summary = "Create part return (RMA)",
-            description = "Opens the RMA lifecycle for one claim line (at most one per line); starts AWAITING_PART")
+    @Operation(operationId = "createPartReturn", summary = "Create part return (RMA)", description = """
+                    Opens the defective-part RMA lifecycle for one claim line, creating a part return in \
+                    AWAITING_PART with the chosen disposition.
+                    Use this tool when the governing policy requires the part back or staff choose to hold or \
+                    return it; do not use updatePartReturn, which advances or annotates an RMA that already \
+                    exists — at most one part return is allowed per claim line.
+                    Preconditions: the claim must exist and not be CANCELLED or CLOSED, the line must belong to \
+                    the claim, and no part return may already exist for that line; no policy check gates creation \
+                    because staff choice is always permitted.
+                    Required inputs: claim id (UUID) as a path parameter and a body with claimLineId (UUID) and \
+                    disposition (HOLD_FOR_INSPECTION, RETURN_TO_VENDOR, SCRAP_AUTHORIZED, or CUSTOMER_RETAINED); \
+                    rmaNumber and holdLocationNote are optional.
+                    Emits a WARRANTY_PART_RETURN_CREATE event, enqueues warranty.part-return.requested so \
+                    pos-inventory can quarantine the defective unit, and republishes the claim snapshot.
+                    Returns 404 when the claim or the line cannot be found, and 409 when the line already has a \
+                    part return or the claim is terminal.
+                    """)
     @ApiResponse(responseCode = "201", description = "Part return created.")
     @ApiResponse(responseCode = "404", description = "Claim or claim line not found.")
     @ApiResponse(responseCode = "409", description = "Line already has a part return, or claim is terminal.")
@@ -57,14 +73,42 @@ public class PartReturnController {
     @PostMapping("/claims/{id}/part-returns")
     public ResponseEntity<PartReturnResponse> createPartReturn(
             @Parameter(description = "Claim id") @PathVariable("id") UUID claimId,
-            @Valid @NotNull @RequestBody PartReturnCreateRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Claim line whose defective part is being returned or held, with its"
+                                    + " disposition and optional RMA details.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Return to vendor", value = """
+                                                                    {"claimLineId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a07",
+                                                                     "disposition":"RETURN_TO_VENDOR",
+                                                                     "rmaNumber":"RMA-88231",
+                                                                     "holdLocationNote":"Hold shelf B3"}
+                                                                    """)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    PartReturnCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(partReturnService.create(claimId, request));
     }
 
-    @Operation(
-            summary = "Update part return (RMA)",
-            description = "Advances the RMA (AWAITING_PART -> ON_HOLD -> SHIPPED -> RECEIVED_BY_VENDOR, or"
-                    + " SCRAPPED/CLOSED per disposition) and/or updates RMA details")
+    @Operation(operationId = "updatePartReturn", summary = "Update part return (RMA)", description = """
+                    Advances a part return through its child state machine — AWAITING_PART to ON_HOLD to SHIPPED \
+                    to RECEIVED_BY_VENDOR, or to SCRAPPED/CLOSED per disposition, where ON_HOLD may be skipped — \
+                    and/or updates RMA details without a lifecycle move.
+                    Use this tool for every change after creation; do not use createPartReturn, which opens a new \
+                    RMA and rejects a line that already has one.
+                    Preconditions: the part return must exist and not be terminal; moving to SHIPPED or \
+                    RECEIVED_BY_VENDOR requires disposition RETURN_TO_VENDOR, and moving to SCRAPPED requires \
+                    disposition SCRAP_AUTHORIZED (either already set or set in the same request).
+                    Required inputs: part return id (UUID) as a path parameter; every body field is optional — \
+                    omit status for a detail-only update, and shippedAt defaults to now when entering SHIPPED.
+                    Emits a WARRANTY_PART_RETURN_UPDATE event, enqueues warranty.part-return.shipped when the \
+                    return enters SHIPPED, and republishes the claim snapshot.
+                    Returns 404 when the part return does not exist, and 409 when the transition is illegal, the \
+                    disposition does not permit the target status, or the return is already terminal.
+                    """)
     @ApiResponse(responseCode = "200", description = "Part return updated.")
     @ApiResponse(responseCode = "404", description = "Part return not found.")
     @ApiResponse(responseCode = "409", description = "Illegal part-return transition.")
@@ -73,13 +117,38 @@ public class PartReturnController {
     @PutMapping("/part-returns/{id}")
     public ResponseEntity<PartReturnResponse> updatePartReturn(
             @Parameter(description = "Part return id") @PathVariable("id") UUID partReturnId,
-            @Valid @NotNull @RequestBody PartReturnUpdateRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Lifecycle move and/or RMA detail changes; all fields optional, omit"
+                                    + " status for a detail-only update.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Ship to vendor", value = """
+                                                                    {"status":"SHIPPED",
+                                                                     "disposition":"RETURN_TO_VENDOR",
+                                                                     "carrier":"UPS",
+                                                                     "trackingNumber":"1Z999AA10123456784",
+                                                                     "shippedAt":"2026-08-12T15:04:05Z"}
+                                                                    """)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    PartReturnUpdateRequest request) {
         return ResponseEntity.ok(partReturnService.update(partReturnId, request));
     }
 
-    @Operation(
-            summary = "Part-return worklist",
-            description = "Hold-shelf / shipping worklist of part returns, filterable by status")
+    @Operation(operationId = "listPartReturns", summary = "Part-return worklist", description = """
+                    Returns the hold-shelf and shipping worklist of part returns across all claims, optionally \
+                    filtered by status.
+                    Use this tool to drive the back-office RMA worklist; use getClaim instead to see the part \
+                    returns of one specific claim.
+                    Preconditions: none — an empty list is returned when nothing matches.
+                    Required inputs: status is an optional query parameter (AWAITING_PART, ON_HOLD, SHIPPED, \
+                    RECEIVED_BY_VENDOR, SCRAPPED, CLOSED); omitting it returns every part return.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the list, which is empty rather than 404 when no part return matches.
+                    """)
     @ApiResponse(responseCode = "200", description = "Part returns returned.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.PART_RETURN_VIEW + "')")
     @GetMapping("/part-returns")

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/PolicyController.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/PolicyController.java
@@ -8,6 +8,8 @@ import com.positivity.warranty.internal.security.WarrantyPermissions;
 import com.positivity.warranty.internal.service.PolicyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,9 +42,36 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/warranty/policies")
 public class PolicyController {
 
+    private static final String POLICY_EXAMPLE = """
+            {"providerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a10",
+             "name":"Michelin passenger replacement — workmanship & materials",
+             "coverageType":"MANUFACTURER_DEFECT",
+             "appliesToType":"MANUFACTURER",
+             "appliesToManufacturerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a11",
+             "effectiveFrom":"2025-01-01",
+             "durationMonths":72,
+             "treadPullPointThirtySeconds":2,
+             "laborCovered":false,
+             "prorationMethod":"TREAD_DEPTH",
+             "requiresPartReturn":true,
+             "requiresPhotoEvidence":true,
+             "transferable":false,
+             "autoRegister":false,
+             "termsText":"Prorated on remaining tread down to the 2/32 pull point."}
+            """;
+
     private final PolicyService policyService;
 
-    @Operation(summary = "List policies", description = "Optionally filter by provider and/or coverage type")
+    @Operation(operationId = "listPolicies", summary = "List policies", description = """
+                    Returns warranty policies, optionally filtered by owning provider and/or coverage type.
+                    Use this tool to browse configured coverage programs; use findApplicablePolicies instead to \
+                    resolve which policies cover a specific product on a specific sale date.
+                    Preconditions: none — an empty list is returned when nothing matches.
+                    Required inputs: providerId and coverageType are optional query parameters; when both are \
+                    given the provider filter is applied first and coverage type filters the result.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the list, which is empty rather than 404 when no policy matches.
+                    """)
     @ApiResponse(responseCode = "200", description = "Policies returned.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.POLICY_VIEW + "')")
     @GetMapping
@@ -53,10 +82,22 @@ public class PolicyController {
         return ResponseEntity.ok(policyService.list(providerId, coverageType));
     }
 
-    @Operation(
-            summary = "Find applicable policies",
-            description = "Policies in effect on the sale date whose appliesTo scope matches any provided key,"
-                    + " ordered most-specific-first (PRODUCT > MANUFACTURER > CATEGORY > ALL)")
+    @Operation(operationId = "findApplicablePolicies", summary = "Find applicable policies", description = """
+                    Resolves the policies in effect on the original sale date whose appliesTo scope matches any \
+                    provided catalog key, ordered most-specific-first (PRODUCT_LIST, then MANUFACTURER, then \
+                    CATEGORY, then ALL).
+                    Use this tool during intake or eligibility work to find the governing policy for a product; \
+                    do not use listPolicies, which lists policies without effective-date or scope matching.
+                    Preconditions: policies must exist with an effectiveFrom/effectiveTo window covering the sale \
+                    date; ALL-scoped policies always match, while scoped policies match only when the \
+                    corresponding key is provided and equal.
+                    Required inputs: saleDate (ISO-8601 date) is required; productEntityId, manufacturerId, and \
+                    categoryId are optional pos-catalog keys, and coverageType optionally restricts the result to \
+                    one coverage type.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with matching policies most specific first (empty when none match), and 400 when \
+                    saleDate is missing or malformed.
+                    """)
     @ApiResponse(responseCode = "200", description = "Matching policies returned, most specific first.")
     @ApiResponse(responseCode = "400", description = "Missing or invalid parameters.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.POLICY_VIEW + "')")
@@ -79,7 +120,16 @@ public class PolicyController {
                 policyService.findApplicable(productEntityId, manufacturerId, categoryId, saleDate, coverageType));
     }
 
-    @Operation(summary = "Get policy", description = "Retrieve a warranty policy by id")
+    @Operation(operationId = "getPolicy", summary = "Get policy", description = """
+                    Returns one warranty policy with its full structured coverage terms, including proration \
+                    method, caps, and evidence requirements.
+                    Use this tool when the policy id is already known; use listPolicies or findApplicablePolicies \
+                    instead to locate a policy.
+                    Preconditions: the policy must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no policy exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Policy returned.")
     @ApiResponse(responseCode = "404", description = "Policy not found.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.POLICY_VIEW + "')")
@@ -89,18 +139,63 @@ public class PolicyController {
         return ResponseEntity.ok(policyService.getById(id));
     }
 
-    @Operation(summary = "Create policy", description = "Create a new warranty policy")
+    @Operation(operationId = "createPolicy", summary = "Create policy", description = """
+                    Creates a warranty policy — one row of structured coverage terms owned by a provider, \
+                    governing eligibility, proration, and evidence requirements for claims.
+                    Use this tool to configure a new coverage program; do not use updatePolicy, which fully \
+                    replaces an existing policy, and do not use createRegistration, which records coverage sold \
+                    to one customer under a policy.
+                    Preconditions: the owning provider must exist; the appliesTo scope must be internally \
+                    consistent — PRODUCT_LIST needs a non-empty appliesToProductEntityIds, CATEGORY needs \
+                    appliesToCategoryId, MANUFACTURER needs appliesToManufacturerId — and effectiveTo must not \
+                    precede effectiveFrom.
+                    Required inputs: providerId (UUID), name, coverageType, appliesToType, effectiveFrom (ISO \
+                    date), and prorationMethod (NONE, TREAD_DEPTH, MILEAGE, or TIME); laborCovered, \
+                    requiresPartReturn, requiresPhotoEvidence, transferable, and autoRegister all default to \
+                    false.
+                    Emits a WARRANTY_POLICY_CREATE event; no claims or registrations are touched.
+                    Returns 404 when the referenced provider cannot be resolved, and 400 when the appliesTo scope \
+                    keys or the effective window are inconsistent.
+                    """)
     @ApiResponse(responseCode = "201", description = "Policy created.")
     @ApiResponse(responseCode = "400", description = "Invalid request.")
     @ApiResponse(responseCode = "404", description = "Referenced provider not found.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.POLICY_MANAGE + "')")
     @EmitEvent(id = "WARRANTY_POLICY_CREATE", apiVersion = "1")
     @PostMapping
-    public ResponseEntity<PolicyResponse> createPolicy(@Valid @NotNull @RequestBody PolicyRequest request) {
+    public ResponseEntity<PolicyResponse> createPolicy(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Structured coverage terms of the program: scope, effective window,"
+                                    + " limits, proration method, and evidence requirements.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Manufacturer tread-depth policy",
+                                                            value = POLICY_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    PolicyRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(policyService.create(request));
     }
 
-    @Operation(summary = "Update policy", description = "Full update of an existing warranty policy")
+    @Operation(operationId = "updatePolicy", summary = "Update policy", description = """
+                    Fully replaces an existing warranty policy's structured coverage terms; every field is \
+                    rewritten from the request, and omitted optional booleans reset to false.
+                    Use this tool to change a coverage program; do not use createPolicy, which adds a new \
+                    program — claims already decided keep their frozen proration inputs regardless of policy \
+                    edits.
+                    Preconditions: the policy and the referenced provider must exist, the appliesTo scope keys \
+                    must be consistent with appliesToType, and effectiveTo must not precede effectiveFrom.
+                    Required inputs: id (UUID) as a path parameter and the same full body as createPolicy — this \
+                    is full-update semantics, so omitting an optional field clears it or resets its default.
+                    Emits a WARRANTY_POLICY_UPDATE event.
+                    Returns 404 when the policy or the referenced provider cannot be resolved, and 400 when the \
+                    appliesTo scope keys or the effective window are inconsistent.
+                    """)
     @ApiResponse(responseCode = "200", description = "Policy updated.")
     @ApiResponse(responseCode = "400", description = "Invalid request.")
     @ApiResponse(responseCode = "404", description = "Policy or referenced provider not found.")
@@ -109,7 +204,21 @@ public class PolicyController {
     @PutMapping("/{id}")
     public ResponseEntity<PolicyResponse> updatePolicy(
             @Parameter(description = "Policy UUID", required = true) @PathVariable @NotNull UUID id,
-            @Valid @NotNull @RequestBody PolicyRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement of the policy's structured coverage terms"
+                                    + " (full-update semantics).",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Manufacturer tread-depth policy",
+                                                            value = POLICY_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    PolicyRequest request) {
         return ResponseEntity.ok(policyService.update(id, request));
     }
 }

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/ProviderController.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/ProviderController.java
@@ -8,6 +8,8 @@ import com.positivity.warranty.internal.security.WarrantyPermissions;
 import com.positivity.warranty.internal.service.ProviderService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -38,9 +40,32 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/warranty/providers")
 public class ProviderController {
 
+    private static final String PROVIDER_EXAMPLE = """
+            {"name":"Michelin North America",
+             "providerType":"MANUFACTURER",
+             "status":"ACTIVE",
+             "apVendorId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a20",
+             "manufacturerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a11",
+             "claimSubmissionMethod":"Portal",
+             "portalUrl":"https://warranty.michelin.example.com",
+             "contactName":"Claims Desk",
+             "contactPhone":"+1-800-555-0100",
+             "contactEmail":"claims@michelin.example.com"}
+            """;
+
     private final ProviderService providerService;
 
-    @Operation(summary = "List providers", description = "Optionally filter by status and/or provider type")
+    @Operation(operationId = "listProviders", summary = "List providers", description = """
+                    Returns warranty providers, optionally filtered by lifecycle status and/or provider type.
+                    Use this tool to browse who funds warranty programs; use getProvider instead when the \
+                    provider id is already known.
+                    Preconditions: none — an empty list is returned when nothing matches.
+                    Required inputs: status (ACTIVE or INACTIVE) and providerType (MANUFACTURER, \
+                    DISTRIBUTOR_PROGRAM, THIRD_PARTY_ADMIN, DEALER) are optional query parameters; when both are \
+                    given the status filter is applied first and provider type filters the result.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the list, which is empty rather than 404 when no provider matches.
+                    """)
     @ApiResponse(responseCode = "200", description = "Providers returned.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.PROVIDER_VIEW + "')")
     @GetMapping
@@ -52,7 +77,16 @@ public class ProviderController {
         return ResponseEntity.ok(providerService.list(status, providerType));
     }
 
-    @Operation(summary = "Get provider", description = "Retrieve a warranty provider by id")
+    @Operation(operationId = "getProvider", summary = "Get provider", description = """
+                    Returns one warranty provider, including its funding type, AP vendor link, and \
+                    claim-submission contact details.
+                    Use this tool when the provider id is already known; use listProviders instead to locate a \
+                    provider by status or type.
+                    Preconditions: the provider must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no provider exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Provider returned.")
     @ApiResponse(responseCode = "404", description = "Provider not found.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.PROVIDER_VIEW + "')")
@@ -62,17 +96,55 @@ public class ProviderController {
         return ResponseEntity.ok(providerService.getById(id));
     }
 
-    @Operation(summary = "Create provider", description = "Create a new warranty provider")
+    @Operation(operationId = "createProvider", summary = "Create provider", description = """
+                    Creates a warranty provider — the party that funds a warranty program, from a manufacturer or \
+                    third-party administrator to the dealer itself.
+                    Use this tool to register a new payer before configuring its policies with createPolicy; do \
+                    not use updateProvider, which rewrites an existing provider.
+                    Preconditions: none — there is no duplicate-name check, so repeating the call creates a \
+                    second provider.
+                    Required inputs: name and providerType (MANUFACTURER, DISTRIBUTOR_PROGRAM, THIRD_PARTY_ADMIN, \
+                    or DEALER — DEALER means self-funded, which later makes vendor reimbursement NOT_APPLICABLE); \
+                    status defaults to ACTIVE, and apVendorId optionally links the pos-accounting vendor for \
+                    credit matching.
+                    Emits a WARRANTY_PROVIDER_CREATE event; no policies or claims are touched.
+                    Returns 201 with the created provider on success.
+                    """)
     @ApiResponse(responseCode = "201", description = "Provider created.")
     @ApiResponse(responseCode = "400", description = "Invalid request.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.PROVIDER_MANAGE + "')")
     @EmitEvent(id = "WARRANTY_PROVIDER_CREATE", apiVersion = "1")
     @PostMapping
-    public ResponseEntity<ProviderResponse> createProvider(@Valid @NotNull @RequestBody ProviderRequest request) {
+    public ResponseEntity<ProviderResponse> createProvider(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Warranty provider to create: funding type, lifecycle status, and"
+                                    + " claim-submission contact details.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Manufacturer provider",
+                                                            value = PROVIDER_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    ProviderRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(providerService.create(request));
     }
 
-    @Operation(summary = "Update provider", description = "Full update of an existing warranty provider")
+    @Operation(operationId = "updateProvider", summary = "Update provider", description = """
+                    Fully replaces an existing warranty provider's fields, including funding type, contact \
+                    details, and the AP vendor link.
+                    Use this tool to change provider data; do not use createProvider, which adds a new provider.
+                    Preconditions: the provider must exist; omitting status keeps the current value, while every \
+                    other field is rewritten from the request and null clears it.
+                    Required inputs: id (UUID) as a path parameter, plus name and providerType; apVendorId, \
+                    manufacturerId, claimSubmissionMethod, and the contact fields are optional.
+                    Emits a WARRANTY_PROVIDER_UPDATE event.
+                    Returns 404 when no provider exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Provider updated.")
     @ApiResponse(responseCode = "400", description = "Invalid request.")
     @ApiResponse(responseCode = "404", description = "Provider not found.")
@@ -81,7 +153,21 @@ public class ProviderController {
     @PutMapping("/{id}")
     public ResponseEntity<ProviderResponse> updateProvider(
             @Parameter(description = "Provider UUID", required = true) @PathVariable @NotNull UUID id,
-            @Valid @NotNull @RequestBody ProviderRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement of the provider's fields (omitting status keeps the"
+                                    + " current value).",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Manufacturer provider",
+                                                            value = PROVIDER_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    ProviderRequest request) {
         return ResponseEntity.ok(providerService.update(id, request));
     }
 }

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/RegistrationController.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/RegistrationController.java
@@ -8,6 +8,8 @@ import com.positivity.warranty.internal.security.WarrantyPermissions;
 import com.positivity.warranty.internal.service.RegistrationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,9 +42,31 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/warranty/registrations")
 public class RegistrationController {
 
+    private static final String REGISTRATION_EXAMPLE = """
+            {"policyId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a30",
+             "customerId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01",
+             "vehicleId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02",
+             "sourceInvoiceId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04",
+             "sourceInvoiceLineId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a05",
+             "contractNumber":"RH-2026-88412",
+             "purchaseDate":"2026-05-14",
+             "expiresAt":"2029-05-14",
+             "status":"ACTIVE"}
+            """;
+
     private final RegistrationService registrationService;
 
-    @Operation(summary = "Search registrations", description = "Optionally filter by customer, vehicle, and status")
+    @Operation(operationId = "searchRegistrations", summary = "Search registrations", description = """
+                    Searches sold-coverage registrations, optionally filtered by customer, vehicle, and lifecycle \
+                    status.
+                    Use this tool to find a customer's road-hazard or extended-plan coverage; use getRegistration \
+                    instead when the registration id is already known.
+                    Preconditions: none — an empty list is returned when nothing matches.
+                    Required inputs: customerId, vehicleId, and status (ACTIVE, EXPIRED, CANCELLED, EXHAUSTED) \
+                    are all optional query parameters; with no filters every registration is returned.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the list, which is empty rather than 404 when nothing matches.
+                    """)
     @ApiResponse(responseCode = "200", description = "Registrations returned.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.REGISTRATION_VIEW + "')")
     @GetMapping
@@ -54,7 +78,16 @@ public class RegistrationController {
         return ResponseEntity.ok(registrationService.search(customerId, vehicleId, status));
     }
 
-    @Operation(summary = "Get registration", description = "Retrieve a warranty registration by id")
+    @Operation(operationId = "getRegistration", summary = "Get registration", description = """
+                    Returns one warranty registration — the sold/instantiated coverage binding a policy to a \
+                    customer, and optionally to a vehicle and its originating invoice line.
+                    Use this tool when the registration id is already known; use searchRegistrations instead to \
+                    locate coverage by customer, vehicle, or status.
+                    Preconditions: the registration must exist.
+                    Required inputs: id (UUID) as a path parameter; there is no request body.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 404 when no registration exists for the supplied id.
+                    """)
     @ApiResponse(responseCode = "200", description = "Registration returned.")
     @ApiResponse(responseCode = "404", description = "Registration not found.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.REGISTRATION_VIEW + "')")
@@ -64,7 +97,20 @@ public class RegistrationController {
         return ResponseEntity.ok(registrationService.getById(id));
     }
 
-    @Operation(summary = "Create registration", description = "Record sold/instantiated coverage")
+    @Operation(operationId = "createRegistration", summary = "Create registration", description = """
+                    Records sold/instantiated coverage — a registration binding a governing policy to a customer, \
+                    and optionally to a vehicle and the originating invoice line.
+                    Use this tool when coverage such as a road-hazard add-on or extended plan is sold; do not use \
+                    createPolicy, which defines the reusable program a registration instantiates.
+                    Preconditions: the governing policy must exist; policies flagged autoRegister create \
+                    registrations automatically from invoiced sales, so manual creation covers the remaining \
+                    cases.
+                    Required inputs: policyId (UUID), customerId (UUID), and purchaseDate (ISO date); vehicleId, \
+                    source invoice references, contractNumber, and expiresAt are optional, and status defaults to \
+                    ACTIVE.
+                    Emits a WARRANTY_REGISTRATION_CREATE event.
+                    Returns 404 when the referenced policy cannot be resolved.
+                    """)
     @ApiResponse(responseCode = "201", description = "Registration created.")
     @ApiResponse(responseCode = "400", description = "Invalid request.")
     @ApiResponse(responseCode = "404", description = "Referenced policy not found.")
@@ -72,11 +118,38 @@ public class RegistrationController {
     @EmitEvent(id = "WARRANTY_REGISTRATION_CREATE", apiVersion = "1")
     @PostMapping
     public ResponseEntity<RegistrationResponse> createRegistration(
-            @Valid @NotNull @RequestBody RegistrationRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Sold coverage to record: governing policy, covered customer and"
+                                    + " vehicle, and the originating sale references.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Road-hazard registration",
+                                                            value = REGISTRATION_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    RegistrationRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(registrationService.create(request));
     }
 
-    @Operation(summary = "Update registration", description = "Full update of an existing warranty registration")
+    @Operation(operationId = "updateRegistration", summary = "Update registration", description = """
+                    Fully replaces an existing warranty registration's fields, including the policy binding, \
+                    source references, and coverage dates.
+                    Use this tool to correct or expire sold coverage; do not use createRegistration, which \
+                    records new coverage.
+                    Preconditions: the registration and the referenced policy must exist; omitting status keeps \
+                    the current value, while the other fields are rewritten from the request and null clears \
+                    them.
+                    Required inputs: id (UUID) as a path parameter, plus policyId, customerId, and purchaseDate; \
+                    vehicleId, source invoice references, contractNumber, expiresAt, and status (ACTIVE, EXPIRED, \
+                    CANCELLED, EXHAUSTED) are optional.
+                    Emits a WARRANTY_REGISTRATION_UPDATE event.
+                    Returns 404 when the registration or the referenced policy cannot be resolved.
+                    """)
     @ApiResponse(responseCode = "200", description = "Registration updated.")
     @ApiResponse(responseCode = "400", description = "Invalid request.")
     @ApiResponse(responseCode = "404", description = "Registration or referenced policy not found.")
@@ -85,7 +158,21 @@ public class RegistrationController {
     @PutMapping("/{id}")
     public ResponseEntity<RegistrationResponse> updateRegistration(
             @Parameter(description = "Registration UUID", required = true) @PathVariable @NotNull UUID id,
-            @Valid @NotNull @RequestBody RegistrationRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Full replacement of the registration's fields (omitting status keeps"
+                                    + " the current value).",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples =
+                                                    @ExampleObject(
+                                                            name = "Road-hazard registration",
+                                                            value = REGISTRATION_EXAMPLE)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    RegistrationRequest request) {
         return ResponseEntity.ok(registrationService.update(id, request));
     }
 }

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/ReimbursementController.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/ReimbursementController.java
@@ -9,6 +9,8 @@ import com.positivity.warranty.internal.security.WarrantyPermissions;
 import com.positivity.warranty.internal.service.ReimbursementService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -45,10 +47,24 @@ public class ReimbursementController {
 
     private final ReimbursementService reimbursementService;
 
-    @Operation(
-            summary = "Submit vendor reimbursement",
-            description = "Creates/updates the claim's single reimbursement NOT_SUBMITTED -> SUBMITTED; claim must"
-                    + " be APPROVED or SETTLED and provider must not be dealer-funded")
+    @Operation(operationId = "submitReimbursement", summary = "Submit vendor reimbursement", description = """
+                    Submits the claim's single vendor reimbursement to the warranty provider, creating the record \
+                    if needed and moving it NOT_SUBMITTED to SUBMITTED.
+                    Use this tool for the back-office recovery step after the customer is settled; do not use \
+                    updateReimbursement, which records the vendor's decision, credit receipt, or write-off on an \
+                    already-submitted reimbursement.
+                    Preconditions: the claim must be APPROVED or SETTLED (settle-customer-first), must have a \
+                    provider assigned, the provider must not be DEALER-funded (self-funded programs are \
+                    NOT_APPLICABLE), and the reimbursement must still be NOT_SUBMITTED — each claim has at most \
+                    one.
+                    Required inputs: claim id (UUID) as a path parameter and a body with amountRequested \
+                    (positive decimal); vendorClaimReference and notes are optional.
+                    Emits a WARRANTY_REIMBURSEMENT_SUBMIT event and enqueues warranty.reimbursement.submitted so \
+                    pos-accounting can expect the vendor credit; the claim's own status is never touched.
+                    Returns 404 when the claim or its provider cannot be resolved, and 409 when the claim state \
+                    disallows submission, no provider is assigned, the provider is dealer-funded, or the \
+                    reimbursement was already submitted (including a concurrent submit).
+                    """)
     @ApiResponse(responseCode = "200", description = "Reimbursement submitted.")
     @ApiResponse(responseCode = "404", description = "Claim or provider not found.")
     @ApiResponse(responseCode = "409", description = "Claim state or reimbursement state does not allow submission.")
@@ -57,14 +73,45 @@ public class ReimbursementController {
     @PostMapping("/claims/{id}/reimbursement/submit")
     public ResponseEntity<ReimbursementResponse> submitReimbursement(
             @Parameter(description = "Claim id") @PathVariable("id") UUID claimId,
-            @Valid @NotNull @RequestBody ReimbursementSubmitRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Amount requested from the vendor with an optional vendor claim"
+                                    + " reference and back-office notes.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Portal submission", value = """
+                                                                    {"amountRequested":145.50,
+                                                                     "vendorClaimReference":"MICH-CLM-99120",
+                                                                     "notes":"Submitted via provider portal"}
+                                                                    """)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    ReimbursementSubmitRequest request) {
         return ResponseEntity.ok(reimbursementService.submit(claimId, request));
     }
 
-    @Operation(
-            summary = "Update vendor reimbursement",
-            description = "Records a vendor decision (APPROVED/PARTIALLY_APPROVED/DENIED), credit receipt, or"
-                    + " write-off; only legal child-lifecycle transitions are accepted")
+    @Operation(operationId = "updateReimbursement", summary = "Update vendor reimbursement", description = """
+                    Records the vendor's resolution on a claim's reimbursement: a decision (APPROVED, \
+                    PARTIALLY_APPROVED, DENIED), the credit receipt (CREDIT_RECEIVED), or a write-off \
+                    (WRITTEN_OFF).
+                    Use this tool after the vendor responds; do not use submitReimbursement, which performs the \
+                    initial NOT_SUBMITTED-to-SUBMITTED move.
+                    Preconditions: the claim must have a reimbursement record and the move must be legal in the \
+                    child state machine — SUBMITTED may resolve to APPROVED, PARTIALLY_APPROVED, or DENIED, \
+                    approvals may then move to CREDIT_RECEIVED, and any non-terminal state may be WRITTEN_OFF; \
+                    DENIED, CREDIT_RECEIVED, WRITTEN_OFF, and NOT_APPLICABLE are terminal and unblock claim \
+                    close.
+                    Required inputs: claim id (UUID) as a path parameter and a body with status; amountApproved \
+                    is required for APPROVED and PARTIALLY_APPROVED, and creditReference typically accompanies \
+                    CREDIT_RECEIVED.
+                    Emits a WARRANTY_REIMBURSEMENT_UPDATE event and enqueues warranty.reimbursement.resolved for \
+                    every resolution status so pos-accounting can match or stop expecting the vendor credit.
+                    Returns 400 when the target status is outside the updatable set or amountApproved is missing, \
+                    404 when the claim or its reimbursement record does not exist, and 409 when the transition is \
+                    illegal from the current status (nextAction lists the legal moves).
+                    """)
     @ApiResponse(responseCode = "200", description = "Reimbursement updated.")
     @ApiResponse(responseCode = "404", description = "Claim or reimbursement not found.")
     @ApiResponse(responseCode = "409", description = "Illegal reimbursement transition.")
@@ -73,13 +120,36 @@ public class ReimbursementController {
     @PutMapping("/claims/{id}/reimbursement")
     public ResponseEntity<ReimbursementResponse> updateReimbursement(
             @Parameter(description = "Claim id") @PathVariable("id") UUID claimId,
-            @Valid @NotNull @RequestBody ReimbursementUpdateRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Vendor resolution: target status with the approved amount, credit"
+                                    + " reference, or notes that go with it.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Vendor approved", value = """
+                                                                    {"status":"APPROVED",
+                                                                     "amountApproved":130.00,
+                                                                     "notes":"Vendor approved at adjusted labor rate"}
+                                                                    """)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    ReimbursementUpdateRequest request) {
         return ResponseEntity.ok(reimbursementService.update(claimId, request));
     }
 
-    @Operation(
-            summary = "Reimbursement worklist",
-            description = "Back-office worklist of vendor reimbursements, filterable by status and provider")
+    @Operation(operationId = "listReimbursements", summary = "Reimbursement worklist", description = """
+                    Returns the back-office worklist of vendor reimbursements across all claims, optionally \
+                    filtered by status and provider.
+                    Use this tool to work open vendor credits; use getClaim instead to see the reimbursement of \
+                    one specific claim.
+                    Preconditions: none — an empty list is returned when nothing matches.
+                    Required inputs: status and providerId are optional query parameters and combine as AND when \
+                    both are given; omitting both returns every reimbursement.
+                    No events are emitted and no state changes; this is a read-only projection.
+                    Returns 200 with the list, which is empty rather than 404 when nothing matches.
+                    """)
     @ApiResponse(responseCode = "200", description = "Reimbursements returned.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.REIMBURSEMENT_VIEW + "')")
     @GetMapping("/reimbursements")

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/ReimbursementController.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/ReimbursementController.java
@@ -113,6 +113,9 @@ public class ReimbursementController {
                     illegal from the current status (nextAction lists the legal moves).
                     """)
     @ApiResponse(responseCode = "200", description = "Reimbursement updated.")
+    @ApiResponse(
+            responseCode = "400",
+            description = "Target status outside the updatable set, or amountApproved missing when required.")
     @ApiResponse(responseCode = "404", description = "Claim or reimbursement not found.")
     @ApiResponse(responseCode = "409", description = "Illegal reimbursement transition.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.REIMBURSEMENT_MANAGE + "')")

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/SettlementController.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/controller/SettlementController.java
@@ -9,6 +9,8 @@ import com.positivity.warranty.internal.service.SettlementReconciliationService;
 import com.positivity.warranty.internal.service.SettlementService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -45,11 +47,31 @@ public class SettlementController {
     private final SettlementService settlementService;
     private final SettlementReconciliationService settlementReconciliationService;
 
-    @Operation(
-            summary = "Execute a settlement",
-            description = "Executes one settlement on an APPROVED (or already SETTLED) claim: creates an invoice"
-                    + " adjustment/refund via pos-invoice for credit/refund types, links a validated replacement"
-                    + " workorder, or records NO_ACTION. The first successful settlement moves the claim to SETTLED.")
+    @Operation(operationId = "createSettlement", summary = "Execute a settlement", description = """
+                    Executes one settlement on an APPROVED or already SETTLED claim: credit types \
+                    (INVOICE_CREDIT, PRORATED_CREDIT, GOODWILL) create an invoice adjustment via pos-invoice, \
+                    REFUND initiates a refund of a captured payment via pos-invoice, REPLACEMENT_WORKORDER links a \
+                    workorder that staff already created through the normal flow, and NO_ACTION records that \
+                    nothing is owed.
+                    Use this tool when the clerk settles the customer; do not use decideClaim, which approves the \
+                    claim first, and do not use submitReimbursement, which is the later vendor-recovery step that \
+                    never blocks customer settlement.
+                    Preconditions: the claim must be APPROVED or SETTLED (concurrent settlements of the same \
+                    claim are serialized under a pessimistic lock), a replacement workorder must already exist in \
+                    the event-fed workorder replica, and pos-invoice writes carry the settlement id as the \
+                    idempotency key (externalReference).
+                    Required inputs: claim id (UUID) and a body with settlementType, coveredAmount, and \
+                    customerAmount (both zero or positive); replacementWorkorderId is required for \
+                    REPLACEMENT_WORKORDER, invoiceId for the credit types, and invoiceId plus paymentId for \
+                    REFUND.
+                    Emits a WARRANTY_CLAIM_SETTLE event and enqueues warranty.claim.settled for pos-accounting; \
+                    the first successful settlement moves the claim APPROVED to SETTLED, and a failed pos-invoice \
+                    write keeps a durable FAILED settlement row for the reconciliation worklist.
+                    Returns 400 when the type-specific reference id is missing, 404 when the claim does not \
+                    exist, 409 when the claim is not settleable, 422 when the replacement workorder cannot be \
+                    resolved, and 502 when the pos-invoice write fails (the settlement is recorded FAILED and \
+                    staff retry with a fresh settlement after checking reconcileSettlements).
+                    """)
     @ApiResponse(responseCode = "201", description = "Settlement executed.")
     @ApiResponse(responseCode = "404", description = "Claim not found.")
     @ApiResponse(responseCode = "409", description = "Claim is not in a settleable state.")
@@ -60,17 +82,45 @@ public class SettlementController {
     @PostMapping("/claims/{id}/settlements")
     public ResponseEntity<SettlementResponse> createSettlement(
             @Parameter(description = "Claim id") @PathVariable("id") UUID claimId,
-            @Valid @NotNull @RequestBody SettlementCreateRequest request) {
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "Settlement to execute: how the customer is made whole, the covered and"
+                                    + " customer amounts, and the type-specific reference ids.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            examples = @ExampleObject(name = "Prorated credit", value = """
+                                                                    {"settlementType":"PRORATED_CREDIT",
+                                                                     "coveredAmount":142.49,
+                                                                     "customerAmount":47.50,
+                                                                     "invoiceId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04",
+                                                                     "notes":"Prorated at 75% remaining tread"}
+                                                                    """)))
+                    @Valid
+                    @NotNull
+                    @RequestBody
+                    SettlementCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(settlementService.create(claimId, request));
     }
 
     @Operation(
+            operationId = "reconcileSettlements",
             summary = "Reconcile FAILED settlements against pos-invoice",
-            description = "Read-only worklist (issue #922): every FAILED adjustment/refund settlement checked"
-                    + " against pos-invoice by its externalReference (the settlement id). Rows with"
-                    + " committedOnInvoice=true are the double-pay risk — pos-invoice committed the money write"
-                    + " even though warranty recorded the settlement as FAILED. Rows with checkStatus=UNKNOWN"
-                    + " could not be verified (pos-invoice unreachable) and should be re-checked.")
+            description = """
+                    Builds the reconciliation worklist for FAILED invoice-writing settlements by asking \
+                    pos-invoice whether each adjustment or refund actually committed, matched by \
+                    externalReference (the settlement id).
+                    Use this tool to detect double-pay risk after a settlement failure; do not retry with \
+                    createSettlement until the row shows committedOnInvoice=false — committedOnInvoice=true means \
+                    pos-invoice committed the money write even though warranty recorded the settlement as FAILED.
+                    Preconditions: none — only settlements already recorded FAILED with an invoice-writing type \
+                    appear, and pos-invoice is consulted live at request time.
+                    Required inputs: none; there are no parameters and no request body.
+                    Emits a WARRANTY_SETTLEMENT_RECONCILIATION audit event; no state changes, this is a read-only \
+                    cross-service check.
+                    Returns 200 with one row per FAILED settlement, where checkStatus UNKNOWN means pos-invoice \
+                    was unreachable for that invoice and the worklist should be re-run before acting.
+                    """)
     @ApiResponse(responseCode = "200", description = "Reconciliation worklist.")
     @PreAuthorize("hasAuthority('" + WarrantyPermissions.CLAIM_SETTLE + "')")
     @EmitEvent(id = "WARRANTY_SETTLEMENT_RECONCILIATION", apiVersion = "1")


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (platform-wide API documentation standard, #1263 rollout wave D of E)
- Parent STORY (durion): ADR-0042 (`durion/docs/adr/0042-openapi-annotation-standards.adr.md`)
- Child issue: louisburroughs/durion-positivity-backend#1263
- Domain: `domain:platform` (catalog, customer, security-service)

## Contract References
- Contract guide entry (durion): `domains/platform/.business-rules/BACKEND_CONTRACT_GUIDE.md` — no contract semantics change; spec deltas are description/operationId/requestBody metadata.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controllers
- [x] `openapi.yaml` regenerated for all three modules; aggregate unchanged
- [ ] Angular SDK regenerated — deferred to a single regen after the full wave stack lands

## Scope

**Wave D of the #1263 rollout**, stacked on #1293 (wave C):

| module | ops | request bodies annotated |
| --- | --- | --- |
| pos-catalog | 66 | 30 |
| pos-customer | 82 | 30 |
| pos-security-service | 64 annotations | 19 |

**Code-derived corrections now in the contract text (highlights):**
- pos-catalog: `getEffectiveLocationPrice` 404s when no ACTIVE/PENDING override exists (old text claimed base-price fallback); guardrail violations are 400, not 409; create/update catalog silently drop unresolvable member ids — callers told to compare returned lists; `bulkIngestCatalogProducts` had no `@Operation` at all and got one.
- pos-customer: the accounts-scoped communication-preference pair are unpersisted stubs — descriptions steer to the parties-scoped operations; `searchParties` accepts paging params but does not apply them; legacy `createCustomer` has no `@Valid`, so DTO validation is not enforced (and the description doesn't claim it).
- pos-security-service: `registerModulePermissions` documented as the lenient startup manifest endpoint every pos-* module calls, disambiguated from strict `registerPermissionsContract`; self-register's five 409 codes enumerated; user/role misses map to 400 today (stale 404 annotations kept, flagged); `deleteUser`/`revokeToken` are silent no-ops; audit search filters accepted-but-unapplied (TODO B-3) called out so agents don't rely on them; audit export documented as an in-memory stub.

## Tests
- [x] `OpenApiRepositoryValidationTest` green with all three at depth-STRICT
- [ ] Integration — n/a
- [ ] Provider behavioral contract tests — n/a
- How to run:
```bash
./mvnw -pl pos-openapi-validation -DskipTests=false -Dtest=OpenApiRepositoryValidationTest test
```

## Risk & Rollback
- Risk level: Low — annotation/documentation only.
- Rollback plan: revert, or flip the three `annotationDepth` entries back to `REPORT_ONLY`.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, rollout branch `docs/1263-wave-d`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a
- [x] Links to parent + child issues are present
