### PR TITLE
feat(marketing): B3 — audience binding, preview explanation, and offer/catalog reference validation (#1148)

### DIFF
--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/client/PriceClient.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/client/PriceClient.java
@@ -1,0 +1,104 @@
+package com.positivity.marketing.internal.client;
+
+import com.positivity.marketing.internal.service.PromotionOfferPort;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+/**
+ * Reads a promotion offer from the pricing service so a campaign can be stopped from
+ * advertising one that is not running (Story #1148).
+ *
+ * <p>This is the module's one synchronous domain read, and it is permitted because pricing is
+ * an ADR-0044 §1 utility rather than a peer domain. It is also the right shape for the
+ * question: offer status changes on its own schedule with no fact to replicate from, and the
+ * answer is only needed at two discrete moments — previewing a campaign and scheduling one —
+ * rather than continuously.
+ *
+ * <p>The three outcomes are kept distinct on purpose. "No such offer" and "an offer that has
+ * expired" are the marketer's mistake and must block scheduling; "pricing did not answer" is
+ * an outage, and reporting it as an invalid campaign would send someone hunting for a data
+ * problem that does not exist.
+ */
+@Slf4j
+@Component
+public class PriceClient implements PromotionOfferPort {
+
+    /**
+     * Service identity for the gateway-header trust model: downstream services accept
+     * {@code X-Authorities} because they are only reachable behind the gateway.
+     */
+    private static final String SERVICE_USER = "pos-marketing-service";
+
+    private static final String AUTHORITIES = "pricing:promotion:view";
+
+    private final RestClient restClient;
+    private final String basePath;
+
+    public PriceClient(
+            @Qualifier("loadBalancedRestClientBuilder") RestClient.Builder restClientBuilder,
+            @Value("${pos.price.service-id:price}") String serviceId,
+            @Value("${pos.price.promotion-offers-base-path:/v1/promotions/offers}") String basePath) {
+        this.basePath = basePath;
+        this.restClient = restClientBuilder.baseUrl("http://" + serviceId).build();
+    }
+
+    @Override
+    public @NonNull OfferLookup findOffer(@NonNull UUID promotionOfferId) {
+        try {
+            PromotionOfferWire wire = restClient
+                    .get()
+                    .uri(basePath + "/{promotionOfferId}", promotionOfferId)
+                    .header("X-User", SERVICE_USER)
+                    .header("X-Authorities", AUTHORITIES)
+                    .retrieve()
+                    .body(PromotionOfferWire.class);
+            if (wire == null) {
+                // A 200 with no body is not an authoritative "does not exist"; treat it as an
+                // outage rather than condemning the campaign on it.
+                log.warn("Promotion offer {} returned an empty body", promotionOfferId);
+                return OfferLookup.unavailable();
+            }
+            return OfferLookup.found(new PromotionOffer(
+                    wire.promotionOfferId() != null ? wire.promotionOfferId() : promotionOfferId,
+                    wire.promoCode(),
+                    wire.status(),
+                    wire.startDate(),
+                    wire.endDate()));
+        } catch (RestClientResponseException e) {
+            if (e.getStatusCode().value() == 404) {
+                return OfferLookup.notFound();
+            }
+            log.warn(
+                    "Promotion offer lookup failed for {}: HTTP {}",
+                    promotionOfferId,
+                    e.getStatusCode().value());
+            return OfferLookup.unavailable();
+        } catch (RestClientException e) {
+            log.warn("Pricing unreachable for promotion offer {}: {}", promotionOfferId, e.getMessage());
+            return OfferLookup.unavailable();
+        } catch (IllegalStateException e) {
+            // Discovery has no instance registered — the same class of answer as an unreachable
+            // one, and it surfaces as IllegalStateException rather than a RestClientException
+            // because it fails before any request is made.
+            log.warn("No pricing instance available for promotion offer {}: {}", promotionOfferId, e.getMessage());
+            return OfferLookup.unavailable();
+        }
+    }
+
+    /** Wire shape of the pricing response; unknown properties are ignored. */
+    private record PromotionOfferWire(
+            @Nullable UUID promotionOfferId,
+            @Nullable String promoCode,
+            @Nullable String status,
+            @Nullable LocalDate startDate,
+            @Nullable LocalDate endDate) {}
+}

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/CampaignController.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/controller/CampaignController.java
@@ -264,9 +264,11 @@ public class CampaignController {
     }
 
     @Operation(operationId = "previewCampaignAudience", summary = "Preview Campaign Audience", description = """
-                    Reports the campaign's last resolved audience snapshot: total segment members, per-channel \
-                    eligible counts after consent, staleness and suppression checks, whether each channel has a \
-                    template, and the readiness problems that would block scheduling.
+                    Reports the campaign's last resolved audience snapshot: total segment members, whether that \
+                    snapshot was truncated by the CRM's candidate ceiling, per-channel eligible counts after \
+                    consent, staleness and suppression checks, a bounded per-channel sample of the individual \
+                    decisions behind those counts, whether each channel has a template, and the readiness \
+                    problems that would block scheduling.
                     Use this tool to gauge reach before scheduling or dispatch; do not use dispatchCampaign, \
                     which actually queues messages for delivery.
                     Preconditions: the campaign must exist and have a segmentId bound; membership is \
@@ -276,6 +278,13 @@ public class CampaignController {
                     Emits a MARKETING_AUDIENCE_PREVIEW audit event and, while the campaign is still DRAFT, \
                     SCHEDULED or PAUSED, asynchronously requests a fresher membership snapshot from \
                     pos-customer; the campaign itself is not modified.
+                    Each sample entry carries the party id, the contact resolved to receive the message (the \
+                    CRM's designated contact for a commercial account, the person themselves for an \
+                    individual), and the machine-readable decision code; it never carries names, addresses or \
+                    contact details, which this module does not hold.
+                    Problems with the campaign's promotionOfferId or catalogFocusRef are reported in warnings \
+                    rather than as errors, because a preview is where a marketer goes to find out what is \
+                    wrong.
                     Returns 404 when the campaign does not exist, and 422 when no segment is bound so there \
                     is nothing to preview.
                     """)
@@ -315,7 +324,10 @@ public class CampaignController {
                     the actual sends and only accepts a campaign that is already SCHEDULED or SENDING.
                     Preconditions: the campaign must exist and be in DRAFT or PAUSED; it must have at least \
                     one channel, a bound segment that is known to this module, active, and matching the \
-                    campaign's audienceType, and an existing template attached for every selected channel.
+                    campaign's audienceType, and an existing template attached for every selected channel; \
+                    any promotionOfferId must resolve in pos-price to an ACTIVE offer whose date window \
+                    includes today, and any catalogFocusRef must be written as kind:value using one of \
+                    product, sku, service or category.
                     Required inputs: campaignId (UUID) as a path parameter; there is no request body.
                     Emits a MARKETING_CAMPAIGN_SCHEDULE event and publishes a campaign-scheduled fact through \
                     the transactional outbox.

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/domain/CatalogFocusRef.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/domain/CatalogFocusRef.java
@@ -1,0 +1,87 @@
+package com.positivity.marketing.internal.domain;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * The catalog thing a campaign points at, written {@code kind:value} (Story #1148).
+ *
+ * <p>A campaign stores this as free text because the catalog aggregate lives in another
+ * domain and cannot be referenced by key. Free text with no grammar, though, is a reference
+ * nobody can ever follow: {@code "alignment"} and {@code "Service - Alignment"} both look
+ * plausible to the marketer typing them and mean nothing to any consumer. Pinning the shape
+ * here is what makes the value interpretable at all, and it is the check that runs before the
+ * campaign is allowed to go out.
+ *
+ * <p>Recognized kinds:
+ *
+ * <ul>
+ *   <li>{@code product:<id-or-name>} — a catalog product
+ *   <li>{@code sku:<sku>} — a product by stock-keeping unit
+ *   <li>{@code service:<id-or-name>} — a catalog service, e.g. {@code service:alignment}
+ *   <li>{@code category:<id-or-name>} — a whole product category
+ * </ul>
+ *
+ * @param kind recognized reference kind, lower-cased
+ * @param value the identifier or name after the separator, trimmed
+ */
+public record CatalogFocusRef(@NonNull Kind kind, @NonNull String value) {
+
+    private static final char SEPARATOR = ':';
+
+    /** Catalog reference kinds a campaign may point at. */
+    public enum Kind {
+        PRODUCT,
+        SKU,
+        SERVICE,
+        CATEGORY;
+
+        static Optional<Kind> of(String token) {
+            return Arrays.stream(values())
+                    .filter(kind -> kind.name().equalsIgnoreCase(token))
+                    .findFirst();
+        }
+
+        /** Wire form, as written in a {@code catalogFocusRef}. */
+        public String wireName() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+    }
+
+    /**
+     * Parse a stored reference.
+     *
+     * @return the parsed reference, or empty when {@code raw} does not follow the grammar —
+     *     unparseable is reported rather than thrown, because the caller gathers every campaign
+     *     readiness problem at once instead of failing on the first
+     */
+    public static @NonNull Optional<CatalogFocusRef> parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return Optional.empty();
+        }
+        String trimmed = raw.trim();
+        int separator = trimmed.indexOf(SEPARATOR);
+        if (separator <= 0 || separator == trimmed.length() - 1) {
+            return Optional.empty();
+        }
+        // Split on the first separator only: a name is allowed to contain colons, a kind is not.
+        String value = trimmed.substring(separator + 1).trim();
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+        return Kind.of(trimmed.substring(0, separator).trim()).map(kind -> new CatalogFocusRef(kind, value));
+    }
+
+    /** The recognized kinds, for an error message that tells the marketer what to write instead. */
+    public static @NonNull String supportedKinds() {
+        return Arrays.stream(Kind.values()).map(Kind::wireName).collect(Collectors.joining(", "));
+    }
+
+    @Override
+    public @NonNull String toString() {
+        return kind.wireName() + SEPARATOR + value;
+    }
+}

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/dto/AudiencePreviewResponse.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/dto/AudiencePreviewResponse.java
@@ -4,6 +4,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIR
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -12,7 +13,14 @@ import java.util.UUID;
  *
  * <p>Reports targeted and eligible counts per channel rather than a recipient list. The gap
  * between the two is the number the marketer needs: it is the difference between "my segment
- * is too narrow" and "most of these people have opted out".
+ * is too narrow" and "most of these people have opted out". A bounded sample per channel
+ * carries the individual decisions behind that gap, so the answer to "why is this number so
+ * low" does not require a second call.
+ *
+ * <p>The sample carries opaque identifiers and decision codes only — no names, addresses, or
+ * contact details. That is not a redaction: this module never replicates them (ADR-0044 R3),
+ * and the shared platform sender resolves the actual address at delivery. A preview therefore
+ * cannot leak contact data, because it never holds any.
  *
  * <p>Membership is replicated asynchronously (ADR-0044), so these counts describe a snapshot
  * with a stated age rather than a live query. Requesting a preview also asks the CRM to refresh
@@ -41,10 +49,11 @@ public record AudiencePreviewResponse(
                 description =
                         "When the CRM resolved this snapshot; null if none has arrived yet. Membership replicates asynchronously, so these counts are as of this moment, not live.",
                 requiredMode = NOT_REQUIRED)
-        java.time.Instant resolvedAt,
+        Instant resolvedAt,
 
         @Schema(
-                description = "Whether the segment resolution hit its candidate ceiling and is partial",
+                description =
+                        "Whether the segment resolution hit its candidate ceiling and is partial; when true the real audience is larger than segmentMatched",
                 requiredMode = REQUIRED)
         boolean truncated,
 
@@ -74,5 +83,32 @@ public record AudiencePreviewResponse(
             long eligible,
 
             @Schema(description = "Whether a template is attached for this channel", requiredMode = REQUIRED)
-            boolean templateAttached) {}
+            boolean templateAttached,
+
+            @Schema(
+                    description =
+                            "A bounded sample of the snapshot with the per-party decision behind the eligible count; identifiers and reason codes only, never contact details",
+                    requiredMode = REQUIRED)
+            List<SampleRecipient> sample) {}
+
+    /** One sampled party and the decision that put it inside or outside the eligible count. */
+    @Schema(description = "One sampled audience member and why it was or was not counted as reachable")
+    public record SampleRecipient(
+            @Schema(description = "Party in the audience snapshot", requiredMode = REQUIRED)
+            UUID partyId,
+
+            @Schema(
+                    description =
+                            "Party whose consent governed the decision and who would be addressed: the CRM's designated contact for a commercial account, the person themselves for an individual. Null when the CRM has reported no decision for this party.",
+                    requiredMode = NOT_REQUIRED)
+            UUID contactPartyId,
+
+            @Schema(description = "Whether this party would be sent to on this channel", requiredMode = REQUIRED)
+            boolean eligible,
+
+            @Schema(
+                    description = "Machine-readable decision code",
+                    example = "CONSENT_OPT_OUT",
+                    requiredMode = REQUIRED)
+            String reason) {}
 }

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/entity/CampaignAudienceMember.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/entity/CampaignAudienceMember.java
@@ -51,4 +51,14 @@ public class CampaignAudienceMember {
 
     @Column(name = "resolved_at", nullable = false)
     private Instant resolvedAt;
+
+    /**
+     * Whether the CRM's candidate scan hit its ceiling, making this snapshot partial. A
+     * property of the snapshot rather than of the member, so every row from one resolution
+     * carries the same value — surfaced in the preview so a short count is never mistaken for
+     * a small audience.
+     */
+    @Column(name = "truncated", nullable = false)
+    @Builder.Default
+    private boolean truncated = false;
 }

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/repository/CampaignAudienceMemberRepository.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/repository/CampaignAudienceMemberRepository.java
@@ -23,4 +23,11 @@ public interface CampaignAudienceMemberRepository extends JpaRepository<Campaign
     /** Age of the snapshot, so a preview can state how current its numbers are. */
     @Query("SELECT MAX(m.resolvedAt) FROM CampaignAudienceMember m WHERE m.campaignId = :campaignId")
     Optional<Instant> findResolvedAt(@Param("campaignId") UUID campaignId);
+
+    /**
+     * Whether the snapshot is partial. Every row from one resolution carries the same value, so
+     * any true means the CRM cut the scan short.
+     */
+    @Query("SELECT COUNT(m) > 0 FROM CampaignAudienceMember m WHERE m.campaignId = :campaignId AND m.truncated = TRUE")
+    boolean isTruncated(@Param("campaignId") UUID campaignId);
 }

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/repository/SuppressionReplicaRepository.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/repository/SuppressionReplicaRepository.java
@@ -1,9 +1,12 @@
 package com.positivity.marketing.internal.repository;
 
 import com.positivity.marketing.internal.entity.SuppressionReplica;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SuppressionReplicaRepository extends JpaRepository<SuppressionReplica, String> {
 
@@ -12,4 +15,12 @@ public interface SuppressionReplicaRepository extends JpaRepository<SuppressionR
     List<SuppressionReplica> findByPartyId(UUID partyId);
 
     boolean existsByPartyIdAndChannel(UUID partyId, String channel);
+
+    /**
+     * Batch-load for audience preview, which evaluates every member of a snapshot. Returns ids
+     * rather than rows because the caller only needs set membership.
+     */
+    @Query("SELECT s.partyId FROM SuppressionReplica s WHERE s.channel = :channel AND s.partyId IN :partyIds")
+    List<UUID> findPartyIdsByChannelAndPartyIdIn(
+            @Param("channel") String channel, @Param("partyIds") Collection<UUID> partyIds);
 }

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/AudienceEligibilityService.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/AudienceEligibilityService.java
@@ -7,12 +7,19 @@ import com.positivity.marketing.internal.repository.SuppressionReplicaRepository
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +49,13 @@ public class AudienceEligibilityService {
     public static final String REASON_CONSENT_STALE = "CONSENT_STALE";
 
     public static final String REASON_SUPPRESSED = "SUPPRESSED";
+
+    /**
+     * Ceiling on the identifiers sent in one {@code IN (...)} predicate. An audience snapshot can
+     * run to tens of thousands of parties and PostgreSQL caps a statement at 65535 bind
+     * parameters, so a whole-snapshot query would fail on exactly the campaigns that matter most.
+     */
+    private static final int LOOKUP_BATCH_SIZE = 1_000;
 
     private final Clock clock;
     private final PartyConsentReplicaRepository consentRepository;
@@ -78,7 +92,40 @@ public class AudienceEligibilityService {
                     maxConsentAge);
             return new Decision(false, REASON_CONSENT_STALE);
         }
-        return new Decision(consent.isAllowed(), consent.getReason());
+        return new Decision(consent.isAllowed(), consent.getReason(), consent.getGoverningPartyId());
+    }
+
+    /**
+     * Decide for a whole audience snapshot in a fixed number of queries.
+     *
+     * <p>Audience preview evaluates every member of a snapshot and would otherwise issue two
+     * queries per party. The batched form answers identically to {@link #decide} — same
+     * precedence, same reason codes — because a preview that disagreed with the send worker
+     * would report reach the campaign never achieves.
+     *
+     * @return one decision per distinct id, in the order the ids were given
+     */
+    @Transactional(readOnly = true)
+    public @NonNull Map<UUID, Decision> decideAll(
+            @NonNull Collection<UUID> partyIds, @NonNull CampaignChannel channel) {
+        List<UUID> distinct = partyIds.stream().distinct().toList();
+        if (distinct.isEmpty()) {
+            return Map.of();
+        }
+        Set<UUID> suppressed = new HashSet<>();
+        Map<UUID, PartyConsentReplica> consents = new HashMap<>();
+        for (List<UUID> batch : partition(distinct)) {
+            suppressed.addAll(suppressionRepository.findPartyIdsByChannelAndPartyIdIn(channel.name(), batch));
+            for (PartyConsentReplica consent : consentRepository.findByChannelAndPartyIdIn(channel.name(), batch)) {
+                consents.put(consent.getPartyId(), consent);
+            }
+        }
+
+        Map<UUID, Decision> decisions = new LinkedHashMap<>();
+        for (UUID partyId : distinct) {
+            decisions.put(partyId, decideFrom(partyId, channel, suppressed, consents.get(partyId)));
+        }
+        return decisions;
     }
 
     /**
@@ -87,16 +134,36 @@ public class AudienceEligibilityService {
      */
     @Transactional(readOnly = true)
     public long countEligible(@NonNull Collection<UUID> partyIds, @NonNull CampaignChannel channel) {
-        if (partyIds.isEmpty()) {
-            return 0;
-        }
-        List<PartyConsentReplica> decisions = consentRepository.findByChannelAndPartyIdIn(channel.name(), partyIds);
-        return decisions.stream()
-                .filter(PartyConsentReplica::isAllowed)
-                .filter(consent -> !isStale(consent))
-                .filter(consent ->
-                        !suppressionRepository.existsByPartyIdAndChannel(consent.getPartyId(), channel.name()))
+        return decideAll(partyIds, channel).values().stream()
+                .filter(Decision::allowed)
                 .count();
+    }
+
+    private Decision decideFrom(
+            UUID partyId, CampaignChannel channel, Set<UUID> suppressed, @Nullable PartyConsentReplica consent) {
+        if (suppressed.contains(partyId)) {
+            return new Decision(false, REASON_SUPPRESSED);
+        }
+        if (consent == null) {
+            return new Decision(false, REASON_NO_CONSENT_DATA);
+        }
+        if (isStale(consent)) {
+            log.warn(
+                    "Consent replica for party {} on {} is older than {}; refusing to send",
+                    partyId,
+                    channel,
+                    maxConsentAge);
+            return new Decision(false, REASON_CONSENT_STALE);
+        }
+        return new Decision(consent.isAllowed(), consent.getReason(), consent.getGoverningPartyId());
+    }
+
+    private static List<List<UUID>> partition(List<UUID> ids) {
+        List<List<UUID>> batches = new ArrayList<>();
+        for (int start = 0; start < ids.size(); start += LOOKUP_BATCH_SIZE) {
+            batches.add(ids.subList(start, Math.min(start + LOOKUP_BATCH_SIZE, ids.size())));
+        }
+        return batches;
     }
 
     private boolean isStale(PartyConsentReplica consent) {
@@ -104,6 +171,20 @@ public class AudienceEligibilityService {
                 || consent.getDecidedAt().isBefore(Instant.now(clock).minus(maxConsentAge));
     }
 
-    /** @param reason machine-readable code, recorded on the send row when denied */
-    public record Decision(boolean allowed, @NonNull String reason) {}
+    /**
+     * @param reason machine-readable code, recorded on the send row when denied
+     * @param contactPartyId the party whose personal consent governed the decision — for a
+     *     commercial account the contact the CRM designates for it, for an individual the person
+     *     themselves. Null when the CRM reported no decision, or replicated one before this field
+     *     existed.
+     */
+    public record Decision(
+            boolean allowed,
+            @NonNull String reason,
+            @Nullable UUID contactPartyId) {
+
+        public Decision(boolean allowed, @NonNull String reason) {
+            this(allowed, reason, null);
+        }
+    }
 }

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/AudienceResolutionService.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/AudienceResolutionService.java
@@ -1,0 +1,144 @@
+package com.positivity.marketing.internal.service;
+
+import com.positivity.marketing.internal.dto.AudiencePreviewResponse;
+import com.positivity.marketing.internal.entity.Campaign;
+import com.positivity.marketing.internal.enums.CampaignChannel;
+import com.positivity.marketing.internal.repository.CampaignAudienceMemberRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Turns a campaign's replicated audience snapshot into the numbers a marketer decides on
+ * (Story #1148).
+ *
+ * <p>Two things about this are worth stating plainly, because both look like defects
+ * otherwise.
+ *
+ * <p><b>The counts are a snapshot, not a query.</b> Segment membership is derived from party
+ * data and has no event boundary to replicate from, so this module asks the CRM and waits for
+ * an answer (ADR-0044 R3). A preview therefore reports the last answer received, stamped with
+ * its age, and asks for a fresher one on the way out — so a second call reflects any change.
+ * Reporting a stale number honestly beats blocking the request on a round trip that may never
+ * complete.
+ *
+ * <p><b>Eligibility is evaluated exactly as the send worker will evaluate it.</b> Same
+ * precedence, same staleness bound, same reason codes — a preview that used a looser rule
+ * would promise reach the campaign never achieves, which is the one way a preview can be
+ * worse than no preview at all.
+ */
+@Slf4j
+@Component
+public class AudienceResolutionService {
+
+    /** Upper bound on the sample, whatever the configuration asks for. */
+    private static final int MAX_SAMPLE_SIZE = 50;
+
+    private final CampaignAudienceMemberRepository audienceRepository;
+    private final AudienceEligibilityService eligibilityService;
+    private final SegmentResolveRequester resolveRequester;
+    private final int sampleSize;
+
+    public AudienceResolutionService(
+            CampaignAudienceMemberRepository audienceRepository,
+            AudienceEligibilityService eligibilityService,
+            SegmentResolveRequester resolveRequester,
+            @Value("${pos.marketing.preview.sample-size:10}") int sampleSize) {
+        this.audienceRepository = audienceRepository;
+        this.eligibilityService = eligibilityService;
+        this.resolveRequester = resolveRequester;
+        this.sampleSize = Math.clamp(sampleSize, 0, MAX_SAMPLE_SIZE);
+    }
+
+    /**
+     * Build the preview for a campaign that already has a segment bound.
+     *
+     * @param channelsWithTemplate channels the campaign has a resolvable template for; a channel
+     *     with reach but no template still cannot send, and the preview is where that is cheapest
+     *     to notice
+     * @param warnings the campaign's readiness problems, reported alongside the counts rather
+     *     than thrown, because a preview is exactly when a marketer wants the whole list
+     */
+    @Transactional
+    public @NonNull AudiencePreviewResponse preview(
+            @NonNull Campaign campaign,
+            @NonNull Set<CampaignChannel> channelsWithTemplate,
+            @NonNull List<String> warnings) {
+        UUID campaignId = campaign.getCampaignId();
+        List<UUID> members = audienceRepository.findPartyIdsByCampaignId(campaignId);
+        Instant resolvedAt = audienceRepository.findResolvedAt(campaignId).orElse(null);
+        boolean truncated = audienceRepository.isTruncated(campaignId);
+
+        // Ask for a fresher snapshot on the way out, but only while the audience can still
+        // change: replacing it under a campaign that is already dispatching would change who
+        // gets contacted partway through a send.
+        if (campaign.getStatus().audienceIsMutable() && campaign.getSegmentId() != null) {
+            resolveRequester.requestResolve(campaignId, campaign.getSegmentId());
+        }
+
+        List<AudiencePreviewResponse.ChannelPreview> channels = campaign.getChannels().stream()
+                .map(channel -> channelPreview(channel, members, channelsWithTemplate.contains(channel)))
+                .toList();
+
+        return new AudiencePreviewResponse(
+                campaignId,
+                campaign.getSegmentId(),
+                campaign.getAudienceType().name(),
+                members.size(),
+                resolvedAt,
+                truncated,
+                channels,
+                warnings);
+    }
+
+    private AudiencePreviewResponse.ChannelPreview channelPreview(
+            CampaignChannel channel, List<UUID> members, boolean templateAttached) {
+        Map<UUID, AudienceEligibilityService.Decision> decisions = eligibilityService.decideAll(members, channel);
+        long eligible = decisions.values().stream()
+                .filter(AudienceEligibilityService.Decision::allowed)
+                .count();
+        return new AudiencePreviewResponse.ChannelPreview(
+                channel.name(), members.size(), eligible, templateAttached, sample(decisions));
+    }
+
+    /**
+     * A bounded sample of the decisions behind the count.
+     *
+     * <p>Refusals come first, because they are what explains the gap between targeted and
+     * eligible — a marketer looking at 287 of 412 wants the reason codes for the missing 125,
+     * not proof that the other 287 are fine. A campaign with no refusals fills the sample with
+     * eligible members instead, so the sample is never empty when the audience is not.
+     *
+     * <p>The whole decision map is scanned rather than the first few entries: the refusals that
+     * explain a gap are rarely at the front of a snapshot, and stopping early would report "no
+     * refusals" for a campaign that has hundreds. The map is already in memory, so the scan
+     * costs nothing beyond the walk.
+     */
+    private List<AudiencePreviewResponse.SampleRecipient> sample(
+            Map<UUID, AudienceEligibilityService.Decision> decisions) {
+        if (sampleSize == 0 || decisions.isEmpty()) {
+            return List.of();
+        }
+        List<AudiencePreviewResponse.SampleRecipient> refused = new ArrayList<>();
+        List<AudiencePreviewResponse.SampleRecipient> allowed = new ArrayList<>();
+        for (Map.Entry<UUID, AudienceEligibilityService.Decision> entry : decisions.entrySet()) {
+            AudienceEligibilityService.Decision decision = entry.getValue();
+            List<AudiencePreviewResponse.SampleRecipient> bucket = decision.allowed() ? allowed : refused;
+            if (bucket.size() < sampleSize) {
+                bucket.add(new AudiencePreviewResponse.SampleRecipient(
+                        entry.getKey(), decision.contactPartyId(), decision.allowed(), decision.reason()));
+            }
+        }
+        List<AudiencePreviewResponse.SampleRecipient> sample = new ArrayList<>(refused);
+        allowed.stream().limit((long) sampleSize - sample.size()).forEach(sample::add);
+        return List.copyOf(sample);
+    }
+}

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CampaignReferenceValidator.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CampaignReferenceValidator.java
@@ -1,0 +1,118 @@
+package com.positivity.marketing.internal.service;
+
+import com.positivity.marketing.internal.domain.CatalogFocusRef;
+import com.positivity.marketing.internal.entity.Campaign;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+
+/**
+ * Checks the cross-domain references a campaign carries before it is allowed out
+ * (Story #1148).
+ *
+ * <p>{@code promotionOfferId} and {@code catalogFocusRef} point at aggregates in other
+ * services and are stored with no foreign key, so nothing stops a campaign from being saved
+ * against an offer that has since expired or a catalog reference that was mistyped. Both
+ * mistakes are invisible until the message lands in a customer's inbox advertising a discount
+ * that will not apply — which is why they are checked at schedule time, the last moment a
+ * campaign can still be fixed.
+ *
+ * <p>Problems are returned rather than thrown so they join the rest of the campaign's
+ * readiness list; a marketer fixing a campaign wants every problem at once.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CampaignReferenceValidator {
+
+    private final Clock clock;
+    private final PromotionOfferPort promotionOfferPort;
+
+    /** Everything wrong with this campaign's offer and catalog references, in message form. */
+    public @NonNull List<String> problems(@NonNull Campaign campaign) {
+        List<String> problems = new ArrayList<>();
+        promotionOfferProblem(campaign.getPromotionOfferId()).ifPresent(problems::add);
+        catalogFocusProblem(campaign.getCatalogFocusRef()).ifPresent(problems::add);
+        return problems;
+    }
+
+    /**
+     * The offer must exist and be running.
+     *
+     * <p>Status and calendar window are checked separately because pricing stores EXPIRED as a
+     * status something has to set: an offer whose end date passed last week can still read
+     * ACTIVE until that happens, and a campaign promoting it would be advertising nothing.
+     *
+     * <p>An unreachable pricing service blocks too, and deliberately so — but with a message
+     * that says so, because "we could not check" and "this offer is wrong" send the marketer
+     * to completely different places. Scheduling is retryable; a sent campaign is not.
+     */
+    private Optional<String> promotionOfferProblem(UUID promotionOfferId) {
+        if (promotionOfferId == null) {
+            return Optional.empty();
+        }
+        PromotionOfferPort.OfferLookup lookup = promotionOfferPort.findOffer(promotionOfferId);
+        return switch (lookup.outcome()) {
+            case NOT_FOUND -> Optional.of("promotion offer " + promotionOfferId + " does not exist");
+            case UNAVAILABLE ->
+                Optional.of("promotion offer " + promotionOfferId + " could not be verified; pricing is unavailable");
+            case FOUND -> activeOfferProblem(promotionOfferId, lookup.offer());
+        };
+    }
+
+    private Optional<String> activeOfferProblem(UUID promotionOfferId, PromotionOfferPort.PromotionOffer offer) {
+        if (offer == null) {
+            return Optional.of(
+                    "promotion offer " + promotionOfferId + " could not be verified; pricing is unavailable");
+        }
+        if (!offer.isActive()) {
+            return Optional.of("promotion offer " + promotionOfferId + " is "
+                    + (offer.status() == null ? "in an unknown status" : offer.status()) + ", not ACTIVE");
+        }
+        // Offers run on calendar days and carry no zone; UTC is the only defensible reading of
+        // "today" for a service that schedules across regions.
+        LocalDate today = LocalDate.now(clock.withZone(ZoneOffset.UTC));
+        if (!offer.runsOn(today)) {
+            return Optional.of("promotion offer " + promotionOfferId + " is ACTIVE but its window ("
+                    + describeWindow(offer) + ") does not include today");
+        }
+        return Optional.empty();
+    }
+
+    private static String describeWindow(PromotionOfferPort.PromotionOffer offer) {
+        return (offer.startDate() == null ? "open" : offer.startDate().toString()) + " to "
+                + (offer.endDate() == null ? "open" : offer.endDate().toString());
+    }
+
+    /**
+     * The catalog reference must be one this platform can interpret.
+     *
+     * <p>Only the grammar is checked. Resolving the reference against the catalog itself needs
+     * either a synchronous read across a domain wall or a replicated catalog fact, and neither
+     * exists for this module: ADR-0044 permits no synchronous edge to the catalog domain, and
+     * {@code catalog.events.v1} carries products only — nothing for the {@code service:} form
+     * that campaigns most often point at. Grammar is what can be verified today, and it is
+     * what catches the mistake actually made in practice: a marketer typing a bare name.
+     */
+    private Optional<String> catalogFocusProblem(String catalogFocusRef) {
+        if (catalogFocusRef == null || catalogFocusRef.isBlank()) {
+            return Optional.empty();
+        }
+        Optional<CatalogFocusRef> parsed = CatalogFocusRef.parse(catalogFocusRef);
+        if (parsed.isEmpty()) {
+            return Optional.of("catalogFocusRef '" + catalogFocusRef.trim()
+                    + "' is not a catalog reference; write it as kind:value using one of "
+                    + CatalogFocusRef.supportedKinds());
+        }
+        log.debug("Campaign catalog focus parsed as {}", parsed.get());
+        return Optional.empty();
+    }
+}

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CampaignSendServiceImpl.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CampaignSendServiceImpl.java
@@ -16,7 +16,9 @@ import com.positivity.marketing.service.CampaignSendService;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,6 +50,7 @@ public class CampaignSendServiceImpl implements CampaignSendService {
     private final CampaignRepository campaignRepository;
     private final CampaignSendRepository sendRepository;
     private final CampaignAudienceMemberRepository audienceRepository;
+    private final AudienceEligibilityService eligibilityService;
     private final SegmentResolveRequester resolveRequester;
 
     @Override
@@ -76,6 +79,17 @@ public class CampaignSendServiceImpl implements CampaignSendService {
         Instant now = Instant.now(clock);
         List<CampaignSend> queued = new ArrayList<>();
 
+        // Who actually gets addressed within each party: for a commercial account the contact
+        // the CRM designates to speak for it, for an individual the person themselves. The CRM
+        // resolves that when it decides consent, so the answer travels on the decision rather
+        // than being re-derived here — re-deriving it would guarantee the two copies drift.
+        // Batched per channel because a snapshot can run to tens of thousands of parties.
+        Map<CampaignChannel, Map<UUID, AudienceEligibilityService.Decision>> decisions =
+                new EnumMap<>(CampaignChannel.class);
+        for (CampaignChannel channel : campaign.getChannels()) {
+            decisions.put(channel, eligibilityService.decideAll(recipients, channel));
+        }
+
         for (UUID partyId : recipients) {
             for (CampaignChannel channel : campaign.getChannels()) {
                 // The uniqueness constraint is the real guarantee; this check just avoids
@@ -85,9 +99,12 @@ public class CampaignSendServiceImpl implements CampaignSendService {
                         .isPresent()) {
                     continue;
                 }
+                AudienceEligibilityService.Decision decision =
+                        decisions.get(channel).get(partyId);
                 queued.add(CampaignSend.builder()
                         .campaignId(campaignId)
                         .recipientPartyId(partyId)
+                        .contactId(decision == null ? null : decision.contactPartyId())
                         .channel(channel)
                         .status(SendStatus.PENDING)
                         .queuedAt(now)

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CampaignSendWorker.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CampaignSendWorker.java
@@ -108,13 +108,23 @@ public class CampaignSendWorker {
             return;
         }
 
-        String denial = denialReason(send);
-        if (denial != null) {
+        // Fails closed on missing or stale replicated data: with no synchronous CRM call
+        // available, a replica that has fallen behind is the one way this worker could mail
+        // someone who has since opted out, so absence of a fresh answer is refusal.
+        AudienceEligibilityService.Decision decision =
+                eligibilityService.decide(send.getRecipientPartyId(), send.getChannel());
+        if (!decision.allowed()) {
             send.setStatus(SendStatus.SUPPRESSED);
-            send.setFailureReason(denial);
+            send.setFailureReason(decision.reason());
             touch(send);
             sendRepository.save(send);
             return;
+        }
+        // The addressed contact is re-read from the send-time decision, not trusted from
+        // dispatch: an account can change who speaks for it between queueing and delivery, and
+        // the sender resolves the address from whatever this row names.
+        if (decision.contactPartyId() != null) {
+            send.setContactId(decision.contactPartyId());
         }
 
         Map<String, String> tokens = tokenValues(campaign);
@@ -156,21 +166,6 @@ public class CampaignSendWorker {
             return;
         }
         fail(send, outcome.failureReason() != null ? outcome.failureReason() : "Provider rejected the message");
-    }
-
-    /**
-     * Why this recipient must not be contacted right now, or null if they may be.
-     *
-     * <p>Delegates to {@link AudienceEligibilityService}, which reads the replicated CRM
-     * decision and <strong>fails closed on missing or stale data</strong>. That matters here:
-     * with no synchronous CRM call available, a replica that has fallen behind is the one way
-     * this worker could mail someone who has since opted out, so absence of a fresh answer is
-     * treated as refusal rather than permission.
-     */
-    private String denialReason(CampaignSend send) {
-        AudienceEligibilityService.Decision decision =
-                eligibilityService.decide(send.getRecipientPartyId(), send.getChannel());
-        return decision.allowed() ? null : decision.reason();
     }
 
     private Map<String, String> tokenValues(Campaign campaign) {

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CampaignServiceImpl.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CampaignServiceImpl.java
@@ -11,13 +11,11 @@ import com.positivity.marketing.internal.enums.ScheduleType;
 import com.positivity.marketing.internal.exception.MarketingDuplicateResourceException;
 import com.positivity.marketing.internal.exception.MarketingResourceNotFoundException;
 import com.positivity.marketing.internal.exception.MarketingUnprocessableEntityException;
-import com.positivity.marketing.internal.repository.CampaignAudienceMemberRepository;
 import com.positivity.marketing.internal.repository.CampaignRepository;
 import com.positivity.marketing.internal.repository.MessageTemplateRepository;
 import com.positivity.marketing.internal.repository.SegmentReplicaRepository;
 import com.positivity.marketing.service.CampaignService;
 import com.positivity.security.common.SecurityContextHelper;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -42,9 +40,8 @@ public class CampaignServiceImpl implements CampaignService {
     private final CampaignRepository campaignRepository;
     private final MessageTemplateRepository templateRepository;
     private final SegmentReplicaRepository segmentReplicaRepository;
-    private final CampaignAudienceMemberRepository audienceRepository;
-    private final AudienceEligibilityService eligibilityService;
-    private final SegmentResolveRequester resolveRequester;
+    private final AudienceResolutionService audienceResolutionService;
+    private final CampaignReferenceValidator referenceValidator;
     private final MarketingFactPublisher factPublisher;
 
     @Override
@@ -183,42 +180,17 @@ public class CampaignServiceImpl implements CampaignService {
         if (campaign.getSegmentId() == null) {
             throw new MarketingUnprocessableEntityException("Campaign has no segment bound; nothing to preview");
         }
-        // Membership arrives asynchronously, so a preview reports the last snapshot and asks for
-        // a fresher one. The snapshot's age travels with the numbers so a marketer can see how
-        // current they are rather than assuming they are live.
-        List<UUID> members = audienceRepository.findPartyIdsByCampaignId(campaignId);
-        Instant resolvedAt = audienceRepository.findResolvedAt(campaignId).orElse(null);
-        if (campaign.getStatus().audienceIsMutable()) {
-            resolveRequester.requestResolve(campaignId, campaign.getSegmentId());
-        }
-
-        List<AudiencePreviewResponse.ChannelPreview> channels = campaign.getChannels().stream()
-                .map(channel -> new AudiencePreviewResponse.ChannelPreview(
-                        channel.name(),
-                        members.size(),
-                        eligibilityService.countEligible(members, channel),
-                        templateFor(campaign, channel).isPresent()))
-                .toList();
-
-        return new AudiencePreviewResponse(
-                campaignId,
-                campaign.getSegmentId(),
-                campaign.getAudienceType().name(),
-                members.size(),
-                resolvedAt,
-                false,
-                channels,
-                readinessProblems(campaign));
+        return audienceResolutionService.preview(campaign, channelsWithTemplate(campaign), readinessProblems(campaign));
     }
 
     /**
      * Everything that would stop this campaign from going out, gathered rather than thrown one at
      * a time — a marketer fixing a campaign wants the whole list, not a game of whack-a-mole.
      *
-     * <p>The segment is checked against the {@code ext_segment} replica. Offer and catalog
-     * validation is deliberately absent: pos-price publishes no events, so there is no fact to
-     * replicate and no synchronous read permitted across the domain wall. That check returns
-     * with FI-1 (#1134), which is the pos-price side of the work.
+     * <p>The segment is checked against the {@code ext_segment} replica; the promotion offer and
+     * catalog reference are checked by {@link CampaignReferenceValidator}, which reads pricing
+     * directly because a campaign advertising an offer that stopped running is a mistake nobody
+     * can recall once it has been sent.
      */
     private List<String> readinessProblems(Campaign campaign) {
         List<String> problems = new ArrayList<>();
@@ -252,7 +224,15 @@ public class CampaignServiceImpl implements CampaignService {
                 problems.add("no " + channel + " template attached");
             }
         }
+        problems.addAll(referenceValidator.problems(campaign));
         return problems;
+    }
+
+    /** The channels whose template both exists and still resolves. */
+    private Set<CampaignChannel> channelsWithTemplate(Campaign campaign) {
+        return campaign.getChannels().stream()
+                .filter(channel -> templateFor(campaign, channel).isPresent())
+                .collect(Collectors.toCollection(java.util.LinkedHashSet::new));
     }
 
     private Optional<UUID> templateFor(Campaign campaign, CampaignChannel channel) {

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CustomerEventsListener.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/CustomerEventsListener.java
@@ -216,6 +216,10 @@ public class CustomerEventsListener {
                 }
             }
         }
+        // The owner reports when its candidate scan hit a ceiling and the list is partial. That
+        // travels with the snapshot: a preview reporting a truncated audience as complete would
+        // let a marketer read a short count as a small audience.
+        boolean truncated = payload.path("truncated").asBoolean(false);
         Instant resolvedAt = Instant.now(clock);
         for (Campaign campaign : campaignRepository.findAll()) {
             if (!segmentId.equals(campaign.getSegmentId())
@@ -229,9 +233,14 @@ public class CustomerEventsListener {
                             .campaignId(campaignId)
                             .partyId(partyId)
                             .resolvedAt(resolvedAt)
+                            .truncated(truncated)
                             .build())
                     .toList());
-            log.info("Campaign {} audience snapshot refreshed: {} member(s)", campaignId, partyIds.size());
+            log.info(
+                    "Campaign {} audience snapshot refreshed: {} member(s){}",
+                    campaignId,
+                    partyIds.size(),
+                    truncated ? " (truncated by the CRM's candidate ceiling)" : "");
         }
     }
 

--- a/pos-marketing/src/main/java/com/positivity/marketing/internal/service/PromotionOfferPort.java
+++ b/pos-marketing/src/main/java/com/positivity/marketing/internal/service/PromotionOfferPort.java
@@ -1,0 +1,83 @@
+package com.positivity.marketing.internal.service;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * How this module asks whether a promotion offer is actually running (Story #1148).
+ *
+ * <p>Stated as a port for the same reason {@link MessageChannelPort} is: the business rule —
+ * a campaign may not advertise an offer that is not live — belongs here, while reaching the
+ * pricing service is an integration detail that lives in {@code internal.client}.
+ *
+ * <p>Implementations never throw. Failing to reach pricing is a legitimate, expected outcome
+ * with its own meaning, and it is reported through {@link Outcome} rather than as an
+ * exception, because the caller must be able to say "we could not check" without confusing it
+ * with "this offer is wrong".
+ */
+public interface PromotionOfferPort {
+
+    /** The only offer status a campaign may promote. */
+    String STATUS_ACTIVE = "ACTIVE";
+
+    /** Look up one offer. Never throws: every failure mode is reported through {@link Outcome}. */
+    @NonNull
+    OfferLookup findOffer(@NonNull UUID promotionOfferId);
+
+    /** Why a lookup ended the way it did. */
+    enum Outcome {
+        /** The offer exists; {@link OfferLookup#offer()} is populated. */
+        FOUND,
+        /** Pricing answered authoritatively that no such offer exists. */
+        NOT_FOUND,
+        /** Pricing could not be reached or refused the read; nothing is known either way. */
+        UNAVAILABLE
+    }
+
+    /** Result of one offer lookup. {@code offer} is populated only when {@code outcome} is FOUND. */
+    record OfferLookup(@NonNull Outcome outcome, @Nullable PromotionOffer offer) {
+
+        public static OfferLookup found(@NonNull PromotionOffer offer) {
+            return new OfferLookup(Outcome.FOUND, offer);
+        }
+
+        public static OfferLookup notFound() {
+            return new OfferLookup(Outcome.NOT_FOUND, null);
+        }
+
+        public static OfferLookup unavailable() {
+            return new OfferLookup(Outcome.UNAVAILABLE, null);
+        }
+    }
+
+    /**
+     * The parts of a promotion offer a campaign cares about.
+     *
+     * <p>{@code startDate}/{@code endDate} are plain dates with no zone, because pricing stores
+     * them that way — an offer runs on calendar days, not instants.
+     *
+     * @param status one of DRAFT, ACTIVE, INACTIVE, EXPIRED
+     */
+    record PromotionOffer(
+            @NonNull UUID promotionOfferId,
+            @Nullable String promoCode,
+            @Nullable String status,
+            @Nullable LocalDate startDate,
+            @Nullable LocalDate endDate) {
+
+        public boolean isActive() {
+            return STATUS_ACTIVE.equalsIgnoreCase(status);
+        }
+
+        /**
+         * Whether the offer's calendar window contains {@code today}. Checked separately from
+         * {@code status} because pricing stores EXPIRED as a status that something has to set —
+         * an offer whose end date has passed can still read ACTIVE until that happens.
+         */
+        public boolean runsOn(@NonNull LocalDate today) {
+            return (startDate == null || !today.isBefore(startDate)) && (endDate == null || !today.isAfter(endDate));
+        }
+    }
+}

--- a/pos-marketing/src/main/resources/application.yml
+++ b/pos-marketing/src/main/resources/application.yml
@@ -89,6 +89,12 @@ pos:
       # Shared platform sender endpoint + shared secret; only read when transport=platform-sender.
       base-url: ${POS_MARKETING_SENDER_BASE_URL:http://localhost:8085}
       api-secret: ${POS_MARKETING_SENDER_API_SECRET:}
+    preview:
+      # How many per-channel decisions an audience preview returns alongside the counts
+      # (Story #1148). Refusals are sampled first, because they are what explains the gap
+      # between targeted and eligible. Identifiers and reason codes only — this module holds
+      # no names or addresses to leak. Clamped to 50.
+      sample-size: ${POS_MARKETING_PREVIEW_SAMPLE_SIZE:10}
     send:
       # Send-worker pacing (Story #1149). The batch size bounds how many recipients one
       # drain locks; the delay paces the provider so a large campaign does not burst.
@@ -109,6 +115,15 @@ pos:
     api-secret: ${POS_EVENTS_API_SECRET:}
   security:
     base-url: ${POS_SECURITY_BASE_URL:http://pos-security-service:8080}
-  # No outbound sibling-service clients: integration with pos-customer is entirely
-  # customer.events.v1 replicas plus one asynchronous command (ADR-0044 R3). pos-price and
-  # pos-catalog validation returns with FI-1 (#1134), which adds the events to replicate.
+  price:
+    # Promotion-offer validation at preview and schedule time (Story #1148). Pricing is an
+    # ADR-0044 §1 utility, so this synchronous edge is permitted — and it is the right shape:
+    # offer status changes on its own schedule with no fact to replicate from, and the answer
+    # is only needed at those two moments rather than continuously. Resolved through Eureka by
+    # the @LoadBalanced builder; the value is a service id, not a URL.
+    service-id: ${POS_PRICE_SERVICE_ID:price}
+    promotion-offers-base-path: ${POS_PRICE_PROMOTION_OFFERS_BASE_PATH:/v1/promotions/offers}
+  # Integration with pos-customer is entirely customer.events.v1 replicas plus one asynchronous
+  # command (ADR-0044 R3) — there is no synchronous edge to the CRM. The catalog reference on a
+  # campaign is grammar-checked only, for the same reason: no synchronous edge is permitted and
+  # catalog.events.v1 carries products, nothing for the service: form campaigns most often use.

--- a/pos-marketing/src/main/resources/db/migration/V8__campaign_audience_truncated.sql
+++ b/pos-marketing/src/main/resources/db/migration/V8__campaign_audience_truncated.sql
@@ -1,0 +1,13 @@
+-- Story #1148: carry the CRM's truncation flag onto the audience snapshot.
+--
+-- customer.segment.resolved already reports whether the owner's candidate scan hit its ceiling
+-- and the membership list is partial, but the flag was dropped on arrival and audience preview
+-- reported every snapshot as complete. A marketer reading a count that is quietly short has no
+-- way to tell an audience that is genuinely small from one that was cut off, so the flag is
+-- stored with the snapshot it describes and surfaced in the preview.
+--
+-- The value is a property of the snapshot rather than of the member, so every row written by
+-- one resolution carries the same value; existing rows predate the flag and default to false,
+-- which is what they were being reported as anyway.
+ALTER TABLE campaign_audience_member
+    ADD COLUMN truncated boolean NOT NULL DEFAULT FALSE;

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/client/PriceClientTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/client/PriceClientTest.java
@@ -1,0 +1,140 @@
+package com.positivity.marketing.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withException;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+import com.positivity.marketing.internal.service.PromotionOfferPort;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Pins the offer lookup's outcome mapping (Story #1148).
+ *
+ * <p>The whole value of this client is the distinction between the three outcomes: collapsing
+ * "pricing is down" into "this offer does not exist" would tell a marketer their campaign is
+ * broken during an outage, and collapsing it the other way would let a campaign advertising a
+ * dead offer sail through scheduling. Everything here guards that boundary.
+ */
+@DisplayName("PriceClient — promotion offer lookup outcomes")
+class PriceClientTest {
+
+    private static final UUID OFFER_ID = UUID.fromString("01960005-0000-7000-8000-0000000000a1");
+    private static final String OFFER_URL = "http://price/v1/promotions/offers/" + OFFER_ID;
+
+    private MockRestServiceServer server;
+    private PriceClient client;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        client = new PriceClient(builder, "price", "/v1/promotions/offers");
+    }
+
+    @Test
+    @DisplayName("an existing offer comes back with the status and window a campaign is judged on")
+    void foundOffer() {
+        server.expect(requestTo(OFFER_URL))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("X-Authorities", "pricing:promotion:view"))
+                .andExpect(header("X-User", "pos-marketing-service"))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("""
+                                {"promotionOfferId":"%s","promoCode":"SPRING20","status":"ACTIVE",
+                                 "startDate":"2026-03-01","endDate":"2026-03-31","discountValue":20.00}
+                                """.formatted(OFFER_ID)));
+
+        PromotionOfferPort.OfferLookup lookup = client.findOffer(OFFER_ID);
+
+        assertThat(lookup.outcome()).isEqualTo(PromotionOfferPort.Outcome.FOUND);
+        assertThat(lookup.offer()).isNotNull();
+        assertThat(lookup.offer().isActive()).isTrue();
+        assertThat(lookup.offer().promoCode()).isEqualTo("SPRING20");
+        assertThat(lookup.offer().startDate()).isEqualTo(LocalDate.of(2026, 3, 1));
+        assertThat(lookup.offer().endDate()).isEqualTo(LocalDate.of(2026, 3, 31));
+    }
+
+    @Test
+    @DisplayName("a 404 is an authoritative answer that the offer does not exist")
+    void missingOffer() {
+        server.expect(requestTo(OFFER_URL)).andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+        assertThat(client.findOffer(OFFER_ID).outcome()).isEqualTo(PromotionOfferPort.Outcome.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("a 5xx says nothing about the offer, so it reports as unavailable rather than missing")
+    void serverErrorIsUnavailable() {
+        server.expect(requestTo(OFFER_URL)).andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        // Reported as NOT_FOUND this would tell the marketer to fix an offer that is fine.
+        assertThat(client.findOffer(OFFER_ID).outcome()).isEqualTo(PromotionOfferPort.Outcome.UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("an I/O failure reports as unavailable")
+    void ioFailureIsUnavailable() {
+        server.expect(requestTo(OFFER_URL)).andRespond(withException(new IOException("connection reset")));
+
+        assertThat(client.findOffer(OFFER_ID).outcome()).isEqualTo(PromotionOfferPort.Outcome.UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("a 200 with no body is treated as an outage, not as a missing offer")
+    void emptyBodyIsUnavailable() {
+        server.expect(requestTo(OFFER_URL))
+                .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON));
+
+        assertThat(client.findOffer(OFFER_ID).outcome()).isEqualTo(PromotionOfferPort.Outcome.UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("a response that omits the id keeps the id that was asked for")
+    void missingIdFallsBackToTheRequestedOne() {
+        server.expect(requestTo(OFFER_URL))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"status\":\"DRAFT\"}"));
+
+        PromotionOfferPort.OfferLookup lookup = client.findOffer(OFFER_ID);
+
+        assertThat(lookup.offer()).isNotNull();
+        assertThat(lookup.offer().promotionOfferId()).isEqualTo(OFFER_ID);
+        assertThat(lookup.offer().isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("an offer with no dates runs on any day")
+    void openEndedOfferRunsToday() {
+        PromotionOfferPort.PromotionOffer offer =
+                new PromotionOfferPort.PromotionOffer(OFFER_ID, "EVERGREEN", "ACTIVE", null, null);
+
+        assertThat(offer.runsOn(LocalDate.of(2026, 8, 14))).isTrue();
+    }
+
+    @Test
+    @DisplayName("the window is inclusive at both ends, and excludes the days outside it")
+    void windowBoundaries() {
+        PromotionOfferPort.PromotionOffer offer = new PromotionOfferPort.PromotionOffer(
+                OFFER_ID, "SPRING20", "ACTIVE", LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+
+        assertThat(offer.runsOn(LocalDate.of(2026, 3, 1))).isTrue();
+        assertThat(offer.runsOn(LocalDate.of(2026, 3, 31))).isTrue();
+        assertThat(offer.runsOn(LocalDate.of(2026, 2, 28))).isFalse();
+        assertThat(offer.runsOn(LocalDate.of(2026, 4, 1))).isFalse();
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/domain/CatalogFocusRefTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/domain/CatalogFocusRefTest.java
@@ -1,0 +1,101 @@
+package com.positivity.marketing.internal.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Pins the grammar a campaign's catalog reference must follow (Story #1148).
+ *
+ * <p>The reference is free text pointing into another domain, so the grammar is the only thing
+ * standing between "the message points at the alignment service" and a string nobody can ever
+ * resolve. The cases below are the mistakes actually made: a bare name, a stray separator, and
+ * a kind this platform has never heard of.
+ */
+@DisplayName("CatalogFocusRef — kind:value grammar")
+class CatalogFocusRefTest {
+
+    @Test
+    @DisplayName("parses the canonical service reference")
+    void parsesServiceReference() {
+        Optional<CatalogFocusRef> parsed = CatalogFocusRef.parse("service:alignment");
+
+        assertThat(parsed).isPresent();
+        assertThat(parsed.get().kind()).isEqualTo(CatalogFocusRef.Kind.SERVICE);
+        assertThat(parsed.get().value()).isEqualTo("alignment");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"product:018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03", "sku:BRK-2201", "category:Brakes"})
+    @DisplayName("parses every recognized kind")
+    void parsesEveryKind(String raw) {
+        assertThat(CatalogFocusRef.parse(raw)).isPresent();
+    }
+
+    @Test
+    @DisplayName("matches the kind case-insensitively and normalizes it")
+    void kindIsCaseInsensitive() {
+        assertThat(CatalogFocusRef.parse("SERVICE:alignment"))
+                .get()
+                .extracting(CatalogFocusRef::kind)
+                .isEqualTo(CatalogFocusRef.Kind.SERVICE);
+    }
+
+    @Test
+    @DisplayName("trims surrounding whitespace on both halves")
+    void trimsWhitespace() {
+        assertThat(CatalogFocusRef.parse("  service : alignment  "))
+                .get()
+                .extracting(CatalogFocusRef::value)
+                .isEqualTo("alignment");
+    }
+
+    @Test
+    @DisplayName("splits on the first separator only, so a name may contain colons")
+    void splitsOnFirstSeparatorOnly() {
+        assertThat(CatalogFocusRef.parse("service:front:alignment"))
+                .get()
+                .extracting(CatalogFocusRef::value)
+                .isEqualTo("front:alignment");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "alignment", // the mistake actually made: a bare name with no kind
+                "wheel-alignment:front", // a kind this platform cannot interpret
+                ":alignment", // no kind
+                "service:", // no value
+                "service:   ", // whitespace is not a value
+                ":"
+            })
+    @DisplayName("rejects anything that cannot be followed back to the catalog")
+    void rejectsUnusableReferences(String raw) {
+        assertThat(CatalogFocusRef.parse(raw)).isEmpty();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   "})
+    @DisplayName("treats absence as absence, not as a malformed reference")
+    void absentIsEmpty(String raw) {
+        assertThat(CatalogFocusRef.parse(raw)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("round-trips back to its wire form so an error message can quote it")
+    void roundTripsToWireForm() {
+        assertThat(CatalogFocusRef.parse("SERVICE:alignment")).get().hasToString("service:alignment");
+    }
+
+    @Test
+    @DisplayName("lists every supported kind, so a rejection can say what to write instead")
+    void listsSupportedKinds() {
+        assertThat(CatalogFocusRef.supportedKinds()).isEqualTo("product, sku, service, category");
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/AudienceEligibilityServiceTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/AudienceEligibilityServiceTest.java
@@ -3,7 +3,9 @@ package com.positivity.marketing.internal.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.positivity.marketing.internal.entity.PartyConsentReplica;
@@ -15,8 +17,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -120,24 +124,103 @@ class AudienceEligibilityServiceTest {
     }
 
     @Test
-    @DisplayName("bulk counting applies the same staleness and suppression rules")
-    void bulkCountMatchesSingleDecision() {
+    @DisplayName("a decision carries the contact whose consent governed it")
+    void decisionCarriesGoverningContact() {
+        UUID contact = UUID.fromString("01960003-0000-7000-8000-000000000042");
+        PartyConsentReplica consent = consent(true, NOW.minus(Duration.ofHours(1)));
+        consent.setGoverningPartyId(contact);
+        when(suppressionRepository.existsByPartyIdAndChannel(any(), anyString()))
+                .thenReturn(false);
+        when(consentRepository.findByPartyIdAndChannel(PARTY, "EMAIL")).thenReturn(Optional.of(consent));
+
+        // For a commercial account this is the contact the CRM designates to speak for it; the
+        // send row records it so the sender addresses the right person.
+        assertThat(service().decide(PARTY, CampaignChannel.EMAIL).contactPartyId())
+                .isEqualTo(contact);
+    }
+
+    @Test
+    @DisplayName("bulk decisions apply the same staleness rule as a single one")
+    void bulkMatchesSingleDecisionOnStaleness() {
         UUID stalePartyId = UUID.fromString("01960003-0000-7000-8000-000000000041");
         PartyConsentReplica fresh = consent(true, NOW.minus(Duration.ofHours(1)));
-        PartyConsentReplica stale = PartyConsentReplica.builder()
-                .consentKey(PartyConsentReplica.keyOf(stalePartyId, "EMAIL"))
-                .partyId(stalePartyId)
+        PartyConsentReplica stale = consentFor(stalePartyId, NOW.minus(Duration.ofDays(3)));
+        when(consentRepository.findByChannelAndPartyIdIn(anyString(), any())).thenReturn(List.of(fresh, stale));
+        when(suppressionRepository.findPartyIdsByChannelAndPartyIdIn(anyString(), any()))
+                .thenReturn(List.of());
+
+        Map<UUID, AudienceEligibilityService.Decision> decisions =
+                service().decideAll(List.of(PARTY, stalePartyId), CampaignChannel.EMAIL);
+
+        assertThat(decisions.get(PARTY).allowed()).isTrue();
+        assertThat(decisions.get(stalePartyId).reason()).isEqualTo(AudienceEligibilityService.REASON_CONSENT_STALE);
+    }
+
+    @Test
+    @DisplayName("bulk decisions let suppression outrank a fresh opt-in, as the single decision does")
+    void bulkAppliesSuppression() {
+        UUID suppressedPartyId = UUID.fromString("01960003-0000-7000-8000-000000000043");
+        when(consentRepository.findByChannelAndPartyIdIn(anyString(), any()))
+                .thenReturn(List.of(
+                        consent(true, NOW.minus(Duration.ofHours(1))),
+                        consentFor(suppressedPartyId, NOW.minus(Duration.ofHours(1)))));
+        when(suppressionRepository.findPartyIdsByChannelAndPartyIdIn(anyString(), any()))
+                .thenReturn(List.of(suppressedPartyId));
+
+        Map<UUID, AudienceEligibilityService.Decision> decisions =
+                service().decideAll(List.of(PARTY, suppressedPartyId), CampaignChannel.EMAIL);
+
+        assertThat(decisions.get(suppressedPartyId).reason()).isEqualTo(AudienceEligibilityService.REASON_SUPPRESSED);
+        assertThat(service().countEligible(List.of(PARTY, suppressedPartyId), CampaignChannel.EMAIL))
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("a party the CRM has said nothing about still gets a decision, refusing it")
+    void bulkCoversPartiesWithNoReplicatedDecision() {
+        UUID unknown = UUID.fromString("01960003-0000-7000-8000-000000000044");
+        when(consentRepository.findByChannelAndPartyIdIn(anyString(), any()))
+                .thenReturn(List.of(consent(true, NOW.minus(Duration.ofHours(1)))));
+        when(suppressionRepository.findPartyIdsByChannelAndPartyIdIn(anyString(), any()))
+                .thenReturn(List.of());
+
+        // Every member of the snapshot must appear, or a preview would silently undercount.
+        Map<UUID, AudienceEligibilityService.Decision> decisions =
+                service().decideAll(List.of(PARTY, unknown), CampaignChannel.EMAIL);
+
+        assertThat(decisions).containsOnlyKeys(PARTY, unknown);
+        assertThat(decisions.get(unknown).reason()).isEqualTo(AudienceEligibilityService.REASON_NO_CONSENT_DATA);
+    }
+
+    @Test
+    @DisplayName("an audience larger than one IN clause is looked up in batches, not one statement")
+    void largeAudienceIsBatched() {
+        List<UUID> audience = Stream.generate(UUID::randomUUID).limit(2_500).toList();
+        when(consentRepository.findByChannelAndPartyIdIn(anyString(), any())).thenReturn(List.of());
+        when(suppressionRepository.findPartyIdsByChannelAndPartyIdIn(anyString(), any()))
+                .thenReturn(List.of());
+
+        // PostgreSQL caps a statement at 65535 bind parameters, so a whole-snapshot IN clause
+        // would fail on exactly the campaigns that matter most.
+        assertThat(service().decideAll(audience, CampaignChannel.EMAIL)).hasSize(2_500);
+        verify(consentRepository, times(3)).findByChannelAndPartyIdIn(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("an empty audience asks the database nothing")
+    void emptyAudienceSkipsQueries() {
+        assertThat(service().decideAll(List.of(), CampaignChannel.EMAIL)).isEmpty();
+        verifyNoInteractions(consentRepository, suppressionRepository);
+    }
+
+    private static PartyConsentReplica consentFor(UUID partyId, Instant decidedAt) {
+        return PartyConsentReplica.builder()
+                .consentKey(PartyConsentReplica.keyOf(partyId, "EMAIL"))
+                .partyId(partyId)
                 .channel("EMAIL")
                 .allowed(true)
                 .reason("OPT_IN")
-                .decidedAt(NOW.minus(Duration.ofDays(3)))
+                .decidedAt(decidedAt)
                 .build();
-        when(consentRepository.findByChannelAndPartyIdIn(anyString(), any())).thenReturn(List.of(fresh, stale));
-        lenient()
-                .when(suppressionRepository.existsByPartyIdAndChannel(any(), anyString()))
-                .thenReturn(false);
-
-        assertThat(service().countEligible(List.of(PARTY, stalePartyId), CampaignChannel.EMAIL))
-                .isEqualTo(1);
     }
 }

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/AudienceResolutionServiceTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/AudienceResolutionServiceTest.java
@@ -1,0 +1,299 @@
+package com.positivity.marketing.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.marketing.internal.dto.AudiencePreviewResponse;
+import com.positivity.marketing.internal.entity.Campaign;
+import com.positivity.marketing.internal.enums.AudienceType;
+import com.positivity.marketing.internal.enums.CampaignChannel;
+import com.positivity.marketing.internal.enums.CampaignStatus;
+import com.positivity.marketing.internal.repository.CampaignAudienceMemberRepository;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link AudienceResolutionService}.
+ *
+ * <p>What is worth pinning here is everything a marketer would misread if it were wrong:
+ *
+ * <ul>
+ *   <li><b>The snapshot's age and truncation travel with the counts.</b> A count that is
+ *       quietly short is indistinguishable from a small audience unless the preview says so.
+ *   <li><b>A refresh is requested only while the audience can still change.</b> Replacing the
+ *       audience of a campaign that is already dispatching would change who gets contacted
+ *       partway through a send.
+ *   <li><b>The sample leads with refusals.</b> They are what explains the gap between targeted
+ *       and eligible; a sample of happy recipients answers a question nobody asked.
+ *   <li><b>The sample carries identifiers and reason codes only.</b> This module replicates no
+ *       names or addresses, so a preview cannot leak contact data.
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AudienceResolutionService — audience preview")
+class AudienceResolutionServiceTest {
+
+    private static final UUID CAMPAIGN_ID = UUID.randomUUID();
+    private static final UUID SEGMENT_ID = UUID.randomUUID();
+    private static final Instant RESOLVED_AT = Instant.parse("2026-08-11T11:00:00Z");
+
+    @Mock
+    private CampaignAudienceMemberRepository audienceRepository;
+
+    @Mock
+    private AudienceEligibilityService eligibilityService;
+
+    @Mock
+    private SegmentResolveRequester resolveRequester;
+
+    private AudienceResolutionService service(int sampleSize) {
+        return new AudienceResolutionService(audienceRepository, eligibilityService, resolveRequester, sampleSize);
+    }
+
+    private static Campaign campaign(CampaignStatus status, CampaignChannel... channels) {
+        return Campaign.builder()
+                .campaignId(CAMPAIGN_ID)
+                .code("SPRING24")
+                .audienceType(AudienceType.COMMERCIAL)
+                .status(status)
+                .segmentId(SEGMENT_ID)
+                .channels(new LinkedHashSet<>(List.of(channels)))
+                .build();
+    }
+
+    /** A snapshot of {@code allowed} reachable parties followed by {@code refused} opted-out ones. */
+    private Map<UUID, AudienceEligibilityService.Decision> snapshot(List<UUID> members, int allowed) {
+        Map<UUID, AudienceEligibilityService.Decision> decisions = new LinkedHashMap<>();
+        for (int i = 0; i < members.size(); i++) {
+            decisions.put(
+                    members.get(i),
+                    i < allowed
+                            ? new AudienceEligibilityService.Decision(true, "OPT_IN", UUID.randomUUID())
+                            : new AudienceEligibilityService.Decision(false, "CONSENT_OPT_OUT"));
+        }
+        return decisions;
+    }
+
+    private static List<UUID> members(int count) {
+        return java.util.stream.Stream.generate(UUID::randomUUID).limit(count).toList();
+    }
+
+    @Nested
+    @DisplayName("counts")
+    class Counts {
+
+        @Test
+        @DisplayName("reports the snapshot's size, age and truncation alongside the per-channel counts")
+        void reportsSnapshotWithItsAge() {
+            List<UUID> members = members(4);
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(members);
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.of(RESOLVED_AT));
+            when(audienceRepository.isTruncated(CAMPAIGN_ID)).thenReturn(true);
+            when(eligibilityService.decideAll(anyCollection(), any())).thenReturn(snapshot(members, 3));
+
+            AudiencePreviewResponse preview =
+                    service(10).preview(campaign(CampaignStatus.DRAFT, CampaignChannel.EMAIL), Set.of(), List.of());
+
+            assertThat(preview.segmentMatched()).isEqualTo(4);
+            assertThat(preview.resolvedAt()).isEqualTo(RESOLVED_AT);
+            // Without this the marketer reads a cut-off count as a small audience.
+            assertThat(preview.truncated()).isTrue();
+            assertThat(preview.channels()).singleElement().satisfies(channel -> {
+                assertThat(channel.channel()).isEqualTo("EMAIL");
+                assertThat(channel.targeted()).isEqualTo(4);
+                assertThat(channel.eligible()).isEqualTo(3);
+            });
+        }
+
+        @Test
+        @DisplayName("reports each channel separately, with whether it has a template")
+        void reportsEachChannel() {
+            List<UUID> members = members(2);
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(members);
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
+            when(eligibilityService.decideAll(anyCollection(), any())).thenReturn(snapshot(members, 1));
+
+            AudiencePreviewResponse preview = service(10)
+                    .preview(
+                            campaign(CampaignStatus.DRAFT, CampaignChannel.EMAIL, CampaignChannel.SMS),
+                            Set.of(CampaignChannel.EMAIL),
+                            List.of());
+
+            assertThat(preview.channels())
+                    .extracting(
+                            AudiencePreviewResponse.ChannelPreview::channel,
+                            AudiencePreviewResponse.ChannelPreview::templateAttached)
+                    .containsExactly(
+                            org.assertj.core.api.Assertions.tuple("EMAIL", true),
+                            org.assertj.core.api.Assertions.tuple("SMS", false));
+        }
+
+        @Test
+        @DisplayName("an empty snapshot previews as zero rather than failing")
+        void emptySnapshot() {
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of());
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
+            when(eligibilityService.decideAll(anyCollection(), any())).thenReturn(Map.of());
+
+            AudiencePreviewResponse preview =
+                    service(10).preview(campaign(CampaignStatus.DRAFT, CampaignChannel.EMAIL), Set.of(), List.of());
+
+            assertThat(preview.segmentMatched()).isZero();
+            assertThat(preview.channels()).singleElement().satisfies(channel -> {
+                assertThat(channel.eligible()).isZero();
+                assertThat(channel.sample()).isEmpty();
+            });
+        }
+
+        @Test
+        @DisplayName("carries the readiness problems through as warnings")
+        void carriesWarnings() {
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of());
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
+
+            AudiencePreviewResponse preview = service(10)
+                    .preview(campaign(CampaignStatus.DRAFT), Set.of(), List.of("promotion offer is EXPIRED"));
+
+            assertThat(preview.warnings()).containsExactly("promotion offer is EXPIRED");
+        }
+    }
+
+    @Nested
+    @DisplayName("refresh request")
+    class RefreshRequest {
+
+        @Test
+        @DisplayName("asks the CRM for a fresher snapshot while the audience can still change")
+        void requestsRefreshWhileMutable() {
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of());
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
+
+            service(10).preview(campaign(CampaignStatus.DRAFT), Set.of(), List.of());
+
+            verify(resolveRequester).requestResolve(CAMPAIGN_ID, SEGMENT_ID);
+        }
+
+        @Test
+        @DisplayName("leaves a frozen audience alone")
+        void doesNotRefreshOnceFrozen() {
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of());
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
+
+            // Replacing the audience mid-send would change who gets contacted partway through.
+            service(10).preview(campaign(CampaignStatus.SENT), Set.of(), List.of());
+
+            verify(resolveRequester, never()).requestResolve(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("sample")
+    class Sample {
+
+        @Test
+        @DisplayName("leads with refusals, because they are what explains the gap")
+        void refusalsComeFirst() {
+            List<UUID> members = members(6);
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(members);
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
+            // The first four are reachable; the refusals sit at the back of the snapshot.
+            when(eligibilityService.decideAll(anyCollection(), any())).thenReturn(snapshot(members, 4));
+
+            AudiencePreviewResponse preview =
+                    service(3).preview(campaign(CampaignStatus.DRAFT, CampaignChannel.EMAIL), Set.of(), List.of());
+
+            List<AudiencePreviewResponse.SampleRecipient> sample =
+                    preview.channels().getFirst().sample();
+            assertThat(sample).hasSize(3);
+            assertThat(sample.subList(0, 2))
+                    .allSatisfy(entry -> assertThat(entry.eligible()).isFalse());
+            assertThat(sample.subList(0, 2))
+                    .allSatisfy(entry -> assertThat(entry.reason()).isEqualTo("CONSENT_OPT_OUT"));
+            // A refusal-only sample would hide that anyone is reachable at all.
+            assertThat(sample.getLast().eligible()).isTrue();
+        }
+
+        @Test
+        @DisplayName("falls back to reachable members when nobody was refused")
+        void allEligibleStillSamples() {
+            List<UUID> members = members(3);
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(members);
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
+            when(eligibilityService.decideAll(anyCollection(), any())).thenReturn(snapshot(members, 3));
+
+            AudiencePreviewResponse preview =
+                    service(10).preview(campaign(CampaignStatus.DRAFT, CampaignChannel.EMAIL), Set.of(), List.of());
+
+            assertThat(preview.channels().getFirst().sample())
+                    .hasSize(3)
+                    .allSatisfy(entry -> assertThat(entry.eligible()).isTrue());
+        }
+
+        @Test
+        @DisplayName("names the contact who would actually be addressed within the party")
+        void reportsTheResolvedContact() {
+            List<UUID> members = members(1);
+            UUID contact = UUID.randomUUID();
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(members);
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
+            when(eligibilityService.decideAll(anyCollection(), any()))
+                    .thenReturn(Map.of(
+                            members.getFirst(), new AudienceEligibilityService.Decision(true, "OPT_IN", contact)));
+
+            AudiencePreviewResponse preview =
+                    service(10).preview(campaign(CampaignStatus.DRAFT, CampaignChannel.EMAIL), Set.of(), List.of());
+
+            // For a commercial account this is the contact the CRM designates to speak for it;
+            // for an individual it is the person themselves.
+            assertThat(preview.channels().getFirst().sample()).singleElement().satisfies(entry -> {
+                assertThat(entry.partyId()).isEqualTo(members.getFirst());
+                assertThat(entry.contactPartyId()).isEqualTo(contact);
+            });
+        }
+
+        @Test
+        @DisplayName("a configured size of zero suppresses the sample entirely")
+        void zeroSampleSize() {
+            List<UUID> members = members(3);
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(members);
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
+            when(eligibilityService.decideAll(anyCollection(), any())).thenReturn(snapshot(members, 0));
+
+            AudiencePreviewResponse preview =
+                    service(0).preview(campaign(CampaignStatus.DRAFT, CampaignChannel.EMAIL), Set.of(), List.of());
+
+            assertThat(preview.channels().getFirst().sample()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("an oversized configured value is clamped rather than honoured")
+        void sampleSizeIsClamped() {
+            List<UUID> members = members(100);
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(members);
+            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
+            when(eligibilityService.decideAll(anyCollection(), any())).thenReturn(snapshot(members, 0));
+
+            // A preview must not become a bulk export of the audience.
+            AudiencePreviewResponse preview =
+                    service(5_000).preview(campaign(CampaignStatus.DRAFT, CampaignChannel.EMAIL), Set.of(), List.of());
+
+            assertThat(preview.channels().getFirst().sample()).hasSize(50);
+        }
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignReferenceValidatorTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignReferenceValidatorTest.java
@@ -1,0 +1,171 @@
+package com.positivity.marketing.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.marketing.internal.entity.Campaign;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link CampaignReferenceValidator}.
+ *
+ * <p>The behaviour worth pinning is what each answer from pricing means for the campaign:
+ *
+ * <ul>
+ *   <li><b>An expired offer blocks, and so does an unreachable pricing service</b> — but with
+ *       different messages. A marketer told "your offer is wrong" during an outage goes
+ *       looking for a data problem that does not exist.
+ *   <li><b>Status and calendar window are separate checks.</b> Pricing stores EXPIRED as a
+ *       status something has to set, so an offer whose end date passed can still read ACTIVE.
+ *   <li><b>An absent reference is not a problem.</b> Both fields are optional; validation
+ *       must not turn "no offer" into "invalid campaign".
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CampaignReferenceValidator — offer and catalog references")
+class CampaignReferenceValidatorTest {
+
+    private static final UUID OFFER_ID = UUID.fromString("01960005-0000-7000-8000-0000000000b1");
+    private static final Instant TODAY = Instant.parse("2026-03-15T09:00:00Z");
+
+    @Mock
+    private PromotionOfferPort promotionOfferPort;
+
+    private CampaignReferenceValidator validator() {
+        return new CampaignReferenceValidator(Clock.fixed(TODAY, ZoneOffset.UTC), promotionOfferPort);
+    }
+
+    private static Campaign campaign(UUID offerId, String catalogFocusRef) {
+        return Campaign.builder()
+                .campaignId(UUID.randomUUID())
+                .promotionOfferId(offerId)
+                .catalogFocusRef(catalogFocusRef)
+                .build();
+    }
+
+    private void pricingAnswers(String status, LocalDate start, LocalDate end) {
+        when(promotionOfferPort.findOffer(OFFER_ID))
+                .thenReturn(PromotionOfferPort.OfferLookup.found(
+                        new PromotionOfferPort.PromotionOffer(OFFER_ID, "SPRING20", status, start, end)));
+    }
+
+    @Nested
+    @DisplayName("promotion offer")
+    class PromotionOffer {
+
+        @Test
+        @DisplayName("an active offer inside its window is no problem at all")
+        void activeAndRunning() {
+            pricingAnswers("ACTIVE", LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+
+            assertThat(validator().problems(campaign(OFFER_ID, null))).isEmpty();
+        }
+
+        @Test
+        @DisplayName("an offer that is not ACTIVE blocks, naming the status it is in")
+        void inactiveOfferBlocks() {
+            pricingAnswers("DRAFT", null, null);
+
+            assertThat(validator().problems(campaign(OFFER_ID, null)))
+                    .singleElement(org.assertj.core.api.InstanceOfAssertFactories.STRING)
+                    .contains("is DRAFT, not ACTIVE");
+        }
+
+        @Test
+        @DisplayName("an ACTIVE offer whose window has passed still blocks")
+        void staleWindowBlocksEvenWhenActive() {
+            // Pricing stores EXPIRED as a status something has to set, so an offer whose end
+            // date passed can still read ACTIVE. The campaign would advertise nothing.
+            pricingAnswers("ACTIVE", LocalDate.of(2026, 1, 1), LocalDate.of(2026, 2, 28));
+
+            assertThat(validator().problems(campaign(OFFER_ID, null)))
+                    .singleElement(org.assertj.core.api.InstanceOfAssertFactories.STRING)
+                    .contains("does not include today")
+                    .contains("2026-01-01 to 2026-02-28");
+        }
+
+        @Test
+        @DisplayName("an ACTIVE offer that has not started yet blocks")
+        void futureWindowBlocks() {
+            pricingAnswers("ACTIVE", LocalDate.of(2026, 4, 1), LocalDate.of(2026, 4, 30));
+
+            assertThat(validator().problems(campaign(OFFER_ID, null))).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("an offer pricing has never heard of blocks as nonexistent")
+        void unknownOfferBlocks() {
+            when(promotionOfferPort.findOffer(OFFER_ID)).thenReturn(PromotionOfferPort.OfferLookup.notFound());
+
+            assertThat(validator().problems(campaign(OFFER_ID, null)))
+                    .singleElement(org.assertj.core.api.InstanceOfAssertFactories.STRING)
+                    .contains("does not exist");
+        }
+
+        @Test
+        @DisplayName("an unreachable pricing service blocks, but says so rather than blaming the offer")
+        void unavailablePricingBlocksWithItsOwnMessage() {
+            when(promotionOfferPort.findOffer(OFFER_ID)).thenReturn(PromotionOfferPort.OfferLookup.unavailable());
+
+            assertThat(validator().problems(campaign(OFFER_ID, null)))
+                    .singleElement(org.assertj.core.api.InstanceOfAssertFactories.STRING)
+                    .contains("could not be verified")
+                    .contains("pricing is unavailable")
+                    .doesNotContain("does not exist");
+        }
+
+        @Test
+        @DisplayName("a campaign with no offer bound is never asked about")
+        void noOfferIsNoQuestion() {
+            assertThat(validator().problems(campaign(null, null))).isEmpty();
+            verifyNoInteractions(promotionOfferPort);
+        }
+    }
+
+    @Nested
+    @DisplayName("catalog focus reference")
+    class CatalogFocus {
+
+        @Test
+        @DisplayName("accepts a well-formed reference")
+        void wellFormedReference() {
+            assertThat(validator().problems(campaign(null, "service:alignment")))
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("rejects a bare name and says what to write instead")
+        void bareNameRejected() {
+            assertThat(validator().problems(campaign(null, "alignment")))
+                    .singleElement(org.assertj.core.api.InstanceOfAssertFactories.STRING)
+                    .contains("is not a catalog reference")
+                    .contains("product, sku, service, category");
+        }
+
+        @Test
+        @DisplayName("a blank reference is absence, not a malformed value")
+        void blankIsAbsent() {
+            assertThat(validator().problems(campaign(null, "   "))).isEmpty();
+        }
+    }
+
+    @Test
+    @DisplayName("gathers both references' problems rather than stopping at the first")
+    void gathersEveryProblem() {
+        when(promotionOfferPort.findOffer(OFFER_ID)).thenReturn(PromotionOfferPort.OfferLookup.notFound());
+
+        // A marketer fixing a campaign wants the whole list, not a game of whack-a-mole.
+        assertThat(validator().problems(campaign(OFFER_ID, "alignment"))).hasSize(2);
+    }
+}

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignSendServiceImplTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignSendServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -28,6 +29,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -77,6 +79,8 @@ class CampaignSendServiceImplTest {
     private static final UUID SEGMENT_ID = UUID.randomUUID();
     private static final UUID PARTY_A = UUID.randomUUID();
     private static final UUID PARTY_B = UUID.randomUUID();
+    private static final UUID CONTACT_A = UUID.randomUUID();
+    private static final UUID CONTACT_B = UUID.randomUUID();
     private static final Instant NOW = Instant.parse("2026-08-11T10:15:30Z");
 
     @Mock
@@ -87,6 +91,9 @@ class CampaignSendServiceImplTest {
 
     @Mock
     private CampaignAudienceMemberRepository audienceRepository;
+
+    @Mock
+    private AudienceEligibilityService eligibilityService;
 
     @Mock
     private SegmentResolveRequester resolveRequester;
@@ -100,7 +107,16 @@ class CampaignSendServiceImplTest {
                 campaignRepository,
                 sendRepository,
                 audienceRepository,
+                eligibilityService,
                 resolveRequester);
+    }
+
+    /** Both parties reachable, each resolving to the contact the CRM designated for it. */
+    private void bothPartiesReachable() {
+        when(eligibilityService.decideAll(anyCollection(), any()))
+                .thenReturn(Map.of(
+                        PARTY_A, new AudienceEligibilityService.Decision(true, "OPT_IN", CONTACT_A),
+                        PARTY_B, new AudienceEligibilityService.Decision(true, "OPT_IN", CONTACT_B)));
     }
 
     private static Campaign campaign(CampaignStatus status, UUID segmentId, CampaignChannel... channels) {
@@ -183,6 +199,7 @@ class CampaignSendServiceImplTest {
                     campaign(CampaignStatus.SCHEDULED, SEGMENT_ID, CampaignChannel.EMAIL, CampaignChannel.SMS);
             when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(scheduled));
             when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of(PARTY_A, PARTY_B));
+            bothPartiesReachable();
             when(sendRepository.findByCampaignIdAndRecipientPartyIdAndChannel(eq(CAMPAIGN_ID), any(), any()))
                     .thenReturn(Optional.empty());
 
@@ -210,11 +227,53 @@ class CampaignSendServiceImplTest {
         }
 
         @Test
+        @DisplayName("records the contact the CRM resolved for each party on the queued row")
+        void stampsResolvedContact() {
+            when(campaignRepository.findById(CAMPAIGN_ID))
+                    .thenReturn(Optional.of(campaign(CampaignStatus.SENDING, SEGMENT_ID, CampaignChannel.EMAIL)));
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of(PARTY_A, PARTY_B));
+            bothPartiesReachable();
+            when(sendRepository.findByCampaignIdAndRecipientPartyIdAndChannel(eq(CAMPAIGN_ID), any(), any()))
+                    .thenReturn(Optional.empty());
+
+            service.dispatch(CAMPAIGN_ID);
+
+            // For a commercial account the CRM designates who speaks for it; for an individual
+            // it is the person themselves. Either way the sender addresses this contact, so the
+            // answer is carried from the consent decision rather than re-derived here.
+            ArgumentCaptor<CampaignSend> saved = ArgumentCaptor.forClass(CampaignSend.class);
+            verify(sendRepository, times(2)).saveAndFlush(saved.capture());
+            assertThat(saved.getAllValues())
+                    .extracting(CampaignSend::getRecipientPartyId, CampaignSend::getContactId)
+                    .containsExactlyInAnyOrder(tuple(PARTY_A, CONTACT_A), tuple(PARTY_B, CONTACT_B));
+        }
+
+        @Test
+        @DisplayName("queues a party the CRM has said nothing about, leaving its contact unresolved")
+        void queuesWithoutContactWhenUndecided() {
+            when(campaignRepository.findById(CAMPAIGN_ID))
+                    .thenReturn(Optional.of(campaign(CampaignStatus.SENDING, SEGMENT_ID, CampaignChannel.EMAIL)));
+            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of(PARTY_A));
+            when(eligibilityService.decideAll(anyCollection(), any())).thenReturn(Map.of());
+            when(sendRepository.findByCampaignIdAndRecipientPartyIdAndChannel(eq(CAMPAIGN_ID), any(), any()))
+                    .thenReturn(Optional.empty());
+
+            // Dispatch does not filter — the worker re-checks eligibility at send time, and a
+            // row with no contact is refused there rather than silently dropped here.
+            assertThat(service.dispatch(CAMPAIGN_ID)).isEqualTo(1);
+
+            ArgumentCaptor<CampaignSend> saved = ArgumentCaptor.forClass(CampaignSend.class);
+            verify(sendRepository).saveAndFlush(saved.capture());
+            assertThat(saved.getValue().getContactId()).isNull();
+        }
+
+        @Test
         @DisplayName("skips a recipient-channel pair that is already queued")
         void skipsAlreadyQueuedPairs() {
             Campaign sending = campaign(CampaignStatus.SENDING, SEGMENT_ID, CampaignChannel.EMAIL);
             when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(sending));
             when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of(PARTY_A, PARTY_B));
+            bothPartiesReachable();
             when(sendRepository.findByCampaignIdAndRecipientPartyIdAndChannel(
                             CAMPAIGN_ID, PARTY_A, CampaignChannel.EMAIL))
                     .thenReturn(Optional.of(new CampaignSend()));
@@ -237,6 +296,7 @@ class CampaignSendServiceImplTest {
             when(campaignRepository.findById(CAMPAIGN_ID))
                     .thenReturn(Optional.of(campaign(CampaignStatus.SENDING, SEGMENT_ID, CampaignChannel.EMAIL)));
             when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of(PARTY_A, PARTY_B));
+            bothPartiesReachable();
             when(sendRepository.findByCampaignIdAndRecipientPartyIdAndChannel(eq(CAMPAIGN_ID), any(), any()))
                     .thenReturn(Optional.empty());
             when(sendRepository.saveAndFlush(any()))

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignSendWorkerTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignSendWorkerTest.java
@@ -173,6 +173,29 @@ class CampaignSendWorkerTest {
     }
 
     @Test
+    @DisplayName("re-reads the addressed contact from the send-time decision rather than trusting dispatch")
+    void refreshesResolvedContactAtSendTime() {
+        UUID contact = UUID.randomUUID();
+        givenOneQueuedSend();
+        when(eligibilityService.decide(PARTY, CampaignChannel.EMAIL))
+                .thenReturn(new AudienceEligibilityService.Decision(true, "OPT_IN", contact));
+        when(messageChannel.send(any())).thenReturn(MessageChannelPort.SendOutcome.accepted("provider-1", null));
+
+        worker().drain();
+
+        // An account can change who speaks for it between queueing and delivery, and the sender
+        // resolves the address from whatever this row names.
+        ArgumentCaptor<MessageChannelPort.OutboundMessage> outbound =
+                ArgumentCaptor.forClass(MessageChannelPort.OutboundMessage.class);
+        verify(messageChannel).send(outbound.capture());
+        assertThat(outbound.getValue().contactId()).isEqualTo(contact);
+
+        ArgumentCaptor<CampaignSend> saved = ArgumentCaptor.forClass(CampaignSend.class);
+        verify(sendRepository).save(saved.capture());
+        assertThat(saved.getValue().getContactId()).isEqualTo(contact);
+    }
+
+    @Test
     @DisplayName("an allowed decision does send, and records the provider id")
     void allowedRecipientIsContacted() {
         givenOneQueuedSend();

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignServiceImplTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CampaignServiceImplTest.java
@@ -3,7 +3,7 @@ package com.positivity.marketing.internal.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -22,7 +22,6 @@ import com.positivity.marketing.internal.enums.ScheduleType;
 import com.positivity.marketing.internal.exception.MarketingDuplicateResourceException;
 import com.positivity.marketing.internal.exception.MarketingResourceNotFoundException;
 import com.positivity.marketing.internal.exception.MarketingUnprocessableEntityException;
-import com.positivity.marketing.internal.repository.CampaignAudienceMemberRepository;
 import com.positivity.marketing.internal.repository.CampaignRepository;
 import com.positivity.marketing.internal.repository.MessageTemplateRepository;
 import com.positivity.marketing.internal.repository.SegmentReplicaRepository;
@@ -31,12 +30,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -69,6 +70,7 @@ class CampaignServiceImplTest {
     private static final UUID CAMPAIGN_ID = UUID.randomUUID();
     private static final UUID SEGMENT_ID = UUID.randomUUID();
     private static final UUID EMAIL_TEMPLATE_ID = UUID.randomUUID();
+    private static final UUID OFFER_ID = UUID.randomUUID();
 
     @Mock
     private CampaignRepository campaignRepository;
@@ -80,19 +82,25 @@ class CampaignServiceImplTest {
     private SegmentReplicaRepository segmentReplicaRepository;
 
     @Mock
-    private CampaignAudienceMemberRepository audienceRepository;
+    private AudienceResolutionService audienceResolutionService;
 
     @Mock
-    private AudienceEligibilityService eligibilityService;
-
-    @Mock
-    private SegmentResolveRequester resolveRequester;
+    private CampaignReferenceValidator referenceValidator;
 
     @Mock
     private MarketingFactPublisher factPublisher;
 
     @InjectMocks
     private CampaignServiceImpl sut;
+
+    /**
+     * Offer and catalog references are checked on every readiness pass, so the default is a
+     * clean bill of health; the tests that care about them override it.
+     */
+    @BeforeEach
+    void referencesAreValid() {
+        lenient().when(referenceValidator.problems(any())).thenReturn(List.of());
+    }
 
     private static Campaign campaign(CampaignStatus status) {
         return Campaign.builder()
@@ -395,6 +403,19 @@ class CampaignServiceImplTest {
         }
 
         @Test
+        @DisplayName("refuses to schedule a campaign whose promotion offer is not running")
+        void schedule_whenOfferNotActive_reportsProblem() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
+            campaignIsReady();
+            when(referenceValidator.problems(any()))
+                    .thenReturn(List.of("promotion offer " + OFFER_ID + " is EXPIRED, not ACTIVE"));
+
+            // Advertising a discount that will not apply cannot be recalled once sent.
+            assertThatThrownBy(() -> sut.schedule(CAMPAIGN_ID)).hasMessageContaining("is EXPIRED, not ACTIVE");
+            verify(factPublisher, never()).campaignScheduled(any());
+        }
+
+        @Test
         @DisplayName("treats a dangling template id as a missing template")
         void schedule_whenTemplateDangling_reportsProblem() {
             when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
@@ -446,57 +467,62 @@ class CampaignServiceImplTest {
     @DisplayName("previewAudience")
     class PreviewAudience {
 
+        /**
+         * Preview itself lives in {@link AudienceResolutionService}; what this class owns is
+         * the campaign-shaped context handed to it — which channels actually have a usable
+         * template, and the readiness problems that ride along as warnings.
+         */
         @Test
-        @DisplayName("reports the last snapshot with its age and asks for a fresher one")
-        void preview_reportsSnapshotAndRequestsRefresh() {
-            Instant resolvedAt = Instant.parse("2026-08-11T11:00:00Z");
-            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
-            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID))
-                    .thenReturn(List.of(UUID.randomUUID(), UUID.randomUUID()));
-            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.of(resolvedAt));
-            when(eligibilityService.countEligible(anyCollection(), any())).thenReturn(1L);
+        @DisplayName("hands the resolver the campaign's usable templates and its readiness problems")
+        void preview_delegatesWithTemplatesAndWarnings() {
+            Campaign existing = campaign(CampaignStatus.DRAFT);
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(existing));
             campaignIsReady();
+            when(audienceResolutionService.preview(any(), any(), any())).thenReturn(preview());
 
-            AudiencePreviewResponse preview = sut.previewAudience(CAMPAIGN_ID);
+            assertThat(sut.previewAudience(CAMPAIGN_ID)).isNotNull();
 
-            // The snapshot's age travels with the numbers so a marketer can see how
-            // current they are rather than assuming they are live.
-            assertThat(preview.segmentMatched()).isEqualTo(2);
-            assertThat(preview.resolvedAt()).isEqualTo(resolvedAt);
-            verify(resolveRequester).requestResolve(CAMPAIGN_ID, SEGMENT_ID);
+            ArgumentCaptor<Set<CampaignChannel>> templates = ArgumentCaptor.captor();
+            ArgumentCaptor<List<String>> warnings = ArgumentCaptor.captor();
+            verify(audienceResolutionService).preview(eq(existing), templates.capture(), warnings.capture());
+            assertThat(templates.getValue()).containsExactly(CampaignChannel.EMAIL);
+            assertThat(warnings.getValue()).isEmpty();
         }
 
         @Test
-        @DisplayName("reports per-channel eligibility and whether a template is attached")
-        void preview_reportsPerChannelDetail() {
+        @DisplayName("reports a dangling template as a channel without one, and warns about it")
+        void preview_whenTemplateDangling_reportsChannelWithoutTemplate() {
             when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
-            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of(UUID.randomUUID()));
-            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
-            when(eligibilityService.countEligible(anyCollection(), any())).thenReturn(0L);
-            campaignIsReady();
-
-            AudiencePreviewResponse preview = sut.previewAudience(CAMPAIGN_ID);
-
-            assertThat(preview.channels()).singleElement().satisfies(channel -> {
-                assertThat(channel.channel()).isEqualTo("EMAIL");
-                assertThat(channel.targeted()).isEqualTo(1);
-                assertThat(channel.eligible()).isZero();
-                assertThat(channel.templateAttached()).isTrue();
-            });
-        }
-
-        @Test
-        @DisplayName("does not request a refresh once the audience is frozen")
-        void preview_whenAudienceImmutable_doesNotRequestRefresh() {
-            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.SENT)));
-            when(audienceRepository.findPartyIdsByCampaignId(CAMPAIGN_ID)).thenReturn(List.of());
-            when(audienceRepository.findResolvedAt(CAMPAIGN_ID)).thenReturn(Optional.empty());
-            when(eligibilityService.countEligible(anyCollection(), any())).thenReturn(0L);
-            campaignIsReady();
+            when(segmentReplicaRepository.findById(SEGMENT_ID))
+                    .thenReturn(Optional.of(segmentReplica(true, "COMMERCIAL")));
+            // Set on the campaign but no longer resolvable: as broken as absent.
+            when(templateRepository.findById(EMAIL_TEMPLATE_ID)).thenReturn(Optional.empty());
+            when(audienceResolutionService.preview(any(), any(), any())).thenReturn(preview());
 
             sut.previewAudience(CAMPAIGN_ID);
 
-            verify(resolveRequester, never()).requestResolve(any(), any());
+            ArgumentCaptor<Set<CampaignChannel>> templates = ArgumentCaptor.captor();
+            ArgumentCaptor<List<String>> warnings = ArgumentCaptor.captor();
+            verify(audienceResolutionService).preview(any(), templates.capture(), warnings.capture());
+            assertThat(templates.getValue()).isEmpty();
+            assertThat(warnings.getValue()).contains("no EMAIL template attached");
+        }
+
+        @Test
+        @DisplayName("carries an invalid promotion offer through as a warning rather than an error")
+        void preview_whenOfferInvalid_warnsWithoutThrowing() {
+            when(campaignRepository.findById(CAMPAIGN_ID)).thenReturn(Optional.of(campaign(CampaignStatus.DRAFT)));
+            campaignIsReady();
+            when(referenceValidator.problems(any())).thenReturn(List.of("promotion offer is EXPIRED, not ACTIVE"));
+            when(audienceResolutionService.preview(any(), any(), any())).thenReturn(preview());
+
+            // A preview is where a marketer goes to find out what is wrong, so an unusable
+            // offer is reported alongside the counts instead of replacing them with a 422.
+            sut.previewAudience(CAMPAIGN_ID);
+
+            ArgumentCaptor<List<String>> warnings = ArgumentCaptor.captor();
+            verify(audienceResolutionService).preview(any(), any(), warnings.capture());
+            assertThat(warnings.getValue()).contains("promotion offer is EXPIRED, not ACTIVE");
         }
 
         @Test
@@ -509,6 +535,12 @@ class CampaignServiceImplTest {
             assertThatThrownBy(() -> sut.previewAudience(CAMPAIGN_ID))
                     .isInstanceOf(MarketingUnprocessableEntityException.class)
                     .hasMessageContaining("nothing to preview");
+            verify(audienceResolutionService, never()).preview(any(), any(), any());
+        }
+
+        private AudiencePreviewResponse preview() {
+            return new AudiencePreviewResponse(
+                    CAMPAIGN_ID, SEGMENT_ID, "COMMERCIAL", 0, null, false, List.of(), List.of());
         }
     }
 

--- a/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CustomerEventsListenerTest.java
+++ b/pos-marketing/src/test/java/com/positivity/marketing/internal/service/CustomerEventsListenerTest.java
@@ -371,7 +371,28 @@ class CustomerEventsListenerTest {
                     .allSatisfy(members -> assertThat(members).singleElement().satisfies(member -> {
                         assertThat(member.getPartyId()).isEqualTo(PARTY_ID);
                         assertThat(member.getResolvedAt()).isEqualTo(NOW);
+                        assertThat(member.isTruncated()).isFalse();
                     }));
+        }
+
+        @Test
+        @DisplayName("carries the owner's truncation flag onto the snapshot it describes")
+        void carriesTruncationFlag() {
+            expectUnprocessed("evt-r5");
+            when(campaignRepository.findAll())
+                    .thenReturn(List.of(campaign(CAMPAIGN_ID, SEGMENT_ID, CampaignStatus.SCHEDULED)));
+
+            listener.onCustomerEvent(
+                    envelope("evt-r5", CustomerSegmentResolvedV1.EVENT_TYPE, """
+                    {"segmentId":"%s","partyIds":["%s"],"truncated":true}""".formatted(SEGMENT_ID, PARTY_ID)));
+
+            // Dropped, a preview would report a cut-off audience as complete and a marketer
+            // would read the short count as a small audience.
+            ArgumentCaptor<List<CampaignAudienceMember>> captor = ArgumentCaptor.captor();
+            verify(audienceRepository).saveAll(captor.capture());
+            assertThat(captor.getValue())
+                    .singleElement()
+                    .satisfies(member -> assertThat(member.isTruncated()).isTrue());
         }
 
         @Test


### PR DESCRIPTION
## Capability & Traceability
- Capability: not stated on the child issue — plan reference is `durion/domains/crm/plan-odoo-parity-pos-customer.md` §3 (WS-B, Wave 2)
- Parent STORY (durion): not linked on the child issue
- Child issue: Refs louisburroughs/durion-positivity-backend#1148 — **deliberately not `Closes`.** One acceptance criterion (catalog reference *resolvable*) is not met and is tracked in #1306; #1148 should stay open until that lands.
- Follow-up: #1306 — publish `catalog.service.updated` so `catalogFocusRef` can be resolved
- Domain: `domain:marketing` (`pos-marketing`), with one read into `domain:pricing`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/marketing/.business-rules/BACKEND_CONTRACT_GUIDE.md` → audience preview / campaign scheduling. **Not yet updated** — this PR changes `AudiencePreviewResponse` and the readiness rules for `POST /v1/marketing/campaigns/{campaignId}/schedule`, so the guide needs a matching entry. Flagging rather than silently skipping.
- Durion contract PR (if applicable): none opened

Contract-relevant changes in this PR:
- `AudiencePreviewResponse` — `truncated` now carries a real value; `ChannelPreview` gains `sample`; new nested `SampleRecipient` record. Additive: no field removed or retyped.
- `CampaignController` — `@Operation` descriptions updated for `previewCampaignAudience` and `scheduleCampaign`.
- `scheduleCampaign` gains two new 422 causes (promotion offer not running, malformed `catalogFocusRef`).
- No event schema changed.

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — **not done.** Regeneration runs the `openapi` Maven profile, which boots the service on a fixed port; repo history shows these files are refreshed in dedicated docs commits (most recently #1296) rather than per feature PR. `pos-marketing/openapi.yaml` is stale for the fields listed above.
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — **not done**, follows the regenerated spec.

## Scope

### What changed

**Audience preview** — new `internal/service/AudienceResolutionService`
- The CRM's truncation flag is no longer dropped. `customer.segment.resolved` already reported whether the owner's candidate scan hit its ceiling, but the listener discarded it and the preview hardcoded `truncated: false`, so a cut-off snapshot read as a complete one. It is now stored alongside the snapshot it describes (migration `V8`) and reported.
- Each channel returns a bounded sample of the individual decisions behind its eligible count. Refusals come first, because they are what explains the gap between targeted and eligible; a campaign with no refusals shows reachable members instead. Size is `pos.marketing.preview.sample-size` (default 10, clamped to 50).
- Preview logic moved out of `CampaignServiceImpl`, which now only supplies campaign-shaped context: the channels with a usable template, and the readiness problems that ride along as warnings.

**Contact resolution** — `CampaignSend.contactId` existed but was never populated
- Dispatch now stamps the contact each party resolves to, and the send worker re-reads it from the send-time decision (an account can change who speaks for it between queueing and delivery).
- The value comes from the consent decision's `governingPartyId`, which pos-customer already resolves and replicates — the CRM's designated contact for a commercial account, the person themselves for an individual. Re-deriving that rule here would guarantee the two copies drift.

**Reference validation** — new `internal/client/PriceClient`, `internal/service/PromotionOfferPort`, `internal/service/CampaignReferenceValidator`, `internal/domain/CatalogFocusRef`
- A campaign whose `promotionOfferId` is missing, not `ACTIVE`, or outside its date window can no longer be scheduled. Status and window are checked separately: pricing stores `EXPIRED` as a status that something has to set, so an offer whose end date passed last week can still read `ACTIVE`.
- An unreachable pricing service also blocks, but with its own message. "We could not check" and "this offer is wrong" send a marketer to completely different places, and scheduling is retryable where a sent campaign is not.
- `catalogFocusRef` is now grammar-checked as `kind:value` over `product | sku | service | category`, which catches the mistake actually made in practice: a bare name that no consumer can follow.

**Batching** — `AudienceEligibilityService.decideAll`
- Answers a whole snapshot in a fixed number of queries, chunked at 1000 ids. The previous path issued one suppression query per member, and an unchunked `IN` clause would exceed PostgreSQL's 65535 bind-parameter cap on exactly the largest campaigns.

### Why

Issue #1148 asks for audience binding plus preview, and for the offer and catalog references to be validated. Binding and the consent/suppression filtering already existed; what was missing was an explanation of the numbers (truncation, per-party reasons), the resolved contact, and any validation of the two cross-domain references.

### Deviation from the issue's stated file list — please read

The issue lists `internal/client/{CustomerClient,PriceClient,CatalogClient}.java` as load-balanced RestClients. `DomainWallsTest` in `pos-archunit` (build-failing since #902) whitelists pos-price as an ADR-0044 §1 utility but not the customer or catalog domains, so two of those three clients would fail the build. ADR-0044 is canonical in the durion repo, so amending it is out of scope here.

- **PriceClient** — added as specified. Permitted edge, and the right shape: offer status changes on its own schedule with no fact to replicate from, and the answer is only needed when previewing or scheduling.
- **CustomerClient** — not added. The issue offers "pos-customer gateway REST **or** a segment replica"; the replica path already exists and this PR extends it. Contact resolution turned out not to need a client at all, since `governingPartyId` is already replicated on `ext_party_consent`.
- **CatalogClient** — not added, so `catalogFocusRef` is grammar-checked but **not resolved**. This is the one acceptance criterion not met, and it is why this PR does not close #1148.

#### Why catalog resolution is split into #1306

Both routes available *today* are closed:

1. **Synchronous read** — ADR-0044 R1 permits no synchronous edge from a domain module to pos-catalog. `DomainWallsTest` fails the build on it, and the ADR is canonical in the durion repo.
2. **Event-fed replica** — `catalog.events.v1` carries `catalog.product.updated` and nothing else (`pos-domain-events/.../catalog/` defines exactly one `EVENT_TYPE`). pos-catalog has a `ServiceEntity` but publishes no fact for it, and `service:` is the form campaigns most often point at — the repo's own canonical example is `service:alignment`. A replica alone would therefore leave the primary case unresolved.

#1306 takes route 2 properly: add `catalog.service.updated` in pos-catalog, then replicate products *and* services into an `ext_catalog` table here (the pattern pos-warranty already uses) and resolve all four `CatalogFocusRef.Kind` values against it. No domain wall is crossed.

On the masked sample: the acceptance criterion is "no raw PII beyond masked sample". The sample here carries opaque identifiers and machine-readable reason codes and nothing else, because this module replicates no names or addresses (ADR-0044 R3) and the shared platform sender resolves the address at delivery. That is strictly less exposure than a masked sample, not a redaction of one.

## Tests
- [x] Unit tests added/updated — new: `PriceClientTest` (7), `CatalogFocusRefTest` (18), `CampaignReferenceValidatorTest` (11), `AudienceResolutionServiceTest` (11). Updated: `AudienceEligibilityServiceTest` (batch decisions, governing contact, chunking, empty audience), `CampaignServiceImplTest`, `CampaignSendServiceImplTest` (contact stamping), `CampaignSendWorkerTest` (send-time contact refresh), `CustomerEventsListenerTest` (truncation flag).
- [ ] Integration tests added/updated — none; no new `*IT` surface. The pricing edge is covered by `MockRestServiceServer` rather than a live service.
- [ ] Provider behavioral contract tests added/updated — none added.
- How to run:
  ```bash
  ./mvnw -pl pos-marketing -am -DskipTests=false test
  ./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests,DomainWallsTest -Dsurefire.failIfNoSpecifiedTests=false test
  ```
  Both green locally. `DomainWallsTest` reports `total violating client sources: 0`. Checkstyle, Spotless, SpotBugs and the module's JaCoCo floors all pass in the same run.

## Risk & Rollback
- Risk level: **Medium**
- The behavioural risk is scheduling, not sending: a campaign with a bound `promotionOfferId` will now fail `scheduleCampaign` if pricing is unreachable or the offer is not running. That is deliberate fail-closed behaviour, and it is worth naming because it makes campaign scheduling newly dependent on pos-price availability. Campaigns without an offer bound are unaffected. Dispatch and delivery are unaffected either way.
- Migration `V8` is additive with a default (`ALTER TABLE campaign_audience_member ADD COLUMN truncated boolean NOT NULL DEFAULT FALSE`); existing rows read as non-truncated, which is what they were already being reported as.
- Rollback plan: revert the commit. `V8` can be left in place — the column is unread by the previous code and harmless. If only the pricing dependency needs backing out, point `pos.price.service-id` at nothing and the validator degrades to blocking with an "unavailable" message; a genuine opt-out would mean reverting `CampaignReferenceValidator` from `readinessProblems`.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is `claude/issue-1148-tt0qjp`, fixed by the automation that produced this work; no cap-id was stated on the issue.
- [ ] PR title starts with `[CAP:<cap-id>]` — no cap-id available; not guessed. Retitle if you have one.
- [x] Links to parent + child issues are present — child only; the issue names no durion parent.
- [ ] Contract guide updated (when contract semantics changed) — needed, see Contract References above.
- [ ] Required CI checks passing — pending first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Mou5SjukahjMf2289vskp