### PR TITLE
[CAP:319] Catalog: re-land live vendor stock on Product Detail onto main (#1225, supersedes #1324)

### DIFF
--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,9 +1,9 @@
-generatedAt: "2026-08-14T20:53:04.829365+00:00"
+generatedAt: "2026-08-15T12:00:25.194673+00:00"
 root: "."
 summary:
   manifestCount: 22
-  permissionCount: 422
-  uniquePermissionCount: 422
+  permissionCount: 423
+  uniquePermissionCount: 423
   duplicatePermissionNameCount: 0
   parseIssueCount: 0
 manifests:
@@ -786,7 +786,7 @@ manifests:
     domain: "supplier"
     serviceName: "pos-supplier"
     version: "1.0"
-    permissionCount: 7
+    permissionCount: 8
     permissions:
       - name: "supplier:audit:read"
         description: "Read supplier exchange audit records"
@@ -802,6 +802,8 @@ manifests:
         description: "View the purchase-order transmission ledger and its stuck-transmission queue"
       - name: "supplier:transmission:resolve"
         description: "Resolve a purchase-order transmission awaiting manual review (confirm with vendor reference, mark not received, or cancel)"
+      - name: "supplier:stock:inquire"
+        description: "Ask a vendor, live, what stock it holds for a receiving location (the approved synchronous supplier read)"
   - module: "pos-tax"
     path: "pos-tax/src/main/resources/permissions.yaml"
     domain: "tax"
@@ -3018,6 +3020,12 @@ permissions:
     source: "pos-supplier/src/main/resources/permissions.yaml"
   - name: "supplier:profile:write"
     description: "Create and edit vendor profiles, auth configs, commercial accounts, and endpoint bindings"
+    domain: "supplier"
+    serviceName: "pos-supplier"
+    module: "pos-supplier"
+    source: "pos-supplier/src/main/resources/permissions.yaml"
+  - name: "supplier:stock:inquire"
+    description: "Ask a vendor, live, what stock it holds for a receiving location (the approved synchronous supplier read)"
     domain: "supplier"
     serviceName: "pos-supplier"
     module: "pos-supplier"

--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -1295,6 +1295,8 @@ paths:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1admin~1profiles~1{vendorProfileId}~1bindings
   /v1/supplier/admin/profiles/{vendorProfileId}/bindings/{bindingId}:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1admin~1profiles~1{vendorProfileId}~1bindings~1{bindingId}
+  /v1/supplier/stock/inquiries:
+    $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1stock~1inquiries
   /v1/supplier/transmissions/purchase-order/{purchaseOrderId}:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1transmissions~1purchase-order~1{purchaseOrderId}
   /v1/supplier/transmissions/{transmissionIntentId}:

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 45;
+    public static final int CATALOG_VERSION = 46;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -529,7 +529,9 @@ public final class GatewayPermissionCatalog {
 
         // ── New batch (bits 451–452) ──────────────────────────────────────────
         "PERM_supplier:transmission:read", // 451
-        "PERM_supplier:transmission:resolve" // 452
+        "PERM_supplier:transmission:resolve", // 452
+        // ── New batch (bit 453) ───────────────────────────────────────────────
+        "PERM_supplier:stock:inquire" // 453
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,13 +1142,13 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 45")
+    @DisplayName("CATALOG_VERSION is 46")
     void catalogVersionMatchesCurrent() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(45);
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(46);
     }
 
     @Test
-    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 452")
+    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 453")
     void authorityByBitCoversNewEntries() {
         // batch-2: previously missing (bits 241-261)
         assertThat(GatewayPermissionCatalog.authorityForBit(241)).isEqualTo("PERM_accounting:events:reprocess");
@@ -1286,8 +1286,12 @@ class SecurityGatewayConfigTest {
         // are different powers (ADR-0052 §4).
         assertThat(GatewayPermissionCatalog.authorityForBit(451)).isEqualTo("PERM_supplier:transmission:read");
         assertThat(GatewayPermissionCatalog.authorityForBit(452)).isEqualTo("PERM_supplier:transmission:resolve");
+        // Live stock inquiry (#1225): the authority pos-catalog asserts when composing Product
+        // Detail. Separate from the pricecatalog permissions because reading a vendor's staged
+        // prices and making a live call to that vendor on a customer's page view are different acts.
+        assertThat(GatewayPermissionCatalog.authorityForBit(453)).isEqualTo("PERM_supplier:stock:inquire");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(453)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(454)).isNull();
     }
 
     @Test

--- a/pos-archunit/src/test/java/com/positivity/archunit/DomainWallsTest.java
+++ b/pos-archunit/src/test/java/com/positivity/archunit/DomainWallsTest.java
@@ -101,6 +101,26 @@ class DomainWallsTest {
             "pos-order", Set.of("pos-invoice"));
 
     /**
+     * Class-scoped exceptions to ADR-0044 R1: {@code origin module → client source file name → the
+     * exact set of domain modules that ONE file may target synchronously}.
+     *
+     * <p>Narrower than {@link #SCOPED_MODULE_EXCEPTIONS} on purpose. A module-level grant says "this
+     * module may call that one", and every future client added to the module inherits it silently. A
+     * file-level grant says "this one class may", so a second client reaching for the same target
+     * still fails the build and has to argue its own case.
+     *
+     * <p>pos-catalog → pos-supplier, from {@code SupplierStockClientImpl} only: live vendor stock is
+     * the one cross-domain fact that cannot be replicated. It lives at the vendor, changes without
+     * telling us, and is worthless once stale — a replica of it would be a confidently wrong number
+     * on a customer's screen. Permitted per the <b>ADR-0044 amendment 2026-08-10</b> ("Live supplier
+     * stock inquiry is the single approved synchronous cross-module supplier read"), which names the
+     * approved callers as the Product Detail composition and pos-order procurement. Everything else
+     * pos-catalog needs from pos-supplier — vendor prices — already arrives as events.
+     */
+    private static final Map<String, Map<String, Set<String>>> SCOPED_FILE_EXCEPTIONS =
+            Map.of("pos-catalog", Map.of("SupplierStockClientImpl.java", Set.of("pos-supplier")));
+
+    /**
      * Startup-infra classes exempt per ADR-0044 R2 (registration calls, best-effort
      * at boot).
      */
@@ -121,14 +141,18 @@ class DomainWallsTest {
             for (Path module : modules.filter(DomainWallsTest::isPosModule).toList()) {
                 String originModule = module.getFileName().toString();
                 Set<String> scopedExceptions = SCOPED_MODULE_EXCEPTIONS.getOrDefault(originModule, Set.of());
+                Map<String, Set<String>> fileExceptions = SCOPED_FILE_EXCEPTIONS.getOrDefault(originModule, Map.of());
                 for (Path source : clientSources(module)) {
                     if (EXEMPT_FILES.matcher(source.toString()).matches()) {
                         continue;
                     }
+                    Set<String> allowedForThisFile =
+                            fileExceptions.getOrDefault(source.getFileName().toString(), Set.of());
                     Set<String> targets = referencedServices(source);
                     targets.removeIf(target -> target.equals(originModule)
                             || UTILITY_MODULES.contains(target)
                             || scopedExceptions.contains(target)
+                            || allowedForThisFile.contains(target)
                             || !isPosModule(repoRoot.resolve(target)));
                     if (!targets.isEmpty()) {
                         violations

--- a/pos-catalog/README.md
+++ b/pos-catalog/README.md
@@ -91,12 +91,38 @@ function without it.
 A first deployment of a replica consumer should replay before trusting the replica: it holds only
 facts published after it started.
 
+## Live supplier stock on Product Detail (#1225)
+
+Product Detail carries a `supplierAvailability` component when
+`pos.supplier.stock.vendor-profile-id` names a vendor profile. Unset, the component is **absent** rather
+than present-and-degraded: a block that always says "unavailable" teaches a reader to skip it.
+
+This is the **one synchronous cross-domain read** in this module (ADR-0044 amendment 2026-08-10).
+Everything else it needs from another domain arrives as events. Vendor stock is the exception because it
+cannot be replicated — it lives at the vendor, changes without telling us, and is worthless once stale,
+so a replica of it would be a confidently wrong number on a customer's screen. `DomainWallsTest`
+allowlists `SupplierStockClientImpl` **by file name**; any other client here that reaches for
+pos-supplier still fails the build.
+
+Three different nothings reach the page, and the component keeps them apart:
+
+| What happened | `status` | `vendorStatus` | `availableQuantity` |
+| --- | --- | --- | --- |
+| Vendor stated a quantity | `OK` | `AVAILABLE` | the quantity |
+| Vendor said it has none | `OK` | `UNAVAILABLE` | `0` — a fact |
+| Vendor does not carry it | `OK` | `NOT_LISTED` | `null` |
+| Vendor said nothing, or could not be reached | `UNAVAILABLE` | `NOT_ANSWERED` or absent | `null` |
+
+Only the second row justifies telling a customer the vendor is out of stock. Nothing on this path
+defaults a missing quantity to zero.
+
 ## Configuration
 
-| Property                | Default  | Description                  |
-| ----------------------- | -------- | ---------------------------- |
-| `SPRING_DATASOURCE_URL` | required | PostgreSQL connection URL    |
-| `EUREKA_SERVER_URL`     | required | Eureka service discovery URL |
+| Property                                | Default  | Description                                                     |
+| --------------------------------------- | -------- | --------------------------------------------------------------- |
+| `SPRING_DATASOURCE_URL`                 | required | PostgreSQL connection URL                                        |
+| `EUREKA_SERVER_URL`                     | required | Eureka service discovery URL                                     |
+| `pos.supplier.stock.vendor-profile-id`  | unset    | Vendor profile asked for live stock; unset disables the component |
 
 ## Dependencies
 

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -5526,6 +5526,8 @@ components:
           $ref: '#/components/schemas/PricingInfo'
         availability:
           $ref: '#/components/schemas/AvailabilityInfo'
+        supplierAvailability:
+          $ref: '#/components/schemas/SupplierAvailabilityInfo'
         substitutions:
           type: array
           description: Substitution product suggestions
@@ -5578,6 +5580,54 @@ components:
           example: Newer Model
       required:
       - productId
+    SupplierAvailabilityInfo:
+      type: object
+      description: Live vendor stock with a status indicator. A null quantity means the vendor stated nothing; zero means the vendor stated it has none, and only that justifies showing a customer that the vendor is out of stock.
+      properties:
+        availableQuantity:
+          type: integer
+          format: int32
+          description: Quantity the vendor can supply. Null whenever the status is not OK, and null even under OK when the vendor answered without stating a quantity.
+          example: 8
+        earliestDeliveryDate:
+          type: string
+          format: date
+          description: Earliest date the vendor promised any quantity, when it stated one.
+          example: 2026-08-20
+        vendorStatus:
+          type: string
+          description: Whether the vendor carries this product at all. NOT_LISTED is a definite answer; UNAVAILABLE means the vendor holds none right now.
+          enum:
+          - AVAILABLE
+          - UNAVAILABLE
+          - NOT_LISTED
+          - NOT_ANSWERED
+          example: AVAILABLE
+        status:
+          type: string
+          description: Supplier data status
+          enum:
+          - OK
+          - UNAVAILABLE
+          - STALE
+          - ERROR
+          example: OK
+        asOf:
+          type: string
+          format: date-time
+          description: When the vendor stated this. A cached answer carries the age of the fact, not of the cache hit.
+          example: 2026-08-14 12:00:00+00:00
+        confidence:
+          type: string
+          description: Confidence in the supplier data
+          enum:
+          - LOW
+          - MEDIUM
+          - HIGH
+          example: HIGH
+      required:
+      - confidence
+      - status
     ServiceDto:
       type: object
       description: Catalog service item

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -5615,7 +5615,7 @@ components:
         asOf:
           type: string
           format: date-time
-          description: When the vendor stated this. A cached answer carries the age of the fact, not of the cache hit.
+          description: When the supplier fact was obtained. Present only when the vendor answered — a degraded component carries no timestamp, because there is no vendor statement to date. A cached answer carries the age of the fact, not of the cache hit.
           example: 2026-08-14 12:00:00+00:00
         confidence:
           type: string
@@ -6077,6 +6077,8 @@ components:
         offset:
           type: integer
           format: int64
+        sort:
+          $ref: '#/components/schemas/SortObject'
         paged:
           type: boolean
         pageNumber:
@@ -6085,8 +6087,6 @@ components:
         pageSize:
           type: integer
           format: int32
-        sort:
-          $ref: '#/components/schemas/SortObject'
         unpaged:
           type: boolean
     SortObject:

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/client/SupplierStockClient.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/client/SupplierStockClient.java
@@ -1,0 +1,65 @@
+package com.positivity.catalog.internal.client;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Client for the supplier live stock inquiry — the platform's single approved synchronous
+ * cross-domain supplier read (ADR-0044 amendment 2026-08-10, CAP-319 #1225).
+ *
+ * <h2>This is the allowlisted edge, and it is deliberately narrow</h2>
+ *
+ * ADR-0044 R1 forbids synchronous domain-to-domain calls, and every other cross-domain read in this
+ * module goes through an event-fed replica. The amendment permits exactly one exception, for exactly
+ * one reason: vendor stock cannot be replicated. It is a fact that lives at the vendor, changes
+ * without telling us, and is worthless the moment it is stale — a replica of it would be a
+ * confidently wrong number on a customer's screen.
+ *
+ * <p>{@code DomainWallsTest} allowlists this file by name, not pos-catalog as a module. Any other
+ * client here that reaches for pos-supplier still fails the build.
+ *
+ * <h2>Absence is not zero, and it never throws</h2>
+ *
+ * An empty {@link Optional} means "we could not find out" — the vendor was unreachable, the
+ * capability is not configured, or the deployment has no supplier integration at all. It never means
+ * "the vendor has none". The composition renders the difference.
+ */
+public interface SupplierStockClient {
+
+    /**
+     * Asks a vendor what it holds for one article at one receiving location.
+     *
+     * @param vendorProfileId the vendor profile to ask
+     * @param deliveryLocationId the receiving location; availability is consignee-specific, so an
+     *     answer for one location is never valid for another
+     * @param articleEan EAN/GTIN of the article, when known
+     * @param supplierArticleCode the vendor's own article code, when known
+     * @return the answer, or empty when no answer could be obtained — never an exception, and never
+     *     a fabricated zero
+     */
+    Optional<StockInquiryClientResponse> inquireStock(
+            UUID vendorProfileId, UUID deliveryLocationId, String articleEan, String supplierArticleCode);
+
+    /**
+     * The vendor's answer about one inquiry.
+     *
+     * @param status document-level outcome as the supplier service reported it
+     * @param lines per-article answers; empty unless the status is {@code OK}
+     * @param asOf when the answer was obtained; a cached answer carries the age of the fact
+     */
+    record StockInquiryClientResponse(String status, List<StockInquiryClientLine> lines, Instant asOf) {}
+
+    /**
+     * One article's answer.
+     *
+     * @param status {@code AVAILABLE}, {@code UNAVAILABLE}, {@code NOT_LISTED} or
+     *     {@code NOT_ANSWERED}
+     * @param availableQuantity quantity the vendor can supply; null when it stated none, and zero
+     *     only when the status is {@code UNAVAILABLE}
+     * @param earliestDeliveryDate earliest date the vendor promised any quantity, when stated
+     */
+    record StockInquiryClientLine(String status, Integer availableQuantity, LocalDate earliestDeliveryDate) {}
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/client/SupplierStockClientImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/client/SupplierStockClientImpl.java
@@ -1,0 +1,109 @@
+package com.positivity.catalog.internal.client;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * RestClient implementation of {@link SupplierStockClient}: {@code POST
+ * /v1/supplier/stock/inquiries} on the supplier service.
+ *
+ * <h2>Every failure is an empty answer</h2>
+ *
+ * A customer is waiting on the page this feeds. Nothing here rethrows: a connection refused, a
+ * timeout, a 4xx, a body that will not deserialise, and the supplier service reporting its own
+ * degraded status all become {@link Optional#empty()}, which the composition renders as "we could not
+ * find out" rather than as no stock. The supplier service is already built never to fail for a
+ * vendor-side problem, so an exception reaching this catch means something structural is wrong on
+ * our side — logged at warn, and still not allowed to take a product page down.
+ *
+ * <h2>Disabled unless a profile is configured</h2>
+ *
+ * A deployment with no supplier integration sets no {@code pos.supplier.stock.vendor-profile-id} and
+ * this client is never asked anything, so the component simply does not appear. That is the default:
+ * live vendor stock is an opt-in for deployments that have a trading partner, not something every
+ * installation inherits.
+ */
+@Slf4j
+@Component
+public class SupplierStockClientImpl implements SupplierStockClient {
+
+    private final RestClient restClient;
+    private final String basePath;
+
+    public SupplierStockClientImpl(
+            @Qualifier("loadBalancedRestClientBuilder") RestClient.Builder restClientBuilder,
+            @Value("${pos.supplier.service-id:supplier}") String serviceId,
+            @Value("${pos.supplier.base-path:/v1/supplier}") String basePath) {
+        this.basePath = basePath;
+        this.restClient = restClientBuilder.baseUrl("http://" + serviceId).build();
+    }
+
+    @Override
+    public Optional<StockInquiryClientResponse> inquireStock(
+            UUID vendorProfileId, UUID deliveryLocationId, String articleEan, String supplierArticleCode) {
+
+        if (vendorProfileId == null || deliveryLocationId == null) {
+            return Optional.empty();
+        }
+        if (isBlank(articleEan) && isBlank(supplierArticleCode)) {
+            // Nothing to ask about. Calling anyway would spend a vendor round trip to be told what
+            // we already know.
+            return Optional.empty();
+        }
+
+        InquiryRequest body = new InquiryRequest(
+                UUID.randomUUID(),
+                vendorProfileId,
+                deliveryLocationId,
+                List.of(new InquiryRequestLine(emptyToNull(articleEan), emptyToNull(supplierArticleCode), 1)));
+
+        try {
+            StockInquiryClientResponse response = restClient
+                    .post()
+                    .uri(basePath + "/stock/inquiries")
+                    .header("X-User", "pos-catalog-service")
+                    .header("X-Authorities", "supplier:stock:inquire")
+                    .body(body)
+                    .retrieve()
+                    .body(StockInquiryClientResponse.class);
+
+            if (response == null || !"OK".equals(response.status())) {
+                log.debug(
+                        "Supplier stock inquiry did not answer for profile {}: status={}",
+                        vendorProfileId,
+                        response == null ? "no body" : response.status());
+                return Optional.empty();
+            }
+            return Optional.of(response);
+        } catch (Exception e) {
+            // The supplier service reports vendor trouble as a status, not an exception, so an
+            // exception here is ours: unreachable service, wrong path, undeserialisable body. Still
+            // not a reason to fail a product page.
+            log.warn("Supplier stock inquiry failed for profile {}: {}", vendorProfileId, e.toString());
+            return Optional.empty();
+        }
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static String emptyToNull(String value) {
+        return isBlank(value) ? null : value;
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal request shape (mirrors the supplier service API contract)
+    // -----------------------------------------------------------------------
+
+    private record InquiryRequest(
+            UUID inquiryId, UUID vendorProfileId, UUID deliveryLocationId, List<InquiryRequestLine> lines) {}
+
+    private record InquiryRequestLine(String articleEan, String supplierArticleCode, int requestedQuantity) {}
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductDetailView.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductDetailView.java
@@ -202,8 +202,9 @@ public class ProductDetailView {
         private DataStatus status;
 
         @Schema(
-                description = "When the vendor stated this. A cached answer carries the age of the fact, not of"
-                        + " the cache hit.",
+                description = "When the supplier fact was obtained. Present only when the vendor answered — a"
+                        + " degraded component carries no timestamp, because there is no vendor statement to date."
+                        + " A cached answer carries the age of the fact, not of the cache hit.",
                 example = "2026-08-14T12:00:00Z",
                 requiredMode = NOT_REQUIRED)
         private Instant asOf;

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductDetailView.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductDetailView.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,6 +40,13 @@ public class ProductDetailView {
 
     @Schema(description = "Availability information with status indicator", requiredMode = NOT_REQUIRED)
     private AvailabilityInfo availability;
+
+    @Schema(
+            description = "Live vendor stock for this product, when the deployment has a supplier integration"
+                    + " configured. Absent otherwise — its absence means the question was never asked, not that a"
+                    + " vendor has none.",
+            requiredMode = NOT_REQUIRED)
+    private SupplierAvailabilityInfo supplierAvailability;
 
     @Schema(description = "Substitution product suggestions", example = "[]", requiredMode = NOT_REQUIRED)
     private List<SubstitutionHint> substitutions;
@@ -152,6 +160,58 @@ public class ProductDetailView {
         private DataConfidence confidence;
     }
 
+    /**
+     * Live vendor stock, asked of the supplier at request time (CAP-319 #1225).
+     *
+     * <p>The only component here whose data is not ours and cannot be replicated: vendor stock lives
+     * at the vendor, changes without telling us, and is worthless once stale. That is why it is
+     * fetched synchronously under the ADR-0044 amendment while every other cross-domain read on this
+     * page comes from an event-fed replica.
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(
+            description = "Live vendor stock with a status indicator. A null quantity means the vendor stated"
+                    + " nothing; zero means the vendor stated it has none, and only that justifies showing a"
+                    + " customer that the vendor is out of stock.")
+    public static class SupplierAvailabilityInfo {
+
+        @Schema(
+                description = "Quantity the vendor can supply. Null whenever the status is not OK, and null even"
+                        + " under OK when the vendor answered without stating a quantity.",
+                example = "8",
+                requiredMode = NOT_REQUIRED)
+        private Integer availableQuantity;
+
+        @Schema(
+                description = "Earliest date the vendor promised any quantity, when it stated one.",
+                example = "2026-08-20",
+                requiredMode = NOT_REQUIRED)
+        private LocalDate earliestDeliveryDate;
+
+        @Schema(
+                description = "Whether the vendor carries this product at all. NOT_LISTED is a definite answer;"
+                        + " UNAVAILABLE means the vendor holds none right now.",
+                example = "AVAILABLE",
+                requiredMode = NOT_REQUIRED)
+        private SupplierStockStatus vendorStatus;
+
+        @Schema(description = "Supplier data status", example = "OK", requiredMode = REQUIRED)
+        private DataStatus status;
+
+        @Schema(
+                description = "When the vendor stated this. A cached answer carries the age of the fact, not of"
+                        + " the cache hit.",
+                example = "2026-08-14T12:00:00Z",
+                requiredMode = NOT_REQUIRED)
+        private Instant asOf;
+
+        @Schema(description = "Confidence in the supplier data", example = "HIGH", requiredMode = REQUIRED)
+        private DataConfidence confidence;
+    }
+
     @Data
     @Builder
     @NoArgsConstructor
@@ -181,6 +241,19 @@ public class ProductDetailView {
         CATALOG,
         INVENTORY,
         SUPPLY_CHAIN
+    }
+
+    /** What a vendor said about an article, as reported by the supplier service. */
+    @Schema(description = "The vendor's answer about this article")
+    public enum SupplierStockStatus {
+        /** The vendor stated an availability. */
+        AVAILABLE,
+        /** The vendor stated it has none — an answer, not a silence. */
+        UNAVAILABLE,
+        /** The vendor does not carry, or will not sell, this article. */
+        NOT_LISTED,
+        /** The vendor returned the article without stating an availability. */
+        NOT_ANSWERED
     }
 
     @Schema(description = "Data confidence level")

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductDetailServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductDetailServiceImpl.java
@@ -2,6 +2,7 @@ package com.positivity.catalog.internal.service;
 
 import com.positivity.catalog.internal.client.InventoryClient;
 import com.positivity.catalog.internal.client.PricingClient;
+import com.positivity.catalog.internal.client.SupplierStockClient;
 import com.positivity.catalog.internal.dto.ProductDetailView;
 import com.positivity.catalog.internal.dto.ProductDetailView.*;
 import com.positivity.catalog.internal.entity.ProductEntity;
@@ -38,10 +39,21 @@ public class ProductDetailServiceImpl implements ProductDetailService {
     private final ProductReplacementRepository productReplacementRepository;
     private final PricingClient pricingClient;
     private final InventoryClient inventoryClient;
+    private final SupplierStockClient supplierStockClient;
     private final ObjectMapper objectMapper;
 
     @Value("${pos.price.default-customer-tier-id:00000000-0000-0000-0000-000000000001}")
     private UUID defaultCustomerTierId;
+
+    /**
+     * Vendor profile this deployment asks about live stock, if any.
+     *
+     * <p>Unset by default and unset for every deployment without a trading partner, which is what
+     * keeps the supplier component out of the response entirely rather than present and permanently
+     * degraded. A component that is always there saying "unavailable" trains a reader to ignore it.
+     */
+    @Value("${pos.supplier.stock.vendor-profile-id:}")
+    private String supplierVendorProfileId;
 
     /**
      * Retrieves a consolidated product detail view with pricing and availability.
@@ -77,6 +89,9 @@ public class ProductDetailServiceImpl implements ProductDetailService {
         // Fetch availability (with graceful degradation)
         AvailabilityInfo availability = fetchAvailabilityInfo(productId, locationId, requestTime, product);
 
+        // Ask the vendor for live stock (the one approved synchronous cross-domain read)
+        SupplierAvailabilityInfo supplierAvailability = fetchSupplierAvailability(product, locationId, requestTime);
+
         // Fetch substitutions (from catalog)
         List<SubstitutionHint> substitutions = fetchSubstitutions(productId);
 
@@ -89,10 +104,94 @@ public class ProductDetailServiceImpl implements ProductDetailService {
                 .specifications(specifications)
                 .pricing(pricing)
                 .availability(availability)
+                .supplierAvailability(supplierAvailability)
                 .substitutions(substitutions)
                 .generatedAt(requestTime)
                 .confidence(overallConfidence)
                 .build();
+    }
+
+    /**
+     * Asks the supplier what it holds for this product at this location (CAP-319 #1225).
+     *
+     * <h2>Absent, not degraded, when the deployment has no supplier</h2>
+     *
+     * Without a configured vendor profile this returns null and the component does not appear. A
+     * component permanently present and permanently {@code UNAVAILABLE} would teach a reader to skip
+     * it, which is the opposite of what a status is for.
+     *
+     * <h2>Three different nothings</h2>
+     *
+     * A vendor that said it has none is {@code UNAVAILABLE} with quantity {@code 0} — a fact worth
+     * showing. A vendor that could not be reached, or that answered without a quantity, is
+     * {@code DataStatus.UNAVAILABLE} with quantity null — a page should say it does not know rather
+     * than say there is none. And a vendor that does not carry the product at all is
+     * {@code NOT_LISTED}: a definite answer, which is why its data status is OK.
+     */
+    private SupplierAvailabilityInfo fetchSupplierAvailability(
+            ProductEntity product, UUID locationId, Instant requestTime) {
+
+        if (supplierVendorProfileId == null || supplierVendorProfileId.isBlank()) {
+            return null;
+        }
+        UUID vendorProfileId;
+        try {
+            vendorProfileId = UUID.fromString(supplierVendorProfileId.trim());
+        } catch (IllegalArgumentException e) {
+            log.warn("pos.supplier.stock.vendor-profile-id is not a UUID: {}", supplierVendorProfileId);
+            return null;
+        }
+
+        Optional<SupplierStockClient.StockInquiryClientResponse> answer;
+        try {
+            answer = supplierStockClient.inquireStock(
+                    vendorProfileId, locationId, product.getProductCode(), product.getSku());
+        } catch (Exception e) {
+            // The client already swallows everything it can. This catch is for what it cannot —
+            // a bean wiring fault, an error thrown before its own try block — and exists because a
+            // supplier problem must never be the reason a product page returns 500. Every sibling
+            // component on this page does the same.
+            log.warn("Supplier stock lookup failed for productId={}: {}", product.getId(), e.toString());
+            answer = Optional.empty();
+        }
+
+        if (answer.isEmpty() || answer.get().lines().isEmpty()) {
+            return SupplierAvailabilityInfo.builder()
+                    .status(DataStatus.UNAVAILABLE)
+                    .confidence(DataConfidence.LOW)
+                    .asOf(requestTime)
+                    .build();
+        }
+
+        SupplierStockClient.StockInquiryClientLine line = answer.get().lines().getFirst();
+        SupplierStockStatus vendorStatus = parseVendorStatus(line.status());
+        boolean answered = vendorStatus == SupplierStockStatus.AVAILABLE
+                || vendorStatus == SupplierStockStatus.UNAVAILABLE
+                || vendorStatus == SupplierStockStatus.NOT_LISTED;
+
+        return SupplierAvailabilityInfo.builder()
+                // Carried through exactly as the supplier reported it: null stays null. Defaulting a
+                // missing quantity to zero here would undo the whole chain that kept "did not say"
+                // apart from "has none".
+                .availableQuantity(line.availableQuantity())
+                .earliestDeliveryDate(line.earliestDeliveryDate())
+                .vendorStatus(vendorStatus)
+                .status(answered ? DataStatus.OK : DataStatus.UNAVAILABLE)
+                .asOf(answer.get().asOf() == null ? requestTime : answer.get().asOf())
+                .confidence(answered ? DataConfidence.HIGH : DataConfidence.LOW)
+                .build();
+    }
+
+    private static SupplierStockStatus parseVendorStatus(String status) {
+        if (status == null) {
+            return SupplierStockStatus.NOT_ANSWERED;
+        }
+        try {
+            return SupplierStockStatus.valueOf(status);
+        } catch (IllegalArgumentException e) {
+            // A status this version does not know about is not an availability claim.
+            return SupplierStockStatus.NOT_ANSWERED;
+        }
     }
 
     /**

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductDetailServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/ProductDetailServiceImpl.java
@@ -156,10 +156,12 @@ public class ProductDetailServiceImpl implements ProductDetailService {
         }
 
         if (answer.isEmpty() || answer.get().lines().isEmpty()) {
+            // No asOf: there is no vendor statement to date. Stamping the render time here would
+            // present "we could not find out" as a fact obtained just now, which is the same class of
+            // fabrication as defaulting an unstated quantity to zero.
             return SupplierAvailabilityInfo.builder()
                     .status(DataStatus.UNAVAILABLE)
                     .confidence(DataConfidence.LOW)
-                    .asOf(requestTime)
                     .build();
         }
 
@@ -177,7 +179,16 @@ public class ProductDetailServiceImpl implements ProductDetailService {
                 .earliestDeliveryDate(line.earliestDeliveryDate())
                 .vendorStatus(vendorStatus)
                 .status(answered ? DataStatus.OK : DataStatus.UNAVAILABLE)
-                .asOf(answer.get().asOf() == null ? requestTime : answer.get().asOf())
+                // Dated only when the vendor actually said something. The supplier's own asOf is
+                // preferred because it carries the age of a cached answer; the request time is the
+                // fallback for an answered line the supplier left undated, where "obtained now" is
+                // true. An unanswered line is left undated entirely.
+                .asOf(
+                        answered
+                                ? (answer.get().asOf() == null
+                                        ? requestTime
+                                        : answer.get().asOf())
+                                : null)
                 .confidence(answered ? DataConfidence.HIGH : DataConfidence.LOW)
                 .build();
     }

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductDetailDegradationTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductDetailDegradationTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import com.positivity.catalog.internal.client.InventoryClient;
 import com.positivity.catalog.internal.client.PricingClient;
+import com.positivity.catalog.internal.client.SupplierStockClient;
 import com.positivity.catalog.internal.dto.ProductDetailView;
 import com.positivity.catalog.internal.dto.ProductDetailView.DataConfidence;
 import com.positivity.catalog.internal.dto.ProductDetailView.DataStatus;
@@ -73,6 +74,9 @@ class ProductDetailDegradationTest {
     @Mock
     private InventoryClient inventoryClient;
 
+    @Mock
+    private SupplierStockClient supplierStockClient;
+
     private ProductDetailServiceImpl service;
     private ProductEntity product;
 
@@ -84,6 +88,7 @@ class ProductDetailDegradationTest {
                 productReplacementRepository,
                 pricingClient,
                 inventoryClient,
+                supplierStockClient,
                 new ObjectMapper());
 
         product = new ProductEntity();

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductDetailSupplierAvailabilityTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductDetailSupplierAvailabilityTest.java
@@ -163,6 +163,18 @@ class ProductDetailSupplierAvailabilityTest {
         assertThat(info.getStatus()).isEqualTo(DataStatus.UNAVAILABLE);
         assertThat(info.getAvailableQuantity()).isNull();
         assertThat(info.getVendorStatus()).isNull();
+        // No timestamp either: dating "we could not find out" would present it as a fact obtained
+        // just now, the same fabrication as defaulting an unstated quantity to zero.
+        assertThat(info.getAsOf()).isNull();
+    }
+
+    @Test
+    void leavesAnUnansweredLineUndatedEvenWhenTheVendorReplied() {
+        vendorAnswers("NOT_ANSWERED", null, null);
+
+        // The vendor replied, so there is an answer document — but it said nothing about this
+        // article, and asOf dates a vendor statement rather than a round trip.
+        assertThat(component().getAsOf()).isNull();
     }
 
     @Test

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductDetailSupplierAvailabilityTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductDetailSupplierAvailabilityTest.java
@@ -1,0 +1,207 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.client.InventoryClient;
+import com.positivity.catalog.internal.client.PricingClient;
+import com.positivity.catalog.internal.client.SupplierStockClient;
+import com.positivity.catalog.internal.dto.ProductDetailView;
+import com.positivity.catalog.internal.dto.ProductDetailView.DataStatus;
+import com.positivity.catalog.internal.dto.ProductDetailView.SupplierStockStatus;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.repository.ProductReplacementRepository;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Product Detail supplier availability component (#1225)")
+class ProductDetailSupplierAvailabilityTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-14T12:00:00Z");
+    private static final Instant VENDOR_ASOF = Instant.parse("2026-08-14T11:59:00Z");
+    private static final UUID PRODUCT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c1");
+    private static final UUID LOCATION_ID = UUID.fromString("00000000-0000-0000-0000-0000000000c2");
+    private static final String PROFILE_ID = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c";
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private ProductReplacementRepository productReplacementRepository;
+
+    @Mock
+    private PricingClient pricingClient;
+
+    @Mock
+    private InventoryClient inventoryClient;
+
+    @Mock
+    private SupplierStockClient supplierStockClient;
+
+    private ProductDetailServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProductDetailServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                productRepository,
+                productReplacementRepository,
+                pricingClient,
+                inventoryClient,
+                supplierStockClient,
+                new ObjectMapper());
+        ReflectionTestUtils.setField(service, "supplierVendorProfileId", PROFILE_ID);
+
+        ProductEntity product = new ProductEntity();
+        product.setId(PRODUCT_ID);
+        product.setSku("SKU-1001");
+        product.setLongDescription("Front brake rotor");
+        when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product));
+        when(productReplacementRepository.findAll()).thenReturn(List.of());
+        when(pricingClient.fetchPrice(any(), any(), any())).thenReturn(Optional.empty());
+        when(inventoryClient.fetchAvailability(anyString(), any())).thenReturn(Optional.empty());
+    }
+
+    private void vendorAnswers(String lineStatus, Integer quantity, LocalDate earliest) {
+        when(supplierStockClient.inquireStock(any(), any(), any(), any()))
+                .thenReturn(Optional.of(new SupplierStockClient.StockInquiryClientResponse(
+                        "OK",
+                        List.of(new SupplierStockClient.StockInquiryClientLine(lineStatus, quantity, earliest)),
+                        VENDOR_ASOF)));
+    }
+
+    private ProductDetailView.SupplierAvailabilityInfo component() {
+        return service.getProductDetail(PRODUCT_ID, LOCATION_ID).getSupplierAvailability();
+    }
+
+    @Test
+    void showsWhatTheVendorSaidWhenItAnswers() {
+        vendorAnswers("AVAILABLE", 8, LocalDate.of(2026, 8, 20));
+
+        ProductDetailView.SupplierAvailabilityInfo info = component();
+
+        assertThat(info.getStatus()).isEqualTo(DataStatus.OK);
+        assertThat(info.getVendorStatus()).isEqualTo(SupplierStockStatus.AVAILABLE);
+        assertThat(info.getAvailableQuantity()).isEqualTo(8);
+        assertThat(info.getEarliestDeliveryDate()).isEqualTo(LocalDate.of(2026, 8, 20));
+    }
+
+    @Test
+    void datesTheComponentByWhenTheVendorSaidItNotByWhenThePageRendered() {
+        vendorAnswers("AVAILABLE", 8, null);
+
+        // A cached supplier answer carries the age of the fact. Restamping it here would make a
+        // minute-old availability look like it was just confirmed.
+        assertThat(component().getAsOf()).isEqualTo(VENDOR_ASOF);
+    }
+
+    @Test
+    void keepsAVendorStatedZeroAsAFact() {
+        vendorAnswers("UNAVAILABLE", 0, null);
+
+        ProductDetailView.SupplierAvailabilityInfo info = component();
+
+        assertThat(info.getStatus()).isEqualTo(DataStatus.OK);
+        assertThat(info.getVendorStatus()).isEqualTo(SupplierStockStatus.UNAVAILABLE);
+        assertThat(info.getAvailableQuantity()).isZero();
+    }
+
+    @Test
+    void neverTurnsSilenceIntoZero() {
+        vendorAnswers("NOT_ANSWERED", null, null);
+
+        ProductDetailView.SupplierAvailabilityInfo info = component();
+
+        // The whole chain exists to keep these apart: a page must say it does not know rather than
+        // say the vendor has none.
+        assertThat(info.getAvailableQuantity()).isNull();
+        assertThat(info.getStatus()).isEqualTo(DataStatus.UNAVAILABLE);
+    }
+
+    @Test
+    void treatsAnArticleTheVendorDoesNotCarryAsADefiniteAnswer() {
+        vendorAnswers("NOT_LISTED", null, null);
+
+        ProductDetailView.SupplierAvailabilityInfo info = component();
+
+        // "We don't stock that" is information, not a failure to answer, so the data status is OK
+        // even though there is no quantity.
+        assertThat(info.getStatus()).isEqualTo(DataStatus.OK);
+        assertThat(info.getVendorStatus()).isEqualTo(SupplierStockStatus.NOT_LISTED);
+        assertThat(info.getAvailableQuantity()).isNull();
+    }
+
+    @Test
+    void degradesWithoutQuantitiesWhenTheSupplierCouldNotAnswer() {
+        when(supplierStockClient.inquireStock(any(), any(), any(), any())).thenReturn(Optional.empty());
+
+        ProductDetailView.SupplierAvailabilityInfo info = component();
+
+        assertThat(info.getStatus()).isEqualTo(DataStatus.UNAVAILABLE);
+        assertThat(info.getAvailableQuantity()).isNull();
+        assertThat(info.getVendorStatus()).isNull();
+    }
+
+    @Test
+    void omitsTheComponentEntirelyWhenTheDeploymentHasNoSupplier() {
+        ReflectionTestUtils.setField(service, "supplierVendorProfileId", "");
+
+        assertThat(service.getProductDetail(PRODUCT_ID, LOCATION_ID).getSupplierAvailability())
+                .isNull();
+        // A component that is always present and always degraded teaches a reader to skip it.
+        verifyNoInteractions(supplierStockClient);
+    }
+
+    @Test
+    void omitsTheComponentWhenTheConfiguredProfileIsNotAUuid() {
+        ReflectionTestUtils.setField(service, "supplierVendorProfileId", "not-a-uuid");
+
+        assertThat(service.getProductDetail(PRODUCT_ID, LOCATION_ID).getSupplierAvailability())
+                .isNull();
+        verify(supplierStockClient, never()).inquireStock(any(), any(), any(), any());
+    }
+
+    @Test
+    void asksAboutTheProductAtTheLocationTheCallerNamed() {
+        vendorAnswers("AVAILABLE", 4, null);
+
+        service.getProductDetail(PRODUCT_ID, LOCATION_ID);
+
+        // Availability is consignee-specific; asking without the caller's location would answer for
+        // somewhere else.
+        verify(supplierStockClient).inquireStock(UUID.fromString(PROFILE_ID), LOCATION_ID, null, "SKU-1001");
+    }
+
+    @Test
+    void aSupplierFailureNeverStopsTheRestOfThePage() {
+        when(supplierStockClient.inquireStock(any(), any(), any(), any()))
+                .thenThrow(new IllegalStateException("supplier service exploded"));
+
+        // The client is the layer that swallows; if something still escapes it, the composition must
+        // not turn a vendor problem into a 500 on a product page.
+        assertThat(service.getProductDetail(PRODUCT_ID, LOCATION_ID)).isNotNull();
+    }
+}

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -23,7 +23,7 @@ public final class DownstreamPermissionCatalog {
      * {@code PermissionCode.CATALOG_VERSION}.
      * Updated automatically by {@code scripts/generate-permissions.py --sync}.
      */
-    public static final int CATALOG_VERSION = 45;
+    public static final int CATALOG_VERSION = 46;
 
     /**
      * Index-to-authority mapping. Entry at position N is the {@code PERM_*}-prefixed
@@ -555,7 +555,9 @@ public final class DownstreamPermissionCatalog {
 
         // ── New batch (bits 451–452) ──────────────────────────────────────────
         "PERM_supplier:transmission:read", // 451
-        "PERM_supplier:transmission:resolve" // 452
+        "PERM_supplier:transmission:resolve", // 452
+        // ── New batch (bit 453) ───────────────────────────────────────────────
+        "PERM_supplier:stock:inquire" // 453
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -590,13 +590,14 @@ public enum PermissionCode {
     INVENTORY__SUPPLIER_STOCK_HINT__VIEW(450, "inventory:supplier_stock_hint:view"),
     // ── Supplier (new) ─────────────────────────────────────────────────────────
     SUPPLIER__TRANSMISSION__READ(451, "supplier:transmission:read"),
-    SUPPLIER__TRANSMISSION__RESOLVE(452, "supplier:transmission:resolve");
+    SUPPLIER__TRANSMISSION__RESOLVE(452, "supplier:transmission:resolve"),
+    SUPPLIER__STOCK__INQUIRE(453, "supplier:stock:inquire");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 45;
+    public static final int CATALOG_VERSION = 46;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 453;
-    private static final int EXPECTED_CATALOG_VERSION = 45;
+    private static final int EXPECTED_PERMISSION_COUNT = 454;
+    private static final int EXPECTED_CATALOG_VERSION = 46;
 
     // -------------------------------------------------------------------------
     // AC-1: Catalog size — EXPECTED_PERMISSION_COUNT entries

--- a/pos-supplier/README.md
+++ b/pos-supplier/README.md
@@ -98,11 +98,20 @@ created seconds ago may not be matchable yet, and its line is quarantined until 
 empty replica — Kafka disabled, or nothing consumed yet — reports `CATALOG_UNAVAILABLE` rather than
 turning a whole vendor catalog into `NO_CATALOG_MATCH` misses an operator would go hunting for.
 
-### Live stock inquiry (A2.5) — no HTTP surface, one in-process contract
+### Live stock inquiry (A2.5) — `supplier:stock:inquire`
 
-`SupplierStockService.inquireLiveStock` is the platform's **single approved synchronous cross-module
-supplier read** (ADR-0044 amendment, 2026-08-10). Approved callers are pos-catalog's Product Detail
-composition and pos-order procurement, and the grant is per calling class, not per module.
+| Route | Operation | Notes |
+| --- | --- | --- |
+| `POST …/stock/inquiries` | `inquireSupplierStock` | Always 200 when the request is well formed. Vendor failure is a status, not an error status |
+
+Its own permission rather than a reuse of the price-catalogue ones: reading a vendor's already-staged
+prices and calling that vendor on every customer page view are different acts with different costs, and
+a deployment must be able to have the first without the second.
+
+This is the platform's **single approved synchronous cross-module supplier read** (ADR-0044 amendment,
+2026-08-10). Approved callers are pos-catalog's Product Detail composition and pos-order procurement,
+and the grant is per calling class, not per module — `DomainWallsTest` allowlists the one client file
+by name, so a second client in the same module reaching for pos-supplier still fails the build.
 
 It **never throws for a vendor-side failure**. Both callers have something useful to render without
 live stock and nothing useful to render if this call blows up, so every failure is a status:

--- a/pos-supplier/openapi.yaml
+++ b/pos-supplier/openapi.yaml
@@ -2881,16 +2881,6 @@ components:
           format: date-time
         failureDetail:
           type: string
-    Line:
-      type: object
-      properties:
-        articleEan:
-          type: string
-        supplierArticleCode:
-          type: string
-        requestedQuantity:
-          type: integer
-          format: int32
     StockInquiryRequest:
       type: object
       properties:
@@ -2906,7 +2896,18 @@ components:
         lines:
           type: array
           items:
-            $ref: '#/components/schemas/Line'
+            $ref: '#/components/schemas/StockInquiryRequestLine'
+    StockInquiryRequestLine:
+      type: object
+      description: One inquired article. Named explicitly because an unqualified "Line" collides with other modules' schemas of the same name when specs are merged for SDK generation.
+      properties:
+        articleEan:
+          type: string
+        supplierArticleCode:
+          type: string
+        requestedQuantity:
+          type: integer
+          format: int32
     StockInquiryLine:
       type: object
       description: The vendor's answer about one inquired article.

--- a/pos-supplier/openapi.yaml
+++ b/pos-supplier/openapi.yaml
@@ -24,6 +24,8 @@ tags:
   description: Admin CRUD over vendor profiles — one row per configured supplier connection
 - name: Supplier Exchange Audit
   description: Read the supplier exchange-audit trail. Metadata is free to browse; reading stored payload content requires the same permission and is itself recorded.
+- name: Supplier Stock Inquiry
+  description: 'Ask a vendor, live, what stock it holds for a receiving location. Vendor-side failure is reported as a status on a 200 response, never as an error status: callers are expected to degrade and render without live stock rather than fail their own flow.'
 paths:
   /v1/supplier/admin/profiles/{vendorProfileId}:
     get:
@@ -880,6 +882,83 @@ paths:
       - bearerAuth: []
       x-required-permissions:
       - supplier:transmission:resolve
+  /v1/supplier/stock/inquiries:
+    post:
+      tags:
+      - Supplier Stock Inquiry
+      summary: Ask a vendor for live stock availability
+      description: 'Places a real-time availability inquiry with the vendor bound to the given profile, for the given receiving location, and returns what the vendor said; availability is consignee-specific, so an answer for one location is never valid for another.
+
+        Use this tool when a decision depends on what a vendor holds right now — composing a product page, quoting procurement; do not use it to read a vendor''s prices, which arrive as price-catalogue events and are read from the price catalogue instead.
+
+        Preconditions: the caller must hold supplier:stock:inquire, and the vendor profile must exist, be enabled, carry a STOCK_INQUIRY binding and map a delivery account to the receiving location; a profile meeting none of these is reported as a status rather than an error.
+
+        Required inputs: a JSON body carrying inquiryId, vendorProfileId, deliveryLocationId and at least one line with a quantity of one or more and at least one article identifier.
+
+        Emits a SUPPLIER_STOCK_INQUIRY event; the inquiry creates nothing and changes nothing, so it is safe to repeat, and repeating it within the cache window returns the same answer without a second vendor call.
+
+        Returns 200 with a status for every outcome including vendor failure — OK means the vendor answered and the per-article outcomes are on the lines, SUPPLIER_UNAVAILABLE means it did not answer usefully, NOT_LISTED means it carries none of the inquired articles, CAPABILITY_NOT_CONFIGURED means this deployment has not bound stock inquiry for the vendor, and CONFIGURATION_ERROR means the profile is bound and wrong and is raised before any vendor call; a null quantity means the vendor stated nothing while a quantity of zero means it stated that it has none, and only the second justifies telling a customer an article is out of stock.
+
+        Returns 400 when the body is malformed — a missing identifier, an empty line list, a line with no article identity, or a quantity below one.
+
+        Returns 403 when the caller lacks supplier:stock:inquire.
+
+        '
+      operationId: inquireSupplierStock
+      requestBody:
+        description: 'The inquiry: which vendor to ask, which receiving location the question is about, and the articles to ask about.'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StockInquiryRequest'
+            examples:
+              oneArticle:
+                description: oneArticle
+                value:
+                  inquiryId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                  vendorProfileId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c
+                  deliveryLocationId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5f
+                  lines:
+                  - articleEan: '4019238001234'
+                    requestedQuantity: 4
+        required: true
+      responses:
+        '200':
+          description: The inquiry was processed. Read `status` before reading the lines — a non-OK status carries no vendor data, and that is the normal degraded case rather than an error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StockInquiryResponse'
+              examples:
+                answered:
+                  description: answered
+                  value:
+                    inquiryId: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+                    status: OK
+                    lines:
+                    - articleEan: '4019238001234'
+                      status: AVAILABLE
+                      availableQuantity: 8
+                      earliestDeliveryDate: 2026-08-20
+                    asOf: 2026-08-14 12:00:00+00:00
+        '400':
+          description: 'The request body is malformed: a missing identifier, an empty line list, a line with no article identity, or a quantity below 1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '401':
+          description: 'Authentication is missing or the bearer token is invalid. The response has NO body: the gateway rejects unauthenticated calls with a bodiless status, so clients must not attempt to parse an error envelope here.'
+        '403':
+          description: The caller lacks `supplier:stock:inquire`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth: []
+      x-required-permissions:
+      - supplier:stock:inquire
   /v1/supplier/admin/profiles:
     get:
       tags:
@@ -2802,6 +2881,90 @@ components:
           format: date-time
         failureDetail:
           type: string
+    Line:
+      type: object
+      properties:
+        articleEan:
+          type: string
+        supplierArticleCode:
+          type: string
+        requestedQuantity:
+          type: integer
+          format: int32
+    StockInquiryRequest:
+      type: object
+      properties:
+        inquiryId:
+          type: string
+          format: uuid
+        vendorProfileId:
+          type: string
+          format: uuid
+        deliveryLocationId:
+          type: string
+          format: uuid
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/Line'
+    StockInquiryLine:
+      type: object
+      description: The vendor's answer about one inquired article.
+      properties:
+        articleEan:
+          type: string
+          description: EAN/GTIN of the article, as the vendor stated it.
+        supplierArticleCode:
+          type: string
+          description: The vendor's own article code, as the vendor stated it.
+        status:
+          type: string
+          description: What the vendor said about this article.
+          enum:
+          - AVAILABLE
+          - UNAVAILABLE
+          - NOT_LISTED
+          - NOT_ANSWERED
+        availableQuantity:
+          type: integer
+          format: int32
+          description: Quantity the vendor can supply. Null when the vendor stated no quantity, which includes every line it did not answer; zero only when the status is UNAVAILABLE, meaning the vendor stated it has none.
+        earliestDeliveryDate:
+          type: string
+          format: date
+          description: Earliest date the vendor promised any quantity, when stated.
+        quotedUnitPrice:
+          type: number
+          description: Quoted unit price, when the vendor norm carries one.
+        currency:
+          type: string
+          description: ISO 4217 currency of the quoted price, when quoted.
+    StockInquiryResponse:
+      type: object
+      description: 'Live vendor availability for the inquired articles. Vendor-side failure is reported as a status, never as an error: callers render without live stock rather than failing their own flow. A null quantity means the vendor stated nothing; a quantity of zero means the vendor stated it has none. Only the second justifies telling a customer an article is out of stock.'
+      properties:
+        inquiryId:
+          type: string
+          format: uuid
+          description: The inquiry identity supplied by the caller, echoed back.
+        status:
+          type: string
+          description: Whether the vendor answered, and if not, why not.
+          enum:
+          - OK
+          - SUPPLIER_UNAVAILABLE
+          - NOT_LISTED
+          - CAPABILITY_NOT_CONFIGURED
+          - CONFIGURATION_ERROR
+        lines:
+          type: array
+          description: Per-article answers; empty unless the status is OK.
+          items:
+            $ref: '#/components/schemas/StockInquiryLine'
+        asOf:
+          type: string
+          format: date-time
+          description: When this answer was obtained. Present when the status is OK; a cached answer carries the instant of the original inquiry, not of the cache hit.
     PriceCatalogImportSummary:
       type: object
       description: Bookkeeping summary of one vendor PRICAT import run.

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/config/SupplierEventTypes.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/config/SupplierEventTypes.java
@@ -102,6 +102,11 @@ public final class SupplierEventTypes {
                 EventTypeRegistration.approval(
                                 "SUPPLIER_TRANSMISSION_RESOLVE",
                                 "Resolve a purchase-order transmission awaiting manual review")
+                        .build(),
+                // Live stock inquiry (CAP-319). Threshold is a write's, not a read's: this makes a
+                // synchronous call to a trading partner while a customer waits, so the latency worth
+                // alerting on is the vendor's, not this module's.
+                EventTypeRegistration.write("SUPPLIER_STOCK_INQUIRY", "Ask a vendor for live stock availability")
                         .build());
     }
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierStockInquiryController.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierStockInquiryController.java
@@ -1,0 +1,164 @@
+package com.positivity.supplier.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.shared.error.ApiError;
+import com.positivity.supplier.internal.security.SupplierPermissions;
+import com.positivity.supplier.service.SupplierStockService;
+import com.positivity.supplier.service.model.StockInquiryRequest;
+import com.positivity.supplier.service.model.StockInquiryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Live vendor stock inquiry — the platform's single approved synchronous supplier read
+ * (ADR-0044 amendment 2026-08-10, ADR-0049 §4, CAP-319 #1225).
+ *
+ * <h2>Why this endpoint always returns 200</h2>
+ *
+ * Its callers compose a product page and a procurement quote. Both have something useful to render
+ * without live vendor stock and nothing useful to render if this call fails, so a vendor being
+ * unreachable is not an error condition here — it is an answer, carried as a status on a 200 body.
+ * Returning 502 or 504 for an unreachable vendor would make every caller implement the same
+ * try/catch whose only sensible body is "carry on without it", and the first caller to forget one
+ * would take down a page over a supplier's bad afternoon.
+ *
+ * <p>The 4xx responses that do exist are about the request, not the vendor: a malformed body, or a
+ * caller without the authority. Those are defects worth failing on.
+ *
+ * <h2>Why POST for a read</h2>
+ *
+ * An inquiry names a set of articles, and a set does not fit sensibly in a query string. The
+ * operation creates nothing, is safe to retry, and is annotated as an inquiry rather than a
+ * mutation — the method is a consequence of the payload, not a claim about side effects.
+ */
+@Tag(
+        name = "Supplier Stock Inquiry",
+        description = "Ask a vendor, live, what stock it holds for a receiving location. Vendor-side failure is"
+                + " reported as a status on a 200 response, never as an error status: callers are expected to"
+                + " degrade and render without live stock rather than fail their own flow.")
+@RestController
+@RequiredArgsConstructor
+@Validated
+@SecurityRequirement(name = "bearerAuth")
+@RequestMapping("/v1/supplier/stock")
+public class SupplierStockInquiryController {
+
+    private static final String UNAUTHENTICATED_DESCRIPTION = "Authentication is missing or the bearer token is"
+            + " invalid. The response has NO body: the gateway rejects unauthenticated calls with a bodiless"
+            + " status, so clients must not attempt to parse an error envelope here.";
+
+    private static final String REQUEST_EXAMPLE = """
+            {
+              "inquiryId": "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+              "vendorProfileId": "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c",
+              "deliveryLocationId": "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5f",
+              "lines": [
+                { "articleEan": "4019238001234", "supplierArticleCode": null, "requestedQuantity": 4 }
+              ]
+            }""";
+
+    private static final String ANSWERED_EXAMPLE = """
+            {
+              "inquiryId": "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b",
+              "status": "OK",
+              "lines": [
+                {
+                  "articleEan": "4019238001234",
+                  "supplierArticleCode": null,
+                  "status": "AVAILABLE",
+                  "availableQuantity": 8,
+                  "earliestDeliveryDate": "2026-08-20",
+                  "quotedUnitPrice": null,
+                  "currency": null
+                }
+              ],
+              "asOf": "2026-08-14T12:00:00Z"
+            }""";
+
+    private final SupplierStockService stockService;
+
+    /**
+     * Asks the vendor what it holds for the receiving location named in the request.
+     *
+     * @param request the inquiry: vendor profile, delivery location, and article lines
+     * @return the typed answer; always 200 when the request itself is well formed
+     */
+    @PostMapping("/inquiries")
+    @PreAuthorize("hasAuthority('" + SupplierPermissions.STOCK_INQUIRE + "')")
+    @EmitEvent(id = "SUPPLIER_STOCK_INQUIRY", apiVersion = "1")
+    @Operation(
+            operationId = "inquireSupplierStock",
+            summary = "Ask a vendor for live stock availability",
+            description = """
+                    Places a real-time availability inquiry with the vendor bound to the given profile, for the given \
+                    receiving location, and returns what the vendor said; availability is consignee-specific, so an \
+                    answer for one location is never valid for another.
+                    Use this tool when a decision depends on what a vendor holds right now — composing a product \
+                    page, quoting procurement; do not use it to read a vendor's prices, which arrive as \
+                    price-catalogue events and are read from the price catalogue instead.
+                    Preconditions: the caller must hold supplier:stock:inquire, and the vendor profile must exist, be \
+                    enabled, carry a STOCK_INQUIRY binding and map a delivery account to the receiving location; a \
+                    profile meeting none of these is reported as a status rather than an error.
+                    Required inputs: a JSON body carrying inquiryId, vendorProfileId, deliveryLocationId and at \
+                    least one line with a quantity of one or more and at least one article identifier.
+                    Emits a SUPPLIER_STOCK_INQUIRY event; the inquiry creates nothing and changes nothing, so it is \
+                    safe to repeat, and repeating it within the cache window returns the same answer without a \
+                    second vendor call.
+                    Returns 200 with a status for every outcome including vendor failure — OK means the vendor \
+                    answered and the per-article outcomes are on the lines, SUPPLIER_UNAVAILABLE means it did not \
+                    answer usefully, NOT_LISTED means it carries none of the inquired articles, \
+                    CAPABILITY_NOT_CONFIGURED means this deployment has not bound stock inquiry for the vendor, and \
+                    CONFIGURATION_ERROR means the profile is bound and wrong and is raised before any vendor call; a \
+                    null quantity means the vendor stated nothing while a quantity of zero means it stated that it \
+                    has none, and only the second justifies telling a customer an article is out of stock.
+                    Returns 400 when the body is malformed — a missing identifier, an empty line list, a line with \
+                    no article identity, or a quantity below one.
+                    Returns 403 when the caller lacks supplier:stock:inquire.
+                    """,
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            description = "The inquiry: which vendor to ask, which receiving location the question is"
+                                    + " about, and the articles to ask about.",
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = StockInquiryRequest.class),
+                                            examples = @ExampleObject(name = "oneArticle", value = REQUEST_EXAMPLE))))
+    @ApiResponse(
+            responseCode = "200",
+            description = "The inquiry was processed. Read `status` before reading the lines — a non-OK status"
+                    + " carries no vendor data, and that is the normal degraded case rather than an error.",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = StockInquiryResponse.class),
+                            examples = @ExampleObject(name = "answered", value = ANSWERED_EXAMPLE)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "The request body is malformed: a missing identifier, an empty line list, a line with no"
+                    + " article identity, or a quantity below 1.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(responseCode = "401", description = UNAUTHENTICATED_DESCRIPTION, content = @Content)
+    @ApiResponse(
+            responseCode = "403",
+            description = "The caller lacks `supplier:stock:inquire`.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<StockInquiryResponse> inquireSupplierStock(@Valid @RequestBody StockInquiryRequest request) {
+        return ResponseEntity.ok(stockService.inquireLiveStock(request));
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/security/SupplierPermissions.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/security/SupplierPermissions.java
@@ -68,5 +68,20 @@ public final class SupplierPermissions {
      */
     public static final String TRANSMISSION_RESOLVE = "supplier:transmission:resolve";
 
+    /**
+     * Ask a vendor, live, what stock it holds for a receiving location (CAP-319, ADR-0044
+     * amendment 2026-08-10).
+     *
+     * <p>Its own permission rather than a reuse of {@link #PRICECATALOG_READ}, because reading a
+     * vendor's already-staged prices and placing a call to that vendor on every customer page view
+     * are different acts with different costs. A deployment that wants the price catalogue without
+     * putting a trading partner's endpoint in the path of its own product pages needs to be able to
+     * say so, and one permission covering both would take that choice away.
+     *
+     * <p>Held by the composing services rather than by people: pos-catalog asserts it when building
+     * Product Detail, pos-order when quoting procurement.
+     */
+    public static final String STOCK_INQUIRE = "supplier:stock:inquire";
+
     private SupplierPermissions() {}
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/service/model/StockInquiryRequest.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/service/model/StockInquiryRequest.java
@@ -1,5 +1,6 @@
 package com.positivity.supplier.service.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -33,6 +34,10 @@ public record StockInquiryRequest(
      * @param supplierArticleCode vendor's own article code, when known
      * @param requestedQuantity quantity whose availability is being checked; {@code >= 1}
      */
+    @Schema(
+            name = "StockInquiryRequestLine",
+            description = "One inquired article. Named explicitly because an unqualified \"Line\" collides with other"
+                    + " modules' schemas of the same name when specs are merged for SDK generation.")
     public record Line(
             @Nullable String articleEan, @Nullable String supplierArticleCode, int requestedQuantity) {
 

--- a/pos-supplier/src/main/resources/permissions.yaml
+++ b/pos-supplier/src/main/resources/permissions.yaml
@@ -16,3 +16,5 @@ permissions:
     description: "View the purchase-order transmission ledger and its stuck-transmission queue"
   - name: "supplier:transmission:resolve"
     description: "Resolve a purchase-order transmission awaiting manual review (confirm with vendor reference, mark not received, or cancel)"
+  - name: "supplier:stock:inquire"
+    description: "Ask a vendor, live, what stock it holds for a receiving location (the approved synchronous supplier read)"


### PR DESCRIPTION
> **Re-lands #1324, which never reached `main`.** No new work — same commit, correct base, plus one file I had missed.

## What went wrong

#1324 was stacked on `cap/319-supplier-stock-inquiry` (the base of #1323). #1323 merged to `main` at 03:01 with a **merge commit** and its branch was **not deleted**, so GitHub never retargeted #1324. When #1324 merged at 11:59 it merged into that already-merged branch, leaving the catalog half in a dead end:

```
main            …── c28a5fd (merge #1323)          ← supplier half only
cap/319-supplier-stock-inquiry
                …── b4b4c49 ── d370eef ── 01fd61f  ← #1324 landed HERE
```

`git merge-base --is-ancestor d370eefb8 origin/main` → **not on main**, and `pos-catalog/internal/client/` on `main` still holds only `InventoryClient`/`PricingClient`.

This PR is `d370eefb8` cherry-picked onto current `main`. Clean pick — its parent was already an ancestor of `main`.

## Also fixed while re-landing

`docs/permissions-report.yaml` was **not** in the original commit and should have been. It is the generated permission report, committed alongside every prior permission change (b44ac53, a88a4a8, 10952ac all carry it). It now records `permissionCount: 423` and `pos-supplier: 8`, picking up `supplier:stock:inquire`.

## Capability & Traceability
- Capability: `cap:319`
- Parent STORY (durion): louisburroughs/durion#374
- Child issue: louisburroughs/durion-positivity-backend#1225
- Domain: `domain:positivity`, `domain:product`
- Supersedes: #1324 (merged to the wrong base)

## Contract References
- Contract guide entry (durion): `domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md` → supplier live stock inquiry
- `POST /v1/supplier/stock/inquiries`; `ProductDetailView.supplierAvailability`. Both module specs and `pos-api-gateway/docs/openapi-aggregate.yaml` regenerated.

## Contract Chain
- [x] OpenAPI annotations on the controller (ADR-0042 depth-STRICT)
- [x] `openapi.yaml` + aggregate regenerated
- [ ] Angular SDK regenerated — owed

## Scope

Unchanged from #1324; the substance is reviewed there. In brief:

- **`supplier:stock:inquire`, bit 453, CATALOG_VERSION 45 → 46.** The two services are separate, so the approved synchronous read is REST and needs its own authority — reading staged vendor prices and calling a vendor on every page view are different acts with different costs.
- **`DomainWallsTest` gains file-scoped exceptions.** A module-level grant is inherited silently by every client added later; pos-catalog may reach pos-supplier from `SupplierStockClientImpl` and nowhere else.
- **Absent, not degraded**, when no vendor profile is configured.
- **Three different nothings stay apart**: vendor-stated zero is a fact (`UNAVAILABLE`/`0`), an article the vendor does not carry is a definite answer (`NOT_LISTED`/`null`, status OK), and silence or unreachability is `null` with a degraded status.

## Tests
- [x] Unit — `ProductDetailSupplierAvailabilityTest` (10)
- [x] Integration — permission catalog version/count gates
- [ ] Provider behavioral contract tests — sandbox smoke test still owed
- How to run:
```bash
./mvnw -pl pos-catalog,pos-supplier -am test
./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test
./mvnw -pl pos-openapi-validation test
```
Re-verified on this base: pos-catalog **210**, pos-supplier **928**.

## Risk & Rollback
- Risk level: **Medium**, for the **CATALOG_VERSION 45 → 46 fleet-coordinated rollout**, not the code. durion#389 already tracks an un-shipped catalog rollout; this stacks another version onto that coordination and must not deploy piecemeal.
- Rollback plan: revert. The permission bit is additive; the component is absent unless a profile is configured.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues present
- [x] Contract guide updated
- [ ] Required CI checks passing — pending

## Cleanup after merge
Delete `cap/319-supplier-stock-inquiry` and `cap/319-catalog-supplier-availability`. Both are merged and both are now traps: anything branched from them starts from history that is not on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mv7zVYjwbVu5GRqrfkfHc7
