### PR TITLE
[CAP:319] Supplier: live stock inquiry A2.5 with a degradation contract that never throws (#1225)

### DIFF
--- a/pos-supplier/README.md
+++ b/pos-supplier/README.md
@@ -12,10 +12,11 @@ supplier APIs, and the exchange audit trail of what was sent and received.
 | Governing ADRs | ADR-0050 (vendor profile configuration), ADR-0051 (protocol adapter versioning), ADR-0052 (outbound idempotency / duplicate-order prevention) |
 
 This module owns **how** we reach a supplier, and — as the codec waves land — **what** we say to
-them for each capability. Two codecs exist today, both in `internal.adapter.ediwheelb`: PRICAT B4.0
-(#1224) and Stock Report B2.1 (#1228). The remaining capabilities still have SPI ports in
-`internal.spi` and no codec behind them. ADR-0053 governs the price-catalog behaviour described
-below.
+them for each capability. Codecs exist today for PRICAT B4.0 (#1224) and Stock Report B2.1 (#1228) in
+`internal.adapter.ediwheelb`, order create/status C1.0/C1.1 (#1226) in `internal.adapter.ediwheelc1`,
+and live stock inquiry A2.5 (#1225) in `internal.adapter.ediwheela2`. The remaining capabilities still
+have SPI ports in `internal.spi` and no codec behind them. ADR-0053 governs the price-catalog
+behaviour described below.
 
 **Shipment tracking is out of scope for this module**, and not as a gap awaiting a codec (#1313).
 EDIWheel shipment tracking is an exchange between logistics providers and suppliers; a service
@@ -96,6 +97,43 @@ product identity codes on `catalog.events.v1` and `CatalogProductEventsListener`
 created seconds ago may not be matchable yet, and its line is quarantined until the next import. An
 empty replica — Kafka disabled, or nothing consumed yet — reports `CATALOG_UNAVAILABLE` rather than
 turning a whole vendor catalog into `NO_CATALOG_MATCH` misses an operator would go hunting for.
+
+### Live stock inquiry (A2.5) — no HTTP surface, one in-process contract
+
+`SupplierStockService.inquireLiveStock` is the platform's **single approved synchronous cross-module
+supplier read** (ADR-0044 amendment, 2026-08-10). Approved callers are pos-catalog's Product Detail
+composition and pos-order procurement, and the grant is per calling class, not per module.
+
+It **never throws for a vendor-side failure**. Both callers have something useful to render without
+live stock and nothing useful to render if this call blows up, so every failure is a status:
+
+| Status | Means |
+|---|---|
+| `OK` | The vendor answered. Per-article outcomes are on the lines. |
+| `SUPPLIER_UNAVAILABLE` | Unreachable, timed out, breaker open, or answered something unreadable. |
+| `NOT_LISTED` | The vendor carries none of the inquired articles. |
+| `CAPABILITY_NOT_CONFIGURED` | No `STOCK_INQUIRY` binding on the profile (ADR-0050 §3). |
+| `CONFIGURATION_ERROR` | The profile is switched on and wrong — an unmapped delivery location, a missing agency code. Raised **before** any network call. |
+
+Per line: `AVAILABLE`, `UNAVAILABLE`, `NOT_LISTED`, `NOT_ANSWERED`. The distinction that matters is
+`UNAVAILABLE` (the vendor said it has none — quantity `0`, a fact) versus `NOT_ANSWERED` (the vendor
+said nothing — quantity `null`). Only the first justifies telling a customer an article is out of
+stock, and nothing in this path coerces one into the other.
+
+**A2.5 carries no price.** The norm answers availability and delivery dates only; the sibling C1.0
+inquiry is the one with `PriceDetails`. The quote fields on the response stay null here, and a
+supplier price comes from the PRICAT price entries that own it (CAP-318).
+
+**The delivery location is part of the question, not a refinement of it.** Availability is
+consignee-specific, so the inquiry requires a location, the codec refuses to encode without the
+vendor account mapped to it, and the cache key carries it — a shared entry would tell a customer that
+stock at another branch is available at the one fitting the tyre.
+
+Caching is per article, not per inquiry (`pos.supplier.stockinquiry.cache-ttl`, default 60s): a
+product page asks about one article repeatedly and a procurement screen asks about several at once.
+Only `AVAILABLE` and `UNAVAILABLE` are stored. Failures are not — caching one bad moment would extend
+it into a minute of identical failures — and neither is `NOT_LISTED`, so an operator who fixes a
+catalogue mapping sees the fix on the next page load.
 
 ### Stock report (B2.1) — no API surface
 

--- a/pos-supplier/pom.xml
+++ b/pos-supplier/pom.xml
@@ -46,6 +46,15 @@
             <artifactId>pos-events</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!--
+            CAP-319 (#1225): the live stock inquiry's short-TTL cache. Caffeine rather than a
+            hand-rolled map because this cache is on a customer-facing path and needs a bound and an
+            expiry it cannot be talked out of; the same choice pos-catalog and pos-customer made.
+        -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
         <!-- H2 for local dev (application-dev.yml) and tests; not configured in alpha/prod profiles -->
         <dependency>
             <groupId>com.h2database</groupId>

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/A2Values.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/A2Values.java
@@ -1,0 +1,94 @@
+package com.positivity.supplier.internal.adapter.ediwheela2;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Scalar parsing at the A2 wire boundary.
+ *
+ * <h2>Absence is not zero</h2>
+ *
+ * Every method here answers null for "the vendor stated nothing", the same rule the stock report
+ * (#1228) and the C1 family enforce. For an availability answer the distinction is the whole point:
+ * a vendor that did not answer and a vendor that answered "none" produce very different sentences
+ * on a product page, and coercing the first into {@code 0} would put "out of stock" in front of a
+ * customer on the strength of a timeout.
+ */
+final class A2Values {
+
+    /**
+     * Date formats seen across the EDIWheel norms. The spec declares {@code format: date} (ISO),
+     * but sibling norms state dates as {@code yyyyMMdd} and vendors reuse their formatters, so both
+     * are accepted rather than losing a delivery date to a format quibble.
+     */
+    private static final List<DateTimeFormatter> DATE_FORMATS =
+            List.of(DateTimeFormatter.ISO_LOCAL_DATE, DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+    private A2Values() {}
+
+    /**
+     * Parses a quantity element.
+     *
+     * @return the whole quantity, or null when the element is absent or states nothing
+     */
+    @Nullable
+    static Integer quantity(StockInquiryA2Wire.@Nullable Quantity quantity) {
+        if (quantity == null) {
+            return null;
+        }
+        String value = trimToNull(quantity.quantityValue);
+        if (value == null) {
+            return null;
+        }
+        try {
+            // Some markets state whole quantities with a decimal part ("4.000"); take the integral
+            // part rather than discarding a line that is well formed for its market.
+            return new BigDecimal(value.replace(',', '.')).intValueExact();
+        } catch (ArithmeticException | NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /** Whether a stated quantity could not be read — the caller records it as unmapped. */
+    static boolean isUnreadableQuantity(StockInquiryA2Wire.@Nullable Quantity quantity) {
+        return quantity != null && trimToNull(quantity.quantityValue) != null && quantity(quantity) == null;
+    }
+
+    /**
+     * Parses a date element.
+     *
+     * @return the date, or null when absent or unreadable
+     */
+    @Nullable
+    static LocalDate date(@Nullable String value) {
+        String trimmed = trimToNull(value);
+        if (trimmed == null) {
+            return null;
+        }
+        for (DateTimeFormatter format : DATE_FORMATS) {
+            try {
+                return LocalDate.parse(trimmed, format);
+            } catch (RuntimeException e) {
+                // Try the next format; an unreadable date is reported by the caller as unmapped.
+            }
+        }
+        return null;
+    }
+
+    /** Whether a stated date could not be read. */
+    static boolean isUnreadableDate(@Nullable String value) {
+        return trimToNull(value) != null && date(value) == null;
+    }
+
+    @Nullable
+    static String trimToNull(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/A2XmlSupport.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/A2XmlSupport.java
@@ -1,0 +1,46 @@
+package com.positivity.supplier.internal.adapter.ediwheela2;
+
+import com.positivity.supplier.internal.adapter.ediwheelxml.EdiwheelXmlException;
+import com.positivity.supplier.internal.adapter.ediwheelxml.EdiwheelXmlSupport;
+import jakarta.xml.bind.JAXBContext;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * The A2 family's view of the shared EDIWheel XML plumbing ({@link EdiwheelXmlSupport}).
+ *
+ * <p>Translation only. The shared support parses; this class decides what a parse failure
+ * <em>means</em> for a stock inquiry, which is not what it means for an order: an unreadable quote
+ * is simply an unavailable vendor, whereas an unreadable order response is a transmission
+ * ambiguity.
+ */
+final class A2XmlSupport {
+
+    private A2XmlSupport() {}
+
+    /** Builds a JAXB context for one root type. */
+    @NonNull
+    static JAXBContext contextFor(@NonNull Class<?> rootType) {
+        return EdiwheelXmlSupport.contextFor(rootType);
+    }
+
+    /** Serialises an inquiry document: XML declaration, fully qualified. */
+    @NonNull
+    static String marshal(@NonNull JAXBContext context, @NonNull Object document) {
+        try {
+            return EdiwheelXmlSupport.marshal(context, document);
+        } catch (EdiwheelXmlException e) {
+            throw new StockInquiryEncodeException("Unable to serialise an EDIWheel A2.5 document", e);
+        }
+    }
+
+    /** Parses a vendor quote, normalising element namespaces first. */
+    @NonNull
+    static <T> T unmarshal(@NonNull JAXBContext context, @NonNull Class<T> rootType, @NonNull String body) {
+        try {
+            return EdiwheelXmlSupport.unmarshal(context, rootType, body);
+        } catch (EdiwheelXmlException e) {
+            throw new StockInquiryDecodeException(
+                    "Response body is not a readable EDIWheel A2.5 " + rootType.getSimpleName(), e);
+        }
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/EdiwheelA25StockInquiryCodec.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/EdiwheelA25StockInquiryCodec.java
@@ -1,0 +1,341 @@
+package com.positivity.supplier.internal.adapter.ediwheela2;
+
+import com.positivity.supplier.internal.domain.model.PartyContext;
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiry;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiryResult;
+import com.positivity.supplier.internal.spi.SupplierAdapterCodec;
+import jakarta.xml.bind.JAXBContext;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * EDIWheel A2.5 stock inquiry codec: canonical inquiry in, canonical availability out
+ * ({@code durion/docs/ediwheel/Swagger_UPX-Stock Inquiry PROD_1_2.yaml}, {@code POST /A2_5/inquiry}).
+ *
+ * <h2>What this norm answers</h2>
+ *
+ * A four-valued {@code Availability} code per line, plus a schedule of quantities against delivery
+ * dates. It carries <strong>no price</strong>; the sibling C1.0 inquiry is the norm that adds
+ * {@code PriceDetails}. The canonical quote fields therefore stay null here rather than being filled
+ * with a number the vendor never stated.
+ *
+ * <h2>Three ways to have no quantity, and they are not the same</h2>
+ *
+ * <ul>
+ *   <li>{@code Availability=3} — the vendor says it has none. A stated zero, and the only case where
+ *       this codec emits {@code 0}.
+ *   <li>{@code Availability=0} — the vendor could not determine availability. Null: silence.
+ *   <li>A line error naming the article as unknown — the vendor has never heard of it. Null, and
+ *       {@code NOT_LISTED}, because retrying an identical inquiry cannot change the answer.
+ * </ul>
+ *
+ * Coercing any of these into the others would put a definite sentence in front of a customer on the
+ * strength of a vendor's silence.
+ *
+ * <h2>Why some vendor errors are our fault, not theirs</h2>
+ *
+ * The EDIWheel error-code table ({@code EDIWheel-XML_Order_Response_C1.pdf}) distinguishes vendor
+ * trouble from a buyer whose profile is wrong: an unmapped consignee, an invalid buyer id, a wrong
+ * agency-code qualifier. Reporting those as {@code SUPPLIER_UNAVAILABLE} would tell an operator to
+ * wait for a vendor that is working perfectly. They map to {@code CONFIGURATION_ERROR} so the
+ * operator is pointed at the profile instead.
+ */
+@Component
+public class EdiwheelA25StockInquiryCodec implements SupplierAdapterCodec {
+
+    /** Fixed by the norm: this document family is {@code A2}. */
+    private static final String DOCUMENT_ID = "A2";
+
+    /** Fixed by the norm: variant {@code 5} is A2.5. */
+    private static final String VARIANT = "5";
+
+    /** Error codes that are not errors, per the spec's own enums and code table. */
+    private static final Set<String> NON_ERROR_CODES = Set.of("0", "1");
+
+    /**
+     * Line-level codes meaning "this article is not one I can sell you", as opposed to a transient
+     * failure. Retrying an identical inquiry against these cannot succeed.
+     *
+     * <ul>
+     *   <li>{@code 903} invalid article identification code
+     *   <li>{@code 911} incorrect EAN number (not known on supplier side)
+     *   <li>{@code 928} mandatory EAN code missing for this line
+     *   <li>{@code 933} this material cannot be ordered via ad hoc EDI
+     *   <li>{@code 940} incorrect supplier material number (not known on supplier side)
+     *   <li>{@code 941} wrong EAN / supplier material number combination
+     *   <li>{@code 945} material status set to not sellable
+     * </ul>
+     */
+    private static final Set<String> NOT_LISTED_LINE_CODES = Set.of("903", "911", "928", "933", "940", "941", "945");
+
+    /**
+     * Header-level codes describing <em>our</em> configuration rather than the vendor's health.
+     *
+     * <ul>
+     *   <li>{@code 907}, {@code 913} invalid consignee (ship-to) party id
+     *   <li>{@code 908} no authority to select consignee
+     *   <li>{@code 914} missing buyer (sold-to) identification number
+     *   <li>{@code 915} buyer party id invalid
+     *   <li>{@code 920} account not activated for this buyer party id
+     *   <li>{@code 924}, {@code 925} incorrect buyer / consignee agency code qualifier
+     *   <li>{@code 926}, {@code 927} missing mapping for the customer-assigned buyer / consignee id
+     *   <li>{@code 930} buyer definition error in the supplier system
+     *   <li>{@code 936} wrong buyer-consignee combination
+     *   <li>{@code 937} consignee definition error in the supplier system
+     * </ul>
+     */
+    private static final Set<String> CONFIGURATION_HEADER_CODES =
+            Set.of("907", "908", "913", "914", "915", "920", "924", "925", "926", "927", "930", "936", "937");
+
+    private final JAXBContext inquiryContext = A2XmlSupport.contextFor(StockInquiryA2Wire.Inquiry.class);
+    private final JAXBContext quoteContext = A2XmlSupport.contextFor(StockInquiryA2Wire.Quote.class);
+
+    @Override
+    @NonNull
+    public SupplierCapability capability() {
+        return SupplierCapability.STOCK_INQUIRY;
+    }
+
+    @Override
+    @NonNull
+    public ProtocolFamily family() {
+        return ProtocolFamily.EDIWHEEL_A25;
+    }
+
+    @Override
+    @NonNull
+    public ProtocolVersion version() {
+        return ProtocolVersion.A2_5;
+    }
+
+    /**
+     * Builds the transport-free request for one inquiry.
+     *
+     * @param inquiry the canonical inquiry
+     * @param partyContext buyer identity
+     * @param deliveryAccountNumber the vendor's account number for the receiving location
+     * @param deliveryAgencyCode agency code of that delivery account
+     * @throws StockInquiryEncodeException when a required vendor field has no canonical source
+     */
+    @NonNull
+    public SupplierRequestSpec buildRequest(
+            @NonNull SupplierStockInquiry inquiry,
+            @NonNull PartyContext partyContext,
+            @Nullable String deliveryAccountNumber,
+            @Nullable String deliveryAgencyCode) {
+        String body = encodeInquiry(inquiry, partyContext, deliveryAccountNumber, deliveryAgencyCode);
+        // Idempotent: an inquiry commits nothing, so a pre-send failure may be retried freely
+        // (ADR-0052 §5) — unlike an order, where a retry can duplicate a physical delivery.
+        return new SupplierRequestSpec("POST", null, Map.of(), body, "application/xml", "application/xml", true);
+    }
+
+    /**
+     * Serialises a canonical inquiry as an A2.5 {@code inquiry_A2} document.
+     *
+     * @throws StockInquiryEncodeException when a required vendor field has no canonical source
+     */
+    @NonNull
+    public String encodeInquiry(
+            @NonNull SupplierStockInquiry inquiry,
+            @NonNull PartyContext partyContext,
+            @Nullable String deliveryAccountNumber,
+            @Nullable String deliveryAgencyCode) {
+        StockInquiryA2Wire.Inquiry document = new StockInquiryA2Wire.Inquiry();
+        document.documentId = DOCUMENT_ID;
+        document.variant = VARIANT;
+        document.customerReference =
+                StockInquiryA2Wire.DocumentReference.of(inquiry.inquiryId().toString());
+        document.buyerParty = StockInquiryA2Wire.Party.of(
+                partyContext.billingAccountNumber(),
+                requireAgencyCode(partyContext.billingAgencyCode(), "billing account"));
+
+        // Availability is consignee-specific. A profile that cannot name the receiving location's
+        // account produces an inquiry the vendor would answer for the wrong place, so the encode
+        // fails here rather than asking a question whose answer would be quietly misleading.
+        if (deliveryAccountNumber == null || deliveryAccountNumber.isBlank()) {
+            throw new StockInquiryEncodeException(
+                    "Stock inquiry requires a delivery account for the receiving location, but the vendor profile"
+                            + " maps none");
+        }
+        document.consignee = StockInquiryA2Wire.Party.of(
+                deliveryAccountNumber, requireAgencyCode(deliveryAgencyCode, "delivery account"));
+
+        int lineNumber = 0;
+        for (SupplierStockInquiry.Line line : inquiry.lines()) {
+            lineNumber++;
+            document.orderLines.add(toWireLine(line, lineNumber));
+        }
+        return A2XmlSupport.marshal(inquiryContext, document);
+    }
+
+    /**
+     * Decodes an A2.5 {@code quote_A2} into the canonical result.
+     *
+     * @param body response body as received
+     * @throws StockInquiryDecodeException when the body is not a readable A2.5 quote
+     */
+    @NonNull
+    public SupplierStockInquiryResult decodeQuote(@Nullable String body) {
+        if (body == null || body.isBlank()) {
+            throw new StockInquiryDecodeException("Stock inquiry response body was empty");
+        }
+        StockInquiryA2Wire.Quote quote = A2XmlSupport.unmarshal(quoteContext, StockInquiryA2Wire.Quote.class, body);
+
+        String headerErrorCode = quote.errorHead == null ? null : A2Values.trimToNull(quote.errorHead.errorCode);
+        if (headerErrorCode != null && !NON_ERROR_CODES.contains(headerErrorCode)) {
+            SupplierStockInquiryResult.Status status = CONFIGURATION_HEADER_CODES.contains(headerErrorCode)
+                    ? SupplierStockInquiryResult.Status.CONFIGURATION_ERROR
+                    : SupplierStockInquiryResult.Status.SUPPLIER_UNAVAILABLE;
+            // A document-level error is the vendor refusing the question, not an answer about any
+            // article. No lines are carried: reporting them would attribute a per-article meaning to
+            // a rejection that never looked at the articles.
+            return new SupplierStockInquiryResult(status, List.of(), null);
+        }
+
+        List<SupplierStockInquiryResult.Line> lines = new ArrayList<>();
+        for (StockInquiryA2Wire.QuoteLine wireLine : quote.orderLines) {
+            if (wireLine != null && wireLine.orderedArticle != null) {
+                lines.add(toCanonicalLine(wireLine.orderedArticle));
+            }
+        }
+
+        // NOT_LISTED at document level means the vendor carries none of what we asked about — the
+        // answer a single-article product page needs. With a mixed answer the document is OK and the
+        // per-line statuses carry the detail, because "we stock one of these three" is not "not
+        // listed".
+        boolean noneListed = !lines.isEmpty()
+                && lines.stream().allMatch(line -> line.status() == SupplierStockInquiryResult.LineStatus.NOT_LISTED);
+        SupplierStockInquiryResult.Status status =
+                noneListed ? SupplierStockInquiryResult.Status.NOT_LISTED : SupplierStockInquiryResult.Status.OK;
+
+        // A2.5 states no snapshot instant of its own. asOf is stamped by the caller from the
+        // exchange, since for a live inquiry "as of" is simply when we asked.
+        return new SupplierStockInquiryResult(status, lines, null);
+    }
+
+    private SupplierStockInquiryResult.Line toCanonicalLine(StockInquiryA2Wire.QuoteArticle article) {
+        String ean = article.articleIdentification == null
+                ? null
+                : A2Values.trimToNull(article.articleIdentification.eanuccArticleId);
+        String supplierCode = article.articleIdentification == null
+                ? null
+                : A2Values.trimToNull(article.articleIdentification.manufacturersArticleId);
+
+        String lineErrorCode = article.error == null ? null : A2Values.trimToNull(article.error.errorCode);
+        boolean lineRejected = lineErrorCode != null && !NON_ERROR_CODES.contains(lineErrorCode);
+        if (lineRejected && NOT_LISTED_LINE_CODES.contains(lineErrorCode)) {
+            return new SupplierStockInquiryResult.Line(
+                    ean, supplierCode, SupplierStockInquiryResult.LineStatus.NOT_LISTED, null, null, null, null);
+        }
+        if (lineRejected) {
+            // Rejected for a reason that says nothing about whether the vendor stocks the article —
+            // an invalid delivery date, a quantity we asked wrongly for. Nothing is stated, so
+            // nothing is claimed.
+            return new SupplierStockInquiryResult.Line(
+                    ean, supplierCode, SupplierStockInquiryResult.LineStatus.NOT_ANSWERED, null, null, null, null);
+        }
+
+        String availability = A2Values.trimToNull(article.availability);
+        LocalDate earliest = earliestDeliveryDate(article);
+        Integer scheduled = scheduledQuantity(article);
+
+        if ("3".equals(availability)) {
+            // The vendor stated it has none. The one place a zero is a fact.
+            return new SupplierStockInquiryResult.Line(
+                    ean, supplierCode, SupplierStockInquiryResult.LineStatus.UNAVAILABLE, 0, null, null, null);
+        }
+        if ("1".equals(availability) || "2".equals(availability)) {
+            // Code 2 is "not in the requested quantity — consider the announced actual quantity", so
+            // the schedule is the answer for both codes. Where a vendor answered available but
+            // scheduled nothing, the quantity stays null: it said yes without saying how many.
+            return new SupplierStockInquiryResult.Line(
+                    ean,
+                    supplierCode,
+                    SupplierStockInquiryResult.LineStatus.AVAILABLE,
+                    scheduled,
+                    earliest,
+                    null,
+                    null);
+        }
+        // Availability "0" (could not be determined) or absent.
+        return new SupplierStockInquiryResult.Line(
+                ean, supplierCode, SupplierStockInquiryResult.LineStatus.NOT_ANSWERED, null, earliest, null, null);
+    }
+
+    /**
+     * Total quantity the vendor scheduled across its promised delivery dates.
+     *
+     * @return the total, or null when the vendor scheduled nothing readable — never 0, because a
+     *     schedule we could not read is not a vendor saying it has none
+     */
+    @Nullable
+    private static Integer scheduledQuantity(StockInquiryA2Wire.QuoteArticle article) {
+        int total = 0;
+        boolean stated = false;
+        for (StockInquiryA2Wire.ScheduleDetail detail : article.scheduleDetails) {
+            if (detail == null) {
+                continue;
+            }
+            Integer quantity = A2Values.quantity(
+                    detail.confirmedQuantity != null ? detail.confirmedQuantity : detail.availableQuantity);
+            if (quantity != null) {
+                total += quantity;
+                stated = true;
+            }
+        }
+        return stated ? total : null;
+    }
+
+    /** Earliest date the vendor promised any quantity, or null when it promised no dated quantity. */
+    @Nullable
+    private static LocalDate earliestDeliveryDate(StockInquiryA2Wire.QuoteArticle article) {
+        LocalDate earliest = null;
+        for (StockInquiryA2Wire.ScheduleDetail detail : article.scheduleDetails) {
+            if (detail == null) {
+                continue;
+            }
+            LocalDate date = A2Values.date(detail.deliveryDate);
+            if (date != null && (earliest == null || date.isBefore(earliest))) {
+                earliest = date;
+            }
+        }
+        return earliest;
+    }
+
+    private static StockInquiryA2Wire.InquiryLine toWireLine(SupplierStockInquiry.Line line, int lineNumber) {
+        StockInquiryA2Wire.InquiryLine wireLine = new StockInquiryA2Wire.InquiryLine();
+        // The norm caps LineID at six characters and the canonical inquiry does not carry one, so
+        // position in the request is the identity — which is also what the quote echoes back.
+        wireLine.lineId = String.format("%06d", lineNumber);
+
+        StockInquiryA2Wire.ArticleIdentification identification = new StockInquiryA2Wire.ArticleIdentification();
+        identification.eanuccArticleId = A2Values.trimToNull(line.articleEan());
+        identification.manufacturersArticleId = A2Values.trimToNull(line.supplierArticleCode());
+
+        StockInquiryA2Wire.InquiryArticle article = new StockInquiryA2Wire.InquiryArticle();
+        article.articleIdentification = identification;
+        article.requestedQuantity = StockInquiryA2Wire.Quantity.of(line.requestedQuantity());
+        wireLine.orderedArticle = article;
+        return wireLine;
+    }
+
+    @NonNull
+    private static String requireAgencyCode(@Nullable String agencyCode, String role) {
+        String value = A2Values.trimToNull(agencyCode);
+        if (value == null) {
+            throw new StockInquiryEncodeException(
+                    "EDIWheel A2.5 requires an agency code for the " + role + ", but the vendor profile states none");
+        }
+        return value;
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/StockInquiryA2Wire.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/StockInquiryA2Wire.java
@@ -1,0 +1,264 @@
+package com.positivity.supplier.internal.adapter.ediwheela2;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Literal shape of the EDIWheel A2.5 stock-inquiry documents
+ * ({@code durion/docs/ediwheel/Swagger_UPX-Stock Inquiry PROD_1_2.yaml}).
+ *
+ * <p>Package-private (ADR-0051 §2): these are vendor types and only the codec in this package may
+ * see them. They are JAXB classes rather than records because JAXB binds fields on a no-arg
+ * constructor, and every numeric arrives as a string — parsed at this boundary so a malformed
+ * vendor value never becomes a malformed canonical one.
+ *
+ * <p>Only the parts of the norm this capability uses are modelled. Elements a vendor sends that are
+ * not declared here are ignored on the way in, which is what lets a vendor extend its documents
+ * without breaking our reader.
+ */
+final class StockInquiryA2Wire {
+
+    private StockInquiryA2Wire() {}
+
+    /** {@code ew:inquiry_A2} — the document we send to ask about availability. */
+    @XmlRootElement(name = "inquiry_A2")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(
+            name = "inquiryA2",
+            propOrder = {"documentId", "variant", "customerReference", "buyerParty", "consignee", "orderLines"})
+    static class Inquiry {
+
+        /** Always {@code A2} for this norm family. */
+        @XmlElement(name = "DocumentID", required = true)
+        String documentId;
+
+        /** Always {@code 5} for A2.5. */
+        @XmlElement(name = "Variant", required = true)
+        String variant;
+
+        /** Our reference for this inquiry, echoed back on the quote. */
+        @XmlElement(name = "CustomerReference")
+        DocumentReference customerReference;
+
+        @XmlElement(name = "BuyerParty", required = true)
+        Party buyerParty;
+
+        /**
+         * The delivery party: the vendor's account for the receiving location.
+         *
+         * <p>Availability is location-specific — the same article can be in stock for one
+         * consignee and not another — which is why the canonical read requires a delivery location
+         * and why the inquiry cache may never be keyed without one.
+         */
+        @XmlElement(name = "Consignee")
+        Party consignee;
+
+        @XmlElement(name = "OrderLine")
+        List<InquiryLine> orderLines = new ArrayList<>();
+    }
+
+    /** {@code ew:quote_A2} — the vendor's answer. */
+    @XmlRootElement(name = "quote_A2")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class Quote {
+
+        @XmlElement(name = "DocumentID")
+        String documentId;
+
+        @XmlElement(name = "Variant")
+        String variant;
+
+        /** Document-level outcome; {@code "0"} and {@code "1"} are the non-error codes. */
+        @XmlElement(name = "ErrorHead")
+        ErrorBlock errorHead;
+
+        /** Our reference, echoed back. */
+        @XmlElement(name = "CustomerReference")
+        DocumentReference customerReference;
+
+        @XmlElement(name = "BuyerParty")
+        Party buyerParty;
+
+        @XmlElement(name = "Consignee")
+        Party consignee;
+
+        @XmlElement(name = "OrderLine")
+        List<QuoteLine> orderLines = new ArrayList<>();
+    }
+
+    /** {@code ew:OrderLine} of an inquiry. */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(
+            name = "inquiryLineA2",
+            propOrder = {"lineId", "orderedArticle"})
+    static class InquiryLine {
+
+        @XmlElement(name = "LineID", required = true)
+        String lineId;
+
+        @XmlElement(name = "OrderedArticle", required = true)
+        InquiryArticle orderedArticle;
+    }
+
+    /** {@code ew:OrderedArticle} of an inquiry line. */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(
+            name = "inquiryArticleA2",
+            propOrder = {"articleIdentification", "requestedQuantity"})
+    static class InquiryArticle {
+
+        @XmlElement(name = "ArticleIdentification", required = true)
+        ArticleIdentification articleIdentification;
+
+        @XmlElement(name = "RequestedQuantity", required = true)
+        Quantity requestedQuantity;
+    }
+
+    /** {@code ew:OrderLine} of a quote. */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class QuoteLine {
+
+        @XmlElement(name = "LineID")
+        String lineId;
+
+        @XmlElement(name = "OrderedArticle")
+        QuoteArticle orderedArticle;
+    }
+
+    /** {@code ew:OrderedArticle} of a quote line. */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class QuoteArticle {
+
+        @XmlElement(name = "ArticleIdentification")
+        ArticleIdentification articleIdentification;
+
+        /**
+         * Four-valued availability code: {@code 0} could not be determined, {@code 1} available in
+         * the requested quantity, {@code 2} partially available, {@code 3} not currently available.
+         *
+         * <p>{@code 3} is a statement and {@code 0} is a silence — the codec keeps them apart.
+         */
+        @XmlElement(name = "Availability")
+        String availability;
+
+        @XmlElement(name = "ArticleComment")
+        String articleComment;
+
+        @XmlElement(name = "RequestedQuantity")
+        Quantity requestedQuantity;
+
+        /** Line-level outcome; the code table distinguishes "not known to the supplier". */
+        @XmlElement(name = "Error")
+        ErrorBlock error;
+
+        /** Quantities the vendor can deliver, against the dates it can deliver them. */
+        @XmlElement(name = "ScheduleDetails")
+        List<ScheduleDetail> scheduleDetails = new ArrayList<>();
+    }
+
+    /** {@code ew:ScheduleDetails} — one promised quantity at one date. */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class ScheduleDetail {
+
+        @XmlElement(name = "DeliveryDate")
+        String deliveryDate;
+
+        /**
+         * The quantity available at {@link #deliveryDate}.
+         *
+         * <p>The spec names this element {@code ConfirmedQuantity} on A2.5 while giving it the
+         * {@code AvailableQuantity} schema. Both spellings are accepted rather than losing a
+         * quantity to a naming inconsistency in the source document.
+         */
+        @XmlElement(name = "ConfirmedQuantity")
+        Quantity confirmedQuantity;
+
+        @XmlElement(name = "AvailableQuantity")
+        Quantity availableQuantity;
+    }
+
+    /** {@code ew:ArticleIdentification} — the identifiers naming one article. */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(
+            name = "articleIdentificationA2",
+            propOrder = {"buyersArticleId", "manufacturersArticleId", "eanuccArticleId"})
+    static class ArticleIdentification {
+
+        @XmlElement(name = "BuyersArticleID")
+        String buyersArticleId;
+
+        @XmlElement(name = "ManufacturersArticleID")
+        String manufacturersArticleId;
+
+        /** 13-digit GTIN. */
+        @XmlElement(name = "EANUCCArticleID")
+        String eanuccArticleId;
+    }
+
+    /** {@code ew:BuyerParty} / {@code ew:Consignee}. */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(
+            name = "partyA2",
+            propOrder = {"partyId", "agencyCode"})
+    static class Party {
+
+        @XmlElement(name = "PartyID", required = true)
+        String partyId;
+
+        @XmlElement(name = "AgencyCode", required = true)
+        String agencyCode;
+
+        static Party of(String partyId, String agencyCode) {
+            Party party = new Party();
+            party.partyId = partyId;
+            party.agencyCode = agencyCode;
+            return party;
+        }
+    }
+
+    /** A quantity element: one {@code QuantityValue} child. */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "quantityA2")
+    static class Quantity {
+
+        @XmlElement(name = "QuantityValue", required = true)
+        String quantityValue;
+
+        static Quantity of(int value) {
+            Quantity quantity = new Quantity();
+            quantity.quantityValue = Integer.toString(value);
+            return quantity;
+        }
+    }
+
+    /** {@code ew:CustomerReference} — a single document identifier. */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "documentReferenceA2")
+    static class DocumentReference {
+
+        @XmlElement(name = "DocumentID", required = true)
+        String documentId;
+
+        static DocumentReference of(String documentId) {
+            DocumentReference reference = new DocumentReference();
+            reference.documentId = documentId;
+            return reference;
+        }
+    }
+
+    /** {@code ew:ErrorHead} / {@code ew:Error}. */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class ErrorBlock {
+
+        @XmlElement(name = "ErrorCode")
+        String errorCode;
+
+        @XmlElement(name = "ErrorText")
+        String errorText;
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/StockInquiryDecodeException.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/StockInquiryDecodeException.java
@@ -1,0 +1,19 @@
+package com.positivity.supplier.internal.adapter.ediwheela2;
+
+/**
+ * An A2.5 quote document could not be read.
+ *
+ * <p>Unlike an unreadable order response (ADR-0052 §3), this is not an ambiguity: nothing was
+ * committed by asking. The caller turns it into {@code SUPPLIER_UNAVAILABLE} — we asked, we did not
+ * get a usable answer — and the caller degrades rather than failing its own flow.
+ */
+public class StockInquiryDecodeException extends RuntimeException {
+
+    public StockInquiryDecodeException(String message) {
+        super(message);
+    }
+
+    public StockInquiryDecodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/StockInquiryEncodeException.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/StockInquiryEncodeException.java
@@ -1,0 +1,19 @@
+package com.positivity.supplier.internal.adapter.ediwheela2;
+
+/**
+ * A canonical inquiry could not be expressed as an A2.5 document.
+ *
+ * <p>Always a configuration or programming fault on our side — a missing agency code, an article
+ * with no identifier the norm can carry — never a vendor failure, so the caller reports
+ * {@code CONFIGURATION_ERROR} and makes no network call.
+ */
+public class StockInquiryEncodeException extends RuntimeException {
+
+    public StockInquiryEncodeException(String message) {
+        super(message);
+    }
+
+    public StockInquiryEncodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/package-info.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheela2/package-info.java
@@ -1,0 +1,35 @@
+/**
+ * EDIWheel A2 XML adapter package (ADR-0051 §2): one package per wire-format family.
+ *
+ * <p>Covers the A2.5 stock inquiry norm from
+ * {@code durion/docs/ediwheel/Swagger_UPX-Stock Inquiry PROD_1_2.yaml}, with the shared EDIWheel
+ * error-code tables from {@code EDIWheel-XML_Order_Response_C1.pdf}. Everything vendor-shaped
+ * lives here and nowhere else: the JAXB types model the documents literally, vendor element names
+ * and all, and are package-private so a vendor type can never escape into the domain, an event
+ * payload, or an API contract. Codecs convert to and from the canonical models in
+ * {@code com.positivity.supplier.internal.domain.model} and perform no I/O (ADR-0051 §5).
+ *
+ * <h2>What A2.5 does and does not answer</h2>
+ *
+ * A2.5 answers <em>availability</em>: a four-valued code per line, plus a schedule of quantities
+ * against delivery dates. It carries <strong>no price</strong> — the sibling C1.0 inquiry on the
+ * same Michelin endpoint is the norm that adds {@code PriceDetails/NetUnitPrice}. Callers that
+ * need a supplier price take it from the PRICAT price entries (CAP-318), which is the owner of
+ * that fact; the quote fields on the canonical result stay null on this norm rather than being
+ * filled with a number A2.5 never stated.
+ *
+ * <h2>Why a package-level namespace declaration</h2>
+ *
+ * The A2 norms put their documents in {@code http://www.reifen.net}, the same namespace as the C1
+ * family, so outbound documents are emitted fully qualified. Inbound documents are normalised into
+ * that namespace before unmarshalling rather than being required to arrive in it — see
+ * {@code com.positivity.supplier.internal.adapter.ediwheelxml.EdiwheelXmlSupport}.
+ */
+@jakarta.xml.bind.annotation.XmlSchema(
+        namespace = "http://www.reifen.net",
+        elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED,
+        // Prefix pinned to ew: for the same reason the C1 package pins it — the norm's own examples
+        // use it, and an inquiry a vendor parses is the wrong place to bet on every vendor's parser
+        // being namespace-correct rather than prefix-matching.
+        xmlns = {@jakarta.xml.bind.annotation.XmlNs(prefix = "ew", namespaceURI = "http://www.reifen.net")})
+package com.positivity.supplier.internal.adapter.ediwheela2;

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelc1/C1XmlSupport.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelc1/C1XmlSupport.java
@@ -1,50 +1,25 @@
 package com.positivity.supplier.internal.adapter.ediwheelc1;
 
+import com.positivity.supplier.internal.adapter.ediwheelxml.EdiwheelXmlException;
+import com.positivity.supplier.internal.adapter.ediwheelxml.EdiwheelXmlSupport;
 import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Marshaller;
-import jakarta.xml.bind.Unmarshaller;
-import java.io.StringReader;
-import java.io.StringWriter;
-import javax.xml.XMLConstants;
-import javax.xml.parsers.SAXParserFactory;
-import javax.xml.transform.sax.SAXSource;
 import org.jspecify.annotations.NonNull;
-import org.xml.sax.Attributes;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.XMLFilterImpl;
 
 /**
- * JAXB plumbing shared by the C1 codecs: one context per document type, qualified output, and a
- * deliberately forgiving reader.
+ * The C1 family's view of the shared EDIWheel XML plumbing
+ * ({@link EdiwheelXmlSupport} — one JAXB context per document type, qualified output, a
+ * namespace-normalising reader that processes no external entities).
  *
- * <h2>Reading is namespace-normalising, writing is not</h2>
- *
- * Outbound documents are emitted exactly as the norm states them — every element qualified in
- * {@code http://www.reifen.net}. Inbound documents are rewritten into that namespace before
- * unmarshalling, whatever namespace (or none) their elements arrived in.
- *
- * <p>The asymmetry is intentional. What we send is a commercial document a vendor may hold us
- * to, so it follows the norm to the letter. What we receive is a document some vendor's stack
- * produced, and in practice the C1 family arrives with children variously qualified, unqualified
- * or under a vendor's own namespace. A strict reader would reject an order confirmation whose
- * content is entirely well formed — leaving a real, accepted purchase order looking to us like a
- * transport failure, which under ADR-0052 §3 is exactly the ambiguity that ends in
- * {@code MANUAL_REVIEW}. Being generous about namespaces on the way in costs nothing and removes
- * a whole class of false ambiguity.
- *
- * <h2>External entities are disabled</h2>
- *
- * These documents come from outside this deployment. The parser is configured to process no
- * external entities and no DTDs at all, so a vendor document cannot make this process read a
- * local file or open a network connection.
+ * <p>This class exists to translate, not to parse. The shared support throws
+ * {@link EdiwheelXmlException}; C1 callers expect {@link OrderEncodeException} and
+ * {@link OrderDecodeException}, because for an order document an unreadable body is a
+ * transmission ambiguity (ADR-0052 §3) rather than a generic parse failure — and that meaning
+ * belongs to the family, not to the parser.
  */
 final class C1XmlSupport {
 
     /** Namespace of the EDIWheel C1 norms. */
-    static final String NAMESPACE = "http://www.reifen.net";
+    static final String NAMESPACE = EdiwheelXmlSupport.NAMESPACE;
 
     private C1XmlSupport() {}
 
@@ -56,24 +31,15 @@ final class C1XmlSupport {
      */
     @NonNull
     static JAXBContext contextFor(@NonNull Class<?> rootType) {
-        try {
-            return JAXBContext.newInstance(rootType);
-        } catch (JAXBException e) {
-            throw new IllegalStateException("Unable to build a JAXB context for " + rootType.getName(), e);
-        }
+        return EdiwheelXmlSupport.contextFor(rootType);
     }
 
-    /** Serialises a root document: XML declaration, {@code ew:}-prefixed, fully qualified. */
+    /** Serialises a root document: XML declaration, fully qualified. */
     @NonNull
     static String marshal(@NonNull JAXBContext context, @NonNull Object document) {
         try {
-            Marshaller marshaller = context.createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-            marshaller.setProperty(Marshaller.JAXB_ENCODING, "UTF-8");
-            StringWriter writer = new StringWriter();
-            marshaller.marshal(document, writer);
-            return writer.toString();
-        } catch (JAXBException e) {
+            return EdiwheelXmlSupport.marshal(context, document);
+        } catch (EdiwheelXmlException e) {
             throw new OrderEncodeException("Unable to serialise an EDIWheel C1 document", e);
         }
     }
@@ -81,80 +47,15 @@ final class C1XmlSupport {
     /**
      * Parses a vendor document into {@code rootType}, normalising element namespaces first.
      *
-     * <p>Unmarshalling is deliberately <strong>untyped</strong> — {@code unmarshal(source)} rather
-     * than {@code unmarshal(source, rootType)}. The typed overload force-binds whatever root
-     * element it finds into the requested class, so an unrelated document, or a body that is not a
-     * C1 document at all, decodes into an empty instance instead of failing. For an order response
-     * that empty instance carries no error code, which reads as <em>the vendor accepted the
-     * order</em> — a purchase order silently marked confirmed on the strength of a body nobody
-     * could read. The untyped call rejects an unexpected root element, and the instance check below
-     * closes the remainder.
-     *
      * @throws OrderDecodeException when the body is not parseable as that document
      */
     @NonNull
     static <T> T unmarshal(@NonNull JAXBContext context, @NonNull Class<T> rootType, @NonNull String body) {
-        Object parsed;
         try {
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            SAXSource source = new SAXSource(namespaceNormalisingReader(), new InputSource(new StringReader(body)));
-            parsed = unmarshaller.unmarshal(source);
-        } catch (OrderDecodeException e) {
-            throw e;
-        } catch (Exception e) {
+            return EdiwheelXmlSupport.unmarshal(context, rootType, body);
+        } catch (EdiwheelXmlException e) {
             throw new OrderDecodeException(
                     "Response body is not a readable EDIWheel C1 " + rootType.getSimpleName(), e);
-        }
-        if (!rootType.isInstance(parsed)) {
-            throw new OrderDecodeException("Response body is not an EDIWheel C1 " + rootType.getSimpleName() + " but a "
-                    + (parsed == null ? "null document" : parsed.getClass().getSimpleName()));
-        }
-        return rootType.cast(parsed);
-    }
-
-    private static XMLReader namespaceNormalisingReader() {
-        SAXParserFactory factory = SAXParserFactory.newInstance();
-        factory.setNamespaceAware(true);
-        try {
-            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            XMLFilterImpl filter = new NamespaceNormalisingFilter();
-            filter.setParent(factory.newSAXParser().getXMLReader());
-            return filter;
-        } catch (Exception e) {
-            throw new OrderDecodeException("Unable to build a secure XML reader for an EDIWheel C1 document", e);
-        }
-    }
-
-    /**
-     * Rewrites every element into {@link #NAMESPACE}, whatever namespace it arrived in.
-     *
-     * <p>Attributes are left alone: the C1 norms carry no meaningful namespaced attributes, and
-     * rewriting {@code xsi:*} would break rather than help.
-     */
-    private static final class NamespaceNormalisingFilter extends XMLFilterImpl {
-
-        @Override
-        public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
-            super.startElement(NAMESPACE, localName, localName, atts);
-        }
-
-        @Override
-        public void endElement(String uri, String localName, String qName) throws SAXException {
-            super.endElement(NAMESPACE, localName, localName);
-        }
-
-        @Override
-        public void startPrefixMapping(String prefix, String uri) throws SAXException {
-            // Swallowed: the rewritten document declares its own single namespace, and passing the
-            // vendor's prefixes through would bind them to URIs no element now uses.
-        }
-
-        @Override
-        public void endPrefixMapping(String prefix) throws SAXException {
-            // See startPrefixMapping.
         }
     }
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelxml/EdiwheelXmlException.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelxml/EdiwheelXmlException.java
@@ -1,0 +1,20 @@
+package com.positivity.supplier.internal.adapter.ediwheelxml;
+
+/**
+ * An EDIWheel document could not be serialised or parsed.
+ *
+ * <p>Deliberately family-agnostic and deliberately not surfaced beyond an adapter: each family
+ * translates it into its own typed encode/decode failure, because what a broken document
+ * <em>means</em> differs by capability. An unreadable order response is a transmission ambiguity
+ * (ADR-0052 §3); an unreadable inquiry response is just an unavailable vendor.
+ */
+public class EdiwheelXmlException extends RuntimeException {
+
+    public EdiwheelXmlException(String message) {
+        super(message);
+    }
+
+    public EdiwheelXmlException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelxml/EdiwheelXmlSupport.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelxml/EdiwheelXmlSupport.java
@@ -1,0 +1,172 @@
+package com.positivity.supplier.internal.adapter.ediwheelxml;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+import java.io.StringReader;
+import java.io.StringWriter;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.sax.SAXSource;
+import org.jspecify.annotations.NonNull;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.XMLFilterImpl;
+
+/**
+ * JAXB plumbing shared by every EDIWheel XML family: one context per document type, qualified
+ * output, and a deliberately forgiving, externally-inert reader.
+ *
+ * <h2>Why this is family-agnostic</h2>
+ *
+ * The C1 norms (order, order status) and the A2 norms (stock inquiry) are different document
+ * families, and ADR-0051 §2 keeps a package per family for exactly that reason. What they are not
+ * different about is XML: both are {@code http://www.reifen.net} documents parsed by the same
+ * rules. Copying this class per family would mean copying the hardening below — and a second copy
+ * is a copy that can silently fall behind the first, which for parser security is the failure that
+ * matters. Families keep their own wire types and their own typed exceptions; they share this.
+ *
+ * <h2>Reading is namespace-normalising, writing is not</h2>
+ *
+ * Outbound documents are emitted exactly as the norm states them — every element qualified in
+ * {@link #NAMESPACE}. Inbound documents are rewritten into that namespace before unmarshalling,
+ * whatever namespace (or none) their elements arrived in.
+ *
+ * <p>The asymmetry is intentional. What we send is a commercial document a vendor may hold us to,
+ * so it follows the norm to the letter. What we receive is a document some vendor's stack produced,
+ * and in practice these arrive with children variously qualified, unqualified or under a vendor's
+ * own namespace. A strict reader would reject a document whose content is entirely well formed —
+ * turning a real answer into what looks like a transport failure, which for an order is the
+ * ambiguity ADR-0052 §3 exists to avoid and for an inquiry is a needless
+ * {@code SUPPLIER_UNAVAILABLE}.
+ *
+ * <h2>External entities are disabled</h2>
+ *
+ * These documents come from outside this deployment. The parser processes no external entities and
+ * no DTDs at all, so a vendor document cannot make this process read a local file or open a network
+ * connection.
+ */
+public final class EdiwheelXmlSupport {
+
+    /** Namespace of the EDIWheel norms. */
+    public static final String NAMESPACE = "http://www.reifen.net";
+
+    private EdiwheelXmlSupport() {}
+
+    /**
+     * Builds a JAXB context for one root type.
+     *
+     * @throws IllegalStateException when the type is not bindable — a code defect, surfaced at
+     *     startup rather than on the first vendor call
+     */
+    @NonNull
+    public static JAXBContext contextFor(@NonNull Class<?> rootType) {
+        try {
+            return JAXBContext.newInstance(rootType);
+        } catch (JAXBException e) {
+            throw new IllegalStateException("Unable to build a JAXB context for " + rootType.getName(), e);
+        }
+    }
+
+    /**
+     * Serialises a root document: XML declaration, fully qualified.
+     *
+     * @throws EdiwheelXmlException when the document cannot be serialised; callers translate this
+     *     into their family's typed encode failure
+     */
+    @NonNull
+    public static String marshal(@NonNull JAXBContext context, @NonNull Object document) {
+        try {
+            Marshaller marshaller = context.createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+            marshaller.setProperty(Marshaller.JAXB_ENCODING, "UTF-8");
+            StringWriter writer = new StringWriter();
+            marshaller.marshal(document, writer);
+            return writer.toString();
+        } catch (JAXBException e) {
+            throw new EdiwheelXmlException("Unable to serialise an EDIWheel document", e);
+        }
+    }
+
+    /**
+     * Parses a vendor document into {@code rootType}, normalising element namespaces first.
+     *
+     * <p>Unmarshalling is deliberately <strong>untyped</strong> — {@code unmarshal(source)} rather
+     * than {@code unmarshal(source, rootType)}. The typed overload force-binds whatever root element
+     * it finds into the requested class, so an unrelated document, or a body that is not an EDIWheel
+     * document at all, decodes into an empty instance instead of failing. An empty instance carries
+     * no error code, which reads as <em>the vendor said yes</em> — an order silently marked
+     * confirmed, or an inquiry answered with silent nulls, on the strength of a body nobody could
+     * read. The untyped call rejects an unexpected root element, and the instance check below closes
+     * the remainder.
+     *
+     * @throws EdiwheelXmlException when the body is not parseable as that document
+     */
+    @NonNull
+    public static <T> T unmarshal(@NonNull JAXBContext context, @NonNull Class<T> rootType, @NonNull String body) {
+        Object parsed;
+        try {
+            Unmarshaller unmarshaller = context.createUnmarshaller();
+            SAXSource source = new SAXSource(namespaceNormalisingReader(), new InputSource(new StringReader(body)));
+            parsed = unmarshaller.unmarshal(source);
+        } catch (EdiwheelXmlException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new EdiwheelXmlException("Response body is not a readable EDIWheel " + rootType.getSimpleName(), e);
+        }
+        if (!rootType.isInstance(parsed)) {
+            throw new EdiwheelXmlException("Response body is not an EDIWheel " + rootType.getSimpleName() + " but a "
+                    + (parsed == null ? "null document" : parsed.getClass().getSimpleName()));
+        }
+        return rootType.cast(parsed);
+    }
+
+    private static XMLReader namespaceNormalisingReader() {
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        factory.setNamespaceAware(true);
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            XMLFilterImpl filter = new NamespaceNormalisingFilter();
+            filter.setParent(factory.newSAXParser().getXMLReader());
+            return filter;
+        } catch (Exception e) {
+            throw new EdiwheelXmlException("Unable to build a secure XML reader for an EDIWheel document", e);
+        }
+    }
+
+    /**
+     * Rewrites every element into {@link #NAMESPACE}, whatever namespace it arrived in.
+     *
+     * <p>Attributes are left alone: the norms carry no meaningful namespaced attributes, and
+     * rewriting {@code xsi:*} would break rather than help.
+     */
+    private static final class NamespaceNormalisingFilter extends XMLFilterImpl {
+
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+            super.startElement(NAMESPACE, localName, localName, atts);
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qName) throws SAXException {
+            super.endElement(NAMESPACE, localName, localName);
+        }
+
+        @Override
+        public void startPrefixMapping(String prefix, String uri) throws SAXException {
+            // Swallowed: the rewritten document declares its own single namespace, and passing the
+            // vendor's prefixes through would bind them to URIs no element now uses.
+        }
+
+        @Override
+        public void endPrefixMapping(String prefix) throws SAXException {
+            // See startPrefixMapping.
+        }
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/SupplierStockInquiryResult.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/SupplierStockInquiryResult.java
@@ -2,21 +2,28 @@ package com.positivity.supplier.internal.domain.model;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Result of a stock availability read. Also reused as the line shape of the B-series stock
- * <em>report</em> snapshot until CAP-322 grows a dedicated snapshot model — both answer
- * "how much of which article does the vendor have, as of when".
+ * Result of a stock availability read.
  *
- * <p>Numeric fields are wrapper types on purpose: <strong>null means "not stated by the
- * vendor", never zero</strong> — a vendor that did not answer availability must not be
- * mistaken for a vendor with no stock.
+ * <p>Numeric fields are wrapper types on purpose: <strong>null means "not stated by the vendor",
+ * never zero</strong> — a vendor that did not answer availability must not be mistaken for a vendor
+ * with no stock.
  *
- * @param status typed outcome; non-{@link Status#OK} statuses carry no vendor data and map
+ * <h2>Why the answer is per line as well as per document</h2>
+ *
+ * An inquiry may name several articles and a vendor routinely answers them differently: it stocks
+ * the first, has none of the second, and has never heard of the third. A single document-level
+ * status cannot say that, and collapsing it would either hide that an article is unknown or declare
+ * the whole inquiry unanswered because one line was. {@link #status} therefore describes the
+ * document — did we get an answer at all — and {@link Line#status()} describes each article.
+ *
+ * @param status document-level outcome; non-{@link Status#OK} statuses carry no vendor data and map
  *     the unbound/unavailable cases of ADR-0050 §3 without leaking errors
  * @param lines per-article availability; empty unless status is {@link Status#OK}
  * @param asOf vendor-stated snapshot instant; present when status is {@link Status#OK}
@@ -27,11 +34,11 @@ public record SupplierStockInquiryResult(
         @Nullable Instant asOf) {
 
     public enum Status {
-        /** The vendor answered the inquiry. */
+        /** The vendor answered the inquiry. Per-line outcomes are on the lines. */
         OK,
         /** The vendor endpoint could not be reached or failed. */
         SUPPLIER_UNAVAILABLE,
-        /** The vendor does not list the inquired article(s). */
+        /** The vendor lists none of the inquired articles. */
         NOT_LISTED,
         /** No binding exists for this capability on the vendor profile (ADR-0050 §3). */
         CAPABILITY_NOT_CONFIGURED,
@@ -39,22 +46,58 @@ public record SupplierStockInquiryResult(
         CONFIGURATION_ERROR
     }
 
+    /** What the vendor said about one article. */
+    public enum LineStatus {
+        /** The vendor stated an availability for this article. */
+        AVAILABLE,
+        /**
+         * The vendor stated that it has none. This is an answer, not a silence: it is the one case
+         * where a quantity of zero is a fact rather than an assumption.
+         */
+        UNAVAILABLE,
+        /**
+         * The vendor does not know, or will not sell, this article. Retrying an identical inquiry
+         * cannot change this, which is what separates it from {@link Status#SUPPLIER_UNAVAILABLE}.
+         */
+        NOT_LISTED,
+        /**
+         * The vendor returned the line without stating an availability — it could not determine
+         * one, or it rejected the line for a reason unrelated to the article's identity.
+         */
+        NOT_ANSWERED
+    }
+
     /**
      * Per-article availability answer.
      *
      * @param articleEan EAN/GTIN of the article, when stated
      * @param supplierArticleCode vendor's own article code, when stated
-     * @param availableQuantity available quantity; {@code null} when the vendor did not state
-     *     one (never coerced to zero)
-     * @param quotedUnitPrice quoted unit price; {@code null} when the vendor did not quote
+     * @param status what the vendor said about this article
+     * @param availableQuantity available quantity; {@code null} when the vendor did not state one
+     *     (never coerced to zero), {@code 0} only when {@link LineStatus#UNAVAILABLE}
+     * @param earliestDeliveryDate earliest date the vendor promised any quantity, when stated
+     * @param quotedUnitPrice quoted unit price; {@code null} when the vendor did not quote. The
+     *     A2.5 norm carries no price at all — only the C1.0 inquiry does — so on that norm this is
+     *     always null and a supplier price is taken from the PRICAT entries that own it
      * @param currency ISO currency of {@code quotedUnitPrice}, when quoted
      */
     public record Line(
             @Nullable String articleEan,
             @Nullable String supplierArticleCode,
+            @NonNull LineStatus status,
             @Nullable Integer availableQuantity,
+            @Nullable LocalDate earliestDeliveryDate,
             @Nullable BigDecimal quotedUnitPrice,
-            @Nullable String currency) {}
+            @Nullable String currency) {
+
+        public Line {
+            Objects.requireNonNull(status, "status must not be null");
+            if (status != LineStatus.AVAILABLE && status != LineStatus.UNAVAILABLE && availableQuantity != null) {
+                throw new IllegalArgumentException(
+                        "a quantity may only accompany an answered line, but status was " + status);
+            }
+        }
+    }
 
     public SupplierStockInquiryResult {
         Objects.requireNonNull(status, "status must not be null");

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/spi/SupplierStockReportPort.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/spi/SupplierStockReportPort.java
@@ -3,25 +3,25 @@ package com.positivity.supplier.internal.spi;
 import com.positivity.supplier.internal.domain.model.PartyContext;
 import com.positivity.supplier.internal.domain.model.SupplierExchange;
 import com.positivity.supplier.internal.domain.model.SupplierRef;
-import com.positivity.supplier.internal.domain.model.SupplierStockInquiryResult;
+import com.positivity.supplier.internal.domain.model.SupplierStockSnapshot;
 import org.jspecify.annotations.NonNull;
 
 /**
  * Capability port: batch stock snapshot fetch at country level
  * ({@code STOCK_REPORT}; EDIWheel Stock Report B2.1/C1.0).
  *
- * <p>Governing ADRs: ADR-0049 §3 (feeds the {@code supplier.stockreport.updated} fact
- * consumed by pos-inventory), ADR-0052 §5 (batch reads are idempotent by checkpointed window
- * and may retry freely).
+ * <p>Governing ADRs: ADR-0049 §3 (feeds the {@code supplier.stockreport.updated} fact consumed by
+ * pos-inventory), ADR-0052 §5 (batch reads are idempotent by checkpointed window and may retry
+ * freely).
  *
- * <p>The snapshot reuses {@link SupplierStockInquiryResult} as its shape (article identity,
- * quantity, as-of instant) until the stock-report capability (CAP-322) grows a dedicated
- * snapshot model.
+ * <p>The snapshot has its own model, {@link SupplierStockSnapshot}, since CAP-322: a report states
+ * what a market holds, an inquiry answers what a named consignee can get, and the two stopped
+ * being the same shape as soon as the report gained scope and vendor as-of semantics.
  */
 public interface SupplierStockReportPort {
 
     /** Fetches the vendor's current stock snapshot for the profile's market. */
     @NonNull
-    SupplierExchange<SupplierStockInquiryResult> fetchStockSnapshot(
+    SupplierExchange<SupplierStockSnapshot> fetchStockSnapshot(
             @NonNull SupplierRef supplierRef, @NonNull PartyContext partyContext);
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/stockinquiry/service/StockInquiryCache.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/stockinquiry/service/StockInquiryCache.java
@@ -1,0 +1,129 @@
+package com.positivity.supplier.internal.stockinquiry.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiryResult;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Short-TTL cache of per-article availability answers (DECISION-POSITIVITY-008).
+ *
+ * <h2>The delivery location is part of the key, not a detail of it</h2>
+ *
+ * Availability is consignee-specific: the same article can be in stock for one branch and not for
+ * the branch down the road, because the vendor answers against the address it will ship to. A cache
+ * keyed on article and vendor alone would serve one location's answer to another — a customer told
+ * "available today" about stock that is four hundred kilometres from the fitter who will fit it.
+ * The key carries the location for that reason, and the type will not let a caller omit it.
+ *
+ * <h2>Only answers are cached</h2>
+ *
+ * A vendor that was unreachable a second ago may be reachable now, and an article the vendor could
+ * not determine availability for is not a fact worth remembering. Caching those would extend one
+ * failure into a minute of identical failures for every customer looking at the page. Only
+ * {@code AVAILABLE} and {@code UNAVAILABLE} — the two cases where the vendor actually said
+ * something — are stored.
+ *
+ * <p>{@code NOT_LISTED} is deliberately <em>not</em> cached either, even though it is stable. It is
+ * usually the signal that a catalogue mapping is wrong, and an operator who fixes the mapping should
+ * see the fix on the next page load rather than a minute later, wondering whether it worked.
+ */
+@Component
+public class StockInquiryCache {
+
+    /**
+     * Ceiling on entries. A cache this short-lived exists to absorb the repeat views of one product
+     * page, not to hold a catalogue; the bound is what keeps a burst of distinct articles from
+     * turning a cache into a memory leak.
+     */
+    private static final int MAX_ENTRIES = 20_000;
+
+    private final Cache<Key, Answer> entries;
+    private final boolean enabled;
+
+    public StockInquiryCache(
+            @Value("${pos.supplier.stockinquiry.cache-enabled:true}") boolean enabled,
+            @Value("${pos.supplier.stockinquiry.cache-ttl:PT60S}") Duration ttl) {
+        this.enabled = enabled && !ttl.isZero() && !ttl.isNegative();
+        this.entries = Caffeine.newBuilder()
+                .maximumSize(MAX_ENTRIES)
+                .expireAfterWrite(this.enabled ? ttl : Duration.ofMillis(1))
+                .build();
+    }
+
+    /** Whether caching is switched on for this deployment. */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /** The cached answer for one article at one location, or null when there is none. */
+    @Nullable
+    public Answer get(@NonNull Key key) {
+        return enabled ? entries.getIfPresent(key) : null;
+    }
+
+    /**
+     * Stores an answer, if it is the kind of answer worth remembering.
+     *
+     * <p>Silently ignores anything else, so a caller cannot accidentally extend a vendor outage by
+     * caching it.
+     */
+    public void put(@NonNull Key key, SupplierStockInquiryResult.@NonNull Line line, @NonNull Instant asOf) {
+        if (!enabled) {
+            return;
+        }
+        if (line.status() != SupplierStockInquiryResult.LineStatus.AVAILABLE
+                && line.status() != SupplierStockInquiryResult.LineStatus.UNAVAILABLE) {
+            return;
+        }
+        entries.put(key, new Answer(line, asOf));
+    }
+
+    /** Drops everything; used by tests and by an operator-triggered refresh. */
+    public void clear() {
+        entries.invalidateAll();
+    }
+
+    /**
+     * What identifies one cached answer.
+     *
+     * @param vendorProfileId the vendor asked
+     * @param deliveryLocationId the receiving location the answer is about — never optional
+     * @param articleKey the article identity as inquired, normalised by the caller
+     */
+    public record Key(
+            @NonNull UUID vendorProfileId,
+            @NonNull UUID deliveryLocationId,
+            @NonNull String articleKey) {
+
+        public Key {
+            Objects.requireNonNull(vendorProfileId, "vendorProfileId must not be null");
+            Objects.requireNonNull(deliveryLocationId, "deliveryLocationId must not be null");
+            Objects.requireNonNull(articleKey, "articleKey must not be null");
+        }
+    }
+
+    /**
+     * A remembered answer.
+     *
+     * @param line what the vendor said
+     * @param asOf when the vendor said it — carried so a cached answer reports the age of the fact
+     *     rather than the age of the cache hit
+     */
+    public record Answer(
+            SupplierStockInquiryResult.@NonNull Line line,
+            @NonNull Instant asOf) {
+
+        public Answer {
+            Objects.requireNonNull(line, "line must not be null");
+            Objects.requireNonNull(asOf, "asOf must not be null");
+        }
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/stockinquiry/service/StockInquiryRunner.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/stockinquiry/service/StockInquiryRunner.java
@@ -1,0 +1,183 @@
+package com.positivity.supplier.internal.stockinquiry.service;
+
+import com.positivity.supplier.internal.adapter.ediwheela2.EdiwheelA25StockInquiryCodec;
+import com.positivity.supplier.internal.adapter.ediwheela2.StockInquiryDecodeException;
+import com.positivity.supplier.internal.adapter.ediwheela2.StockInquiryEncodeException;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.client.SupplierHttpRequest;
+import com.positivity.supplier.internal.client.SupplierHttpResponse;
+import com.positivity.supplier.internal.domain.model.PartyContext;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiry;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiryResult;
+import com.positivity.supplier.internal.entity.SupplierAccountEntity;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.registry.AdapterResolution;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedPartyAccounts;
+import com.positivity.supplier.internal.spi.ExchangeOutcome;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+
+/**
+ * Runs one live stock inquiry end to end (CAP-319 #1225).
+ *
+ * <h2>This method does not throw</h2>
+ *
+ * A stock inquiry sits inside a product page and a procurement screen. If it threw, every caller
+ * would need a try/catch whose only sensible body is "render without live stock" — and the first
+ * caller to forget one takes down a page over a vendor's bad afternoon. So every failure becomes a
+ * status: an unbound capability, an unmapped delivery location, a refused connection, a timeout, an
+ * unreadable answer. The exception types still exist and are still specific; they are translated
+ * here, once, rather than at every call site.
+ *
+ * <h2>Configuration failures never reach the network</h2>
+ *
+ * The binding, the codec and both party accounts are resolved before a request is built. A profile
+ * that cannot name the receiving location's account is answered {@code CONFIGURATION_ERROR} without
+ * a call, because the alternative — asking the vendor about an unstated address — returns an answer
+ * that looks right and is about the wrong place.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockInquiryRunner {
+
+    private final SupplierProfileResolver profileResolver;
+    private final AdapterRegistry adapterRegistry;
+    private final SupplierBaseClient baseClient;
+
+    /**
+     * Asks the vendor what it has, for one receiving location.
+     *
+     * <p>The commercial identity is resolved here rather than passed in: the billing account and the
+     * delivery account both come from the vendor profile, and a caller that supplied them could
+     * supply a pair the profile does not agree with.
+     *
+     * @param supplierRef the vendor profile alias to ask
+     * @param deliveryLocationId the receiving location the question is about; required, because
+     *     availability is consignee-specific
+     * @param inquiry the articles to ask about
+     * @return the canonical answer; never null, and never an exception for a vendor-side failure
+     */
+    @NonNull
+    public SupplierStockInquiryResult inquire(
+            @NonNull SupplierRef supplierRef, @NonNull UUID deliveryLocationId, @NonNull SupplierStockInquiry inquiry) {
+
+        ResolvedBinding binding;
+        EdiwheelA25StockInquiryCodec codec;
+        SupplierAccountEntity billing;
+        SupplierAccountEntity delivery;
+        try {
+            binding = profileResolver.resolveBinding(supplierRef, SupplierCapability.STOCK_INQUIRY);
+            codec = resolveCodec(binding);
+            ResolvedPartyAccounts accounts = profileResolver.resolvePartyContext(supplierRef, deliveryLocationId);
+            billing = accounts.billing();
+            delivery = accounts.delivery();
+        } catch (SupplierConfigurationException e) {
+            return configurationOutcome(supplierRef, e);
+        }
+
+        PartyContext partyContext =
+                new PartyContext(billing.getAccountNumber(), billing.getAgencyCode(), deliveryLocationId);
+
+        SupplierRequestSpec spec;
+        try {
+            spec = codec.buildRequest(
+                    inquiry,
+                    partyContext,
+                    delivery == null ? null : delivery.getAccountNumber(),
+                    delivery == null ? null : delivery.getAgencyCode());
+        } catch (StockInquiryEncodeException e) {
+            log.warn("Cannot express a stock inquiry for supplier {} in A2.5: {}", supplierRef.value(), e.getMessage());
+            return failed(SupplierStockInquiryResult.Status.CONFIGURATION_ERROR);
+        }
+
+        SupplierHttpResponse response = baseClient.exchange(toHttpRequest(binding, spec));
+        if (!response.isSuccess()) {
+            // Every non-OK outcome is the same answer to a caller rendering a page: we could not
+            // find out. The distinctions the client draws (pre-send, ambiguous, rejected) matter for
+            // retry safety on state-creating calls, and an inquiry creates no state.
+            log.debug(
+                    "Stock inquiry to supplier {} did not answer: outcome={} detail={}",
+                    supplierRef.value(),
+                    response.outcome(),
+                    response.failureDetail());
+            return failed(
+                    response.outcome() == ExchangeOutcome.CONFIGURATION_ERROR
+                            ? SupplierStockInquiryResult.Status.CONFIGURATION_ERROR
+                            : SupplierStockInquiryResult.Status.SUPPLIER_UNAVAILABLE);
+        }
+
+        try {
+            return codec.decodeQuote(response.body());
+        } catch (StockInquiryDecodeException e) {
+            // An answer we cannot read is not an answer. Reporting the articles as unavailable would
+            // turn our parsing problem into the vendor's empty warehouse.
+            log.warn("Unreadable stock inquiry answer from supplier {}: {}", supplierRef.value(), e.getMessage());
+            return failed(SupplierStockInquiryResult.Status.SUPPLIER_UNAVAILABLE);
+        }
+    }
+
+    /**
+     * Maps a configuration failure to the status that tells an operator where to look.
+     *
+     * <p>An unbound capability is a deployment that has not switched this vendor on, which is a
+     * normal state and reported as such (ADR-0050 §3). Everything else — an unknown alias, a
+     * disabled profile, a missing account mapping — is a profile that is switched on and wrong.
+     */
+    private SupplierStockInquiryResult configurationOutcome(SupplierRef supplierRef, SupplierConfigurationException e) {
+        if (SupplierConfigurationException.CAPABILITY_NOT_CONFIGURED.equals(e.getCode())) {
+            log.debug("Stock inquiry not configured for supplier {}", supplierRef.value());
+            return failed(SupplierStockInquiryResult.Status.CAPABILITY_NOT_CONFIGURED);
+        }
+        log.warn(
+                "Stock inquiry for supplier {} is misconfigured: {} — {}",
+                supplierRef.value(),
+                e.getCode(),
+                e.getMessage());
+        return failed(SupplierStockInquiryResult.Status.CONFIGURATION_ERROR);
+    }
+
+    private static SupplierStockInquiryResult failed(SupplierStockInquiryResult.Status status) {
+        return new SupplierStockInquiryResult(status, List.of(), null);
+    }
+
+    /**
+     * Turns the codec's transport-free spec into a transport request against the resolved binding.
+     * The join lives here so the adapter package stays free of transport types (ADR-0051 §2).
+     */
+    private SupplierHttpRequest toHttpRequest(ResolvedBinding binding, SupplierRequestSpec spec) {
+        return new SupplierHttpRequest(
+                binding,
+                HttpMethod.valueOf(spec.method()),
+                spec.pathSuffix(),
+                spec.queryParams(),
+                spec.body(),
+                spec.contentType(),
+                spec.accept(),
+                spec.idempotent());
+    }
+
+    private EdiwheelA25StockInquiryCodec resolveCodec(ResolvedBinding binding) {
+        AdapterResolution resolution =
+                adapterRegistry.resolve(SupplierCapability.STOCK_INQUIRY, binding.family(), binding.version());
+        if (resolution instanceof AdapterResolution.Resolved resolved
+                && resolved.codec() instanceof EdiwheelA25StockInquiryCodec codec) {
+            return codec;
+        }
+        throw new SupplierConfigurationException(
+                SupplierConfigurationException.CAPABILITY_NOT_CONFIGURED,
+                "No stock-inquiry codec registered for " + binding.family() + " "
+                        + binding.version().value());
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/stockinquiry/service/SupplierStockServiceImpl.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/stockinquiry/service/SupplierStockServiceImpl.java
@@ -1,0 +1,190 @@
+package com.positivity.supplier.internal.stockinquiry.service;
+
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiry;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiryResult;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.repository.SupplierProfileRepository;
+import com.positivity.supplier.service.SupplierStockService;
+import com.positivity.supplier.service.model.StockInquiryRequest;
+import com.positivity.supplier.service.model.StockInquiryResponse;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+
+/**
+ * The platform's single approved synchronous supplier read (ADR-0044 amendment 2026-08-10,
+ * ADR-0049 §4), implemented for CAP-319 (#1225).
+ *
+ * <h2>It answers; it does not fail</h2>
+ *
+ * Callers are a product page and a procurement screen, both of which have something useful to show
+ * without live vendor stock and nothing useful to show if this call throws. Every failure is
+ * therefore a status. The only exceptions that escape are the ones that mean the caller passed
+ * nonsense — a null request — because those are defects in the caller, not conditions to render.
+ *
+ * <h2>Cache reads are per article, not per inquiry</h2>
+ *
+ * A product page asks about one article many times; a procurement screen asks about several at
+ * once, overlapping with what the page already asked. Caching whole inquiries would miss both
+ * patterns, so the cache is keyed per article and an inquiry asks the vendor only about the articles
+ * it does not already have an answer for. When every article is a hit, no call is made at all.
+ *
+ * <p>A cached answer keeps the {@code asOf} of the original inquiry rather than the moment it was
+ * served. A caller deciding whether an availability is fresh enough to promise a customer needs the
+ * age of the vendor's statement, and stamping "now" on a cache hit would report a minute-old fact as
+ * current.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SupplierStockServiceImpl implements SupplierStockService {
+
+    private final SupplierProfileRepository profileRepository;
+    private final StockInquiryRunner runner;
+    private final StockInquiryCache cache;
+    private final Clock clock;
+
+    @Override
+    @NonNull
+    public StockInquiryResponse inquireLiveStock(@NonNull StockInquiryRequest request) {
+        Optional<SupplierProfileEntity> profile = profileRepository.findById(request.vendorProfileId());
+        if (profile.isEmpty()) {
+            // The caller named a vendor this deployment does not have. That is a configuration
+            // problem where the caller lives, not a vendor being unreachable, and saying so is what
+            // stops an operator waiting for a supplier to come back.
+            log.warn("Stock inquiry names unknown vendor profile {}", request.vendorProfileId());
+            return failed(request, StockInquiryResponse.Status.CONFIGURATION_ERROR);
+        }
+
+        Map<String, StockInquiryRequest.Line> byKey = new LinkedHashMap<>();
+        for (StockInquiryRequest.Line line : request.lines()) {
+            byKey.put(articleKey(line.articleEan(), line.supplierArticleCode()), line);
+        }
+
+        Map<String, StockInquiryCache.Answer> hits = new LinkedHashMap<>();
+        List<StockInquiryRequest.Line> misses = new ArrayList<>();
+        for (Map.Entry<String, StockInquiryRequest.Line> entry : byKey.entrySet()) {
+            StockInquiryCache.Answer cached = cache.get(
+                    new StockInquiryCache.Key(request.vendorProfileId(), request.deliveryLocationId(), entry.getKey()));
+            if (cached == null) {
+                misses.add(entry.getValue());
+            } else {
+                hits.put(entry.getKey(), cached);
+            }
+        }
+
+        if (misses.isEmpty()) {
+            return served(request, hits, List.of());
+        }
+
+        SupplierRef supplierRef = new SupplierRef(profile.get().getSupplierRef());
+        SupplierStockInquiry inquiry = new SupplierStockInquiry(
+                request.inquiryId(),
+                misses.stream()
+                        .map(line -> new SupplierStockInquiry.Line(
+                                line.articleEan(), line.supplierArticleCode(), line.requestedQuantity()))
+                        .toList());
+
+        SupplierStockInquiryResult result = runner.inquire(supplierRef, request.deliveryLocationId(), inquiry);
+        if (result.status() != SupplierStockInquiryResult.Status.OK
+                && result.status() != SupplierStockInquiryResult.Status.NOT_LISTED) {
+            // The vendor did not answer. Cached articles are not reported alongside it: a mixed
+            // answer would look like a partial success, and a caller cannot tell which half of it to
+            // trust. One inquiry, one verdict.
+            return failed(request, map(result.status()));
+        }
+
+        Instant asOf = Instant.now(clock);
+        for (SupplierStockInquiryResult.Line line : result.lines()) {
+            cache.put(
+                    new StockInquiryCache.Key(
+                            request.vendorProfileId(),
+                            request.deliveryLocationId(),
+                            articleKey(line.articleEan(), line.supplierArticleCode())),
+                    line,
+                    asOf);
+        }
+        return served(request, hits, result.lines());
+    }
+
+    /**
+     * Builds the answer from cached lines plus freshly inquired ones.
+     *
+     * <p>{@code asOf} on the document is the oldest fact in it. A caller asking "how current is
+     * this?" is really asking "what is the worst case here?", and reporting the newest would let one
+     * fresh line vouch for a set that is mostly older.
+     */
+    private StockInquiryResponse served(
+            StockInquiryRequest request,
+            Map<String, StockInquiryCache.Answer> hits,
+            List<SupplierStockInquiryResult.Line> fresh) {
+
+        Instant now = Instant.now(clock);
+        List<StockInquiryResponse.Line> lines = new ArrayList<>();
+        Instant oldest = null;
+
+        for (StockInquiryCache.Answer answer : hits.values()) {
+            lines.add(toResponseLine(answer.line()));
+            oldest = older(oldest, answer.asOf());
+        }
+        for (SupplierStockInquiryResult.Line line : fresh) {
+            lines.add(toResponseLine(line));
+            oldest = older(oldest, now);
+        }
+
+        boolean noneListed = !lines.isEmpty()
+                && lines.stream().allMatch(line -> line.status() == StockInquiryResponse.LineStatus.NOT_LISTED);
+        StockInquiryResponse.Status status =
+                noneListed ? StockInquiryResponse.Status.NOT_LISTED : StockInquiryResponse.Status.OK;
+        return new StockInquiryResponse(request.inquiryId(), status, lines, oldest == null ? now : oldest);
+    }
+
+    private static Instant older(@Nullable Instant current, Instant candidate) {
+        return current == null || candidate.isBefore(current) ? candidate : current;
+    }
+
+    private static StockInquiryResponse.Line toResponseLine(SupplierStockInquiryResult.Line line) {
+        return new StockInquiryResponse.Line(
+                line.articleEan(),
+                line.supplierArticleCode(),
+                StockInquiryResponse.LineStatus.valueOf(line.status().name()),
+                line.availableQuantity(),
+                line.earliestDeliveryDate(),
+                line.quotedUnitPrice(),
+                line.currency());
+    }
+
+    private static StockInquiryResponse.Status map(SupplierStockInquiryResult.Status status) {
+        return StockInquiryResponse.Status.valueOf(status.name());
+    }
+
+    /** A failed inquiry carries no lines and no asOf: there is no fact to date. */
+    private static StockInquiryResponse failed(StockInquiryRequest request, StockInquiryResponse.Status status) {
+        return new StockInquiryResponse(request.inquiryId(), status, List.of(), null);
+    }
+
+    /**
+     * The identity an answer is remembered and matched by.
+     *
+     * <p>Both identifiers participate: a vendor may echo either, and keying on one alone would let
+     * an answer about an article identified by EAN be served for a request that named a supplier
+     * code, which are not guaranteed to be the same article.
+     */
+    private static String articleKey(@Nullable String articleEan, @Nullable String supplierArticleCode) {
+        return normalise(articleEan) + "|" + normalise(supplierArticleCode);
+    }
+
+    private static String normalise(@Nullable String value) {
+        return value == null ? "" : value.trim().toUpperCase(java.util.Locale.ROOT);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/service/model/StockInquiryResponse.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/service/model/StockInquiryResponse.java
@@ -1,7 +1,9 @@
 package com.positivity.supplier.service.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -13,28 +15,51 @@ import org.jspecify.annotations.Nullable;
  * approved synchronous read: vendor-side failure never surfaces as an exception, always as a
  * non-{@link Status#OK} status the caller can render around.
  *
- * <p>Numeric fields are wrapper types on purpose: <strong>null means "not stated by the
- * vendor", never zero</strong> — a vendor that did not answer availability must not be mistaken
- * for a vendor with no stock.
+ * <p>Numeric fields are wrapper types on purpose: <strong>null means "not stated by the vendor",
+ * never zero</strong> — a vendor that did not answer availability must not be mistaken for a vendor
+ * with no stock.
+ *
+ * <h2>Two levels of answer</h2>
+ *
+ * {@link #status} says whether we got an answer at all. {@link Line#status()} says what the vendor
+ * said about each article, because an inquiry naming three articles is routinely answered three
+ * different ways and a single status cannot carry that.
  *
  * @param inquiryId the caller-minted inquiry correlation identity, echoed back
- * @param status typed outcome; non-{@link Status#OK} statuses carry no vendor data
+ * @param status document-level outcome; non-{@link Status#OK} statuses carry no vendor data
  * @param lines per-article availability; empty unless status is {@link Status#OK}
- * @param asOf vendor-stated snapshot instant; present when status is {@link Status#OK}
+ * @param asOf when this answer was obtained; present when status is {@link Status#OK}
  */
+@Schema(
+        name = "StockInquiryResponse",
+        description = "Live vendor availability for the inquired articles. Vendor-side failure is reported as a status,"
+                + " never as an error: callers render without live stock rather than failing their own flow."
+                + " A null quantity means the vendor stated none, which is not the same as a quantity of"
+                + " zero.")
 public record StockInquiryResponse(
-        @NonNull UUID inquiryId,
-        @NonNull Status status,
-        @NonNull List<Line> lines,
-        @Nullable Instant asOf) {
+        @Schema(description = "The inquiry identity supplied by the caller, echoed back.") @NonNull
+        UUID inquiryId,
+
+        @Schema(description = "Whether the vendor answered, and if not, why not.") @NonNull
+        Status status,
+
+        @Schema(description = "Per-article answers; empty unless the status is OK.") @NonNull
+        List<Line> lines,
+
+        @Schema(
+                description = "When this answer was obtained. Present when the status is OK; a cached answer"
+                        + " carries the instant of the original inquiry, not of the cache hit.")
+        @Nullable
+        Instant asOf) {
 
     /** Typed inquiry outcomes; the non-OK cases map ADR-0050 §3/§5 without leaking errors. */
+    @Schema(name = "StockInquiryStatus", description = "Document-level outcome of a live stock inquiry.")
     public enum Status {
-        /** The vendor answered the inquiry. */
+        /** The vendor answered the inquiry. Per-article outcomes are on the lines. */
         OK,
         /** The vendor endpoint could not be reached, failed, or its circuit breaker is open. */
         SUPPLIER_UNAVAILABLE,
-        /** The vendor does not list the inquired article(s). */
+        /** The vendor lists none of the inquired articles. */
         NOT_LISTED,
         /** No binding exists for this capability on the vendor profile (ADR-0050 §3). */
         CAPABILITY_NOT_CONFIGURED,
@@ -42,22 +67,67 @@ public record StockInquiryResponse(
         CONFIGURATION_ERROR
     }
 
+    /** What the vendor said about one article. */
+    @Schema(
+            name = "StockInquiryLineStatus",
+            description = "What the vendor said about one article. UNAVAILABLE is the vendor stating it has none;"
+                    + " NOT_ANSWERED is the vendor stating nothing. Only the first justifies showing a"
+                    + " customer that the article is out of stock.")
+    public enum LineStatus {
+        /** The vendor stated an availability for this article. */
+        AVAILABLE,
+        /** The vendor stated that it has none — an answer, not a silence. */
+        UNAVAILABLE,
+        /** The vendor does not know, or will not sell, this article. Retrying cannot change it. */
+        NOT_LISTED,
+        /** The vendor returned the article without stating an availability. */
+        NOT_ANSWERED
+    }
+
     /**
      * Per-article availability answer.
      *
      * @param articleEan EAN/GTIN of the article, when stated
      * @param supplierArticleCode vendor's own article code, when stated
-     * @param availableQuantity available quantity; {@code null} when the vendor did not state
-     *     one (never coerced to zero)
-     * @param quotedUnitPrice quoted unit price; {@code null} when the vendor did not quote
+     * @param status what the vendor said about this article
+     * @param availableQuantity available quantity; {@code null} when the vendor did not state one
+     *     (never coerced to zero), {@code 0} only when {@link LineStatus#UNAVAILABLE}
+     * @param earliestDeliveryDate earliest date the vendor promised any quantity, when stated
+     * @param quotedUnitPrice quoted unit price, when the norm carries one. The A2.5 stock inquiry
+     *     carries no price, so on that norm this is always null and a supplier price is read from
+     *     the supplier price entries that own it
      * @param currency ISO 4217 currency of {@code quotedUnitPrice}, when quoted
      */
+    @Schema(name = "StockInquiryLine", description = "The vendor's answer about one inquired article.")
     public record Line(
-            @Nullable String articleEan,
-            @Nullable String supplierArticleCode,
-            @Nullable Integer availableQuantity,
-            @Nullable BigDecimal quotedUnitPrice,
-            @Nullable String currency) {}
+            @Schema(description = "EAN/GTIN of the article, as the vendor stated it.") @Nullable
+            String articleEan,
+
+            @Schema(description = "The vendor's own article code, as the vendor stated it.") @Nullable
+            String supplierArticleCode,
+
+            @Schema(description = "What the vendor said about this article.") @NonNull
+            LineStatus status,
+
+            @Schema(
+                    description = "Quantity the vendor can supply. Null when the vendor stated none; zero only"
+                            + " when the vendor said it has none.")
+            @Nullable
+            Integer availableQuantity,
+
+            @Schema(description = "Earliest date the vendor promised any quantity, when stated.") @Nullable
+            LocalDate earliestDeliveryDate,
+
+            @Schema(description = "Quoted unit price, when the vendor norm carries one.") @Nullable
+            BigDecimal quotedUnitPrice,
+
+            @Schema(description = "ISO 4217 currency of the quoted price, when quoted.") @Nullable
+            String currency) {
+
+        public Line {
+            Objects.requireNonNull(status, "status must not be null");
+        }
+    }
 
     public StockInquiryResponse {
         Objects.requireNonNull(inquiryId, "inquiryId must not be null");

--- a/pos-supplier/src/main/java/com/positivity/supplier/service/model/StockInquiryResponse.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/service/model/StockInquiryResponse.java
@@ -34,8 +34,8 @@ import org.jspecify.annotations.Nullable;
         name = "StockInquiryResponse",
         description = "Live vendor availability for the inquired articles. Vendor-side failure is reported as a status,"
                 + " never as an error: callers render without live stock rather than failing their own flow."
-                + " A null quantity means the vendor stated none, which is not the same as a quantity of"
-                + " zero.")
+                + " A null quantity means the vendor stated nothing; a quantity of zero means the vendor stated"
+                + " it has none. Only the second justifies telling a customer an article is out of stock.")
 public record StockInquiryResponse(
         @Schema(description = "The inquiry identity supplied by the caller, echoed back.") @NonNull
         UUID inquiryId,
@@ -110,8 +110,9 @@ public record StockInquiryResponse(
             LineStatus status,
 
             @Schema(
-                    description = "Quantity the vendor can supply. Null when the vendor stated none; zero only"
-                            + " when the vendor said it has none.")
+                    description = "Quantity the vendor can supply. Null when the vendor stated no quantity, which"
+                            + " includes every line it did not answer; zero only when the status is UNAVAILABLE,"
+                            + " meaning the vendor stated it has none.")
             @Nullable
             Integer availableQuantity,
 
@@ -126,6 +127,14 @@ public record StockInquiryResponse(
 
         public Line {
             Objects.requireNonNull(status, "status must not be null");
+            // The degradation contract enforced by the type rather than trusted to whoever builds
+            // one of these. A quantity on a line the vendor never answered is a number with no
+            // author, and it is precisely the value a consumer would render as fact. The canonical
+            // model carries the same guard; this is the copy that faces callers outside the module.
+            if (status != LineStatus.AVAILABLE && status != LineStatus.UNAVAILABLE && availableQuantity != null) {
+                throw new IllegalArgumentException(
+                        "a quantity may only accompany an answered line, but status was " + status);
+            }
         }
     }
 

--- a/pos-supplier/src/main/resources/application.yml
+++ b/pos-supplier/src/main/resources/application.yml
@@ -131,6 +131,17 @@ pos:
       # a burst of requests for one import; the cap stops a genuinely broken consumer, loudly.
       republish-cooldown: ${SUPPLIER_PRICAT_REPUBLISH_COOLDOWN:PT10M}
       republish-max-attempts: ${SUPPLIER_PRICAT_REPUBLISH_MAX_ATTEMPTS:3}
+    # ── Live stock inquiry / A2.5 (CAP-319) ─────────────────────────────────────────────
+    #
+    # The one synchronous supplier read the platform allows (ADR-0044 amendment). A customer is
+    # waiting on it, so the profile's connect/read timeouts govern how long a page can be held up:
+    # a profile bound to STOCK_INQUIRY wants short ones, not the generous budgets a nightly batch
+    # can afford.
+    stockinquiry:
+      # Absorbs the repeat views of one product page. Short on purpose: an availability is only
+      # worth repeating while it is still plausibly true.
+      cache-ttl: ${SUPPLIER_STOCKINQUIRY_CACHE_TTL:PT60S}
+      cache-enabled: ${SUPPLIER_STOCKINQUIRY_CACHE_ENABLED:true}
     # ── Stock report / B2.1 (CAP-322) ───────────────────────────────────────────────────
     #
     # Same chunking problem as PRICAT: a country-level report is as wide as a catalog. A binding

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheela2/EdiwheelA25StockInquiryCodecTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheela2/EdiwheelA25StockInquiryCodecTest.java
@@ -1,0 +1,326 @@
+package com.positivity.supplier.internal.adapter.ediwheela2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.positivity.supplier.internal.domain.model.PartyContext;
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiry;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiryResult;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiryResult.LineStatus;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("EDIWheel A2.5 stock inquiry codec (#1225)")
+class EdiwheelA25StockInquiryCodecTest {
+
+    private static final UUID INQUIRY_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b");
+
+    private final EdiwheelA25StockInquiryCodec codec = new EdiwheelA25StockInquiryCodec();
+
+    private static PartyContext party() {
+        return new PartyContext("30012456", "92", UUID.randomUUID());
+    }
+
+    private static SupplierStockInquiry inquiry(SupplierStockInquiry.Line... lines) {
+        return new SupplierStockInquiry(INQUIRY_ID, List.of(lines));
+    }
+
+    private static SupplierStockInquiry.Line line(String ean, String supplierCode, int quantity) {
+        return new SupplierStockInquiry.Line(ean, supplierCode, quantity);
+    }
+
+    /** A quote wrapping the given order lines, with a clean header. */
+    private static String quote(String orderLines) {
+        return """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <ew:quote_A2 xmlns:ew="http://www.reifen.net">
+                  <ew:DocumentID>A2</ew:DocumentID>
+                  <ew:Variant>5</ew:Variant>
+                  <ew:ErrorHead><ew:ErrorCode>0</ew:ErrorCode></ew:ErrorHead>
+                  <ew:BuyerParty><ew:PartyID>30012456</ew:PartyID><ew:AgencyCode>92</ew:AgencyCode></ew:BuyerParty>
+                %s
+                </ew:quote_A2>
+                """.formatted(orderLines);
+    }
+
+    private static String orderLine(String availability, String schedule, String error) {
+        return """
+                  <ew:OrderLine>
+                    <ew:LineID>000001</ew:LineID>
+                    <ew:OrderedArticle>
+                      <ew:ArticleIdentification>
+                        <ew:EANUCCArticleID>4019238001234</ew:EANUCCArticleID>
+                        <ew:ManufacturersArticleID>MICH-123</ew:ManufacturersArticleID>
+                      </ew:ArticleIdentification>
+                      %s
+                      %s
+                      %s
+                    </ew:OrderedArticle>
+                  </ew:OrderLine>
+                """.formatted(
+                        availability == null ? "" : "<ew:Availability>" + availability + "</ew:Availability>",
+                        schedule == null ? "" : schedule,
+                        error == null ? "" : "<ew:Error><ew:ErrorCode>" + error + "</ew:ErrorCode></ew:Error>");
+    }
+
+    private static String schedule(String date, int quantity) {
+        return """
+                <ew:ScheduleDetails>
+                  <ew:DeliveryDate>%s</ew:DeliveryDate>
+                  <ew:ConfirmedQuantity><ew:QuantityValue>%d</ew:QuantityValue></ew:ConfirmedQuantity>
+                </ew:ScheduleDetails>
+                """.formatted(date, quantity);
+    }
+
+    @Test
+    void registersUnderTheStockInquiryTriple() {
+        assertThat(codec.capability()).isEqualTo(SupplierCapability.STOCK_INQUIRY);
+        assertThat(codec.family()).isEqualTo(ProtocolFamily.EDIWHEEL_A25);
+        assertThat(codec.version()).isEqualTo(ProtocolVersion.A2_5);
+    }
+
+    @Nested
+    @DisplayName("encode")
+    class Encode {
+
+        @Test
+        void writesTheNormsFixedDocumentIdentityAndBothParties() {
+            String xml = codec.encodeInquiry(inquiry(line("4019238001234", null, 4)), party(), "50098765", "92");
+
+            assertThat(xml).contains("<ew:DocumentID>A2</ew:DocumentID>");
+            assertThat(xml).contains("<ew:Variant>5</ew:Variant>");
+            assertThat(xml).contains("<ew:PartyID>30012456</ew:PartyID>");
+            assertThat(xml).contains("<ew:PartyID>50098765</ew:PartyID>");
+            assertThat(xml).contains("<ew:EANUCCArticleID>4019238001234</ew:EANUCCArticleID>");
+            assertThat(xml).contains("<ew:QuantityValue>4</ew:QuantityValue>");
+        }
+
+        @Test
+        void echoesTheInquiryIdSoTheQuoteCanBeTiedBackToTheAsk() {
+            String xml = codec.encodeInquiry(inquiry(line("4019238001234", null, 1)), party(), "50098765", "92");
+
+            assertThat(xml).contains(INQUIRY_ID.toString());
+        }
+
+        @Test
+        void numbersLinesSoTheQuoteCanBeMatchedToThem() {
+            String xml = codec.encodeInquiry(
+                    inquiry(line("4019238001234", null, 1), line(null, "MICH-9", 2)), party(), "50098765", "92");
+
+            assertThat(xml).contains("<ew:LineID>000001</ew:LineID>");
+            assertThat(xml).contains("<ew:LineID>000002</ew:LineID>");
+        }
+
+        @Test
+        void refusesToAskWithoutADeliveryAccount() {
+            // Availability is consignee-specific. Asking without one would get an answer for
+            // whichever address the vendor defaults to — right-looking and about the wrong place.
+            assertThatThrownBy(() -> codec.encodeInquiry(inquiry(line("4019238001234", null, 1)), party(), null, "92"))
+                    .isInstanceOf(StockInquiryEncodeException.class)
+                    .hasMessageContaining("delivery account");
+        }
+
+        @Test
+        void refusesToAskWithoutAnAgencyCode() {
+            assertThatThrownBy(() ->
+                            codec.encodeInquiry(inquiry(line("4019238001234", null, 1)), party(), "50098765", null))
+                    .isInstanceOf(StockInquiryEncodeException.class)
+                    .hasMessageContaining("agency code");
+        }
+
+        @Test
+        void marksTheRequestRetryableBecauseAnInquiryCommitsNothing() {
+            SupplierRequestSpec spec =
+                    codec.buildRequest(inquiry(line("4019238001234", null, 1)), party(), "50098765", "92");
+
+            assertThat(spec.method()).isEqualTo("POST");
+            assertThat(spec.contentType()).isEqualTo("application/xml");
+            assertThat(spec.idempotent()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("decode")
+    class Decode {
+
+        @Test
+        void readsAnAvailableLineWithItsScheduledQuantityAndEarliestDate() {
+            SupplierStockInquiryResult result =
+                    codec.decodeQuote(quote(orderLine("1", schedule("2026-08-20", 4), "0")));
+
+            assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.OK);
+            SupplierStockInquiryResult.Line line = result.lines().getFirst();
+            assertThat(line.status()).isEqualTo(LineStatus.AVAILABLE);
+            assertThat(line.availableQuantity()).isEqualTo(4);
+            assertThat(line.earliestDeliveryDate()).isEqualTo(LocalDate.of(2026, 8, 20));
+            assertThat(line.articleEan()).isEqualTo("4019238001234");
+        }
+
+        @Test
+        void sumsAPartialAnswerAcrossItsPromisedDatesAndKeepsTheEarliest() {
+            // Code 2 says "not in the requested quantity — consider the announced actual quantity",
+            // so the schedule is the answer rather than a reason to report nothing.
+            SupplierStockInquiryResult result = codec.decodeQuote(
+                    quote(orderLine("2", schedule("2026-09-01", 2) + schedule("2026-08-25", 3), "0")));
+
+            SupplierStockInquiryResult.Line line = result.lines().getFirst();
+            assertThat(line.status()).isEqualTo(LineStatus.AVAILABLE);
+            assertThat(line.availableQuantity()).isEqualTo(5);
+            assertThat(line.earliestDeliveryDate()).isEqualTo(LocalDate.of(2026, 8, 25));
+        }
+
+        @Test
+        void treatsAnExplicitlyUnavailableArticleAsAStatedZero() {
+            SupplierStockInquiryResult result = codec.decodeQuote(quote(orderLine("3", null, "0")));
+
+            SupplierStockInquiryResult.Line line = result.lines().getFirst();
+            assertThat(line.status()).isEqualTo(LineStatus.UNAVAILABLE);
+            // The one place a zero is a fact: the vendor said it has none.
+            assertThat(line.availableQuantity()).isZero();
+        }
+
+        @Test
+        void treatsAnUndeterminedAvailabilityAsSilenceNotAsZero() {
+            SupplierStockInquiryResult result = codec.decodeQuote(quote(orderLine("0", null, "0")));
+
+            SupplierStockInquiryResult.Line line = result.lines().getFirst();
+            assertThat(line.status()).isEqualTo(LineStatus.NOT_ANSWERED);
+            // Coercing this to 0 would print "out of stock" on the strength of a vendor shrug.
+            assertThat(line.availableQuantity()).isNull();
+        }
+
+        @Test
+        void readsAnUnknownEanAsNotListedRatherThanUnavailable() {
+            // 911: incorrect EAN number (not known on supplier side). Retrying cannot help, which
+            // is exactly what separates this from a vendor being down.
+            SupplierStockInquiryResult result = codec.decodeQuote(quote(orderLine(null, null, "911")));
+
+            assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.NOT_LISTED);
+            assertThat(result.lines().getFirst().status()).isEqualTo(LineStatus.NOT_LISTED);
+            assertThat(result.lines().getFirst().availableQuantity()).isNull();
+        }
+
+        @Test
+        void readsAnUnknownSupplierMaterialNumberAsNotListed() {
+            SupplierStockInquiryResult result = codec.decodeQuote(quote(orderLine(null, null, "940")));
+
+            assertThat(result.lines().getFirst().status()).isEqualTo(LineStatus.NOT_LISTED);
+        }
+
+        @Test
+        void readsANoLongerSellableArticleAsNotListed() {
+            // 945: material status set to not sellable. The vendor knows it and will not sell it —
+            // for a buyer that is the same answer as never having carried it.
+            SupplierStockInquiryResult result = codec.decodeQuote(quote(orderLine(null, null, "945")));
+
+            assertThat(result.lines().getFirst().status()).isEqualTo(LineStatus.NOT_LISTED);
+        }
+
+        @Test
+        void doesNotCallALineNotListedForAnErrorAboutSomethingElse() {
+            // 912: requested delivery date invalid. That says nothing about whether the vendor
+            // stocks the article, so claiming NOT_LISTED would invent an answer.
+            SupplierStockInquiryResult result = codec.decodeQuote(quote(orderLine(null, null, "912")));
+
+            assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.OK);
+            assertThat(result.lines().getFirst().status()).isEqualTo(LineStatus.NOT_ANSWERED);
+        }
+
+        @Test
+        void reportsNotListedForTheDocumentOnlyWhenNoInquiredArticleIsCarried() {
+            String mixed = orderLine("1", schedule("2026-08-20", 4), "0") + orderLine(null, null, "911");
+
+            SupplierStockInquiryResult result = codec.decodeQuote(quote(mixed));
+
+            // "We stock one of these two" is not "not listed"; the document is answered and the
+            // detail lives on the lines.
+            assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.OK);
+            assertThat(result.lines())
+                    .extracting(SupplierStockInquiryResult.Line::status)
+                    .containsExactly(LineStatus.AVAILABLE, LineStatus.NOT_LISTED);
+        }
+
+        @Test
+        void readsAProfileFaultAsConfigurationErrorRatherThanBlamingTheVendor() {
+            // 927: missing mapping for the customer-assigned consignee id. The vendor is healthy;
+            // our profile is wrong, and an operator told "supplier unavailable" would wait forever.
+            String body = quote("").replace("<ew:ErrorCode>0</ew:ErrorCode>", "<ew:ErrorCode>927</ew:ErrorCode>");
+
+            SupplierStockInquiryResult result = codec.decodeQuote(body);
+
+            assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.CONFIGURATION_ERROR);
+            assertThat(result.lines()).isEmpty();
+        }
+
+        @Test
+        void readsAnUnrecognisedHeaderErrorAsSupplierUnavailable() {
+            String body = quote("").replace("<ew:ErrorCode>0</ew:ErrorCode>", "<ew:ErrorCode>910</ew:ErrorCode>");
+
+            SupplierStockInquiryResult result = codec.decodeQuote(body);
+
+            assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.SUPPLIER_UNAVAILABLE);
+        }
+
+        @Test
+        void acceptsAQuoteWhoseElementsArriveUnqualified() {
+            // Vendors differ on whether they qualify children. Rejecting a well-formed answer over
+            // a namespace would report an available article as an unavailable vendor.
+            String unqualified = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <quote_A2>
+                      <DocumentID>A2</DocumentID>
+                      <ErrorHead><ErrorCode>0</ErrorCode></ErrorHead>
+                      <OrderLine>
+                        <LineID>000001</LineID>
+                        <OrderedArticle>
+                          <ArticleIdentification><EANUCCArticleID>4019238001234</EANUCCArticleID></ArticleIdentification>
+                          <Availability>1</Availability>
+                          <ScheduleDetails>
+                            <DeliveryDate>20260820</DeliveryDate>
+                            <ConfirmedQuantity><QuantityValue>6</QuantityValue></ConfirmedQuantity>
+                          </ScheduleDetails>
+                        </OrderedArticle>
+                      </OrderLine>
+                    </quote_A2>
+                    """;
+
+            SupplierStockInquiryResult result = codec.decodeQuote(unqualified);
+
+            assertThat(result.lines().getFirst().availableQuantity()).isEqualTo(6);
+            // yyyyMMdd as well as ISO: sibling norms state dates that way and vendors reuse them.
+            assertThat(result.lines().getFirst().earliestDeliveryDate()).isEqualTo(LocalDate.of(2026, 8, 20));
+        }
+
+        @Test
+        void rejectsABodyThatIsNotAQuoteRatherThanReadingItAsAnEmptyAnswer() {
+            // An empty instance would carry no error and no lines, which reads as "the vendor
+            // answered and had nothing" — a definite claim from an unreadable body.
+            assertThatThrownBy(() -> codec.decodeQuote("<html><body>502 Bad Gateway</body></html>"))
+                    .isInstanceOf(StockInquiryDecodeException.class);
+        }
+
+        @Test
+        void rejectsAnEmptyBody() {
+            assertThatThrownBy(() -> codec.decodeQuote("  ")).isInstanceOf(StockInquiryDecodeException.class);
+        }
+
+        @Test
+        void neverQuotesAPriceBecauseTheNormCarriesNone() {
+            SupplierStockInquiryResult result =
+                    codec.decodeQuote(quote(orderLine("1", schedule("2026-08-20", 4), "0")));
+
+            // A2.5 has no price element at all — only the C1.0 inquiry does. A supplier price comes
+            // from the PRICAT entries that own it, never invented here.
+            assertThat(result.lines().getFirst().quotedUnitPrice()).isNull();
+            assertThat(result.lines().getFirst().currency()).isNull();
+        }
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/domain/model/DomainModelInvariantsTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/domain/model/DomainModelInvariantsTest.java
@@ -136,17 +136,43 @@ class DomainModelInvariantsTest {
         void unstatedQuantityStaysNullNeverZero() {
             // A vendor that did not answer availability must not be mistaken for a vendor
             // with no stock: null is "not stated", 0 is "none available".
-            SupplierStockInquiryResult.Line unstated =
-                    new SupplierStockInquiryResult.Line("4019238001234", null, null, null, null);
+            SupplierStockInquiryResult.Line unstated = new SupplierStockInquiryResult.Line(
+                    "4019238001234", null, SupplierStockInquiryResult.LineStatus.NOT_ANSWERED, null, null, null, null);
 
             assertThat(unstated.availableQuantity()).isNull();
             assertThat(unstated.quotedUnitPrice()).isNull();
         }
 
         @Test
+        void anUnansweredLineCannotCarryAQuantity() {
+            // The type refuses the combination rather than trusting every caller to avoid it: a
+            // quantity on a line the vendor never answered is a number with no author.
+            assertThatThrownBy(() -> new SupplierStockInquiryResult.Line(
+                            "4019238001234",
+                            null,
+                            SupplierStockInquiryResult.LineStatus.NOT_LISTED,
+                            0,
+                            null,
+                            null,
+                            null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void anExplicitlyUnavailableLineMayStateZero() {
+            // "I have none" is an answer, and the only case where zero is a fact rather than an
+            // assumption.
+            SupplierStockInquiryResult.Line none = new SupplierStockInquiryResult.Line(
+                    "4019238001234", null, SupplierStockInquiryResult.LineStatus.UNAVAILABLE, 0, null, null, null);
+
+            assertThat(none.availableQuantity()).isZero();
+        }
+
+        @Test
         void linesAreDefensivelyCopied() {
             List<SupplierStockInquiryResult.Line> source = new ArrayList<>();
-            source.add(new SupplierStockInquiryResult.Line(null, "MICH-123", 4, null, null));
+            source.add(new SupplierStockInquiryResult.Line(
+                    null, "MICH-123", SupplierStockInquiryResult.LineStatus.AVAILABLE, 4, null, null, null));
             SupplierStockInquiryResult result =
                     new SupplierStockInquiryResult(SupplierStockInquiryResult.Status.OK, source, null);
 

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/stockinquiry/service/StockInquiryRunnerTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/stockinquiry/service/StockInquiryRunnerTest.java
@@ -1,0 +1,274 @@
+package com.positivity.supplier.internal.stockinquiry.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.supplier.internal.adapter.ediwheela2.EdiwheelA25StockInquiryCodec;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.client.SupplierHttpRequest;
+import com.positivity.supplier.internal.client.SupplierHttpResponse;
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiry;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiryResult;
+import com.positivity.supplier.internal.entity.SupplierAccountEntity;
+import com.positivity.supplier.internal.entity.SupplierAuthConfigEntity;
+import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.registry.AdapterResolution;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedPartyAccounts;
+import com.positivity.supplier.internal.spi.ExchangeOutcome;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Live stock inquiry degradation (#1225, ADR-0049 §4)")
+class StockInquiryRunnerTest {
+
+    private static final UUID PROFILE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c");
+    private static final UUID LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5f");
+    private static final SupplierRef SUPPLIER = new SupplierRef("michelin-eu");
+
+    private static final String GOOD_QUOTE = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ew:quote_A2 xmlns:ew="http://www.reifen.net">
+              <ew:DocumentID>A2</ew:DocumentID>
+              <ew:ErrorHead><ew:ErrorCode>0</ew:ErrorCode></ew:ErrorHead>
+              <ew:OrderLine>
+                <ew:LineID>000001</ew:LineID>
+                <ew:OrderedArticle>
+                  <ew:ArticleIdentification><ew:EANUCCArticleID>4019238001234</ew:EANUCCArticleID></ew:ArticleIdentification>
+                  <ew:Availability>1</ew:Availability>
+                  <ew:ScheduleDetails>
+                    <ew:DeliveryDate>2026-08-20</ew:DeliveryDate>
+                    <ew:ConfirmedQuantity><ew:QuantityValue>8</ew:QuantityValue></ew:ConfirmedQuantity>
+                  </ew:ScheduleDetails>
+                </ew:OrderedArticle>
+              </ew:OrderLine>
+            </ew:quote_A2>
+            """;
+
+    @Mock
+    private SupplierProfileResolver profileResolver;
+
+    @Mock
+    private AdapterRegistry adapterRegistry;
+
+    @Mock
+    private SupplierBaseClient baseClient;
+
+    private StockInquiryRunner runner;
+
+    @BeforeEach
+    void setUp() {
+        runner = new StockInquiryRunner(profileResolver, adapterRegistry, baseClient);
+        when(profileResolver.resolveBinding(SUPPLIER, SupplierCapability.STOCK_INQUIRY))
+                .thenReturn(binding());
+        when(profileResolver.resolvePartyContext(SUPPLIER, LOCATION_ID))
+                .thenReturn(new ResolvedPartyAccounts(account("30012456", "91"), account("50098765", "92")));
+        when(adapterRegistry.resolve(
+                        SupplierCapability.STOCK_INQUIRY, ProtocolFamily.EDIWHEEL_A25, ProtocolVersion.A2_5))
+                .thenReturn(new AdapterResolution.Resolved(new EdiwheelA25StockInquiryCodec()));
+    }
+
+    private static ResolvedBinding binding() {
+        SupplierProfileEntity profile = new SupplierProfileEntity();
+        profile.setVendorProfileId(PROFILE_ID);
+        profile.setSupplierRef(SUPPLIER.value());
+        profile.setEnabled(true);
+
+        SupplierEndpointBindingEntity endpointBinding = new SupplierEndpointBindingEntity();
+        endpointBinding.setVendorProfileId(PROFILE_ID);
+        endpointBinding.setCapability(SupplierCapability.STOCK_INQUIRY);
+        endpointBinding.setProtocolFamily(ProtocolFamily.EDIWHEEL_A25);
+        endpointBinding.setProtocolVersion("A2_5");
+        endpointBinding.setEnabled(true);
+
+        return new ResolvedBinding(
+                profile,
+                endpointBinding,
+                new SupplierAuthConfigEntity(),
+                SupplierCapability.STOCK_INQUIRY,
+                ProtocolFamily.EDIWHEEL_A25,
+                ProtocolVersion.A2_5);
+    }
+
+    private static SupplierAccountEntity account(String number, String agency) {
+        SupplierAccountEntity account = new SupplierAccountEntity();
+        account.setAccountNumber(number);
+        account.setAgencyCode(agency);
+        return account;
+    }
+
+    private static SupplierStockInquiry inquiry() {
+        return new SupplierStockInquiry(
+                UUID.randomUUID(), List.of(new SupplierStockInquiry.Line("4019238001234", null, 4)));
+    }
+
+    private static SupplierHttpResponse response(ExchangeOutcome outcome, String body) {
+        return new SupplierHttpResponse(
+                outcome,
+                outcome.isSuccess() ? 200 : 503,
+                body,
+                "corr-1",
+                1,
+                Duration.ofMillis(120),
+                outcome.isSuccess() ? null : "vendor unavailable");
+    }
+
+    @Test
+    void returnsTheVendorsAnswerWhenTheVendorAnswers() {
+        when(baseClient.exchange(any())).thenReturn(response(ExchangeOutcome.OK, GOOD_QUOTE));
+
+        SupplierStockInquiryResult result = runner.inquire(SUPPLIER, LOCATION_ID, inquiry());
+
+        assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.OK);
+        assertThat(result.lines()).hasSize(1);
+        assertThat(result.lines().getFirst().availableQuantity()).isEqualTo(8);
+    }
+
+    @Test
+    void sendsTheProfilesBillingAndDeliveryAccountsRatherThanAnythingTheCallerSupplied() {
+        when(baseClient.exchange(any())).thenReturn(response(ExchangeOutcome.OK, GOOD_QUOTE));
+
+        runner.inquire(SUPPLIER, LOCATION_ID, inquiry());
+
+        ArgumentCaptor<SupplierHttpRequest> captor = ArgumentCaptor.forClass(SupplierHttpRequest.class);
+        verify(baseClient).exchange(captor.capture());
+        // Both identities come from the profile. A caller able to supply them could supply a pair
+        // the profile does not agree with, and the vendor would answer for the wrong address.
+        assertThat(captor.getValue().body()).contains("30012456").contains("50098765");
+    }
+
+    @Test
+    void reportsAnUnreachableVendorAsUnavailableRatherThanThrowing() {
+        when(baseClient.exchange(any())).thenReturn(response(ExchangeOutcome.PRE_SEND_FAILURE, null));
+
+        SupplierStockInquiryResult result = runner.inquire(SUPPLIER, LOCATION_ID, inquiry());
+
+        // A product page has something to render without live stock and nothing to render if this
+        // throws.
+        assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.SUPPLIER_UNAVAILABLE);
+        assertThat(result.lines()).isEmpty();
+    }
+
+    @Test
+    void reportsAnOpenBreakerAsUnavailableWithoutWaitingOnTheVendor() {
+        // The base client answers PRE_SEND_FAILURE immediately when the breaker is open, so the
+        // caller-facing latency of a failing vendor is the breaker's, not the vendor's timeout.
+        when(baseClient.exchange(any()))
+                .thenReturn(new SupplierHttpResponse(
+                        ExchangeOutcome.PRE_SEND_FAILURE,
+                        null,
+                        null,
+                        "corr-1",
+                        1,
+                        Duration.ofMillis(1),
+                        "circuit breaker open"));
+
+        SupplierStockInquiryResult result = runner.inquire(SUPPLIER, LOCATION_ID, inquiry());
+
+        assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.SUPPLIER_UNAVAILABLE);
+    }
+
+    @Test
+    void reportsAReadTimeoutAsUnavailableRatherThanAsAnEmptyWarehouse() {
+        when(baseClient.exchange(any())).thenReturn(response(ExchangeOutcome.POST_SEND_AMBIGUOUS, null));
+
+        SupplierStockInquiryResult result = runner.inquire(SUPPLIER, LOCATION_ID, inquiry());
+
+        assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.SUPPLIER_UNAVAILABLE);
+        assertThat(result.lines()).isEmpty();
+    }
+
+    @Test
+    void reportsAnUnreadableAnswerAsUnavailableRatherThanAsNoStock() {
+        when(baseClient.exchange(any())).thenReturn(response(ExchangeOutcome.OK, "<html>502</html>"));
+
+        SupplierStockInquiryResult result = runner.inquire(SUPPLIER, LOCATION_ID, inquiry());
+
+        // Our parsing problem must not become the vendor's empty warehouse.
+        assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.SUPPLIER_UNAVAILABLE);
+    }
+
+    @Test
+    void reportsAnUnboundCapabilityWithoutCallingAnyone() {
+        when(profileResolver.resolveBinding(SUPPLIER, SupplierCapability.STOCK_INQUIRY))
+                .thenThrow(new SupplierConfigurationException(
+                        SupplierConfigurationException.CAPABILITY_NOT_CONFIGURED, "not bound"));
+
+        SupplierStockInquiryResult result = runner.inquire(SUPPLIER, LOCATION_ID, inquiry());
+
+        assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.CAPABILITY_NOT_CONFIGURED);
+        verifyNoInteractions(baseClient);
+    }
+
+    @Test
+    void reportsAnUnmappedDeliveryLocationAsConfigurationErrorBeforeAnyNetworkCall() {
+        when(profileResolver.resolvePartyContext(SUPPLIER, LOCATION_ID))
+                .thenThrow(new SupplierConfigurationException(
+                        SupplierConfigurationException.MISSING_DELIVERY_MAPPING, "no mapping"));
+
+        SupplierStockInquiryResult result = runner.inquire(SUPPLIER, LOCATION_ID, inquiry());
+
+        // Asking anyway would return an answer about whichever address the vendor defaults to —
+        // right-looking, and about the wrong place.
+        assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.CONFIGURATION_ERROR);
+        verify(baseClient, never()).exchange(any());
+    }
+
+    @Test
+    void reportsAProfileWithNoDeliveryAccountAsConfigurationErrorRatherThanAskingWithoutOne() {
+        when(profileResolver.resolvePartyContext(SUPPLIER, LOCATION_ID))
+                .thenReturn(new ResolvedPartyAccounts(account("30012456", "91"), null));
+
+        SupplierStockInquiryResult result = runner.inquire(SUPPLIER, LOCATION_ID, inquiry());
+
+        assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.CONFIGURATION_ERROR);
+        verify(baseClient, never()).exchange(any());
+    }
+
+    @Test
+    void reportsAMissingCodecAsCapabilityNotConfigured() {
+        when(adapterRegistry.resolve(
+                        SupplierCapability.STOCK_INQUIRY, ProtocolFamily.EDIWHEEL_A25, ProtocolVersion.A2_5))
+                .thenReturn(new AdapterResolution.NotConfigured("no codec bound for STOCK_INQUIRY/EDIWHEEL_A25/A2_5"));
+
+        SupplierStockInquiryResult result = runner.inquire(SUPPLIER, LOCATION_ID, inquiry());
+
+        assertThat(result.status()).isEqualTo(SupplierStockInquiryResult.Status.CAPABILITY_NOT_CONFIGURED);
+        verifyNoInteractions(baseClient);
+    }
+
+    @Test
+    void marksTheExchangeRetryableBecauseAnInquiryCommitsNothing() {
+        when(baseClient.exchange(any())).thenReturn(response(ExchangeOutcome.OK, GOOD_QUOTE));
+
+        runner.inquire(SUPPLIER, LOCATION_ID, inquiry());
+
+        ArgumentCaptor<SupplierHttpRequest> captor = ArgumentCaptor.forClass(SupplierHttpRequest.class);
+        verify(baseClient).exchange(captor.capture());
+        assertThat(captor.getValue().idempotent()).isTrue();
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/stockinquiry/service/SupplierStockServiceImplTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/stockinquiry/service/SupplierStockServiceImplTest.java
@@ -1,0 +1,287 @@
+package com.positivity.supplier.internal.stockinquiry.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiry;
+import com.positivity.supplier.internal.domain.model.SupplierStockInquiryResult;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.repository.SupplierProfileRepository;
+import com.positivity.supplier.service.model.StockInquiryRequest;
+import com.positivity.supplier.service.model.StockInquiryResponse;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Approved synchronous stock read (#1225, ADR-0044 amendment)")
+class SupplierStockServiceImplTest {
+
+    private static final UUID PROFILE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c");
+    private static final UUID LOCATION_A = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01");
+    private static final UUID LOCATION_B = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02");
+    private static final String EAN = "4019238001234";
+    private static final Instant NOW = Instant.parse("2026-08-14T12:00:00Z");
+    private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @Mock
+    private SupplierProfileRepository profileRepository;
+
+    @Mock
+    private StockInquiryRunner runner;
+
+    private StockInquiryCache cache;
+    private SupplierStockServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        cache = new StockInquiryCache(true, Duration.ofSeconds(60));
+        service = new SupplierStockServiceImpl(profileRepository, runner, cache, CLOCK);
+
+        SupplierProfileEntity profile = new SupplierProfileEntity();
+        profile.setVendorProfileId(PROFILE_ID);
+        profile.setSupplierRef("michelin-eu");
+        profile.setEnabled(true);
+        when(profileRepository.findById(PROFILE_ID)).thenReturn(Optional.of(profile));
+    }
+
+    private static StockInquiryRequest request(UUID locationId) {
+        return new StockInquiryRequest(
+                UUID.randomUUID(), PROFILE_ID, locationId, List.of(new StockInquiryRequest.Line(EAN, null, 4)));
+    }
+
+    private static SupplierStockInquiryResult answered(int quantity) {
+        return new SupplierStockInquiryResult(
+                SupplierStockInquiryResult.Status.OK,
+                List.of(new SupplierStockInquiryResult.Line(
+                        EAN,
+                        null,
+                        SupplierStockInquiryResult.LineStatus.AVAILABLE,
+                        quantity,
+                        LocalDate.of(2026, 8, 20),
+                        null,
+                        null)),
+                null);
+    }
+
+    private static SupplierStockInquiryResult failed(SupplierStockInquiryResult.Status status) {
+        return new SupplierStockInquiryResult(status, List.of(), null);
+    }
+
+    @Test
+    void returnsTheVendorsAnswerWithTheInquiryIdEchoedBack() {
+        when(runner.inquire(any(), any(), any())).thenReturn(answered(8));
+        StockInquiryRequest request = request(LOCATION_A);
+
+        StockInquiryResponse response = service.inquireLiveStock(request);
+
+        assertThat(response.inquiryId()).isEqualTo(request.inquiryId());
+        assertThat(response.status()).isEqualTo(StockInquiryResponse.Status.OK);
+        assertThat(response.lines()).hasSize(1);
+        assertThat(response.lines().getFirst().availableQuantity()).isEqualTo(8);
+        assertThat(response.lines().getFirst().earliestDeliveryDate()).isEqualTo(LocalDate.of(2026, 8, 20));
+        assertThat(response.asOf()).isEqualTo(NOW);
+    }
+
+    @Test
+    void asksTheVendorOnlyOnceForRepeatedViewsOfTheSameArticle() {
+        when(runner.inquire(any(), any(), any())).thenReturn(answered(8));
+
+        service.inquireLiveStock(request(LOCATION_A));
+        StockInquiryResponse second = service.inquireLiveStock(request(LOCATION_A));
+
+        verify(runner, times(1)).inquire(any(), any(), any());
+        assertThat(second.lines().getFirst().availableQuantity()).isEqualTo(8);
+    }
+
+    @Test
+    void neverServesOneLocationsAnswerToAnother() {
+        when(runner.inquire(any(), any(), any())).thenReturn(answered(8));
+
+        service.inquireLiveStock(request(LOCATION_A));
+        service.inquireLiveStock(request(LOCATION_B));
+
+        // Availability is consignee-specific. A shared entry would tell a customer that stock four
+        // hundred kilometres away is available at the branch fitting the tyre.
+        verify(runner).inquire(any(SupplierRef.class), eq(LOCATION_A), any(SupplierStockInquiry.class));
+        verify(runner).inquire(any(SupplierRef.class), eq(LOCATION_B), any(SupplierStockInquiry.class));
+    }
+
+    @Test
+    void asksTheVendorOnlyAboutArticlesItHasNoAnswerFor() {
+        when(runner.inquire(any(), any(), any())).thenReturn(answered(8));
+        service.inquireLiveStock(request(LOCATION_A));
+
+        StockInquiryRequest twoArticles = new StockInquiryRequest(
+                UUID.randomUUID(),
+                PROFILE_ID,
+                LOCATION_A,
+                List.of(
+                        new StockInquiryRequest.Line(EAN, null, 4),
+                        new StockInquiryRequest.Line("9999999999999", null, 2)));
+        when(runner.inquire(any(), any(), any()))
+                .thenReturn(new SupplierStockInquiryResult(
+                        SupplierStockInquiryResult.Status.OK,
+                        List.of(new SupplierStockInquiryResult.Line(
+                                "9999999999999",
+                                null,
+                                SupplierStockInquiryResult.LineStatus.UNAVAILABLE,
+                                0,
+                                null,
+                                null,
+                                null)),
+                        null));
+
+        StockInquiryResponse response = service.inquireLiveStock(twoArticles);
+
+        ArgumentCaptor<SupplierStockInquiry> captor = ArgumentCaptor.forClass(SupplierStockInquiry.class);
+        verify(runner, times(2)).inquire(any(), any(), captor.capture());
+        assertThat(captor.getValue().lines()).hasSize(1);
+        assertThat(captor.getValue().lines().getFirst().articleEan()).isEqualTo("9999999999999");
+        // Both articles are answered: one from the cache, one from the vendor.
+        assertThat(response.lines()).hasSize(2);
+    }
+
+    @Test
+    void datesTheAnswerByTheOldestFactInIt() {
+        when(runner.inquire(any(), any(), any())).thenReturn(answered(8));
+        service.inquireLiveStock(request(LOCATION_A));
+
+        // A later call served from that cached answer must not claim to be current: a caller asking
+        // how fresh this is wants the worst case, not the newest line in the set.
+        SupplierStockServiceImpl later = new SupplierStockServiceImpl(
+                profileRepository, runner, cache, Clock.fixed(NOW.plusSeconds(30), ZoneOffset.UTC));
+
+        StockInquiryResponse response = later.inquireLiveStock(request(LOCATION_A));
+
+        assertThat(response.asOf()).isEqualTo(NOW);
+    }
+
+    @Test
+    void doesNotRememberAVendorThatCouldNotAnswer() {
+        when(runner.inquire(any(), any(), any()))
+                .thenReturn(failed(SupplierStockInquiryResult.Status.SUPPLIER_UNAVAILABLE));
+
+        service.inquireLiveStock(request(LOCATION_A));
+        service.inquireLiveStock(request(LOCATION_A));
+
+        // Caching a failure would turn one bad moment into a minute of identical failures for every
+        // customer viewing the page.
+        verify(runner, times(2)).inquire(any(), any(), any());
+    }
+
+    @Test
+    void doesNotRememberAnArticleTheVendorCouldNotDetermine() {
+        when(runner.inquire(any(), any(), any()))
+                .thenReturn(new SupplierStockInquiryResult(
+                        SupplierStockInquiryResult.Status.OK,
+                        List.of(new SupplierStockInquiryResult.Line(
+                                EAN, null, SupplierStockInquiryResult.LineStatus.NOT_ANSWERED, null, null, null, null)),
+                        null));
+
+        service.inquireLiveStock(request(LOCATION_A));
+        service.inquireLiveStock(request(LOCATION_A));
+
+        verify(runner, times(2)).inquire(any(), any(), any());
+    }
+
+    @Test
+    void doesNotRememberAnUnlistedArticleSoACatalogueFixShowsImmediately() {
+        when(runner.inquire(any(), any(), any()))
+                .thenReturn(new SupplierStockInquiryResult(
+                        SupplierStockInquiryResult.Status.NOT_LISTED,
+                        List.of(new SupplierStockInquiryResult.Line(
+                                EAN, null, SupplierStockInquiryResult.LineStatus.NOT_LISTED, null, null, null, null)),
+                        null));
+
+        StockInquiryResponse first = service.inquireLiveStock(request(LOCATION_A));
+        service.inquireLiveStock(request(LOCATION_A));
+
+        assertThat(first.status()).isEqualTo(StockInquiryResponse.Status.NOT_LISTED);
+        // NOT_LISTED usually means a mapping is wrong. An operator who fixes it should see the fix
+        // on the next page load, not a minute later wondering whether it worked.
+        verify(runner, times(2)).inquire(any(), any(), any());
+    }
+
+    @Test
+    void passesEveryDegradedOutcomeThroughUntouched() {
+        for (SupplierStockInquiryResult.Status status : List.of(
+                SupplierStockInquiryResult.Status.SUPPLIER_UNAVAILABLE,
+                SupplierStockInquiryResult.Status.CAPABILITY_NOT_CONFIGURED,
+                SupplierStockInquiryResult.Status.CONFIGURATION_ERROR)) {
+            when(runner.inquire(any(), any(), any())).thenReturn(failed(status));
+
+            StockInquiryResponse response = service.inquireLiveStock(request(LOCATION_A));
+
+            assertThat(response.status().name()).isEqualTo(status.name());
+            assertThat(response.lines()).isEmpty();
+            // No fact, so no date to put on one.
+            assertThat(response.asOf()).isNull();
+        }
+    }
+
+    @Test
+    void reportsAnUnknownVendorProfileAsConfigurationErrorWithoutAsking() {
+        when(profileRepository.findById(PROFILE_ID)).thenReturn(Optional.empty());
+
+        StockInquiryResponse response = service.inquireLiveStock(request(LOCATION_A));
+
+        assertThat(response.status()).isEqualTo(StockInquiryResponse.Status.CONFIGURATION_ERROR);
+        verifyNoInteractions(runner);
+    }
+
+    @Test
+    void makesNoCallAtAllWhenEveryArticleIsAlreadyAnswered() {
+        when(runner.inquire(any(), any(), any())).thenReturn(answered(8));
+        service.inquireLiveStock(request(LOCATION_A));
+
+        service.inquireLiveStock(request(LOCATION_A));
+
+        verify(runner, times(1)).inquire(any(), any(), any());
+    }
+
+    @Test
+    void asksEveryTimeWhenCachingIsSwitchedOff() {
+        StockInquiryCache disabled = new StockInquiryCache(false, Duration.ofSeconds(60));
+        SupplierStockServiceImpl uncached = new SupplierStockServiceImpl(profileRepository, runner, disabled, CLOCK);
+        when(runner.inquire(any(), any(), any())).thenReturn(answered(8));
+
+        uncached.inquireLiveStock(request(LOCATION_A));
+        uncached.inquireLiveStock(request(LOCATION_A));
+
+        verify(runner, times(2)).inquire(any(), any(), any());
+    }
+
+    @Test
+    void neverThrowsForAVendorSideFailure() {
+        when(runner.inquire(any(), any(), any()))
+                .thenReturn(failed(SupplierStockInquiryResult.Status.SUPPLIER_UNAVAILABLE));
+
+        // The whole point of the degradation contract: a page renders without live stock rather than
+        // failing because a supplier had a bad afternoon.
+        assertThat(service.inquireLiveStock(request(LOCATION_A))).isNotNull();
+        verify(runner, never()).inquire(eq(null), any(), any());
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/service/model/ServiceModelInvariantsTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/service/model/ServiceModelInvariantsTest.java
@@ -131,6 +131,19 @@ class ServiceModelInvariantsTest {
         }
 
         @Test
+        void refusesAQuantityOnALineTheVendorNeverAnswered() {
+            // The public DTO is the one callers outside this module construct, so the guard has to
+            // live here too and not only on the canonical model. NOT_LISTED with a number attached
+            // is the shape a consumer would render as fact.
+            assertThatThrownBy(() -> new StockInquiryResponse.Line(
+                            "4019238001234", null, StockInquiryResponse.LineStatus.NOT_LISTED, 0, null, null, null))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> new StockInquiryResponse.Line(
+                            "4019238001234", null, StockInquiryResponse.LineStatus.NOT_ANSWERED, 3, null, null, null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
         void aVendorStatedZeroIsDistinguishableFromAVendorSayingNothing() {
             // The pair the whole degradation contract turns on: only the first justifies telling a
             // customer the article is out of stock.

--- a/pos-supplier/src/test/java/com/positivity/supplier/service/model/ServiceModelInvariantsTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/service/model/ServiceModelInvariantsTest.java
@@ -123,17 +123,32 @@ class ServiceModelInvariantsTest {
             // Degradation contract of the single approved synchronous supplier read
             // (ADR-0049 §4): "vendor did not state" must remain distinguishable from
             // "vendor stated zero".
-            StockInquiryResponse.Line unstated = new StockInquiryResponse.Line("4019238001234", null, null, null, null);
+            StockInquiryResponse.Line unstated = new StockInquiryResponse.Line(
+                    "4019238001234", null, StockInquiryResponse.LineStatus.NOT_ANSWERED, null, null, null, null);
 
             assertThat(unstated.availableQuantity()).isNull();
             assertThat(unstated.quotedUnitPrice()).isNull();
         }
 
         @Test
+        void aVendorStatedZeroIsDistinguishableFromAVendorSayingNothing() {
+            // The pair the whole degradation contract turns on: only the first justifies telling a
+            // customer the article is out of stock.
+            StockInquiryResponse.Line statedNone = new StockInquiryResponse.Line(
+                    "4019238001234", null, StockInquiryResponse.LineStatus.UNAVAILABLE, 0, null, null, null);
+            StockInquiryResponse.Line saidNothing = new StockInquiryResponse.Line(
+                    "4019238001234", null, StockInquiryResponse.LineStatus.NOT_ANSWERED, null, null, null, null);
+
+            assertThat(statedNone.availableQuantity()).isZero();
+            assertThat(saidNothing.availableQuantity()).isNull();
+        }
+
+        @Test
         void echoesInquiryIdAndCopiesLines() {
             UUID inquiryId = UUID.randomUUID();
             List<StockInquiryResponse.Line> source = new ArrayList<>();
-            source.add(new StockInquiryResponse.Line(null, "MICH-123", 0, null, null));
+            source.add(new StockInquiryResponse.Line(
+                    null, "MICH-123", StockInquiryResponse.LineStatus.UNAVAILABLE, 0, null, null, null));
             StockInquiryResponse response =
                     new StockInquiryResponse(inquiryId, StockInquiryResponse.Status.OK, source, null);
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:319`
- Parent STORY (durion): louisburroughs/durion#374
- Child issue: louisburroughs/durion-positivity-backend#1225
- Domain: `domain:positivity`

## Contract References
- Contract guide entry (durion): `domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md` → supplier live stock inquiry
- Source spec: `durion/docs/ediwheel/Swagger_UPX-Stock Inquiry PROD_1_2.yaml` (`POST /A2_5/inquiry`); error-code tables from `EDIWheel-XML_Order_Response_C1.pdf`

## Contract Chain (when a Controller changed)
No controller changed — this capability has no HTTP surface. It is an in-process contract (`SupplierStockService`) consumed by pos-catalog and pos-order. The public DTOs changed shape; the Angular SDK is unaffected until the pos-catalog composition exposes it in the second PR.

## Scope

**Supplier half of #1225.** CAP-317 left the contracts for the platform's one approved synchronous supplier read — `SupplierStockService`, `StockInquiryRequest`/`Response`, the SPI port — and no implementation behind them. This adds the A2.5 codec, the runner that drives it, and the short-TTL cache.

### The degradation contract is the feature

The read **never throws for a vendor-side failure**. Its callers are a product page and a procurement screen: both have something useful to render without live stock and nothing useful to render if this call blows up. An unbound capability, an unmapped delivery location, a refused connection, a timeout, an unreadable answer — all statuses. Configuration problems are answered *before* any network call, because asking a vendor about an address our profile cannot state returns an answer that looks right and is about the wrong place.

### Two findings from the spec that change what the story assumed

**1. A2.5 carries no price.** It answers a four-valued availability code plus a schedule of quantities against dates. `PriceDetails/NetUnitPrice` belongs to the sibling **C1.0** inquiry on the same Michelin endpoint. So the quote fields stay null on this norm rather than being filled with a number the vendor never stated, and a supplier price comes from the PRICAT entries that own it (CAP-318). The story's AC-2 says "quantities, delivery estimate" and its canonical model carries `quotedUnitPrice` — those cannot both be satisfied by A2.5. **Implementing C1.0 as well would deliver price; that is a separate decision, not something to slip in here.**

**2. A single document-level status cannot say what a vendor says.** An inquiry naming three articles is routinely answered three ways: stocks the first, has none of the second, has never heard of the third. So the canonical and public line models gain a per-line status — `AVAILABLE`, `UNAVAILABLE`, `NOT_LISTED`, `NOT_ANSWERED` — while the document status keeps "did we get an answer at all" and reports `NOT_LISTED` only when the vendor carries none of what was asked, which is exactly the answer a single-article product page needs. Both DTOs were merged but unimplemented, so nothing consumed the old shape.

### The three-state quantity rule, carried through

Same rule the stock report established. `Availability=3` is the vendor saying it has none — the only place a zero is emitted. `Availability=0` is the vendor unable to determine one and stays null. An article the vendor does not know stays null and is `NOT_LISTED`, because retrying an identical inquiry cannot change it. The canonical `Line` **refuses** a quantity on a line nobody answered, so this is a type invariant rather than a convention someone has to remember.

### Vendor error codes are read, not guessed

From the EDIWheel table in `EDIWheel-XML_Order_Response_C1.pdf`. Line codes `903/911/928/933/940/941/945` mean the article is not one the vendor will sell → `NOT_LISTED`. Header codes for an invalid consignee, an unmapped party or a wrong agency qualifier describe **our** profile → `CONFIGURATION_ERROR`, so an operator is pointed at the profile instead of waiting for a vendor that is working perfectly.

### Cache

Keyed per article **and per delivery location**, and the key type will not let a caller omit the location: availability is consignee-specific, and a shared entry would tell a customer that stock at another branch is available at the one fitting the tyre. Only `AVAILABLE`/`UNAVAILABLE` are stored — caching a failure would extend one bad moment into a minute of identical failures, and caching `NOT_LISTED` would hide a catalogue fix for a minute. A cached answer keeps the `asOf` of the original inquiry; a document reports the **oldest** fact in it.

### Shared XML plumbing

Moved to `internal.adapter.ediwheelxml`, shared by the C1 and A2 families. Both parse `http://www.reifen.net` documents by the same rules, and a second copy of the XXE hardening is a copy that can fall behind the first. Families keep their own wire types and typed exceptions, because an unreadable order response is a transmission ambiguity (ADR-0052 §3) while an unreadable quote is just an unavailable vendor.

### Deviation worth calling out

**No `SupplierStockInquiryPort` implementation**, which the story's task list asks for. No SPI capability port is implemented anywhere in this module — PRICAT, stock report and orders all drive their codec from a runner in their own slice — and implementing this one alone would require an `exchangeAuditId` that nothing currently produces. The runner follows the delivered pattern. If the ports are meant to become real, that is a module-wide change and its own story.

Also corrects `SupplierStockReportPort`, which still declared the inquiry result as a report's shape; CAP-322 gave the report its own model.

## Tests
- [x] Unit tests added/updated — codec 22 (encode, decode, every availability code, the error-code table, namespace tolerance), runner 11 (the full degradation matrix), service 13 (cache isolation, `asOf` semantics, partial-hit inquiries, failure passthrough)
- [x] Integration tests added/updated — none needed; no schema or HTTP surface changed
- [ ] Provider behavioral contract tests — the sandbox smoke test against a Michelin binding is owed and cannot run here (no sandbox credentials in CI)
- How to run:
```bash
./mvnw -pl pos-supplier -am test
./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test
```
All green: pos-supplier **927**, pos-archunit 21, module ArchUnit 14, spotless.

## Risk & Rollback
- Risk level: **Low**. No schema change, no HTTP surface, no event. Nothing calls `SupplierStockService` until the second PR wires the Product Detail component, and the capability does nothing at all without a `STOCK_INQUIRY` binding on a profile.
- Rollback plan: revert the commit. The only outward-facing change is the shape of two DTOs that had no implementation and no consumer.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated (no contract semantics changed that a caller depends on yet)
- [ ] Required CI checks passing — pending

## Still owed on #1225 (second PR)
- pos-catalog Product Detail `supplierAvailability` component, following the established degradation contract.
- The narrow class-level `DomainWallsTest` allowlist for the approved synchronous read — deliberately not widened here, and worth reviewing on its own.
- OpenAPI/SDK regeneration once the composition exposes the component; the contract guide entry.
- Sandbox smoke test against the Michelin binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mv7zVYjwbVu5GRqrfkfHc7
