### PR TITLE
[CAP:318] Product-fact replay and PRICAT quarantine re-application (#1309, #1310)

### DIFF
--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,4 +1,4 @@
-generatedAt: "2026-08-14T15:11:02.218788+00:00"
+generatedAt: "2026-08-14T15:38:47.573888+00:00"
 root: "."
 summary:
   manifestCount: 22

--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,4 +1,4 @@
-generatedAt: "2026-08-14T13:17:31.879002+00:00"
+generatedAt: "2026-08-14T15:11:02.218788+00:00"
 root: "."
 summary:
   manifestCount: 22

--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -275,6 +275,8 @@ paths:
     $ref: ../../pos-catalog/openapi.yaml#/paths/~1v1~1products
   /v1/products/by-code:
     $ref: ../../pos-catalog/openapi.yaml#/paths/~1v1~1products~1by-code
+  /v1/products/facts/replay:
+    $ref: ../../pos-catalog/openapi.yaml#/paths/~1v1~1products~1facts~1replay
   /v1/products/items/{itemId}/costs:
     $ref: ../../pos-catalog/openapi.yaml#/paths/~1v1~1products~1items~1{itemId}~1costs
   /v1/products/items/{itemId}/costs/audit:
@@ -1273,6 +1275,8 @@ paths:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1admin~1audit~1exchanges~1{exchangeAuditId}~1payload
   /v1/supplier/admin/price-catalog/{vendorProfileId}/imports:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1admin~1price-catalog~1{vendorProfileId}~1imports
+  /v1/supplier/admin/price-catalog/{vendorProfileId}/quarantine/reapply:
+    $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1admin~1price-catalog~1{vendorProfileId}~1quarantine~1reapply
   /v1/supplier/admin/price-catalog/{vendorProfileId}/unmatched-lines:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1admin~1price-catalog~1{vendorProfileId}~1unmatched-lines
   /v1/supplier/admin/profiles:

--- a/pos-catalog/README.md
+++ b/pos-catalog/README.md
@@ -73,6 +73,24 @@ Routing rule for new stories: computing **what a customer pays** → pos-price; 
 
 Product mutations queue a `catalog.product.updated` fact (payload `ProductUpdatedV1`, schema version 2) on `catalog.events.v1` via the transactional outbox (`pos.catalog.kafka.enabled`), reconciled hourly on `catalog.manifest.v1`. Schema version 2 (#1023, additive) added `baseUom`, `trackingLevel`, `uomConversions[]` (`uomCode`, `uomType`, `factorToBase`, `precisionScale`), `substitutionGroupId`, and `substitutionProductIds[]` so pos-inventory can replicate UoM conversions, tracking level, and substitution membership (`ext_product_uom` et al.). UoM and substitution-membership mutations bump the product's `updatedAt` (the envelope `aggregateVersion`) and re-emit the fact for every affected product.
 
+### Replay for replica consumers (#1309)
+
+`POST /v1/products/facts/replay` re-emits `catalog.product.updated` facts so a consumer's replica
+can be seeded or repaired — the mechanism ADR-0044 §4 has always required owners to provide, and
+which this module lacked until pos-supplier's PRICAT matching became the first consumer that cannot
+function without it.
+
+- **Producer-side only.** No replica-holding module needs code for a replay to reach it.
+- **Indistinguishable from live facts.** The same `CatalogFactPublisher` produces them, with
+  `aggregateVersion` still the product's `updatedAt` epoch millis — so a consumer's ordinary stale
+  guard prevents a replayed older fact regressing newer replica state. New `eventId`s are expected.
+- **Paged and resumable.** `afterProductId` is a cursor over the product id (not an offset, which
+  would shift under concurrent writes and drop a product out of the window), `updatedSince` narrows
+  the set, and `limit` is capped at 1000 per call. A short page means the catalog end was reached.
+
+A first deployment of a replica consumer should replay before trusting the replica: it holds only
+facts published after it started.
+
 ## Configuration
 
 | Property                | Default  | Description                  |

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -2278,6 +2278,69 @@ paths:
         - catalog:price_book:read
       x-required-permissions:
       - catalog:price_book:read
+  /v1/products/facts/replay:
+    post:
+      tags:
+      - Products API
+      summary: Re-emit Product Facts for Replica Consumers
+      description: 'Re-publishes catalog.product.updated facts for one bounded page of products so that event-fed replicas in other modules can be seeded or repaired, returning what it emitted and a cursor for the next page.
+
+        Use this tool to fill a consumer''s replica after a first deployment or a consumer outage longer than broker retention; do not use it to fix one product, which republishes itself on its next ordinary update.
+
+        Preconditions: Kafka publication must be enabled, or the facts queue in the outbox and reach nobody; replayed facts are indistinguishable from live ones, so consumers apply them through their normal path and their stale guard prevents an older fact regressing newer state.
+
+        Required inputs: none; afterProductId resumes a previous page, updatedSince restricts to products changed at or after an instant, and limit bounds the page at 1000.
+
+        Emits a CATALOG_PRODUCT_FACT_REPLAY event and queues one product fact per product in the page; no catalog state changes.
+
+        Returns 200 with complete=true and a null cursor once the catalog end is reached, and 400 when limit is out of range or a parameter is malformed.
+
+        '
+      operationId: replayProductFacts
+      parameters:
+      - name: afterProductId
+        in: query
+        description: Resume cursor from a previous call; omit to start at the beginning.
+        required: false
+        schema:
+          type: string
+          format: uuid
+          example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+      - name: updatedSince
+        in: query
+        description: Restrict to products changed at or after this instant; omit to replay all.
+        required: false
+        schema:
+          type: string
+          format: date-time
+          example: 2026-08-01 00:00:00+00:00
+      - name: limit
+        in: query
+        description: Maximum facts to emit in this call (1–1000).
+        required: false
+        schema:
+          type: integer
+          default: 500
+          example: 500
+          maximum: 1000
+          minimum: 1
+      responses:
+        '200':
+          description: What this page emitted and where to resume.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductFactReplayResultDto'
+        '400':
+          description: A parameter is malformed or the limit is out of range
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductFactReplayResultDto'
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_EDIT
   /v1/catalogs:
     post:
       tags:
@@ -5095,6 +5158,32 @@ components:
           example: No active price book rule; MSRP used
       required:
       - source
+    ProductFactReplayResultDto:
+      type: object
+      description: Outcome of one page of a product-fact replay.
+      properties:
+        emitted:
+          type: integer
+          format: int32
+          description: Facts published by this call.
+          example: 500
+        nextAfterId:
+          type: string
+          format: uuid
+          description: Cursor for the next page; null when the catalog end was reached.
+          example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+        complete:
+          type: boolean
+          description: True when no further pages remain for this filter.
+          example: false
+        updatedSince:
+          type: string
+          format: date-time
+          description: The updatedSince filter this page ran under, echoed back.
+        startedAt:
+          type: string
+          format: date-time
+          description: When this page began.
     BulkIngestRequestCatalogBulkIngestRecord:
       type: object
       description: 'Generic bulk ingest request: a batch of records for a job scoped to a location'
@@ -5938,16 +6027,16 @@ components:
         offset:
           type: integer
           format: int64
-        sort:
-          $ref: '#/components/schemas/SortObject'
-        paged:
-          type: boolean
         pageNumber:
           type: integer
           format: int32
         pageSize:
           type: integer
           format: int32
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        paged:
+          type: boolean
         unpaged:
           type: boolean
     SortObject:

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -2332,11 +2332,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProductFactReplayResultDto'
         '400':
-          description: A parameter is malformed or the limit is out of range
+          description: A parameter is malformed or the limit is out of range.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProductFactReplayResultDto'
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - ROLE_ADMIN
@@ -5184,6 +5184,69 @@ components:
           type: string
           format: date-time
           description: When this page began.
+    ApiError:
+      type: object
+      description: Standard error response envelope returned by all Durion backend APIs
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+          example: ORDER_NOT_FOUND
+        message:
+          type: string
+          description: Human-readable error message
+          example: Order '550e8400-e29b-41d4-a716-446655440000' was not found
+        status:
+          type: integer
+          format: int32
+          description: HTTP status code
+          example: 404
+        timestamp:
+          type: string
+          description: ISO 8601 UTC timestamp of the error
+          example: 2026-03-17 14:30:00+00:00
+        correlationId:
+          type: string
+          description: Unique correlation ID for distributed request tracing
+          example: 550e8400-e29b-41d4-a716-446655440000
+        fieldErrors:
+          type: array
+          description: Field-level validation errors; present (non-null) for validation-related errors such as VALIDATION_ERROR or VALIDATION_FAILED; omitted for all other error types
+          items:
+            $ref: '#/components/schemas/FieldError'
+        referenceId:
+          type: string
+          description: Workflow or review-case reference identifier, when applicable
+          example: REVIEW-2026-000123
+        nextAction:
+          type: string
+          description: Recommended next step for the caller, when applicable
+          example: Retry the request with a valid quantity
+        supportAction:
+          type: string
+          description: Support or admin investigation guidance, when applicable
+          example: Contact support with the correlation ID for assistance
+      required:
+      - code
+      - correlationId
+      - message
+      - status
+      - timestamp
+    FieldError:
+      type: object
+      description: Validation error for a specific request field
+      properties:
+        field:
+          type: string
+          description: Field name
+          example: quantity
+        message:
+          type: string
+          description: Validation failure message
+          example: must be greater than 0
+      required:
+      - field
+      - message
     BulkIngestRequestCatalogBulkIngestRecord:
       type: object
       description: 'Generic bulk ingest request: a batch of records for a job scoped to a location'
@@ -5782,69 +5845,6 @@ components:
           type: string
           description: Manufacturer part number of the matched product, null when unknown.
           example: HDW-001
-    ApiError:
-      type: object
-      description: Standard error response envelope returned by all Durion backend APIs
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-          example: ORDER_NOT_FOUND
-        message:
-          type: string
-          description: Human-readable error message
-          example: Order '550e8400-e29b-41d4-a716-446655440000' was not found
-        status:
-          type: integer
-          format: int32
-          description: HTTP status code
-          example: 404
-        timestamp:
-          type: string
-          description: ISO 8601 UTC timestamp of the error
-          example: 2026-03-17 14:30:00+00:00
-        correlationId:
-          type: string
-          description: Unique correlation ID for distributed request tracing
-          example: 550e8400-e29b-41d4-a716-446655440000
-        fieldErrors:
-          type: array
-          description: Field-level validation errors; present (non-null) for validation-related errors such as VALIDATION_ERROR or VALIDATION_FAILED; omitted for all other error types
-          items:
-            $ref: '#/components/schemas/FieldError'
-        referenceId:
-          type: string
-          description: Workflow or review-case reference identifier, when applicable
-          example: REVIEW-2026-000123
-        nextAction:
-          type: string
-          description: Recommended next step for the caller, when applicable
-          example: Retry the request with a valid quantity
-        supportAction:
-          type: string
-          description: Support or admin investigation guidance, when applicable
-          example: Contact support with the correlation ID for assistance
-      required:
-      - code
-      - correlationId
-      - message
-      - status
-      - timestamp
-    FieldError:
-      type: object
-      description: Validation error for a specific request field
-      properties:
-        field:
-          type: string
-          description: Field name
-          example: quantity
-        message:
-          type: string
-          description: Validation failure message
-          example: must be greater than 0
-      required:
-      - field
-      - message
     SupplierPriceEntryDto:
       type: object
       description: A vendor price for a product in one market, effective from a date.
@@ -6027,6 +6027,8 @@ components:
         offset:
           type: integer
           format: int64
+        paged:
+          type: boolean
         pageNumber:
           type: integer
           format: int32
@@ -6035,8 +6037,6 @@ components:
           format: int32
         sort:
           $ref: '#/components/schemas/SortObject'
-        paged:
-          type: boolean
         unpaged:
           type: boolean
     SortObject:

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogEventTypes.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogEventTypes.java
@@ -36,6 +36,12 @@ public final class CatalogEventTypes {
                 EventTypeRegistration.fastRead(
                                 "CATALOG_PRODUCT_CODE_LOOKUP", "Resolve a product by exact EAN or UPC product code")
                         .build(),
+                // Replica seeding / repair (ADR-0044 §4, #1309). An approval-grade budget rather
+                // than a write: one call queues up to a thousand facts, so a write threshold would
+                // alert on every healthy replay.
+                EventTypeRegistration.approval(
+                                "CATALOG_PRODUCT_FACT_REPLAY", "Re-emit product facts for event-fed replica consumers")
+                        .build(),
                 // Supplier price entries applied from PRICAT imports (ADR-0053, #1308)
                 EventTypeRegistration.fastRead(
                                 "CATALOG_SUPPLIER_PRICE_LATEST",

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
@@ -602,7 +602,10 @@ public class ProductController {
                     @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ProductFactReplayResultDto.class)))
-    @ApiResponse(responseCode = "400", description = "A parameter is malformed or the limit is out of range")
+    @ApiResponse(
+            responseCode = "400",
+            description = "A parameter is malformed or the limit is out of range.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     public ResponseEntity<ProductFactReplayResultDto> replayProductFacts(
             @Parameter(
                             description = "Resume cursor from a previous call; omit to start at the beginning.",

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
@@ -12,6 +12,7 @@ import com.positivity.catalog.internal.dto.ProductCodeMatch;
 import com.positivity.catalog.internal.dto.ProductCreateRequestDto;
 import com.positivity.catalog.internal.dto.ProductDetailView;
 import com.positivity.catalog.internal.dto.ProductDto;
+import com.positivity.catalog.internal.dto.ProductFactReplayResultDto;
 import com.positivity.catalog.internal.dto.ProductLifecycleResponse;
 import com.positivity.catalog.internal.dto.ProductLifecycleUpdateRequest;
 import com.positivity.catalog.internal.dto.ProductReplacementRequest;
@@ -22,6 +23,7 @@ import com.positivity.catalog.service.CatalogService;
 import com.positivity.catalog.service.LocationPriceOverrideService;
 import com.positivity.catalog.service.ProductCodeLookupService;
 import com.positivity.catalog.service.ProductDetailService;
+import com.positivity.catalog.service.ProductFactReplayService;
 import com.positivity.catalog.service.ProductLifecycleService;
 import com.positivity.catalog.service.ProductMasterDataService;
 import com.positivity.catalog.service.ProductSearchService;
@@ -36,6 +38,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -56,6 +61,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Slf4j
 @RestController
+@org.springframework.validation.annotation.Validated
 @RequestMapping("/v1/products")
 @Tag(name = "Products API", description = "API for products, lifecycle, and pricing")
 public class ProductController {
@@ -67,6 +73,7 @@ public class ProductController {
     private final ProductMasterDataService productMasterDataService;
     private final ProductSearchService productSearchService;
     private final ProductCodeLookupService productCodeLookupService;
+    private final ProductFactReplayService productFactReplayService;
 
     @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_EDIT')")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -560,6 +567,65 @@ public class ProductController {
                 .getProductById(productId)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_EDIT')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
+    @PostMapping("/facts/replay")
+    @EmitEvent(id = "CATALOG_PRODUCT_FACT_REPLAY", apiVersion = "1")
+    @Operation(
+            operationId = "replayProductFacts",
+            summary = "Re-emit Product Facts for Replica Consumers",
+            description = """
+            Re-publishes catalog.product.updated facts for one bounded page of products so that \
+            event-fed replicas in other modules can be seeded or repaired, returning what it emitted and \
+            a cursor for the next page.
+            Use this tool to fill a consumer's replica after a first deployment or a consumer outage \
+            longer than broker retention; do not use it to fix one product, which republishes itself on \
+            its next ordinary update.
+            Preconditions: Kafka publication must be enabled, or the facts queue in the outbox and \
+            reach nobody; replayed facts are indistinguishable from live ones, so consumers apply them \
+            through their normal path and their stale guard prevents an older fact regressing newer state.
+            Required inputs: none; afterProductId resumes a previous page, updatedSince restricts to \
+            products changed at or after an instant, and limit bounds the page at 1000.
+            Emits a CATALOG_PRODUCT_FACT_REPLAY event and queues one product fact per product in the \
+            page; no catalog state changes.
+            Returns 200 with complete=true and a null cursor once the catalog end is reached, and 400 \
+            when limit is out of range or a parameter is malformed.
+            """)
+    @ApiResponse(
+            responseCode = "200",
+            description = "What this page emitted and where to resume.",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ProductFactReplayResultDto.class)))
+    @ApiResponse(responseCode = "400", description = "A parameter is malformed or the limit is out of range")
+    public ResponseEntity<ProductFactReplayResultDto> replayProductFacts(
+            @Parameter(
+                            description = "Resume cursor from a previous call; omit to start at the beginning.",
+                            schema =
+                                    @Schema(
+                                            type = "string",
+                                            format = "uuid",
+                                            example = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"))
+                    @RequestParam(required = false)
+                    UUID afterProductId,
+            @Parameter(
+                            description = "Restrict to products changed at or after this instant; omit to replay all.",
+                            schema = @Schema(type = "string", format = "date-time", example = "2026-08-01T00:00:00Z"))
+                    @RequestParam(required = false)
+                    Instant updatedSince,
+            @Parameter(
+                            description = "Maximum facts to emit in this call (1–1000).",
+                            schema = @Schema(type = "integer", example = "500", defaultValue = "500"))
+                    @RequestParam(defaultValue = "500")
+                    @Min(1)
+                    @Max(1000)
+                    int limit) {
+        return ResponseEntity.ok(productFactReplayService.replayPage(afterProductId, updatedSince, limit));
     }
 
     @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_VIEW')")

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductFactReplayResultDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductFactReplayResultDto.java
@@ -1,0 +1,42 @@
+package com.positivity.catalog.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Result of one bounded product-fact replay page (#1309, ADR-0044 §4).
+ *
+ * <p>A replay is paged rather than fire-and-forget because a full catalog is tens of thousands of
+ * facts: one request would either time out or flood the broker, and an operator would have no way
+ * to tell a slow replay from a stuck one. Each call reports what it emitted and where to resume,
+ * so progress is visible between pages and a replay can be stopped and continued.
+ *
+ * @param emitted      facts published by this call
+ * @param nextAfterId  cursor to pass as {@code afterProductId} on the next call; null when the
+ *                     replay reached the end of the catalog
+ * @param complete     true when no further pages remain for this filter
+ * @param updatedSince the filter this page ran under, echoed so a paging script cannot drift
+ * @param startedAt    when this page began
+ */
+@Schema(description = "Outcome of one page of a product-fact replay.")
+public record ProductFactReplayResultDto(
+        @Schema(description = "Facts published by this call.", example = "500")
+        int emitted,
+
+        @Schema(
+                description = "Cursor for the next page; null when the catalog end was reached.",
+                example = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b")
+        @Nullable
+        UUID nextAfterId,
+
+        @Schema(description = "True when no further pages remain for this filter.", example = "false")
+        boolean complete,
+
+        @Schema(description = "The updatedSince filter this page ran under, echoed back.") @Nullable
+        Instant updatedSince,
+
+        @Schema(description = "When this page began.") @NonNull
+        Instant startedAt) {}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/ProductRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/ProductRepository.java
@@ -2,6 +2,7 @@ package com.positivity.catalog.internal.repository;
 
 import com.positivity.catalog.internal.entity.ProductCodeType;
 import com.positivity.catalog.internal.entity.ProductEntity;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -20,6 +21,24 @@ public interface ProductRepository extends JpaRepository<ProductEntity, UUID> {
 
     boolean existsByManufacturerIdAndManufacturerPartNumberIgnoreCaseAndIdNot(
             UUID manufacturerId, String manufacturerPartNumber, UUID id);
+
+    /**
+     * A page of products for fact replay (#1309), ordered by id so a cursor can resume where the
+     * previous page stopped.
+     *
+     * <p>Cursor rather than offset paging on purpose: a replay of a large catalog runs over several
+     * requests, and offsets shift under concurrent product writes — a product created mid-replay
+     * would silently displace another out of the window and leave a replica short of exactly the
+     * fact the replay was meant to deliver.
+     */
+    @Query("""
+      SELECT p FROM ProductEntity p
+      WHERE (:afterId IS NULL OR p.id > :afterId)
+        AND (:updatedSince IS NULL OR p.updatedAt >= :updatedSince)
+      ORDER BY p.id ASC
+      """)
+    List<ProductEntity> findForReplay(
+            @Param("afterId") UUID afterId, @Param("updatedSince") Instant updatedSince, Pageable pageable);
 
     /**
      * Exact match on a product code within its scheme (ADR-0053 §5). Returns a list rather than an

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductFactReplayServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductFactReplayServiceImpl.java
@@ -1,0 +1,91 @@
+package com.positivity.catalog.internal.service;
+
+import com.positivity.catalog.internal.config.CatalogFactPublisher;
+import com.positivity.catalog.internal.dto.ProductFactReplayResultDto;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import com.positivity.catalog.service.ProductFactReplayService;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Bounded, resumable re-emission of {@code catalog.product.updated} facts (#1309, ADR-0044 §4).
+ *
+ * <h2>Same publisher as live traffic</h2>
+ *
+ * Facts are produced by {@link CatalogFactPublisher} — the one every ordinary product write already
+ * uses — rather than by a parallel replay-specific serializer. That is the whole point: a replayed
+ * fact must be indistinguishable from a live one, or consumers would need to know which kind they
+ * are holding. A second code path would drift from the first the moment the payload gained a field,
+ * which is precisely how #1224's product codes would have been missed.
+ *
+ * <h2>Ordering and the stale guard</h2>
+ *
+ * {@code aggregateVersion} stays the product's {@code updatedAt} epoch millis, so a replayed fact
+ * carries the same version as the live fact for that state. Consumers skip strictly-lower versions,
+ * which means a replay can never regress a replica that already holds something newer — the guard
+ * they already have is the guard this relies on. New {@code eventId}s per re-emit are expected;
+ * consumers dedupe on them for redelivery, not for replay.
+ *
+ * <h2>Why paged rather than fire-and-forget</h2>
+ *
+ * A full catalog is tens of thousands of facts. One request would either time out or bury live
+ * traffic behind a burst on the outbox, and an operator would have no way to distinguish a slow
+ * replay from a stuck one. Cursor paging over the product id keeps each call bounded, makes
+ * progress visible between calls, and lets a replay be stopped and resumed. The cursor is the id,
+ * not an offset: offsets shift under concurrent writes, and a product created mid-replay would push
+ * another out of the window — leaving a replica short of exactly the fact the replay existed to
+ * deliver.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductFactReplayServiceImpl implements ProductFactReplayService {
+
+    /** Bound on one call, so a mistyped limit cannot turn a replay into a broker flood. */
+    public static final int MAX_LIMIT = 1000;
+
+    private final ProductRepository productRepository;
+    private final CatalogFactPublisher catalogFactPublisher;
+    private final Clock clock;
+
+    @Override
+    @NonNull
+    @Transactional
+    public ProductFactReplayResultDto replayPage(
+            @Nullable UUID afterProductId, @Nullable Instant updatedSince, int limit) {
+        int pageSize = Math.min(Math.max(limit, 1), MAX_LIMIT);
+        Instant startedAt = Instant.now(clock);
+
+        List<ProductEntity> products =
+                productRepository.findForReplay(afterProductId, updatedSince, PageRequest.of(0, pageSize));
+
+        for (ProductEntity product : products) {
+            catalogFactPublisher.publishProductUpdated(product);
+        }
+
+        // A short page means the catalog end was reached: the query is ordered by id and bounded by
+        // the cursor, so there is nothing after it for this filter.
+        boolean complete = products.size() < pageSize;
+        UUID nextAfterId =
+                complete || products.isEmpty() ? null : products.getLast().getId();
+
+        log.info(
+                "Replayed {} product facts (after={}, updatedSince={}, complete={})",
+                products.size(),
+                afterProductId,
+                updatedSince,
+                complete);
+
+        return new ProductFactReplayResultDto(products.size(), nextAfterId, complete, updatedSince, startedAt);
+    }
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/service/ProductFactReplayService.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/service/ProductFactReplayService.java
@@ -1,0 +1,37 @@
+package com.positivity.catalog.service;
+
+import com.positivity.catalog.internal.dto.ProductFactReplayResultDto;
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Re-emits {@code catalog.product.updated} facts so event-fed replicas can be seeded or repaired
+ * (ADR-0044 §4, #1309).
+ *
+ * <p>ADR-0044 §4 has always required owners to provide a replay mechanism; pos-catalog had none,
+ * and pos-supplier's PRICAT matching is the first consumer that cannot function without it — its
+ * {@code ext_product_code} replica is built only from facts published after the consumer starts, so
+ * on a fresh deployment it is empty and every vendor line quarantines.
+ *
+ * <p>The replay is a producer-side capability by design: no replica-holding module needs code for a
+ * replay to reach it. Re-emitted facts are indistinguishable in content from live ones, so every
+ * consumer applies them through its normal path, with its normal stale guard, and a replayed older
+ * fact cannot regress a replica that already holds something newer.
+ *
+ * Issue: CAP-318 #1309
+ */
+public interface ProductFactReplayService {
+
+    /**
+     * Emits one bounded page of product facts.
+     *
+     * @param afterProductId resume cursor from a previous call; null starts at the beginning
+     * @param updatedSince   restrict to products changed at or after this instant; null replays all
+     * @param limit          maximum facts to emit in this call
+     * @return what this page emitted and where to resume
+     */
+    @NonNull
+    ProductFactReplayResultDto replayPage(@Nullable UUID afterProductId, @Nullable Instant updatedSince, int limit);
+}

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/controller/ProductCodeLookupControllerTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/controller/ProductCodeLookupControllerTest.java
@@ -14,6 +14,7 @@ import com.positivity.catalog.service.CatalogService;
 import com.positivity.catalog.service.LocationPriceOverrideService;
 import com.positivity.catalog.service.ProductCodeLookupService;
 import com.positivity.catalog.service.ProductDetailService;
+import com.positivity.catalog.service.ProductFactReplayService;
 import com.positivity.catalog.service.ProductLifecycleService;
 import com.positivity.catalog.service.ProductMasterDataService;
 import com.positivity.catalog.service.ProductSearchService;
@@ -69,6 +70,9 @@ class ProductCodeLookupControllerTest {
 
     @MockitoBean
     ProductSearchService productSearchService;
+
+    @MockitoBean
+    ProductFactReplayService productFactReplayService;
 
     @BeforeEach
     void setUpClock() {

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductFactReplayServiceImplTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductFactReplayServiceImplTest.java
@@ -1,0 +1,147 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.config.CatalogFactPublisher;
+import com.positivity.catalog.internal.dto.ProductFactReplayResultDto;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Product-fact replay for replica consumers (#1309, ADR-0044 §4)")
+class ProductFactReplayServiceImplTest {
+
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-14T12:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private CatalogFactPublisher catalogFactPublisher;
+
+    private ProductFactReplayServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProductFactReplayServiceImpl(productRepository, catalogFactPublisher, CLOCK);
+    }
+
+    private static List<ProductEntity> products(int count) {
+        List<ProductEntity> products = new ArrayList<>();
+        IntStream.rangeClosed(1, count).forEach(i -> {
+            ProductEntity product = new ProductEntity();
+            product.setId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a%02d".formatted(i)));
+            product.setSku("SKU-" + i);
+            products.add(product);
+        });
+        return products;
+    }
+
+    @Test
+    void publishesOneFactPerProductThroughTheOrdinaryPublisher() {
+        when(productRepository.findForReplay(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(products(3));
+
+        ProductFactReplayResultDto result = service.replayPage(null, null, 500);
+
+        // The ordinary publisher, not a replay-specific one: a replayed fact must be
+        // indistinguishable from a live one, and a second serializer would drift from the first.
+        verify(catalogFactPublisher, times(3)).publishProductUpdated(any(ProductEntity.class));
+        assertThat(result.emitted()).isEqualTo(3);
+    }
+
+    @Test
+    void reportsCompleteWhenThePageIsShorterThanTheLimit() {
+        when(productRepository.findForReplay(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(products(2));
+
+        ProductFactReplayResultDto result = service.replayPage(null, null, 500);
+
+        assertThat(result.complete()).isTrue();
+        assertThat(result.nextAfterId()).isNull();
+    }
+
+    @Test
+    void returnsTheLastProductIdAsTheCursorWhenAFullPageIsEmitted() {
+        List<ProductEntity> page = products(3);
+        when(productRepository.findForReplay(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(page);
+
+        ProductFactReplayResultDto result = service.replayPage(null, null, 3);
+
+        assertThat(result.complete()).isFalse();
+        assertThat(result.nextAfterId()).isEqualTo(page.getLast().getId());
+    }
+
+    @Test
+    void resumesFromTheSuppliedCursor() {
+        UUID cursor = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a05");
+        when(productRepository.findForReplay(eq(cursor), isNull(), any(Pageable.class)))
+                .thenReturn(products(1));
+
+        service.replayPage(cursor, null, 500);
+
+        verify(productRepository).findForReplay(eq(cursor), isNull(), any(Pageable.class));
+    }
+
+    @Test
+    void passesTheUpdatedSinceFilterThrough() {
+        Instant since = Instant.parse("2026-08-01T00:00:00Z");
+        when(productRepository.findForReplay(isNull(), eq(since), any(Pageable.class)))
+                .thenReturn(products(1));
+
+        ProductFactReplayResultDto result = service.replayPage(null, since, 500);
+
+        assertThat(result.updatedSince()).isEqualTo(since);
+    }
+
+    @Test
+    void capsTheRequestedLimitSoAMistypedCallCannotFloodTheBroker() {
+        when(productRepository.findForReplay(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(products(1));
+
+        service.replayPage(null, null, 100_000);
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(productRepository).findForReplay(isNull(), isNull(), captor.capture());
+        assertThat(captor.getValue().getPageSize()).isEqualTo(ProductFactReplayServiceImpl.MAX_LIMIT);
+    }
+
+    @Test
+    void treatsAnEmptyCatalogAsAFinishedReplayRatherThanAnError() {
+        when(productRepository.findForReplay(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        ProductFactReplayResultDto result = service.replayPage(null, null, 500);
+
+        assertThat(result.emitted()).isZero();
+        assertThat(result.complete()).isTrue();
+        assertThat(result.nextAfterId()).isNull();
+        verify(catalogFactPublisher, never()).publishProductUpdated(any());
+    }
+}

--- a/pos-supplier/README.md
+++ b/pos-supplier/README.md
@@ -118,6 +118,21 @@ least one usable line), `EMPTY` (the vendor sent no lines), `REJECTED` (the vend
 none of them decoded — a codec or vendor-format break, not a quiet warehouse), `FAILED` (no usable
 answer at all).
 
+### Quarantine re-application
+
+`POST …/price-catalog/{vendorProfileId}/quarantine/reapply` re-matches the profile's open quarantine
+against the current product-code replica and applies whatever now resolves — **with no vendor call**
+(ADR-0053 §5). An hourly sweep does the same for every enabled profile; the cadence is its own,
+because what makes a line matchable is a change in the catalog, not the vendor's next fetch.
+
+Skipped on purpose: `NO_IDENTIFIER` and `MALFORMED_LINE`. No catalog fix rescues a line that carried
+nothing to match on, so retrying them would keep the worklist permanently non-empty.
+
+A re-application creates **its own manifest** referencing the import it healed
+(`reapplied_from_import_id`), rather than editing the original's counters. Those counters record
+what the vendor sent and how much matched *at the time*, and a fourth chunk of a three-chunk import
+is not something a consumer's completeness check can accept.
+
 ### Gateway routing
 
 `Path=/supplier/**` with `StripPrefix=1`, plus the gateway's global `ApiVersionHeaderToPathFilter`:
@@ -393,15 +408,13 @@ nothing), then update the Angular SDK.
 
 ### Known gaps
 
-- PRICAT re-application from the quarantine after a catalog fix is not yet automated: the rows carry
-  the values needed for it (ADR-0053 §5), but today a re-import is what closes them.
 - Manufacturer-part matching, ADR-0053 §5's third match step, needs a supplier-to-manufacturer mapping
   that no vendor profile carries yet.
 - The 500-line chunk default is ADR-0053's estimate and is still owed a validation against the first
   Michelin sandbox pull.
-- The `ext_product_code` replica has no backfill path yet: it is built from facts published after the
-  consumer starts, so a first deployment needs pos-catalog to re-emit (ADR-0044 §4 replay) before
-  PRICAT lines can match.
+- The `ext_product_code` replica is seeded by pos-catalog's product-fact replay
+  (`POST /v1/products/facts/replay`, #1309); a first deployment must run it before PRICAT lines can
+  match, because the replica holds only facts published after its consumer started.
 - Stock-report snapshots are published but not yet consumed: the pos-inventory hint representation is
   a domain decision (#1312) and the consumer waits on it.
 - `SupplierShipmentTrackingPort` has no adapter and cannot get one from the spec we hold: the LEX v1

--- a/pos-supplier/openapi.yaml
+++ b/pos-supplier/openapi.yaml
@@ -1402,15 +1402,17 @@ paths:
 
         batch size is a deployment setting rather than a caller choice.
 
-        Emits a SUPPLIER_PRICECATALOG_REAPPLY event, creates a re-application manifest that references
+        Emits a SUPPLIER_PRICECATALOG_REAPPLY event and creates one re-application manifest per origin
 
-        the import it healed, closes the lines it matched, and publishes their prices; the original
+        import — a quarantine spans every import that left a line open, and each manifest carries one
 
-        import''s counters are left untouched, because they record what the vendor sent at the time.
+        vendor document''s identity — closing the lines it matched and publishing their prices; the
 
-        Returns 200 with the re-application summary, 204 when nothing matched — the healthy steady state,
+        original imports'' counters are left untouched, because they record what the vendor sent at the time.
 
-        not a failure — and 404 when the profile does not exist.
+        Returns 200 with one summary per healed import, 204 when nothing matched — the healthy steady
+
+        state, not a failure — and 404 when the profile does not exist.
 
         '
       operationId: reapplySupplierPriceCatalogQuarantine
@@ -1425,11 +1427,13 @@ paths:
           example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
       responses:
         '200':
-          description: Summary of the re-application manifest.
+          description: One summary per origin import that had lines resolve.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PriceCatalogImportSummary'
+                type: array
+                items:
+                  $ref: '#/components/schemas/PriceCatalogImportSummary'
         '204':
           description: 'Nothing in the quarantine resolved. The response has NO body: an empty result is the healthy steady state, not an error envelope to parse.'
         '404':

--- a/pos-supplier/openapi.yaml
+++ b/pos-supplier/openapi.yaml
@@ -1377,6 +1377,79 @@ paths:
       - bearerAuth: []
       x-required-permissions:
       - supplier:profile:write
+  /v1/supplier/admin/price-catalog/{vendorProfileId}/quarantine/reapply:
+    post:
+      tags:
+      - Supplier Price Catalog
+      summary: Re-apply quarantined price-catalog lines
+      description: 'Re-matches the profile''s open unmatched-line quarantine against the current product-code replica
+
+        and applies whatever now resolves, staging it and publishing it exactly as an import would — with
+
+        no call to the vendor.
+
+        Use this tool after a catalog fix, or after the product-code replica has been seeded, to close
+
+        lines that were quarantined for a reason that no longer holds; do not use it to fetch fresh
+
+        prices, which is triggerSupplierPriceCatalogImport.
+
+        Preconditions: the profile must exist; lines that carried no identifier and lines whose values
+
+        never decoded are skipped, because no catalog fix can rescue them.
+
+        Required inputs: vendorProfileId (UUIDv7) as a path parameter; there is no request body, and the
+
+        batch size is a deployment setting rather than a caller choice.
+
+        Emits a SUPPLIER_PRICECATALOG_REAPPLY event, creates a re-application manifest that references
+
+        the import it healed, closes the lines it matched, and publishes their prices; the original
+
+        import''s counters are left untouched, because they record what the vendor sent at the time.
+
+        Returns 200 with the re-application summary, 204 when nothing matched — the healthy steady state,
+
+        not a failure — and 404 when the profile does not exist.
+
+        '
+      operationId: reapplySupplierPriceCatalogQuarantine
+      parameters:
+      - name: vendorProfileId
+        in: path
+        description: Vendor profile whose quarantine to work (UUIDv7).
+        required: true
+        schema:
+          type: string
+          format: uuid
+          example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+      responses:
+        '200':
+          description: Summary of the re-application manifest.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PriceCatalogImportSummary'
+        '204':
+          description: 'Nothing in the quarantine resolved. The response has NO body: an empty result is the healthy steady state, not an error envelope to parse.'
+        '404':
+          description: No vendor profile exists with the supplied id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '401':
+          description: 'Authentication is missing or the bearer token is invalid. The response has NO body: the gateway rejects unauthenticated calls with a bodiless status, so clients must not attempt to parse an error envelope here.'
+        '403':
+          description: Authenticated caller lacks supplier:pricecatalog:import.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth: []
+      x-required-permissions:
+      - supplier:pricecatalog:import
   /v1/supplier/admin/price-catalog/{vendorProfileId}/imports:
     get:
       tags:

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/config/SupplierEventTypes.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/config/SupplierEventTypes.java
@@ -83,6 +83,12 @@ public final class SupplierEventTypes {
                 EventTypeRegistration.search(
                                 "SUPPLIER_PRICECATALOG_UNMATCHED_LIST",
                                 "List price-catalog lines quarantined for catalog review")
+                        .build(),
+                // Re-application stages and publishes a batch of lines, so it carries a write's
+                // latency rather than a read's.
+                EventTypeRegistration.write(
+                                "SUPPLIER_PRICECATALOG_REAPPLY",
+                                "Re-apply quarantined price-catalog lines after a catalog fix")
                         .build());
     }
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierPriceCatalogAdminController.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierPriceCatalogAdminController.java
@@ -128,6 +128,71 @@ public class SupplierPriceCatalogAdminController {
     }
 
     @Operation(
+            operationId = "reapplySupplierPriceCatalogQuarantine",
+            summary = "Re-apply quarantined price-catalog lines",
+            description = """
+                    Re-matches the profile's open unmatched-line quarantine against the current product-code replica
+                    and applies whatever now resolves, staging it and publishing it exactly as an import would — with
+                    no call to the vendor.
+                    Use this tool after a catalog fix, or after the product-code replica has been seeded, to close
+                    lines that were quarantined for a reason that no longer holds; do not use it to fetch fresh
+                    prices, which is triggerSupplierPriceCatalogImport.
+                    Preconditions: the profile must exist; lines that carried no identifier and lines whose values
+                    never decoded are skipped, because no catalog fix can rescue them.
+                    Required inputs: vendorProfileId (UUIDv7) as a path parameter; there is no request body, and the
+                    batch size is a deployment setting rather than a caller choice.
+                    Emits a SUPPLIER_PRICECATALOG_REAPPLY event, creates a re-application manifest that references
+                    the import it healed, closes the lines it matched, and publishes their prices; the original
+                    import's counters are left untouched, because they record what the vendor sent at the time.
+                    Returns 200 with the re-application summary, 204 when nothing matched — the healthy steady state,
+                    not a failure — and 404 when the profile does not exist.
+                    """)
+    @ApiResponse(
+            responseCode = "200",
+            description = "Summary of the re-application manifest.",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PriceCatalogImportSummary.class)))
+    @ApiResponse(
+            responseCode = "204",
+            description = "Nothing in the quarantine resolved. The response has NO body: an empty result is the"
+                    + " healthy steady state, not an error envelope to parse.",
+            content = @Content(schema = @Schema(hidden = true)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "No vendor profile exists with the supplied id.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "401",
+            description = UNAUTHENTICATED_DESCRIPTION,
+            content = @Content(schema = @Schema(hidden = true)))
+    @ApiResponse(
+            responseCode = "403",
+            description = "Authenticated caller lacks supplier:pricecatalog:import.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @PreAuthorize("hasAuthority('" + SupplierPermissions.PRICECATALOG_IMPORT + "')")
+    @EmitEvent(id = "SUPPLIER_PRICECATALOG_REAPPLY", apiVersion = "1")
+    @PostMapping("/{vendorProfileId}/quarantine/reapply")
+    public ResponseEntity<PriceCatalogImportSummary> reapplyQuarantine(
+            @Parameter(
+                            description = "Vendor profile whose quarantine to work (UUIDv7).",
+                            required = true,
+                            schema =
+                                    @Schema(
+                                            type = "string",
+                                            format = "uuid",
+                                            example = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"))
+                    @PathVariable
+                    @NotNull
+                    UUID vendorProfileId) {
+        return priceCatalogService
+                .reapplyQuarantine(vendorProfileId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    @Operation(
             operationId = "listSupplierPriceCatalogImports",
             summary = "List vendor price-catalog imports",
             description = """

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierPriceCatalogAdminController.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierPriceCatalogAdminController.java
@@ -9,6 +9,7 @@ import com.positivity.supplier.service.model.PriceCatalogImportSummary;
 import com.positivity.supplier.service.model.UnmatchedPriceCatalogLineView;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -141,19 +143,20 @@ public class SupplierPriceCatalogAdminController {
                     never decoded are skipped, because no catalog fix can rescue them.
                     Required inputs: vendorProfileId (UUIDv7) as a path parameter; there is no request body, and the
                     batch size is a deployment setting rather than a caller choice.
-                    Emits a SUPPLIER_PRICECATALOG_REAPPLY event, creates a re-application manifest that references
-                    the import it healed, closes the lines it matched, and publishes their prices; the original
-                    import's counters are left untouched, because they record what the vendor sent at the time.
-                    Returns 200 with the re-application summary, 204 when nothing matched — the healthy steady state,
-                    not a failure — and 404 when the profile does not exist.
+                    Emits a SUPPLIER_PRICECATALOG_REAPPLY event and creates one re-application manifest per origin
+                    import — a quarantine spans every import that left a line open, and each manifest carries one
+                    vendor document's identity — closing the lines it matched and publishing their prices; the
+                    original imports' counters are left untouched, because they record what the vendor sent at the time.
+                    Returns 200 with one summary per healed import, 204 when nothing matched — the healthy steady
+                    state, not a failure — and 404 when the profile does not exist.
                     """)
     @ApiResponse(
             responseCode = "200",
-            description = "Summary of the re-application manifest.",
+            description = "One summary per origin import that had lines resolve.",
             content =
                     @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = PriceCatalogImportSummary.class)))
+                            array = @ArraySchema(schema = @Schema(implementation = PriceCatalogImportSummary.class))))
     @ApiResponse(
             responseCode = "204",
             description = "Nothing in the quarantine resolved. The response has NO body: an empty result is the"
@@ -174,7 +177,7 @@ public class SupplierPriceCatalogAdminController {
     @PreAuthorize("hasAuthority('" + SupplierPermissions.PRICECATALOG_IMPORT + "')")
     @EmitEvent(id = "SUPPLIER_PRICECATALOG_REAPPLY", apiVersion = "1")
     @PostMapping("/{vendorProfileId}/quarantine/reapply")
-    public ResponseEntity<PriceCatalogImportSummary> reapplyQuarantine(
+    public ResponseEntity<List<PriceCatalogImportSummary>> reapplyQuarantine(
             @Parameter(
                             description = "Vendor profile whose quarantine to work (UUIDv7).",
                             required = true,
@@ -186,10 +189,8 @@ public class SupplierPriceCatalogAdminController {
                     @PathVariable
                     @NotNull
                     UUID vendorProfileId) {
-        return priceCatalogService
-                .reapplyQuarantine(vendorProfileId)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.noContent().build());
+        List<PriceCatalogImportSummary> summaries = priceCatalogService.reapplyQuarantine(vendorProfileId);
+        return summaries.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(summaries);
     }
 
     @Operation(

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/PriceCatalogImportEntity.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/PriceCatalogImportEntity.java
@@ -144,6 +144,19 @@ public class PriceCatalogImportEntity {
     @Column(name = "correlation_id", nullable = false, length = 100)
     private String correlationId;
 
+    /**
+     * Set when this manifest re-applied quarantined lines of an earlier import (#1310); null for an
+     * ordinary vendor fetch.
+     *
+     * <p>A re-application gets its own manifest rather than editing the original's counters,
+     * because those counters record what the vendor sent and how much of it matched <em>at the
+     * time</em>. Rewriting them later would destroy that record and contradict the chunk sequencing
+     * consumers already applied — chunk 4 of a 3-chunk import is not something a completeness check
+     * can accept.
+     */
+    @Column(name = "reapplied_from_import_id", updatable = false)
+    private UUID reappliedFromImportId;
+
     /** Operator-facing failure summary for a FAILED import; never a credential. */
     @Column(name = "failure_detail", length = 2000)
     private String failureDetail;

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplicationScheduler.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplicationScheduler.java
@@ -47,9 +47,10 @@ public class QuarantineReapplicationScheduler {
             try {
                 reapplicationService
                         .reapply(profile.getVendorProfileId())
-                        .ifPresent(manifest -> log.info(
-                                "Quarantine sweep re-applied {} lines for profile {} as import {}",
+                        .forEach(manifest -> log.info(
+                                "Quarantine sweep re-applied {} lines of import {} for profile {} as import {}",
                                 manifest.getLinesMatched(),
+                                manifest.getReappliedFromImportId(),
                                 profile.getVendorProfileId(),
                                 manifest.getImportManifestId()));
             } catch (Exception e) {

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplicationScheduler.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplicationScheduler.java
@@ -1,0 +1,64 @@
+package com.positivity.supplier.internal.pricecatalog.service;
+
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.repository.SupplierProfileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Sweeps every enabled profile's quarantine on a cron, re-applying lines that the catalog can now
+ * resolve (#1310, ADR-0053 §5).
+ *
+ * <h2>Its own cadence, not the import's</h2>
+ *
+ * What makes a quarantined line matchable is a change in the <em>catalog</em> — a product created,
+ * a code corrected, or the product-code replica finally seeded. None of that has anything to do
+ * with when the vendor is next fetched, so tying re-application to the import schedule would leave
+ * lines waiting on a vendor for a fix that already happened on our side. A vendor fetched weekly
+ * would strand a correction for a week.
+ *
+ * <h2>No lease</h2>
+ *
+ * Unlike the import scheduler this takes no schedule lease. Two instances sweeping at once is
+ * harmless: the work is idempotent by construction — a line closed by one instance is no longer
+ * open for the other, and a line matched twice in the same instant produces one closed row because
+ * the close and the staging commit together. A lease would add a failure mode (a stuck lease
+ * blocking recovery) to protect against something that costs nothing.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.supplier.pricat", name = "reapply-enabled", matchIfMissing = true)
+public class QuarantineReapplicationScheduler {
+
+    private final SupplierProfileRepository profileRepository;
+    private final QuarantineReapplier reapplicationService;
+
+    /** Re-applies each enabled profile's quarantine; one failure never stops the other profiles. */
+    @Scheduled(cron = "${pos.supplier.pricat.reapply-cron:0 15 * * * *}")
+    public void sweep() {
+        for (SupplierProfileEntity profile : profileRepository.findAll()) {
+            if (!profile.isEnabled()) {
+                continue;
+            }
+            try {
+                reapplicationService
+                        .reapply(profile.getVendorProfileId())
+                        .ifPresent(manifest -> log.info(
+                                "Quarantine sweep re-applied {} lines for profile {} as import {}",
+                                manifest.getLinesMatched(),
+                                profile.getVendorProfileId(),
+                                manifest.getImportManifestId()));
+            } catch (Exception e) {
+                log.warn(
+                        "Quarantine re-application failed for profile {}: {}",
+                        profile.getVendorProfileId(),
+                        e.toString(),
+                        e);
+            }
+        }
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplicationWriter.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplicationWriter.java
@@ -1,0 +1,243 @@
+package com.positivity.supplier.internal.pricecatalog.service;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.DomainTopics;
+import com.positivity.domainevents.supplier.SupplierPriceCatalogImportCompletedV1;
+import com.positivity.domainevents.supplier.SupplierPriceCatalogLine;
+import com.positivity.domainevents.supplier.SupplierPriceCatalogUpdatedV1;
+import com.positivity.shared.id.UUIDv7Generator;
+import com.positivity.supplier.internal.audit.SupplierCorrelationContext;
+import com.positivity.supplier.internal.domain.model.SupplierPriceCatalogEntry;
+import com.positivity.supplier.internal.entity.PriceCatalogEntryEntity;
+import com.positivity.supplier.internal.entity.PriceCatalogImportEntity;
+import com.positivity.supplier.internal.entity.PriceCatalogUnmatchedLineEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.enums.PriceCatalogImportStatus;
+import com.positivity.supplier.internal.pricecatalog.service.QuarantineReapplier.ResolvedLine;
+import com.positivity.supplier.internal.repository.PriceCatalogEntryRepository;
+import com.positivity.supplier.internal.repository.PriceCatalogImportRepository;
+import com.positivity.supplier.internal.repository.PriceCatalogUnmatchedLineRepository;
+import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Commits a re-application: staged entries, closed quarantine rows, and the events describing them,
+ * in one transaction (ADR-0053 §5/§7, ADR-0044 §4).
+ *
+ * <p>Separate from {@link QuarantineReapplier} for the same reason the import writer is
+ * separate: a {@code @Transactional} method called from a sibling method of the same bean is not
+ * proxied, so "the rows and their events commit together" would silently not hold.
+ *
+ * <p>Closing a quarantine row and publishing its price are the same fact. If the close committed
+ * without the event, an operator's worklist would go quiet while consumers never received the
+ * price — the worst of the two failures, because nothing would look wrong.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QuarantineReapplicationWriter {
+
+    private final PriceCatalogImportRepository importRepository;
+    private final PriceCatalogEntryRepository entryRepository;
+    private final PriceCatalogUnmatchedLineRepository unmatchedLineRepository;
+    private final SupplierOutboxEventWriter outboxWriter;
+    private final Clock clock;
+
+    /**
+     * Stages the resolved lines under a fresh manifest, closes their quarantine rows, and publishes
+     * the chunked events plus a completion event.
+     *
+     * @param profile   the vendor profile being re-applied
+     * @param resolved  lines that now match
+     * @param appliedAt the instant of this re-application
+     * @param chunkSize event chunk size
+     * @return the re-application manifest
+     */
+    @NonNull
+    @Transactional
+    public PriceCatalogImportEntity commit(
+            @NonNull SupplierProfileEntity profile,
+            @NonNull List<ResolvedLine> resolved,
+            @NonNull Instant appliedAt,
+            int chunkSize) {
+
+        PriceCatalogUnmatchedLineEntity first = resolved.getFirst().quarantineRow();
+        // The original manifest, which the quarantine row's FK guarantees exists. Its norm is copied
+        // rather than invented: these lines came from that vendor document, and a consumer reading
+        // protocolVersion on the event is asking which norm produced the prices, not which code
+        // path re-applied them.
+        PriceCatalogImportEntity origin = importRepository
+                .findById(first.getImportManifestId())
+                .orElseThrow(() -> new IllegalStateException("Quarantined line " + first.getUnmatchedLineId()
+                        + " references import " + first.getImportManifestId() + ", which does not exist"));
+        String correlationId = SupplierCorrelationContext.currentOrGenerate();
+        List<List<ResolvedLine>> chunks = partition(resolved, chunkSize);
+
+        PriceCatalogImportEntity manifest = importRepository.save(PriceCatalogImportEntity.builder()
+                .vendorProfileId(profile.getVendorProfileId())
+                .supplierRef(profile.getSupplierRef())
+                .protocolFamily(origin.getProtocolFamily())
+                .protocolVersion(origin.getProtocolVersion())
+                .status(PriceCatalogImportStatus.COMPLETED)
+                .sourceDocumentId(first.getSourceDocumentId())
+                .sourceDocumentDate(first.getSourceDocumentDate())
+                .buyerAccountNumber(first.getBuyerAccountNumber())
+                .countryCode(first.getCountryCode())
+                .currency(first.getCurrency())
+                .fetchedAt(first.getFetchedAt())
+                .completedAt(appliedAt)
+                .linesFetched(resolved.size())
+                .linesMatched(resolved.size())
+                .linesUnmatched(0)
+                .linesDuplicate(0)
+                .chunkCount(chunks.size())
+                .chunkSize(chunkSize)
+                .correlationId(correlationId)
+                .reappliedFromImportId(first.getImportManifestId())
+                .build());
+
+        for (ResolvedLine line : resolved) {
+            entryRepository.save(toEntryEntity(line, manifest));
+            PriceCatalogUnmatchedLineEntity row = line.quarantineRow();
+            row.setResolvedAt(appliedAt);
+            row.setResolvedProductId(line.productId());
+            unmatchedLineRepository.save(row);
+        }
+
+        publish(manifest, chunks, appliedAt);
+        return manifest;
+    }
+
+    private void publish(PriceCatalogImportEntity manifest, List<List<ResolvedLine>> chunks, Instant completedAt) {
+        String topic = DomainTopics.events("supplier");
+        int sequence = 0;
+        for (List<ResolvedLine> chunk : chunks) {
+            sequence++;
+            SupplierPriceCatalogUpdatedV1 payload = new SupplierPriceCatalogUpdatedV1(
+                    manifest.getImportManifestId(),
+                    manifest.getVendorProfileId(),
+                    manifest.getSupplierRef(),
+                    sequence,
+                    chunks.size(),
+                    manifest.getSourceDocumentId(),
+                    manifest.getSourceDocumentDate(),
+                    manifest.getBuyerAccountNumber(),
+                    manifest.getCountryCode(),
+                    manifest.getCurrency(),
+                    manifest.getProtocolVersion(),
+                    manifest.getFetchedAt(),
+                    chunk.stream()
+                            .map(QuarantineReapplicationWriter::toEventLine)
+                            .toList());
+            outboxWriter.publish(
+                    topic, envelope(manifest, SupplierPriceCatalogUpdatedV1.EVENT_TYPE, sequence, payload));
+        }
+
+        // A completion event with its own chunkCount, so a consumer can confirm the re-application
+        // whole exactly as it confirms an import. Without it the consumer would hold chunks of a
+        // manifest that never declares a total and could never be marked complete.
+        SupplierPriceCatalogImportCompletedV1 completion = new SupplierPriceCatalogImportCompletedV1(
+                manifest.getImportManifestId(),
+                manifest.getVendorProfileId(),
+                manifest.getSupplierRef(),
+                manifest.getStatus().name(),
+                manifest.getLinesFetched(),
+                manifest.getLinesMatched(),
+                manifest.getLinesUnmatched(),
+                manifest.getLinesDuplicate(),
+                manifest.getChunkCount(),
+                manifest.getChunkSize(),
+                null,
+                manifest.getSourceDocumentId(),
+                manifest.getSourceDocumentDate(),
+                manifest.getBuyerAccountNumber(),
+                manifest.getCountryCode(),
+                manifest.getCurrency(),
+                manifest.getFetchedAt(),
+                completedAt);
+        outboxWriter.publish(
+                topic,
+                envelope(manifest, SupplierPriceCatalogImportCompletedV1.EVENT_TYPE, chunks.size() + 1L, completion));
+    }
+
+    private <T> DomainEventEnvelope<T> envelope(
+            PriceCatalogImportEntity manifest, String eventType, long aggregateVersion, T payload) {
+        return new DomainEventEnvelope<>(
+                UUIDv7Generator.generate(),
+                eventType,
+                1,
+                manifest.getImportManifestId(),
+                aggregateVersion,
+                Instant.now(clock),
+                "pos-supplier",
+                manifest.getCorrelationId(),
+                manifest.getCreatedBy(),
+                payload);
+    }
+
+    private static SupplierPriceCatalogLine toEventLine(ResolvedLine line) {
+        SupplierPriceCatalogEntry entry = line.entry();
+        return new SupplierPriceCatalogLine(
+                line.productId(),
+                line.method().name(),
+                entry.articleEan(),
+                entry.supplierArticleCode(),
+                entry.xReferenceCode(),
+                entry.suggestedRetailPrice(),
+                entry.grossPrice(),
+                entry.netPrice(),
+                entry.taxRate(),
+                entry.recyclingFee(),
+                entry.effectiveFrom(),
+                entry.positionNumber());
+    }
+
+    private static PriceCatalogEntryEntity toEntryEntity(ResolvedLine line, PriceCatalogImportEntity manifest) {
+        SupplierPriceCatalogEntry entry = line.entry();
+        return PriceCatalogEntryEntity.builder()
+                .importManifestId(manifest.getImportManifestId())
+                .vendorProfileId(manifest.getVendorProfileId())
+                .positionNumber(entry.positionNumber())
+                .articleEan(entry.articleEan())
+                .supplierArticleCode(entry.supplierArticleCode())
+                .xReferenceCode(entry.xReferenceCode())
+                .matchedProductId(line.productId())
+                .matchMethod(line.method())
+                .suggestedRetailPrice(entry.suggestedRetailPrice())
+                .grossPrice(entry.grossPrice())
+                .netPrice(entry.netPrice())
+                .taxRate(entry.taxRate())
+                .recyclingFee(entry.recyclingFee())
+                .effectiveFrom(entry.effectiveFrom())
+                .buyerAccountNumber(manifest.getBuyerAccountNumber())
+                .countryCode(entry.countryCode())
+                .currency(entry.currency())
+                .sourceDocumentId(entry.sourceDocumentId())
+                .sourceDocumentDate(entry.sourceDocumentDate())
+                // The vendor's own fetch time, not now: the prices are as fresh as the document
+                // they came from, and pretending otherwise would let a re-application outrank a
+                // newer fetch in the latest-selection tie-break.
+                .fetchedAt(manifest.getFetchedAt())
+                .build();
+    }
+
+    private static <T> List<List<T>> partition(List<T> items, int size) {
+        if (items.isEmpty()) {
+            return List.of();
+        }
+        int chunkSize = Math.max(1, size);
+        List<List<T>> chunks = new ArrayList<>((items.size() + chunkSize - 1) / chunkSize);
+        for (int start = 0; start < items.size(); start += chunkSize) {
+            chunks.add(List.copyOf(items.subList(start, Math.min(items.size(), start + chunkSize))));
+        }
+        return chunks;
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplier.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplier.java
@@ -1,0 +1,189 @@
+package com.positivity.supplier.internal.pricecatalog.service;
+
+import com.positivity.supplier.internal.domain.model.SupplierPriceCatalogEntry;
+import com.positivity.supplier.internal.entity.PriceCatalogImportEntity;
+import com.positivity.supplier.internal.entity.PriceCatalogUnmatchedLineEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.enums.PriceCatalogMatchMethod;
+import com.positivity.supplier.internal.enums.UnmatchedLineReason;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
+import com.positivity.supplier.internal.repository.PriceCatalogUnmatchedLineRepository;
+import com.positivity.supplier.internal.repository.SupplierProfileRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+/**
+ * Re-matches quarantined PRICAT lines against the current product-code replica and applies the ones
+ * that now resolve — without asking the vendor for the document again (ADR-0053 §5).
+ *
+ * <h2>Why this exists</h2>
+ *
+ * #1224 shipped the quarantine but not this: the only way to close a quarantined line was to re-run
+ * the whole import. That asks a trading partner for a document we already hold, produces a second
+ * manifest for the same catalog, and is useless for lines quarantined as
+ * {@link UnmatchedLineReason#CATALOG_UNAVAILABLE} — a replica gap, which has nothing to do with the
+ * vendor and cannot be fixed by talking to them.
+ *
+ * <h2>Its own manifest, not the original's counters</h2>
+ *
+ * A re-application produces a new import manifest that points back at the one it healed
+ * ({@code reappliedFromImportId}). The original's counters record what the vendor sent and how much
+ * of it matched <em>at the time</em>; rewriting them later would destroy that record. It would also
+ * contradict the chunk sequencing consumers have already applied — chunk 4 of a 3-chunk import is
+ * not something a completeness check can accept, and #1308's consumer would read it as a discrepancy
+ * rather than a repair.
+ *
+ * <h2>Matching stays exactly as strict</h2>
+ *
+ * The same deterministic order as the original import: exact EAN, then the cross-reference code as a
+ * UPC. A second chance for the catalog to have changed is not a licence for a looser match.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuarantineReapplier {
+
+    /**
+     * Reasons worth retrying. {@link UnmatchedLineReason#NO_IDENTIFIER} and
+     * {@link UnmatchedLineReason#MALFORMED_LINE} are excluded on purpose: no catalog fix can rescue
+     * a line that carried nothing to match on, or one whose values never decoded, so retrying them
+     * would burn lookups forever and keep an operator's worklist permanently non-empty.
+     */
+    private static final List<UnmatchedLineReason> RETRYABLE_REASONS = List.of(
+            UnmatchedLineReason.NO_CATALOG_MATCH,
+            UnmatchedLineReason.AMBIGUOUS_CATALOG_MATCH,
+            UnmatchedLineReason.CATALOG_UNAVAILABLE);
+
+    private final SupplierProfileRepository profileRepository;
+    private final PriceCatalogUnmatchedLineRepository unmatchedLineRepository;
+    private final ProductCodeResolver productCodeResolver;
+    private final QuarantineReapplicationWriter reapplicationWriter;
+    private final Clock clock;
+
+    @Value("${pos.supplier.pricat.reapply-batch-size:2000}")
+    private int batchSize;
+
+    @Value("${pos.supplier.pricat.chunk-size:500}")
+    private int chunkSize;
+
+    /**
+     * Re-matches one batch of a profile's open quarantine and applies what now resolves.
+     *
+     * @param vendorProfileId profile whose quarantine to work
+     * @return the re-application manifest, or empty when nothing matched — an empty result is the
+     *         healthy steady state, not a failure
+     * @throws SupplierConfigurationException when no profile exists with that id
+     */
+    @NonNull
+    public Optional<PriceCatalogImportEntity> reapply(@NonNull UUID vendorProfileId) {
+        SupplierProfileEntity profile = profileRepository
+                .findById(vendorProfileId)
+                .orElseThrow(() -> new SupplierConfigurationException(
+                        SupplierConfigurationException.UNKNOWN_SUPPLIER,
+                        "No vendor profile exists with id " + vendorProfileId));
+
+        List<PriceCatalogUnmatchedLineEntity> candidates =
+                unmatchedLineRepository.findByVendorProfileIdAndResolvedAtIsNullAndReasonIn(
+                        vendorProfileId, RETRYABLE_REASONS, PageRequest.of(0, Math.max(1, batchSize)));
+        if (candidates.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<ResolvedLine> resolved = new ArrayList<>();
+        for (PriceCatalogUnmatchedLineEntity line : candidates) {
+            match(line).ifPresent(resolved::add);
+        }
+
+        if (resolved.isEmpty()) {
+            log.debug(
+                    "Re-application for profile {} matched none of {} candidate lines",
+                    vendorProfileId,
+                    candidates.size());
+            return Optional.empty();
+        }
+
+        PriceCatalogImportEntity manifest =
+                reapplicationWriter.commit(profile, resolved, Instant.now(clock), chunkSize);
+        log.info(
+                "Re-applied {} of {} quarantined lines for profile {} as import {}",
+                resolved.size(),
+                candidates.size(),
+                vendorProfileId,
+                manifest.getImportManifestId());
+        return Optional.of(manifest);
+    }
+
+    /** Same deterministic order as the original import: exact EAN, then cross-reference as a UPC. */
+    private Optional<ResolvedLine> match(PriceCatalogUnmatchedLineEntity line) {
+        ResolvedLine byEan = resolve(line, line.getArticleEan(), "EAN", PriceCatalogMatchMethod.EAN);
+        if (byEan != null) {
+            return Optional.of(byEan);
+        }
+        ResolvedLine byXref = resolve(line, line.getXReferenceCode(), "UPC", PriceCatalogMatchMethod.UPC_XREFERENCE);
+        return Optional.ofNullable(byXref);
+    }
+
+    @Nullable
+    private ResolvedLine resolve(
+            PriceCatalogUnmatchedLineEntity line,
+            @Nullable String code,
+            String codeType,
+            PriceCatalogMatchMethod method) {
+        if (code == null || code.isBlank()) {
+            return null;
+        }
+        ProductCodeResolver.Resolution resolution = productCodeResolver.resolve(codeType, code);
+        if (resolution instanceof ProductCodeResolver.Resolution.Matched matched) {
+            return new ResolvedLine(line, toEntry(line), matched.productId(), method);
+        }
+        // Still unresolvable, still unreachable, or still ambiguous: the row stays open with its
+        // original reason. Rewriting the reason on every sweep would churn the worklist without
+        // telling an operator anything new.
+        return null;
+    }
+
+    /** Rebuilds the canonical entry from the values the quarantine row kept (ADR-0053 §5). */
+    private SupplierPriceCatalogEntry toEntry(PriceCatalogUnmatchedLineEntity line) {
+        return new SupplierPriceCatalogEntry(
+                line.getArticleEan(),
+                line.getSupplierArticleCode(),
+                line.getXReferenceCode(),
+                line.getSuggestedRetailPrice(),
+                line.getGrossPrice(),
+                line.getNetPrice(),
+                line.getTaxRate(),
+                line.getRecyclingFee(),
+                line.getEffectiveFrom(),
+                line.getCountryCode(),
+                line.getCurrency(),
+                line.getSourceDocumentId(),
+                line.getSourceDocumentDate(),
+                line.getImportManifestId(),
+                line.getPositionNumber());
+    }
+
+    /**
+     * A quarantined line that now resolves, with everything the writer needs to stage and publish it.
+     *
+     * @param quarantineRow the row to close
+     * @param entry         the canonical entry rebuilt from that row's stored values
+     * @param productId     the product it now matches
+     * @param method        which identifier matched
+     */
+    public record ResolvedLine(
+            PriceCatalogUnmatchedLineEntity quarantineRow,
+            SupplierPriceCatalogEntry entry,
+            UUID productId,
+            PriceCatalogMatchMethod method) {}
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplier.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplier.java
@@ -12,7 +12,9 @@ import com.positivity.supplier.internal.repository.SupplierProfileRepository;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +45,15 @@ import org.springframework.stereotype.Service;
  * contradict the chunk sequencing consumers have already applied — chunk 4 of a 3-chunk import is
  * not something a completeness check can accept, and #1308's consumer would read it as a discrepancy
  * rather than a repair.
+ *
+ * <h2>One manifest per origin import</h2>
+ *
+ * A profile's quarantine spans every import that ever left a line open, so a batch routinely mixes
+ * them. Resolved lines are therefore grouped by the import they came from and committed one
+ * manifest per group. Collapsing them into a single manifest would stamp every published price with
+ * the first line's document identity and fetch timestamp — attributing prices to a document that
+ * never contained them, and feeding the latest-selection tie-break (ADR-0053 §2) a fetch time that
+ * belongs to a different fetch.
  *
  * <h2>Matching stays exactly as strict</h2>
  *
@@ -81,12 +92,12 @@ public class QuarantineReapplier {
      * Re-matches one batch of a profile's open quarantine and applies what now resolves.
      *
      * @param vendorProfileId profile whose quarantine to work
-     * @return the re-application manifest, or empty when nothing matched — an empty result is the
-     *         healthy steady state, not a failure
+     * @return one manifest per origin import that had lines resolve; empty when nothing matched,
+     *         which is the healthy steady state rather than a failure
      * @throws SupplierConfigurationException when no profile exists with that id
      */
     @NonNull
-    public Optional<PriceCatalogImportEntity> reapply(@NonNull UUID vendorProfileId) {
+    public List<PriceCatalogImportEntity> reapply(@NonNull UUID vendorProfileId) {
         SupplierProfileEntity profile = profileRepository
                 .findById(vendorProfileId)
                 .orElseThrow(() -> new SupplierConfigurationException(
@@ -97,31 +108,40 @@ public class QuarantineReapplier {
                 unmatchedLineRepository.findByVendorProfileIdAndResolvedAtIsNullAndReasonIn(
                         vendorProfileId, RETRYABLE_REASONS, PageRequest.of(0, Math.max(1, batchSize)));
         if (candidates.isEmpty()) {
-            return Optional.empty();
+            return List.of();
         }
 
-        List<ResolvedLine> resolved = new ArrayList<>();
+        // Grouped by origin import, in encounter order, because a profile's quarantine spans every
+        // import that ever left a line open and the manifest carries one document's identity.
+        Map<UUID, List<ResolvedLine>> byOriginImport = new LinkedHashMap<>();
         for (PriceCatalogUnmatchedLineEntity line : candidates) {
-            match(line).ifPresent(resolved::add);
+            match(line)
+                    .ifPresent(resolvedLine -> byOriginImport
+                            .computeIfAbsent(line.getImportManifestId(), key -> new ArrayList<>())
+                            .add(resolvedLine));
         }
 
-        if (resolved.isEmpty()) {
+        if (byOriginImport.isEmpty()) {
             log.debug(
                     "Re-application for profile {} matched none of {} candidate lines",
                     vendorProfileId,
                     candidates.size());
-            return Optional.empty();
+            return List.of();
         }
 
-        PriceCatalogImportEntity manifest =
-                reapplicationWriter.commit(profile, resolved, Instant.now(clock), chunkSize);
-        log.info(
-                "Re-applied {} of {} quarantined lines for profile {} as import {}",
-                resolved.size(),
-                candidates.size(),
-                vendorProfileId,
-                manifest.getImportManifestId());
-        return Optional.of(manifest);
+        Instant appliedAt = Instant.now(clock);
+        List<PriceCatalogImportEntity> manifests = new ArrayList<>(byOriginImport.size());
+        byOriginImport.forEach((originImportId, lines) -> {
+            PriceCatalogImportEntity manifest = reapplicationWriter.commit(profile, lines, appliedAt, chunkSize);
+            manifests.add(manifest);
+            log.info(
+                    "Re-applied {} quarantined lines of import {} for profile {} as import {}",
+                    lines.size(),
+                    originImportId,
+                    vendorProfileId,
+                    manifest.getImportManifestId());
+        });
+        return manifests;
     }
 
     /** Same deterministic order as the original import: exact EAN, then cross-reference as a UPC. */

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/SupplierPriceCatalogServiceImpl.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/SupplierPriceCatalogServiceImpl.java
@@ -37,6 +37,7 @@ public class SupplierPriceCatalogServiceImpl implements SupplierPriceCatalogServ
     private final PriceCatalogUnmatchedLineRepository unmatchedLineRepository;
     private final SupplierProfileRepository profileRepository;
     private final PriceCatalogImporter importService;
+    private final QuarantineReapplier reapplicationService;
 
     @Override
     @NonNull
@@ -82,6 +83,12 @@ public class SupplierPriceCatalogServiceImpl implements SupplierPriceCatalogServ
     private static <T> PagedResponse<T> toPage(Page<T> source, int page, int size) {
         List<T> items = source.getContent();
         return new PagedResponse<>(items, page, size, source.getTotalElements(), source.getTotalPages());
+    }
+
+    @Override
+    @NonNull
+    public Optional<PriceCatalogImportSummary> reapplyQuarantine(@NonNull UUID vendorProfileId) {
+        return reapplicationService.reapply(vendorProfileId).map(SupplierPriceCatalogServiceImpl::toSummary);
     }
 
     static PriceCatalogImportSummary toSummary(PriceCatalogImportEntity row) {

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/SupplierPriceCatalogServiceImpl.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/SupplierPriceCatalogServiceImpl.java
@@ -87,8 +87,10 @@ public class SupplierPriceCatalogServiceImpl implements SupplierPriceCatalogServ
 
     @Override
     @NonNull
-    public Optional<PriceCatalogImportSummary> reapplyQuarantine(@NonNull UUID vendorProfileId) {
-        return reapplicationService.reapply(vendorProfileId).map(SupplierPriceCatalogServiceImpl::toSummary);
+    public List<PriceCatalogImportSummary> reapplyQuarantine(@NonNull UUID vendorProfileId) {
+        return reapplicationService.reapply(vendorProfileId).stream()
+                .map(SupplierPriceCatalogServiceImpl::toSummary)
+                .toList();
     }
 
     static PriceCatalogImportSummary toSummary(PriceCatalogImportEntity row) {

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/repository/PriceCatalogUnmatchedLineRepository.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/repository/PriceCatalogUnmatchedLineRepository.java
@@ -24,4 +24,7 @@ public interface PriceCatalogUnmatchedLineRepository extends JpaRepository<Price
      */
     List<PriceCatalogUnmatchedLineEntity> findByVendorProfileIdAndResolvedAtIsNullAndReasonIn(
             UUID vendorProfileId, List<UnmatchedLineReason> reasons, Pageable pageable);
+
+    /** How many open rows are retryable, so a caller can size a re-application before running it. */
+    long countByVendorProfileIdAndResolvedAtIsNullAndReasonIn(UUID vendorProfileId, List<UnmatchedLineReason> reasons);
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/service/SupplierPriceCatalogService.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/service/SupplierPriceCatalogService.java
@@ -64,4 +64,19 @@ public interface SupplierPriceCatalogService {
      */
     @NonNull
     PriceCatalogImportSummary runImport(@NonNull UUID vendorProfileId);
+
+    /**
+     * Re-matches the profile's open quarantine against the current product-code replica and applies
+     * whatever now resolves, without asking the vendor for the document again (ADR-0053 §5).
+     *
+     * <p>Lines that carried no identifier, or whose values never decoded, are skipped: no catalog
+     * fix can rescue them, and retrying them forever would keep an operator's worklist permanently
+     * non-empty.
+     *
+     * @param vendorProfileId profile whose quarantine to work
+     * @return the summary of the re-application manifest, or empty when nothing matched — which is
+     *         the healthy steady state rather than a failure
+     */
+    @NonNull
+    Optional<PriceCatalogImportSummary> reapplyQuarantine(@NonNull UUID vendorProfileId);
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/service/SupplierPriceCatalogService.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/service/SupplierPriceCatalogService.java
@@ -3,6 +3,7 @@ package com.positivity.supplier.service;
 import com.positivity.supplier.service.model.PagedResponse;
 import com.positivity.supplier.service.model.PriceCatalogImportSummary;
 import com.positivity.supplier.service.model.UnmatchedPriceCatalogLineView;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -73,10 +74,15 @@ public interface SupplierPriceCatalogService {
      * fix can rescue them, and retrying them forever would keep an operator's worklist permanently
      * non-empty.
      *
+     * <p>Returns one summary per origin import that had lines resolve. A profile's quarantine spans
+     * every import that ever left a line open, and each re-application manifest carries one vendor
+     * document's identity — so a batch that heals lines from three imports produces three summaries,
+     * not one summary attributing every price to whichever document happened to be first.
+     *
      * @param vendorProfileId profile whose quarantine to work
-     * @return the summary of the re-application manifest, or empty when nothing matched — which is
-     *         the healthy steady state rather than a failure
+     * @return one summary per origin import that resolved; empty when nothing matched, which is the
+     *         healthy steady state rather than a failure
      */
     @NonNull
-    Optional<PriceCatalogImportSummary> reapplyQuarantine(@NonNull UUID vendorProfileId);
+    List<PriceCatalogImportSummary> reapplyQuarantine(@NonNull UUID vendorProfileId);
 }

--- a/pos-supplier/src/main/resources/application.yml
+++ b/pos-supplier/src/main/resources/application.yml
@@ -119,6 +119,12 @@ pos:
       # binding's own cron.
       poll-interval-ms: ${SUPPLIER_PRICAT_POLL_INTERVAL_MS:60000}
       scheduler-enabled: ${SUPPLIER_PRICAT_SCHEDULER_ENABLED:true}
+      # Quarantine re-application (#1310). The sweep runs on its own cadence rather than with an
+      # import: what makes a quarantined line matchable is a change in the CATALOG, which has
+      # nothing to do with when the vendor is next fetched.
+      reapply-batch-size: ${SUPPLIER_PRICAT_REAPPLY_BATCH_SIZE:2000}
+      reapply-cron: ${SUPPLIER_PRICAT_REAPPLY_CRON:0 15 * * * *}
+      reapply-enabled: ${SUPPLIER_PRICAT_REAPPLY_ENABLED:true}
     # ── Stock report / B2.1 (CAP-322) ───────────────────────────────────────────────────
     #
     # Same chunking problem as PRICAT: a country-level report is as wide as a catalog. A binding

--- a/pos-supplier/src/main/resources/db/migration/V12__pricat_reapplication.sql
+++ b/pos-supplier/src/main/resources/db/migration/V12__pricat_reapplication.sql
@@ -1,0 +1,16 @@
+-- CAP-318 / #1310: re-application of quarantined PRICAT lines (ADR-0053 §5).
+--
+-- V10 and V11 are reserved for the stock-report wave (#1228) which is in flight; this migration
+-- deliberately takes V12 so the two can merge in either order without a version collision.
+--
+-- A re-application produces its OWN import manifest rather than mutating the original's counters.
+-- The original import's numbers are a record of what the vendor sent and how much of it we could
+-- match AT THE TIME, and rewriting them later would destroy that record while also contradicting
+-- the chunk sequencing consumers already applied: chunk 4 of a 3-chunk import is not a thing a
+-- completeness check can accept. The new manifest points back at the one it healed.
+ALTER TABLE supplier_pricat_import ADD COLUMN reapplied_from_import_id uuid;
+
+COMMENT ON COLUMN supplier_pricat_import.reapplied_from_import_id IS
+    'Set when this manifest re-applied quarantined lines of an earlier import (#1310); null for a vendor fetch.';
+
+CREATE INDEX idx_spricat_import_reapplied_from ON supplier_pricat_import (reapplied_from_import_id);

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/controller/SupplierPriceCatalogAdminControllerWebMvcTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/controller/SupplierPriceCatalogAdminControllerWebMvcTest.java
@@ -182,18 +182,17 @@ class SupplierPriceCatalogAdminControllerWebMvcTest {
 
         @Test
         void returnsTheReapplicationSummaryWhenLinesResolved() throws Exception {
-            when(priceCatalogService.reapplyQuarantine(PROFILE_ID))
-                    .thenReturn(java.util.Optional.of(summary("COMPLETED")));
+            when(priceCatalogService.reapplyQuarantine(PROFILE_ID)).thenReturn(List.of(summary("COMPLETED")));
 
             mockMvc.perform(authed(post(BASE + "/quarantine/reapply"), SupplierPermissions.PRICECATALOG_IMPORT))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.importManifestId").value(MANIFEST_ID.toString()));
+                    .andExpect(jsonPath("$[0].importManifestId").value(MANIFEST_ID.toString()));
         }
 
         @Test
         void returns204WhenNothingResolved() throws Exception {
             // An empty quarantine sweep is the healthy steady state, not an error.
-            when(priceCatalogService.reapplyQuarantine(PROFILE_ID)).thenReturn(java.util.Optional.empty());
+            when(priceCatalogService.reapplyQuarantine(PROFILE_ID)).thenReturn(List.of());
 
             mockMvc.perform(authed(post(BASE + "/quarantine/reapply"), SupplierPermissions.PRICECATALOG_IMPORT))
                     .andExpect(status().isNoContent());

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/controller/SupplierPriceCatalogAdminControllerWebMvcTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/controller/SupplierPriceCatalogAdminControllerWebMvcTest.java
@@ -177,6 +177,43 @@ class SupplierPriceCatalogAdminControllerWebMvcTest {
     }
 
     @Nested
+    @DisplayName("POST /quarantine/reapply")
+    class ReapplyQuarantine {
+
+        @Test
+        void returnsTheReapplicationSummaryWhenLinesResolved() throws Exception {
+            when(priceCatalogService.reapplyQuarantine(PROFILE_ID))
+                    .thenReturn(java.util.Optional.of(summary("COMPLETED")));
+
+            mockMvc.perform(authed(post(BASE + "/quarantine/reapply"), SupplierPermissions.PRICECATALOG_IMPORT))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.importManifestId").value(MANIFEST_ID.toString()));
+        }
+
+        @Test
+        void returns204WhenNothingResolved() throws Exception {
+            // An empty quarantine sweep is the healthy steady state, not an error.
+            when(priceCatalogService.reapplyQuarantine(PROFILE_ID)).thenReturn(java.util.Optional.empty());
+
+            mockMvc.perform(authed(post(BASE + "/quarantine/reapply"), SupplierPermissions.PRICECATALOG_IMPORT))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void isDeniedToAReaderWhoCannotTrigger() throws Exception {
+            mockMvc.perform(authed(post(BASE + "/quarantine/reapply"), SupplierPermissions.PRICECATALOG_READ))
+                    .andExpect(status().isForbidden());
+
+            verify(priceCatalogService, never()).reapplyQuarantine(PROFILE_ID);
+        }
+
+        @Test
+        void isRejectedWithoutAuthentication() throws Exception {
+            mockMvc.perform(post(BASE + "/quarantine/reapply")).andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
     @DisplayName("GET /imports")
     class ListImports {
 

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplicationWriterTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplicationWriterTest.java
@@ -1,0 +1,233 @@
+package com.positivity.supplier.internal.pricecatalog.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.supplier.SupplierPriceCatalogImportCompletedV1;
+import com.positivity.domainevents.supplier.SupplierPriceCatalogUpdatedV1;
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.SupplierPriceCatalogEntry;
+import com.positivity.supplier.internal.entity.PriceCatalogEntryEntity;
+import com.positivity.supplier.internal.entity.PriceCatalogImportEntity;
+import com.positivity.supplier.internal.entity.PriceCatalogUnmatchedLineEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.enums.PriceCatalogImportStatus;
+import com.positivity.supplier.internal.enums.PriceCatalogMatchMethod;
+import com.positivity.supplier.internal.enums.UnmatchedLineReason;
+import com.positivity.supplier.internal.pricecatalog.service.QuarantineReapplier.ResolvedLine;
+import com.positivity.supplier.internal.repository.PriceCatalogEntryRepository;
+import com.positivity.supplier.internal.repository.PriceCatalogImportRepository;
+import com.positivity.supplier.internal.repository.PriceCatalogUnmatchedLineRepository;
+import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Quarantine re-application persistence and events (#1310)")
+class QuarantineReapplicationWriterTest {
+
+    private static final UUID PROFILE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c");
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d");
+    private static final UUID ORIGIN_IMPORT = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b");
+    private static final UUID NEW_MANIFEST = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a60");
+    private static final Instant VENDOR_FETCHED_AT = Instant.parse("2026-08-13T08:00:00Z");
+    private static final Instant APPLIED_AT = Instant.parse("2026-08-14T12:00:00Z");
+    private static final Clock CLOCK = Clock.fixed(APPLIED_AT, ZoneOffset.UTC);
+
+    @Mock
+    private PriceCatalogImportRepository importRepository;
+
+    @Mock
+    private PriceCatalogEntryRepository entryRepository;
+
+    @Mock
+    private PriceCatalogUnmatchedLineRepository unmatchedLineRepository;
+
+    @Mock
+    private SupplierOutboxEventWriter outboxWriter;
+
+    private QuarantineReapplicationWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        writer = new QuarantineReapplicationWriter(
+                importRepository, entryRepository, unmatchedLineRepository, outboxWriter, CLOCK);
+
+        when(importRepository.findById(ORIGIN_IMPORT))
+                .thenReturn(Optional.of(PriceCatalogImportEntity.builder()
+                        .importManifestId(ORIGIN_IMPORT)
+                        .vendorProfileId(PROFILE_ID)
+                        .protocolFamily(ProtocolFamily.EDIWHEEL_B)
+                        .protocolVersion("B4_0")
+                        .status(PriceCatalogImportStatus.COMPLETED)
+                        .linesFetched(100)
+                        .linesMatched(80)
+                        .linesUnmatched(20)
+                        .chunkCount(1)
+                        .build()));
+        when(importRepository.save(any(PriceCatalogImportEntity.class))).thenAnswer(inv -> {
+            PriceCatalogImportEntity entity = inv.getArgument(0);
+            if (entity.getImportManifestId() == null) {
+                entity.setImportManifestId(NEW_MANIFEST);
+            }
+            return entity;
+        });
+        when(entryRepository.save(any(PriceCatalogEntryEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(unmatchedLineRepository.save(any(PriceCatalogUnmatchedLineEntity.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private static SupplierProfileEntity profile() {
+        SupplierProfileEntity profile = new SupplierProfileEntity();
+        profile.setVendorProfileId(PROFILE_ID);
+        profile.setSupplierRef("michelin-eu");
+        profile.setEnabled(true);
+        return profile;
+    }
+
+    private static ResolvedLine resolvedLine(int position) {
+        PriceCatalogUnmatchedLineEntity row = PriceCatalogUnmatchedLineEntity.builder()
+                .unmatchedLineId(UUID.randomUUID())
+                .importManifestId(ORIGIN_IMPORT)
+                .vendorProfileId(PROFILE_ID)
+                .positionNumber(position)
+                .articleEan("352870999908" + position)
+                .supplierArticleCode("99990" + position)
+                .reason(UnmatchedLineReason.NO_CATALOG_MATCH)
+                .netPrice(new BigDecimal("90.00"))
+                .effectiveFrom(LocalDate.of(2026, 2, 1))
+                .buyerAccountNumber("30012456")
+                .countryCode("SE")
+                .currency("SEK")
+                .sourceDocumentId("PRICAT-1")
+                .sourceDocumentDate(LocalDate.of(2026, 1, 30))
+                .fetchedAt(VENDOR_FETCHED_AT)
+                .build();
+        SupplierPriceCatalogEntry entry = new SupplierPriceCatalogEntry(
+                row.getArticleEan(),
+                row.getSupplierArticleCode(),
+                null,
+                null,
+                null,
+                row.getNetPrice(),
+                null,
+                null,
+                row.getEffectiveFrom(),
+                row.getCountryCode(),
+                row.getCurrency(),
+                row.getSourceDocumentId(),
+                row.getSourceDocumentDate(),
+                row.getImportManifestId(),
+                position);
+        return new ResolvedLine(row, entry, PRODUCT_ID, PriceCatalogMatchMethod.EAN);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<DomainEventEnvelope<?>> capturedEvents() {
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(outboxWriter, org.mockito.Mockito.atLeastOnce()).publish(eq("supplier.events.v1"), captor.capture());
+        return captor.getAllValues();
+    }
+
+    @Test
+    void createsItsOwnManifestPointingAtTheImportItHealed() {
+        PriceCatalogImportEntity manifest = writer.commit(profile(), List.of(resolvedLine(1)), APPLIED_AT, 500);
+
+        assertThat(manifest.getReappliedFromImportId()).isEqualTo(ORIGIN_IMPORT);
+        assertThat(manifest.getLinesMatched()).isEqualTo(1);
+        assertThat(manifest.getLinesUnmatched()).isZero();
+        assertThat(manifest.getStatus()).isEqualTo(PriceCatalogImportStatus.COMPLETED);
+    }
+
+    @Test
+    void leavesTheOriginalImportsCountersUntouched() {
+        writer.commit(profile(), List.of(resolvedLine(1)), APPLIED_AT, 500);
+
+        // The original records what the vendor sent and how much matched AT THE TIME. Only the new
+        // manifest is written; the healed one is read and left alone.
+        ArgumentCaptor<PriceCatalogImportEntity> captor = ArgumentCaptor.forClass(PriceCatalogImportEntity.class);
+        verify(importRepository).save(captor.capture());
+        assertThat(captor.getValue().getImportManifestId()).isNotEqualTo(ORIGIN_IMPORT);
+    }
+
+    @Test
+    void carriesTheOriginalNormRatherThanInventingOne() {
+        PriceCatalogImportEntity manifest = writer.commit(profile(), List.of(resolvedLine(1)), APPLIED_AT, 500);
+
+        assertThat(manifest.getProtocolFamily()).isEqualTo(ProtocolFamily.EDIWHEEL_B);
+        assertThat(manifest.getProtocolVersion()).isEqualTo("B4_0");
+    }
+
+    @Test
+    void closesEveryLineItApplied() {
+        writer.commit(profile(), List.of(resolvedLine(1), resolvedLine(2)), APPLIED_AT, 500);
+
+        ArgumentCaptor<PriceCatalogUnmatchedLineEntity> captor =
+                ArgumentCaptor.forClass(PriceCatalogUnmatchedLineEntity.class);
+        verify(unmatchedLineRepository, times(2)).save(captor.capture());
+        assertThat(captor.getAllValues()).allSatisfy(row -> {
+            assertThat(row.getResolvedAt()).isEqualTo(APPLIED_AT);
+            assertThat(row.getResolvedProductId()).isEqualTo(PRODUCT_ID);
+        });
+    }
+
+    @Test
+    void datesTheStagedEntryByTheVendorFetchNotByTheReapplication() {
+        writer.commit(profile(), List.of(resolvedLine(1)), APPLIED_AT, 500);
+
+        ArgumentCaptor<PriceCatalogEntryEntity> captor = ArgumentCaptor.forClass(PriceCatalogEntryEntity.class);
+        verify(entryRepository).save(captor.capture());
+        // Stamping "now" would let a re-applied old price outrank a newer fetch in the
+        // latest-selection tie-break (ADR-0053 §2).
+        assertThat(captor.getValue().getFetchedAt()).isEqualTo(VENDOR_FETCHED_AT);
+        assertThat(captor.getValue().getImportManifestId()).isEqualTo(NEW_MANIFEST);
+        assertThat(captor.getValue().getMatchedProductId()).isEqualTo(PRODUCT_ID);
+    }
+
+    @Test
+    void publishesChunksAndACompletionEventSoAConsumerCanConfirmItWhole() {
+        writer.commit(profile(), List.of(resolvedLine(1), resolvedLine(2), resolvedLine(3)), APPLIED_AT, 2);
+
+        List<DomainEventEnvelope<?>> events = capturedEvents();
+        assertThat(events).hasSize(3);
+        assertThat(events.stream()
+                        .filter(e -> SupplierPriceCatalogUpdatedV1.EVENT_TYPE.equals(e.eventType()))
+                        .count())
+                .isEqualTo(2);
+
+        DomainEventEnvelope<?> completion = events.getLast();
+        assertThat(completion.eventType()).isEqualTo(SupplierPriceCatalogImportCompletedV1.EVENT_TYPE);
+        SupplierPriceCatalogImportCompletedV1 payload = (SupplierPriceCatalogImportCompletedV1) completion.payload();
+        assertThat(payload.chunkCount()).isEqualTo(2);
+        assertThat(payload.linesMatched()).isEqualTo(3);
+    }
+
+    @Test
+    void keysEveryEventOnTheReapplicationManifestNotTheOriginal() {
+        writer.commit(profile(), List.of(resolvedLine(1)), APPLIED_AT, 500);
+
+        assertThat(capturedEvents())
+                .allSatisfy(event -> assertThat(event.aggregateId()).isEqualTo(NEW_MANIFEST));
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplierTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplierTest.java
@@ -1,0 +1,218 @@
+package com.positivity.supplier.internal.pricecatalog.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.supplier.internal.entity.PriceCatalogImportEntity;
+import com.positivity.supplier.internal.entity.PriceCatalogUnmatchedLineEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.enums.PriceCatalogMatchMethod;
+import com.positivity.supplier.internal.enums.UnmatchedLineReason;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
+import com.positivity.supplier.internal.pricecatalog.service.QuarantineReapplier.ResolvedLine;
+import com.positivity.supplier.internal.repository.PriceCatalogUnmatchedLineRepository;
+import com.positivity.supplier.internal.repository.SupplierProfileRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Quarantine re-application (#1310, ADR-0053 §5)")
+class QuarantineReapplierTest {
+
+    private static final UUID PROFILE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c");
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5d");
+    private static final UUID ORIGIN_IMPORT = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b");
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-14T12:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private SupplierProfileRepository profileRepository;
+
+    @Mock
+    private PriceCatalogUnmatchedLineRepository unmatchedLineRepository;
+
+    @Mock
+    private ProductCodeResolver productCodeResolver;
+
+    @Mock
+    private QuarantineReapplicationWriter reapplicationWriter;
+
+    private QuarantineReapplier service;
+
+    @BeforeEach
+    void setUp() {
+        service = new QuarantineReapplier(
+                profileRepository, unmatchedLineRepository, productCodeResolver, reapplicationWriter, CLOCK);
+        ReflectionTestUtils.setField(service, "batchSize", 2000);
+        ReflectionTestUtils.setField(service, "chunkSize", 500);
+
+        SupplierProfileEntity profile = new SupplierProfileEntity();
+        profile.setVendorProfileId(PROFILE_ID);
+        profile.setSupplierRef("michelin-eu");
+        profile.setEnabled(true);
+        when(profileRepository.findById(PROFILE_ID)).thenReturn(Optional.of(profile));
+        when(reapplicationWriter.commit(any(), anyList(), any(), anyInt()))
+                .thenReturn(PriceCatalogImportEntity.builder()
+                        .importManifestId(UUID.randomUUID())
+                        .vendorProfileId(PROFILE_ID)
+                        .linesMatched(1)
+                        .build());
+    }
+
+    private static PriceCatalogUnmatchedLineEntity quarantined(String ean, String xref, UnmatchedLineReason reason) {
+        return PriceCatalogUnmatchedLineEntity.builder()
+                .unmatchedLineId(UUID.randomUUID())
+                .importManifestId(ORIGIN_IMPORT)
+                .vendorProfileId(PROFILE_ID)
+                .positionNumber(7)
+                .articleEan(ean)
+                .supplierArticleCode("999908")
+                .xReferenceCode(xref)
+                .reason(reason)
+                .netPrice(new BigDecimal("90.00"))
+                .grossPrice(new BigDecimal("100.00"))
+                .effectiveFrom(LocalDate.of(2026, 2, 1))
+                .buyerAccountNumber("30012456")
+                .countryCode("SE")
+                .currency("SEK")
+                .sourceDocumentId("PRICAT-1")
+                .sourceDocumentDate(LocalDate.of(2026, 1, 30))
+                .fetchedAt(Instant.parse("2026-08-13T08:00:00Z"))
+                .build();
+    }
+
+    private void candidates(PriceCatalogUnmatchedLineEntity... rows) {
+        when(unmatchedLineRepository.findByVendorProfileIdAndResolvedAtIsNullAndReasonIn(
+                        eq(PROFILE_ID), anyList(), any(Pageable.class)))
+                .thenReturn(List.of(rows));
+    }
+
+    @Test
+    void appliesALineThatTheCatalogCanNowResolve() {
+        candidates(quarantined("3528709999083", null, UnmatchedLineReason.NO_CATALOG_MATCH));
+        when(productCodeResolver.resolve("EAN", "3528709999083"))
+                .thenReturn(new ProductCodeResolver.Resolution.Matched(PRODUCT_ID));
+
+        assertThat(service.reapply(PROFILE_ID)).isPresent();
+
+        ArgumentCaptor<List<ResolvedLine>> captor = ArgumentCaptor.forClass(List.class);
+        verify(reapplicationWriter).commit(any(), captor.capture(), any(), eq(500));
+        assertThat(captor.getValue()).singleElement().satisfies(line -> {
+            assertThat(line.productId()).isEqualTo(PRODUCT_ID);
+            assertThat(line.method()).isEqualTo(PriceCatalogMatchMethod.EAN);
+            // Rebuilt from the row's own stored values — no vendor call (ADR-0053 §5).
+            assertThat(line.entry().netPrice()).isEqualByComparingTo(new BigDecimal("90.00"));
+            assertThat(line.entry().sourceDocumentId()).isEqualTo("PRICAT-1");
+        });
+    }
+
+    @Test
+    void recoversALineThatWasQuarantinedOnlyBecauseTheReplicaWasUnavailable() {
+        candidates(quarantined("3528709999083", null, UnmatchedLineReason.CATALOG_UNAVAILABLE));
+        when(productCodeResolver.resolve("EAN", "3528709999083"))
+                .thenReturn(new ProductCodeResolver.Resolution.Matched(PRODUCT_ID));
+
+        assertThat(service.reapply(PROFILE_ID)).isPresent();
+    }
+
+    @Test
+    void fallsBackToTheCrossReferenceCodeExactlyAsTheImportDoes() {
+        candidates(quarantined(null, "0123456789012", UnmatchedLineReason.NO_CATALOG_MATCH));
+        when(productCodeResolver.resolve("UPC", "0123456789012"))
+                .thenReturn(new ProductCodeResolver.Resolution.Matched(PRODUCT_ID));
+
+        assertThat(service.reapply(PROFILE_ID)).isPresent();
+    }
+
+    @Test
+    void leavesALineOpenWhenTheCatalogStillCannotResolveIt() {
+        candidates(quarantined("3528709999083", null, UnmatchedLineReason.NO_CATALOG_MATCH));
+        when(productCodeResolver.resolve("EAN", "3528709999083"))
+                .thenReturn(new ProductCodeResolver.Resolution.NotFound());
+
+        assertThat(service.reapply(PROFILE_ID)).isEmpty();
+        verify(reapplicationWriter, never()).commit(any(), anyList(), any(), anyInt());
+    }
+
+    @Test
+    void leavesAnAmbiguousLineOpenRatherThanPickingAProduct() {
+        candidates(quarantined("3528709999083", null, UnmatchedLineReason.AMBIGUOUS_CATALOG_MATCH));
+        when(productCodeResolver.resolve("EAN", "3528709999083"))
+                .thenReturn(new ProductCodeResolver.Resolution.Ambiguous("two products"));
+
+        assertThat(service.reapply(PROFILE_ID)).isEmpty();
+    }
+
+    @Test
+    void neverRetriesReasonsNoCatalogFixCanRescue() {
+        service.reapply(PROFILE_ID);
+
+        ArgumentCaptor<List<UnmatchedLineReason>> captor = ArgumentCaptor.forClass(List.class);
+        verify(unmatchedLineRepository)
+                .findByVendorProfileIdAndResolvedAtIsNullAndReasonIn(eq(PROFILE_ID), captor.capture(), any());
+        assertThat(captor.getValue())
+                .doesNotContain(UnmatchedLineReason.NO_IDENTIFIER, UnmatchedLineReason.MALFORMED_LINE)
+                .containsExactlyInAnyOrder(
+                        UnmatchedLineReason.NO_CATALOG_MATCH,
+                        UnmatchedLineReason.AMBIGUOUS_CATALOG_MATCH,
+                        UnmatchedLineReason.CATALOG_UNAVAILABLE);
+    }
+
+    @Test
+    void doesNothingWhenTheQuarantineIsEmpty() {
+        when(unmatchedLineRepository.findByVendorProfileIdAndResolvedAtIsNullAndReasonIn(
+                        eq(PROFILE_ID), anyList(), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        assertThat(service.reapply(PROFILE_ID)).isEmpty();
+        verify(reapplicationWriter, never()).commit(any(), anyList(), any(), anyInt());
+    }
+
+    @Test
+    void isANoOpOnASecondRunBecauseClosedLinesAreNoLongerCandidates() {
+        // The repository filters on resolvedAt IS NULL, so a line closed by the previous run simply
+        // is not returned again — the idempotency is in the query, not in a flag the caller must
+        // remember to check.
+        candidates(quarantined("3528709999083", null, UnmatchedLineReason.NO_CATALOG_MATCH));
+        when(productCodeResolver.resolve("EAN", "3528709999083"))
+                .thenReturn(new ProductCodeResolver.Resolution.Matched(PRODUCT_ID));
+        assertThat(service.reapply(PROFILE_ID)).isPresent();
+
+        when(unmatchedLineRepository.findByVendorProfileIdAndResolvedAtIsNullAndReasonIn(
+                        eq(PROFILE_ID), anyList(), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        assertThat(service.reapply(PROFILE_ID)).isEmpty();
+    }
+
+    @Test
+    void refusesAnUnknownProfileRatherThanSilentlyDoingNothing() {
+        when(profileRepository.findById(PROFILE_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.reapply(PROFILE_ID)).isInstanceOf(SupplierConfigurationException.class);
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplierTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplierTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -117,7 +118,7 @@ class QuarantineReapplierTest {
         when(productCodeResolver.resolve("EAN", "3528709999083"))
                 .thenReturn(new ProductCodeResolver.Resolution.Matched(PRODUCT_ID));
 
-        assertThat(service.reapply(PROFILE_ID)).isPresent();
+        assertThat(service.reapply(PROFILE_ID)).hasSize(1);
 
         ArgumentCaptor<List<ResolvedLine>> captor = ArgumentCaptor.forClass(List.class);
         verify(reapplicationWriter).commit(any(), captor.capture(), any(), eq(500));
@@ -136,7 +137,7 @@ class QuarantineReapplierTest {
         when(productCodeResolver.resolve("EAN", "3528709999083"))
                 .thenReturn(new ProductCodeResolver.Resolution.Matched(PRODUCT_ID));
 
-        assertThat(service.reapply(PROFILE_ID)).isPresent();
+        assertThat(service.reapply(PROFILE_ID)).hasSize(1);
     }
 
     @Test
@@ -145,7 +146,7 @@ class QuarantineReapplierTest {
         when(productCodeResolver.resolve("UPC", "0123456789012"))
                 .thenReturn(new ProductCodeResolver.Resolution.Matched(PRODUCT_ID));
 
-        assertThat(service.reapply(PROFILE_ID)).isPresent();
+        assertThat(service.reapply(PROFILE_ID)).hasSize(1);
     }
 
     @Test
@@ -200,7 +201,7 @@ class QuarantineReapplierTest {
         candidates(quarantined("3528709999083", null, UnmatchedLineReason.NO_CATALOG_MATCH));
         when(productCodeResolver.resolve("EAN", "3528709999083"))
                 .thenReturn(new ProductCodeResolver.Resolution.Matched(PRODUCT_ID));
-        assertThat(service.reapply(PROFILE_ID)).isPresent();
+        assertThat(service.reapply(PROFILE_ID)).hasSize(1);
 
         when(unmatchedLineRepository.findByVendorProfileIdAndResolvedAtIsNullAndReasonIn(
                         eq(PROFILE_ID), anyList(), any(Pageable.class)))
@@ -214,5 +215,36 @@ class QuarantineReapplierTest {
         when(profileRepository.findById(PROFILE_ID)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.reapply(PROFILE_ID)).isInstanceOf(SupplierConfigurationException.class);
+    }
+
+    @Test
+    void commitsOneManifestPerOriginImportRatherThanCollapsingThem() {
+        // A profile's quarantine spans every import that ever left a line open. One manifest for all
+        // of them would stamp every published price with the first line's document identity and
+        // fetch timestamp — attributing prices to a document that never contained them, and feeding
+        // the latest-selection tie-break a fetch time belonging to a different fetch.
+        UUID otherImport = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a70");
+        PriceCatalogUnmatchedLineEntity fromFirstImport =
+                quarantined("3528709999083", null, UnmatchedLineReason.NO_CATALOG_MATCH);
+        PriceCatalogUnmatchedLineEntity fromSecondImport =
+                quarantined("3528709999084", null, UnmatchedLineReason.NO_CATALOG_MATCH);
+        fromSecondImport.setImportManifestId(otherImport);
+        candidates(fromFirstImport, fromSecondImport);
+        when(productCodeResolver.resolve("EAN", "3528709999083"))
+                .thenReturn(new ProductCodeResolver.Resolution.Matched(PRODUCT_ID));
+        when(productCodeResolver.resolve("EAN", "3528709999084"))
+                .thenReturn(new ProductCodeResolver.Resolution.Matched(PRODUCT_ID));
+
+        assertThat(service.reapply(PROFILE_ID)).hasSize(2);
+
+        ArgumentCaptor<List<ResolvedLine>> captor = ArgumentCaptor.forClass(List.class);
+        verify(reapplicationWriter, times(2)).commit(any(), captor.capture(), any(), anyInt());
+        assertThat(captor.getAllValues())
+                .allSatisfy(group -> assertThat(group)
+                        .extracting(line -> line.quarantineRow().getImportManifestId())
+                        .containsOnly(group.getFirst().quarantineRow().getImportManifestId()));
+        assertThat(captor.getAllValues())
+                .extracting(group -> group.getFirst().quarantineRow().getImportManifestId())
+                .containsExactlyInAnyOrder(ORIGIN_IMPORT, otherImport);
     }
 }


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:318`
- Parent STORY (durion): louisburroughs/durion#373
- Child issues: louisburroughs/durion-positivity-backend#1309, louisburroughs/durion-positivity-backend#1310
- Domain: `domain:positivity`, `domain:product`

## Contract References
- Contract guide entry (durion): `domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md` → "CAP-318 — PRICAT B4.0 price-catalog sync"
- Governing ADRs: **ADR-0044 §4** (replay is an owner obligation), **ADR-0053 §5** (re-application without a vendor re-fetch), ADR-0053 §2 (effective dating)

## Contract Chain
- [x] OpenAPI annotations on both new endpoints (ADR-0042 depth-STRICT)
- [x] `pos-catalog/openapi.yaml`, `pos-supplier/openapi.yaml` and the gateway aggregate regenerated
- [ ] Angular SDK regenerated — follow-up; adds `replayProductFacts` and `reapplySupplierPriceCatalogQuarantine`

## Why these two together

They are one operational gap seen from both ends. A replica that cannot be seeded and a quarantine that cannot be worked leave PRICAT matching **nothing** on a fresh deployment, with no way out but re-fetching from the vendor — which does not help, because the problem is on our side.

## #1309 — pos-catalog product-fact replay

`POST /v1/products/facts/replay` re-emits `catalog.product.updated` so a consumer's replica can be seeded or repaired.

- **Same publisher as live traffic.** Facts come from the `CatalogFactPublisher` every ordinary write already uses. A parallel replay-specific serializer would drift the moment the payload gained a field — which is precisely how #1224's `productCode`/`productCodeType` would have been missed.
- **Consumers need no code.** `aggregateVersion` stays the product's `updatedAt`, so the stale guard consumers already have prevents a replayed older fact regressing newer state.
- **Paged, resumable, cursored on product id.** A full catalog is tens of thousands of facts: one request would time out or bury live traffic behind an outbox burst. The cursor is the id and not an offset, because offsets shift under concurrent writes — a product created mid-replay would push another out of the window, leaving the replica short of exactly the fact the replay existed to deliver. Limit capped at 1000.
- Permission: existing `ROLE_ADMIN` / `ROLE_CATALOG_EDIT` — **no new bit, no CATALOG_VERSION movement**.

## #1310 — pos-supplier quarantine re-application

`POST …/price-catalog/{vendorProfileId}/quarantine/reapply`, plus an hourly sweep of every enabled profile.

- **Its own cadence.** What makes a quarantined line matchable is a change in the *catalog*, not the vendor's next fetch. Tying re-application to the import schedule would strand a correction behind a weekly vendor pull.
- **Skips what no fix can rescue.** `NO_IDENTIFIER` and `MALFORMED_LINE` are never retried; retrying them forever would keep an operator's worklist permanently non-empty.
- **Matching stays exactly as strict** — exact EAN, then cross-reference as UPC. A second chance for the catalog to have changed is not a licence for a looser match.
- **No lease on the sweep**, deliberately: two instances is harmless because a closed line is no longer a candidate, and a lease would add a stuck-lease failure mode to protect against nothing.

### The design decision #1310 flagged — decided and recorded

A re-application creates **its own manifest** referencing the import it healed (`reapplied_from_import_id`, V12), rather than editing the original's counters. Two reasons:

1. Those counters record what the vendor sent and how much matched **at the time**. Rewriting them later destroys that record.
2. A fourth chunk of a three-chunk import is not something #1308's completeness check can accept — it would read a repair as a discrepancy and request a re-emit.

Staged entries keep the vendor's **original** fetch timestamp, so a re-applied old price cannot outrank a newer fetch in the latest-selection tie-break (ADR-0053 §2).

## Migration numbering
pos-supplier takes **V12**, leaving V10/V11 to the in-flight stock-report wave (#1228), so the two PRs can merge in either order without a version collision.

## Tests
- [x] Replay: one fact per product through the ordinary publisher, short page ⇒ complete, full page ⇒ cursor, resume from cursor, `updatedSince` passthrough, limit capped, empty catalog is a finished replay rather than an error
- [x] Re-application: line the catalog can now resolve, `CATALOG_UNAVAILABLE` recovery, cross-reference fallback, still-unresolved and still-ambiguous left open, non-retryable reasons never queried, empty quarantine is a no-op, second run is a no-op because closed lines are no longer candidates, unknown profile refused
- [x] Re-application writer: own manifest pointing at the healed import, original counters untouched, original norm carried rather than invented, every applied line closed, entry dated by the vendor fetch not the re-application, chunks plus a completion event, events keyed on the new manifest
- [x] Web layer: 200 with summary, **204 when nothing resolved** (healthy steady state, not an error), permission split, unauthenticated

```
./mvnw -pl pos-catalog -DskipTests=false verify      # 197 unit + 79 IT
./mvnw -pl pos-supplier -DskipTests=false verify     # 745
./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests,ClasspathVisibilityGuardTest,EntityStandardsArchitectureTest,DomainWallsTest -Dsurefire.failIfNoSpecifiedTests=false test
./scripts/check-flyway-hygiene.sh && ./scripts/generate-permissions.sh --sync --check
```

All green locally.

## Deploy notes
- The replay is what closes durion#389's outstanding prerequisite: run it after deploying so the `ext_product_code` replica is seeded **before** the first PRICAT import, or that import quarantines everything.
- `POS_CATALOG_KAFKA_ENABLED` must be true or the replayed facts queue in the outbox and reach nobody.
- The hourly re-application sweep is on by default (`SUPPLIER_PRICAT_REAPPLY_ENABLED`); it is a no-op when quarantines are empty.

## Risk & Rollback
- Risk level: Low–Medium. The replay only re-publishes existing facts, and re-application only writes rows the vendor already sent. The additive V12 column is the sole schema change.
- Rollback: revert the merge; V12 is additive and can be left in place.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated (supplier/catalog sections already merged; both READMEs updated here)
- [ ] Required CI checks passing

Closes #1309
Closes #1310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mv7zVYjwbVu5GRqrfkfHc7