### PR TITLE
fix(customer): partial updates no longer wipe VINs; fix commercial name transposition

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CustomerDTO.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CustomerDTO.java
@@ -3,7 +3,6 @@ package com.positivity.customer.internal.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -44,12 +43,20 @@ public class CustomerDTO {
 
     @NotBlank
     @Size(max = 100)
-    @Schema(description = "Last name of the customer", example = "Doe", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "Last name of the customer. For a commercial party (customerType=COMMERCIAL), this"
+                    + " field carries the organization's legal/registered name instead.",
+            example = "Doe",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String lastName;
 
     @NotBlank
     @Size(max = 100)
-    @Schema(description = "First name of the customer", example = "John", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            description = "First name of the customer. For a commercial party (customerType=COMMERCIAL), this"
+                    + " field carries the organization's display name instead.",
+            example = "John",
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String firstName;
 
     @Size(max = 255)
@@ -61,12 +68,12 @@ public class CustomerDTO {
             deprecated = true)
     private String primaryAddress;
 
-    @Builder.Default
     @Schema(
-            description = "List of vehicle VINs associated with the customer",
+            description = "List of vehicle VINs associated with the customer. Omitting this field on an update"
+                    + " leaves the customer's existing VINs unchanged; sending an empty list clears them.",
             example = "[\"1HGCM82633A004352\"]",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private List<String> vehicleVins = new ArrayList<>();
+    private List<String> vehicleVins;
 
     @Size(max = 50)
     @Schema(

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CommercialPartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CommercialPartyServiceImpl.java
@@ -226,8 +226,8 @@ public class CommercialPartyServiceImpl implements CustomerService {
     private CommercialParty toEntity(CustomerDTO dto) {
         CommercialParty entity = createEntityByType(dto.getCustomerType());
         entity.setCustomerNumber(dto.getCustomerNumber());
-        entity.setLegalName(dto.getFirstName());
-        entity.setDisplayName(dto.getLastName());
+        entity.setLegalName(dto.getLastName());
+        entity.setDisplayName(dto.getFirstName());
         entity.setPrimaryAddress(dto.getPrimaryAddress());
         if (dto.getVehicleVins() != null) {
             entity.getVehicleVins().addAll(dto.getVehicleVins());
@@ -245,11 +245,11 @@ public class CommercialPartyServiceImpl implements CustomerService {
         if (dto.getCustomerNumber() != null) {
             entity.setCustomerNumber(dto.getCustomerNumber());
         }
-        if (dto.getFirstName() != null) {
-            entity.setLegalName(dto.getFirstName());
-        }
         if (dto.getLastName() != null) {
-            entity.setDisplayName(dto.getLastName());
+            entity.setLegalName(dto.getLastName());
+        }
+        if (dto.getFirstName() != null) {
+            entity.setDisplayName(dto.getFirstName());
         }
         if (dto.getPrimaryAddress() != null) {
             entity.setPrimaryAddress(dto.getPrimaryAddress());

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/CommercialPartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/CommercialPartyServiceImplTest.java
@@ -35,8 +35,9 @@ import org.springframework.data.domain.PageRequest;
  * behind an organization — so this service is the simpler sibling of
  * {@link PersonPartyServiceImpl}. What it does have is a
  * {@link CustomerDTO}-shaped API that carries organization names in
- * person-shaped fields, and the mapping between the two is <em>not</em>
- * symmetric; see {@link Mapping#roundTripSwapsTheNameFields()}.
+ * person-shaped fields: {@code lastName} holds the legal/registered name and
+ * {@code firstName} holds the display name, symmetrically on both read and
+ * write; see {@link Mapping#roundTripPreservesTheNameFields()}.
  *
  * <p>
  * Commercial parties hold no locally searchable email, so an email-only query
@@ -92,14 +93,14 @@ class CommercialPartyServiceImplTest {
         }
 
         @Test
-        @DisplayName("writes firstName to the legal name and lastName to the display name")
+        @DisplayName("writes lastName to the legal name and firstName to the display name")
         void writeMapping() {
             when(commercialRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
             service.createCustomer(CustomerDTO.builder()
                     .customerType("COMMERCIAL")
-                    .firstName("Fleet Co LLC")
-                    .lastName("Fleet Co")
+                    .lastName("Fleet Co LLC")
+                    .firstName("Fleet Co")
                     .build());
 
             ArgumentCaptor<CommercialParty> captor = ArgumentCaptor.forClass(CommercialParty.class);
@@ -109,23 +110,21 @@ class CommercialPartyServiceImplTest {
         }
 
         @Test
-        @DisplayName("a create-then-read round trip returns the two names swapped")
-        void roundTripSwapsTheNameFields() {
+        @DisplayName("a create-then-read round trip preserves both name fields")
+        void roundTripPreservesTheNameFields() {
             when(commercialRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
             CustomerDTO created = service.createCustomer(CustomerDTO.builder()
                     .customerType("COMMERCIAL")
-                    .firstName("Fleet Co LLC")
-                    .lastName("Fleet Co")
+                    .lastName("Fleet Co LLC")
+                    .firstName("Fleet Co")
                     .build());
 
-            // Documents current behaviour, not desired behaviour. toEntity maps firstName ->
-            // legalName and lastName -> displayName, while toDTO maps legalName -> lastName and
-            // displayName -> firstName. The two directions disagree, so a client that POSTs a
-            // commercial party and reads it back gets its two name fields transposed.
-            // updateEntityFromDTO follows toEntity, so the same transposition applies on update.
-            assertThat(created.getFirstName()).isEqualTo("Fleet Co");
+            // toEntity now maps lastName -> legalName and firstName -> displayName, agreeing with
+            // toDTO's legalName -> lastName / displayName -> firstName. updateEntityFromDTO follows
+            // toEntity, so the same agreement holds on update (issue #1246).
             assertThat(created.getLastName()).isEqualTo("Fleet Co LLC");
+            assertThat(created.getFirstName()).isEqualTo("Fleet Co");
         }
     }
 
@@ -262,8 +261,8 @@ class CommercialPartyServiceImplTest {
         }
 
         @Test
-        @DisplayName("an update that names no VINs clears the ones the party had")
-        void omittingVinsClearsThem() {
+        @DisplayName("an update that omits VINs leaves the ones the party had")
+        void omittingVinsLeavesThemUnchanged() {
             CommercialParty existing = party();
             when(commercialRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
             when(commercialRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
@@ -271,11 +270,10 @@ class CommercialPartyServiceImplTest {
             service.updateCustomer(
                     PARTY_ID, CustomerDTO.builder().primaryAddress("2 Depot Rd").build());
 
-            // Documents current behaviour, not desired behaviour — same cause as the person-party
-            // case: CustomerDTO declares vehicleVins @Builder.Default with an empty ArrayList and
-            // initializes it in the no-args constructor Jackson uses, so the `!= null` guard in
-            // updateEntityFromDTO can never be false and a partial update drops every VIN.
-            assertThat(existing.getVehicleVins()).isEmpty();
+            // CustomerDTO's vehicleVins has no field initializer, so an absent field in the request
+            // body deserializes as null, not an empty list (issue #1245). The `!= null` guard in
+            // updateEntityFromDTO now actually skips the clear()/addAll() branch on a partial update.
+            assertThat(existing.getVehicleVins()).containsExactly("VIN-1");
         }
 
         @Test

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/PersonPartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/PersonPartyServiceImplTest.java
@@ -377,8 +377,8 @@ class PersonPartyServiceImplTest {
         }
 
         @Test
-        @DisplayName("an update that names no VINs clears the ones the party had")
-        void omittingVinsClearsThem() {
+        @DisplayName("an update that omits VINs leaves the ones the party had")
+        void omittingVinsLeavesThemUnchanged() {
             PersonParty existing = party(PERSON_ID);
             when(customerRepository.findById(PARTY_ID)).thenReturn(Optional.of(existing));
             when(customerRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
@@ -386,13 +386,11 @@ class PersonPartyServiceImplTest {
             service.updateCustomer(
                     PARTY_ID, CustomerDTO.builder().primaryAddress("2 Oak Ave").build());
 
-            // Documents current behaviour, not desired behaviour. updateEntityFromDTO guards on
-            // `vehicleVins != null`, but CustomerDTO declares the field @Builder.Default with an
-            // empty ArrayList and initializes it in the no-args constructor Jackson uses, so the
-            // guard can never be false: a partial update that simply omits vehicleVins reaches the
-            // clear()/addAll() branch with an empty list and drops every VIN association. The other
-            // optional fields on this DTO are plain nullable references and behave as intended.
-            assertThat(existing.getVehicleVins()).isEmpty();
+            // CustomerDTO's vehicleVins has no field initializer, so an absent field in the request
+            // body deserializes as null, not an empty list (issue #1245), and updateEntityFromDTO's
+            // `vehicleVins != null` guard now actually skips the clear()/addAll() branch on a
+            // partial update, matching how the DTO's other optional fields already behave.
+            assertThat(existing.getVehicleVins()).containsExactly("VIN-1");
         }
 
         @Test


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A — ad hoc bug-fix PR, not tied to a durion capability/story
- Parent STORY (durion): N/A
- Child issue: louisburroughs/durion-positivity-backend#1245, louisburroughs/durion-positivity-backend#1246
- Domain: `domain:crm`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): no `BACKEND_CONTRACT_GUIDE.md` entry update — this PR does not change the `CustomerDTO` request/response shape or any endpoint's public contract. It fixes two implementation bugs (a partial-update guard that was unreachable, and a write-mapping that disagreed with the read-mapping) so behavior matches what was already documented/intended; the only DTO change is `@Schema` description text plus dropping an internal field initializer that Jackson doesn't expose either way.
- Durion contract PR (if applicable): none

## Contract Chain (when a Controller changed)
- [x] N/A — no controller changed in this PR

## Scope
- What changed:
  - `CustomerDTO.vehicleVins` no longer has a field initializer / `@Builder.Default`, so an absent `vehicleVins` in a partial-update request body deserializes as `null` instead of an empty list, letting the existing `!= null` guard in `PersonPartyServiceImpl`/`CommercialPartyServiceImpl` actually skip the clear.
  - `CommercialPartyServiceImpl.toEntity`/`updateEntityFromDTO` now map `lastName -> legalName` and `firstName -> displayName`, agreeing with the existing `toDTO` read mapping.
  - Documented the person-shaped-fields-carry-org-names convention on `CustomerDTO`'s `firstName`/`lastName` `@Schema` descriptions.
- Why: #1245 — a partial `PUT /v1/crm/{id}` that omits `vehicleVins` was silently deleting every VIN on the party. #1246 — `CommercialPartyServiceImpl` transposed `legalName`/`displayName` between its read and write mappings, corrupting the pair on any create-then-read or read-modify-write cycle.

## Tests
- [x] Unit tests added/updated
- How to run:
  - `./mvnw -pl pos-customer -am -Dtest=PersonPartyServiceImplTest,CommercialPartyServiceImplTest test` — 22 + 16 test cases, 0 failures
  - `./mvnw -pl pos-customer -am test` (full module suite) — 0 failures, 0 errors
  - `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test` — 12 tests, 0 failures
  - `./mvnw spotless:apply` — no additional formatting changes needed

## Risk & Rollback
- Risk level: Low — behavior-restoring bug fix scoped to `pos-customer`, no schema/migration changes.
- Rollback plan: revert this commit; the prior (buggy) behavior returns.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — not applicable, this is not a capability-tracked change
- [ ] PR title starts with `[CAP:<cap-id>]` — not applicable, see above
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — N/A, no contract semantics changed
- [ ] Required CI checks passing
