### PR TITLE
fix(security): use constant-time comparison for shared-secret auth filters

### DIFF
--- a/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/config/EventsApiSecurityFilter.java
+++ b/pos-event-receiver/src/main/java/com/positivity/poseventreceiver/internal/config/EventsApiSecurityFilter.java
@@ -5,6 +5,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -102,7 +104,11 @@ public class EventsApiSecurityFilter extends OncePerRequestFilter {
 
         // Validate the shared secret
         String providedSecret = request.getHeader(SECRET_HEADER);
-        if (providedSecret == null || !expectedSecret.equals(providedSecret)) {
+        boolean authorized = providedSecret != null
+                && MessageDigest.isEqual(
+                        expectedSecret.getBytes(StandardCharsets.UTF_8),
+                        providedSecret.getBytes(StandardCharsets.UTF_8));
+        if (!authorized) {
             log.warn("Unauthorized request to {} {} - invalid or missing {} header", method, path, SECRET_HEADER);
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             response.setContentType("application/json");

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/security/PermissionRegistrationSecretFilter.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/security/PermissionRegistrationSecretFilter.java
@@ -7,6 +7,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
@@ -72,7 +74,11 @@ public class PermissionRegistrationSecretFilter extends OncePerRequestFilter {
         }
 
         String providedSecret = request.getHeader(SECRET_HEADER);
-        if (providedSecret == null || !expectedSecret.equals(providedSecret)) {
+        boolean authorized = providedSecret != null
+                && MessageDigest.isEqual(
+                        expectedSecret.getBytes(StandardCharsets.UTF_8),
+                        providedSecret.getBytes(StandardCharsets.UTF_8));
+        if (!authorized) {
             writeUnauthorized(
                     response,
                     request,


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A (targeted security fix, not capability-tracked)
- Parent STORY (durion): N/A
- Child issue: louisburroughs/durion-positivity-backend#1242
- Domain: `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- N/A — no controller/DTO/OpenAPI/event contract changes. This PR only changes the internal comparison logic inside two existing security filters; request/response shapes and authentication behavior (accept/reject decisions) are unchanged.

## Contract Chain (when a Controller changed)
- N/A — no controller changed

## Scope
- What changed: `EventsApiSecurityFilter` (`pos-event-receiver`) and `PermissionRegistrationSecretFilter` (`pos-security-service`) now compare the configured shared secret against the request header using `MessageDigest.isEqual` instead of `String.equals`.
- Why: `String.equals` short-circuits on the first differing byte, so comparison time leaks information about how many leading bytes of a guessed secret are correct — a timing side-channel against the only credential gating the Events API write path (`X-Events-Api-Secret`) and the permission-registration endpoint (`X-Permissions-Api-Secret`). See #1242 for full details and severity assessment.

## Tests
- [x] Unit tests added/updated — no new tests needed; existing `EventsApiSecurityFilterTest` is comparison-agnostic per the issue and continues to pin accept/reject behavior.
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated
- How to run:
  - `./mvnw -pl pos-event-receiver -Dtest=EventsApiSecurityFilterTest -DskipTests=false test` (22 tests pass)
  - `./mvnw -pl pos-security-service -DskipTests=false test` (456 tests pass, full module suite — no dedicated filter test exists for `PermissionRegistrationSecretFilter`; behavior is covered by `ContractBehaviorIT`)
  - `./mvnw -pl pos-event-receiver -DskipTests=false test` (168 tests pass, full module suite)

## Risk & Rollback
- Risk level: Low — behavior-preserving change (same accept/reject outcomes), no API/schema changes.
- Rollback plan: revert this commit; the previous `String.equals` comparison had no functional bugs, only a timing side-channel.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, this repo's convention names this branch `claude/issue-1242-gkl2o2`
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, not capability-tracked
- [x] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed) — N/A, no contract semantics changed
- [ ] Required CI checks passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBaSKgAFhKt2A8VETN2joC)_