### PR TITLE
fix(accounting): gate PostgreSQL-only entry-number gap query on the active dialect

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/config/DatabaseDialectSupport.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/config/DatabaseDialectSupport.java
@@ -1,0 +1,53 @@
+package com.positivity.accounting.internal.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Runtime answer to "is the active database PostgreSQL?", resolved once from
+ * the Hibernate dialect the {@link EntityManagerFactory} was built with.
+ *
+ * <p>The module runs on PostgreSQL/TimescaleDB in every deployed profile but on
+ * H2 in the dev profile and in the Spring Boot slice/contract tests. A handful
+ * of native queries are PostgreSQL-only ({@code generate_series}, regex
+ * {@code substring}, {@code ::bigint} casts) and fail with an H2 parse error
+ * rather than degrading, so their callers need a portable way to ask the
+ * question instead of relying on javadoc that nothing enforces.
+ *
+ * @author Louis Burroughs
+ * @since 2026-08-14
+ */
+@Component
+public class DatabaseDialectSupport {
+
+    private static final Logger log = LoggerFactory.getLogger(DatabaseDialectSupport.class);
+
+    private final boolean postgreSql;
+
+    public DatabaseDialectSupport(EntityManagerFactory entityManagerFactory) {
+        Dialect dialect = entityManagerFactory
+                .unwrap(SessionFactoryImplementor.class)
+                .getJdbcServices()
+                .getDialect();
+        this.postgreSql = dialect instanceof PostgreSQLDialect;
+        log.info(
+                "Resolved Hibernate dialect {}; PostgreSQL-only queries are {}",
+                dialect.getClass().getName(),
+                postgreSql ? "enabled" : "disabled");
+    }
+
+    /**
+     * Whether the active Hibernate dialect is PostgreSQL (which includes the
+     * TimescaleDB deployments, since they use {@link PostgreSQLDialect}).
+     *
+     * @return true when PostgreSQL-only SQL may be executed
+     */
+    public boolean isPostgreSql() {
+        return postgreSql;
+    }
+}

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/AccountingSequenceRepository.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/repository/AccountingSequenceRepository.java
@@ -43,8 +43,13 @@ public interface AccountingSequenceRepository extends JpaRepository<AccountingSe
      *
      * <p><strong>PostgreSQL only</strong> ({@code generate_series}, regex
      * {@code substring}) — must not be executed against the H2 dev/test
-     * database. Exercised by the Docker-gated concurrency IT and the PG16
-     * migration validation only.
+     * database, where it fails to parse ({@code CROSS JOIN LATERAL} is
+     * unsupported; H2 reports {@code 42102 Table "LATERAL" not found}).
+     * Callers must gate on
+     * {@code com.positivity.accounting.internal.config.DatabaseDialectSupport#isPostgreSql()};
+     * {@code FinancialReportingServiceImpl#checkEntryNumberGaps} is the only
+     * production caller and does so. Exercised by the Docker-gated concurrency
+     * IT and the PG16 migration validation only.
      *
      * <p>The stored side parses the numeric suffix of {@code entry_number}
      * server-side (the digits after the last {@code '-'}) rather than

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/FinancialReportingServiceImpl.java
@@ -1,5 +1,6 @@
 package com.positivity.accounting.internal.service;
 
+import com.positivity.accounting.internal.config.DatabaseDialectSupport;
 import com.positivity.accounting.internal.dto.AccountDrilldownResponse;
 import com.positivity.accounting.internal.dto.AgedPayablesReport;
 import com.positivity.accounting.internal.dto.AgedPayablesRow;
@@ -128,6 +129,7 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
     private final VendorBillRepository vendorBillRepository;
     private final APPaymentAllocationRepository apPaymentAllocationRepository;
     private final InvoiceBalanceCalculator invoiceBalanceCalculator;
+    private final DatabaseDialectSupport databaseDialectSupport;
     private final Clock clock;
 
     public FinancialReportingServiceImpl(
@@ -142,6 +144,7 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
             VendorBillRepository vendorBillRepository,
             APPaymentAllocationRepository apPaymentAllocationRepository,
             InvoiceBalanceCalculator invoiceBalanceCalculator,
+            DatabaseDialectSupport databaseDialectSupport,
             Clock clock) {
         this.journalEntryRepository = journalEntryRepository;
         this.statementLineMappingRepository = statementLineMappingRepository;
@@ -154,6 +157,7 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
         this.vendorBillRepository = vendorBillRepository;
         this.apPaymentAllocationRepository = apPaymentAllocationRepository;
         this.invoiceBalanceCalculator = invoiceBalanceCalculator;
+        this.databaseDialectSupport = databaseDialectSupport;
         this.clock = clock;
     }
 
@@ -413,8 +417,21 @@ public class FinancialReportingServiceImpl implements FinancialReportingService 
      * keys are {@code JE-{YYYYMM}} on the entry's transaction month, so the
      * lexicographic comparison against the as-of month boundary is a correct
      * chronological cut. A clean ledger yields an empty footnote.
+     *
+     * <p>The gap query is PostgreSQL-only and fails to parse on H2, so on any
+     * other dialect (the dev profile and the H2-backed Spring Boot tests) the
+     * footnote is reported empty rather than executing the query. This is the
+     * enforcement of the constraint that
+     * {@code AccountingSequenceRepository#findMissingEntryNumbers} documents:
+     * before it existed, whether the report blew up on H2 depended on whether
+     * any {@code accounting_sequence} row had handed out a number yet.
      */
     private List<EntryNumberGapCheck> checkEntryNumberGaps(LocalDate asOf) {
+        if (!databaseDialectSupport.isPostgreSql()) {
+            log.debug("Skipping entry-number gap footnote as of {}: the gap query requires PostgreSQL", asOf);
+            return List.of();
+        }
+
         String asOfScopeBoundary =
                 String.format("%s%04d%02d", ENTRY_NUMBER_SCOPE_PREFIX, asOf.getYear(), asOf.getMonthValue());
 

--- a/pos-accounting/src/main/java/com/positivity/accounting/service/FinancialReportingService.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/service/FinancialReportingService.java
@@ -65,7 +65,9 @@ public interface FinancialReportingService {
      * Also runs the entry-number gap-check (per monthly sequence scope, see
      * {@code AccountingSequenceRepository#findMissingEntryNumbers}) and
      * attaches the results as a footnote block; the footnote is empty on a
-     * clean ledger.
+     * clean ledger. The gap query is PostgreSQL-only, so the footnote is also
+     * reported empty when the service runs on another database (the H2 dev
+     * profile and the H2-backed tests).
      *
      * Returns empty rows with zero totals (balanced = true) and an empty gap
      * footnote when no POSTED data exists as of the requested date.

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/config/DatabaseDialectSupportTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/config/DatabaseDialectSupportTest.java
@@ -1,0 +1,48 @@
+package com.positivity.accounting.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link DatabaseDialectSupport} (issue #1244): PostgreSQL-only
+ * SQL must be gated on the dialect the EntityManagerFactory was actually built
+ * with, not on the deployment profile a caller assumes is active.
+ */
+class DatabaseDialectSupportTest {
+
+    @Test
+    @DisplayName("Reports PostgreSQL when the session factory was built with the PostgreSQL dialect")
+    void detectsPostgreSql() {
+        assertThat(new DatabaseDialectSupport(entityManagerFactoryWith(new PostgreSQLDialect())).isPostgreSql())
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("Reports non-PostgreSQL for the H2 dev/test dialect")
+    void detectsH2AsNonPostgreSql() {
+        assertThat(new DatabaseDialectSupport(entityManagerFactoryWith(new H2Dialect())).isPostgreSql())
+                .isFalse();
+    }
+
+    private static EntityManagerFactory entityManagerFactoryWith(Dialect dialect) {
+        JdbcServices jdbcServices = mock(JdbcServices.class);
+        when(jdbcServices.getDialect()).thenReturn(dialect);
+
+        SessionFactoryImplementor sessionFactory = mock(SessionFactoryImplementor.class);
+        when(sessionFactory.getJdbcServices()).thenReturn(jdbcServices);
+
+        EntityManagerFactory entityManagerFactory = mock(EntityManagerFactory.class);
+        when(entityManagerFactory.unwrap(SessionFactoryImplementor.class)).thenReturn(sessionFactory);
+        return entityManagerFactory;
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingG2ServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingG2ServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import com.positivity.accounting.internal.config.DatabaseDialectSupport;
 import com.positivity.accounting.internal.dto.AgedPayablesReport;
 import com.positivity.accounting.internal.dto.AgedReceivablesReport;
 import com.positivity.accounting.internal.dto.GeneralLedgerAccountSection;
@@ -97,6 +98,9 @@ class FinancialReportingG2ServiceTest {
     @Mock
     private InvoiceBalanceCalculator invoiceBalanceCalculator;
 
+    @Mock
+    private DatabaseDialectSupport databaseDialectSupport;
+
     private FinancialReportingServiceImpl service;
 
     @BeforeEach
@@ -113,6 +117,7 @@ class FinancialReportingG2ServiceTest {
                 vendorBillRepository,
                 apPaymentAllocationRepository,
                 invoiceBalanceCalculator,
+                databaseDialectSupport,
                 Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
     }
 

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingServiceImplTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingServiceImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.positivity.accounting.internal.config.DatabaseDialectSupport;
 import com.positivity.accounting.internal.dto.EntryNumberGapCheck;
 import com.positivity.accounting.internal.dto.TrialBalanceAccountTotal;
 import com.positivity.accounting.internal.dto.TrialBalanceReport;
@@ -79,6 +80,9 @@ class FinancialReportingServiceImplTest {
     @Mock
     private InvoiceBalanceCalculator invoiceBalanceCalculator;
 
+    @Mock
+    private DatabaseDialectSupport databaseDialectSupport;
+
     private FinancialReportingServiceImpl service;
 
     @BeforeEach
@@ -95,6 +99,7 @@ class FinancialReportingServiceImplTest {
                 vendorBillRepository,
                 apPaymentAllocationRepository,
                 invoiceBalanceCalculator,
+                databaseDialectSupport,
                 Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
     }
 
@@ -118,6 +123,7 @@ class FinancialReportingServiceImplTest {
                         ACCT_CASH, "1000", "Cash", new BigDecimal("150.00"), new BigDecimal("40.00")),
                 new TrialBalanceAccountTotal(
                         ACCT_REVENUE, "4000", "Revenue", new BigDecimal("40.00"), new BigDecimal("150.00")));
+        when(databaseDialectSupport.isPostgreSql()).thenReturn(true);
         when(accountingSequenceRepository.findAllByOrderByScopeKeyAsc()).thenReturn(List.of());
 
         TrialBalanceReport report = service.generateTrialBalance(AS_OF);
@@ -160,6 +166,7 @@ class FinancialReportingServiceImplTest {
                 new TrialBalanceAccountTotal(ACCT_CASH, "1000", "Cash", new BigDecimal("100.00"), BigDecimal.ZERO),
                 new TrialBalanceAccountTotal(
                         ACCT_REVENUE, "4000", "Revenue", BigDecimal.ZERO, new BigDecimal("90.00")));
+        when(databaseDialectSupport.isPostgreSql()).thenReturn(true);
         when(accountingSequenceRepository.findAllByOrderByScopeKeyAsc()).thenReturn(List.of());
 
         TrialBalanceReport report = service.generateTrialBalance(AS_OF);
@@ -174,6 +181,7 @@ class FinancialReportingServiceImplTest {
     void balancedIgnoresBigDecimalScaleDifferences() {
         aggregatedTotals(new TrialBalanceAccountTotal(
                 ACCT_CASH, "1000", "Cash", new BigDecimal("100.0"), new BigDecimal("100.00")));
+        when(databaseDialectSupport.isPostgreSql()).thenReturn(true);
         when(accountingSequenceRepository.findAllByOrderByScopeKeyAsc()).thenReturn(List.of());
 
         TrialBalanceReport report = service.generateTrialBalance(AS_OF);
@@ -186,6 +194,7 @@ class FinancialReportingServiceImplTest {
     void populatesGapFootnoteForJeScopesUpToAsOfMonth() {
         aggregatedTotals(new TrialBalanceAccountTotal(
                 ACCT_CASH, "1000", "Cash", new BigDecimal("10.00"), new BigDecimal("10.00")));
+        when(databaseDialectSupport.isPostgreSql()).thenReturn(true);
         when(accountingSequenceRepository.findAllByOrderByScopeKeyAsc())
                 .thenReturn(List.of(
                         sequence("INV-202605"), sequence("JE-202605"), sequence("JE-202606"), sequence("JE-202607")));
@@ -200,6 +209,23 @@ class FinancialReportingServiceImplTest {
         // Scopes after the as-of month and non-JE scopes are never gap-checked
         verify(accountingSequenceRepository, never()).findMissingEntryNumbers("JE-202607");
         verify(accountingSequenceRepository, never()).findMissingEntryNumbers("INV-202605");
+    }
+
+    @Test
+    @DisplayName("Reports an empty gap footnote without touching the PostgreSQL-only query on another dialect")
+    void skipsGapFootnoteOnNonPostgreSqlDialect() {
+        // Regression guard for issue #1244: the gap query uses CROSS JOIN LATERAL
+        // generate_series and fails to parse on H2, so a populated
+        // accounting_sequence table used to break Trial Balance (and the report
+        // exports built on it) in every H2-backed test and in the dev profile.
+        aggregatedTotals(new TrialBalanceAccountTotal(
+                ACCT_CASH, "1000", "Cash", new BigDecimal("10.00"), new BigDecimal("10.00")));
+
+        TrialBalanceReport report = service.generateTrialBalance(AS_OF);
+
+        assertThat(report.getEntryNumberGaps()).isEmpty();
+        assertThat(report.getBalanced()).isTrue();
+        verifyNoInteractions(accountingSequenceRepository);
     }
 
     @Test

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingTaxLiabilityServiceTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingTaxLiabilityServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import com.positivity.accounting.internal.config.DatabaseDialectSupport;
 import com.positivity.accounting.internal.dto.TaxLiabilityReport;
 import com.positivity.accounting.internal.dto.TaxLiabilityRow;
 import com.positivity.accounting.internal.entity.CreditMemo;
@@ -90,6 +91,9 @@ class FinancialReportingTaxLiabilityServiceTest {
     @Mock
     private InvoiceBalanceCalculator invoiceBalanceCalculator;
 
+    @Mock
+    private DatabaseDialectSupport databaseDialectSupport;
+
     private FinancialReportingServiceImpl service;
 
     @BeforeEach
@@ -106,6 +110,7 @@ class FinancialReportingTaxLiabilityServiceTest {
                 vendorBillRepository,
                 apPaymentAllocationRepository,
                 invoiceBalanceCalculator,
+                databaseDialectSupport,
                 Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
     }
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — bug fix on `main`, not part of a capability wave
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1244
- Domain: `domain:accounting`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/accounting/.business-rules/BACKEND_CONTRACT_GUIDE.md` → Trial Balance / entry-number gap footnote
- Durion contract PR (if applicable): none — no wire contract changed. No controller, DTO, event, or `openapi.yaml` was touched; the response schema is unchanged. On PostgreSQL (every deployed profile) the report is byte-identical to before. The only observable difference is on non-PostgreSQL databases (the H2 dev profile and H2-backed tests), where `entryNumberGaps` is now reported empty instead of the request failing with a 500.

## Contract Chain (when a Controller changed)
No controller changed.
- [ ] OpenAPI annotations updated on the controller — n/a
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope
**What changed:**
- New `internal/config/DatabaseDialectSupport` — resolves the Hibernate dialect the `EntityManagerFactory` was built with, once at startup, and answers `isPostgreSql()`.
- `FinancialReportingServiceImpl.checkEntryNumberGaps` now returns an empty footnote on any other dialect instead of executing the PostgreSQL-only gap query.
- Javadoc updated on `AccountingSequenceRepository.findMissingEntryNumbers` (states the H2 error and names the gate callers must use) and on the `FinancialReportingService.generateTrialBalance` contract (footnote is empty off PostgreSQL).

**Why:**
`./mvnw -pl pos-accounting verify -DskipITs=false` failed on `main`: `ReportExportRenderingContractBehaviorIT` hit `Table "LATERAL" not found [42102]` from H2. The Trial Balance gap footnote calls `AccountingSequenceRepository.findMissingEntryNumbers`, whose native SQL uses `CROSS JOIN LATERAL generate_series`, a regex `substring`, and a `::bigint` cast — all PostgreSQL-only. The method's javadoc already said it must not run against H2, but nothing enforced that.

The failure was order-dependent, which is why it read as flaky: the footnote only issues the query for a sequence scope whose `next_value > 1`, so it fired only when an earlier IT had left rows in the shared H2 `accounting_sequence` table. Running the report-export IT alone leaves the table empty and passes.

Because `pos-accounting` fails early in a reactor `verify`, no module ordered after it reached its own `verify` phase — this blocked a green full-reactor `verify` for every capability.

This takes option 1 from #1244 (gate the call, matching the javadoc's stated intent): smallest change, keeps the report working on H2, and makes the "must not be executed against H2" rule real instead of advisory. I grepped the module for other PostgreSQL-only native SQL (`generate_series`, `LATERAL`, `::`, `jsonb`, `ILIKE`) — this is the only one, so there is no second latent leak of the same shape.

## Tests
- [x] Unit tests added/updated
- [x] Integration tests added/updated — no new IT; the existing `ReportExportRenderingContractBehaviorIT` is the regression case and now passes in a full-module run
- [ ] Provider behavioral contract tests added/updated — n/a

Added:
- `FinancialReportingServiceImplTest.skipsGapFootnoteOnNonPostgreSqlDialect` — asserts the footnote is empty and `AccountingSequenceRepository` is never touched on a non-PostgreSQL dialect.
- `DatabaseDialectSupportTest` — PostgreSQL vs H2 detection.
- Existing trial-balance tests now stub the dialect as PostgreSQL, so the gap-footnote assertions still exercise the real path.

**How to run** — validate with a full-module `verify`, not the single class; the class alone leaves `accounting_sequence` empty and cannot reproduce the failure:

```bash
./mvnw -pl pos-accounting -am install -DskipTests
./mvnw -pl pos-accounting verify -DskipITs=false
```

Result on this branch: **BUILD SUCCESS**. Unit phase 1244 tests, 0 failures, 0 errors. Integration phase **216 tests, 0 failures, 0 errors, 21 skipped** — same totals as the failing run in #1244 with the 1 error gone. The 21 skips are the Docker-gated ITs (`@Testcontainers(disabledWithoutDocker = true)`) in an environment with no Docker daemon, unchanged from before.

The gate is visible in the test logs: `Resolved Hibernate dialect org.hibernate.dialect.H2Dialect; PostgreSQL-only queries are disabled`.

## Risk & Rollback
- Risk level: Low. No production behavior change — every deployed profile runs PostgreSQL, where `isPostgreSql()` is true and the gap query executes exactly as before. The dialect is read once from the already-built `EntityManagerFactory`, so no extra connection or startup dependency.
- Rollback plan: revert the single commit. The pre-existing `verify` failure returns; nothing else depends on the new component.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, not a capability branch (`claude/issue-1244-ickm9q`)
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, same reason
- [x] Links to parent + child issues are present (child issue #1244; no parent STORY)
- [x] Contract guide updated (when contract semantics changed) — no contract semantics changed
- [ ] Required CI checks passing — pending first run

Fixes #1244

---
_Generated by [Claude Code](https://claude.ai/code/session_01B151wfQM7NREzm5W43a8BW)_