### PR TITLE
fix(customer): firstName/lastName required-on-create only, not on partial update

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/controller/CustomerController.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/controller/CustomerController.java
@@ -130,8 +130,8 @@ public class CustomerController {
                     where COMMERCIAL routes to the commercial service and anything else creates a person \
                     party, and customerNumber, primaryAddress, and vehicleVins are optional.
                     Emits a CUSTOMER_CUSTOMER_CREATE event and publishes a party-changed customer fact.
-                    Returns 201 with the stored customer on success; field validation is not enforced on \
-                    this legacy path, so a malformed JSON body producing 400 is the only rejection.
+                    Returns 201 with the stored customer on success; returns 400 for a malformed JSON body or \
+                    when firstName/lastName are blank or absent.
                     """)
     @ApiResponse(responseCode = "201", description = "Customer created successfully.")
     @PostMapping

--- a/pos-customer/src/main/java/com/positivity/customer/internal/dto/CustomerDTO.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/dto/CustomerDTO.java
@@ -1,7 +1,6 @@
 package com.positivity.customer.internal.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.UUID;
@@ -41,22 +40,23 @@ public class CustomerDTO {
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String customerNumber;
 
-    @NotBlank
     @Size(max = 100)
     @Schema(
             description = "Last name of the customer. For a commercial party (customerType=COMMERCIAL), this"
-                    + " field carries the organization's legal/registered name instead.",
+                    + " field carries the organization's legal/registered name instead. Required when creating a"
+                    + " customer (POST); optional on update (PUT), where an absent value leaves the existing name"
+                    + " unchanged.",
             example = "Doe",
-            requiredMode = Schema.RequiredMode.REQUIRED)
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String lastName;
 
-    @NotBlank
     @Size(max = 100)
     @Schema(
             description = "First name of the customer. For a commercial party (customerType=COMMERCIAL), this"
-                    + " field carries the organization's display name instead.",
+                    + " field carries the organization's display name instead. Required when creating a customer"
+                    + " (POST); optional on update (PUT), where an absent value leaves the existing name unchanged.",
             example = "John",
-            requiredMode = Schema.RequiredMode.REQUIRED)
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String firstName;
 
     @Size(max = 255)

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CommercialPartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CommercialPartyServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -300,7 +301,7 @@ public class CommercialPartyServiceImpl implements CustomerService {
         return entity.getPartyType();
     }
 
-    private static boolean isBlank(String value) {
+    private static boolean isBlank(@Nullable String value) {
         return value == null || value.isBlank();
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/CommercialPartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/CommercialPartyServiceImpl.java
@@ -127,6 +127,9 @@ public class CommercialPartyServiceImpl implements CustomerService {
     @Transactional
     public CustomerDTO createCustomer(@NonNull CustomerDTO dto) {
         log.debug("Creating new customer: {}", dto);
+        if (isBlank(dto.getFirstName()) || isBlank(dto.getLastName())) {
+            throw new IllegalArgumentException("firstName and lastName are required to create a customer");
+        }
         CommercialParty customer = toEntity(dto);
 
         // Determine party type and save to appropriate repository
@@ -295,5 +298,9 @@ public class CommercialPartyServiceImpl implements CustomerService {
      */
     private PartyType determineCustomerType(CommercialParty entity) {
         return entity.getPartyType();
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonPartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonPartyServiceImpl.java
@@ -132,6 +132,9 @@ public class PersonPartyServiceImpl implements CustomerService {
     @Transactional
     public CustomerDTO createCustomer(@NonNull CustomerDTO dto) {
         log.debug("Creating new customer: {}", dto);
+        if (isBlank(dto.getFirstName()) || isBlank(dto.getLastName())) {
+            throw new IllegalArgumentException("firstName and lastName are required to create a customer");
+        }
         PersonParty customer = toEntity(dto);
 
         // Determine party type and save to appropriate repository
@@ -325,5 +328,9 @@ public class PersonPartyServiceImpl implements CustomerService {
      */
     private PartyType determineCustomerType(PersonParty entity) {
         return entity.getPartyType();
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonPartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PersonPartyServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -330,7 +331,7 @@ public class PersonPartyServiceImpl implements CustomerService {
         return entity.getPartyType();
     }
 
-    private static boolean isBlank(String value) {
+    private static boolean isBlank(@Nullable String value) {
         return value == null || value.isBlank();
     }
 }

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/CommercialPartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/CommercialPartyServiceImplTest.java
@@ -253,16 +253,20 @@ class CommercialPartyServiceImplTest {
         @Test
         @DisplayName("rejects a create with a blank firstName or lastName")
         void createRejectsBlankNames() {
-            assertThatThrownBy(() -> service.createCustomer(CustomerDTO.builder()
-                            .customerType("COMMERCIAL")
-                            .firstName("Fleet Co")
-                            .build()))
-                    .isInstanceOf(IllegalArgumentException.class);
-            assertThatThrownBy(() -> service.createCustomer(CustomerDTO.builder()
-                            .customerType("COMMERCIAL")
-                            .lastName("Fleet Co LLC")
-                            .build()))
-                    .isInstanceOf(IllegalArgumentException.class);
+            for (String blank : new String[] {null, "", "   "}) {
+                assertThatThrownBy(() -> service.createCustomer(CustomerDTO.builder()
+                                .customerType("COMMERCIAL")
+                                .firstName(blank)
+                                .lastName("Fleet Co LLC")
+                                .build()))
+                        .isInstanceOf(IllegalArgumentException.class);
+                assertThatThrownBy(() -> service.createCustomer(CustomerDTO.builder()
+                                .customerType("COMMERCIAL")
+                                .firstName("Fleet Co")
+                                .lastName(blank)
+                                .build()))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
 
             verifyNoInteractions(commercialRepository);
         }

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/CommercialPartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/CommercialPartyServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.positivity.customer.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -217,6 +218,8 @@ class CommercialPartyServiceImplTest {
             service.createCustomer(CustomerDTO.builder()
                     .customerType("COMMERCIAL")
                     .customerNumber("C-2001")
+                    .lastName("Fleet Co LLC")
+                    .firstName("Fleet Co")
                     .primaryAddress("1 Depot Rd")
                     .vehicleVins(List.of("VIN-1"))
                     .build());
@@ -234,14 +237,34 @@ class CommercialPartyServiceImplTest {
             when(commercialRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
             for (String type : new String[] {null, "", "commercial", "PERSON", "NONSENSE"}) {
-                assertThat(service.createCustomer(
-                                CustomerDTO.builder().customerType(type).build()))
+                assertThat(service.createCustomer(CustomerDTO.builder()
+                                .customerType(type)
+                                .lastName("Fleet Co LLC")
+                                .firstName("Fleet Co")
+                                .build()))
                         .isNotNull();
             }
 
             // This service owns commercial parties only, and an unrecognized type string must not
             // throw at the API boundary.
             verify(commercialRepository, org.mockito.Mockito.times(5)).save(any(CommercialParty.class));
+        }
+
+        @Test
+        @DisplayName("rejects a create with a blank firstName or lastName")
+        void createRejectsBlankNames() {
+            assertThatThrownBy(() -> service.createCustomer(CustomerDTO.builder()
+                            .customerType("COMMERCIAL")
+                            .firstName("Fleet Co")
+                            .build()))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> service.createCustomer(CustomerDTO.builder()
+                            .customerType("COMMERCIAL")
+                            .lastName("Fleet Co LLC")
+                            .build()))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verifyNoInteractions(commercialRepository);
         }
 
         @Test

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/PersonPartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/PersonPartyServiceImplTest.java
@@ -344,16 +344,20 @@ class PersonPartyServiceImplTest {
         @Test
         @DisplayName("rejects a create with a blank firstName or lastName")
         void createRejectsBlankNames() {
-            assertThatThrownBy(() -> service.createCustomer(CustomerDTO.builder()
-                            .customerType("PERSON")
-                            .firstName("Ada")
-                            .build()))
-                    .isInstanceOf(IllegalArgumentException.class);
-            assertThatThrownBy(() -> service.createCustomer(CustomerDTO.builder()
-                            .customerType("PERSON")
-                            .lastName("Lovelace")
-                            .build()))
-                    .isInstanceOf(IllegalArgumentException.class);
+            for (String blank : new String[] {null, "", "   "}) {
+                assertThatThrownBy(() -> service.createCustomer(CustomerDTO.builder()
+                                .customerType("PERSON")
+                                .firstName(blank)
+                                .lastName("Lovelace")
+                                .build()))
+                        .isInstanceOf(IllegalArgumentException.class);
+                assertThatThrownBy(() -> service.createCustomer(CustomerDTO.builder()
+                                .customerType("PERSON")
+                                .firstName("Ada")
+                                .lastName(blank)
+                                .build()))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
 
             verifyNoInteractions(customerRepository);
         }

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/PersonPartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/PersonPartyServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.positivity.customer.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.never;
@@ -327,14 +328,34 @@ class PersonPartyServiceImplTest {
             when(customerRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
             for (String type : new String[] {null, "", "person", "COMMERCIAL", "NONSENSE"}) {
-                assertThat(service.createCustomer(
-                                CustomerDTO.builder().customerType(type).build()))
+                assertThat(service.createCustomer(CustomerDTO.builder()
+                                .customerType(type)
+                                .firstName("Ada")
+                                .lastName("Lovelace")
+                                .build()))
                         .isNotNull();
             }
 
             // This service owns person parties only; the type string cannot make it produce another
             // kind, and an unrecognized value must not throw at the API boundary.
             verify(customerRepository, org.mockito.Mockito.times(5)).save(any(PersonParty.class));
+        }
+
+        @Test
+        @DisplayName("rejects a create with a blank firstName or lastName")
+        void createRejectsBlankNames() {
+            assertThatThrownBy(() -> service.createCustomer(CustomerDTO.builder()
+                            .customerType("PERSON")
+                            .firstName("Ada")
+                            .build()))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> service.createCustomer(CustomerDTO.builder()
+                            .customerType("PERSON")
+                            .lastName("Lovelace")
+                            .build()))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verifyNoInteractions(customerRepository);
         }
 
         @Test


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A — ad hoc bug-fix PR, not tied to a durion capability/story
- Parent STORY (durion): N/A
- Child issue: louisburroughs/durion-positivity-backend#1298
- Domain: `domain:crm`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): no `BACKEND_CONTRACT_GUIDE.md` entry update — this narrows the OpenAPI-advertised `required` set (firstName/lastName go from REQUIRED to NOT_REQUIRED on the shared `CustomerDTO`) rather than widening it, and adds real enforcement (400 on blank names) only on the create path where it was already documented as required. No new fields, no removed fields, no response-shape change.
- Durion contract PR (if applicable): none

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller — `createCustomer`'s `@Operation` description now states it returns 400 when firstName/lastName are blank/absent
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — not regenerated in this PR; only `@Schema`/`@Operation` description text and `requiredMode` changed, no field additions/removals
- [ ] Angular SDK regenerated — not needed, no shape change

## Scope
- What changed:
  - `CustomerDTO.firstName`/`lastName` drop `@NotBlank` and switch to `@Schema(requiredMode = NOT_REQUIRED)`, with descriptions clarifying they're required on create (`POST`) and optional on update (`PUT`, where absent means "leave unchanged").
  - `PersonPartyServiceImpl.createCustomer` and `CommercialPartyServiceImpl.createCustomer` now throw `IllegalArgumentException` (→ 400 via the existing `CrmExceptionHandler`) when `firstName` or `lastName` is blank, so "required on create" is actually enforced instead of being decorative.
  - `CustomerController.createCustomer`'s `@Operation` description updated to match (previously claimed "field validation is not enforced on this legacy path").
- Why: fixes #1298 — a review comment on #1297 correctly flagged that `@NotBlank`/`REQUIRED` on these fields contradicted `updateCustomer`'s documented partial-update semantics, and that neither endpoint applied `@Valid` so the annotations weren't enforced anyway. Chose the "keep one DTO, validate required-on-create explicitly" option (vs. splitting into separate create/update DTOs) per user decision — smaller change, no new classes, no controller/interface signature changes.

## Tests
- [x] Unit tests added/updated
- How to run:
  - `./mvnw -pl pos-customer -am -Dtest=PersonPartyServiceImplTest,CommercialPartyServiceImplTest test` — 23 + 17 test cases (added `createRejectsBlankNames` to each; updated the two `unknownTypeStillCreates*` loop tests and `CommercialPartyServiceImplTest.createPublishes` to pass names now that create validates them), 0 failures
  - `./mvnw -pl pos-customer -am test` (full module suite) — 0 failures, 0 errors
  - `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test` — 12 tests, 0 failures
  - `./mvnw spotless:apply` — applied (import ordering / test formatting)

## Risk & Rollback
- Risk level: Low — validation-only change scoped to `pos-customer`'s legacy flat customer create/update path; no schema/migration changes.
- Rollback plan: revert this commit; `firstName`/`lastName` return to being `@NotBlank`+REQUIRED-but-unenforced.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — not applicable, this is not a capability-tracked change
- [ ] PR title starts with `[CAP:<cap-id>]` — not applicable, see above
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed) — N/A, no contract semantics changed (see Contract References above)
- [ ] Required CI checks passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01JjtTeippTe2gNqoWrioH86)_