### PR TITLE
test(accounting): state the non-PostgreSQL dialect explicitly in the gap-footnote guard

### DIFF
--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingServiceImplTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/FinancialReportingServiceImplTest.java
@@ -220,6 +220,8 @@ class FinancialReportingServiceImplTest {
         // exports built on it) in every H2-backed test and in the dev profile.
         aggregatedTotals(new TrialBalanceAccountTotal(
                 ACCT_CASH, "1000", "Cash", new BigDecimal("10.00"), new BigDecimal("10.00")));
+        // Stated, not inherited from the mock default: the dialect is the subject of this test.
+        when(databaseDialectSupport.isPostgreSql()).thenReturn(false);
 
         TrialBalanceReport report = service.generateTrialBalance(AS_OF);
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — test-only follow-up to a merged bug fix
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1244 (fix merged in #1303)
- Domain: `domain:accounting`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): n/a — no contract-relevant file changed. This PR touches one test file only; no controller, DTO, event, `openapi.yaml`, or validation/error model is involved. `BACKEND_CONTRACT_GUIDE.md` is referenced here only to satisfy the Contract Sync Enforcement check if it triggers.
- Durion contract PR (if applicable): none

## Contract Chain (when a Controller changed)
No controller changed.
- [ ] OpenAPI annotations updated on the controller — n/a
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope
**What changed:** `FinancialReportingServiceImplTest.skipsGapFootnoteOnNonPostgreSqlDialect` now stubs `DatabaseDialectSupport.isPostgreSql()` to `false` explicitly instead of relying on Mockito's default boolean return.

**Why:** This is the review comment Copilot left on #1303 ([discussion_r3780534012](https://github.com/louisburroughs/durion-positivity-backend/pull/1303#discussion_r3780534012)). The fix was pushed to the branch after #1303 had already been merged, so it never landed — it is carried here as a fresh change on top of the merged history rather than stacked on it.

The point is worth taking: the dialect is the subject of that test, so leaving it implicit means the test would silently stop testing what it claims if the mock setup were refactored (a custom default answer, a shared fixture, or a strictness change).

## Tests
- [x] Unit tests added/updated — one existing test made explicit; no behavior change
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a

**How to run:**

```bash
./mvnw -pl pos-accounting -Dtest=FinancialReportingServiceImplTest test
```

Result on this branch, rebased onto current `main` (`6f77ddb`): 7 tests, 0 failures, 0 errors.

## Risk & Rollback
- Risk level: Low. Test-only; no production code touched.
- Rollback plan: revert the single commit.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, not a capability branch
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, same reason
- [x] Links to parent + child issues are present (issue #1244, merged PR #1303)
- [x] Contract guide updated (when contract semantics changed) — no contract semantics changed
- [ ] Required CI checks passing — pending first run

---
_Generated by [Claude Code](https://claude.ai/code/session_01B151wfQM7NREzm5W43a8BW)_