### PR TITLE
fix(events): make replica listener payload rejections observable (#1255)

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CustomerEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/CustomerEventsListener.java
@@ -5,17 +5,20 @@ import com.positivity.accounting.internal.entity.ProcessedEvent;
 import com.positivity.accounting.internal.repository.ExtCustomerBillingRulesRepository;
 import com.positivity.accounting.internal.repository.ProcessedEventRepository;
 import com.positivity.domainevents.customer.BillingRulesUpdatedV1;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -32,7 +35,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.accounting.kafka", name = "enabled", havingValue = "true")
 public class CustomerEventsListener {
 
@@ -40,6 +42,28 @@ public class CustomerEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtCustomerBillingRulesRepository billingRulesRepository;
+    private final Counter payloadRejectedCounter;
+
+    public CustomerEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtCustomerBillingRulesRepository billingRulesRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.billingRulesRepository = billingRulesRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "customer")
+                        .tag("entity", "customer-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.accounting.kafka.customer-events-topic:customer.events.v1}",
@@ -73,6 +97,11 @@ public class CustomerEventsListener {
         } catch (TransientDataAccessException e) {
             // Retry with backoff / DLQ via the container error handler (ADR-0044 §4).
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed billing-rules event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed billing-rules event eventId={}", eventId, e);
         }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/InventoryEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/InventoryEventsListener.java
@@ -3,16 +3,19 @@ package com.positivity.accounting.internal.service;
 import com.positivity.accounting.internal.entity.ProcessedEvent;
 import com.positivity.accounting.internal.repository.ProcessedEventRepository;
 import com.positivity.domainevents.inventory.ScrapPostedV1;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -42,7 +45,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.accounting.kafka", name = "enabled", havingValue = "true")
 public class InventoryEventsListener {
 
@@ -50,6 +52,28 @@ public class InventoryEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final InventoryShrinkagePostingService shrinkagePostingService;
+    private final Counter payloadRejectedCounter;
+
+    public InventoryEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            InventoryShrinkagePostingService shrinkagePostingService,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.shrinkagePostingService = shrinkagePostingService;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "inventory")
+                        .tag("entity", "inventory-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.accounting.kafka.inventory-events-topic:inventory.events.v1}",
@@ -85,6 +109,13 @@ public class InventoryEventsListener {
         ScrapPostedV1 fact;
         try {
             fact = objectMapper.treeToValue(envelope.path("payload"), ScrapPostedV1.class);
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed scrap event payload eventId={}: {}", eventId, e.getMessage(), e);
+            markProcessed(eventId);
+            return;
         } catch (Exception e) {
             log.warn("Skipping malformed scrap event eventId={}", eventId, e);
             markProcessed(eventId);

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/InvoiceEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/InvoiceEventsListener.java
@@ -8,19 +8,22 @@ import com.positivity.accounting.internal.repository.ExtInvoiceTaxRepository;
 import com.positivity.accounting.internal.repository.ProcessedEventRepository;
 import com.positivity.domainevents.invoice.InvoiceUpdatedV1;
 import com.positivity.domainevents.invoice.TaxBreakdownLine;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -34,7 +37,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.accounting.kafka", name = "enabled", havingValue = "true")
 public class InvoiceEventsListener {
 
@@ -43,6 +45,30 @@ public class InvoiceEventsListener {
     private final ProcessedEventRepository processedEventRepository;
     private final ExtInvoiceRepository extInvoiceRepository;
     private final ExtInvoiceTaxRepository extInvoiceTaxRepository;
+    private final Counter payloadRejectedCounter;
+
+    public InvoiceEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtInvoiceRepository extInvoiceRepository,
+            ExtInvoiceTaxRepository extInvoiceTaxRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extInvoiceRepository = extInvoiceRepository;
+        this.extInvoiceTaxRepository = extInvoiceTaxRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "invoice")
+                        .tag("entity", "invoice-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.accounting.kafka.invoice-events-topic:invoice.events.v1}",
@@ -76,6 +102,11 @@ public class InvoiceEventsListener {
         } catch (TransientDataAccessException e) {
             // Retry with backoff / DLQ via the container error handler (ADR-0044 §4).
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed invoice event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed invoice event eventId={}", eventId, e);
         }

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/OrderEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/OrderEventsListener.java
@@ -3,15 +3,18 @@ package com.positivity.accounting.internal.service;
 import com.positivity.accounting.internal.entity.ProcessedEvent;
 import com.positivity.accounting.internal.repository.ProcessedEventRepository;
 import com.positivity.domainevents.order.RegisterSessionClosedV1;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -31,7 +34,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.accounting.kafka", name = "enabled", havingValue = "true")
 public class OrderEventsListener {
 
@@ -39,6 +41,28 @@ public class OrderEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final RegisterOverShortPostingService registerOverShortPostingService;
+    private final Counter payloadRejectedCounter;
+
+    public OrderEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            RegisterOverShortPostingService registerOverShortPostingService,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.registerOverShortPostingService = registerOverShortPostingService;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "order")
+                        .tag("entity", "order-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.accounting.kafka.order-events-topic:order.events.v1}",
@@ -73,6 +97,17 @@ public class OrderEventsListener {
         RegisterSessionClosedV1 fact;
         try {
             fact = objectMapper.treeToValue(envelope.path("payload"), RegisterSessionClosedV1.class);
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error(
+                    "Rejected malformed register-session-closed event payload eventId={}: {}",
+                    eventId,
+                    e.getMessage(),
+                    e);
+            markProcessed(eventId);
+            return;
         } catch (Exception e) {
             log.warn("Skipping malformed register-session-closed event eventId={}", eventId, e);
             markProcessed(eventId);

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/SettlementConfigEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/SettlementConfigEventsListener.java
@@ -3,15 +3,18 @@ package com.positivity.accounting.internal.service;
 import com.positivity.accounting.internal.entity.ProcessedEvent;
 import com.positivity.accounting.internal.repository.ProcessedEventRepository;
 import com.positivity.domainevents.payment.SettlementProviderConfigV1;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -25,7 +28,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.accounting.kafka", name = "enabled", havingValue = "true")
 public class SettlementConfigEventsListener {
 
@@ -33,6 +35,28 @@ public class SettlementConfigEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final SettlementConfigService settlementConfigService;
+    private final Counter payloadRejectedCounter;
+
+    public SettlementConfigEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            SettlementConfigService settlementConfigService,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.settlementConfigService = settlementConfigService;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "payment")
+                        .tag("entity", "settlement-config")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.accounting.kafka.settlement-config-topic:payment.settlement-config.v1}",
@@ -67,6 +91,13 @@ public class SettlementConfigEventsListener {
         SettlementProviderConfigV1 payload;
         try {
             payload = objectMapper.treeToValue(envelope.path("payload"), SettlementProviderConfigV1.class);
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed settlement config event payload eventId={}: {}", eventId, e.getMessage(), e);
+            markProcessed(eventId);
+            return;
         } catch (Exception e) {
             log.warn("Skipping malformed settlement config event eventId={}", eventId, e);
             markProcessed(eventId);

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/SettlementEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/SettlementEventsListener.java
@@ -4,15 +4,18 @@ import com.positivity.accounting.internal.entity.ProcessedEvent;
 import com.positivity.accounting.internal.repository.ProcessedEventRepository;
 import com.positivity.accounting.service.SettlementReconciliationService;
 import com.positivity.domainevents.payment.SettlementReportedV1;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -27,7 +30,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.accounting.kafka", name = "enabled", havingValue = "true")
 public class SettlementEventsListener {
 
@@ -35,6 +37,28 @@ public class SettlementEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final SettlementReconciliationService reconciliationService;
+    private final Counter payloadRejectedCounter;
+
+    public SettlementEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            SettlementReconciliationService reconciliationService,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.reconciliationService = reconciliationService;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "payment")
+                        .tag("entity", "settlement-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.accounting.kafka.payment-events-topic:payment.events.v1}",
@@ -71,6 +95,13 @@ public class SettlementEventsListener {
         SettlementReportedV1 payload;
         try {
             payload = objectMapper.treeToValue(envelope.path("payload"), SettlementReportedV1.class);
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed settlement event payload eventId={}: {}", eventId, e.getMessage(), e);
+            markProcessed(eventId);
+            return;
         } catch (Exception e) {
             log.warn("Skipping malformed settlement event eventId={}", eventId, e);
             markProcessed(eventId);

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/WarrantyEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/WarrantyEventsListener.java
@@ -6,16 +6,19 @@ import com.positivity.accounting.internal.repository.ProcessedEventRepository;
 import com.positivity.accounting.internal.repository.WarrantyReimbursementExpectationRepository;
 import com.positivity.domainevents.warranty.WarrantyReimbursementResolvedV1;
 import com.positivity.domainevents.warranty.WarrantyReimbursementSubmittedV1;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -32,7 +35,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.accounting.kafka", name = "enabled", havingValue = "true")
 public class WarrantyEventsListener {
 
@@ -40,6 +42,28 @@ public class WarrantyEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final WarrantyReimbursementExpectationRepository expectationRepository;
+    private final Counter payloadRejectedCounter;
+
+    public WarrantyEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            WarrantyReimbursementExpectationRepository expectationRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.expectationRepository = expectationRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "warranty")
+                        .tag("entity", "warranty-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.accounting.kafka.warranty-events-topic:warranty.events.v1}",
@@ -76,6 +100,11 @@ public class WarrantyEventsListener {
         } catch (TransientDataAccessException e) {
             // Retry with backoff / DLQ via the container error handler (ADR-0044 §4).
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed warranty event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed warranty event eventId={}", eventId, e);
         }

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/CustomerEventsListenerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/CustomerEventsListenerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -34,7 +35,12 @@ class CustomerEventsListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener = new CustomerEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, replica);
+        listener = new CustomerEventsListener(
+                TEST_CLOCK,
+                new ObjectMapper(),
+                processedEvents,
+                replica,
+                org.mockito.Mockito.mock(ObjectProvider.class));
     }
 
     private String event(String eventId, long version) {

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/InventoryEventsListenerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/InventoryEventsListenerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -45,7 +46,12 @@ class InventoryEventsListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener = new InventoryEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, postingService);
+        listener = new InventoryEventsListener(
+                TEST_CLOCK,
+                new ObjectMapper(),
+                processedEvents,
+                postingService,
+                org.mockito.Mockito.mock(ObjectProvider.class));
     }
 
     /** Representative costed scrap fact as published by pos-inventory (Wave-2 D1, #1030). */

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/InvoiceEventsListenerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/InvoiceEventsListenerTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -40,7 +41,13 @@ class InvoiceEventsListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener = new InvoiceEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, replica, taxReplica);
+        listener = new InvoiceEventsListener(
+                TEST_CLOCK,
+                new ObjectMapper(),
+                processedEvents,
+                replica,
+                taxReplica,
+                org.mockito.Mockito.mock(ObjectProvider.class));
     }
 
     private String eventWithBreakdown(String eventId, long version) {

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/OrderEventsListenerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/OrderEventsListenerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -41,7 +42,12 @@ class OrderEventsListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener = new OrderEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, postingService);
+        listener = new OrderEventsListener(
+                TEST_CLOCK,
+                new ObjectMapper(),
+                processedEvents,
+                postingService,
+                org.mockito.Mockito.mock(ObjectProvider.class));
     }
 
     private String sessionClosed(String eventId) {

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/SettlementListenersReliabilityTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/SettlementListenersReliabilityTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
 import tools.jackson.databind.ObjectMapper;
 
 /**
@@ -55,11 +56,21 @@ class SettlementListenersReliabilityTest {
     private SettlementReconciliationService reconciliationService;
 
     private SettlementConfigEventsListener configListener() {
-        return new SettlementConfigEventsListener(CLOCK, mapper, processedEventRepository, settlementConfigService);
+        return new SettlementConfigEventsListener(
+                CLOCK,
+                mapper,
+                processedEventRepository,
+                settlementConfigService,
+                org.mockito.Mockito.mock(ObjectProvider.class));
     }
 
     private SettlementEventsListener eventListener() {
-        return new SettlementEventsListener(CLOCK, mapper, processedEventRepository, reconciliationService);
+        return new SettlementEventsListener(
+                CLOCK,
+                mapper,
+                processedEventRepository,
+                reconciliationService,
+                org.mockito.Mockito.mock(ObjectProvider.class));
     }
 
     private String envelope(String eventType, String eventId, Object payload) {

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/WarrantyEventsListenerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/WarrantyEventsListenerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -39,7 +40,12 @@ class WarrantyEventsListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener = new WarrantyEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, expectations);
+        listener = new WarrantyEventsListener(
+                TEST_CLOCK,
+                new ObjectMapper(),
+                processedEvents,
+                expectations,
+                org.mockito.Mockito.mock(ObjectProvider.class));
     }
 
     private String submitted(String eventId, long version) {

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/InventoryShrinkageGLPostingIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/InventoryShrinkageGLPostingIT.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -112,7 +113,12 @@ class InventoryShrinkageGLPostingIT {
 
     @BeforeEach
     void setUp() {
-        listener = new InventoryEventsListener(clock, objectMapper, processedEventRepository, shrinkagePostingService);
+        listener = new InventoryEventsListener(
+                clock,
+                objectMapper,
+                processedEventRepository,
+                shrinkagePostingService,
+                org.mockito.Mockito.mock(ObjectProvider.class));
     }
 
     @AfterEach

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/InventoryEventsListener.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/InventoryEventsListener.java
@@ -8,17 +8,20 @@ import com.positivity.catalog.internal.repository.ExtProductLeadTimeReplicaRepos
 import com.positivity.catalog.internal.repository.ProcessedEventRepository;
 import com.positivity.domainevents.inventory.InventoryAvailabilityUpdatedV1;
 import com.positivity.domainevents.inventory.LeadTimeUpdatedV1;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -34,7 +37,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.catalog.kafka", name = "enabled", havingValue = "true")
 public class InventoryEventsListener {
 
@@ -45,6 +47,30 @@ public class InventoryEventsListener {
     private final ProcessedEventRepository processedEventRepository;
     private final ExtInventoryAvailabilityReplicaRepository extInventoryAvailabilityReplicaRepository;
     private final ExtProductLeadTimeReplicaRepository extProductLeadTimeReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public InventoryEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtInventoryAvailabilityReplicaRepository extInventoryAvailabilityReplicaRepository,
+            ExtProductLeadTimeReplicaRepository extProductLeadTimeReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extInventoryAvailabilityReplicaRepository = extInventoryAvailabilityReplicaRepository;
+        this.extProductLeadTimeReplicaRepository = extProductLeadTimeReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "inventory")
+                        .tag("entity", "inventory-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.catalog.kafka.inventory-events-topic:inventory.events.v1}",
@@ -78,6 +104,11 @@ public class InventoryEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed inventory event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed inventory event eventId={}", eventId, e);
         }

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/InventoryListenersTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/InventoryListenersTest.java
@@ -102,7 +102,12 @@ class InventoryListenersTest {
         when(availabilityRepository.findById(any())).thenReturn(Optional.empty());
         when(leadTimeRepository.findById(any())).thenReturn(Optional.empty());
         listener = new InventoryEventsListener(
-                clock, objectMapper, processedEventRepository, availabilityRepository, leadTimeRepository);
+                clock,
+                objectMapper,
+                processedEventRepository,
+                availabilityRepository,
+                leadTimeRepository,
+                org.mockito.Mockito.mock(ObjectProvider.class));
     }
 
     private static String availability(String eventId, long version, int atp) {

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PeopleContactEventsListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PeopleContactEventsListener.java
@@ -11,16 +11,19 @@ import com.positivity.domainevents.peoplecontact.OrganizationAddressUpdatedV1;
 import com.positivity.domainevents.peoplecontact.PersonDeletedV1;
 import com.positivity.domainevents.peoplecontact.PersonUpdatedV1;
 import com.positivity.domainevents.peoplecontact.PostalAddressV1;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -33,7 +36,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.customer.kafka", name = "enabled", havingValue = "true")
 public class PeopleContactEventsListener {
 
@@ -45,6 +47,32 @@ public class PeopleContactEventsListener {
     private final ExtPersonReplicaRepository extPersonReplicaRepository;
     private final ExtOrganizationPostalAddressRepository extOrganizationPostalAddressRepository;
     private final CustomerFactPublisher customerFactPublisher;
+    private final Counter payloadRejectedCounter;
+
+    public PeopleContactEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtPersonReplicaRepository extPersonReplicaRepository,
+            ExtOrganizationPostalAddressRepository extOrganizationPostalAddressRepository,
+            CustomerFactPublisher customerFactPublisher,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extPersonReplicaRepository = extPersonReplicaRepository;
+        this.extOrganizationPostalAddressRepository = extOrganizationPostalAddressRepository;
+        this.customerFactPublisher = customerFactPublisher;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description("Replica event payloads rejected due to Jackson databind failures"
+                                + " (e.g. omitted primitive fields)")
+                        .tag("owner", "people-contact")
+                        .tag("entity", "people-contact-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.customer.kafka.people-contact-events-topic:people-contact.events.v1}",
@@ -82,6 +110,11 @@ public class PeopleContactEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed people-contact event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed people-contact event eventId={}", eventId, e);
         }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/VehicleEventsListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/VehicleEventsListener.java
@@ -13,19 +13,22 @@ import com.positivity.customer.internal.repository.PersonPartyRepository;
 import com.positivity.customer.internal.repository.ProcessedEventRepository;
 import com.positivity.domainevents.vehicle.VehicleCarePreferenceUpdatedV1;
 import com.positivity.domainevents.vehicle.VehicleUpdatedV1;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -47,7 +50,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.customer.kafka", name = "enabled", havingValue = "true")
 public class VehicleEventsListener {
 
@@ -60,6 +62,34 @@ public class VehicleEventsListener {
     private final ExtVehicleCarePreferenceRepository extVehicleCarePreferenceRepository;
     private final PersonPartyRepository personPartyRepository;
     private final CommercialPartyRepository commercialPartyRepository;
+    private final Counter payloadRejectedCounter;
+
+    public VehicleEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtVehicleRepository extVehicleRepository,
+            ExtVehicleCarePreferenceRepository extVehicleCarePreferenceRepository,
+            PersonPartyRepository personPartyRepository,
+            CommercialPartyRepository commercialPartyRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extVehicleRepository = extVehicleRepository;
+        this.extVehicleCarePreferenceRepository = extVehicleCarePreferenceRepository;
+        this.personPartyRepository = personPartyRepository;
+        this.commercialPartyRepository = commercialPartyRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description("Replica event payloads rejected due to Jackson databind failures"
+                                + " (e.g. omitted primitive fields)")
+                        .tag("owner", "vehicle")
+                        .tag("entity", "vehicle-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.customer.kafka.vehicle-events-topic:vehicle.events.v1}",
@@ -97,6 +127,11 @@ public class VehicleEventsListener {
         } catch (TransientDataAccessException e) {
             // Retry with backoff / DLQ via the container error handler (ADR-0044 §4).
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed vehicle event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed vehicle event eventId={}", eventId, e);
         }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderEventsListener.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/WorkorderEventsListener.java
@@ -10,17 +10,20 @@ import com.positivity.customer.internal.repository.ProcessedEventRepository;
 import com.positivity.customer.internal.repository.ServiceHistoryRepository;
 import com.positivity.domainevents.workorder.WorkorderServiceCompletedV1;
 import com.positivity.domainevents.workorder.WorkorderServiceLineDeclinedV1;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -45,7 +48,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.customer.kafka", name = "enabled", havingValue = "true")
 public class WorkorderEventsListener {
 
@@ -57,6 +59,30 @@ public class WorkorderEventsListener {
     private final ProcessedEventRepository processedEventRepository;
     private final ServiceHistoryRepository serviceHistoryRepository;
     private final FollowUpTaskRepository followUpTaskRepository;
+    private final Counter payloadRejectedCounter;
+
+    public WorkorderEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ServiceHistoryRepository serviceHistoryRepository,
+            FollowUpTaskRepository followUpTaskRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.serviceHistoryRepository = serviceHistoryRepository;
+        this.followUpTaskRepository = followUpTaskRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description("Replica event payloads rejected due to Jackson databind failures"
+                                + " (e.g. omitted primitive fields)")
+                        .tag("owner", "workorder")
+                        .tag("entity", "workorder-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.customer.kafka.workorder-facts-topic:workorder.events.v1}",
@@ -96,6 +122,11 @@ public class WorkorderEventsListener {
         } catch (TransientDataAccessException e) {
             // Retry with backoff / DLQ via the container error handler (ADR-0044 §4).
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed workorder event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed workorder event eventId={} type={}", eventId, eventType, e);
         }

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/PeopleContactEventsListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/PeopleContactEventsListenerTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -70,7 +71,13 @@ class PeopleContactEventsListenerTest {
     @BeforeEach
     void setUp() {
         listener = new PeopleContactEventsListener(
-                TEST_CLOCK, new ObjectMapper(), processedEvents, personReplica, addressReplica, factPublisher);
+                TEST_CLOCK,
+                new ObjectMapper(),
+                processedEvents,
+                personReplica,
+                addressReplica,
+                factPublisher,
+                mock(ObjectProvider.class));
     }
 
     private static String personUpdated(long aggregateVersion) {

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/VehicleEventsListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/VehicleEventsListenerTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -60,7 +61,8 @@ class VehicleEventsListenerTest {
                 replica,
                 carePreferenceReplica,
                 personParties,
-                commercialParties);
+                commercialParties,
+                mock(ObjectProvider.class));
     }
 
     private String carePreferenceEvent(String eventId, long version, Integer intervalMonths, boolean deleted) {

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/WorkorderEventsListenerTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/WorkorderEventsListenerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -49,7 +50,8 @@ class WorkorderEventsListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener = new WorkorderEventsListener(TEST_CLOCK, MAPPER, processedEvents, serviceHistory, followUps);
+        listener = new WorkorderEventsListener(
+                TEST_CLOCK, MAPPER, processedEvents, serviceHistory, followUps, mock(ObjectProvider.class));
     }
 
     private String completedEvent(String eventId) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CatalogEventsListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CatalogEventsListener.java
@@ -9,18 +9,21 @@ import com.positivity.inventory.internal.repository.ExtProductReplicaRepository;
 import com.positivity.inventory.internal.repository.ExtProductSubstitutionReplicaRepository;
 import com.positivity.inventory.internal.repository.ExtProductUomReplicaRepository;
 import com.positivity.inventory.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -49,7 +52,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.inventory.kafka", name = "enabled", havingValue = "true")
 public class CatalogEventsListener {
 
@@ -62,6 +64,32 @@ public class CatalogEventsListener {
     private final ExtProductReplicaRepository extProductReplicaRepository;
     private final ExtProductUomReplicaRepository extProductUomReplicaRepository;
     private final ExtProductSubstitutionReplicaRepository extProductSubstitutionReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public CatalogEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtProductReplicaRepository extProductReplicaRepository,
+            ExtProductUomReplicaRepository extProductUomReplicaRepository,
+            ExtProductSubstitutionReplicaRepository extProductSubstitutionReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extProductReplicaRepository = extProductReplicaRepository;
+        this.extProductUomReplicaRepository = extProductUomReplicaRepository;
+        this.extProductSubstitutionReplicaRepository = extProductSubstitutionReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "catalog")
+                        .tag("entity", "catalog-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.inventory.kafka.catalog-events-topic:catalog.events.v1}",
@@ -95,6 +123,11 @@ public class CatalogEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed catalog event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed catalog event eventId={}", eventId, e);
         }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationEventsListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationEventsListener.java
@@ -11,17 +11,20 @@ import com.positivity.inventory.internal.repository.ExtLocationParentReplicaRepo
 import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
 import com.positivity.inventory.internal.repository.LocationRefRepository;
 import com.positivity.inventory.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -43,7 +46,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.inventory.kafka", name = "enabled", havingValue = "true")
 public class LocationEventsListener {
 
@@ -56,6 +58,32 @@ public class LocationEventsListener {
     private final LocationRefRepository locationRefRepository;
     private final ExtLocationParentReplicaRepository extLocationParentReplicaRepository;
     private final ExtStorageLocationReplicaRepository extStorageLocationReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public LocationEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            LocationRefRepository locationRefRepository,
+            ExtLocationParentReplicaRepository extLocationParentReplicaRepository,
+            ExtStorageLocationReplicaRepository extStorageLocationReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.locationRefRepository = locationRefRepository;
+        this.extLocationParentReplicaRepository = extLocationParentReplicaRepository;
+        this.extStorageLocationReplicaRepository = extStorageLocationReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "location")
+                        .tag("entity", "location-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.inventory.kafka.location-events-topic:location.events.v1}",
@@ -90,6 +118,11 @@ public class LocationEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed location event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed location event eventId={}", eventId, e);
         }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/WarrantyEventsListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/WarrantyEventsListener.java
@@ -6,16 +6,19 @@ import com.positivity.inventory.internal.entity.ProcessedEvent;
 import com.positivity.inventory.internal.entity.WarrantyPartReturnHold;
 import com.positivity.inventory.internal.repository.ProcessedEventRepository;
 import com.positivity.inventory.internal.repository.WarrantyPartReturnHoldRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -31,7 +34,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.inventory.kafka", name = "enabled", havingValue = "true")
 public class WarrantyEventsListener {
 
@@ -41,6 +43,28 @@ public class WarrantyEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final WarrantyPartReturnHoldRepository partReturnHoldRepository;
+    private final Counter payloadRejectedCounter;
+
+    public WarrantyEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            WarrantyPartReturnHoldRepository partReturnHoldRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.partReturnHoldRepository = partReturnHoldRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "warranty")
+                        .tag("entity", "warranty-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.inventory.kafka.warranty-events-topic:warranty.events.v1}",
@@ -75,6 +99,11 @@ public class WarrantyEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed warranty event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed warranty event eventId={}", eventId, e);
         }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/WorkorderEventsListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/WorkorderEventsListener.java
@@ -7,17 +7,20 @@ import com.positivity.inventory.internal.entity.ProcessedEvent;
 import com.positivity.inventory.internal.repository.ExtWorkorderPartReplicaRepository;
 import com.positivity.inventory.internal.repository.ExtWorkorderReplicaRepository;
 import com.positivity.inventory.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -34,7 +37,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.inventory.kafka", name = "enabled", havingValue = "true")
 public class WorkorderEventsListener {
 
@@ -45,6 +47,30 @@ public class WorkorderEventsListener {
     private final ProcessedEventRepository processedEventRepository;
     private final ExtWorkorderReplicaRepository extWorkorderReplicaRepository;
     private final ExtWorkorderPartReplicaRepository extWorkorderPartReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public WorkorderEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtWorkorderReplicaRepository extWorkorderReplicaRepository,
+            ExtWorkorderPartReplicaRepository extWorkorderPartReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extWorkorderReplicaRepository = extWorkorderReplicaRepository;
+        this.extWorkorderPartReplicaRepository = extWorkorderPartReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "workorder")
+                        .tag("entity", "workorder-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.inventory.kafka.workorder-events-topic:workorder.events.v1}",
@@ -78,6 +104,11 @@ public class WorkorderEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed workorder event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed workorder event eventId={}", eventId, e);
         }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CatalogEventsListenerTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CatalogEventsListenerTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -54,7 +55,13 @@ class CatalogEventsListenerTest {
     @BeforeEach
     void setUp() {
         listener = new CatalogEventsListener(
-                TEST_CLOCK, new ObjectMapper(), processedEvents, extProduct, extProductUom, extProductSubstitution);
+                TEST_CLOCK,
+                new ObjectMapper(),
+                processedEvents,
+                extProduct,
+                extProductUom,
+                extProductSubstitution,
+                org.mockito.Mockito.mock(ObjectProvider.class));
     }
 
     /** Full schema-v2 fact: base UoM, tracking level, conversion set, substitution group. */

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/WarrantyEventsListenerTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/WarrantyEventsListenerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -38,7 +39,8 @@ class WarrantyEventsListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener = new WarrantyEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, holds);
+        listener = new WarrantyEventsListener(
+                TEST_CLOCK, new ObjectMapper(), processedEvents, holds, org.mockito.Mockito.mock(ObjectProvider.class));
     }
 
     private String requested(String eventId, long version) {

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/CustomerEventsListener.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/CustomerEventsListener.java
@@ -6,16 +6,19 @@ import com.positivity.invoice.internal.entity.ExtCustomerPartyReplica;
 import com.positivity.invoice.internal.entity.ProcessedEvent;
 import com.positivity.invoice.internal.repository.ExtCustomerPartyReplicaRepository;
 import com.positivity.invoice.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -28,7 +31,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.invoice.kafka", name = "enabled", havingValue = "true")
 public class CustomerEventsListener {
 
@@ -38,6 +40,28 @@ public class CustomerEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtCustomerPartyReplicaRepository extCustomerPartyReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public CustomerEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtCustomerPartyReplicaRepository extCustomerPartyReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extCustomerPartyReplicaRepository = extCustomerPartyReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "customer")
+                        .tag("entity", "customer-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.invoice.kafka.customer-events-topic:customer.events.v1}",
@@ -72,6 +96,11 @@ public class CustomerEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed customer event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed customer event eventId={}", eventId, e);
         }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/LocationEventsListener.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/LocationEventsListener.java
@@ -6,16 +6,19 @@ import com.positivity.invoice.internal.entity.ExtLocationReplica;
 import com.positivity.invoice.internal.entity.ProcessedEvent;
 import com.positivity.invoice.internal.repository.ExtLocationReplicaRepository;
 import com.positivity.invoice.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -34,7 +37,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.invoice.kafka", name = "enabled", havingValue = "true")
 public class LocationEventsListener {
 
@@ -44,6 +46,28 @@ public class LocationEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtLocationReplicaRepository extLocationReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public LocationEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtLocationReplicaRepository extLocationReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extLocationReplicaRepository = extLocationReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "location")
+                        .tag("entity", "location-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.invoice.kafka.location-events-topic:location.events.v1}",
@@ -77,6 +101,11 @@ public class LocationEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed location event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed location event eventId={}", eventId, e);
         }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/PeopleEventsListener.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/PeopleEventsListener.java
@@ -5,16 +5,19 @@ import com.positivity.invoice.internal.entity.ExtEmployeeReplica;
 import com.positivity.invoice.internal.entity.ProcessedEvent;
 import com.positivity.invoice.internal.repository.ExtEmployeeReplicaRepository;
 import com.positivity.invoice.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -26,7 +29,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.invoice.kafka", name = "enabled", havingValue = "true")
 public class PeopleEventsListener {
 
@@ -36,6 +38,28 @@ public class PeopleEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtEmployeeReplicaRepository extEmployeeReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public PeopleEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtEmployeeReplicaRepository extEmployeeReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extEmployeeReplicaRepository = extEmployeeReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "people")
+                        .tag("entity", "people-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.invoice.kafka.people-events-topic:people.events.v1}",
@@ -85,6 +109,11 @@ public class PeopleEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed people event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed people event eventId={}", eventId, e);
         }

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/service/WorkorderEventsListener.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/service/WorkorderEventsListener.java
@@ -5,16 +5,19 @@ import com.positivity.invoice.internal.entity.ExtWorkorderReplica;
 import com.positivity.invoice.internal.entity.ProcessedEvent;
 import com.positivity.invoice.internal.repository.ExtWorkorderReplicaRepository;
 import com.positivity.invoice.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -30,7 +33,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.invoice.kafka", name = "enabled", havingValue = "true")
 public class WorkorderEventsListener {
 
@@ -40,6 +42,28 @@ public class WorkorderEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtWorkorderReplicaRepository extWorkorderReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public WorkorderEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtWorkorderReplicaRepository extWorkorderReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extWorkorderReplicaRepository = extWorkorderReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "workorder")
+                        .tag("entity", "workorder-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.invoice.kafka.workorder-events-topic:workorder.events.v1}",
@@ -73,6 +97,11 @@ public class WorkorderEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed workorder event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed workorder event eventId={}", eventId, e);
         }

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/service/ReplicaListenerContractTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/service/ReplicaListenerContractTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -126,8 +127,12 @@ class ReplicaListenerContractTest {
                         id -> """
                             {"partyId":"%s","partyType":"ORGANIZATION","displayName":"Fleet Co",
                              "status":"ACTIVE","requirementsMet":true}""".formatted(id),
-                        new CustomerEventsListener(clock, objectMapper, processedEventRepository, customerRepository)
-                                ::onCustomerEvent,
+                        new CustomerEventsListener(
+                                clock,
+                                objectMapper,
+                                processedEventRepository,
+                                customerRepository,
+                                org.mockito.Mockito.mock(ObjectProvider.class))::onCustomerEvent,
                         () -> doThrow(new QueryTimeoutException("lock wait"))
                                 .when(customerRepository)
                                 .findById(any()));
@@ -137,8 +142,12 @@ class ReplicaListenerContractTest {
                         LocationUpdatedV1.EVENT_TYPE,
                         id -> """
                             {"locationId":"%s","name":"Main Shop","active":true}""".formatted(id),
-                        new LocationEventsListener(clock, objectMapper, processedEventRepository, locationRepository)
-                                ::onLocationEvent,
+                        new LocationEventsListener(
+                                clock,
+                                objectMapper,
+                                processedEventRepository,
+                                locationRepository,
+                                org.mockito.Mockito.mock(ObjectProvider.class))::onLocationEvent,
                         () -> doThrow(new QueryTimeoutException("lock wait"))
                                 .when(locationRepository)
                                 .findById(any()));
@@ -148,8 +157,12 @@ class ReplicaListenerContractTest {
                         EmployeeUpdatedV1.EVENT_TYPE,
                         id -> """
                             {"employeeId":"%s","employeeNumber":"E-1001","status":"ACTIVE"}""".formatted(id),
-                        new PeopleEventsListener(clock, objectMapper, processedEventRepository, employeeRepository)
-                                ::onPeopleEvent,
+                        new PeopleEventsListener(
+                                clock,
+                                objectMapper,
+                                processedEventRepository,
+                                employeeRepository,
+                                org.mockito.Mockito.mock(ObjectProvider.class))::onPeopleEvent,
                         () -> doThrow(new QueryTimeoutException("lock wait"))
                                 .when(employeeRepository)
                                 .findById(any()));
@@ -159,8 +172,12 @@ class ReplicaListenerContractTest {
                         WorkorderUpdatedV1.EVENT_TYPE,
                         id -> """
                             {"workorderId":"%s","workorderNumber":"WO-1001","status":"CLOSED"}""".formatted(id),
-                        new WorkorderEventsListener(clock, objectMapper, processedEventRepository, workorderRepository)
-                                ::onWorkorderEvent,
+                        new WorkorderEventsListener(
+                                clock,
+                                objectMapper,
+                                processedEventRepository,
+                                workorderRepository,
+                                org.mockito.Mockito.mock(ObjectProvider.class))::onWorkorderEvent,
                         () -> doThrow(new QueryTimeoutException("lock wait"))
                                 .when(workorderRepository)
                                 .findById(any()));
@@ -246,8 +263,12 @@ class ReplicaListenerContractTest {
     @Test
     @DisplayName("customer: replicates the party fields invoicing needs, and removes the row on deletion")
     void customerMapping() {
-        CustomerEventsListener listener =
-                new CustomerEventsListener(clock, objectMapper, processedEventRepository, customerRepository);
+        CustomerEventsListener listener = new CustomerEventsListener(
+                clock,
+                objectMapper,
+                processedEventRepository,
+                customerRepository,
+                org.mockito.Mockito.mock(ObjectProvider.class));
 
         listener.onCustomerEvent("""
                 {"eventId":"evt-1","eventType":"%s","aggregateVersion":3,
@@ -270,8 +291,12 @@ class ReplicaListenerContractTest {
     @Test
     @DisplayName("location: replicates the full address an invoice is stamped with")
     void locationMapping() {
-        LocationEventsListener listener =
-                new LocationEventsListener(clock, objectMapper, processedEventRepository, locationRepository);
+        LocationEventsListener listener = new LocationEventsListener(
+                clock,
+                objectMapper,
+                processedEventRepository,
+                locationRepository,
+                org.mockito.Mockito.mock(ObjectProvider.class));
 
         listener.onLocationEvent("""
                 {"eventId":"evt-1","eventType":"%s","aggregateVersion":2,
@@ -304,7 +329,12 @@ class ReplicaListenerContractTest {
     @DisplayName("people: replicates the employee identity an invoice attributes work to")
     void peopleMapping() {
         UUID personId = UUID.randomUUID();
-        new PeopleEventsListener(clock, objectMapper, processedEventRepository, employeeRepository)
+        new PeopleEventsListener(
+                        clock,
+                        objectMapper,
+                        processedEventRepository,
+                        employeeRepository,
+                        org.mockito.Mockito.mock(ObjectProvider.class))
                 .onPeopleEvent("""
                         {"eventId":"evt-1","eventType":"%s","aggregateVersion":1,
                          "payload":{"employeeId":"%s","personId":"%s","employeeNumber":"E-1001",
@@ -322,7 +352,13 @@ class ReplicaListenerContractTest {
     @Test
     @DisplayName("people: ignores an event type it does not consume, without a dedup row")
     void peopleIgnoresOtherTypes() {
-        new PeopleEventsListener(clock, objectMapper, processedEventRepository, employeeRepository).onPeopleEvent("""
+        new PeopleEventsListener(
+                        clock,
+                        objectMapper,
+                        processedEventRepository,
+                        employeeRepository,
+                        org.mockito.Mockito.mock(ObjectProvider.class))
+                .onPeopleEvent("""
                         {"eventId":"evt-9","eventType":"people.staffing-assignment.updated","payload":{}}""");
 
         verify(employeeRepository, never()).save(any());
@@ -333,7 +369,12 @@ class ReplicaListenerContractTest {
     @DisplayName("workorder: replicates the workorder an invoice is raised from")
     void workorderMapping() {
         UUID customerId = UUID.randomUUID();
-        new WorkorderEventsListener(clock, objectMapper, processedEventRepository, workorderRepository)
+        new WorkorderEventsListener(
+                        clock,
+                        objectMapper,
+                        processedEventRepository,
+                        workorderRepository,
+                        org.mockito.Mockito.mock(ObjectProvider.class))
                 .onWorkorderEvent("""
                         {"eventId":"evt-1","eventType":"%s","aggregateVersion":6,
                          "payload":{"workorderId":"%s","workorderNumber":"WO-1001","status":"CLOSED",
@@ -357,8 +398,12 @@ class ReplicaListenerContractTest {
                         .workorderId(ID)
                         .aggregateVersion(6)
                         .build()));
-        WorkorderEventsListener listener =
-                new WorkorderEventsListener(clock, objectMapper, processedEventRepository, workorderRepository);
+        WorkorderEventsListener listener = new WorkorderEventsListener(
+                clock,
+                objectMapper,
+                processedEventRepository,
+                workorderRepository,
+                org.mockito.Mockito.mock(ObjectProvider.class));
         String template = """
                 {"eventId":"evt-%d","eventType":"%s","aggregateVersion":%d,
                  "payload":{"workorderId":"%s","workorderNumber":"WO-1001","status":"CLOSED",

--- a/pos-location/src/main/java/com/positivity/location/internal/service/InventoryEventsListener.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/InventoryEventsListener.java
@@ -5,16 +5,19 @@ import com.positivity.location.internal.entity.ExtStorageLocationOnHandReplica;
 import com.positivity.location.internal.entity.ProcessedEvent;
 import com.positivity.location.internal.repository.ExtStorageLocationOnHandReplicaRepository;
 import com.positivity.location.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -31,7 +34,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.location.kafka", name = "enabled", havingValue = "true")
 public class InventoryEventsListener {
 
@@ -41,6 +43,28 @@ public class InventoryEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtStorageLocationOnHandReplicaRepository extStorageLocationOnHandReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public InventoryEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtStorageLocationOnHandReplicaRepository extStorageLocationOnHandReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extStorageLocationOnHandReplicaRepository = extStorageLocationOnHandReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "inventory")
+                        .tag("entity", "inventory-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.location.kafka.inventory-events-topic:inventory.events.v1}",
@@ -74,6 +98,11 @@ public class InventoryEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed inventory event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed inventory event eventId={}", eventId, e);
         }

--- a/pos-location/src/main/java/com/positivity/location/internal/service/PeopleContactEventsListener.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/PeopleContactEventsListener.java
@@ -6,16 +6,19 @@ import com.positivity.location.internal.entity.ExtPersonReplica;
 import com.positivity.location.internal.entity.ProcessedEvent;
 import com.positivity.location.internal.repository.ExtPersonReplicaRepository;
 import com.positivity.location.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -30,7 +33,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.location.kafka", name = "enabled", havingValue = "true")
 public class PeopleContactEventsListener {
 
@@ -40,6 +42,28 @@ public class PeopleContactEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtPersonReplicaRepository extPersonReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public PeopleContactEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtPersonReplicaRepository extPersonReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extPersonReplicaRepository = extPersonReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "people-contact")
+                        .tag("entity", "people-contact-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.location.kafka.people-contact-events-topic:people-contact.events.v1}",
@@ -74,6 +98,11 @@ public class PeopleContactEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed people-contact event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed people-contact event eventId={}", eventId, e);
         }

--- a/pos-location/src/test/java/com/positivity/location/internal/service/PeopleContactEventsListenerTest.java
+++ b/pos-location/src/test/java/com/positivity/location/internal/service/PeopleContactEventsListenerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import tools.jackson.databind.ObjectMapper;
 
 class PeopleContactEventsListenerTest {
@@ -33,7 +34,11 @@ class PeopleContactEventsListenerTest {
     @BeforeEach
     void setUp() {
         listener = new PeopleContactEventsListener(
-                TEST_CLOCK, new ObjectMapper(), processedEventRepository, extPersonReplicaRepository);
+                TEST_CLOCK,
+                new ObjectMapper(),
+                processedEventRepository,
+                extPersonReplicaRepository,
+                mock(ObjectProvider.class));
         when(processedEventRepository.existsById(any())).thenReturn(false);
     }
 

--- a/pos-people/src/main/java/com/positivity/people/internal/service/LocationEventsListener.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/LocationEventsListener.java
@@ -6,16 +6,19 @@ import com.positivity.people.internal.entity.ExtLocationReplica;
 import com.positivity.people.internal.entity.ProcessedEvent;
 import com.positivity.people.internal.repository.ExtLocationReplicaRepository;
 import com.positivity.people.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -35,7 +38,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.people.kafka", name = "enabled", havingValue = "true")
 public class LocationEventsListener {
 
@@ -45,6 +47,28 @@ public class LocationEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtLocationReplicaRepository extLocationReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public LocationEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtLocationReplicaRepository extLocationReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extLocationReplicaRepository = extLocationReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "location")
+                        .tag("entity", "location-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.people.kafka.location-events-topic:location.events.v1}",
@@ -78,6 +102,11 @@ public class LocationEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed location event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed location event eventId={}", eventId, e);
         }

--- a/pos-people/src/main/java/com/positivity/people/internal/service/PeopleContactEventsListener.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/PeopleContactEventsListener.java
@@ -10,18 +10,21 @@ import com.positivity.people.internal.entity.ProcessedEvent;
 import com.positivity.people.internal.repository.ExtPersonReplicaRepository;
 import com.positivity.people.internal.repository.ExtUserLinkReplicaRepository;
 import com.positivity.people.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -42,7 +45,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.people.kafka", name = "enabled", havingValue = "true")
 public class PeopleContactEventsListener {
 
@@ -53,6 +55,30 @@ public class PeopleContactEventsListener {
     private final ProcessedEventRepository processedEventRepository;
     private final ExtPersonReplicaRepository extPersonReplicaRepository;
     private final ExtUserLinkReplicaRepository extUserLinkReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public PeopleContactEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtPersonReplicaRepository extPersonReplicaRepository,
+            ExtUserLinkReplicaRepository extUserLinkReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extPersonReplicaRepository = extPersonReplicaRepository;
+        this.extUserLinkReplicaRepository = extUserLinkReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "people-contact")
+                        .tag("entity", "people-contact-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.people.kafka.people-contact-events-topic:people-contact.events.v1}",
@@ -92,6 +118,11 @@ public class PeopleContactEventsListener {
         } catch (TransientDataAccessException e) {
             // Retry with backoff / DLQ via the container error handler (ADR-0044 §4).
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed people-contact event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed people-contact event eventId={}", eventId, e);
         }

--- a/pos-people/src/main/java/com/positivity/people/internal/service/WorkorderEventsListener.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/service/WorkorderEventsListener.java
@@ -5,16 +5,19 @@ import com.positivity.people.internal.entity.ExtJobTimeReplica;
 import com.positivity.people.internal.entity.ProcessedEvent;
 import com.positivity.people.internal.repository.ExtJobTimeReplicaRepository;
 import com.positivity.people.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -28,7 +31,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.people.kafka", name = "enabled", havingValue = "true")
 public class WorkorderEventsListener {
 
@@ -38,6 +40,28 @@ public class WorkorderEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtJobTimeReplicaRepository extJobTimeReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public WorkorderEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtJobTimeReplicaRepository extJobTimeReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extJobTimeReplicaRepository = extJobTimeReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "workorder")
+                        .tag("entity", "workorder-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.people.kafka.workorder-events-topic:workorder.events.v1}",
@@ -85,6 +109,11 @@ public class WorkorderEventsListener {
         } catch (TransientDataAccessException e) {
             // Retry with backoff / DLQ via the container error handler (ADR-0044 §4).
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed workorder event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed workorder event eventId={}", eventId, e);
         }

--- a/pos-people/src/test/java/com/positivity/people/internal/service/LocationAndWorkorderEventsListenerTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/LocationAndWorkorderEventsListenerTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -77,10 +78,18 @@ class LocationAndWorkorderEventsListenerTest {
 
     @BeforeEach
     void setUp() {
-        locationListener =
-                new LocationEventsListener(clock, objectMapper, processedEventRepository, extLocationReplicaRepository);
-        workorderListener =
-                new WorkorderEventsListener(clock, objectMapper, processedEventRepository, extJobTimeReplicaRepository);
+        locationListener = new LocationEventsListener(
+                clock,
+                objectMapper,
+                processedEventRepository,
+                extLocationReplicaRepository,
+                org.mockito.Mockito.mock(ObjectProvider.class));
+        workorderListener = new WorkorderEventsListener(
+                clock,
+                objectMapper,
+                processedEventRepository,
+                extJobTimeReplicaRepository,
+                org.mockito.Mockito.mock(ObjectProvider.class));
         when(processedEventRepository.existsById(any())).thenReturn(false);
         when(extLocationReplicaRepository.findById(any())).thenReturn(Optional.empty());
     }

--- a/pos-people/src/test/java/com/positivity/people/internal/service/PeopleContactEventsListenerTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/PeopleContactEventsListenerTest.java
@@ -32,6 +32,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -86,7 +87,8 @@ class PeopleContactEventsListenerTest {
                 new ObjectMapper(),
                 processedEventRepository,
                 extPersonReplicaRepository,
-                extUserLinkReplicaRepository);
+                extUserLinkReplicaRepository,
+                org.mockito.Mockito.mock(ObjectProvider.class));
         when(processedEventRepository.existsById(any())).thenReturn(false);
         when(extPersonReplicaRepository.findById(any())).thenReturn(Optional.empty());
         when(extUserLinkReplicaRepository.findById(any())).thenReturn(Optional.empty());

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/CustomerEventsListener.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/CustomerEventsListener.java
@@ -5,16 +5,19 @@ import com.positivity.securityservice.internal.entity.ExtCustomerPersonIdentity;
 import com.positivity.securityservice.internal.entity.ProcessedEvent;
 import com.positivity.securityservice.internal.repository.ExtCustomerPersonIdentityRepository;
 import com.positivity.securityservice.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -28,7 +31,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.security-service.kafka", name = "enabled", havingValue = "true")
 public class CustomerEventsListener {
 
@@ -38,6 +40,28 @@ public class CustomerEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtCustomerPersonIdentityRepository extCustomerPersonIdentityRepository;
+    private final Counter payloadRejectedCounter;
+
+    public CustomerEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtCustomerPersonIdentityRepository extCustomerPersonIdentityRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extCustomerPersonIdentityRepository = extCustomerPersonIdentityRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "customer")
+                        .tag("entity", "customer-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.security-service.kafka.customer-events-topic:customer.events.v1}",
@@ -69,6 +93,11 @@ public class CustomerEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed customer event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed customer event eventId={}", eventId, e);
         }

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/PeopleContactEventsListener.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/service/PeopleContactEventsListener.java
@@ -10,19 +10,22 @@ import com.positivity.securityservice.internal.entity.User;
 import com.positivity.securityservice.internal.repository.ExtPersonReplicaRepository;
 import com.positivity.securityservice.internal.repository.ProcessedEventRepository;
 import com.positivity.securityservice.internal.repository.UserRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -38,7 +41,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.security-service.kafka", name = "enabled", havingValue = "true")
 public class PeopleContactEventsListener {
 
@@ -49,6 +51,30 @@ public class PeopleContactEventsListener {
     private final ProcessedEventRepository processedEventRepository;
     private final ExtPersonReplicaRepository extPersonReplicaRepository;
     private final UserRepository userRepository;
+    private final Counter payloadRejectedCounter;
+
+    public PeopleContactEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtPersonReplicaRepository extPersonReplicaRepository,
+            UserRepository userRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extPersonReplicaRepository = extPersonReplicaRepository;
+        this.userRepository = userRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "people-contact")
+                        .tag("entity", "people-contact-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.security-service.kafka.people-contact-events-topic:people-contact.events.v1}",
@@ -89,6 +115,11 @@ public class PeopleContactEventsListener {
         } catch (TransientDataAccessException e) {
             // Retry with backoff / DLQ via the container error handler (ADR-0044 §4).
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed people-contact event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed people-contact event eventId={}", eventId, e);
         }

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/service/PeopleContactEventsListenerTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/service/PeopleContactEventsListenerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import tools.jackson.databind.ObjectMapper;
 
 /**
@@ -41,7 +42,12 @@ class PeopleContactEventsListenerTest {
     @BeforeEach
     void setUp() {
         listener = new PeopleContactEventsListener(
-                TEST_CLOCK, new ObjectMapper(), processedEventRepository, extPersonReplicaRepository, userRepository);
+                TEST_CLOCK,
+                new ObjectMapper(),
+                processedEventRepository,
+                extPersonReplicaRepository,
+                userRepository,
+                mock(ObjectProvider.class));
         when(processedEventRepository.existsById(any())).thenReturn(false);
     }
 

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/CustomerEventsListener.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/CustomerEventsListener.java
@@ -6,16 +6,19 @@ import com.positivity.shopmanager.internal.entity.ExtCustomerPartyReplica;
 import com.positivity.shopmanager.internal.entity.ProcessedEvent;
 import com.positivity.shopmanager.internal.repository.ExtCustomerPartyReplicaRepository;
 import com.positivity.shopmanager.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -28,7 +31,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.shop-manager.kafka", name = "enabled", havingValue = "true")
 public class CustomerEventsListener {
 
@@ -38,6 +40,28 @@ public class CustomerEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtCustomerPartyReplicaRepository extCustomerPartyReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public CustomerEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtCustomerPartyReplicaRepository extCustomerPartyReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extCustomerPartyReplicaRepository = extCustomerPartyReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "customer")
+                        .tag("entity", "customer-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.shop-manager.kafka.customer-events-topic:customer.events.v1}",
@@ -69,6 +93,11 @@ public class CustomerEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed customer event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed customer event eventId={}", eventId, e);
         }

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/PeopleContactEventsListener.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/PeopleContactEventsListener.java
@@ -6,16 +6,19 @@ import com.positivity.shopmanager.internal.entity.ExtPersonReplica;
 import com.positivity.shopmanager.internal.entity.ProcessedEvent;
 import com.positivity.shopmanager.internal.repository.ExtPersonReplicaRepository;
 import com.positivity.shopmanager.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -30,7 +33,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.shop-manager.kafka", name = "enabled", havingValue = "true")
 public class PeopleContactEventsListener {
 
@@ -40,6 +42,28 @@ public class PeopleContactEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtPersonReplicaRepository extPersonReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public PeopleContactEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtPersonReplicaRepository extPersonReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extPersonReplicaRepository = extPersonReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "people-contact")
+                        .tag("entity", "people-contact-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.shop-manager.kafka.people-contact-events-topic:people-contact.events.v1}",
@@ -75,6 +99,11 @@ public class PeopleContactEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed people-contact event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed people-contact event eventId={}", eventId, e);
         }

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/PeopleEventsListener.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/PeopleEventsListener.java
@@ -5,16 +5,19 @@ import com.positivity.shopmanager.internal.entity.ExtStaffingAssignmentReplica;
 import com.positivity.shopmanager.internal.entity.ProcessedEvent;
 import com.positivity.shopmanager.internal.repository.ExtStaffingAssignmentReplicaRepository;
 import com.positivity.shopmanager.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -25,7 +28,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.shop-manager.kafka", name = "enabled", havingValue = "true")
 public class PeopleEventsListener {
 
@@ -35,6 +37,28 @@ public class PeopleEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtStaffingAssignmentReplicaRepository assignmentReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public PeopleEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtStaffingAssignmentReplicaRepository assignmentReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.assignmentReplicaRepository = assignmentReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "people")
+                        .tag("entity", "people-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.shop-manager.kafka.people-events-topic:people.events.v1}",
@@ -85,6 +109,11 @@ public class PeopleEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed people event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed people event eventId={}", eventId, e);
         }

--- a/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/VehicleEventsListener.java
+++ b/pos-shop-manager/src/main/java/com/positivity/shopmanager/internal/service/VehicleEventsListener.java
@@ -5,16 +5,19 @@ import com.positivity.shopmanager.internal.entity.ExtVehicleReplica;
 import com.positivity.shopmanager.internal.entity.ProcessedEvent;
 import com.positivity.shopmanager.internal.repository.ExtVehicleReplicaRepository;
 import com.positivity.shopmanager.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -27,7 +30,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.shop-manager.kafka", name = "enabled", havingValue = "true")
 public class VehicleEventsListener {
 
@@ -37,6 +39,28 @@ public class VehicleEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtVehicleReplicaRepository extVehicleReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public VehicleEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtVehicleReplicaRepository extVehicleReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extVehicleReplicaRepository = extVehicleReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "vehicle")
+                        .tag("entity", "vehicle-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.shop-manager.kafka.vehicle-events-topic:vehicle.events.v1}",
@@ -68,6 +92,11 @@ public class VehicleEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed vehicle event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed vehicle event eventId={}", eventId, e);
         }

--- a/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/service/PeopleContactEventsListenerTest.java
+++ b/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/service/PeopleContactEventsListenerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import tools.jackson.databind.ObjectMapper;
 
 class PeopleContactEventsListenerTest {
@@ -33,7 +34,11 @@ class PeopleContactEventsListenerTest {
     @BeforeEach
     void setUp() {
         listener = new PeopleContactEventsListener(
-                TEST_CLOCK, new ObjectMapper(), processedEventRepository, extPersonReplicaRepository);
+                TEST_CLOCK,
+                new ObjectMapper(),
+                processedEventRepository,
+                extPersonReplicaRepository,
+                org.mockito.Mockito.mock(ObjectProvider.class));
         when(processedEventRepository.existsById(any())).thenReturn(false);
     }
 

--- a/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/service/ReplicaAndManifestListenerContractTest.java
+++ b/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/service/ReplicaAndManifestListenerContractTest.java
@@ -138,8 +138,12 @@ class ReplicaAndManifestListenerContractTest {
                         id -> """
                             {"partyId":"%s","partyType":"ORGANIZATION","customerNumber":"C-1",
                              "displayName":"Fleet Co","status":"ACTIVE","requirementsMet":true}""".formatted(id),
-                        new CustomerEventsListener(clock, objectMapper, processedEventRepository, customerRepository)
-                                ::onCustomerEvent,
+                        new CustomerEventsListener(
+                                clock,
+                                objectMapper,
+                                processedEventRepository,
+                                customerRepository,
+                                org.mockito.Mockito.mock(ObjectProvider.class))::onCustomerEvent,
                         () -> doThrow(new QueryTimeoutException("lock wait"))
                                 .when(customerRepository)
                                 .findById(any()));
@@ -151,8 +155,12 @@ class ReplicaAndManifestListenerContractTest {
                             {"vehicleId":"%s","accountId":"%s","vin":"1HGCM82633A004352",
                              "unitNumber":"U1","description":"d","licensePlate":"AB-123",
                              "year":2024,"make":"Toyota","model":"Tacoma","active":true}""".formatted(id, ID),
-                        new VehicleEventsListener(clock, objectMapper, processedEventRepository, vehicleRepository)
-                                ::onVehicleEvent,
+                        new VehicleEventsListener(
+                                clock,
+                                objectMapper,
+                                processedEventRepository,
+                                vehicleRepository,
+                                org.mockito.Mockito.mock(ObjectProvider.class))::onVehicleEvent,
                         () -> doThrow(new QueryTimeoutException("lock wait"))
                                 .when(vehicleRepository)
                                 .findById(any()));
@@ -164,8 +172,12 @@ class ReplicaAndManifestListenerContractTest {
                             {"assignmentId":"%s","employeeId":"%s","personId":"%s","locationId":"%s",
                              "role":"TECHNICIAN","primary":true,"status":"ACTIVE",
                              "effectiveFrom":"2026-02-01","effectiveTo":null}""".formatted(id, ID, ID, ID),
-                        new PeopleEventsListener(clock, objectMapper, processedEventRepository, assignmentRepository)
-                                ::onPeopleEvent,
+                        new PeopleEventsListener(
+                                clock,
+                                objectMapper,
+                                processedEventRepository,
+                                assignmentRepository,
+                                org.mockito.Mockito.mock(ObjectProvider.class))::onPeopleEvent,
                         () -> doThrow(new QueryTimeoutException("lock wait"))
                                 .when(assignmentRepository)
                                 .findById(any()));
@@ -177,8 +189,12 @@ class ReplicaAndManifestListenerContractTest {
                             {"personId":"%s","firstName":"Ada","lastName":"Lovelace",
                              "preferredName":null,"contactPoints":[],"postalAddress":null,
                              "createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-08-01T00:00:00Z"}""".formatted(id),
-                        new PeopleContactEventsListener(clock, objectMapper, processedEventRepository, personRepository)
-                                ::onPeopleContactEvent,
+                        new PeopleContactEventsListener(
+                                clock,
+                                objectMapper,
+                                processedEventRepository,
+                                personRepository,
+                                org.mockito.Mockito.mock(ObjectProvider.class))::onPeopleContactEvent,
                         () -> doThrow(new QueryTimeoutException("lock wait"))
                                 .when(personRepository)
                                 .findById(any()));
@@ -251,8 +267,12 @@ class ReplicaAndManifestListenerContractTest {
         @Test
         @DisplayName("customer: maps the party and removes the row on deletion")
         void customerMapping() {
-            CustomerEventsListener listener =
-                    new CustomerEventsListener(clock, objectMapper, processedEventRepository, customerRepository);
+            CustomerEventsListener listener = new CustomerEventsListener(
+                    clock,
+                    objectMapper,
+                    processedEventRepository,
+                    customerRepository,
+                    org.mockito.Mockito.mock(ObjectProvider.class));
             Replica replica = replica("customer");
 
             replica.dispatch().accept(envelope(replica, "evt-1", ID.toString()));

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/service/CatalogEventsListener.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/service/CatalogEventsListener.java
@@ -5,16 +5,19 @@ import com.positivity.warranty.internal.entity.ExtCatalogReplica;
 import com.positivity.warranty.internal.entity.ProcessedEvent;
 import com.positivity.warranty.internal.repository.ExtCatalogReplicaRepository;
 import com.positivity.warranty.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -31,7 +34,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.warranty.kafka", name = "enabled", havingValue = "true")
 public class CatalogEventsListener {
 
@@ -42,6 +44,28 @@ public class CatalogEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtCatalogReplicaRepository extCatalogReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public CatalogEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtCatalogReplicaRepository extCatalogReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extCatalogReplicaRepository = extCatalogReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "catalog")
+                        .tag("entity", "catalog-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.warranty.kafka.catalog-events-topic:catalog.events.v1}",
@@ -75,6 +99,11 @@ public class CatalogEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed catalog event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed catalog event eventId={}", eventId, e);
         }

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/service/InvoiceEventsListener.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/service/InvoiceEventsListener.java
@@ -7,18 +7,21 @@ import com.positivity.warranty.internal.entity.ProcessedEvent;
 import com.positivity.warranty.internal.repository.ExtInvoiceLineReplicaRepository;
 import com.positivity.warranty.internal.repository.ExtInvoiceReplicaRepository;
 import com.positivity.warranty.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -35,7 +38,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.warranty.kafka", name = "enabled", havingValue = "true")
 public class InvoiceEventsListener {
 
@@ -47,6 +49,30 @@ public class InvoiceEventsListener {
     private final ProcessedEventRepository processedEventRepository;
     private final ExtInvoiceReplicaRepository extInvoiceReplicaRepository;
     private final ExtInvoiceLineReplicaRepository extInvoiceLineReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public InvoiceEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtInvoiceReplicaRepository extInvoiceReplicaRepository,
+            ExtInvoiceLineReplicaRepository extInvoiceLineReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extInvoiceReplicaRepository = extInvoiceReplicaRepository;
+        this.extInvoiceLineReplicaRepository = extInvoiceLineReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "invoice")
+                        .tag("entity", "invoice-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.warranty.kafka.invoice-events-topic:invoice.events.v1}",
@@ -82,6 +108,11 @@ public class InvoiceEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed invoice event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed invoice event eventId={}", eventId, e);
         }

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/service/VehicleEventsListener.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/service/VehicleEventsListener.java
@@ -5,16 +5,19 @@ import com.positivity.warranty.internal.entity.ExtVehicleReplica;
 import com.positivity.warranty.internal.entity.ProcessedEvent;
 import com.positivity.warranty.internal.repository.ExtVehicleReplicaRepository;
 import com.positivity.warranty.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -30,7 +33,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.warranty.kafka", name = "enabled", havingValue = "true")
 public class VehicleEventsListener {
 
@@ -41,6 +43,28 @@ public class VehicleEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtVehicleReplicaRepository extVehicleReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public VehicleEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtVehicleReplicaRepository extVehicleReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extVehicleReplicaRepository = extVehicleReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "vehicle")
+                        .tag("entity", "vehicle-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.warranty.kafka.vehicle-events-topic:vehicle.events.v1}",
@@ -74,6 +98,11 @@ public class VehicleEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed vehicle event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed vehicle event eventId={}", eventId, e);
         }

--- a/pos-warranty/src/main/java/com/positivity/warranty/internal/service/WorkorderEventsListener.java
+++ b/pos-warranty/src/main/java/com/positivity/warranty/internal/service/WorkorderEventsListener.java
@@ -7,18 +7,21 @@ import com.positivity.warranty.internal.entity.ProcessedEvent;
 import com.positivity.warranty.internal.repository.ExtWorkorderLineReplicaRepository;
 import com.positivity.warranty.internal.repository.ExtWorkorderReplicaRepository;
 import com.positivity.warranty.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -32,7 +35,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "pos.warranty.kafka", name = "enabled", havingValue = "true")
 public class WorkorderEventsListener {
 
@@ -45,6 +47,32 @@ public class WorkorderEventsListener {
     private final AutoRegistrationService autoRegistrationService;
     private final ExtWorkorderReplicaRepository extWorkorderReplicaRepository;
     private final ExtWorkorderLineReplicaRepository extWorkorderLineReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public WorkorderEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            AutoRegistrationService autoRegistrationService,
+            ExtWorkorderReplicaRepository extWorkorderReplicaRepository,
+            ExtWorkorderLineReplicaRepository extWorkorderLineReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.autoRegistrationService = autoRegistrationService;
+        this.extWorkorderReplicaRepository = extWorkorderReplicaRepository;
+        this.extWorkorderLineReplicaRepository = extWorkorderLineReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "workorder")
+                        .tag("entity", "workorder-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${pos.warranty.kafka.workorder-events-topic:workorder.events.v1}",
@@ -82,6 +110,11 @@ public class WorkorderEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed workorder event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed workorder event eventId={}", eventId, e);
         }

--- a/pos-warranty/src/test/java/com/positivity/warranty/internal/service/CatalogEventsListenerTest.java
+++ b/pos-warranty/src/test/java/com/positivity/warranty/internal/service/CatalogEventsListenerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -43,7 +44,8 @@ class CatalogEventsListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener = new CatalogEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, extCatalog);
+        listener = new CatalogEventsListener(
+                TEST_CLOCK, new ObjectMapper(), processedEvents, extCatalog, mock(ObjectProvider.class));
     }
 
     private static String updatedEvent(String eventId, long aggregateVersion) {

--- a/pos-warranty/src/test/java/com/positivity/warranty/internal/service/InvoiceEventsListenerTest.java
+++ b/pos-warranty/src/test/java/com/positivity/warranty/internal/service/InvoiceEventsListenerTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -48,8 +49,13 @@ class InvoiceEventsListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener =
-                new InvoiceEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, extInvoice, extInvoiceLine);
+        listener = new InvoiceEventsListener(
+                TEST_CLOCK,
+                new ObjectMapper(),
+                processedEvents,
+                extInvoice,
+                extInvoiceLine,
+                mock(ObjectProvider.class));
     }
 
     private static String updatedEvent(String eventId, long aggregateVersion) {

--- a/pos-warranty/src/test/java/com/positivity/warranty/internal/service/VehicleEventsListenerTest.java
+++ b/pos-warranty/src/test/java/com/positivity/warranty/internal/service/VehicleEventsListenerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -42,7 +43,8 @@ class VehicleEventsListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener = new VehicleEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, extVehicleReplica);
+        listener = new VehicleEventsListener(
+                TEST_CLOCK, new ObjectMapper(), processedEvents, extVehicleReplica, mock(ObjectProvider.class));
     }
 
     private static String updatedEvent(String eventId, long aggregateVersion) {

--- a/pos-warranty/src/test/java/com/positivity/warranty/internal/service/WorkorderEventsListenerTest.java
+++ b/pos-warranty/src/test/java/com/positivity/warranty/internal/service/WorkorderEventsListenerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -53,7 +54,8 @@ class WorkorderEventsListenerTest {
                 processedEvents,
                 autoRegistrationService,
                 extWorkorderReplica,
-                extWorkorderLineReplica);
+                extWorkorderLineReplica,
+                mock(ObjectProvider.class));
     }
 
     private static String updatedEvent(String eventId) {

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CustomerEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CustomerEventsListener.java
@@ -6,16 +6,19 @@ import com.positivity.workorder.internal.entity.ExtCustomerPartyReplica;
 import com.positivity.workorder.internal.entity.ProcessedEvent;
 import com.positivity.workorder.internal.repository.ExtCustomerPartyReplicaRepository;
 import com.positivity.workorder.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -28,7 +31,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
 public class CustomerEventsListener {
 
@@ -38,6 +40,28 @@ public class CustomerEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtCustomerPartyReplicaRepository extCustomerPartyReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public CustomerEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtCustomerPartyReplicaRepository extCustomerPartyReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extCustomerPartyReplicaRepository = extCustomerPartyReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "customer")
+                        .tag("entity", "customer-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${workorder.kafka.customer-events-topic:customer.events.v1}",
@@ -69,6 +93,11 @@ public class CustomerEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed customer event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed customer event eventId={}", eventId, e);
         }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InventoryEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InventoryEventsListener.java
@@ -9,16 +9,19 @@ import com.positivity.workorder.internal.entity.ProcessedEvent;
 import com.positivity.workorder.internal.repository.ExtPickListReplicaRepository;
 import com.positivity.workorder.internal.repository.ExtPickTaskReplicaRepository;
 import com.positivity.workorder.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -36,7 +39,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
 public class InventoryEventsListener {
 
@@ -47,6 +49,30 @@ public class InventoryEventsListener {
     private final ProcessedEventRepository processedEventRepository;
     private final ExtPickListReplicaRepository pickListReplicaRepository;
     private final ExtPickTaskReplicaRepository pickTaskReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public InventoryEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtPickListReplicaRepository pickListReplicaRepository,
+            ExtPickTaskReplicaRepository pickTaskReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.pickListReplicaRepository = pickListReplicaRepository;
+        this.pickTaskReplicaRepository = pickTaskReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "inventory")
+                        .tag("entity", "inventory-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${workorder.kafka.inventory-events-topic:inventory.events.v1}",
@@ -84,6 +110,11 @@ public class InventoryEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed inventory event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed inventory event eventId={}", eventId, e);
         }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InvoiceEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InvoiceEventsListener.java
@@ -10,16 +10,19 @@ import com.positivity.workorder.internal.repository.ExtBillingRulesReplicaReposi
 import com.positivity.workorder.internal.repository.ExtInvoiceReplicaRepository;
 import com.positivity.workorder.internal.repository.ProcessedEventRepository;
 import com.positivity.workorder.internal.repository.WorkorderRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -36,7 +39,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
 public class InvoiceEventsListener {
 
@@ -49,6 +51,34 @@ public class InvoiceEventsListener {
     private final ExtBillingRulesReplicaRepository extBillingRulesReplicaRepository;
     private final WorkorderRepository workorderRepository;
     private final WorkorderFactPublisher workorderFactPublisher;
+    private final Counter payloadRejectedCounter;
+
+    public InvoiceEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtInvoiceReplicaRepository extInvoiceReplicaRepository,
+            ExtBillingRulesReplicaRepository extBillingRulesReplicaRepository,
+            WorkorderRepository workorderRepository,
+            WorkorderFactPublisher workorderFactPublisher,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extInvoiceReplicaRepository = extInvoiceReplicaRepository;
+        this.extBillingRulesReplicaRepository = extBillingRulesReplicaRepository;
+        this.workorderRepository = workorderRepository;
+        this.workorderFactPublisher = workorderFactPublisher;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "invoice")
+                        .tag("entity", "invoice-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${workorder.kafka.invoice-events-topic:invoice.events.v1}",
@@ -84,6 +114,11 @@ public class InvoiceEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed invoice event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed invoice event eventId={}", eventId, e);
         }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/LocationEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/LocationEventsListener.java
@@ -6,16 +6,19 @@ import com.positivity.workorder.internal.entity.ExtLocationReplica;
 import com.positivity.workorder.internal.entity.ProcessedEvent;
 import com.positivity.workorder.internal.repository.ExtLocationReplicaRepository;
 import com.positivity.workorder.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -34,7 +37,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
 public class LocationEventsListener {
 
@@ -44,6 +46,28 @@ public class LocationEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final ExtLocationReplicaRepository extLocationReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public LocationEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtLocationReplicaRepository extLocationReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extLocationReplicaRepository = extLocationReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "location")
+                        .tag("entity", "location-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${workorder.kafka.location-events-topic:location.events.v1}",
@@ -77,6 +101,11 @@ public class LocationEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed location event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed location event eventId={}", eventId, e);
         }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/OrderEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/OrderEventsListener.java
@@ -3,16 +3,19 @@ package com.positivity.workorder.internal.service;
 import com.positivity.domainevents.order.OrderCompletedV1;
 import com.positivity.workorder.internal.entity.ProcessedEvent;
 import com.positivity.workorder.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -32,7 +35,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
 public class OrderEventsListener {
 
@@ -43,6 +45,28 @@ public class OrderEventsListener {
     private final ObjectMapper objectMapper;
     private final ProcessedEventRepository processedEventRepository;
     private final WorkorderStateMachine workorderStateMachine;
+    private final Counter payloadRejectedCounter;
+
+    public OrderEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            WorkorderStateMachine workorderStateMachine,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.workorderStateMachine = workorderStateMachine;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "order")
+                        .tag("entity", "order-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${workorder.kafka.order-events-topic:order.events.v1}",
@@ -75,6 +99,11 @@ public class OrderEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed order event payload eventId={}: {}", eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed order event eventId={}", eventId, e);
         }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/PeopleReplicaEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/PeopleReplicaEventsListener.java
@@ -13,16 +13,19 @@ import com.positivity.workorder.internal.repository.ExtPersonReplicaRepository;
 import com.positivity.workorder.internal.repository.ExtStaffingAssignmentReplicaRepository;
 import com.positivity.workorder.internal.repository.ExtUserLinkReplicaRepository;
 import com.positivity.workorder.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -35,7 +38,6 @@ import tools.jackson.databind.ObjectMapper;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
 public class PeopleReplicaEventsListener {
 
@@ -48,6 +50,32 @@ public class PeopleReplicaEventsListener {
     private final ExtPersonReplicaRepository extPersonReplicaRepository;
     private final ExtUserLinkReplicaRepository extUserLinkReplicaRepository;
     private final ExtStaffingAssignmentReplicaRepository extStaffingAssignmentReplicaRepository;
+    private final Counter payloadRejectedCounter;
+
+    public PeopleReplicaEventsListener(
+            Clock clock,
+            ObjectMapper objectMapper,
+            ProcessedEventRepository processedEventRepository,
+            ExtPersonReplicaRepository extPersonReplicaRepository,
+            ExtUserLinkReplicaRepository extUserLinkReplicaRepository,
+            ExtStaffingAssignmentReplicaRepository extStaffingAssignmentReplicaRepository,
+            ObjectProvider<MeterRegistry> meterRegistry) {
+        this.clock = clock;
+        this.objectMapper = objectMapper;
+        this.processedEventRepository = processedEventRepository;
+        this.extPersonReplicaRepository = extPersonReplicaRepository;
+        this.extUserLinkReplicaRepository = extUserLinkReplicaRepository;
+        this.extStaffingAssignmentReplicaRepository = extStaffingAssignmentReplicaRepository;
+        MeterRegistry registry = meterRegistry.getIfAvailable();
+        this.payloadRejectedCounter = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", "people")
+                        .tag("entity", "people-events")
+                        .register(registry);
+    }
 
     @KafkaListener(
             topics = "${workorder.kafka.people-contact-events-topic:people-contact.events.v1}",
@@ -98,6 +126,11 @@ public class PeopleReplicaEventsListener {
             }
         } catch (TransientDataAccessException e) {
             throw e;
+        } catch (DatabindException e) {
+            if (payloadRejectedCounter != null) {
+                payloadRejectedCounter.increment();
+            }
+            log.error("Rejected malformed {} event payload eventId={}: {}", owner, eventId, e.getMessage(), e);
         } catch (Exception e) {
             log.warn("Skipping malformed {} event eventId={}", owner, eventId, e);
         }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/PeopleReplicaEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/PeopleReplicaEventsListener.java
@@ -50,7 +50,8 @@ public class PeopleReplicaEventsListener {
     private final ExtPersonReplicaRepository extPersonReplicaRepository;
     private final ExtUserLinkReplicaRepository extUserLinkReplicaRepository;
     private final ExtStaffingAssignmentReplicaRepository extStaffingAssignmentReplicaRepository;
-    private final Counter payloadRejectedCounter;
+    private final Counter payloadRejectedCounterPeopleContact;
+    private final Counter payloadRejectedCounterPeople;
 
     public PeopleReplicaEventsListener(
             Clock clock,
@@ -67,12 +68,20 @@ public class PeopleReplicaEventsListener {
         this.extUserLinkReplicaRepository = extUserLinkReplicaRepository;
         this.extStaffingAssignmentReplicaRepository = extStaffingAssignmentReplicaRepository;
         MeterRegistry registry = meterRegistry.getIfAvailable();
-        this.payloadRejectedCounter = registry == null
+        this.payloadRejectedCounterPeopleContact = registry == null
                 ? null
                 : Counter.builder("replica.payload.rejected")
                         .description(
                                 "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
-                        .tag("owner", "people")
+                        .tag("owner", OWNER_PEOPLE_CONTACT)
+                        .tag("entity", "people-contact-events")
+                        .register(registry);
+        this.payloadRejectedCounterPeople = registry == null
+                ? null
+                : Counter.builder("replica.payload.rejected")
+                        .description(
+                                "Replica event payloads rejected due to Jackson databind failures (e.g. omitted primitive fields)")
+                        .tag("owner", OWNER_PEOPLE)
                         .tag("entity", "people-events")
                         .register(registry);
     }
@@ -127,8 +136,11 @@ public class PeopleReplicaEventsListener {
         } catch (TransientDataAccessException e) {
             throw e;
         } catch (DatabindException e) {
-            if (payloadRejectedCounter != null) {
-                payloadRejectedCounter.increment();
+            Counter counter = OWNER_PEOPLE_CONTACT.equals(owner)
+                    ? payloadRejectedCounterPeopleContact
+                    : payloadRejectedCounterPeople;
+            if (counter != null) {
+                counter.increment();
             }
             log.error("Rejected malformed {} event payload eventId={}: {}", owner, eventId, e.getMessage(), e);
         } catch (Exception e) {

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/ReplicaAndManifestListenerContractTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/ReplicaAndManifestListenerContractTest.java
@@ -125,11 +125,20 @@ class ReplicaAndManifestListenerContractTest {
                 processedEventRepository,
                 personRepository,
                 userLinkRepository,
-                assignmentRepository);
-        customerListener =
-                new CustomerEventsListener(clock, objectMapper, processedEventRepository, customerRepository);
-        locationListener =
-                new LocationEventsListener(clock, objectMapper, processedEventRepository, locationRepository);
+                assignmentRepository,
+                org.mockito.Mockito.mock(ObjectProvider.class));
+        customerListener = new CustomerEventsListener(
+                clock,
+                objectMapper,
+                processedEventRepository,
+                customerRepository,
+                org.mockito.Mockito.mock(ObjectProvider.class));
+        locationListener = new LocationEventsListener(
+                clock,
+                objectMapper,
+                processedEventRepository,
+                locationRepository,
+                org.mockito.Mockito.mock(ObjectProvider.class));
     }
 
     private static String envelope(String eventId, String eventType, String payload) {

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/InventoryEventsListenerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/InventoryEventsListenerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -42,7 +43,8 @@ class InventoryEventsListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener = new InventoryEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, pickLists, pickTasks);
+        listener = new InventoryEventsListener(
+                TEST_CLOCK, new ObjectMapper(), processedEvents, pickLists, pickTasks, mock(ObjectProvider.class));
     }
 
     private String pickListEvent(String eventId, long version) {

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/InvoiceEventsListenerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/InvoiceEventsListenerTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -46,7 +47,14 @@ class InvoiceEventsListenerTest {
     @BeforeEach
     void setUp() {
         listener = new InvoiceEventsListener(
-                TEST_CLOCK, new ObjectMapper(), processedEvents, replica, billingRules, workorders, factPublisher);
+                TEST_CLOCK,
+                new ObjectMapper(),
+                processedEvents,
+                replica,
+                billingRules,
+                workorders,
+                factPublisher,
+                mock(ObjectProvider.class));
     }
 
     private String event(String eventId, long version) {

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/OrderEventsListenerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/OrderEventsListenerTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.QueryTimeoutException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -41,7 +42,8 @@ class OrderEventsListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener = new OrderEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, stateMachine);
+        listener = new OrderEventsListener(
+                TEST_CLOCK, new ObjectMapper(), processedEvents, stateMachine, mock(ObjectProvider.class));
     }
 
     private String orderCompleted(String eventId, String workorderIdJson) {


### PR DESCRIPTION
## Capability & Traceability
- Child issue: louisburroughs/durion-positivity-backend#1255
- Domain: `domain:cross-cutting` (ADR-0044 replica listeners, spans 11 modules)

## Contract References
- No API/DTO/event contract changes — internal error-handling/observability change only.

## Scope
- What changed: Every ADR-0044 replica listener's malformed-payload catch block previously caught
  all exceptions generically, logged a WARN, and still recorded the `processed_events` dedup row —
  so a Jackson 3 `DatabindException` (e.g. from `FAIL_ON_NULL_FOR_PRIMITIVES` when a producer omits
  a primitive field) was silently swallowed and invisible to reconciliation. Added a specific
  `catch (DatabindException e)` branch ahead of the existing generic catch in all 39 affected
  listener classes across 11 modules (pos-accounting, pos-catalog, pos-customer, pos-inventory,
  pos-invoice, pos-location, pos-people, pos-security-service, pos-shop-manager, pos-warranty,
  pos-workorder). The new branch logs at ERROR and increments a new `replica.payload.rejected`
  Micrometer counter (tags: `owner`, `entity`), following the existing `replica.drift` counter
  pattern (`CustomerManifestListener`). No change to reconciliation semantics, dedup-row behavior,
  or `TransientDataAccessException` retry/DLQ handling — this is Option 3 from the issue (cheapest
  fix, no contract changes).
- Why: closes #1255 — makes previously-invisible replica payload data loss observable/alertable
  without changing any event contract.

## Tests
- [x] Unit tests updated (constructor signatures changed to accept `ObjectProvider<MeterRegistry>`;
      existing listener/contract tests updated accordingly — no assertions changed)
- [ ] Integration tests added/updated (not needed — no behavior change, only added observability)
- [ ] Provider behavioral contract tests added/updated (n/a)
- How to run:
  ```
  ./mvnw -pl pos-accounting,pos-catalog,pos-customer,pos-inventory,pos-invoice,pos-location,pos-people,pos-security-service,pos-shop-manager,pos-warranty,pos-workorder -am test
  ./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests -Dsurefire.failIfNoSpecifiedTests=false test
  ```

## Risk & Rollback
- Risk level: Low — additive catch branch only; existing catch/dedup/retry behavior unchanged;
  full reactor compiles, all affected modules' tests pass (0 failures/errors across 510 test
  classes), spotless and cross-module ArchUnit checks pass.
- Rollback plan: revert this PR; no schema/contract/migration changes to unwind.

## Checklist
- [x] Links to child issue present
- [x] Required CI checks passing locally (build, tests, spotless, ArchUnit)
