### PR TITLE
[CAP:322] Supplier: EDIWheel Stock Report B2.1 snapshots with availability-hint events (#1228)

### DIFF
--- a/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierStockReportLine.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierStockReportLine.java
@@ -1,0 +1,51 @@
+package com.positivity.domainevents.supplier;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One article's reported availability inside a {@link SupplierStockReportUpdatedV1} chunk.
+ *
+ * <p>{@code availableQuantity} is nullable and that distinction is the contract: null means the
+ * vendor reported the article without stating a quantity, zero means the vendor explicitly said it
+ * has none. A consumer that collapses the two turns a silence into an out-of-stock.
+ *
+ * <p>Lines are not resolved to catalog products. Unlike PRICAT, a stock report is an availability
+ * hint rather than a commercial commitment, so matching is the consumer's decision — pos-inventory
+ * stores hints against the identifiers it can resolve and ignores the rest.
+ *
+ * @param articleEan          EAN/GTIN the vendor stated, when present
+ * @param supplierArticleCode vendor's own article code — an alias, never an identifier
+ * @param buyersArticleId     the buyer's own code as the vendor holds it, when present
+ * @param description         vendor article description, when present
+ * @param availableQuantity   quantity reported; null means none stated, which is not zero
+ */
+public record SupplierStockReportLine(
+        @Nullable String articleEan,
+        @Nullable String supplierArticleCode,
+        @Nullable String buyersArticleId,
+        @Nullable String description,
+        @Nullable Integer availableQuantity) {
+
+    /** Marker for the absent-quantity case, so consumers do not invent their own sentinel. */
+    public boolean quantityStated() {
+        return availableQuantity != null;
+    }
+
+    /** Whether the vendor explicitly reported no stock, as opposed to stating nothing. */
+    public boolean explicitlyOutOfStock() {
+        return availableQuantity != null && availableQuantity == 0;
+    }
+
+    /** Best available identity for logging; never used as a match key by the producer. */
+    @NonNull
+    public String describeIdentity() {
+        if (articleEan != null) {
+            return "ean:" + articleEan;
+        }
+        if (buyersArticleId != null) {
+            return "buyerArticle:" + buyersArticleId;
+        }
+        return "supplier:" + supplierArticleCode;
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierStockReportUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierStockReportUpdatedV1.java
@@ -1,0 +1,65 @@
+package com.positivity.domainevents.supplier;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Payload for {@code supplier.stockreport.updated} v1 on {@code supplier.events.v1}
+ * (ADR-0049 §3, CAP-322).
+ *
+ * <p>Published by pos-supplier as one chunk of a vendor stock snapshot, for pos-inventory to hold
+ * as <strong>supplier availability hints</strong>. Hints are not owned stock: nothing here may
+ * enter inventory valuation or on-hand availability-to-promise, because it describes a vendor's
+ * warehouse rather than ours.
+ *
+ * <h2>Two timestamps, deliberately</h2>
+ *
+ * {@code snapshotAsOf} is the vendor's own statement of when the snapshot was taken; {@code
+ * fetchedAt} is when we asked. A report fetched at noon may describe stock as of 06:00, and
+ * staleness must be judged against the vendor's figure — the fetch time only says when we last
+ * heard, not how fresh the answer was.
+ *
+ * <h2>Absence is not zero</h2>
+ *
+ * A snapshot lists what the vendor chose to report. An article that appears with no quantity, and
+ * an article that does not appear at all, are both "no data" — neither means the vendor has none.
+ * Only an explicit zero means out of stock, and {@link SupplierStockReportLine} keeps that
+ * distinction rather than leaving it to each consumer to rediscover.
+ *
+ * @param snapshotId      identity of this snapshot; the event aggregate id
+ * @param vendorProfileId vendor profile that produced it (ADR-0050 §1 identity)
+ * @param supplierRef     profile alias at fetch time; descriptive only
+ * @param chunkSequence   1-based sequence of this chunk within the snapshot
+ * @param chunkCount      total chunks in the snapshot, so a consumer can detect a gap without a
+ *                        second event type
+ * @param documentId      vendor document id, when stated
+ * @param buyerAccountNumber buyer account the snapshot was produced for
+ * @param countryCode     market the snapshot covers, when the profile states one
+ * @param snapshotAsOf    vendor-stated snapshot instant; null when the vendor stated no time
+ * @param fetchedAt       when the producer fetched the document
+ * @param linesReported   total lines in the whole snapshot, across every chunk
+ * @param lines           the lines carried by this chunk; never empty for a published chunk
+ */
+public record SupplierStockReportUpdatedV1(
+        @NonNull UUID snapshotId,
+        @NonNull UUID vendorProfileId,
+        @NonNull String supplierRef,
+        int chunkSequence,
+        int chunkCount,
+        @Nullable String documentId,
+        @NonNull String buyerAccountNumber,
+        @Nullable String countryCode,
+        @Nullable Instant snapshotAsOf,
+        @NonNull Instant fetchedAt,
+        int linesReported,
+        @NonNull List<SupplierStockReportLine> lines) {
+
+    /** Event type of this payload on {@code supplier.events.v1}. */
+    public static final String EVENT_TYPE = "supplier.stockreport.updated";
+
+    /** Payload schema version; additive changes only within v1 (ADR-0044 §3). */
+    public static final int SCHEMA_VERSION = 1;
+}

--- a/pos-supplier/README.md
+++ b/pos-supplier/README.md
@@ -113,6 +113,11 @@ Snapshots are append-only. A failed or undecodable fetch records a `FAILED` snap
 the previous snapshot stays the last thing the vendor actually said — a vendor outage is not a
 statement that a warehouse is empty.
 
+Four terminal statuses, and the distinction between the middle two is the point: `COMPLETED` (at
+least one usable line), `EMPTY` (the vendor sent no lines), `REJECTED` (the vendor sent lines and
+none of them decoded — a codec or vendor-format break, not a quiet warehouse), `FAILED` (no usable
+answer at all).
+
 ### Gateway routing
 
 `Path=/supplier/**` with `StripPrefix=1`, plus the gateway's global `ApiVersionHeaderToPathFilter`:

--- a/pos-supplier/README.md
+++ b/pos-supplier/README.md
@@ -11,10 +11,11 @@ supplier APIs, and the exchange audit trail of what was sent and received.
 | Compose port | `8096` → container `8080` |
 | Governing ADRs | ADR-0050 (vendor profile configuration), ADR-0051 (protocol adapter versioning), ADR-0052 (outbound idempotency / duplicate-order prevention) |
 
-This module owns **how** we reach a supplier, and — as CAP-318 lands its codecs — **what** we say to
-them for each capability. The first codec is EDIWheel PRICAT B4.0 (`internal.adapter.ediwheelb`,
-issue #1224); the remaining capabilities still have SPI ports in `internal.spi` and no codec behind
-them. ADR-0053 governs the price-catalog behaviour described below.
+This module owns **how** we reach a supplier, and — as the codec waves land — **what** we say to
+them for each capability. Two codecs exist today, both in `internal.adapter.ediwheelb`: PRICAT B4.0
+(#1224) and Stock Report B2.1 (#1228). The remaining capabilities still have SPI ports in
+`internal.spi` and no codec behind them. ADR-0053 governs the price-catalog behaviour described
+below.
 
 ---
 
@@ -87,6 +88,30 @@ product identity codes on `catalog.events.v1` and `CatalogProductEventsListener`
 created seconds ago may not be matchable yet, and its line is quarantined until the next import. An
 empty replica — Kafka disabled, or nothing consumed yet — reports `CATALOG_UNAVAILABLE` rather than
 turning a whole vendor catalog into `NO_CATALOG_MATCH` misses an operator would go hunting for.
+
+### Stock report (B2.1) — no API surface
+
+A scheduled snapshot feed with no endpoints: pos-supplier fetches the vendor's country-level stock
+report on the binding's cron and publishes it as chunked `supplier.stockreport.updated` events for
+pos-inventory to hold as **availability hints**. Hints are not owned stock and must never enter
+valuation or on-hand ATP (ADR-0048).
+
+Three states, kept distinct end to end, because collapsing them is how a vendor's silence becomes a
+false out-of-stock:
+
+| Vendor said | Stored / published as | Means |
+| --- | --- | --- |
+| `"quantityValue": "0"` | `0` | The vendor reports it has none |
+| `"quantityValue": ""` or absent | `null` | The vendor listed the article without stating a quantity |
+| article not in the document | no line at all | The vendor did not mention it |
+
+The snapshot carries **two timestamps**: `snapshotAsOf` is the vendor's own statement of when the
+snapshot was taken, `fetchedAt` is when we asked. A report fetched at noon may describe stock as of
+06:00, and staleness is judged against the vendor's figure.
+
+Snapshots are append-only. A failed or undecodable fetch records a `FAILED` snapshot and stops, so
+the previous snapshot stays the last thing the vendor actually said — a vendor outage is not a
+statement that a warehouse is empty.
 
 ### Gateway routing
 
@@ -372,6 +397,10 @@ nothing), then update the Angular SDK.
 - The `ext_product_code` replica has no backfill path yet: it is built from facts published after the
   consumer starts, so a first deployment needs pos-catalog to re-emit (ADR-0044 §4 replay) before
   PRICAT lines can match.
+- Stock-report snapshots are published but not yet consumed: the pos-inventory hint representation is
+  a domain decision (#1312) and the consumer waits on it.
+- `SupplierShipmentTrackingPort` has no adapter and cannot get one from the spec we hold: the LEX v1
+  document declares only a write operation, so there is nothing to fetch (#1313).
 - V5 (`protocol_version` widened to 64) has run against H2 in PostgreSQL mode only; this environment has
   no Docker daemon for `FlywayMigrationIT`.
 - `EndpointBindingRequest.version` is bounded but not validated against the adapter registry.

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb/EdiwheelB21StockReportCodec.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb/EdiwheelB21StockReportCodec.java
@@ -1,0 +1,258 @@
+package com.positivity.supplier.internal.adapter.ediwheelb;
+
+import com.positivity.supplier.internal.domain.model.PartyContext;
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.domain.model.SupplierStockSnapshot;
+import com.positivity.supplier.internal.spi.SupplierAdapterCodec;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * EDIWheel Stock Report B2.1 codec: {@code GET /B2_1/report} (CAP-322 #1228).
+ *
+ * <p>Registered under {@code (STOCK_REPORT, EDIWHEEL_B, B2_1)} (ADR-0051 §3). Like every codec it
+ * performs no I/O: it produces a transport-free request spec and maps a response body to the
+ * canonical snapshot (ADR-0051 §5).
+ *
+ * <h2>Absence is not zero</h2>
+ *
+ * A stock report lists what the vendor chose to report. A line with no stated quantity decodes to a
+ * null quantity, and an article missing from the document produces no line at all — neither is a
+ * statement that the vendor has none. Coercing either to zero would tell a counter user a tyre is
+ * unavailable on the strength of a vendor's silence.
+ *
+ * <h2>The vendor's clock, and ours</h2>
+ *
+ * {@code issueDate}/{@code issueTime} are the vendor's statement of when the snapshot was taken.
+ * They are decoded as stated and kept distinct from the fetch timestamp the import records: a
+ * report fetched at noon may describe stock as of 06:00, and staleness is measured against the
+ * vendor's figure, not ours.
+ */
+@Component
+@RequiredArgsConstructor
+public class EdiwheelB21StockReportCodec implements SupplierAdapterCodec {
+
+    /** Envelope header date: {@code yyyyMMdd} in the norm's examples. */
+    private static final DateTimeFormatter VENDOR_DATE = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    /** Envelope header time: {@code HHmm} or {@code HHmmss}. */
+    private static final DateTimeFormatter VENDOR_TIME_SHORT = DateTimeFormatter.ofPattern("HHmm");
+
+    private static final DateTimeFormatter VENDOR_TIME_LONG = DateTimeFormatter.ofPattern("HHmmss");
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @NonNull
+    public SupplierCapability capability() {
+        return SupplierCapability.STOCK_REPORT;
+    }
+
+    @Override
+    @NonNull
+    public ProtocolFamily family() {
+        return ProtocolFamily.EDIWHEEL_B;
+    }
+
+    @Override
+    @NonNull
+    public ProtocolVersion version() {
+        return ProtocolVersion.B2_1;
+    }
+
+    /**
+     * Builds the snapshot fetch.
+     *
+     * <p>B2.1 takes no query parameters in the norm — the buyer is identified by the credential the
+     * binding carries. The buyer account is passed here anyway and sent only when the binding's
+     * vendor expects it, because the sibling C1.0 report on the same spec does take
+     * {@code buyerParty}/{@code agencyCode} and a deployment binding a C1.0 endpoint to this codec
+     * would otherwise silently fetch nothing.
+     *
+     * @param partyContext buyer identity from the profile's billing account
+     * @param includeBuyerParty whether to send the buyer identification as query parameters
+     * @return a transport-free request spec
+     */
+    @NonNull
+    public SupplierRequestSpec buildRequest(@NonNull PartyContext partyContext, boolean includeBuyerParty) {
+        Map<String, String> query = new LinkedHashMap<>();
+        if (includeBuyerParty) {
+            query.put("buyerParty", partyContext.billingAccountNumber());
+            if (partyContext.billingAgencyCode() != null
+                    && !partyContext.billingAgencyCode().isBlank()) {
+                query.put("agencyCode", partyContext.billingAgencyCode());
+            }
+        }
+        // Idempotent: a stock report is a read of vendor state with no commercial effect, so a
+        // retry after transmission costs nothing but a second snapshot (ADR-0052 §5).
+        return new SupplierRequestSpec("GET", null, query, null, null, "application/json", true);
+    }
+
+    /**
+     * Decodes a B2.1 response body into the canonical snapshot.
+     *
+     * @param body response body as received
+     * @return the snapshot, including any lines that could not be decoded
+     * @throws StockReportDecodeException when the body is not a B2.1 document, or the vendor
+     *                                    signalled a document-level error code
+     */
+    @NonNull
+    public SupplierStockSnapshot decode(@Nullable String body) {
+        if (body == null || body.isBlank()) {
+            throw new StockReportDecodeException("Stock report response body was empty");
+        }
+        StockReportB21Wire.StockReport report;
+        try {
+            report = objectMapper.readValue(body, StockReportB21Wire.StockReport.class);
+        } catch (Exception e) {
+            throw new StockReportDecodeException("Stock report response body is not a B2.1 document", e);
+        }
+        if (report == null) {
+            throw new StockReportDecodeException("Stock report response body decoded to no document");
+        }
+
+        StockReportB21Wire.EnvelopeHeader header = report.envelopeHeader();
+        String errorCode = header == null ? null : trimToNull(header.errorCode());
+        if (errorCode != null && !"0".equals(errorCode)) {
+            // A document-level error is a vendor rejection, not an empty warehouse. Treating it as
+            // a snapshot would publish "no stock reported" for an entire market.
+            throw new StockReportDecodeException("Stock report carries vendor error code " + errorCode);
+        }
+
+        String documentId = header == null ? null : trimToNull(header.documentId());
+        LocalDate issuedOn = header == null ? null : parseDate(header.issueDate());
+        Instant issuedAt = issuedOn == null ? null : parseInstant(issuedOn, header.issueTime());
+
+        List<StockReportB21Wire.Line> wireLines = report.lineLevel() == null ? List.of() : report.lineLevel();
+        List<SupplierStockSnapshot.Line> lines = new ArrayList<>(wireLines.size());
+        List<SupplierStockSnapshot.RejectedLine> rejected = new ArrayList<>();
+
+        for (StockReportB21Wire.Line wireLine : wireLines) {
+            if (wireLine == null) {
+                rejected.add(new SupplierStockSnapshot.RejectedLine(null, "null stock report line"));
+                continue;
+            }
+            try {
+                lines.add(toLine(wireLine));
+            } catch (IllegalArgumentException e) {
+                rejected.add(new SupplierStockSnapshot.RejectedLine(trimToNull(wireLine.lineId()), e.getMessage()));
+            }
+        }
+
+        return new SupplierStockSnapshot(
+                documentId,
+                issuedOn,
+                issuedAt,
+                report.buyerParty() == null ? null : trimToNull(report.buyerParty()),
+                lines,
+                rejected,
+                wireLines.size());
+    }
+
+    private SupplierStockSnapshot.Line toLine(StockReportB21Wire.Line wireLine) {
+        StockReportB21Wire.Article article = wireLine.article();
+        StockReportB21Wire.ArticleIdentification identity = article == null ? null : article.articleIdentification();
+        String ean = identity == null ? null : trimToNull(identity.eanuccarticleID());
+        String supplierCode = identity == null ? null : trimToNull(identity.manufacturersArticleId());
+        String buyersArticleId = identity == null ? null : trimToNull(identity.buyersArticleId());
+
+        if (ean == null && supplierCode == null && buyersArticleId == null) {
+            throw new IllegalArgumentException("line states no article identity");
+        }
+
+        String description = article == null || article.articleDescription() == null
+                ? null
+                : trimToNull(article.articleDescription().articleDescriptionText());
+
+        Integer quantity = article == null || article.availableQuantity() == null
+                ? null
+                : parseQuantity(article.availableQuantity().quantityValue());
+
+        return new SupplierStockSnapshot.Line(
+                trimToNull(wireLine.lineId()), ean, supplierCode, buyersArticleId, description, quantity);
+    }
+
+    /**
+     * Parses a reported quantity. A blank or absent value yields null — the vendor stated no
+     * quantity, which the caller must not read as zero.
+     */
+    @Nullable
+    private Integer parseQuantity(@Nullable String raw) {
+        String value = trimToNull(raw);
+        if (value == null) {
+            return null;
+        }
+        try {
+            // Some markets state whole quantities with a decimal part ("12.000"); take the integral
+            // part rather than rejecting a line that is perfectly well formed for its market.
+            return new BigDecimal(value.replace(',', '.')).intValueExact();
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException("quantityValue is not a whole number: '" + value + "'");
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("quantityValue is not a number: '" + value + "'");
+        }
+    }
+
+    @Nullable
+    private LocalDate parseDate(@Nullable String raw) {
+        String value = trimToNull(raw);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(value, VENDOR_DATE);
+        } catch (Exception e) {
+            try {
+                return LocalDate.parse(value);
+            } catch (Exception alsoIgnored) {
+                // A header date that will not parse is descriptive only; the import's own fetch
+                // timestamp still bounds the snapshot, so this must not fail a whole document.
+                return null;
+            }
+        }
+    }
+
+    @Nullable
+    private Instant parseInstant(LocalDate date, @Nullable String rawTime) {
+        String value = trimToNull(rawTime);
+        if (value == null) {
+            return null;
+        }
+        LocalTime time;
+        try {
+            time = LocalTime.parse(value, value.length() > 4 ? VENDOR_TIME_LONG : VENDOR_TIME_SHORT);
+        } catch (Exception e) {
+            return null;
+        }
+        // The norm states no zone. UTC is assumed and the assumption is recorded here rather than
+        // hidden: the alternative — the server's zone — would make the same document decode
+        // differently depending on where it was processed.
+        return LocalDateTime.of(date, time).toInstant(ZoneOffset.UTC);
+    }
+
+    @Nullable
+    private static String trimToNull(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb/StockReportB21Wire.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb/StockReportB21Wire.java
@@ -1,0 +1,56 @@
+package com.positivity.supplier.internal.adapter.ediwheelb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/**
+ * Literal shape of an EDIWheel Stock Report B2.1 document
+ * ({@code durion/docs/ediwheel/EDIWHEEL STOCK REPORT PROD_0 (1).yaml}).
+ *
+ * <p>Package-private (ADR-0051 §2): these are vendor types and only the codec in this package may
+ * see them. Quantities arrive as strings, like every other numeric in the EDIWheel norms, and are
+ * parsed at this boundary so a malformed vendor value never becomes a malformed canonical one.
+ */
+final class StockReportB21Wire {
+
+    private StockReportB21Wire() {}
+
+    /** Root document: envelope header, totals, buyer party, and the reported lines. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record StockReport(
+            EnvelopeHeader envelopeHeader, String totalLineItemsNumber, String buyerParty, List<Line> lineLevel) {}
+
+    /**
+     * Document-level header. {@code errorCode} is {@code "0"} on a good document; {@code issueDate}
+     * and {@code issueTime} are the vendor's own statement of when the snapshot was taken, which is
+     * deliberately not the same fact as when we fetched it.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record EnvelopeHeader(String issueDate, String issueTime, String documentId, String variant, String errorCode) {}
+
+    /** One reported line. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Line(String lineId, Article article) {}
+
+    /** One article's identity, description and availability. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Article(
+            ArticleIdentification articleIdentification,
+            ArticleDescription articleDescription,
+            AvailableQuantity availableQuantity) {}
+
+    /** Vendor article identity. {@code eanuccarticleID} is the EAN/GTIN. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record ArticleIdentification(String buyersArticleId, String manufacturersArticleId, String eanuccarticleID) {}
+
+    /** Vendor article description text. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record ArticleDescription(String articleDescriptionText) {}
+
+    /**
+     * Reported quantity. Absent or blank means the vendor stated no quantity for the line, which is
+     * not the same as reporting zero.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record AvailableQuantity(String quantityValue) {}
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb/StockReportDecodeException.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb/StockReportDecodeException.java
@@ -1,0 +1,20 @@
+package com.positivity.supplier.internal.adapter.ediwheelb;
+
+/**
+ * The vendor answered, but with something that is not a usable B2.1 stock report — an unparseable
+ * body, or one carrying a document-level vendor error code.
+ *
+ * <p>Distinct from a rejected line, which is quarantined while the snapshot continues. This fails
+ * the whole snapshot, and it must: publishing a vendor rejection as an empty stock report would
+ * tell every consumer that an entire market has nothing in stock.
+ */
+public class StockReportDecodeException extends RuntimeException {
+
+    public StockReportDecodeException(String message) {
+        super(message);
+    }
+
+    public StockReportDecodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/SupplierStockSnapshot.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/SupplierStockSnapshot.java
@@ -1,0 +1,77 @@
+package com.positivity.supplier.internal.domain.model;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One vendor stock-report snapshot: what the vendor said it had, for a whole market, at one
+ * moment (EDIWheel Stock Report B2.1).
+ *
+ * <p>The dedicated model {@code SupplierStockReportPort} was waiting for (CAP-322). It differs
+ * from a stock <em>inquiry</em> in what its silences mean: an inquiry asks about named articles
+ * and answers each one, while a snapshot lists what the vendor chose to report. An article
+ * missing from a snapshot is therefore <strong>no data</strong>, not zero stock — the vendor did
+ * not say it has none, it did not mention it. Consumers must not turn absence into availability
+ * of zero.
+ *
+ * @param documentId    vendor document id from the envelope header, when stated
+ * @param issuedOn      vendor-stated issue date of the document
+ * @param issuedAt      vendor-stated issue instant when the document carried a time; else null
+ * @param buyerParty    buyer account the snapshot was produced for
+ * @param lines         per-article availability the vendor reported
+ * @param rejectedLines lines that could not be decoded, kept with their reason
+ * @param linesFetched  how many lines the document contained before any filtering
+ */
+public record SupplierStockSnapshot(
+        @Nullable String documentId,
+        @Nullable LocalDate issuedOn,
+        @Nullable Instant issuedAt,
+        @Nullable String buyerParty,
+        @NonNull List<Line> lines,
+        @NonNull List<RejectedLine> rejectedLines,
+        int linesFetched) {
+
+    public SupplierStockSnapshot {
+        Objects.requireNonNull(lines, "lines must not be null");
+        Objects.requireNonNull(rejectedLines, "rejectedLines must not be null");
+        lines = List.copyOf(lines);
+        rejectedLines = List.copyOf(rejectedLines);
+    }
+
+    /**
+     * One article's reported availability.
+     *
+     * @param lineId              vendor line id, when stated
+     * @param articleEan          EAN/GTIN identity, when stated
+     * @param supplierArticleCode vendor's own article code — an alias, never an identifier
+     * @param buyersArticleId     the buyer's own code as the vendor holds it, when stated
+     * @param description         vendor article description, when stated
+     * @param availableQuantity   quantity the vendor reported; null means the vendor stated none,
+     *                            which is not the same as reporting zero
+     */
+    public record Line(
+            @Nullable String lineId,
+            @Nullable String articleEan,
+            @Nullable String supplierArticleCode,
+            @Nullable String buyersArticleId,
+            @Nullable String description,
+            @Nullable Integer availableQuantity) {}
+
+    /**
+     * A line the codec could not decode.
+     *
+     * @param lineId vendor line id, when stated
+     * @param detail operator-facing explanation; never a payload dump
+     */
+    public record RejectedLine(
+            @Nullable String lineId, @NonNull String detail) {
+
+        public RejectedLine {
+            Objects.requireNonNull(detail, "detail must not be null");
+        }
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/SupplierStockSnapshot.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/SupplierStockSnapshot.java
@@ -50,8 +50,10 @@ public record SupplierStockSnapshot(
      * @param supplierArticleCode vendor's own article code — an alias, never an identifier
      * @param buyersArticleId     the buyer's own code as the vendor holds it, when stated
      * @param description         vendor article description, when stated
-     * @param availableQuantity   quantity the vendor reported; null means the vendor stated none,
-     *                            which is not the same as reporting zero
+     * @param availableQuantity   quantity the vendor stated for this line. Null means the vendor
+     *                            listed the article WITHOUT stating any quantity — it is not a
+     *                            statement that stock is zero. An explicit {@code 0} is that
+     *                            statement, and the two must never be collapsed
      */
     public record Line(
             @Nullable String lineId,

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/StockSnapshotEntity.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/StockSnapshotEntity.java
@@ -1,0 +1,128 @@
+package com.positivity.supplier.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * One vendor stock-report snapshot fetch (CAP-322 #1228): what the vendor said it had, for a whole
+ * market, at one moment.
+ *
+ * <p>Snapshots are append-only and never merged. A later snapshot does not correct an earlier one —
+ * it describes a different moment, and both remain true of theirs. That is why "latest" is a query
+ * over {@link #snapshotAsOf} rather than an update in place, and why a failed fetch leaves the
+ * previous snapshot standing as the last thing the vendor actually said.
+ *
+ * <p>Like the exchange audit and the PRICAT import, no foreign key to {@code supplier_profile}:
+ * ADR-0050 §6/§7 require the received-document record to outlive the configuration that produced it.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "supplier_stock_snapshot",
+        indexes = {
+            @Index(name = "idx_sstock_snapshot_profile_asof", columnList = "vendor_profile_id, snapshot_as_of"),
+            @Index(name = "idx_sstock_snapshot_status", columnList = "status"),
+            @Index(name = "idx_sstock_snapshot_correlation", columnList = "correlation_id")
+        })
+public class StockSnapshotEntity {
+
+    /** Snapshot identity (UUIDv7); the event aggregate id and Kafka record key. */
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "snapshot_id", updatable = false, nullable = false)
+    private UUID snapshotId;
+
+    @Column(name = "vendor_profile_id", nullable = false, updatable = false)
+    private UUID vendorProfileId;
+
+    /** Profile alias as at the fetch; descriptive snapshot only, never a query key. */
+    @Column(name = "supplier_ref", nullable = false, updatable = false, length = 100)
+    private String supplierRef;
+
+    @Column(name = "protocol_version", nullable = false, updatable = false, length = 64)
+    private String protocolVersion;
+
+    @Column(name = "status", nullable = false, length = 32)
+    private String status;
+
+    @Column(name = "document_id", length = 255)
+    private String documentId;
+
+    /** Vendor-stated issue date of the document. */
+    @Column(name = "issued_on")
+    private LocalDate issuedOn;
+
+    /**
+     * Vendor-stated snapshot instant. Distinct from {@link #fetchedAt} on purpose: staleness is
+     * measured against what the vendor said, not against when we asked.
+     */
+    @Column(name = "snapshot_as_of")
+    private Instant snapshotAsOf;
+
+    @Column(name = "buyer_account_number", nullable = false, length = 64)
+    private String buyerAccountNumber;
+
+    @Column(name = "country_code", length = 8)
+    private String countryCode;
+
+    @Column(name = "fetched_at", nullable = false)
+    private Instant fetchedAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    @Column(name = "lines_reported", nullable = false)
+    @Builder.Default
+    private int linesReported = 0;
+
+    @Column(name = "lines_rejected", nullable = false)
+    @Builder.Default
+    private int linesRejected = 0;
+
+    @Column(name = "chunk_count", nullable = false)
+    @Builder.Default
+    private int chunkCount = 0;
+
+    @Column(name = "chunk_size", nullable = false)
+    @Builder.Default
+    private int chunkSize = 0;
+
+    @Column(name = "exchange_audit_id")
+    private UUID exchangeAuditId;
+
+    @Column(name = "correlation_id", nullable = false, length = 100)
+    private String correlationId;
+
+    /** Operator-facing failure summary for a FAILED snapshot; never a credential. */
+    @Column(name = "failure_detail", length = 2000)
+    private String failureDetail;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false, length = 100)
+    private String createdBy;
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/StockSnapshotLineEntity.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/StockSnapshotLineEntity.java
@@ -1,0 +1,80 @@
+package com.positivity.supplier.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * One article's reported availability within a stock snapshot (CAP-322 #1228).
+ *
+ * <p>{@code availableQuantity} is nullable and the nullability is the point: null means the vendor
+ * reported the article without stating a quantity, zero means it explicitly reported none. The
+ * column is therefore deliberately NOT declared NOT NULL with a zero default — a default would
+ * silently convert "the vendor said nothing" into "the vendor said none", which is the single
+ * mistake this feed most needs to avoid.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "supplier_stock_snapshot_line",
+        indexes = {
+            @Index(name = "idx_sstock_line_snapshot", columnList = "snapshot_id"),
+            @Index(name = "idx_sstock_line_ean", columnList = "vendor_profile_id, article_ean")
+        })
+public class StockSnapshotLineEntity {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "line_id", updatable = false, nullable = false)
+    private UUID lineId;
+
+    @Column(name = "snapshot_id", nullable = false, updatable = false)
+    private UUID snapshotId;
+
+    @Column(name = "vendor_profile_id", nullable = false, updatable = false)
+    private UUID vendorProfileId;
+
+    /** Vendor's own line id within the document, when stated. */
+    @Column(name = "vendor_line_id", updatable = false, length = 64)
+    private String vendorLineId;
+
+    @Column(name = "article_ean", updatable = false, length = 64)
+    private String articleEan;
+
+    /** Vendor's own article code — an alias for display, never an identifier. */
+    @Column(name = "supplier_article_code", updatable = false, length = 64)
+    private String supplierArticleCode;
+
+    /** The buyer's own code as the vendor holds it, when stated. */
+    @Column(name = "buyers_article_id", updatable = false, length = 64)
+    private String buyersArticleId;
+
+    @Column(name = "description", updatable = false, length = 512)
+    private String description;
+
+    /** Null means the vendor stated no quantity; zero means it reported none. */
+    @Column(name = "available_quantity", updatable = false)
+    private Integer availableQuantity;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/SupplierEndpointBindingEntity.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/SupplierEndpointBindingEntity.java
@@ -102,16 +102,17 @@ public class SupplierEndpointBindingEntity {
     private boolean enabled;
 
     /**
-     * Per-binding chunk size for catalog-style batch capabilities (ADR-0053 §7); {@code null} uses
-     * the deployment default {@code pos.supplier.pricat.chunk-size}.
+     * Per-binding chunk size for every chunked batch feed this binding drives — the price catalog
+     * (ADR-0053 §7) and the stock report alike; {@code null} uses the feed's deployment default.
      *
      * <p>Lives on the binding rather than in configuration alone because the right value is a
      * property of one vendor's documents — how many lines fit a broker message depends on how wide
      * that vendor's lines are — and a deployment talking to two vendors should not have to pick one
-     * number for both.
+     * number for both. One column rather than one per feed, so tuning a vendor cannot leave half
+     * its feeds on the default by accident.
      */
-    @Column(name = "pricat_chunk_size")
-    private Integer pricatChunkSize;
+    @Column(name = "event_chunk_size")
+    private Integer eventChunkSize;
 
     /** Exchange-audit payload capture level (ADR-0050 §7); {@code null} = deployment default. */
     @Enumerated(EnumType.STRING)

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/PriceCatalogImporter.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/PriceCatalogImporter.java
@@ -126,9 +126,9 @@ public class PriceCatalogImporter {
         }
 
         PreparedImport prepared = prepare(document, importManifestId);
-        int chunkSize = binding.binding().getPricatChunkSize() == null
+        int chunkSize = binding.binding().getEventChunkSize() == null
                 ? defaultChunkSize
-                : binding.binding().getPricatChunkSize();
+                : binding.binding().getEventChunkSize();
 
         return stagingWriter.commit(
                 prepared, document, binding, billing, importManifestId, correlationId, fetchedAt, chunkSize);

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/repository/StockSnapshotLineRepository.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/repository/StockSnapshotLineRepository.java
@@ -1,0 +1,14 @@
+package com.positivity.supplier.internal.repository;
+
+import com.positivity.supplier.internal.entity.StockSnapshotLineEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Lines of a vendor stock snapshot (CAP-322). */
+public interface StockSnapshotLineRepository extends JpaRepository<StockSnapshotLineEntity, UUID> {
+
+    List<StockSnapshotLineEntity> findBySnapshotIdOrderByCreatedAtAsc(UUID snapshotId);
+
+    long countBySnapshotId(UUID snapshotId);
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/repository/StockSnapshotRepository.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/repository/StockSnapshotRepository.java
@@ -1,0 +1,17 @@
+package com.positivity.supplier.internal.repository;
+
+import com.positivity.supplier.internal.entity.StockSnapshotEntity;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Append-only vendor stock snapshots (CAP-322). */
+public interface StockSnapshotRepository extends JpaRepository<StockSnapshotEntity, UUID> {
+
+    Page<StockSnapshotEntity> findByVendorProfileIdOrderByFetchedAtDesc(UUID vendorProfileId, Pageable pageable);
+
+    Optional<StockSnapshotEntity> findFirstByVendorProfileIdAndStatusOrderByFetchedAtDesc(
+            UUID vendorProfileId, String status);
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/stockreport/service/StockReportImporter.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/stockreport/service/StockReportImporter.java
@@ -1,0 +1,145 @@
+package com.positivity.supplier.internal.stockreport.service;
+
+import com.positivity.supplier.internal.adapter.ediwheelb.EdiwheelB21StockReportCodec;
+import com.positivity.supplier.internal.adapter.ediwheelb.StockReportDecodeException;
+import com.positivity.supplier.internal.audit.SupplierCorrelationContext;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.client.SupplierHttpRequest;
+import com.positivity.supplier.internal.client.SupplierHttpResponse;
+import com.positivity.supplier.internal.domain.model.PartyContext;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.domain.model.SupplierStockSnapshot;
+import com.positivity.supplier.internal.entity.StockSnapshotEntity;
+import com.positivity.supplier.internal.entity.SupplierAccountEntity;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.registry.AdapterResolution;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedPartyAccounts;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+
+/**
+ * Runs one vendor stock-report fetch end to end (CAP-322 #1228).
+ *
+ * <p>Resolve the binding and buyer account, fetch through the shared base client, decode with the
+ * registered codec, then hand the snapshot to {@link StockReportSnapshotWriter}, which commits it
+ * with its events.
+ *
+ * <h2>A failed fetch keeps the last good snapshot</h2>
+ *
+ * Snapshots are append-only and nothing here supersedes or deletes one. A failed exchange or an
+ * undecodable document records a {@code FAILED} snapshot and stops, so a consumer's availability
+ * hints keep their existing staleness rather than being replaced by an empty answer. A vendor
+ * outage is not a statement that a warehouse is empty — the same rule PRICAT applies to prices.
+ *
+ * <h2>Absence carries through</h2>
+ *
+ * The codec decodes an unstated quantity to null and this layer never fills it in. Whether an
+ * article missing from a snapshot means "gone" or "unmentioned" is the consumer's judgement, and
+ * pos-inventory cannot make it correctly if the producer has already guessed.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockReportImporter {
+
+    /** Same default as PRICAT: a country-level report is as wide as a catalog (ADR-0053 §7). */
+    public static final int DEFAULT_CHUNK_SIZE = 500;
+
+    private final SupplierProfileResolver profileResolver;
+    private final AdapterRegistry adapterRegistry;
+    private final SupplierBaseClient baseClient;
+    private final StockReportSnapshotWriter snapshotWriter;
+    private final Clock clock;
+
+    @Value("${pos.supplier.stockreport.chunk-size:" + DEFAULT_CHUNK_SIZE + "}")
+    private int defaultChunkSize;
+
+    @Value("${pos.supplier.stockreport.send-buyer-party:false}")
+    private boolean sendBuyerParty;
+
+    /**
+     * Fetches and records the vendor's current stock snapshot.
+     *
+     * @param supplierRef vendor profile alias to fetch for
+     * @return the persisted snapshot row; a failed fetch is a terminal row, not an exception
+     * @throws SupplierConfigurationException when the profile, binding, codec or billing account is
+     *                                        not configured — a deployment defect, surfaced loudly
+     */
+    @NonNull
+    public StockSnapshotEntity runSnapshot(@NonNull SupplierRef supplierRef) {
+        ResolvedBinding binding = profileResolver.resolveBinding(supplierRef, SupplierCapability.STOCK_REPORT);
+        EdiwheelB21StockReportCodec codec = resolveCodec(binding);
+        ResolvedPartyAccounts accounts = profileResolver.resolvePartyContext(supplierRef, null);
+        SupplierAccountEntity billing = accounts.billing();
+
+        String correlationId = SupplierCorrelationContext.currentOrGenerate();
+        Instant fetchedAt = Instant.now(clock);
+
+        PartyContext partyContext = new PartyContext(billing.getAccountNumber(), billing.getAgencyCode(), null);
+        SupplierRequestSpec spec = codec.buildRequest(partyContext, sendBuyerParty);
+        SupplierHttpResponse response = baseClient.exchange(toHttpRequest(binding, spec));
+
+        if (!response.isSuccess()) {
+            return snapshotWriter.persistFailure(
+                    binding,
+                    billing,
+                    correlationId,
+                    fetchedAt,
+                    "vendor exchange failed: " + response.outcome()
+                            + (response.failureDetail() == null ? "" : " — " + response.failureDetail()));
+        }
+
+        SupplierStockSnapshot snapshot;
+        try {
+            snapshot = codec.decode(response.body());
+        } catch (StockReportDecodeException e) {
+            return snapshotWriter.persistFailure(binding, billing, correlationId, fetchedAt, e.getMessage());
+        }
+
+        int chunkSize = binding.binding().getEventChunkSize() == null
+                ? defaultChunkSize
+                : binding.binding().getEventChunkSize();
+
+        return snapshotWriter.commit(snapshot, binding, billing, correlationId, fetchedAt, chunkSize);
+    }
+
+    /**
+     * Turns the codec's transport-free spec into a transport request against the resolved binding.
+     * The join lives here so the adapter package stays free of transport types (ADR-0051 §2).
+     */
+    private SupplierHttpRequest toHttpRequest(ResolvedBinding binding, SupplierRequestSpec spec) {
+        return new SupplierHttpRequest(
+                binding,
+                HttpMethod.valueOf(spec.method()),
+                spec.pathSuffix(),
+                spec.queryParams(),
+                spec.body(),
+                spec.contentType(),
+                spec.accept(),
+                spec.idempotent());
+    }
+
+    private EdiwheelB21StockReportCodec resolveCodec(ResolvedBinding binding) {
+        AdapterResolution resolution =
+                adapterRegistry.resolve(SupplierCapability.STOCK_REPORT, binding.family(), binding.version());
+        if (resolution instanceof AdapterResolution.Resolved resolved
+                && resolved.codec() instanceof EdiwheelB21StockReportCodec codec) {
+            return codec;
+        }
+        throw new SupplierConfigurationException(
+                SupplierConfigurationException.CAPABILITY_NOT_CONFIGURED,
+                "No stock-report codec registered for " + binding.family() + " "
+                        + binding.version().value());
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/stockreport/service/StockReportScheduler.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/stockreport/service/StockReportScheduler.java
@@ -1,0 +1,121 @@
+package com.positivity.supplier.internal.stockreport.service;
+
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.entity.StockSnapshotEntity;
+import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.repository.StockSnapshotRepository;
+import com.positivity.supplier.internal.repository.SupplierEndpointBindingRepository;
+import com.positivity.supplier.internal.repository.SupplierProfileRepository;
+import com.positivity.supplier.internal.service.SupplierScheduleCoordinator;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.support.CronExpression;
+import org.springframework.stereotype.Component;
+
+/**
+ * Fires scheduled stock-report snapshots for bindings that carry a cron (CAP-322 #1228).
+ *
+ * <p>Same shape as the PRICAT scheduler and for the same reasons: a poll re-reads binding
+ * configuration every cycle so a retimed or disabled binding takes effect without a restart, the
+ * schedule lease keeps two instances from fetching the same snapshot twice, and the coordinator's
+ * checkpointed page mechanism is deliberately unused because a stock report is a whole snapshot
+ * rather than a window — there is nothing to advance a checkpoint over.
+ *
+ * <p>"When did this last run" is answered by the snapshot table, which is the real record.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.supplier.stockreport", name = "scheduler-enabled", matchIfMissing = true)
+public class StockReportScheduler {
+
+    private final SupplierEndpointBindingRepository bindingRepository;
+    private final SupplierProfileRepository profileRepository;
+    private final StockSnapshotRepository snapshotRepository;
+    private final SupplierScheduleCoordinator scheduleCoordinator;
+    private final StockReportImporter importer;
+    private final Clock clock;
+
+    /** Polls due bindings. Each runs at most once per tick, on at most one instance. */
+    @Scheduled(fixedDelayString = "${pos.supplier.stockreport.poll-interval-ms:60000}")
+    public void runDueSnapshots() {
+        Instant now = Instant.now(clock);
+        for (SupplierEndpointBindingEntity binding :
+                bindingRepository.findByCapabilityAndEnabledTrueAndScheduleCronIsNotNull(
+                        SupplierCapability.STOCK_REPORT)) {
+            try {
+                runIfDue(binding, now);
+            } catch (Exception e) {
+                // One unreachable vendor must not stop the others from refreshing their snapshots.
+                log.warn("Scheduled stock report for binding {} failed: {}", binding.getId(), e.toString(), e);
+            }
+        }
+    }
+
+    private void runIfDue(SupplierEndpointBindingEntity binding, Instant now) {
+        Optional<SupplierProfileEntity> profile = profileRepository.findById(binding.getVendorProfileId());
+        if (profile.isEmpty() || !profile.get().isEnabled()) {
+            return;
+        }
+        if (!isDue(binding, now)) {
+            return;
+        }
+
+        String ownerToken = SupplierScheduleCoordinator.newOwnerToken();
+        if (!scheduleCoordinator.tryClaim(binding.getId(), ownerToken)) {
+            return;
+        }
+        String outcome = "FAILED";
+        try {
+            StockSnapshotEntity result =
+                    importer.runSnapshot(new SupplierRef(profile.get().getSupplierRef()));
+            outcome = result.getStatus();
+            log.info(
+                    "Scheduled stock snapshot {} for profile {} finished with status {}",
+                    result.getSnapshotId(),
+                    result.getVendorProfileId(),
+                    result.getStatus());
+        } finally {
+            // Released whatever happened: holding the lease after a failure would block the next
+            // scheduled attempt until it expired.
+            scheduleCoordinator.release(binding.getId(), ownerToken, outcome);
+        }
+    }
+
+    private boolean isDue(SupplierEndpointBindingEntity binding, Instant now) {
+        CronExpression cron;
+        try {
+            cron = CronExpression.parse(binding.getScheduleCron());
+        } catch (IllegalArgumentException e) {
+            // Logged every tick on purpose: a binding that silently never fires is exactly the
+            // failure an operator cannot see.
+            log.warn(
+                    "Binding {} has an unparseable schedule cron '{}': {}",
+                    binding.getId(),
+                    binding.getScheduleCron(),
+                    e.getMessage());
+            return false;
+        }
+        Optional<StockSnapshotEntity> last =
+                snapshotRepository
+                        .findByVendorProfileIdOrderByFetchedAtDesc(binding.getVendorProfileId(), PageRequest.of(0, 1))
+                        .stream()
+                        .findFirst();
+        if (last.isEmpty()) {
+            return true;
+        }
+        LocalDateTime lastRun = LocalDateTime.ofInstant(last.get().getFetchedAt(), ZoneOffset.UTC);
+        LocalDateTime next = cron.next(lastRun);
+        return next != null && !next.isAfter(LocalDateTime.ofInstant(now, ZoneOffset.UTC));
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/stockreport/service/StockReportSnapshotWriter.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/stockreport/service/StockReportSnapshotWriter.java
@@ -1,0 +1,224 @@
+package com.positivity.supplier.internal.stockreport.service;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.DomainTopics;
+import com.positivity.domainevents.supplier.SupplierStockReportLine;
+import com.positivity.domainevents.supplier.SupplierStockReportUpdatedV1;
+import com.positivity.shared.id.UUIDv7Generator;
+import com.positivity.supplier.internal.domain.model.SupplierStockSnapshot;
+import com.positivity.supplier.internal.entity.StockSnapshotEntity;
+import com.positivity.supplier.internal.entity.StockSnapshotLineEntity;
+import com.positivity.supplier.internal.entity.SupplierAccountEntity;
+import com.positivity.supplier.internal.repository.StockSnapshotLineRepository;
+import com.positivity.supplier.internal.repository.StockSnapshotRepository;
+import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Commits one stock snapshot and the events describing it, in a single transaction
+ * (ADR-0044 §4, CAP-322).
+ *
+ * <p>Separate from the fetch orchestration for the same reason the PRICAT writer is: a
+ * {@code @Transactional} method called from a sibling method of the same bean is not proxied, so
+ * "the snapshot and its events commit together" would silently not be true.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockReportSnapshotWriter {
+
+    /** Snapshot statuses; a failed or empty fetch is a recorded outcome, not an exception. */
+    public static final String STATUS_COMPLETED = "COMPLETED";
+
+    public static final String STATUS_EMPTY = "EMPTY";
+
+    public static final String STATUS_FAILED = "FAILED";
+
+    /**
+     * B2.1 states no market on the document and the vendor profile carries no country, so the
+     * snapshot's scope is the buyer account alone. The column and the event field stay for the
+     * sibling C1.0 report, whose request does take a market — recording null here is honest, where
+     * inventing a country would give a consumer a scope the vendor never stated.
+     */
+    private static final String NO_MARKET_STATED = null;
+
+    private final StockSnapshotRepository snapshotRepository;
+    private final StockSnapshotLineRepository snapshotLineRepository;
+    private final SupplierOutboxEventWriter outboxWriter;
+    private final Clock clock;
+
+    /**
+     * Persists a decoded snapshot and publishes it as chunked {@code supplier.stockreport.updated}
+     * events.
+     *
+     * <p>Chunked for the same reason PRICAT is: a country-level stock report is as wide as a
+     * catalog, and one message would exceed broker limits for a real dealer. Each chunk carries its
+     * sequence and the total, so a consumer can detect a gap without a second event type.
+     */
+    @NonNull
+    @Transactional
+    public StockSnapshotEntity commit(
+            @NonNull SupplierStockSnapshot snapshot,
+            @NonNull ResolvedBinding binding,
+            @NonNull SupplierAccountEntity billing,
+            @NonNull String correlationId,
+            @NonNull Instant fetchedAt,
+            int chunkSize) {
+
+        List<List<SupplierStockSnapshot.Line>> chunks = partition(snapshot.lines(), chunkSize);
+        Instant completedAt = Instant.now(clock);
+        String status = snapshot.lines().isEmpty() ? STATUS_EMPTY : STATUS_COMPLETED;
+
+        StockSnapshotEntity row = snapshotRepository.save(StockSnapshotEntity.builder()
+                .vendorProfileId(binding.profile().getVendorProfileId())
+                .supplierRef(binding.profile().getSupplierRef())
+                .protocolVersion(binding.version().value())
+                .status(status)
+                .documentId(snapshot.documentId())
+                .issuedOn(snapshot.issuedOn())
+                .snapshotAsOf(snapshot.issuedAt())
+                .buyerAccountNumber(billing.getAccountNumber())
+                .countryCode(NO_MARKET_STATED)
+                .fetchedAt(fetchedAt)
+                .completedAt(completedAt)
+                .linesReported(snapshot.lines().size())
+                .linesRejected(snapshot.rejectedLines().size())
+                .chunkCount(chunks.size())
+                .chunkSize(chunkSize)
+                .correlationId(correlationId)
+                .build());
+
+        for (SupplierStockSnapshot.Line line : snapshot.lines()) {
+            snapshotLineRepository.save(StockSnapshotLineEntity.builder()
+                    .snapshotId(row.getSnapshotId())
+                    .vendorProfileId(row.getVendorProfileId())
+                    .vendorLineId(line.lineId())
+                    .articleEan(line.articleEan())
+                    .supplierArticleCode(line.supplierArticleCode())
+                    .buyersArticleId(line.buyersArticleId())
+                    .description(truncate(line.description(), 512))
+                    .availableQuantity(line.availableQuantity())
+                    .build());
+        }
+
+        publish(row, chunks);
+
+        log.info(
+                "Stock snapshot {} for profile {}: {} lines reported, {} rejected, {} chunks, vendor asOf {}",
+                row.getSnapshotId(),
+                row.getVendorProfileId(),
+                row.getLinesReported(),
+                row.getLinesRejected(),
+                chunks.size(),
+                row.getSnapshotAsOf());
+        return row;
+    }
+
+    /**
+     * Records a failed fetch or decode. No lines, no events: the previous snapshot stays the last
+     * thing the vendor actually said, and a consumer's hints keep their existing staleness rather
+     * than being replaced by an empty answer.
+     */
+    @NonNull
+    @Transactional
+    public StockSnapshotEntity persistFailure(
+            @NonNull ResolvedBinding binding,
+            @NonNull SupplierAccountEntity billing,
+            @NonNull String correlationId,
+            @NonNull Instant fetchedAt,
+            @Nullable String failureDetail) {
+        StockSnapshotEntity row = snapshotRepository.save(StockSnapshotEntity.builder()
+                .vendorProfileId(binding.profile().getVendorProfileId())
+                .supplierRef(binding.profile().getSupplierRef())
+                .protocolVersion(binding.version().value())
+                .status(STATUS_FAILED)
+                .buyerAccountNumber(billing.getAccountNumber())
+                .countryCode(NO_MARKET_STATED)
+                .fetchedAt(fetchedAt)
+                .correlationId(correlationId)
+                .failureDetail(truncate(failureDetail, 2000))
+                .build());
+        log.warn("Stock snapshot {} failed: {}", row.getSnapshotId(), failureDetail);
+        return row;
+    }
+
+    private void publish(StockSnapshotEntity row, List<List<SupplierStockSnapshot.Line>> chunks) {
+        String topic = DomainTopics.events("supplier");
+        int sequence = 0;
+        for (List<SupplierStockSnapshot.Line> chunk : chunks) {
+            sequence++;
+            SupplierStockReportUpdatedV1 payload = new SupplierStockReportUpdatedV1(
+                    row.getSnapshotId(),
+                    row.getVendorProfileId(),
+                    row.getSupplierRef(),
+                    sequence,
+                    chunks.size(),
+                    row.getDocumentId(),
+                    row.getBuyerAccountNumber(),
+                    row.getCountryCode(),
+                    row.getSnapshotAsOf(),
+                    row.getFetchedAt(),
+                    row.getLinesReported(),
+                    chunk.stream().map(StockReportSnapshotWriter::toEventLine).toList());
+            outboxWriter.publish(
+                    topic,
+                    new DomainEventEnvelope<>(
+                            UUIDv7Generator.generate(),
+                            SupplierStockReportUpdatedV1.EVENT_TYPE,
+                            SupplierStockReportUpdatedV1.SCHEMA_VERSION,
+                            row.getSnapshotId(),
+                            sequence,
+                            Instant.now(clock),
+                            "pos-supplier",
+                            row.getCorrelationId(),
+                            row.getCreatedBy(),
+                            payload));
+        }
+    }
+
+    private static SupplierStockReportLine toEventLine(SupplierStockSnapshot.Line line) {
+        return new SupplierStockReportLine(
+                line.articleEan(),
+                line.supplierArticleCode(),
+                line.buyersArticleId(),
+                line.description(),
+                line.availableQuantity());
+    }
+
+    private static <T> List<List<T>> partition(List<T> items, int size) {
+        if (items.isEmpty()) {
+            return List.of();
+        }
+        int chunkSize = Math.max(1, size);
+        List<List<T>> chunks = new ArrayList<>((items.size() + chunkSize - 1) / chunkSize);
+        for (int start = 0; start < items.size(); start += chunkSize) {
+            chunks.add(List.copyOf(items.subList(start, Math.min(items.size(), start + chunkSize))));
+        }
+        return chunks;
+    }
+
+    @Nullable
+    private static String truncate(@Nullable String value, int max) {
+        if (value == null) {
+            return null;
+        }
+        return value.length() <= max ? value : value.substring(0, max);
+    }
+
+    /** Snapshot id accessor used by the orchestration layer's logging. */
+    @NonNull
+    public static UUID idOf(@NonNull StockSnapshotEntity snapshot) {
+        return snapshot.getSnapshotId();
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/stockreport/service/StockReportSnapshotWriter.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/stockreport/service/StockReportSnapshotWriter.java
@@ -43,6 +43,15 @@ public class StockReportSnapshotWriter {
 
     public static final String STATUS_EMPTY = "EMPTY";
 
+    /**
+     * The vendor sent lines and none of them decoded. Distinct from {@link #STATUS_EMPTY} on
+     * purpose: "the vendor reported nothing" and "the vendor reported something we could not read"
+     * are different problems with different owners — the first is a quiet warehouse, the second is
+     * a codec or a vendor format change — and an operator filtering on EMPTY would never see the
+     * second.
+     */
+    public static final String STATUS_REJECTED = "REJECTED";
+
     public static final String STATUS_FAILED = "FAILED";
 
     /**
@@ -78,7 +87,7 @@ public class StockReportSnapshotWriter {
 
         List<List<SupplierStockSnapshot.Line>> chunks = partition(snapshot.lines(), chunkSize);
         Instant completedAt = Instant.now(clock);
-        String status = snapshot.lines().isEmpty() ? STATUS_EMPTY : STATUS_COMPLETED;
+        String status = classify(snapshot);
 
         StockSnapshotEntity row = snapshotRepository.save(StockSnapshotEntity.builder()
                 .vendorProfileId(binding.profile().getVendorProfileId())
@@ -151,6 +160,18 @@ public class StockReportSnapshotWriter {
                 .build());
         log.warn("Stock snapshot {} failed: {}", row.getSnapshotId(), failureDetail);
         return row;
+    }
+
+    /**
+     * A document with no lines at all is {@code EMPTY}; one whose lines all failed to decode is
+     * {@code REJECTED}; anything with at least one usable line is {@code COMPLETED}, with the
+     * rejected count recorded alongside.
+     */
+    private static String classify(SupplierStockSnapshot snapshot) {
+        if (!snapshot.lines().isEmpty()) {
+            return STATUS_COMPLETED;
+        }
+        return snapshot.linesFetched() == 0 ? STATUS_EMPTY : STATUS_REJECTED;
     }
 
     private void publish(StockSnapshotEntity row, List<List<SupplierStockSnapshot.Line>> chunks) {

--- a/pos-supplier/src/main/resources/application.yml
+++ b/pos-supplier/src/main/resources/application.yml
@@ -119,6 +119,18 @@ pos:
       # binding's own cron.
       poll-interval-ms: ${SUPPLIER_PRICAT_POLL_INTERVAL_MS:60000}
       scheduler-enabled: ${SUPPLIER_PRICAT_SCHEDULER_ENABLED:true}
+    # ── Stock report / B2.1 (CAP-322) ───────────────────────────────────────────────────
+    #
+    # Same chunking problem as PRICAT: a country-level report is as wide as a catalog. A binding
+    # may override the size; the binding column governs both feeds.
+    stockreport:
+      chunk-size: ${SUPPLIER_STOCKREPORT_CHUNK_SIZE:500}
+      poll-interval-ms: ${SUPPLIER_STOCKREPORT_POLL_INTERVAL_MS:60000}
+      scheduler-enabled: ${SUPPLIER_STOCKREPORT_SCHEDULER_ENABLED:true}
+      # B2.1 identifies the buyer by credential and takes no query parameters. The sibling C1.0
+      # report on the same spec DOES take buyerParty/agencyCode, so a deployment binding a C1.0
+      # endpoint to this codec turns this on rather than silently fetching nothing.
+      send-buyer-party: ${SUPPLIER_STOCKREPORT_SEND_BUYER_PARTY:false}
     # ── Event outbox drain (ADR-0044 §4) ────────────────────────────────────────────────
     outbox:
       poll-interval-ms: ${SUPPLIER_OUTBOX_POLL_INTERVAL_MS:1000}

--- a/pos-supplier/src/main/resources/db/migration/V10__stock_report_snapshots.sql
+++ b/pos-supplier/src/main/resources/db/migration/V10__stock_report_snapshots.sql
@@ -45,8 +45,11 @@ CREATE TABLE supplier_stock_snapshot (
     created_by character varying(100),
 
     CONSTRAINT pk_supplier_stock_snapshot PRIMARY KEY (snapshot_id),
+    -- REJECTED is deliberately distinct from EMPTY: "the vendor reported nothing" and "the vendor
+    -- reported something we could not read" are different problems with different owners, and an
+    -- operator filtering on EMPTY would never see the second.
     CONSTRAINT ck_sstock_snapshot_status
-        CHECK (status IN ('COMPLETED', 'EMPTY', 'FAILED'))
+        CHECK (status IN ('COMPLETED', 'EMPTY', 'REJECTED', 'FAILED'))
 );
 
 CREATE INDEX idx_sstock_snapshot_profile_asof ON supplier_stock_snapshot (vendor_profile_id, snapshot_as_of);

--- a/pos-supplier/src/main/resources/db/migration/V10__stock_report_snapshots.sql
+++ b/pos-supplier/src/main/resources/db/migration/V10__stock_report_snapshots.sql
@@ -1,0 +1,85 @@
+-- CAP-322 / #1228: vendor stock-report snapshots (EDIWheel B2.1).
+--
+-- A snapshot is what the vendor said it had, for a whole market, at one moment. Snapshots are
+-- append-only and never merged: a later one does not correct an earlier one, it describes a
+-- different moment, and both stay true of theirs. "Latest" is therefore a query over
+-- snapshot_as_of, and a failed fetch leaves the previous snapshot standing as the last thing the
+-- vendor actually said.
+--
+-- H2(MODE=PostgreSQL)-compatible, matching V2/V3/V8/V9.
+--
+-- No foreign key to supplier_profile, for the reasons V3 records: ADR-0050 §6/§7 require the
+-- received-document record to outlive the configuration that produced it.
+CREATE TABLE supplier_stock_snapshot (
+    snapshot_id uuid NOT NULL,
+
+    vendor_profile_id uuid NOT NULL,
+    supplier_ref character varying(100) NOT NULL,
+    protocol_version character varying(64) NOT NULL,
+
+    status character varying(32) NOT NULL,
+
+    document_id character varying(255),
+    issued_on date,
+    -- The VENDOR's statement of when the snapshot was taken. Deliberately separate from fetched_at:
+    -- a report fetched at noon may describe stock as of 06:00, and staleness is judged against the
+    -- vendor's figure, not against when we happened to ask.
+    snapshot_as_of timestamp(6) with time zone,
+
+    buyer_account_number character varying(64) NOT NULL,
+    country_code character varying(8),
+
+    fetched_at timestamp(6) with time zone NOT NULL,
+    completed_at timestamp(6) with time zone,
+
+    lines_reported integer DEFAULT 0 NOT NULL,
+    lines_rejected integer DEFAULT 0 NOT NULL,
+    chunk_count integer DEFAULT 0 NOT NULL,
+    chunk_size integer DEFAULT 0 NOT NULL,
+
+    exchange_audit_id uuid,
+    correlation_id character varying(100) NOT NULL,
+    failure_detail character varying(2000),
+
+    created_at timestamp(6) with time zone NOT NULL,
+    created_by character varying(100),
+
+    CONSTRAINT pk_supplier_stock_snapshot PRIMARY KEY (snapshot_id),
+    CONSTRAINT ck_sstock_snapshot_status
+        CHECK (status IN ('COMPLETED', 'EMPTY', 'FAILED'))
+);
+
+CREATE INDEX idx_sstock_snapshot_profile_asof ON supplier_stock_snapshot (vendor_profile_id, snapshot_as_of);
+CREATE INDEX idx_sstock_snapshot_status ON supplier_stock_snapshot (status);
+CREATE INDEX idx_sstock_snapshot_correlation ON supplier_stock_snapshot (correlation_id);
+
+-- ── Reported lines ──────────────────────────────────────────────────────────────────────────
+--
+-- available_quantity is NULLABLE WITH NO DEFAULT, and that is load-bearing. Null means the vendor
+-- reported the article without stating a quantity; 0 means it explicitly reported none. A NOT NULL
+-- DEFAULT 0 would silently turn every vendor silence into an out-of-stock, which is the single
+-- mistake this feed most needs to avoid.
+CREATE TABLE supplier_stock_snapshot_line (
+    line_id uuid NOT NULL,
+
+    snapshot_id uuid NOT NULL,
+    vendor_profile_id uuid NOT NULL,
+
+    vendor_line_id character varying(64),
+    article_ean character varying(64),
+    -- Display alias only. Never an identifier (ADR-0053 §5's rule holds for every feed).
+    supplier_article_code character varying(64),
+    buyers_article_id character varying(64),
+    description character varying(512),
+
+    available_quantity integer,
+
+    created_at timestamp(6) with time zone NOT NULL,
+
+    CONSTRAINT pk_supplier_stock_snapshot_line PRIMARY KEY (line_id),
+    CONSTRAINT fk_sstock_line_snapshot
+        FOREIGN KEY (snapshot_id) REFERENCES supplier_stock_snapshot (snapshot_id)
+);
+
+CREATE INDEX idx_sstock_line_snapshot ON supplier_stock_snapshot_line (snapshot_id);
+CREATE INDEX idx_sstock_line_ean ON supplier_stock_snapshot_line (vendor_profile_id, article_ean);

--- a/pos-supplier/src/main/resources/db/migration/V11__rename_binding_chunk_size.sql
+++ b/pos-supplier/src/main/resources/db/migration/V11__rename_binding_chunk_size.sql
@@ -1,0 +1,10 @@
+-- CAP-322 / #1228: the per-binding chunk size is no longer PRICAT-specific.
+--
+-- V8 introduced pricat_chunk_size for the price catalog. The stock report (B2.1) has the same
+-- problem for the same reason — a country-level document is as wide as a catalog, and how many
+-- lines fit a broker message depends on how wide that vendor's lines are — so the setting is one
+-- property of the binding rather than one per feed. Renamed rather than duplicated: two columns
+-- would let a deployment tune one feed and silently leave the other on the default.
+--
+-- Pre-production rename, no compatibility shim per platform policy.
+ALTER TABLE supplier_endpoint_binding RENAME COLUMN pricat_chunk_size TO event_chunk_size;

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheelb/EdiwheelB21StockReportCodecTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheelb/EdiwheelB21StockReportCodecTest.java
@@ -1,0 +1,199 @@
+package com.positivity.supplier.internal.adapter.ediwheelb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.positivity.supplier.internal.domain.model.PartyContext;
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.domain.model.SupplierStockSnapshot;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+@DisplayName("EDIWheel Stock Report B2.1 codec (#1228)")
+class EdiwheelB21StockReportCodecTest {
+
+    private final EdiwheelB21StockReportCodec codec = new EdiwheelB21StockReportCodec(new ObjectMapper());
+
+    private static String goldenDocument() throws IOException {
+        try (InputStream in =
+                EdiwheelB21StockReportCodecTest.class.getResourceAsStream("/fixtures/stock-report-b21-sample.json")) {
+            assertThat(in)
+                    .as("golden stock-report fixture must be on the test classpath")
+                    .isNotNull();
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
+    void registersUnderTheStockReportTriple() {
+        assertThat(codec.capability()).isEqualTo(SupplierCapability.STOCK_REPORT);
+        assertThat(codec.family()).isEqualTo(ProtocolFamily.EDIWHEEL_B);
+        assertThat(codec.version()).isEqualTo(ProtocolVersion.B2_1);
+    }
+
+    @Nested
+    @DisplayName("buildRequest")
+    class BuildRequest {
+
+        @Test
+        void sendsNoQueryParametersForB21() {
+            SupplierRequestSpec spec = codec.buildRequest(new PartyContext("30012456", "91", null), false);
+
+            assertThat(spec.method()).isEqualTo("GET");
+            assertThat(spec.queryParams()).isEmpty();
+            assertThat(spec.accept()).isEqualTo("application/json");
+        }
+
+        @Test
+        void sendsBuyerIdentificationWhenTheBindingIsAC10Endpoint() {
+            SupplierRequestSpec spec = codec.buildRequest(new PartyContext("30012456", "91", null), true);
+
+            assertThat(spec.queryParams())
+                    .containsEntry("buyerParty", "30012456")
+                    .containsEntry("agencyCode", "91");
+        }
+
+        @Test
+        void isRetryableBecauseASnapshotReadHasNoCommercialEffect() {
+            assertThat(codec.buildRequest(new PartyContext("30012456", null, null), false)
+                            .idempotent())
+                    .isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("decode")
+    class Decode {
+
+        @Test
+        void readsTheVendorsOwnSnapshotTimeSeparatelyFromTheDocumentDate() throws IOException {
+            SupplierStockSnapshot snapshot = codec.decode(goldenDocument());
+
+            assertThat(snapshot.documentId()).isEqualTo("STOCKREPORT-4046266_20260814");
+            assertThat(snapshot.issuedOn()).isEqualTo(LocalDate.of(2026, 8, 14));
+            assertThat(snapshot.issuedAt()).isEqualTo(Instant.parse("2026-08-14T06:00:00Z"));
+            assertThat(snapshot.buyerParty()).isEqualTo("30012456");
+        }
+
+        @Test
+        void mapsArticleIdentityAndQuantity() throws IOException {
+            SupplierStockSnapshot.Line first =
+                    codec.decode(goldenDocument()).lines().getFirst();
+
+            assertThat(first.lineId()).isEqualTo("1");
+            assertThat(first.articleEan()).isEqualTo("3528709999083");
+            assertThat(first.supplierArticleCode()).isEqualTo("999908");
+            assertThat(first.buyersArticleId()).isEqualTo("BUY-1");
+            assertThat(first.description()).isEqualTo("255/55R19 111VXL PS4 SUV");
+            assertThat(first.availableQuantity()).isEqualTo(42);
+        }
+
+        @Test
+        void keepsAnExplicitZeroDistinctFromAnUnstatedQuantity() throws IOException {
+            var lines = codec.decode(goldenDocument()).lines();
+
+            // Line 2 says zero: the vendor reported it has none.
+            assertThat(lines.get(1).availableQuantity()).isZero();
+            // Line 3 says nothing: the vendor mentioned the article without stating a quantity, and
+            // that must not become zero.
+            assertThat(lines.get(2).availableQuantity()).isNull();
+        }
+
+        @Test
+        void rejectsALineWithNoArticleIdentityWithoutDiscardingTheSnapshot() throws IOException {
+            SupplierStockSnapshot snapshot = codec.decode(goldenDocument());
+
+            assertThat(snapshot.lines()).hasSize(3);
+            assertThat(snapshot.rejectedLines()).singleElement().satisfies(line -> {
+                assertThat(line.lineId()).isEqualTo("4");
+                assertThat(line.detail()).contains("no article identity");
+            });
+            assertThat(snapshot.lines().size() + snapshot.rejectedLines().size())
+                    .isEqualTo(snapshot.linesFetched());
+        }
+
+        @Test
+        void rejectsAnUnparseableQuantityAsALineRatherThanADocument() {
+            String body = """
+                    {"envelopeHeader":{"issueDate":"20260814","documentId":"D1","variant":"B2_1","errorCode":"0"},
+                     "lineLevel":[{"lineId":"1","article":{"articleIdentification":{"eanuccarticleID":"3528709999083"},
+                       "availableQuantity":{"quantityValue":"lots"}}}]}
+                    """;
+
+            SupplierStockSnapshot snapshot = codec.decode(body);
+
+            assertThat(snapshot.lines()).isEmpty();
+            assertThat(snapshot.rejectedLines())
+                    .singleElement()
+                    .satisfies(line -> assertThat(line.detail()).contains("not a number"));
+        }
+
+        @Test
+        void acceptsAWholeQuantityStatedWithADecimalPart() {
+            String body = """
+                    {"envelopeHeader":{"issueDate":"20260814","documentId":"D1","variant":"B2_1","errorCode":"0"},
+                     "lineLevel":[{"lineId":"1","article":{"articleIdentification":{"eanuccarticleID":"3528709999083"},
+                       "availableQuantity":{"quantityValue":"12.000"}}}]}
+                    """;
+
+            assertThat(codec.decode(body).lines().getFirst().availableQuantity())
+                    .isEqualTo(12);
+        }
+
+        @Test
+        void failsTheDocumentWhenTheVendorSignalsAnErrorCode() {
+            String body = """
+                    {"envelopeHeader":{"issueDate":"20260814","documentId":"D1","variant":"B2_1","errorCode":"42"},
+                     "lineLevel":[]}
+                    """;
+
+            assertThatThrownBy(() -> codec.decode(body))
+                    .isInstanceOf(StockReportDecodeException.class)
+                    .hasMessageContaining("vendor error code 42");
+        }
+
+        @Test
+        void failsOnAnEmptyOrNonDocumentBody() {
+            assertThatThrownBy(() -> codec.decode("   ")).isInstanceOf(StockReportDecodeException.class);
+            assertThatThrownBy(() -> codec.decode("<html>gateway timeout</html>"))
+                    .isInstanceOf(StockReportDecodeException.class)
+                    .hasMessageContaining("not a B2.1 document");
+        }
+
+        @Test
+        void treatsALineLessDocumentAsAnEmptySnapshotNotAFailure() {
+            String body = """
+                    {"envelopeHeader":{"issueDate":"20260814","documentId":"D1","variant":"B2_1","errorCode":"0"},
+                     "lineLevel":[]}
+                    """;
+
+            SupplierStockSnapshot snapshot = codec.decode(body);
+
+            assertThat(snapshot.lines()).isEmpty();
+            assertThat(snapshot.linesFetched()).isZero();
+        }
+
+        @Test
+        void toleratesAHeaderWithNoTimeWithoutInventingOne() {
+            String body = """
+                    {"envelopeHeader":{"issueDate":"20260814","documentId":"D1","variant":"B2_1","errorCode":"0"},
+                     "lineLevel":[]}
+                    """;
+
+            SupplierStockSnapshot snapshot = codec.decode(body);
+
+            assertThat(snapshot.issuedOn()).isEqualTo(LocalDate.of(2026, 8, 14));
+            assertThat(snapshot.issuedAt()).isNull();
+        }
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/stockreport/service/StockReportImporterTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/stockreport/service/StockReportImporterTest.java
@@ -1,4 +1,4 @@
-package com.positivity.supplier.internal.pricecatalog.service;
+package com.positivity.supplier.internal.stockreport.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.positivity.supplier.internal.adapter.ediwheelb.EdiwheelB40PricatCodec;
+import com.positivity.supplier.internal.adapter.ediwheelb.EdiwheelB21StockReportCodec;
 import com.positivity.supplier.internal.client.SupplierBaseClient;
 import com.positivity.supplier.internal.client.SupplierHttpRequest;
 import com.positivity.supplier.internal.client.SupplierHttpResponse;
@@ -18,13 +18,12 @@ import com.positivity.supplier.internal.domain.model.ProtocolFamily;
 import com.positivity.supplier.internal.domain.model.ProtocolVersion;
 import com.positivity.supplier.internal.domain.model.SupplierCapability;
 import com.positivity.supplier.internal.domain.model.SupplierRef;
-import com.positivity.supplier.internal.entity.PriceCatalogImportEntity;
+import com.positivity.supplier.internal.entity.StockSnapshotEntity;
 import com.positivity.supplier.internal.entity.SupplierAccountEntity;
 import com.positivity.supplier.internal.entity.SupplierAuthConfigEntity;
 import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
 import com.positivity.supplier.internal.entity.SupplierProfileEntity;
 import com.positivity.supplier.internal.exception.SupplierConfigurationException;
-import com.positivity.supplier.internal.pricecatalog.service.ProductCodeResolver.Resolution;
 import com.positivity.supplier.internal.registry.AdapterRegistry;
 import com.positivity.supplier.internal.registry.AdapterResolution;
 import com.positivity.supplier.internal.service.SupplierProfileResolver;
@@ -50,19 +49,19 @@ import tools.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@DisplayName("PRICAT import orchestration (#1224)")
-class PriceCatalogImporterTest {
+@DisplayName("Stock report fetch orchestration (#1228)")
+class StockReportImporterTest {
 
     private static final UUID PROFILE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c");
-    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d");
     private static final SupplierRef SUPPLIER = new SupplierRef("michelin-eu");
-    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-13T09:00:00Z"), ZoneOffset.UTC);
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-14T09:00:00Z"), ZoneOffset.UTC);
 
     private static final String GOOD_DOCUMENT = """
-            {"envelopeHeader":{"documentId":"DOC-1","date":"202608130900","countryCode":"SE","currency":"SEK",
-              "ediwheelVersion":"B4.0","errorCode":"0"},
-             "articles":[{"pos":1,"ean":"3528709999083","supplierCode":"999908","netValue":"90.00",
-              "netValueValidFrom":"20260201"}]}
+            {"envelopeHeader":{"issueDate":"20260814","issueTime":"0600","documentId":"D1","variant":"B2_1",
+              "errorCode":"0"},
+             "buyerParty":"30012456",
+             "lineLevel":[{"lineId":"1","article":{"articleIdentification":{"eanuccarticleID":"3528709999083"},
+               "availableQuantity":{"quantityValue":"42"}}}]}
             """;
 
     @Mock
@@ -75,30 +74,26 @@ class PriceCatalogImporterTest {
     private SupplierBaseClient baseClient;
 
     @Mock
-    private ProductCodeResolver productCodeResolver;
+    private StockReportSnapshotWriter snapshotWriter;
 
-    @Mock
-    private PriceCatalogStagingWriter stagingWriter;
-
-    private PriceCatalogImporter service;
+    private StockReportImporter importer;
 
     @BeforeEach
     void setUp() {
-        service = new PriceCatalogImporter(
-                profileResolver, adapterRegistry, baseClient, productCodeResolver, stagingWriter, CLOCK);
-        ReflectionTestUtils.setField(service, "defaultChunkSize", 500);
+        importer = new StockReportImporter(profileResolver, adapterRegistry, baseClient, snapshotWriter, CLOCK);
+        ReflectionTestUtils.setField(importer, "defaultChunkSize", 500);
+        ReflectionTestUtils.setField(importer, "sendBuyerParty", false);
 
-        when(profileResolver.resolveBinding(SUPPLIER, SupplierCapability.PRICE_CATALOG))
+        when(profileResolver.resolveBinding(SUPPLIER, SupplierCapability.STOCK_REPORT))
                 .thenReturn(binding(null));
         when(profileResolver.resolvePartyContext(SUPPLIER, null))
                 .thenReturn(new ResolvedPartyAccounts(billing(), null));
-        when(adapterRegistry.resolve(SupplierCapability.PRICE_CATALOG, ProtocolFamily.EDIWHEEL_B, ProtocolVersion.B4_0))
-                .thenReturn(new AdapterResolution.Resolved(new EdiwheelB40PricatCodec(new ObjectMapper())));
-        when(productCodeResolver.resolve("EAN", "3528709999083")).thenReturn(new Resolution.Matched(PRODUCT_ID));
-        when(stagingWriter.commit(any(), any(), any(), any(), any(), anyString(), any(), anyInt()))
-                .thenReturn(PriceCatalogImportEntity.builder().build());
-        when(stagingWriter.persistFailure(any(), any(), any(), any(), anyString(), any()))
-                .thenReturn(PriceCatalogImportEntity.builder().build());
+        when(adapterRegistry.resolve(SupplierCapability.STOCK_REPORT, ProtocolFamily.EDIWHEEL_B, ProtocolVersion.B2_1))
+                .thenReturn(new AdapterResolution.Resolved(new EdiwheelB21StockReportCodec(new ObjectMapper())));
+        when(snapshotWriter.commit(any(), any(), any(), anyString(), any(), anyInt()))
+                .thenReturn(StockSnapshotEntity.builder().build());
+        when(snapshotWriter.persistFailure(any(), any(), anyString(), any(), any()))
+                .thenReturn(StockSnapshotEntity.builder().build());
     }
 
     private static ResolvedBinding binding(Integer chunkSizeOverride) {
@@ -110,9 +105,9 @@ class PriceCatalogImporterTest {
         SupplierEndpointBindingEntity endpointBinding = new SupplierEndpointBindingEntity();
         endpointBinding.setId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5e"));
         endpointBinding.setVendorProfileId(PROFILE_ID);
-        endpointBinding.setCapability(SupplierCapability.PRICE_CATALOG);
+        endpointBinding.setCapability(SupplierCapability.STOCK_REPORT);
         endpointBinding.setProtocolFamily(ProtocolFamily.EDIWHEEL_B);
-        endpointBinding.setProtocolVersion("B4_0");
+        endpointBinding.setProtocolVersion("B2_1");
         endpointBinding.setEnabled(true);
         endpointBinding.setEventChunkSize(chunkSizeOverride);
 
@@ -120,9 +115,9 @@ class PriceCatalogImporterTest {
                 profile,
                 endpointBinding,
                 new SupplierAuthConfigEntity(),
-                SupplierCapability.PRICE_CATALOG,
+                SupplierCapability.STOCK_REPORT,
                 ProtocolFamily.EDIWHEEL_B,
-                ProtocolVersion.B4_0);
+                ProtocolVersion.B2_1);
     }
 
     private static SupplierAccountEntity billing() {
@@ -144,73 +139,84 @@ class PriceCatalogImporterTest {
     }
 
     @Test
-    void stagesTheDocumentOnASuccessfulFetch() {
+    void commitsTheSnapshotOnASuccessfulFetch() {
         when(baseClient.exchange(any(SupplierHttpRequest.class)))
                 .thenReturn(response(ExchangeOutcome.OK, GOOD_DOCUMENT));
 
-        service.runImport(SUPPLIER);
+        importer.runSnapshot(SUPPLIER);
 
-        verify(stagingWriter).commit(any(), any(), any(), any(), any(), anyString(), any(), eq(500));
-        verify(stagingWriter, never()).persistFailure(any(), any(), any(), any(), anyString(), any());
+        verify(snapshotWriter).commit(any(), any(), any(), anyString(), any(), eq(500));
+        verify(snapshotWriter, never()).persistFailure(any(), any(), anyString(), any(), any());
     }
 
     @Test
-    void sendsTheBuyerAccountAsTheVendorQuery() {
+    void sendsNoQueryParametersUnlessTheBindingIsAC10Endpoint() {
         when(baseClient.exchange(any(SupplierHttpRequest.class)))
                 .thenReturn(response(ExchangeOutcome.OK, GOOD_DOCUMENT));
 
-        service.runImport(SUPPLIER);
+        importer.runSnapshot(SUPPLIER);
 
         ArgumentCaptor<SupplierHttpRequest> captor = ArgumentCaptor.forClass(SupplierHttpRequest.class);
         verify(baseClient).exchange(captor.capture());
-        assertThat(captor.getValue().queryParams())
-                .containsEntry("buyerParty", "30012456")
-                .containsEntry("agencyCode", "91");
+        assertThat(captor.getValue().queryParams()).isEmpty();
         assertThat(captor.getValue().idempotent()).isTrue();
     }
 
     @Test
+    void sendsBuyerIdentificationWhenConfiguredForAC10Endpoint() {
+        ReflectionTestUtils.setField(importer, "sendBuyerParty", true);
+        when(baseClient.exchange(any(SupplierHttpRequest.class)))
+                .thenReturn(response(ExchangeOutcome.OK, GOOD_DOCUMENT));
+
+        importer.runSnapshot(SUPPLIER);
+
+        ArgumentCaptor<SupplierHttpRequest> captor = ArgumentCaptor.forClass(SupplierHttpRequest.class);
+        verify(baseClient).exchange(captor.capture());
+        assertThat(captor.getValue().queryParams()).containsEntry("buyerParty", "30012456");
+    }
+
+    @Test
     void prefersTheBindingsChunkSizeOverTheDeploymentDefault() {
-        when(profileResolver.resolveBinding(SUPPLIER, SupplierCapability.PRICE_CATALOG))
+        when(profileResolver.resolveBinding(SUPPLIER, SupplierCapability.STOCK_REPORT))
                 .thenReturn(binding(120));
         when(baseClient.exchange(any(SupplierHttpRequest.class)))
                 .thenReturn(response(ExchangeOutcome.OK, GOOD_DOCUMENT));
 
-        service.runImport(SUPPLIER);
+        importer.runSnapshot(SUPPLIER);
 
-        verify(stagingWriter).commit(any(), any(), any(), any(), any(), anyString(), any(), eq(120));
+        verify(snapshotWriter).commit(any(), any(), any(), anyString(), any(), eq(120));
     }
 
     @Test
-    void recordsAFailedExchangeWithoutStagingAnything() {
+    void recordsAFailedExchangeWithoutCommittingASnapshot() {
         when(baseClient.exchange(any(SupplierHttpRequest.class)))
                 .thenReturn(response(ExchangeOutcome.PRE_SEND_FAILURE, null));
 
-        service.runImport(SUPPLIER);
+        importer.runSnapshot(SUPPLIER);
 
-        verify(stagingWriter).persistFailure(any(), any(), any(), any(), anyString(), anyString());
-        verify(stagingWriter, never()).commit(any(), any(), any(), any(), any(), anyString(), any(), anyInt());
+        verify(snapshotWriter).persistFailure(any(), any(), anyString(), any(), anyString());
+        verify(snapshotWriter, never()).commit(any(), any(), any(), anyString(), any(), anyInt());
     }
 
     @Test
-    void recordsAnUndecodableDocumentAsAFailedImport() {
+    void recordsAnUndecodableDocumentAsAFailedSnapshotRatherThanAnEmptyOne() {
         when(baseClient.exchange(any(SupplierHttpRequest.class)))
                 .thenReturn(response(ExchangeOutcome.OK, "<html>maintenance</html>"));
 
-        service.runImport(SUPPLIER);
+        importer.runSnapshot(SUPPLIER);
 
         ArgumentCaptor<String> detail = ArgumentCaptor.forClass(String.class);
-        verify(stagingWriter).persistFailure(any(), any(), any(), any(), anyString(), detail.capture());
-        assertThat(detail.getValue()).contains("not a B4.0 catalog document");
-        verify(stagingWriter, never()).commit(any(), any(), any(), any(), any(), anyString(), any(), anyInt());
+        verify(snapshotWriter).persistFailure(any(), any(), anyString(), any(), detail.capture());
+        assertThat(detail.getValue()).contains("not a B2.1 document");
+        verify(snapshotWriter, never()).commit(any(), any(), any(), anyString(), any(), anyInt());
     }
 
     @Test
     void refusesToRunWhenNoCodecIsRegisteredForTheBoundNorm() {
-        when(adapterRegistry.resolve(SupplierCapability.PRICE_CATALOG, ProtocolFamily.EDIWHEEL_B, ProtocolVersion.B4_0))
+        when(adapterRegistry.resolve(SupplierCapability.STOCK_REPORT, ProtocolFamily.EDIWHEEL_B, ProtocolVersion.B2_1))
                 .thenReturn(new AdapterResolution.NotConfigured("nothing registered"));
 
-        assertThatThrownBy(() -> service.runImport(SUPPLIER)).isInstanceOf(SupplierConfigurationException.class);
+        assertThatThrownBy(() -> importer.runSnapshot(SUPPLIER)).isInstanceOf(SupplierConfigurationException.class);
 
         verify(baseClient, never()).exchange(any());
     }

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/stockreport/service/StockReportSchedulerTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/stockreport/service/StockReportSchedulerTest.java
@@ -1,0 +1,204 @@
+package com.positivity.supplier.internal.stockreport.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.entity.StockSnapshotEntity;
+import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.repository.StockSnapshotRepository;
+import com.positivity.supplier.internal.repository.SupplierEndpointBindingRepository;
+import com.positivity.supplier.internal.repository.SupplierProfileRepository;
+import com.positivity.supplier.internal.service.SupplierScheduleCoordinator;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Scheduled stock snapshots (#1228)")
+class StockReportSchedulerTest {
+
+    private static final UUID PROFILE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c");
+    private static final UUID BINDING_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5e");
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-13T09:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private SupplierEndpointBindingRepository bindingRepository;
+
+    @Mock
+    private SupplierProfileRepository profileRepository;
+
+    @Mock
+    private StockSnapshotRepository snapshotRepository;
+
+    @Mock
+    private SupplierScheduleCoordinator scheduleCoordinator;
+
+    @Mock
+    private StockReportImporter importer;
+
+    private StockReportScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new StockReportScheduler(
+                bindingRepository, profileRepository, snapshotRepository, scheduleCoordinator, importer, CLOCK);
+
+        SupplierProfileEntity profile = new SupplierProfileEntity();
+        profile.setVendorProfileId(PROFILE_ID);
+        profile.setSupplierRef("michelin-eu");
+        profile.setEnabled(true);
+        when(profileRepository.findById(PROFILE_ID)).thenReturn(Optional.of(profile));
+
+        when(bindingRepository.findByCapabilityAndEnabledTrueAndScheduleCronIsNotNull(SupplierCapability.STOCK_REPORT))
+                .thenReturn(List.of(binding("0 0 3 * * *")));
+        when(scheduleCoordinator.tryClaim(eq(BINDING_ID), anyString())).thenReturn(true);
+
+        StockSnapshotEntity result = StockSnapshotEntity.builder()
+                .snapshotId(UUID.randomUUID())
+                .vendorProfileId(PROFILE_ID)
+                .status("COMPLETED")
+                .build();
+        when(importer.runSnapshot(any(SupplierRef.class))).thenReturn(result);
+    }
+
+    private static SupplierEndpointBindingEntity binding(String cron) {
+        SupplierEndpointBindingEntity binding = new SupplierEndpointBindingEntity();
+        binding.setId(BINDING_ID);
+        binding.setVendorProfileId(PROFILE_ID);
+        binding.setCapability(SupplierCapability.STOCK_REPORT);
+        binding.setScheduleCron(cron);
+        binding.setEnabled(true);
+        return binding;
+    }
+
+    private void lastImportAt(Instant fetchedAt) {
+        Page<StockSnapshotEntity> page = new PageImpl<>(List.of(StockSnapshotEntity.builder()
+                .snapshotId(UUID.randomUUID())
+                .vendorProfileId(PROFILE_ID)
+                .fetchedAt(fetchedAt)
+                .status("COMPLETED")
+                .build()));
+        when(snapshotRepository.findByVendorProfileIdOrderByFetchedAtDesc(eq(PROFILE_ID), any(Pageable.class)))
+                .thenReturn(page);
+    }
+
+    @Test
+    void runsImmediatelyWhenTheProfileHasNeverImported() {
+        when(snapshotRepository.findByVendorProfileIdOrderByFetchedAtDesc(eq(PROFILE_ID), any(Pageable.class)))
+                .thenReturn(Page.empty());
+
+        scheduler.runDueSnapshots();
+
+        verify(importer).runSnapshot(new SupplierRef("michelin-eu"));
+    }
+
+    @Test
+    void runsWhenTheCronFireTimeAfterTheLastImportHasPassed() {
+        lastImportAt(Instant.parse("2026-08-12T03:00:00Z"));
+
+        scheduler.runDueSnapshots();
+
+        verify(importer).runSnapshot(new SupplierRef("michelin-eu"));
+    }
+
+    @Test
+    void doesNotRunBeforeTheNextCronFireTime() {
+        lastImportAt(Instant.parse("2026-08-13T03:00:00Z"));
+
+        scheduler.runDueSnapshots();
+
+        verify(importer, never()).runSnapshot(any());
+    }
+
+    @Test
+    void skipsTheRunWhenAnotherInstanceHoldsTheLease() {
+        when(snapshotRepository.findByVendorProfileIdOrderByFetchedAtDesc(eq(PROFILE_ID), any(Pageable.class)))
+                .thenReturn(Page.empty());
+        when(scheduleCoordinator.tryClaim(eq(BINDING_ID), anyString())).thenReturn(false);
+
+        scheduler.runDueSnapshots();
+
+        verify(importer, never()).runSnapshot(any());
+    }
+
+    @Test
+    void releasesTheLeaseWithTheRunOutcome() {
+        when(snapshotRepository.findByVendorProfileIdOrderByFetchedAtDesc(eq(PROFILE_ID), any(Pageable.class)))
+                .thenReturn(Page.empty());
+
+        scheduler.runDueSnapshots();
+
+        verify(scheduleCoordinator).release(eq(BINDING_ID), anyString(), eq("COMPLETED"));
+    }
+
+    @Test
+    void releasesTheLeaseEvenWhenTheImportThrows() {
+        when(snapshotRepository.findByVendorProfileIdOrderByFetchedAtDesc(eq(PROFILE_ID), any(Pageable.class)))
+                .thenReturn(Page.empty());
+        when(importer.runSnapshot(any(SupplierRef.class))).thenThrow(new IllegalStateException("boom"));
+
+        scheduler.runDueSnapshots();
+
+        verify(scheduleCoordinator).release(eq(BINDING_ID), anyString(), eq("FAILED"));
+    }
+
+    @Test
+    void skipsADisabledProfileWithoutClaimingItsLease() {
+        SupplierProfileEntity disabled = new SupplierProfileEntity();
+        disabled.setVendorProfileId(PROFILE_ID);
+        disabled.setSupplierRef("michelin-eu");
+        disabled.setEnabled(false);
+        when(profileRepository.findById(PROFILE_ID)).thenReturn(Optional.of(disabled));
+
+        scheduler.runDueSnapshots();
+
+        verify(scheduleCoordinator, never()).tryClaim(any(), anyString());
+    }
+
+    @Test
+    void neverFiresOnAnUnparseableCronRatherThanFiringEveryTick() {
+        when(bindingRepository.findByCapabilityAndEnabledTrueAndScheduleCronIsNotNull(SupplierCapability.STOCK_REPORT))
+                .thenReturn(List.of(binding("not a cron")));
+
+        scheduler.runDueSnapshots();
+
+        verify(importer, never()).runSnapshot(any());
+    }
+
+    @Test
+    void oneFailingBindingDoesNotStopTheOthers() {
+        SupplierEndpointBindingEntity broken = binding("0 0 3 * * *");
+        broken.setVendorProfileId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4aff"));
+        when(bindingRepository.findByCapabilityAndEnabledTrueAndScheduleCronIsNotNull(SupplierCapability.STOCK_REPORT))
+                .thenReturn(List.of(broken, binding("0 0 3 * * *")));
+        when(profileRepository.findById(broken.getVendorProfileId())).thenThrow(new IllegalStateException("db down"));
+        when(snapshotRepository.findByVendorProfileIdOrderByFetchedAtDesc(eq(PROFILE_ID), any(Pageable.class)))
+                .thenReturn(Page.empty());
+
+        scheduler.runDueSnapshots();
+
+        verify(importer).runSnapshot(new SupplierRef("michelin-eu"));
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/stockreport/service/StockReportSnapshotWriterTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/stockreport/service/StockReportSnapshotWriterTest.java
@@ -1,0 +1,218 @@
+package com.positivity.supplier.internal.stockreport.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.supplier.SupplierStockReportUpdatedV1;
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierStockSnapshot;
+import com.positivity.supplier.internal.entity.StockSnapshotEntity;
+import com.positivity.supplier.internal.entity.StockSnapshotLineEntity;
+import com.positivity.supplier.internal.entity.SupplierAccountEntity;
+import com.positivity.supplier.internal.entity.SupplierAuthConfigEntity;
+import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.repository.StockSnapshotLineRepository;
+import com.positivity.supplier.internal.repository.StockSnapshotRepository;
+import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Stock snapshot persistence and events (#1228)")
+class StockReportSnapshotWriterTest {
+
+    private static final UUID PROFILE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c");
+    private static final Instant FETCHED_AT = Instant.parse("2026-08-14T09:00:00Z");
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-14T09:05:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private StockSnapshotRepository snapshotRepository;
+
+    @Mock
+    private StockSnapshotLineRepository snapshotLineRepository;
+
+    @Mock
+    private SupplierOutboxEventWriter outboxWriter;
+
+    private StockReportSnapshotWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        writer = new StockReportSnapshotWriter(snapshotRepository, snapshotLineRepository, outboxWriter, CLOCK);
+        when(snapshotRepository.save(any(StockSnapshotEntity.class))).thenAnswer(inv -> {
+            StockSnapshotEntity entity = inv.getArgument(0);
+            if (entity.getSnapshotId() == null) {
+                entity.setSnapshotId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"));
+            }
+            return entity;
+        });
+        when(snapshotLineRepository.save(any(StockSnapshotLineEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private static ResolvedBinding binding() {
+        SupplierProfileEntity profile = new SupplierProfileEntity();
+        profile.setVendorProfileId(PROFILE_ID);
+        profile.setSupplierRef("michelin-eu");
+        profile.setEnabled(true);
+
+        SupplierEndpointBindingEntity endpointBinding = new SupplierEndpointBindingEntity();
+        endpointBinding.setId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5e"));
+        endpointBinding.setVendorProfileId(PROFILE_ID);
+        endpointBinding.setCapability(SupplierCapability.STOCK_REPORT);
+        endpointBinding.setProtocolFamily(ProtocolFamily.EDIWHEEL_B);
+        endpointBinding.setProtocolVersion("B2_1");
+        endpointBinding.setEnabled(true);
+
+        return new ResolvedBinding(
+                profile,
+                endpointBinding,
+                new SupplierAuthConfigEntity(),
+                SupplierCapability.STOCK_REPORT,
+                ProtocolFamily.EDIWHEEL_B,
+                ProtocolVersion.B2_1);
+    }
+
+    private static SupplierAccountEntity billing() {
+        SupplierAccountEntity account = new SupplierAccountEntity();
+        account.setAccountNumber("30012456");
+        account.setAgencyCode("91");
+        return account;
+    }
+
+    private static SupplierStockSnapshot snapshot(int lineCount, Integer quantity) {
+        List<SupplierStockSnapshot.Line> lines = new ArrayList<>();
+        IntStream.rangeClosed(1, lineCount)
+                .forEach(i -> lines.add(new SupplierStockSnapshot.Line(
+                        String.valueOf(i), "352870999908" + i, "99990" + i, "BUY-" + i, "Tyre " + i, quantity)));
+        return new SupplierStockSnapshot(
+                "STOCKREPORT-1",
+                LocalDate.of(2026, 8, 14),
+                Instant.parse("2026-08-14T06:00:00Z"),
+                "30012456",
+                lines,
+                List.of(),
+                lineCount);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<DomainEventEnvelope<?>> capturedEvents() {
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(outboxWriter, org.mockito.Mockito.atLeastOnce()).publish(eq("supplier.events.v1"), captor.capture());
+        return captor.getAllValues();
+    }
+
+    @Test
+    void keepsTheVendorSnapshotTimeSeparateFromTheFetchTime() {
+        StockSnapshotEntity row = writer.commit(snapshot(1, 5), binding(), billing(), "corr-1", FETCHED_AT, 500);
+
+        assertThat(row.getSnapshotAsOf()).isEqualTo(Instant.parse("2026-08-14T06:00:00Z"));
+        assertThat(row.getFetchedAt()).isEqualTo(FETCHED_AT);
+    }
+
+    @Test
+    void persistsOneRowPerReportedLine() {
+        writer.commit(snapshot(3, 5), binding(), billing(), "corr-1", FETCHED_AT, 500);
+
+        verify(snapshotLineRepository, times(3)).save(any(StockSnapshotLineEntity.class));
+    }
+
+    @Test
+    void preservesAnUnstatedQuantityAsNullRatherThanZero() {
+        writer.commit(snapshot(1, null), binding(), billing(), "corr-1", FETCHED_AT, 500);
+
+        ArgumentCaptor<StockSnapshotLineEntity> captor = ArgumentCaptor.forClass(StockSnapshotLineEntity.class);
+        verify(snapshotLineRepository).save(captor.capture());
+        assertThat(captor.getValue().getAvailableQuantity()).isNull();
+
+        SupplierStockReportUpdatedV1 payload =
+                (SupplierStockReportUpdatedV1) capturedEvents().getFirst().payload();
+        assertThat(payload.lines().getFirst().availableQuantity()).isNull();
+        assertThat(payload.lines().getFirst().quantityStated()).isFalse();
+        assertThat(payload.lines().getFirst().explicitlyOutOfStock()).isFalse();
+    }
+
+    @Test
+    void publishesAnExplicitZeroAsOutOfStock() {
+        writer.commit(snapshot(1, 0), binding(), billing(), "corr-1", FETCHED_AT, 500);
+
+        SupplierStockReportUpdatedV1 payload =
+                (SupplierStockReportUpdatedV1) capturedEvents().getFirst().payload();
+        assertThat(payload.lines().getFirst().quantityStated()).isTrue();
+        assertThat(payload.lines().getFirst().explicitlyOutOfStock()).isTrue();
+    }
+
+    @Test
+    void chunksLargeSnapshotsAndNumbersEveryChunk() {
+        writer.commit(snapshot(7, 5), binding(), billing(), "corr-1", FETCHED_AT, 3);
+
+        List<DomainEventEnvelope<?>> events = capturedEvents();
+        assertThat(events).hasSize(3);
+        SupplierStockReportUpdatedV1 last =
+                (SupplierStockReportUpdatedV1) events.getLast().payload();
+        assertThat(last.chunkSequence()).isEqualTo(3);
+        assertThat(last.chunkCount()).isEqualTo(3);
+        assertThat(last.lines()).hasSize(1);
+        assertThat(last.linesReported()).isEqualTo(7);
+    }
+
+    @Test
+    void keysEveryChunkOnTheSnapshot() {
+        writer.commit(snapshot(4, 5), binding(), billing(), "corr-1", FETCHED_AT, 2);
+
+        assertThat(capturedEvents())
+                .allSatisfy(event -> assertThat(event.aggregateId())
+                        .isEqualTo(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b")));
+    }
+
+    @Test
+    void marksALineLessSnapshotEmptyAndPublishesNothing() {
+        StockSnapshotEntity row = writer.commit(snapshot(0, null), binding(), billing(), "corr-1", FETCHED_AT, 500);
+
+        assertThat(row.getStatus()).isEqualTo(StockReportSnapshotWriter.STATUS_EMPTY);
+        verify(outboxWriter, never()).publish(any(), any());
+    }
+
+    @Test
+    void recordsAFailedFetchWithoutPersistingLinesOrPublishing() {
+        StockSnapshotEntity row = writer.persistFailure(
+                binding(), billing(), "corr-1", FETCHED_AT, "vendor exchange failed: PRE_SEND_FAILURE");
+
+        assertThat(row.getStatus()).isEqualTo(StockReportSnapshotWriter.STATUS_FAILED);
+        assertThat(row.getFailureDetail()).contains("PRE_SEND_FAILURE");
+        verify(snapshotLineRepository, never()).save(any());
+        verify(outboxWriter, never()).publish(any(), any());
+    }
+
+    @Test
+    void truncatesAnOverlongFailureDetailToItsColumnWidth() {
+        StockSnapshotEntity row = writer.persistFailure(binding(), billing(), "corr-1", FETCHED_AT, "x".repeat(5000));
+
+        assertThat(row.getFailureDetail()).hasSize(2000);
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/stockreport/service/StockReportSnapshotWriterTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/stockreport/service/StockReportSnapshotWriterTest.java
@@ -191,6 +191,28 @@ class StockReportSnapshotWriterTest {
     }
 
     @Test
+    void marksASnapshotWhoseLinesAllFailedToDecodeAsRejectedNotEmpty() {
+        // The vendor DID report — we could not read it. Classifying that as EMPTY would hide a
+        // codec or vendor-format break behind "quiet warehouse" in every operator query.
+        SupplierStockSnapshot allRejected = new SupplierStockSnapshot(
+                "STOCKREPORT-1",
+                LocalDate.of(2026, 8, 14),
+                Instant.parse("2026-08-14T06:00:00Z"),
+                "30012456",
+                List.of(),
+                List.of(
+                        new SupplierStockSnapshot.RejectedLine("1", "quantityValue is not a number: 'lots'"),
+                        new SupplierStockSnapshot.RejectedLine("2", "line states no article identity")),
+                2);
+
+        StockSnapshotEntity row = writer.commit(allRejected, binding(), billing(), "corr-1", FETCHED_AT, 500);
+
+        assertThat(row.getStatus()).isEqualTo(StockReportSnapshotWriter.STATUS_REJECTED);
+        assertThat(row.getLinesRejected()).isEqualTo(2);
+        verify(outboxWriter, never()).publish(any(), any());
+    }
+
+    @Test
     void marksALineLessSnapshotEmptyAndPublishesNothing() {
         StockSnapshotEntity row = writer.commit(snapshot(0, null), binding(), billing(), "corr-1", FETCHED_AT, 500);
 

--- a/pos-supplier/src/test/resources/fixtures/stock-report-b21-sample.json
+++ b/pos-supplier/src/test/resources/fixtures/stock-report-b21-sample.json
@@ -1,0 +1,54 @@
+{
+  "envelopeHeader": {
+    "issueDate": "20260814",
+    "issueTime": "0600",
+    "documentId": "STOCKREPORT-4046266_20260814",
+    "variant": "B2_1",
+    "errorCode": "0"
+  },
+  "totalLineItemsNumber": "4",
+  "buyerParty": "30012456",
+  "lineLevel": [
+    {
+      "lineId": "1",
+      "article": {
+        "articleIdentification": {
+          "buyersArticleId": "BUY-1",
+          "manufacturersArticleId": "999908",
+          "eanuccarticleID": "3528709999083"
+        },
+        "articleDescription": { "articleDescriptionText": "255/55R19 111VXL PS4 SUV" },
+        "availableQuantity": { "quantityValue": "42" }
+      }
+    },
+    {
+      "lineId": "2",
+      "article": {
+        "articleIdentification": {
+          "manufacturersArticleId": "888801",
+          "eanuccarticleID": "3528709999084"
+        },
+        "articleDescription": { "articleDescriptionText": "205/55R16 91V PRIMACY 4" },
+        "availableQuantity": { "quantityValue": "0" }
+      }
+    },
+    {
+      "lineId": "3",
+      "article": {
+        "articleIdentification": {
+          "manufacturersArticleId": "777701",
+          "eanuccarticleID": "3528709999085"
+        },
+        "articleDescription": { "articleDescriptionText": "225/45R17 94Y PILOT SPORT 5" },
+        "availableQuantity": { "quantityValue": "" }
+      }
+    },
+    {
+      "lineId": "4",
+      "article": {
+        "articleIdentification": {},
+        "availableQuantity": { "quantityValue": "12" }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:322`
- Parent STORY (durion): louisburroughs/durion#377
- Child issue: louisburroughs/durion-positivity-backend#1228 (partial — see *Scope boundary*)
- Domain: `domain:positivity`, `domain:inventory`

## Contract References
- Contract guide entry (durion): `domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md` → CAP-318/322 supplier sections
- Governing ADRs: ADR-0049 §3 (event contract), ADR-0051 §2/§3/§5 (codec seam), ADR-0052 §5 (retry safety), ADR-0044 §3–§4 (event-only), ADR-0048 (inventory owns valuation)
- Source spec: `durion/docs/ediwheel/EDIWHEEL STOCK REPORT PROD_0 (1).yaml`

## Contract Chain
- [x] No new HTTP surface — this feed has no endpoints, so no OpenAPI change and no SDK impact
- [x] New event contract in `pos-domain-events`: `supplier.stockreport.updated` v1

## Scope

Scheduled country-level snapshot fetch → append-only persistence → chunked
`supplier.stockreport.updated` events for pos-inventory to hold as availability hints.

- `EdiwheelB21StockReportCodec` under `(STOCK_REPORT, EDIWHEEL_B, B2_1)`; wire types package-private, transport-free request spec — the seam #1224 established.
- `supplier_stock_snapshot` + `_line` (V10), append-only and never merged: a later snapshot does not correct an earlier one, it describes a different moment.
- Chunked events carrying sequence and total, so a gap is detectable without a second event type.
- Scheduler off the binding cron under the CAP-317 lease.

### Three places this feed could quietly lie, and what stops it

1. **Absence is not zero, and neither is silence.** Explicit `"0"` = the vendor has none; empty quantity = it listed the article without saying how many; article missing = it did not mention the article. All three survive codec → column (**nullable, no default**) → event, where `quantityStated()` / `explicitlyOutOfStock()` stop each consumer rediscovering the distinction. A `NOT NULL DEFAULT 0` anywhere in that chain turns every vendor silence into a false out-of-stock.
2. **The vendor's clock is not ours.** `snapshotAsOf` (vendor-stated) is kept distinct from `fetchedAt` (when we asked); a report fetched at noon may describe stock as of 06:00. The codec records UTC as an explicit assumption rather than letting the server's zone decide.
3. **A vendor error is not an empty warehouse.** A document-level error code fails the snapshot rather than publishing "nothing in stock" for a market.

### One rename

`supplier_endpoint_binding.pricat_chunk_size` → `event_chunk_size` (V11). The stock report has the same width problem for the same reason, so the setting is one property of the binding rather than one per feed — two columns would let a deployment tune one feed and silently leave the other on the default.

## Scope boundary — what #1228 asked for that is **not** here

Both raised as issues rather than guessed at:

- **pos-inventory consumer → #1312.** #1228 states the blocker itself: the hint representation must be agreed with the Inventory domain first. That decision governs whether a vendor's warehouse can ever be mistaken for ours (ADR-0048), so it is not an implementation detail.
- **Shipment tracking → #1313.** The referenced `ShipmentTrackingOAS_v1.yaml` declares exactly one operation — `POST /shipment-tracking`, a **write** that creates a notice. There is no read and nothing to poll, so `SupplierShipmentTrackingPort.fetchTrackingEvents(...)` has no operation to call. Whether the vendor pushes to us (contradicting §12 decision 7, "Inbound flows. None."), we push to them, or a read exists in a spec we do not hold, is an architecture question.

#1228 should therefore stay open until those two land.

## Tests
- [x] Golden-file codec tests: header facts, identity and quantity mapping, explicit-zero vs unstated, unusable line rejected without discarding the snapshot, decimal-stated whole quantities, vendor error code, empty/non-document bodies, missing header time
- [x] Snapshot writer: two-timestamp separation, one row per line, null quantity preserved through to the event, explicit zero published as out-of-stock, chunk numbering, empty snapshot publishes nothing, failure path persists no lines and no events, failure-detail truncation
- [x] Importer: success path, query parameters (B2.1 sends none; C1.0 mode sends buyer identity), binding chunk-size override, failed exchange, undecodable document, unregistered codec
- [x] Scheduler: due-ness, lease claim/release incl. release after a throw, disabled profile, unparseable cron, one failing binding not stopping others

How to run:

```
./mvnw -pl pos-supplier -DskipTests=false verify      # 724
./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests,ClasspathVisibilityGuardTest,EntityStandardsArchitectureTest,DomainWallsTest -Dsurefire.failIfNoSpecifiedTests=false test
./scripts/check-flyway-hygiene.sh
```

All green locally.

## Deploy notes
- `SUPPLIER_KAFKA_ENABLED` must be true for snapshots to reach anyone; the outbox records them either way.
- `SUPPLIER_STOCKREPORT_SEND_BUYER_PARTY` stays **false** for B2.1 (buyer identified by credential). Set it true only when binding this codec to the sibling C1.0 endpoint, which does take `buyerParty`/`agencyCode`.
- V11 renames a column shipped in V8; pre-production, no shim.

## Risk & Rollback
- Risk level: Low–Medium — new feed with no HTTP surface and no consumer yet; the only change to existing behaviour is the binding column rename.
- Rollback: revert the merge; V11's rename would need reversing in a follow-up migration.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated (supplier sections already merged; this feed adds no API surface)
- [ ] Required CI checks passing

Refs #1228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mv7zVYjwbVu5GRqrfkfHc7