### PR TITLE
fix(tax-common): accept real Canadian provinces in SubdivisionForCountryValidator

### DIFF
--- a/pos-tax-common/src/main/java/com/positivity/tax/common/validation/SubdivisionForCountryValidator.java
+++ b/pos-tax-common/src/main/java/com/positivity/tax/common/validation/SubdivisionForCountryValidator.java
@@ -19,6 +19,12 @@ public class SubdivisionForCountryValidator
             "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY", "DC", "AS", "GU", "MP",
             "PR", "UM", "VI");
 
+    // The org.meeuw.i18n:i18n-subdivision-enums dataset carries no Canadian subdivision
+    // data (probing CA yields only "NA"), so — as with the US territories above — the
+    // ISO 3166-2:CA provinces and territories need an explicit fallback.
+    private static final Set<String> CA_SUBDIVISION_CODES =
+            Set.of("AB", "BC", "MB", "NB", "NL", "NS", "NT", "NU", "ON", "PE", "QC", "SK", "YT");
+
     @Override
     public boolean isValid(TaxCalculationRequest.TaxAddress value, ConstraintValidatorContext context) {
         if (value == null) {
@@ -44,6 +50,10 @@ public class SubdivisionForCountryValidator
 
         if (CountryCode.US.equals(country)) {
             return US_SUBDIVISION_CODES.contains(normalizedRegion);
+        }
+
+        if (CountryCode.CA.equals(country)) {
+            return CA_SUBDIVISION_CODES.contains(normalizedRegion);
         }
 
         return false;

--- a/pos-tax-common/src/test/java/com/positivity/tax/common/validation/TaxValidationTest.java
+++ b/pos-tax-common/src/test/java/com/positivity/tax/common/validation/TaxValidationTest.java
@@ -24,9 +24,9 @@ import org.junit.jupiter.params.provider.ValueSource;
  *
  * <p>
  * The subdivision check normalizes {@code US-TX} and {@code tx} to {@code TX}
- * before matching, and carries an explicit US fallback list because the ISO
- * dataset alone does not cover the territories tax law cares about (PR, GU, DC,
- * ...).
+ * before matching, and carries explicit US and CA fallback lists because the ISO
+ * dataset alone does not cover the US territories tax law cares about (PR, GU,
+ * DC, ...) or any Canadian province at all.
  */
 @DisplayName("pos-tax-common validators — country, currency, subdivision")
 class TaxValidationTest {
@@ -107,16 +107,16 @@ class TaxValidationTest {
         }
 
         @ParameterizedTest
-        @CsvSource({"CA, ON", "CA, QC", "CA, BC"})
-        @DisplayName("rejects every real Canadian province — the backing dataset has no CA data")
-        void canadianProvincesAreRejected(String country, String region) {
-            // Documents current behaviour, not desired behaviour. The i18n-subdivision-enums
-            // dataset returns no subdivisions for Canada (probing yields only "NA"), and unlike
-            // the US there is no fallback list, so a valid Canadian address fails validation.
-            // Any consumer validating a Canadian TaxAddress gets a 400 for a correct region code.
-            // The fix — a CA fallback list like the US one, or a different dataset — is a design
-            // call; this test exists so it cannot be fixed silently.
-            assertThat(validator.isValid(address(country, region), null)).isFalse();
+        @CsvSource({
+            "CA, ON", "CA, QC", "CA, BC", "CA, AB", "CA, MB", "CA, NB", "CA, NL", "CA, NS", "CA, NT", "CA, NU",
+            "CA, PE", "CA, SK", "CA, YT"
+        })
+        @DisplayName("accepts every real Canadian province and territory via the explicit fallback list")
+        void canadianProvincesAreAccepted(String country, String region) {
+            // The i18n-subdivision-enums dataset returns no subdivisions for Canada (probing
+            // yields only "NA"), so — like the US territories below — CA needs an explicit
+            // fallback list rather than relying on the backing dataset.
+            assertThat(validator.isValid(address(country, region), null)).isTrue();
         }
 
         @ParameterizedTest

--- a/pos-tax-common/src/test/java/com/positivity/tax/common/validation/TaxValidationTest.java
+++ b/pos-tax-common/src/test/java/com/positivity/tax/common/validation/TaxValidationTest.java
@@ -112,7 +112,7 @@ class TaxValidationTest {
             "CA, PE", "CA, SK", "CA, YT"
         })
         @DisplayName("accepts every real Canadian province and territory via the explicit fallback list")
-        void canadianProvincesAreAccepted(String country, String region) {
+        void canadianProvincesAndTerritoriesAreAccepted(String country, String region) {
             // The i18n-subdivision-enums dataset returns no subdivisions for Canada (probing
             // yields only "NA"), so — like the US territories below — CA needs an explicit
             // fallback list rather than relying on the backing dataset.


### PR DESCRIPTION
## Capability & Traceability
- Child issue: louisburroughs/durion-positivity-backend#1254
- No `cap-id`/parent STORY/domain tag available for this fix — it's a self-contained validator bug fix in a shared library, not tied to a tracked capability.

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/tax/.business-rules/BACKEND_CONTRACT_GUIDE.md` → Tax Address / Subdivision Validation. No controller, DTO, event, or `openapi.yaml` changed — `@ValidSubdivisionForCountry`'s public contract (a `TaxAddress` either passes or fails validation) is unchanged; only which *valid* Canadian inputs now pass has changed, closing a gap versus the documented ISO 3166-2 region rules.
- Durion contract PR (if applicable): none — behavior-only fix, no contract semantics changed.

## Contract Chain (when a Controller changed)
N/A — no controller changed.

## Scope
- What changed: `SubdivisionForCountryValidator` rejected every real Canadian province/territory because the backing `org.meeuw.i18n:i18n-subdivision-enums` dataset has no Canadian subdivision data. Added a `CA_SUBDIVISION_CODES` fallback set (10 provinces + 3 territories: AB, BC, MB, NB, NL, NS, NT, NU, ON, PE, QC, SK, YT), mirroring the existing `US_SUBDIVISION_CODES` fallback used for the same dataset gap on US territories.
- Why: any consumer validating a Canadian `TaxAddress` (`countryCode=CA`, real `regionCode`) got an incorrect 400 at the validation boundary. `CAD` was already accepted by `IsoCurrencyCodeValidator`, so the library only half-supported the Canadian market.

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated
- How to run: `./mvnw -pl pos-tax-common -am -Dtest=TaxValidationTest test`

`TaxValidationTest.canadianProvincesAreRejected` (added in #1251 to pin the buggy behavior) is renamed to `canadianProvincesAndTerritoriesAreAccepted` and flipped to expect acceptance, covering the full CA set (renamed again per review feedback to make clear it covers territories, not just provinces). `usTerritories` and `subdivisionMembership` (including the `CA, TX, false` cross-country case) are unchanged and continue to pass, confirming no regression to US or cross-country handling. Full `pos-tax-common` suite: 92/92 passing.

## Risk & Rollback
- Risk level: Low — additive fallback list scoped to one validator; only affects `CA` inputs, which previously always failed.
- Rollback plan: revert this commit; behavior returns to rejecting all Canadian regions (the prior, broken state).

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, no capability id for this fix (branch is `claude/issue-1254-5ak9ke`, mapped to issue #1254)
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, no capability id for this fix
- [x] Links to child issue present
- [x] Contract guide referenced (BACKEND_CONTRACT_GUIDE.md) — no contract semantics changed, reference included per gate requirement
- [ ] Required CI checks passing
