### PR TITLE
test: restore unit-only coverage above the JaCoCo ratchet floors in 11 modules

### DIFF
--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/CatalogServiceImplItemsTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/CatalogServiceImplItemsTest.java
@@ -1,0 +1,531 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.dto.CatalogDto;
+import com.positivity.catalog.internal.dto.CatalogItemRequestDto;
+import com.positivity.catalog.internal.dto.CatalogItemResponseDto;
+import com.positivity.catalog.internal.dto.NonInventoryProductDto;
+import com.positivity.catalog.internal.dto.ProductDto;
+import com.positivity.catalog.internal.dto.ServiceDto;
+import com.positivity.catalog.internal.entity.CatalogEntity;
+import com.positivity.catalog.internal.entity.Category;
+import com.positivity.catalog.internal.entity.DimensionEntity;
+import com.positivity.catalog.internal.entity.NonInventoryProductEntity;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.ServiceEntity;
+import com.positivity.catalog.internal.entity.Subcategory;
+import com.positivity.catalog.internal.exception.CatalogValidationException;
+import com.positivity.catalog.internal.repository.CatalogRepository;
+import com.positivity.catalog.internal.repository.NonInventoryProductRepository;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import com.positivity.catalog.internal.repository.ServiceRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Catalog item and catalog CRUD. Service search is covered by {@link CatalogServiceImplTest};
+ * this class covers the type-dispatching add/update/delete paths and the entity-to-DTO mapping.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("CatalogServiceImpl item and catalog CRUD")
+class CatalogServiceImplItemsTest {
+
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f9a01");
+    private static final UUID SERVICE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f9a02");
+    private static final UUID NON_INVENTORY_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f9a03");
+    private static final UUID CATALOG_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f9a04");
+    private static final UUID MANUFACTURER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f9a05");
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private ServiceRepository serviceRepository;
+
+    @Mock
+    private NonInventoryProductRepository nonInventoryProductRepository;
+
+    @Mock
+    private CatalogRepository catalogRepository;
+
+    private CatalogServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CatalogServiceImpl(
+                productRepository, serviceRepository, nonInventoryProductRepository, catalogRepository);
+        when(productRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(serviceRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(nonInventoryProductRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(catalogRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private static CatalogItemRequestDto itemRequest() {
+        CatalogItemRequestDto request = new CatalogItemRequestDto();
+        request.setName("Tire 205/55R16");
+        request.setShortDescription("All-season tire");
+        request.setLongDescription("All-season touring tire, 91V");
+        request.setImages(List.of("https://example.invalid/tire.png"));
+        request.setManufacturerPartNumber("MPN-1");
+        request.setManufacturerId(MANUFACTURER_ID.toString());
+        request.setManufacturerName("Acme");
+        request.setManufacturerWarranty("60 months");
+        request.setManufacturerBrand("AcmeGrip");
+        request.setCountryOfOrigin("US");
+        request.setSku("SKU-1");
+        request.setProductCode("3286340123456");
+        request.setType("TIRE");
+        request.setMaterial("Rubber");
+        request.setColor("Black");
+        request.setWarranty("24 months");
+        request.setSpecifications("{\"loadIndex\":91}");
+        return request;
+    }
+
+    private static ProductEntity productEntity() {
+        ProductEntity product = new ProductEntity();
+        product.setId(PRODUCT_ID);
+        product.setName("Tire 205/55R16");
+        product.setShortDescription("All-season tire");
+        product.setLongDescription("All-season touring tire, 91V");
+        product.setSku("SKU-1");
+        product.setManufacturerPartNumber("MPN-1");
+        product.setProductCode("3286340123456");
+        product.setUpc("3286340123456");
+        return product;
+    }
+
+    private static ServiceEntity serviceEntity() {
+        ServiceEntity entity = new ServiceEntity();
+        entity.setId(SERVICE_ID);
+        entity.setName("Mount and balance");
+        entity.setShortDescription("Per wheel");
+        return entity;
+    }
+
+    private static NonInventoryProductEntity nonInventoryEntity() {
+        NonInventoryProductEntity entity = new NonInventoryProductEntity();
+        entity.setId(NON_INVENTORY_ID);
+        entity.setName("Shop supplies");
+        return entity;
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        void mapsAProductWithItsCategorySubcategoryAndDimensions() {
+            ProductEntity entity = productEntity();
+            Category category = new Category();
+            category.setId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f9b01"));
+            category.setName("Tires");
+            entity.setCategory(category);
+            Subcategory subcategory = new Subcategory();
+            subcategory.setId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f9b02"));
+            subcategory.setName("Passenger");
+            entity.setSubcategory(subcategory);
+            DimensionEntity dimension = new DimensionEntity();
+            dimension.setId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f9b03"));
+            dimension.setDescription("Section width");
+            dimension.setUnitOfMeasure("mm");
+            dimension.setDimensionValue(205d);
+            entity.setDimensions(List.of(dimension));
+            when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(entity));
+
+            ProductDto dto = service.getProductById(PRODUCT_ID).orElseThrow();
+
+            assertThat(dto.getId()).isEqualTo(PRODUCT_ID);
+            assertThat(dto.getCategory().getName()).isEqualTo("Tires");
+            assertThat(dto.getSubcategory().getName()).isEqualTo("Passenger");
+            assertThat(dto.getDimensions()).hasSize(1);
+            assertThat(dto.getDimensions().get(0).getUnitOfMeasure()).isEqualTo("mm");
+            // The MPN is echoed into the dedicated mpn field as well as its own.
+            assertThat(dto.getMpn()).isEqualTo("MPN-1");
+        }
+
+        @Test
+        void leavesCategorySubcategoryAndDimensionsUnsetWhenTheProductHasNone() {
+            when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(productEntity()));
+
+            ProductDto dto = service.getProductById(PRODUCT_ID).orElseThrow();
+
+            assertThat(dto.getCategory()).isNull();
+            assertThat(dto.getSubcategory()).isNull();
+            assertThat(dto.getDimensions()).isEmpty();
+        }
+
+        @Test
+        void returnsEmptyForAnUnknownProduct() {
+            when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.getProductById(PRODUCT_ID)).isEmpty();
+        }
+
+        @Test
+        void listsProductsByExactName() {
+            when(productRepository.findByName("Tire 205/55R16")).thenReturn(List.of(productEntity()));
+
+            assertThat(service.getProductsByName("Tire 205/55R16")).hasSize(1);
+        }
+
+        @Test
+        void readsAServiceById() {
+            when(serviceRepository.findById(SERVICE_ID)).thenReturn(Optional.of(serviceEntity()));
+
+            ServiceDto dto = service.getServiceById(SERVICE_ID).orElseThrow();
+
+            assertThat(dto.getName()).isEqualTo("Mount and balance");
+            assertThat(dto.getShortDescription()).isEqualTo("Per wheel");
+        }
+
+        @Test
+        void listsServicesByExactName() {
+            when(serviceRepository.findByName("Mount and balance")).thenReturn(List.of(serviceEntity()));
+
+            assertThat(service.getServicesByName("Mount and balance")).hasSize(1);
+        }
+
+        @Test
+        void readsANonInventoryProductById() {
+            when(nonInventoryProductRepository.findById(NON_INVENTORY_ID))
+                    .thenReturn(Optional.of(nonInventoryEntity()));
+
+            NonInventoryProductDto dto =
+                    service.getNonInventoryProductById(NON_INVENTORY_ID).orElseThrow();
+
+            assertThat(dto.getName()).isEqualTo("Shop supplies");
+        }
+
+        @Test
+        void listsNonInventoryProductsByExactName() {
+            when(nonInventoryProductRepository.findByName("Shop supplies")).thenReturn(List.of(nonInventoryEntity()));
+
+            assertThat(service.getNonInventoryProductsByName("Shop supplies")).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("addCatalogItem")
+    class AddCatalogItem {
+
+        @Test
+        void createsAProductAndCopiesTheRequestOntoTheEntity() {
+            CatalogItemResponseDto response = service.addCatalogItem("PRODUCT", itemRequest());
+
+            ArgumentCaptor<ProductEntity> saved = ArgumentCaptor.forClass(ProductEntity.class);
+            verify(productRepository).save(saved.capture());
+            assertThat(saved.getValue().getName()).isEqualTo("Tire 205/55R16");
+            assertThat(saved.getValue().getManufacturerId()).isEqualTo(MANUFACTURER_ID);
+            // The product code doubles as the UPC, and the long description as the description.
+            assertThat(saved.getValue().getUpc()).isEqualTo("3286340123456");
+            assertThat(saved.getValue().getDescription()).isEqualTo("All-season touring tire, 91V");
+            assertThat(saved.getValue().getAttributes()).isEqualTo("{\"loadIndex\":91}");
+            assertThat(response.getItemType()).isEqualTo("product");
+        }
+
+        @Test
+        void leavesTheManufacturerIdUnsetWhenTheRequestHasNone() {
+            CatalogItemRequestDto request = itemRequest();
+            request.setManufacturerId("  ");
+
+            service.addCatalogItem("product", request);
+
+            ArgumentCaptor<ProductEntity> saved = ArgumentCaptor.forClass(ProductEntity.class);
+            verify(productRepository).save(saved.capture());
+            assertThat(saved.getValue().getManufacturerId()).isNull();
+        }
+
+        @Test
+        void createsAService() {
+            CatalogItemResponseDto response = service.addCatalogItem("service", itemRequest());
+
+            assertThat(response.getItemType()).isEqualTo("service");
+            verify(serviceRepository).save(any(ServiceEntity.class));
+        }
+
+        @Test
+        void createsANonInventoryItem() {
+            CatalogItemResponseDto response = service.addCatalogItem("noninventory", itemRequest());
+
+            assertThat(response.getItemType()).isEqualTo("noninventory");
+            verify(nonInventoryProductRepository).save(any(NonInventoryProductEntity.class));
+        }
+
+        @Test
+        void rejectsAnUnknownItemType() {
+            CatalogItemRequestDto request = itemRequest();
+
+            assertThatThrownBy(() -> service.addCatalogItem("widget", request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("Unsupported item type: widget");
+        }
+
+        @Test
+        void rejectsAMissingItemType() {
+            CatalogItemRequestDto request = itemRequest();
+
+            assertThatThrownBy(() -> service.addCatalogItem(null, request))
+                    .isInstanceOf(CatalogValidationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateCatalogItem")
+    class UpdateCatalogItem {
+
+        @Test
+        void keepsTheExistingProductIdOnTheReplacementEntity() {
+            when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(productEntity()));
+
+            Optional<CatalogItemResponseDto> response = service.updateCatalogItem("product", PRODUCT_ID, itemRequest());
+
+            assertThat(response).isPresent();
+            ArgumentCaptor<ProductEntity> saved = ArgumentCaptor.forClass(ProductEntity.class);
+            verify(productRepository).save(saved.capture());
+            assertThat(saved.getValue().getId()).isEqualTo(PRODUCT_ID);
+        }
+
+        @Test
+        void returnsEmptyForAnUnknownProduct() {
+            when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.updateCatalogItem("product", PRODUCT_ID, itemRequest()))
+                    .isEmpty();
+            verify(productRepository, never()).save(any());
+        }
+
+        @Test
+        void updatesAService() {
+            when(serviceRepository.findById(SERVICE_ID)).thenReturn(Optional.of(serviceEntity()));
+
+            assertThat(service.updateCatalogItem("service", SERVICE_ID, itemRequest()))
+                    .isPresent();
+        }
+
+        @Test
+        void returnsEmptyForAnUnknownService() {
+            when(serviceRepository.findById(SERVICE_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.updateCatalogItem("service", SERVICE_ID, itemRequest()))
+                    .isEmpty();
+        }
+
+        @Test
+        void updatesANonInventoryItem() {
+            when(nonInventoryProductRepository.findById(NON_INVENTORY_ID))
+                    .thenReturn(Optional.of(nonInventoryEntity()));
+
+            assertThat(service.updateCatalogItem("noninventory", NON_INVENTORY_ID, itemRequest()))
+                    .isPresent();
+        }
+
+        @Test
+        void returnsEmptyForAnUnknownNonInventoryItem() {
+            when(nonInventoryProductRepository.findById(NON_INVENTORY_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.updateCatalogItem("noninventory", NON_INVENTORY_ID, itemRequest()))
+                    .isEmpty();
+        }
+
+        @Test
+        void rejectsAnUnknownItemType() {
+            CatalogItemRequestDto request = itemRequest();
+
+            assertThatThrownBy(() -> service.updateCatalogItem("widget", PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteCatalogItem")
+    class DeleteCatalogItem {
+
+        @Test
+        void deletesAnExistingProduct() {
+            when(productRepository.existsById(PRODUCT_ID)).thenReturn(true);
+
+            assertThat(service.deleteCatalogItem("product", PRODUCT_ID)).isTrue();
+            verify(productRepository).deleteById(PRODUCT_ID);
+        }
+
+        @Test
+        void reportsFalseForAProductThatIsNotThere() {
+            when(productRepository.existsById(PRODUCT_ID)).thenReturn(false);
+
+            assertThat(service.deleteCatalogItem("product", PRODUCT_ID)).isFalse();
+            verify(productRepository, never()).deleteById(any(UUID.class));
+        }
+
+        @Test
+        void deletesAnExistingService() {
+            when(serviceRepository.existsById(SERVICE_ID)).thenReturn(true);
+
+            assertThat(service.deleteCatalogItem("service", SERVICE_ID)).isTrue();
+            verify(serviceRepository).deleteById(SERVICE_ID);
+        }
+
+        @Test
+        void reportsFalseForAServiceThatIsNotThere() {
+            when(serviceRepository.existsById(SERVICE_ID)).thenReturn(false);
+
+            assertThat(service.deleteCatalogItem("service", SERVICE_ID)).isFalse();
+        }
+
+        @Test
+        void deletesAnExistingNonInventoryItem() {
+            when(nonInventoryProductRepository.existsById(NON_INVENTORY_ID)).thenReturn(true);
+
+            assertThat(service.deleteCatalogItem("noninventory", NON_INVENTORY_ID))
+                    .isTrue();
+            verify(nonInventoryProductRepository).deleteById(NON_INVENTORY_ID);
+        }
+
+        @Test
+        void reportsFalseForANonInventoryItemThatIsNotThere() {
+            when(nonInventoryProductRepository.existsById(NON_INVENTORY_ID)).thenReturn(false);
+
+            assertThat(service.deleteCatalogItem("noninventory", NON_INVENTORY_ID))
+                    .isFalse();
+        }
+
+        @Test
+        void rejectsAnUnknownItemType() {
+            assertThatThrownBy(() -> service.deleteCatalogItem("widget", PRODUCT_ID))
+                    .isInstanceOf(CatalogValidationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("catalogs")
+    class Catalogs {
+
+        private CatalogDto catalogRequest() {
+            CatalogDto request = new CatalogDto();
+            request.setName("Spring promo");
+            request.setDescription("Seasonal bundle");
+            request.setProductIds(List.of(PRODUCT_ID));
+            request.setServiceIds(List.of(SERVICE_ID));
+            request.setNonInventoryProductIds(List.of(NON_INVENTORY_ID));
+            return request;
+        }
+
+        @Test
+        void resolvesEveryMemberIdWhenCreatingACatalog() {
+            when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(productEntity()));
+            when(serviceRepository.findById(SERVICE_ID)).thenReturn(Optional.of(serviceEntity()));
+            when(nonInventoryProductRepository.findById(NON_INVENTORY_ID))
+                    .thenReturn(Optional.of(nonInventoryEntity()));
+
+            CatalogDto response = service.addCatalog(catalogRequest());
+
+            assertThat(response.getProductIds()).containsExactly(PRODUCT_ID);
+            assertThat(response.getServiceIds()).containsExactly(SERVICE_ID);
+            assertThat(response.getNonInventoryProductIds()).containsExactly(NON_INVENTORY_ID);
+        }
+
+        @Test
+        void dropsMemberIdsThatNoLongerResolve() {
+            when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+            when(serviceRepository.findById(SERVICE_ID)).thenReturn(Optional.empty());
+            when(nonInventoryProductRepository.findById(NON_INVENTORY_ID)).thenReturn(Optional.empty());
+
+            CatalogDto response = service.addCatalog(catalogRequest());
+
+            assertThat(response.getProductIds()).isEmpty();
+            assertThat(response.getServiceIds()).isEmpty();
+            assertThat(response.getNonInventoryProductIds()).isEmpty();
+        }
+
+        @Test
+        void acceptsACatalogWithNoMembersAtAll() {
+            CatalogDto request = new CatalogDto();
+            request.setName("Empty");
+
+            CatalogDto response = service.addCatalog(request);
+
+            assertThat(response.getProductIds()).isEmpty();
+            assertThat(response.getServiceIds()).isEmpty();
+            assertThat(response.getNonInventoryProductIds()).isEmpty();
+        }
+
+        @Test
+        void readsACatalogById() {
+            CatalogEntity entity = new CatalogEntity();
+            entity.setId(CATALOG_ID);
+            entity.setName("Spring promo");
+            entity.setProducts(List.of(productEntity()));
+            when(catalogRepository.findById(CATALOG_ID)).thenReturn(Optional.of(entity));
+
+            CatalogDto dto = service.getCatalogById(CATALOG_ID).orElseThrow();
+
+            assertThat(dto.getProductIds()).containsExactly(PRODUCT_ID);
+            assertThat(dto.getServiceIds()).isEmpty();
+        }
+
+        @Test
+        void searchesCatalogsByPartialName() {
+            CatalogEntity entity = new CatalogEntity();
+            entity.setId(CATALOG_ID);
+            entity.setName("Spring promo");
+            when(catalogRepository.findByNameContainingIgnoreCase("spring")).thenReturn(List.of(entity));
+
+            assertThat(service.getCatalogsByName("spring")).hasSize(1);
+        }
+
+        @Test
+        void keepsTheExistingCatalogIdOnUpdate() {
+            CatalogEntity existing = new CatalogEntity();
+            existing.setId(CATALOG_ID);
+            when(catalogRepository.findById(CATALOG_ID)).thenReturn(Optional.of(existing));
+            CatalogDto request = new CatalogDto();
+            request.setName("Renamed");
+
+            CatalogDto response = service.updateCatalog(CATALOG_ID, request).orElseThrow();
+
+            assertThat(response.getId()).isEqualTo(CATALOG_ID);
+            assertThat(response.getName()).isEqualTo("Renamed");
+        }
+
+        @Test
+        void returnsEmptyWhenUpdatingAnUnknownCatalog() {
+            when(catalogRepository.findById(CATALOG_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.updateCatalog(CATALOG_ID, new CatalogDto())).isEmpty();
+        }
+
+        @Test
+        void deletesAnExistingCatalog() {
+            when(catalogRepository.existsById(CATALOG_ID)).thenReturn(true);
+
+            assertThat(service.deleteCatalog(CATALOG_ID)).isTrue();
+            verify(catalogRepository).deleteById(CATALOG_ID);
+        }
+
+        @Test
+        void reportsFalseForACatalogThatIsNotThere() {
+            when(catalogRepository.existsById(CATALOG_ID)).thenReturn(false);
+
+            assertThat(service.deleteCatalog(CATALOG_ID)).isFalse();
+            verify(catalogRepository, never()).deleteById(any(UUID.class));
+        }
+    }
+}

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ItemCostServiceImplTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ItemCostServiceImplTest.java
@@ -1,0 +1,322 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.dto.ItemCostAuditDto;
+import com.positivity.catalog.internal.dto.ItemCostsDto;
+import com.positivity.catalog.internal.dto.PurchaseOrderReceivedEventDto;
+import com.positivity.catalog.internal.dto.UpdateStandardCostRequestDto;
+import com.positivity.catalog.internal.entity.ItemCostAuditEntity;
+import com.positivity.catalog.internal.entity.ItemCostEntity;
+import com.positivity.catalog.internal.enums.ChangeSourceType;
+import com.positivity.catalog.internal.enums.CostType;
+import com.positivity.catalog.internal.exception.CatalogValidationException;
+import com.positivity.catalog.internal.repository.ItemCostAuditRepository;
+import com.positivity.catalog.internal.repository.ItemCostRepository;
+import com.positivity.security.common.GatewaySecurityConstants;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Item costing: manual standard-cost edits are audited against the acting user, and received
+ * purchase orders roll the last cost and the weighted-average cost forward.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ItemCostServiceImpl")
+class ItemCostServiceImplTest {
+
+    private static final UUID ITEM_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3faa01");
+    private static final UUID AUDIT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3faa02");
+
+    @Mock
+    private ItemCostRepository itemCostRepository;
+
+    @Mock
+    private ItemCostAuditRepository itemCostAuditRepository;
+
+    @InjectMocks
+    private ItemCostServiceImpl service;
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @BeforeEach
+    void stubSaves() {
+        when(itemCostRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(itemCostAuditRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private static void authenticateAs(String username) {
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(username, "n/a", List.of());
+        token.setDetails(Map.of(GatewaySecurityConstants.DETAIL_USERNAME, username));
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    private static ItemCostEntity itemCost(String standard, String last, String average, String qtyOnHand) {
+        ItemCostEntity entity = new ItemCostEntity();
+        entity.setItemId(ITEM_ID);
+        entity.setStandardCost(standard == null ? null : new BigDecimal(standard));
+        entity.setLastCost(last == null ? null : new BigDecimal(last));
+        entity.setAverageCost(average == null ? null : new BigDecimal(average));
+        entity.setQtyOnHand(qtyOnHand == null ? null : new BigDecimal(qtyOnHand));
+        return entity;
+    }
+
+    private static UpdateStandardCostRequestDto costRequest(String newCost, String reasonCode) {
+        UpdateStandardCostRequestDto request = new UpdateStandardCostRequestDto();
+        request.setNewCost(newCost == null ? null : new BigDecimal(newCost));
+        request.setReasonCode(reasonCode);
+        return request;
+    }
+
+    private static PurchaseOrderReceivedEventDto poEvent(String qty, String unitCost) {
+        PurchaseOrderReceivedEventDto event = new PurchaseOrderReceivedEventDto();
+        event.setItemId(ITEM_ID);
+        event.setPurchaseOrderId("PO-1001");
+        event.setReceivedQty(qty == null ? null : new BigDecimal(qty));
+        event.setReceivedUnitCost(unitCost == null ? null : new BigDecimal(unitCost));
+        return event;
+    }
+
+    @Nested
+    @DisplayName("updateStandardCost")
+    class UpdateStandardCost {
+
+        @Test
+        void writesTheNewCostAtFourDecimalPlacesAndAuditsTheChange() {
+            when(itemCostRepository.findByItemId(ITEM_ID)).thenReturn(Optional.of(itemCost("40", null, null, "5")));
+            authenticateAs("jane.smith");
+
+            ItemCostsDto response = service.updateStandardCost(ITEM_ID, costRequest("42.125", "SUPPLIER_INCREASE"));
+
+            assertThat(response.getStandardCost()).isEqualByComparingTo("42.1250");
+            ArgumentCaptor<ItemCostAuditEntity> audit = ArgumentCaptor.forClass(ItemCostAuditEntity.class);
+            verify(itemCostAuditRepository).save(audit.capture());
+            assertThat(audit.getValue().getCostTypeChanged()).isEqualTo(CostType.STANDARD);
+            assertThat(audit.getValue().getOldValue()).isEqualByComparingTo("40");
+            assertThat(audit.getValue().getNewValue()).isEqualByComparingTo("42.1250");
+            assertThat(audit.getValue().getChangeSourceType()).isEqualTo(ChangeSourceType.MANUAL);
+            assertThat(audit.getValue().getChangeSourceId()).isEqualTo("MANUAL");
+            assertThat(audit.getValue().getActor()).isEqualTo("jane.smith");
+            assertThat(audit.getValue().getReasonCode()).isEqualTo("SUPPLIER_INCREASE");
+        }
+
+        @Test
+        void createsTheCostRowForAnItemThatHasNoneYet() {
+            when(itemCostRepository.findByItemId(ITEM_ID)).thenReturn(Optional.empty());
+
+            ItemCostsDto response = service.updateStandardCost(ITEM_ID, costRequest("10", "INITIAL"));
+
+            assertThat(response.getItemId()).isEqualTo(ITEM_ID);
+            assertThat(response.getStandardCost()).isEqualByComparingTo("10.0000");
+            ArgumentCaptor<ItemCostEntity> saved = ArgumentCaptor.forClass(ItemCostEntity.class);
+            verify(itemCostRepository).save(saved.capture());
+            assertThat(saved.getValue().getQtyOnHand()).isEqualByComparingTo("0");
+        }
+
+        @Test
+        void attributesTheChangeToTheSystemWhenNobodyIsAuthenticated() {
+            when(itemCostRepository.findByItemId(ITEM_ID)).thenReturn(Optional.empty());
+
+            service.updateStandardCost(ITEM_ID, costRequest("10", "INITIAL"));
+
+            ArgumentCaptor<ItemCostAuditEntity> audit = ArgumentCaptor.forClass(ItemCostAuditEntity.class);
+            verify(itemCostAuditRepository).save(audit.capture());
+            assertThat(audit.getValue().getActor()).isEqualTo("system");
+        }
+
+        @Test
+        void rejectsAnEditWithNoReasonCode() {
+            UpdateStandardCostRequestDto request = costRequest("10", "  ");
+
+            assertThatThrownBy(() -> service.updateStandardCost(ITEM_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("reasonCode is required");
+            verifyNoInteractions(itemCostRepository);
+        }
+
+        @Test
+        void rejectsAnEditWithAMissingReasonCode() {
+            UpdateStandardCostRequestDto request = costRequest("10", null);
+
+            assertThatThrownBy(() -> service.updateStandardCost(ITEM_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("reasonCode is required");
+        }
+
+        @Test
+        void rejectsANonPositiveCost() {
+            UpdateStandardCostRequestDto request = costRequest("0", "INITIAL");
+
+            assertThatThrownBy(() -> service.updateStandardCost(ITEM_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("newCost must be positive");
+        }
+
+        @Test
+        void rejectsAMissingCost() {
+            UpdateStandardCostRequestDto request = costRequest(null, "INITIAL");
+
+            assertThatThrownBy(() -> service.updateStandardCost(ITEM_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("newCost must be positive");
+        }
+    }
+
+    @Nested
+    @DisplayName("getItemCosts / getAuditHistory")
+    class Reads {
+
+        @Test
+        void reportsTheStoredCosts() {
+            when(itemCostRepository.findByItemId(ITEM_ID)).thenReturn(Optional.of(itemCost("40", "41", "40.5", "5")));
+
+            ItemCostsDto response = service.getItemCosts(ITEM_ID);
+
+            assertThat(response.getStandardCost()).isEqualByComparingTo("40");
+            assertThat(response.getLastCost()).isEqualByComparingTo("41");
+            assertThat(response.getAverageCost()).isEqualByComparingTo("40.5");
+        }
+
+        @Test
+        void reportsAnEmptyCostSheetForAnItemWithNoCostRow() {
+            when(itemCostRepository.findByItemId(ITEM_ID)).thenReturn(Optional.empty());
+
+            ItemCostsDto response = service.getItemCosts(ITEM_ID);
+
+            assertThat(response.getItemId()).isEqualTo(ITEM_ID);
+            assertThat(response.getStandardCost()).isNull();
+        }
+
+        @Test
+        void mapsTheAuditTrailNewestFirst() {
+            ItemCostAuditEntity audit = new ItemCostAuditEntity();
+            audit.setAuditId(AUDIT_ID);
+            audit.setItemId(ITEM_ID);
+            audit.setTimestamp(Instant.parse("2026-03-01T12:00:00Z"));
+            audit.setCostTypeChanged(CostType.AVERAGE);
+            audit.setOldValue(new BigDecimal("40"));
+            audit.setNewValue(new BigDecimal("41"));
+            audit.setChangeSourceType(ChangeSourceType.PURCHASE_ORDER);
+            audit.setChangeSourceId("PO-1001");
+            audit.setActor("system");
+            audit.setReasonCode("RECEIPT");
+            when(itemCostAuditRepository.findByItemIdOrderByTimestampDesc(ITEM_ID))
+                    .thenReturn(List.of(audit));
+
+            List<ItemCostAuditDto> history = service.getAuditHistory(ITEM_ID);
+
+            assertThat(history).hasSize(1);
+            assertThat(history.get(0).getAuditId()).isEqualTo(AUDIT_ID);
+            assertThat(history.get(0).getCostTypeChanged()).isEqualTo(CostType.AVERAGE);
+            assertThat(history.get(0).getChangeSourceId()).isEqualTo("PO-1001");
+            assertThat(history.get(0).getReasonCode()).isEqualTo("RECEIPT");
+        }
+    }
+
+    @Nested
+    @DisplayName("processPoReceivedEvent")
+    class ProcessPoReceivedEvent {
+
+        @Test
+        void rollsTheWeightedAverageForwardAndRecordsBothCostChanges() {
+            ItemCostEntity existing = itemCost(null, "38", "40", "10");
+            when(itemCostRepository.findByItemId(ITEM_ID)).thenReturn(Optional.of(existing));
+
+            service.processPoReceivedEvent(poEvent("10", "50"));
+
+            // (10 × 40 + 10 × 50) / 20 = 45
+            assertThat(existing.getAverageCost()).isEqualByComparingTo("45.0000");
+            assertThat(existing.getLastCost()).isEqualByComparingTo("50.0000");
+            assertThat(existing.getQtyOnHand()).isEqualByComparingTo("20");
+
+            ArgumentCaptor<ItemCostAuditEntity> audits = ArgumentCaptor.forClass(ItemCostAuditEntity.class);
+            verify(itemCostAuditRepository, org.mockito.Mockito.times(2)).save(audits.capture());
+            assertThat(audits.getAllValues())
+                    .extracting(ItemCostAuditEntity::getCostTypeChanged)
+                    .containsExactly(CostType.LAST, CostType.AVERAGE);
+            assertThat(audits.getAllValues())
+                    .allSatisfy(audit -> assertThat(audit.getChangeSourceId()).isEqualTo("PO-1001"));
+            assertThat(audits.getAllValues().get(0).getActor()).isEqualTo("system");
+        }
+
+        @Test
+        void treatsAFirstReceiptAsTheOpeningAverage() {
+            when(itemCostRepository.findByItemId(ITEM_ID)).thenReturn(Optional.empty());
+
+            service.processPoReceivedEvent(poEvent("4", "25"));
+
+            ArgumentCaptor<ItemCostEntity> saved = ArgumentCaptor.forClass(ItemCostEntity.class);
+            verify(itemCostRepository).save(saved.capture());
+            assertThat(saved.getValue().getAverageCost()).isEqualByComparingTo("25.0000");
+            assertThat(saved.getValue().getQtyOnHand()).isEqualByComparingTo("4");
+        }
+
+        @Test
+        void treatsAMissingQuantityOnHandAsZero() {
+            ItemCostEntity existing = itemCost(null, null, null, null);
+            when(itemCostRepository.findByItemId(ITEM_ID)).thenReturn(Optional.of(existing));
+
+            service.processPoReceivedEvent(poEvent("2", "30"));
+
+            assertThat(existing.getQtyOnHand()).isEqualByComparingTo("2");
+            assertThat(existing.getAverageCost()).isEqualByComparingTo("30.0000");
+        }
+
+        @Test
+        void ignoresAnEventWithANonPositiveUnitCost() {
+            service.processPoReceivedEvent(poEvent("10", "0"));
+
+            verify(itemCostRepository, never()).save(any());
+            verify(itemCostAuditRepository, never()).save(any());
+        }
+
+        @Test
+        void ignoresAnEventWithNoUnitCost() {
+            service.processPoReceivedEvent(poEvent("10", null));
+
+            verify(itemCostRepository, never()).save(any());
+        }
+
+        @Test
+        void ignoresAnEventWithANonPositiveQuantity() {
+            service.processPoReceivedEvent(poEvent("0", "10"));
+
+            verify(itemCostRepository, never()).save(any());
+        }
+
+        @Test
+        void ignoresAnEventWithNoQuantity() {
+            service.processPoReceivedEvent(poEvent(null, "10"));
+
+            verify(itemCostRepository, never()).save(any());
+        }
+    }
+}

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/LocationPriceOverrideServiceImplTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/LocationPriceOverrideServiceImplTest.java
@@ -1,0 +1,644 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.dto.EffectiveLocationPriceResponseDto;
+import com.positivity.catalog.internal.dto.GuardrailPolicyUpsertRequestDto;
+import com.positivity.catalog.internal.dto.LocationPriceOverrideCreateRequestDto;
+import com.positivity.catalog.internal.dto.LocationPriceOverrideDecisionRequestDto;
+import com.positivity.catalog.internal.dto.LocationPriceOverrideResponseDto;
+import com.positivity.catalog.internal.entity.ApprovalRequestEntity;
+import com.positivity.catalog.internal.entity.ApprovalRequestStatus;
+import com.positivity.catalog.internal.entity.GuardrailPolicyEntity;
+import com.positivity.catalog.internal.entity.GuardrailPolicyScope;
+import com.positivity.catalog.internal.entity.LocationPriceOverrideEntity;
+import com.positivity.catalog.internal.entity.PriceOverrideStatus;
+import com.positivity.catalog.internal.exception.CatalogNotFoundException;
+import com.positivity.catalog.internal.exception.CatalogValidationException;
+import com.positivity.catalog.internal.repository.ApprovalRequestRepository;
+import com.positivity.catalog.internal.repository.GuardrailPolicyRepository;
+import com.positivity.catalog.internal.repository.LocationPriceOverrideRepository;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import jakarta.persistence.OptimisticLockException;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Location price overrides: guardrail policy decides whether an override is auto-approved or
+ * queued for approval, and every resolved decision invalidates the product-detail cache.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("LocationPriceOverrideServiceImpl")
+class LocationPriceOverrideServiceImplTest {
+
+    private static final UUID LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a01");
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a02");
+    private static final UUID USER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a03");
+    private static final UUID OVERRIDE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a04");
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+
+    @Mock
+    private LocationPriceOverrideRepository locationPriceOverrideRepository;
+
+    @Mock
+    private GuardrailPolicyRepository guardrailPolicyRepository;
+
+    @Mock
+    private ApprovalRequestRepository approvalRequestRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private ProductDetailCacheInvalidationPublisher productDetailCacheInvalidationPublisher;
+
+    private LocationPriceOverrideServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LocationPriceOverrideServiceImpl(
+                locationPriceOverrideRepository,
+                guardrailPolicyRepository,
+                approvalRequestRepository,
+                productRepository,
+                productDetailCacheInvalidationPublisher,
+                Clock.fixed(NOW, ZoneOffset.UTC));
+        when(productRepository.existsById(PRODUCT_ID)).thenReturn(true);
+        when(locationPriceOverrideRepository.save(any())).thenAnswer(invocation -> {
+            LocationPriceOverrideEntity entity = invocation.getArgument(0);
+            if (entity.getId() == null) {
+                entity.setId(OVERRIDE_ID);
+            }
+            return entity;
+        });
+        when(approvalRequestRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    private static GuardrailPolicyEntity policy(String minMargin, String maxDiscount, String autoApproval) {
+        GuardrailPolicyEntity policy = new GuardrailPolicyEntity();
+        policy.setScope(GuardrailPolicyScope.LOCATION);
+        policy.setScopeId(LOCATION_ID);
+        policy.setMinMarginPercent(new BigDecimal(minMargin));
+        policy.setMaxDiscountPercent(new BigDecimal(maxDiscount));
+        policy.setAutoApprovalThresholdPercent(new BigDecimal(autoApproval));
+        return policy;
+    }
+
+    private void stubPolicy(GuardrailPolicyEntity policy) {
+        when(guardrailPolicyRepository.findTopByScopeAndScopeIdOrderByCreatedAtDesc(
+                        GuardrailPolicyScope.LOCATION, LOCATION_ID))
+                .thenReturn(Optional.ofNullable(policy));
+    }
+
+    private static LocationPriceOverrideCreateRequestDto createRequest(String basePrice, String overridePrice) {
+        LocationPriceOverrideCreateRequestDto request = new LocationPriceOverrideCreateRequestDto();
+        request.setLocationId(LOCATION_ID);
+        request.setProductId(PRODUCT_ID);
+        request.setCreatedByUserId(USER_ID);
+        request.setBasePrice(new BigDecimal(basePrice));
+        request.setOverridePrice(new BigDecimal(overridePrice));
+        return request;
+    }
+
+    private static LocationPriceOverrideDecisionRequestDto decisionRequest(Long version) {
+        LocationPriceOverrideDecisionRequestDto request = new LocationPriceOverrideDecisionRequestDto();
+        request.setVersion(version);
+        request.setActorUserId(USER_ID);
+        request.setRejectionReasonCode("PRICE_TOO_LOW");
+        request.setRejectionNotes("Below floor for this line.");
+        return request;
+    }
+
+    private static LocationPriceOverrideEntity override(PriceOverrideStatus status, Long version) {
+        LocationPriceOverrideEntity override = new LocationPriceOverrideEntity();
+        override.setId(OVERRIDE_ID);
+        override.setVersion(version);
+        override.setLocationId(LOCATION_ID);
+        override.setProductId(PRODUCT_ID);
+        override.setBasePrice(new BigDecimal("100.00"));
+        override.setOverridePrice(new BigDecimal("90.00"));
+        override.setStatus(status);
+        return override;
+    }
+
+    private static ApprovalRequestEntity approvalRequest() {
+        ApprovalRequestEntity approvalRequest = new ApprovalRequestEntity();
+        approvalRequest.setOverrideId(OVERRIDE_ID);
+        approvalRequest.setStatus(ApprovalRequestStatus.PENDING);
+        return approvalRequest;
+    }
+
+    @Nested
+    @DisplayName("upsertLocationGuardrailPolicy")
+    class UpsertLocationGuardrailPolicy {
+
+        private GuardrailPolicyUpsertRequestDto policyRequest() {
+            GuardrailPolicyUpsertRequestDto request = new GuardrailPolicyUpsertRequestDto();
+            request.setScopeId(LOCATION_ID);
+            request.setMinMarginPercent(new BigDecimal("10"));
+            request.setMaxDiscountPercent(new BigDecimal("25"));
+            request.setAutoApprovalThresholdPercent(new BigDecimal("5"));
+            return request;
+        }
+
+        @Test
+        void createsThePolicyWhenTheLocationHasNoneYet() {
+            stubPolicy(null);
+
+            LocationPriceOverrideResponseDto response = service.upsertLocationGuardrailPolicy(policyRequest());
+
+            ArgumentCaptor<GuardrailPolicyEntity> saved = ArgumentCaptor.forClass(GuardrailPolicyEntity.class);
+            verify(guardrailPolicyRepository).save(saved.capture());
+            assertThat(saved.getValue().getScope()).isEqualTo(GuardrailPolicyScope.LOCATION);
+            assertThat(saved.getValue().getScopeId()).isEqualTo(LOCATION_ID);
+            assertThat(saved.getValue().getMaxDiscountPercent()).isEqualByComparingTo("25");
+            assertThat(response.getLocationId()).isEqualTo(LOCATION_ID);
+        }
+
+        @Test
+        void updatesTheLatestExistingPolicyRatherThanAddingAnother() {
+            GuardrailPolicyEntity existing = policy("1", "2", "3");
+            stubPolicy(existing);
+
+            service.upsertLocationGuardrailPolicy(policyRequest());
+
+            verify(guardrailPolicyRepository).save(existing);
+            assertThat(existing.getMinMarginPercent()).isEqualByComparingTo("10");
+            assertThat(existing.getAutoApprovalThresholdPercent()).isEqualByComparingTo("5");
+        }
+
+        @Test
+        void rejectsAPolicyMissingItsScope() {
+            GuardrailPolicyUpsertRequestDto request = policyRequest();
+            request.setScopeId(null);
+
+            assertThatThrownBy(() -> service.upsertLocationGuardrailPolicy(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("scopeId is required");
+        }
+
+        @Test
+        void rejectsAPolicyMissingItsMinimumMargin() {
+            GuardrailPolicyUpsertRequestDto request = policyRequest();
+            request.setMinMarginPercent(null);
+
+            assertThatThrownBy(() -> service.upsertLocationGuardrailPolicy(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("minMarginPercent is required");
+        }
+
+        @Test
+        void rejectsAPolicyMissingItsMaximumDiscount() {
+            GuardrailPolicyUpsertRequestDto request = policyRequest();
+            request.setMaxDiscountPercent(null);
+
+            assertThatThrownBy(() -> service.upsertLocationGuardrailPolicy(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("maxDiscountPercent is required");
+        }
+
+        @Test
+        void rejectsAPolicyMissingItsAutoApprovalThreshold() {
+            GuardrailPolicyUpsertRequestDto request = policyRequest();
+            request.setAutoApprovalThresholdPercent(null);
+
+            assertThatThrownBy(() -> service.upsertLocationGuardrailPolicy(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("autoApprovalThresholdPercent is required");
+        }
+    }
+
+    @Nested
+    @DisplayName("createOverride")
+    class CreateOverride {
+
+        @Test
+        void activatesAnOverrideInsideTheAutoApprovalThreshold() {
+            stubPolicy(policy("10", "25", "15"));
+
+            LocationPriceOverrideResponseDto response = service.createOverride(createRequest("100.00", "90.00"));
+
+            ArgumentCaptor<LocationPriceOverrideEntity> saved =
+                    ArgumentCaptor.forClass(LocationPriceOverrideEntity.class);
+            verify(locationPriceOverrideRepository).save(saved.capture());
+            assertThat(saved.getValue().getStatus()).isEqualTo(PriceOverrideStatus.ACTIVE);
+            assertThat(saved.getValue().getResolvedAt()).isEqualTo(NOW);
+            assertThat(saved.getValue().getDiscountPercent()).isEqualByComparingTo("10.0000");
+            assertThat(response.getStatus()).isEqualTo(PriceOverrideStatus.ACTIVE);
+            // Auto-approved overrides never raise an approval request.
+            verifyNoInteractions(approvalRequestRepository);
+            verify(productDetailCacheInvalidationPublisher).invalidateProductAtLocation(PRODUCT_ID, LOCATION_ID);
+        }
+
+        @Test
+        void queuesAnApprovalRequestWhenTheDiscountExceedsTheAutoApprovalThreshold() {
+            stubPolicy(policy("10", "25", "5"));
+
+            LocationPriceOverrideResponseDto response = service.createOverride(createRequest("100.00", "90.00"));
+
+            assertThat(response.getStatus()).isEqualTo(PriceOverrideStatus.PENDING_APPROVAL);
+            ArgumentCaptor<ApprovalRequestEntity> approval = ArgumentCaptor.forClass(ApprovalRequestEntity.class);
+            verify(approvalRequestRepository).save(approval.capture());
+            assertThat(approval.getValue().getOverrideId()).isEqualTo(OVERRIDE_ID);
+            assertThat(approval.getValue().getStatus()).isEqualTo(ApprovalRequestStatus.PENDING);
+            assertThat(approval.getValue().getAssignmentStrategy()).isEqualTo("LOCATION_SCOPE_PRIMARY_THEN_POOL");
+            // The approver assignment is derived from location+product, so it is stable per pair.
+            assertThat(response.getAssignedApproverId())
+                    .isEqualTo(UUID.nameUUIDFromBytes(
+                            (LOCATION_ID + ":" + PRODUCT_ID).getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+        }
+
+        @Test
+        void recordsTheMarginWhenACostIsSupplied() {
+            stubPolicy(policy("10", "25", "15"));
+            LocationPriceOverrideCreateRequestDto request = createRequest("100.00", "90.00");
+            request.setCost(new BigDecimal("45.00"));
+
+            LocationPriceOverrideResponseDto response = service.createOverride(request);
+
+            assertThat(response.getMarginPercent()).isEqualByComparingTo("50.0000");
+        }
+
+        @Test
+        void leavesTheMarginUnsetWhenNoCostIsKnown() {
+            stubPolicy(policy("10", "25", "15"));
+
+            assertThat(service.createOverride(createRequest("100.00", "90.00")).getMarginPercent())
+                    .isNull();
+        }
+
+        @Test
+        void deactivatesAnExistingActiveOverrideForTheSamePair() {
+            stubPolicy(policy("10", "25", "15"));
+            LocationPriceOverrideEntity existing = override(PriceOverrideStatus.ACTIVE, 0L);
+            when(locationPriceOverrideRepository.findByLocationIdAndProductIdAndStatus(
+                            LOCATION_ID, PRODUCT_ID, PriceOverrideStatus.ACTIVE))
+                    .thenReturn(List.of(existing));
+
+            service.createOverride(createRequest("100.00", "90.00"));
+
+            assertThat(existing.getStatus()).isEqualTo(PriceOverrideStatus.INACTIVE);
+            assertThat(existing.getResolvedAt()).isEqualTo(NOW);
+            verify(locationPriceOverrideRepository).save(existing);
+        }
+
+        @Test
+        void rejectsADiscountBeyondThePolicyMaximum() {
+            stubPolicy(policy("10", "5", "5"));
+
+            LocationPriceOverrideCreateRequestDto request = createRequest("100.00", "90.00");
+
+            assertThatThrownBy(() -> service.createOverride(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("MAX_DISCOUNT_EXCEEDED");
+            verify(locationPriceOverrideRepository, never()).save(any());
+        }
+
+        @Test
+        void rejectsAMarginBelowThePolicyMinimum() {
+            stubPolicy(policy("60", "25", "15"));
+            LocationPriceOverrideCreateRequestDto request = createRequest("100.00", "90.00");
+            request.setCost(new BigDecimal("45.00"));
+
+            assertThatThrownBy(() -> service.createOverride(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("MIN_MARGIN_VIOLATION");
+        }
+
+        @Test
+        void rejectsAnOverrideForALocationWithNoPolicy() {
+            stubPolicy(null);
+
+            LocationPriceOverrideCreateRequestDto request = createRequest("100.00", "90.00");
+
+            assertThatThrownBy(() -> service.createOverride(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("GUARDRAIL_POLICY_NOT_FOUND");
+        }
+
+        @Test
+        void rejectsAnOverrideForAnUnknownProduct() {
+            when(productRepository.existsById(PRODUCT_ID)).thenReturn(false);
+
+            LocationPriceOverrideCreateRequestDto request = createRequest("100.00", "90.00");
+
+            assertThatThrownBy(() -> service.createOverride(request))
+                    .isInstanceOf(CatalogNotFoundException.class)
+                    .hasMessageContaining("PRODUCT_NOT_FOUND");
+        }
+
+        @Test
+        void rejectsARequestMissingItsLocation() {
+            LocationPriceOverrideCreateRequestDto request = createRequest("100.00", "90.00");
+            request.setLocationId(null);
+
+            assertThatThrownBy(() -> service.createOverride(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("locationId is required");
+        }
+
+        @Test
+        void rejectsARequestMissingItsProduct() {
+            LocationPriceOverrideCreateRequestDto request = createRequest("100.00", "90.00");
+            request.setProductId(null);
+
+            assertThatThrownBy(() -> service.createOverride(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("productId is required");
+        }
+
+        @Test
+        void rejectsARequestMissingItsAuthor() {
+            LocationPriceOverrideCreateRequestDto request = createRequest("100.00", "90.00");
+            request.setCreatedByUserId(null);
+
+            assertThatThrownBy(() -> service.createOverride(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("createdByUserId is required");
+        }
+
+        @Test
+        void rejectsANonPositiveBasePrice() {
+            LocationPriceOverrideCreateRequestDto request = createRequest("0.00", "90.00");
+
+            assertThatThrownBy(() -> service.createOverride(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("basePrice must be positive");
+        }
+
+        @Test
+        void rejectsAMissingBasePrice() {
+            LocationPriceOverrideCreateRequestDto request = createRequest("100.00", "90.00");
+            request.setBasePrice(null);
+
+            assertThatThrownBy(() -> service.createOverride(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("basePrice must be positive");
+        }
+
+        @Test
+        void rejectsANonPositiveOverridePrice() {
+            LocationPriceOverrideCreateRequestDto request = createRequest("100.00", "0.00");
+
+            assertThatThrownBy(() -> service.createOverride(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("overridePrice must be positive");
+        }
+
+        @Test
+        void rejectsAMissingOverridePrice() {
+            LocationPriceOverrideCreateRequestDto request = createRequest("100.00", "90.00");
+            request.setOverridePrice(null);
+
+            assertThatThrownBy(() -> service.createOverride(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("overridePrice must be positive");
+        }
+
+        @Test
+        void rejectsANegativeCost() {
+            LocationPriceOverrideCreateRequestDto request = createRequest("100.00", "90.00");
+            request.setCost(new BigDecimal("-1"));
+
+            assertThatThrownBy(() -> service.createOverride(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("cost cannot be negative");
+        }
+
+        @Test
+        void rejectsAnOverridePriceAboveTheBasePrice() {
+            LocationPriceOverrideCreateRequestDto request = createRequest("100.00", "110.00");
+
+            assertThatThrownBy(() -> service.createOverride(request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("overridePrice cannot exceed basePrice");
+        }
+    }
+
+    @Nested
+    @DisplayName("getEffectivePrice")
+    class GetEffectivePrice {
+
+        @Test
+        void servesTheOverridePriceWhileAnActiveOverrideExists() {
+            when(locationPriceOverrideRepository.findTopByLocationIdAndProductIdAndStatusOrderByCreatedAtDesc(
+                            LOCATION_ID, PRODUCT_ID, PriceOverrideStatus.ACTIVE))
+                    .thenReturn(Optional.of(override(PriceOverrideStatus.ACTIVE, 0L)));
+
+            EffectiveLocationPriceResponseDto response = service.getEffectivePrice(LOCATION_ID, PRODUCT_ID);
+
+            assertThat(response.getEffectivePrice()).isEqualByComparingTo("90.00");
+            assertThat(response.getOverrideStatus()).isEqualTo(PriceOverrideStatus.ACTIVE);
+        }
+
+        @Test
+        void keepsChargingTheBasePriceWhileAnOverrideIsStillPending() {
+            when(locationPriceOverrideRepository.findTopByLocationIdAndProductIdAndStatusOrderByCreatedAtDesc(
+                            LOCATION_ID, PRODUCT_ID, PriceOverrideStatus.ACTIVE))
+                    .thenReturn(Optional.empty());
+            when(locationPriceOverrideRepository.findTopByLocationIdAndProductIdAndStatusOrderByCreatedAtDesc(
+                            LOCATION_ID, PRODUCT_ID, PriceOverrideStatus.PENDING_APPROVAL))
+                    .thenReturn(Optional.of(override(PriceOverrideStatus.PENDING_APPROVAL, 0L)));
+
+            EffectiveLocationPriceResponseDto response = service.getEffectivePrice(LOCATION_ID, PRODUCT_ID);
+
+            assertThat(response.getEffectivePrice()).isEqualByComparingTo("100.00");
+            assertThat(response.getOverrideStatus()).isEqualTo(PriceOverrideStatus.PENDING_APPROVAL);
+        }
+
+        @Test
+        void failsWhenNeitherAnActiveNorAPendingOverrideExists() {
+            when(locationPriceOverrideRepository.findTopByLocationIdAndProductIdAndStatusOrderByCreatedAtDesc(
+                            any(), any(), any()))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getEffectivePrice(LOCATION_ID, PRODUCT_ID))
+                    .isInstanceOf(CatalogNotFoundException.class)
+                    .hasMessageContaining("EFFECTIVE_PRICE_NOT_FOUND");
+        }
+    }
+
+    @Nested
+    @DisplayName("approveOverride")
+    class ApproveOverride {
+
+        @Test
+        void activatesThePendingOverrideAndClosesItsApprovalRequest() {
+            LocationPriceOverrideEntity pending = override(PriceOverrideStatus.PENDING_APPROVAL, 3L);
+            when(locationPriceOverrideRepository.findById(OVERRIDE_ID)).thenReturn(Optional.of(pending));
+            ApprovalRequestEntity approval = approvalRequest();
+            when(approvalRequestRepository.findByOverrideId(OVERRIDE_ID)).thenReturn(Optional.of(approval));
+
+            LocationPriceOverrideResponseDto response = service.approveOverride(OVERRIDE_ID, decisionRequest(3L));
+
+            assertThat(pending.getStatus()).isEqualTo(PriceOverrideStatus.ACTIVE);
+            assertThat(pending.getApprovedByUserId()).isEqualTo(USER_ID);
+            assertThat(pending.getApprovedAt()).isEqualTo(NOW);
+            assertThat(pending.getResolvedAt()).isEqualTo(NOW);
+            assertThat(approval.getStatus()).isEqualTo(ApprovalRequestStatus.APPROVED);
+            assertThat(approval.getResolvedAt()).isEqualTo(NOW);
+            assertThat(response.getStatus()).isEqualTo(PriceOverrideStatus.ACTIVE);
+            verify(productDetailCacheInvalidationPublisher).invalidateProductAtLocation(PRODUCT_ID, LOCATION_ID);
+        }
+
+        @Test
+        void failsWhenTheOverrideDoesNotExist() {
+            when(locationPriceOverrideRepository.findById(OVERRIDE_ID)).thenReturn(Optional.empty());
+            LocationPriceOverrideDecisionRequestDto request = decisionRequest(3L);
+
+            assertThatThrownBy(() -> service.approveOverride(OVERRIDE_ID, request))
+                    .isInstanceOf(CatalogNotFoundException.class)
+                    .hasMessageContaining("OVERRIDE_NOT_FOUND");
+        }
+
+        @Test
+        void failsWhenTheCallersVersionIsStale() {
+            when(locationPriceOverrideRepository.findById(OVERRIDE_ID))
+                    .thenReturn(Optional.of(override(PriceOverrideStatus.PENDING_APPROVAL, 4L)));
+            LocationPriceOverrideDecisionRequestDto request = decisionRequest(3L);
+
+            assertThatThrownBy(() -> service.approveOverride(OVERRIDE_ID, request))
+                    .isInstanceOf(OptimisticLockException.class);
+        }
+
+        @Test
+        void failsWhenTheOverrideIsNoLongerPending() {
+            when(locationPriceOverrideRepository.findById(OVERRIDE_ID))
+                    .thenReturn(Optional.of(override(PriceOverrideStatus.ACTIVE, 3L)));
+            LocationPriceOverrideDecisionRequestDto request = decisionRequest(3L);
+
+            assertThatThrownBy(() -> service.approveOverride(OVERRIDE_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("INVALID_STATUS");
+        }
+
+        @Test
+        void failsWhenTheApprovalRequestIsMissing() {
+            when(locationPriceOverrideRepository.findById(OVERRIDE_ID))
+                    .thenReturn(Optional.of(override(PriceOverrideStatus.PENDING_APPROVAL, 3L)));
+            when(approvalRequestRepository.findByOverrideId(OVERRIDE_ID)).thenReturn(Optional.empty());
+            LocationPriceOverrideDecisionRequestDto request = decisionRequest(3L);
+
+            assertThatThrownBy(() -> service.approveOverride(OVERRIDE_ID, request))
+                    .isInstanceOf(CatalogNotFoundException.class)
+                    .hasMessageContaining("APPROVAL_REQUEST_NOT_FOUND");
+        }
+
+        @Test
+        void rejectsADecisionCarryingNoVersion() {
+            LocationPriceOverrideDecisionRequestDto request = decisionRequest(null);
+
+            assertThatThrownBy(() -> service.approveOverride(OVERRIDE_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("version is required");
+        }
+
+        @Test
+        void rejectsADecisionCarryingNoActor() {
+            LocationPriceOverrideDecisionRequestDto request = decisionRequest(3L);
+            request.setActorUserId(null);
+
+            assertThatThrownBy(() -> service.approveOverride(OVERRIDE_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("actorUserId is required");
+        }
+    }
+
+    @Nested
+    @DisplayName("rejectOverride")
+    class RejectOverride {
+
+        @Test
+        void rejectsThePendingOverrideAndClosesItsApprovalRequest() {
+            LocationPriceOverrideEntity pending = override(PriceOverrideStatus.PENDING_APPROVAL, 3L);
+            when(locationPriceOverrideRepository.findById(OVERRIDE_ID)).thenReturn(Optional.of(pending));
+            ApprovalRequestEntity approval = approvalRequest();
+            when(approvalRequestRepository.findByOverrideId(OVERRIDE_ID)).thenReturn(Optional.of(approval));
+
+            LocationPriceOverrideResponseDto response = service.rejectOverride(OVERRIDE_ID, decisionRequest(3L));
+
+            assertThat(pending.getStatus()).isEqualTo(PriceOverrideStatus.REJECTED);
+            assertThat(pending.getRejectedBy()).isEqualTo(USER_ID);
+            assertThat(pending.getRejectionReasonCode()).isEqualTo("PRICE_TOO_LOW");
+            assertThat(pending.getRejectionNotes()).isEqualTo("Below floor for this line.");
+            assertThat(approval.getStatus()).isEqualTo(ApprovalRequestStatus.REJECTED);
+            assertThat(response.getStatus()).isEqualTo(PriceOverrideStatus.REJECTED);
+            verify(productDetailCacheInvalidationPublisher).invalidateProductAtLocation(PRODUCT_ID, LOCATION_ID);
+        }
+
+        @Test
+        void requiresAReasonCode() {
+            LocationPriceOverrideDecisionRequestDto request = decisionRequest(3L);
+            request.setRejectionReasonCode("  ");
+
+            assertThatThrownBy(() -> service.rejectOverride(OVERRIDE_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("rejectionReasonCode is required");
+        }
+
+        @Test
+        void requiresRejectionNotes() {
+            LocationPriceOverrideDecisionRequestDto request = decisionRequest(3L);
+            request.setRejectionNotes(null);
+
+            assertThatThrownBy(() -> service.rejectOverride(OVERRIDE_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("rejectionNotes are required");
+        }
+
+        @Test
+        void failsWhenTheOverrideIsNoLongerPending() {
+            when(locationPriceOverrideRepository.findById(OVERRIDE_ID))
+                    .thenReturn(Optional.of(override(PriceOverrideStatus.REJECTED, 3L)));
+            LocationPriceOverrideDecisionRequestDto request = decisionRequest(3L);
+
+            assertThatThrownBy(() -> service.rejectOverride(OVERRIDE_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("INVALID_STATUS");
+        }
+
+        @Test
+        void failsWhenTheOverrideDoesNotExist() {
+            when(locationPriceOverrideRepository.findById(OVERRIDE_ID)).thenReturn(Optional.empty());
+            LocationPriceOverrideDecisionRequestDto request = decisionRequest(3L);
+
+            assertThatThrownBy(() -> service.rejectOverride(OVERRIDE_ID, request))
+                    .isInstanceOf(CatalogNotFoundException.class)
+                    .hasMessageContaining("OVERRIDE_NOT_FOUND");
+        }
+
+        @Test
+        void failsWhenTheApprovalRequestIsMissing() {
+            when(locationPriceOverrideRepository.findById(OVERRIDE_ID))
+                    .thenReturn(Optional.of(override(PriceOverrideStatus.PENDING_APPROVAL, 3L)));
+            when(approvalRequestRepository.findByOverrideId(OVERRIDE_ID)).thenReturn(Optional.empty());
+            LocationPriceOverrideDecisionRequestDto request = decisionRequest(3L);
+
+            assertThatThrownBy(() -> service.rejectOverride(OVERRIDE_ID, request))
+                    .isInstanceOf(CatalogNotFoundException.class)
+                    .hasMessageContaining("APPROVAL_REQUEST_NOT_FOUND");
+        }
+    }
+}

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductLifecycleServiceImplTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductLifecycleServiceImplTest.java
@@ -1,0 +1,574 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.config.CatalogFactPublisher;
+import com.positivity.catalog.internal.dto.ProductLifecycleResponse;
+import com.positivity.catalog.internal.dto.ProductLifecycleUpdateRequest;
+import com.positivity.catalog.internal.dto.ProductReplacementRequest;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.ProductLifecycleState;
+import com.positivity.catalog.internal.entity.ProductReplacementEntity;
+import com.positivity.catalog.internal.exception.CatalogBusinessRuleException;
+import com.positivity.catalog.internal.exception.CatalogForbiddenOperationException;
+import com.positivity.catalog.internal.exception.CatalogNotFoundException;
+import com.positivity.catalog.internal.exception.CatalogValidationException;
+import com.positivity.catalog.internal.repository.ProductReplacementRepository;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import com.positivity.security.common.GatewaySecurityConstants;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Product lifecycle transitions. Discontinuation is a one-way door unless the caller holds
+ * {@code product:lifecycle:override_discontinued} and states a reason, and every accepted
+ * transition invalidates the product-detail cache and publishes a product fact.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ProductLifecycleServiceImpl")
+class ProductLifecycleServiceImplTest {
+
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7a01");
+    private static final UUID REPLACEMENT_PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7a02");
+    private static final UUID REPLACEMENT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7a03");
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final String OVERRIDE_AUTHORITY = "product:lifecycle:override_discontinued";
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private ProductReplacementRepository productReplacementRepository;
+
+    @Mock
+    private ProductDetailCacheInvalidationPublisher productDetailCacheInvalidationPublisher;
+
+    @Mock
+    private CatalogFactPublisher catalogFactPublisher;
+
+    private MeterRegistry meterRegistry;
+    private ProductLifecycleServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        service = new ProductLifecycleServiceImpl(
+                productRepository,
+                productReplacementRepository,
+                meterRegistry,
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                productDetailCacheInvalidationPublisher,
+                catalogFactPublisher);
+        when(productRepository.save(any(ProductEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(productReplacementRepository.save(any(ProductReplacementEntity.class)))
+                .thenAnswer(inv -> {
+                    ProductReplacementEntity entity = inv.getArgument(0);
+                    ReflectionTestUtils.setField(entity, "replacementId", REPLACEMENT_ID);
+                    return entity;
+                });
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    /**
+     * The gateway hands services the audit identity in the authentication details map
+     * ({@code X-User} → {@code username}); {@code SecurityContextHelper} reads that map first
+     * and falls back to the default when it is absent, so a realistic token must carry it.
+     */
+    private static void authenticateAs(String username, String... authorities) {
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                username,
+                "n/a",
+                java.util.Arrays.stream(authorities)
+                        .map(SimpleGrantedAuthority::new)
+                        .toList());
+        token.setDetails(Map.of(GatewaySecurityConstants.DETAIL_USERNAME, username));
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    private static ProductEntity product(UUID id, ProductLifecycleState state) {
+        ProductEntity product = new ProductEntity();
+        product.setId(id);
+        product.setName("Tire 205/55R16");
+        product.setSku("SKU-" + id);
+        product.setLifecycleState(state);
+        return product;
+    }
+
+    private void stubProduct(ProductEntity product) {
+        when(productRepository.findById(product.getId())).thenReturn(Optional.of(product));
+    }
+
+    private static ProductLifecycleUpdateRequest updateRequest(ProductLifecycleState state) {
+        ProductLifecycleUpdateRequest request = new ProductLifecycleUpdateRequest();
+        request.setLifecycleState(state);
+        request.setEffectiveAt(NOW);
+        return request;
+    }
+
+    private double counter(String name) {
+        return meterRegistry.counter(name).count();
+    }
+
+    @Nested
+    @DisplayName("getLifecycle")
+    class GetLifecycle {
+
+        @Test
+        void reportsTheStateAndItsReplacementOptions() {
+            ProductEntity product = product(PRODUCT_ID, ProductLifecycleState.DISCONTINUED);
+            product.setLifecycleStateEffectiveAt(NOW);
+            product.setLifecycleOverrideReason("End of line");
+            stubProduct(product);
+
+            ProductReplacementEntity replacement = new ProductReplacementEntity();
+            ReflectionTestUtils.setField(replacement, "replacementId", REPLACEMENT_ID);
+            replacement.setReplacementProduct(product(REPLACEMENT_PRODUCT_ID, ProductLifecycleState.ACTIVE));
+            replacement.setPriorityOrder(1);
+            replacement.setNotes("Successor SKU");
+            replacement.setEffectiveAt(NOW);
+            when(productReplacementRepository.findByOriginalProduct_IdAndDeletedAtIsNullOrderByPriorityOrderAsc(
+                            PRODUCT_ID))
+                    .thenReturn(List.of(replacement));
+
+            ProductLifecycleResponse response = service.getLifecycle(PRODUCT_ID);
+
+            assertThat(response.getProductId()).isEqualTo(PRODUCT_ID);
+            assertThat(response.getLifecycleState()).isEqualTo(ProductLifecycleState.DISCONTINUED);
+            assertThat(response.getLifecycleOverrideReason()).isEqualTo("End of line");
+            assertThat(response.getReplacementOptions()).hasSize(1);
+            assertThat(response.getReplacementOptions().get(0).getReplacementProductId())
+                    .isEqualTo(REPLACEMENT_PRODUCT_ID);
+            assertThat(response.getReplacementOptions().get(0).getNotes()).isEqualTo("Successor SKU");
+        }
+
+        @Test
+        void treatsAProductWithNoRecordedStateAsActive() {
+            stubProduct(product(PRODUCT_ID, null));
+            when(productReplacementRepository.findByOriginalProduct_IdAndDeletedAtIsNullOrderByPriorityOrderAsc(
+                            PRODUCT_ID))
+                    .thenReturn(List.of());
+
+            assertThat(service.getLifecycle(PRODUCT_ID).getLifecycleState()).isEqualTo(ProductLifecycleState.ACTIVE);
+        }
+
+        @Test
+        void failsForAnUnknownProduct() {
+            when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getLifecycle(PRODUCT_ID))
+                    .isInstanceOf(CatalogNotFoundException.class)
+                    .hasMessageContaining("Product not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateLifecycle")
+    class UpdateLifecycle {
+
+        @Test
+        void movesAnActiveProductToInactiveAndPublishesTheChange() {
+            ProductEntity product = product(PRODUCT_ID, ProductLifecycleState.ACTIVE);
+            stubProduct(product);
+            when(productReplacementRepository.findByOriginalProduct_IdAndDeletedAtIsNullOrderByPriorityOrderAsc(
+                            PRODUCT_ID))
+                    .thenReturn(List.of());
+            authenticateAs("jane.smith");
+
+            ProductLifecycleResponse response =
+                    service.updateLifecycle(PRODUCT_ID, updateRequest(ProductLifecycleState.INACTIVE));
+
+            assertThat(product.getLifecycleState()).isEqualTo(ProductLifecycleState.INACTIVE);
+            assertThat(product.getLifecycleStateEffectiveAt()).isEqualTo(NOW);
+            assertThat(product.getLastStateChangedAt()).isEqualTo(NOW);
+            // A non-UUID principal is hashed to a stable actor id.
+            assertThat(product.getLastStateChangedBy())
+                    .isEqualTo(UUID.nameUUIDFromBytes("jane.smith".getBytes(StandardCharsets.UTF_8)));
+            assertThat(response.getLifecycleState()).isEqualTo(ProductLifecycleState.INACTIVE);
+            verify(productDetailCacheInvalidationPublisher).invalidateProduct(PRODUCT_ID);
+            verify(catalogFactPublisher).publishProductUpdated(product);
+            assertThat(counter("product.lifecycle.state_change.success.count")).isEqualTo(1.0d);
+        }
+
+        @Test
+        void keepsAUuidPrincipalAsTheActorId() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.ACTIVE));
+            when(productReplacementRepository.findByOriginalProduct_IdAndDeletedAtIsNullOrderByPriorityOrderAsc(
+                            PRODUCT_ID))
+                    .thenReturn(List.of());
+            authenticateAs(REPLACEMENT_PRODUCT_ID.toString());
+
+            service.updateLifecycle(PRODUCT_ID, updateRequest(ProductLifecycleState.INACTIVE));
+
+            verify(productRepository)
+                    .save(org.mockito.ArgumentMatchers.argThat(
+                            saved -> REPLACEMENT_PRODUCT_ID.equals(saved.getLastStateChangedBy())));
+        }
+
+        @Test
+        void acceptsAnEffectiveDateInsteadOfAnEffectiveInstant() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.ACTIVE));
+            when(productReplacementRepository.findByOriginalProduct_IdAndDeletedAtIsNullOrderByPriorityOrderAsc(
+                            PRODUCT_ID))
+                    .thenReturn(List.of());
+            ProductLifecycleUpdateRequest request = new ProductLifecycleUpdateRequest();
+            request.setLifecycleState(ProductLifecycleState.INACTIVE);
+            request.setEffectiveDate(LocalDate.of(2026, 3, 2));
+
+            service.updateLifecycle(PRODUCT_ID, request);
+
+            verify(productRepository)
+                    .save(org.mockito.ArgumentMatchers.argThat(saved ->
+                            Instant.parse("2026-03-02T00:00:00Z").equals(saved.getLifecycleStateEffectiveAt())));
+        }
+
+        @Test
+        void rejectsANullRequest() {
+            assertThatThrownBy(() -> service.updateLifecycle(PRODUCT_ID, null))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("request is required");
+            assertThat(counter("product.lifecycle.state_change.denied.count")).isEqualTo(1.0d);
+        }
+
+        @Test
+        void rejectsARequestWithNoTargetState() {
+            ProductLifecycleUpdateRequest request = new ProductLifecycleUpdateRequest();
+            request.setEffectiveAt(NOW);
+
+            assertThatThrownBy(() -> service.updateLifecycle(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("lifecycleState is required");
+        }
+
+        @Test
+        void rejectsARequestWithNeitherAnEffectiveInstantNorDate() {
+            ProductLifecycleUpdateRequest request = new ProductLifecycleUpdateRequest();
+            request.setLifecycleState(ProductLifecycleState.INACTIVE);
+
+            assertThatThrownBy(() -> service.updateLifecycle(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("either effectiveAt or effectiveDate is required");
+        }
+
+        @Test
+        void rejectsATransitionToTheStateTheProductIsAlreadyIn() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.ACTIVE));
+
+            ProductLifecycleUpdateRequest request = updateRequest(ProductLifecycleState.ACTIVE);
+
+            assertThatThrownBy(() -> service.updateLifecycle(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("already set to ACTIVE");
+        }
+
+        @Test
+        void refusesToReactivateADiscontinuedProduct() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.DISCONTINUED));
+            authenticateAs("jane.smith", OVERRIDE_AUTHORITY);
+
+            ProductLifecycleUpdateRequest request = updateRequest(ProductLifecycleState.ACTIVE);
+
+            assertThatThrownBy(() -> service.updateLifecycle(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogBusinessRuleException.class)
+                    .hasMessageContaining("cannot be reactivated");
+            verify(productRepository, never()).save(any());
+        }
+
+        @Test
+        void refusesToDiscontinueWithoutTheOverridePermission() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.ACTIVE));
+            authenticateAs("jane.smith");
+
+            ProductLifecycleUpdateRequest request = updateRequest(ProductLifecycleState.DISCONTINUED);
+            request.setOverrideReason("End of line");
+
+            assertThatThrownBy(() -> service.updateLifecycle(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogForbiddenOperationException.class)
+                    .hasMessageContaining(OVERRIDE_AUTHORITY);
+        }
+
+        @Test
+        void refusesToDiscontinueWhenThereIsNoAuthenticationAtAll() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.ACTIVE));
+
+            ProductLifecycleUpdateRequest request = updateRequest(ProductLifecycleState.DISCONTINUED);
+            request.setOverrideReason("End of line");
+
+            assertThatThrownBy(() -> service.updateLifecycle(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogForbiddenOperationException.class);
+        }
+
+        @Test
+        void refusesToDiscontinueWithoutAStatedReason() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.ACTIVE));
+            authenticateAs("jane.smith", OVERRIDE_AUTHORITY);
+
+            ProductLifecycleUpdateRequest request = updateRequest(ProductLifecycleState.DISCONTINUED);
+            request.setOverrideReason("   ");
+
+            assertThatThrownBy(() -> service.updateLifecycle(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("overrideReason is required");
+        }
+
+        @Test
+        void discontinuesWhenThePermissionAndReasonAreBothPresent() {
+            ProductEntity product = product(PRODUCT_ID, ProductLifecycleState.ACTIVE);
+            stubProduct(product);
+            when(productReplacementRepository.findByOriginalProduct_IdAndDeletedAtIsNullOrderByPriorityOrderAsc(
+                            PRODUCT_ID))
+                    .thenReturn(List.of());
+            authenticateAs("jane.smith", OVERRIDE_AUTHORITY);
+
+            ProductLifecycleUpdateRequest request = updateRequest(ProductLifecycleState.DISCONTINUED);
+            request.setOverrideReason("End of line");
+
+            assertThat(service.updateLifecycle(PRODUCT_ID, request).getLifecycleState())
+                    .isEqualTo(ProductLifecycleState.DISCONTINUED);
+            assertThat(product.getLifecycleOverrideReason()).isEqualTo("End of line");
+        }
+
+        @Test
+        void rejectsAnEffectiveInstantInThePast() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.ACTIVE));
+
+            ProductLifecycleUpdateRequest request = new ProductLifecycleUpdateRequest();
+            request.setLifecycleState(ProductLifecycleState.INACTIVE);
+            request.setEffectiveAt(NOW.minusSeconds(600));
+
+            assertThatThrownBy(() -> service.updateLifecycle(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("effectiveAt cannot be in the past");
+        }
+
+        @Test
+        void toleratesAnEffectiveInstantASecondBehindTheClock() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.ACTIVE));
+            when(productReplacementRepository.findByOriginalProduct_IdAndDeletedAtIsNullOrderByPriorityOrderAsc(
+                            PRODUCT_ID))
+                    .thenReturn(List.of());
+
+            ProductLifecycleUpdateRequest request = new ProductLifecycleUpdateRequest();
+            request.setLifecycleState(ProductLifecycleState.INACTIVE);
+            request.setEffectiveAt(NOW.minusSeconds(1));
+
+            assertThat(service.updateLifecycle(PRODUCT_ID, request)).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("setLifecycleState")
+    class SetLifecycleState {
+
+        @Test
+        void defaultsTheEffectiveDateToTodayWhenNoneIsGiven() {
+            ProductEntity product = product(PRODUCT_ID, ProductLifecycleState.ACTIVE);
+            stubProduct(product);
+            when(productReplacementRepository.findByOriginalProduct_IdAndDeletedAtIsNullOrderByPriorityOrderAsc(
+                            PRODUCT_ID))
+                    .thenReturn(List.of());
+
+            ProductLifecycleResponse response =
+                    service.setLifecycleState(PRODUCT_ID, ProductLifecycleState.INACTIVE, NOW, null, null);
+
+            assertThat(response.getLifecycleState()).isEqualTo(ProductLifecycleState.INACTIVE);
+        }
+
+        @Test
+        void passesAnExplicitEffectiveDateThrough() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.ACTIVE));
+            when(productReplacementRepository.findByOriginalProduct_IdAndDeletedAtIsNullOrderByPriorityOrderAsc(
+                            PRODUCT_ID))
+                    .thenReturn(List.of());
+
+            service.setLifecycleState(PRODUCT_ID, ProductLifecycleState.INACTIVE, null, null, LocalDate.of(2026, 3, 5));
+
+            verify(productRepository)
+                    .save(org.mockito.ArgumentMatchers.argThat(saved ->
+                            Instant.parse("2026-03-05T00:00:00Z").equals(saved.getLifecycleStateEffectiveAt())));
+        }
+    }
+
+    @Nested
+    @DisplayName("replacements")
+    class Replacements {
+
+        private ProductReplacementRequest replacementRequest() {
+            ProductReplacementRequest request = new ProductReplacementRequest();
+            request.setReplacementProductId(REPLACEMENT_PRODUCT_ID);
+            request.setPriorityOrder(1);
+            request.setNotes("Successor SKU");
+            request.setEffectiveAt(NOW);
+            return request;
+        }
+
+        @Test
+        void addsAReplacementToADiscontinuedProduct() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.DISCONTINUED));
+            stubProduct(product(REPLACEMENT_PRODUCT_ID, ProductLifecycleState.ACTIVE));
+
+            ProductLifecycleResponse.ReplacementOption option =
+                    service.addReplacement(PRODUCT_ID, replacementRequest());
+
+            assertThat(option.getReplacementId()).isEqualTo(REPLACEMENT_ID);
+            assertThat(option.getReplacementProductId()).isEqualTo(REPLACEMENT_PRODUCT_ID);
+            assertThat(option.getPriorityOrder()).isEqualTo(1);
+            assertThat(option.getEffectiveAt()).isEqualTo(NOW);
+            verify(productDetailCacheInvalidationPublisher).invalidateProduct(PRODUCT_ID);
+        }
+
+        @Test
+        void stampsTheCurrentInstantWhenNoEffectiveAtIsGiven() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.DISCONTINUED));
+            stubProduct(product(REPLACEMENT_PRODUCT_ID, ProductLifecycleState.ACTIVE));
+            ProductReplacementRequest request = replacementRequest();
+            request.setEffectiveAt(null);
+
+            assertThat(service.addReplacement(PRODUCT_ID, request).getEffectiveAt())
+                    .isEqualTo(NOW);
+        }
+
+        @Test
+        void rejectsARequestWithoutAReplacementProduct() {
+            ProductReplacementRequest request = new ProductReplacementRequest();
+            request.setPriorityOrder(1);
+
+            assertThatThrownBy(() -> service.addReplacement(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("replacementProductId is required");
+        }
+
+        @Test
+        void rejectsANullRequest() {
+            assertThatThrownBy(() -> service.addReplacement(PRODUCT_ID, null))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("replacementProductId is required");
+        }
+
+        @Test
+        void rejectsAProductReplacingItself() {
+            ProductReplacementRequest request = replacementRequest();
+            request.setReplacementProductId(PRODUCT_ID);
+
+            assertThatThrownBy(() -> service.addReplacement(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("cannot be identical");
+        }
+
+        @Test
+        void rejectsANonPositivePriorityOrder() {
+            ProductReplacementRequest request = replacementRequest();
+            request.setPriorityOrder(0);
+
+            assertThatThrownBy(() -> service.addReplacement(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("priorityOrder must be greater than zero");
+        }
+
+        @Test
+        void rejectsAMissingPriorityOrder() {
+            ProductReplacementRequest request = replacementRequest();
+            request.setPriorityOrder(null);
+
+            assertThatThrownBy(() -> service.addReplacement(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("priorityOrder must be greater than zero");
+        }
+
+        @Test
+        void refusesToAddAReplacementToAProductThatIsStillActive() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.ACTIVE));
+            ProductReplacementRequest request = replacementRequest();
+
+            assertThatThrownBy(() -> service.addReplacement(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogBusinessRuleException.class)
+                    .hasMessageContaining("only be added when lifecycleState is DISCONTINUED");
+        }
+
+        @Test
+        void failsWhenTheReplacementProductDoesNotExist() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.DISCONTINUED));
+            when(productRepository.findById(REPLACEMENT_PRODUCT_ID)).thenReturn(Optional.empty());
+            ProductReplacementRequest request = replacementRequest();
+
+            assertThatThrownBy(() -> service.addReplacement(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogNotFoundException.class);
+        }
+
+        @Test
+        void addsAReplacementThroughTheServiceToServiceOverload() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.DISCONTINUED));
+            stubProduct(product(REPLACEMENT_PRODUCT_ID, ProductLifecycleState.ACTIVE));
+
+            ProductLifecycleResponse.ReplacementOption option =
+                    service.addReplacementProduct(PRODUCT_ID, REPLACEMENT_PRODUCT_ID, 2, "Superseded", NOW);
+
+            assertThat(option.getPriorityOrder()).isEqualTo(2);
+            assertThat(option.getNotes()).isEqualTo("Superseded");
+        }
+
+        @Test
+        void listsTheReplacementsRecordedForAProduct() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.DISCONTINUED));
+            ProductReplacementEntity replacement = new ProductReplacementEntity();
+            ReflectionTestUtils.setField(replacement, "replacementId", REPLACEMENT_ID);
+            replacement.setReplacementProduct(product(REPLACEMENT_PRODUCT_ID, ProductLifecycleState.ACTIVE));
+            replacement.setPriorityOrder(1);
+            replacement.setEffectiveAt(NOW);
+            when(productReplacementRepository.findByOriginalProduct_IdAndDeletedAtIsNullOrderByPriorityOrderAsc(
+                            PRODUCT_ID))
+                    .thenReturn(List.of(replacement));
+
+            List<ProductLifecycleResponse.ReplacementOption> options = service.getReplacementProducts(PRODUCT_ID);
+
+            assertThat(options).hasSize(1);
+            assertThat(options.get(0).getReplacementProductId()).isEqualTo(REPLACEMENT_PRODUCT_ID);
+        }
+
+        @Test
+        void tolueratesAReplacementRowWithNoTargetProduct() {
+            stubProduct(product(PRODUCT_ID, ProductLifecycleState.DISCONTINUED));
+            ProductReplacementEntity orphaned = new ProductReplacementEntity();
+            ReflectionTestUtils.setField(orphaned, "replacementId", REPLACEMENT_ID);
+            orphaned.setPriorityOrder(1);
+            when(productReplacementRepository.findByOriginalProduct_IdAndDeletedAtIsNullOrderByPriorityOrderAsc(
+                            PRODUCT_ID))
+                    .thenReturn(List.of(orphaned));
+
+            assertThat(service.getReplacementProducts(PRODUCT_ID).get(0).getReplacementProductId())
+                    .isNull();
+        }
+    }
+}

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductMsrpServiceImplTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductMsrpServiceImplTest.java
@@ -1,0 +1,437 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.dto.CreateMsrpRequestDto;
+import com.positivity.catalog.internal.dto.ProductMsrpDto;
+import com.positivity.catalog.internal.dto.UpdateMsrpRequestDto;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.ProductMsrpEntity;
+import com.positivity.catalog.internal.exception.CatalogBusinessRuleException;
+import com.positivity.catalog.internal.exception.CatalogNotFoundException;
+import com.positivity.catalog.internal.exception.CatalogValidationException;
+import com.positivity.catalog.internal.repository.ProductMsrpRepository;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import jakarta.persistence.OptimisticLockException;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Manufacturer suggested retail prices. A product may carry at most one open-ended MSRP, windows
+ * may not overlap, and a window that has already closed is immutable.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ProductMsrpServiceImpl")
+class ProductMsrpServiceImplTest {
+
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb01");
+    private static final UUID MSRP_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb02");
+    private static final UUID USER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb03");
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final LocalDate TODAY = LocalDate.of(2026, 3, 1);
+
+    @Mock
+    private ProductMsrpRepository productMsrpRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    private ProductMsrpServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service =
+                new ProductMsrpServiceImpl(Clock.fixed(NOW, ZoneOffset.UTC), productMsrpRepository, productRepository);
+        when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product()));
+        when(productMsrpRepository.findOverlapping(any(), any(), any(), any())).thenReturn(List.of());
+        when(productMsrpRepository.save(any())).thenAnswer(invocation -> {
+            ProductMsrpEntity entity = invocation.getArgument(0);
+            if (entity.getMsrpId() == null) {
+                entity.setMsrpId(MSRP_ID);
+            }
+            return entity;
+        });
+    }
+
+    private static ProductEntity product() {
+        ProductEntity product = new ProductEntity();
+        product.setId(PRODUCT_ID);
+        product.setName("Tire 205/55R16");
+        return product;
+    }
+
+    private static ProductMsrpEntity msrp(LocalDate startDate, LocalDate endDate, Long version) {
+        ProductMsrpEntity entity = new ProductMsrpEntity();
+        entity.setMsrpId(MSRP_ID);
+        entity.setProduct(product());
+        entity.setAmount(new BigDecimal("149.9900"));
+        entity.setCurrency("USD");
+        entity.setEffectiveStartDate(startDate);
+        entity.setEffectiveEndDate(endDate);
+        entity.setVersion(version);
+        entity.setCreatedAt(NOW);
+        entity.setUpdatedAt(NOW);
+        entity.setUpdatedBy(USER_ID);
+        return entity;
+    }
+
+    private static CreateMsrpRequestDto createRequest(LocalDate startDate, LocalDate endDate) {
+        CreateMsrpRequestDto request = new CreateMsrpRequestDto();
+        request.setAmount(new BigDecimal("149.99"));
+        request.setCurrency("usd");
+        request.setEffectiveStartDate(startDate);
+        request.setEffectiveEndDate(endDate);
+        request.setCreatedByUserId(USER_ID);
+        return request;
+    }
+
+    private static UpdateMsrpRequestDto updateRequest(LocalDate startDate, LocalDate endDate, Long version) {
+        UpdateMsrpRequestDto request = new UpdateMsrpRequestDto();
+        request.setAmount(new BigDecimal("159.99"));
+        request.setCurrency("USD");
+        request.setEffectiveStartDate(startDate);
+        request.setEffectiveEndDate(endDate);
+        request.setCreatedByUserId(USER_ID);
+        request.setVersion(version);
+        return request;
+    }
+
+    @Nested
+    @DisplayName("createMsrp")
+    class CreateMsrp {
+
+        @Test
+        void storesTheAmountAtFourDecimalsAndUppercasesTheCurrency() {
+            ProductMsrpDto response = service.createMsrp(PRODUCT_ID, createRequest(TODAY, null));
+
+            ArgumentCaptor<ProductMsrpEntity> saved = ArgumentCaptor.forClass(ProductMsrpEntity.class);
+            verify(productMsrpRepository).save(saved.capture());
+            assertThat(saved.getValue().getAmount()).isEqualByComparingTo("149.9900");
+            assertThat(saved.getValue().getCurrency()).isEqualTo("USD");
+            assertThat(saved.getValue().getUpdatedBy()).isEqualTo(USER_ID);
+            assertThat(response.getMsrpId()).isEqualTo(MSRP_ID);
+            assertThat(response.getProductId()).isEqualTo(PRODUCT_ID);
+            assertThat(response.getAmount()).isEqualTo("149.9900");
+        }
+
+        @Test
+        void refusesASecondOpenEndedRecordForTheSameProduct() {
+            when(productMsrpRepository.countByProduct_IdAndEffectiveEndDateIsNull(PRODUCT_ID))
+                    .thenReturn(1L);
+            CreateMsrpRequestDto request = createRequest(TODAY, null);
+
+            assertThatThrownBy(() -> service.createMsrp(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("Only one open-ended MSRP record");
+        }
+
+        @Test
+        void allowsAClosedWindowEvenWhenAnOpenEndedRecordExists() {
+            when(productMsrpRepository.countByProduct_IdAndEffectiveEndDateIsNull(PRODUCT_ID))
+                    .thenReturn(1L);
+
+            assertThat(service.createMsrp(PRODUCT_ID, createRequest(TODAY, TODAY.plusDays(30))))
+                    .isNotNull();
+        }
+
+        @Test
+        void refusesAWindowThatOverlapsAnExistingOne() {
+            when(productMsrpRepository.findOverlapping(eq(PRODUCT_ID), any(), any(), eq(null)))
+                    .thenReturn(List.of(msrp(TODAY, null, 0L)));
+            CreateMsrpRequestDto request = createRequest(TODAY, null);
+
+            assertThatThrownBy(() -> service.createMsrp(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogBusinessRuleException.class)
+                    .hasMessageContaining("overlap");
+        }
+
+        @Test
+        void failsForAnUnknownProduct() {
+            when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+            CreateMsrpRequestDto request = createRequest(TODAY, null);
+
+            assertThatThrownBy(() -> service.createMsrp(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogNotFoundException.class)
+                    .hasMessageContaining("Product not found");
+        }
+
+        @Test
+        void requiresAStartDate() {
+            CreateMsrpRequestDto request = createRequest(null, null);
+
+            assertThatThrownBy(() -> service.createMsrp(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("effectiveStartDate is required");
+        }
+
+        @Test
+        void refusesAnEndDateBeforeTheStartDate() {
+            CreateMsrpRequestDto request = createRequest(TODAY, TODAY.minusDays(1));
+
+            assertThatThrownBy(() -> service.createMsrp(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("effectiveEndDate must be on or after");
+        }
+
+        @Test
+        void requiresAPositiveAmount() {
+            CreateMsrpRequestDto request = createRequest(TODAY, null);
+            request.setAmount(BigDecimal.ZERO);
+
+            assertThatThrownBy(() -> service.createMsrp(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("amount must be positive");
+        }
+
+        @Test
+        void requiresAnAmount() {
+            CreateMsrpRequestDto request = createRequest(TODAY, null);
+            request.setAmount(null);
+
+            assertThatThrownBy(() -> service.createMsrp(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("amount must be positive");
+        }
+
+        @Test
+        void requiresAThreeLetterCurrencyCode() {
+            CreateMsrpRequestDto request = createRequest(TODAY, null);
+            request.setCurrency("DOLLARS");
+
+            assertThatThrownBy(() -> service.createMsrp(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("3-letter ISO code");
+        }
+
+        @Test
+        void requiresACurrency() {
+            CreateMsrpRequestDto request = createRequest(TODAY, null);
+            request.setCurrency("   ");
+
+            assertThatThrownBy(() -> service.createMsrp(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("3-letter ISO code");
+        }
+
+        @Test
+        void requiresANonNullCurrency() {
+            CreateMsrpRequestDto request = createRequest(TODAY, null);
+            request.setCurrency(null);
+
+            assertThatThrownBy(() -> service.createMsrp(PRODUCT_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("3-letter ISO code");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateMsrp")
+    class UpdateMsrp {
+
+        @Test
+        void appliesTheNewWindowAndAmount() {
+            ProductMsrpEntity existing = msrp(TODAY, null, 2L);
+            when(productMsrpRepository.findById(MSRP_ID)).thenReturn(Optional.of(existing));
+            when(productMsrpRepository.countByProduct_IdAndEffectiveEndDateIsNull(PRODUCT_ID))
+                    .thenReturn(1L);
+
+            ProductMsrpDto response = service.updateMsrp(PRODUCT_ID, MSRP_ID, updateRequest(TODAY, null, 2L));
+
+            assertThat(existing.getAmount()).isEqualByComparingTo("159.9900");
+            assertThat(response.getAmount()).isEqualTo("159.9900");
+            assertThat(response.getCurrency()).isEqualTo("USD");
+        }
+
+        @Test
+        void failsWhenTheRecordDoesNotExist() {
+            when(productMsrpRepository.findById(MSRP_ID)).thenReturn(Optional.empty());
+            UpdateMsrpRequestDto request = updateRequest(TODAY, null, null);
+
+            assertThatThrownBy(() -> service.updateMsrp(PRODUCT_ID, MSRP_ID, request))
+                    .isInstanceOf(CatalogNotFoundException.class)
+                    .hasMessageContaining("MSRP record not found");
+        }
+
+        @Test
+        void failsWhenTheRecordBelongsToAnotherProduct() {
+            ProductMsrpEntity foreign = msrp(TODAY, null, 0L);
+            ProductEntity otherProduct = new ProductEntity();
+            otherProduct.setId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb09"));
+            foreign.setProduct(otherProduct);
+            when(productMsrpRepository.findById(MSRP_ID)).thenReturn(Optional.of(foreign));
+            UpdateMsrpRequestDto request = updateRequest(TODAY, null, null);
+
+            assertThatThrownBy(() -> service.updateMsrp(PRODUCT_ID, MSRP_ID, request))
+                    .isInstanceOf(CatalogNotFoundException.class)
+                    .hasMessageContaining("not found for product");
+        }
+
+        @Test
+        void failsWhenTheRecordHasNoProductAtAll() {
+            ProductMsrpEntity orphaned = msrp(TODAY, null, 0L);
+            orphaned.setProduct(null);
+            when(productMsrpRepository.findById(MSRP_ID)).thenReturn(Optional.of(orphaned));
+            UpdateMsrpRequestDto request = updateRequest(TODAY, null, null);
+
+            assertThatThrownBy(() -> service.updateMsrp(PRODUCT_ID, MSRP_ID, request))
+                    .isInstanceOf(CatalogNotFoundException.class);
+        }
+
+        @Test
+        void refusesToEditAWindowThatHasAlreadyClosed() {
+            when(productMsrpRepository.findById(MSRP_ID))
+                    .thenReturn(Optional.of(msrp(TODAY.minusDays(30), TODAY.minusDays(1), 0L)));
+            UpdateMsrpRequestDto request = updateRequest(TODAY, null, null);
+
+            assertThatThrownBy(() -> service.updateMsrp(PRODUCT_ID, MSRP_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("Historical MSRP records are immutable");
+        }
+
+        @Test
+        void allowsEditingAWindowThatEndsToday() {
+            when(productMsrpRepository.findById(MSRP_ID)).thenReturn(Optional.of(msrp(TODAY.minusDays(30), TODAY, 0L)));
+
+            assertThat(service.updateMsrp(PRODUCT_ID, MSRP_ID, updateRequest(TODAY.minusDays(30), TODAY, null)))
+                    .isNotNull();
+        }
+
+        @Test
+        void failsOnAStaleVersion() {
+            when(productMsrpRepository.findById(MSRP_ID)).thenReturn(Optional.of(msrp(TODAY, null, 5L)));
+            UpdateMsrpRequestDto request = updateRequest(TODAY, null, 4L);
+
+            assertThatThrownBy(() -> service.updateMsrp(PRODUCT_ID, MSRP_ID, request))
+                    .isInstanceOf(OptimisticLockException.class);
+        }
+
+        @Test
+        void skipsTheVersionCheckWhenTheCallerSuppliesNone() {
+            when(productMsrpRepository.findById(MSRP_ID)).thenReturn(Optional.of(msrp(TODAY, TODAY.plusDays(1), 5L)));
+
+            assertThat(service.updateMsrp(PRODUCT_ID, MSRP_ID, updateRequest(TODAY, TODAY.plusDays(1), null)))
+                    .isNotNull();
+        }
+
+        @Test
+        void refusesToOpenASecondOpenEndedWindow() {
+            // This record is closed today and another record is already open-ended, so removing
+            // this one's end date would leave two open-ended windows.
+            when(productMsrpRepository.findById(MSRP_ID)).thenReturn(Optional.of(msrp(TODAY, TODAY.plusDays(5), 0L)));
+            when(productMsrpRepository.countByProduct_IdAndEffectiveEndDateIsNull(PRODUCT_ID))
+                    .thenReturn(1L);
+            UpdateMsrpRequestDto request = updateRequest(TODAY, null, null);
+
+            assertThatThrownBy(() -> service.updateMsrp(PRODUCT_ID, MSRP_ID, request))
+                    .isInstanceOf(CatalogValidationException.class)
+                    .hasMessageContaining("Only one open-ended MSRP record");
+        }
+
+        @Test
+        void letsAnAlreadyOpenEndedRecordStayOpenEnded() {
+            when(productMsrpRepository.findById(MSRP_ID)).thenReturn(Optional.of(msrp(TODAY, null, 0L)));
+            when(productMsrpRepository.countByProduct_IdAndEffectiveEndDateIsNull(PRODUCT_ID))
+                    .thenReturn(1L);
+
+            assertThat(service.updateMsrp(PRODUCT_ID, MSRP_ID, updateRequest(TODAY, null, null)))
+                    .isNotNull();
+        }
+
+        @Test
+        void refusesAWindowThatWouldOverlapAnotherRecord() {
+            when(productMsrpRepository.findById(MSRP_ID)).thenReturn(Optional.of(msrp(TODAY, null, 0L)));
+            when(productMsrpRepository.findOverlapping(eq(PRODUCT_ID), any(), any(), eq(MSRP_ID)))
+                    .thenReturn(List.of(msrp(TODAY, null, 0L)));
+            UpdateMsrpRequestDto request = updateRequest(TODAY, TODAY.plusDays(1), null);
+
+            assertThatThrownBy(() -> service.updateMsrp(PRODUCT_ID, MSRP_ID, request))
+                    .isInstanceOf(CatalogBusinessRuleException.class);
+        }
+
+        @Test
+        void validatesTheRequestBeforeLoadingAnything() {
+            UpdateMsrpRequestDto request = updateRequest(null, null, null);
+
+            assertThatThrownBy(() -> service.updateMsrp(PRODUCT_ID, MSRP_ID, request))
+                    .isInstanceOf(CatalogValidationException.class);
+            verify(productMsrpRepository, never()).findById(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        void servesTheMsrpActiveOnTheGivenDate() {
+            when(productMsrpRepository.findActive(PRODUCT_ID, TODAY)).thenReturn(Optional.of(msrp(TODAY, null, 0L)));
+
+            Optional<ProductMsrpDto> active = service.getActiveMsrp(PRODUCT_ID, TODAY);
+
+            assertThat(active).isPresent();
+            assertThat(active.get().getEffectiveStartDate()).isEqualTo(TODAY);
+            assertThat(active.get().getCreatedAt()).isEqualTo(NOW.atOffset(ZoneOffset.UTC));
+        }
+
+        @Test
+        void returnsEmptyWhenNoMsrpCoversTheDate() {
+            when(productMsrpRepository.findActive(PRODUCT_ID, TODAY)).thenReturn(Optional.empty());
+
+            assertThat(service.getActiveMsrp(PRODUCT_ID, TODAY)).isEmpty();
+        }
+
+        @Test
+        void listsEveryMsrpNewestWindowFirst() {
+            when(productMsrpRepository.findByProduct_IdOrderByEffectiveStartDateDesc(PRODUCT_ID))
+                    .thenReturn(List.of(msrp(TODAY, null, 0L)));
+
+            assertThat(service.getAllMsrp(PRODUCT_ID)).hasSize(1);
+        }
+
+        @Test
+        void leavesTimestampsUnsetWhenTheRecordHasNone() {
+            ProductMsrpEntity fresh = msrp(TODAY, null, 0L);
+            fresh.setCreatedAt(null);
+            fresh.setUpdatedAt(null);
+            when(productMsrpRepository.findByProduct_IdOrderByEffectiveStartDateDesc(PRODUCT_ID))
+                    .thenReturn(List.of(fresh));
+
+            ProductMsrpDto dto = service.getAllMsrp(PRODUCT_ID).get(0);
+
+            assertThat(dto.getCreatedAt()).isNull();
+            assertThat(dto.getUpdatedAt()).isNull();
+        }
+
+        @Test
+        void failsForAnUnknownProduct() {
+            when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getAllMsrp(PRODUCT_ID)).isInstanceOf(CatalogNotFoundException.class);
+            assertThatThrownBy(() -> service.getActiveMsrp(PRODUCT_ID, TODAY))
+                    .isInstanceOf(CatalogNotFoundException.class);
+        }
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/PartyRelationshipServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/PartyRelationshipServiceImplTest.java
@@ -1,0 +1,399 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.dto.CreatePartyRelationshipRequest;
+import com.positivity.customer.internal.dto.CreatePartyRelationshipResponse;
+import com.positivity.customer.internal.dto.GetCommercialAccountContactsResponse;
+import com.positivity.customer.internal.entity.CommercialParty;
+import com.positivity.customer.internal.entity.PartyRelationship;
+import com.positivity.customer.internal.entity.PersonParty;
+import com.positivity.customer.internal.enums.PartyRelationshipRole;
+import com.positivity.customer.internal.repository.CommercialPartyRepository;
+import com.positivity.customer.internal.repository.PartyRelationshipRepository;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Party relationships between a commercial account and individuals (#110): at most one primary
+ * billing contact at a time, no overlapping active relationship for the same pair and role, and
+ * identity details read from pos-people rather than stored locally (ADR-0015 I2).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PartyRelationshipServiceImpl")
+class PartyRelationshipServiceImplTest {
+
+    private static final UUID PARTY_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f2a01");
+    private static final UUID PERSON_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f2a02");
+    private static final UUID PERSON_PARTY_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f2a03");
+    private static final UUID RELATIONSHIP_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f2a04");
+    private static final UUID USER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f2a05");
+    private static final LocalDate TODAY = LocalDate.of(2026, 3, 1);
+
+    @Mock
+    private PartyRelationshipRepository partyRelationshipRepository;
+
+    @Mock
+    private CommercialPartyRepository partyRepository;
+
+    @Mock
+    private PersonPartyRepository personRepository;
+
+    @Mock
+    private PersonDirectoryService personDirectoryService;
+
+    @Mock
+    private CustomerFactPublisher customerFactPublisher;
+
+    private PartyRelationshipServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PartyRelationshipServiceImpl(
+                partyRelationshipRepository,
+                partyRepository,
+                personRepository,
+                personDirectoryService,
+                Clock.fixed(Instant.parse("2026-03-01T12:00:00Z"), ZoneOffset.UTC),
+                customerFactPublisher);
+        when(partyRepository.findById(PARTY_ID)).thenReturn(Optional.of(commercialParty()));
+        when(personRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(personParty()));
+        when(partyRelationshipRepository.findOverlappingRelationships(any(), any(), any(), any()))
+                .thenReturn(List.of());
+        when(partyRelationshipRepository.save(any())).thenAnswer(invocation -> {
+            PartyRelationship relationship = invocation.getArgument(0);
+            if (relationship.getPartyRelationshipId() == null) {
+                relationship.setPartyRelationshipId(RELATIONSHIP_ID);
+            }
+            return relationship;
+        });
+        when(personDirectoryService.fetchPersonIdentitiesQuietly(any())).thenReturn(Map.of());
+    }
+
+    private static CommercialParty commercialParty() {
+        CommercialParty party = new CommercialParty();
+        party.setPartyId(PARTY_ID);
+        return party;
+    }
+
+    private static PersonParty personParty() {
+        PersonParty person = new PersonParty();
+        person.setPartyId(PERSON_PARTY_ID);
+        person.setPersonId(PERSON_ID);
+        return person;
+    }
+
+    private static PartyRelationship relationship(Set<PartyRelationshipRole> roles, LocalDate endDate) {
+        PartyRelationship relationship = new PartyRelationship();
+        relationship.setPartyRelationshipId(RELATIONSHIP_ID);
+        relationship.setFromParty(commercialParty());
+        relationship.setToPerson(personParty());
+        relationship.setRoles(roles);
+        relationship.setEffectiveStartDate(LocalDate.of(2026, 1, 1));
+        relationship.setEffectiveEndDate(endDate);
+        return relationship;
+    }
+
+    private static CreatePartyRelationshipRequest createRequest(
+            Set<PartyRelationshipRole> roles, boolean primaryBilling) {
+        return CreatePartyRelationshipRequest.builder()
+                .personId(PERSON_ID)
+                .roles(roles)
+                .isPrimaryBillingContact(primaryBilling)
+                .effectiveStartDate(LocalDate.of(2026, 1, 1))
+                .build();
+    }
+
+    @Nested
+    @DisplayName("createRelationship")
+    class CreateRelationship {
+
+        @Test
+        void createsAPlainRelationshipAndRepublishesThePersonsIdentity() {
+            CreatePartyRelationshipResponse response = service.createRelationship(
+                    PARTY_ID, createRequest(Set.of(PartyRelationshipRole.APPROVER), false), USER_ID);
+
+            ArgumentCaptor<PartyRelationship> saved = ArgumentCaptor.forClass(PartyRelationship.class);
+            verify(partyRelationshipRepository).save(saved.capture());
+            assertThat(saved.getValue().getFromParty().getPartyId()).isEqualTo(PARTY_ID);
+            assertThat(saved.getValue().getToPerson().getPersonId()).isEqualTo(PERSON_ID);
+            assertThat(saved.getValue().getCreatedBy()).isEqualTo(USER_ID);
+            assertThat(response.getRelationshipId()).isEqualTo(RELATIONSHIP_ID);
+            assertThat(response.isPreviousPrimaryDemoted()).isFalse();
+            verify(customerFactPublisher).personIdentityChanged(PERSON_ID);
+            verify(partyRelationshipRepository, never()).demoteExistingPrimaryBillingContact(any(), any());
+        }
+
+        @Test
+        void demotesTheExistingPrimaryWhenANewOneIsDesignated() {
+            when(partyRelationshipRepository.demoteExistingPrimaryBillingContact(PARTY_ID, RELATIONSHIP_ID))
+                    .thenReturn(1);
+
+            CreatePartyRelationshipResponse response = service.createRelationship(
+                    PARTY_ID, createRequest(Set.of(PartyRelationshipRole.BILLING), true), USER_ID);
+
+            assertThat(response.isPrimaryBillingContact()).isTrue();
+            assertThat(response.isPreviousPrimaryDemoted()).isTrue();
+        }
+
+        @Test
+        void reportsNoDemotionWhenTheAccountHadNoPrimaryYet() {
+            when(partyRelationshipRepository.demoteExistingPrimaryBillingContact(PARTY_ID, RELATIONSHIP_ID))
+                    .thenReturn(0);
+
+            assertThat(service.createRelationship(
+                                    PARTY_ID, createRequest(Set.of(PartyRelationshipRole.BILLING), true), USER_ID)
+                            .isPreviousPrimaryDemoted())
+                    .isFalse();
+        }
+
+        @Test
+        void refusesAPrimaryBillingContactThatDoesNotHoldTheBillingRole() {
+            CreatePartyRelationshipRequest request = createRequest(Set.of(PartyRelationshipRole.APPROVER), true);
+
+            assertThatThrownBy(() -> service.createRelationship(PARTY_ID, request, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("must have BILLING role");
+            verify(partyRelationshipRepository, never()).save(any());
+        }
+
+        @Test
+        void refusesAnOverlappingRelationshipForTheSamePairAndRole() {
+            when(partyRelationshipRepository.findOverlappingRelationships(
+                            eq(PARTY_ID), eq(PERSON_PARTY_ID), eq(PartyRelationshipRole.BILLING), eq(TODAY)))
+                    .thenReturn(List.of(relationship(Set.of(PartyRelationshipRole.BILLING), null)));
+            CreatePartyRelationshipRequest request = createRequest(Set.of(PartyRelationshipRole.BILLING), false);
+
+            assertThatThrownBy(() -> service.createRelationship(PARTY_ID, request, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Active relationship already exists");
+        }
+
+        @Test
+        void failsWhenTheCommercialAccountDoesNotExist() {
+            when(partyRepository.findById(PARTY_ID)).thenReturn(Optional.empty());
+            CreatePartyRelationshipRequest request = createRequest(Set.of(PartyRelationshipRole.BILLING), false);
+
+            assertThatThrownBy(() -> service.createRelationship(PARTY_ID, request, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Party not found");
+        }
+
+        @Test
+        void failsWhenThePersonDoesNotExist() {
+            when(personRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.empty());
+            CreatePartyRelationshipRequest request = createRequest(Set.of(PartyRelationshipRole.BILLING), false);
+
+            assertThatThrownBy(() -> service.createRelationship(PARTY_ID, request, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Person not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("getContactsForCommercialAccount")
+    class GetContactsForCommercialAccount {
+
+        @Test
+        void servesContactDetailsFromThePeopleDirectoryRatherThanLocalColumns() {
+            when(partyRepository.existsById(PARTY_ID)).thenReturn(true);
+            when(partyRelationshipRepository.findActiveByFromPartyId(PARTY_ID, TODAY))
+                    .thenReturn(List.of(relationship(Set.of(PartyRelationshipRole.BILLING), null)));
+            when(personDirectoryService.fetchPersonIdentitiesQuietly(Set.of(PERSON_ID)))
+                    .thenReturn(Map.of(
+                            PERSON_ID,
+                            new PersonDirectoryService.PersonIdentity(
+                                    PERSON_ID, "Jane", "Smith", "jane@example.invalid", List.of())));
+
+            GetCommercialAccountContactsResponse response =
+                    service.getContactsForCommercialAccount(PARTY_ID, null, null);
+
+            assertThat(response.getContacts()).hasSize(1);
+            GetCommercialAccountContactsResponse.ContactWithRole contact =
+                    response.getContacts().get(0);
+            assertThat(contact.getIndividualId()).isEqualTo(PERSON_ID);
+            assertThat(contact.getStatus()).isEqualTo("ACTIVE");
+            assertThat(contact.getIndividual().getDisplayName()).isEqualTo("Jane Smith");
+            assertThat(contact.getIndividual().getEmail()).isEqualTo("jane@example.invalid");
+            assertThat(contact.getIndividual().getPhone()).isNull();
+        }
+
+        @Test
+        void leavesTheIndividualBlankWhenTheDirectoryHasNothingForThem() {
+            when(partyRepository.existsById(PARTY_ID)).thenReturn(true);
+            when(partyRelationshipRepository.findActiveByFromPartyId(PARTY_ID, TODAY))
+                    .thenReturn(List.of(relationship(Set.of(PartyRelationshipRole.BILLING), null)));
+
+            GetCommercialAccountContactsResponse.ContactWithRole contact = service.getContactsForCommercialAccount(
+                            PARTY_ID, null, null)
+                    .getContacts()
+                    .get(0);
+
+            assertThat(contact.getIndividual().getDisplayName()).isNull();
+            assertThat(contact.getIndividual().getEmail()).isNull();
+        }
+
+        @Test
+        void readsEveryRelationshipWhenTheCallerAsksForMoreThanActiveOnes() {
+            when(partyRepository.existsById(PARTY_ID)).thenReturn(true);
+            when(partyRelationshipRepository.findByFromPartyPartyId(PARTY_ID))
+                    .thenReturn(List.of(relationship(Set.of(PartyRelationshipRole.BILLING), LocalDate.of(2026, 2, 1))));
+
+            GetCommercialAccountContactsResponse response =
+                    service.getContactsForCommercialAccount(PARTY_ID, null, "INACTIVE");
+
+            assertThat(response.getContacts()).hasSize(1);
+            assertThat(response.getContacts().get(0).getStatus()).isEqualTo("INACTIVE");
+        }
+
+        @Test
+        void filtersToTheRequestedRoles() {
+            when(partyRepository.existsById(PARTY_ID)).thenReturn(true);
+            when(partyRelationshipRepository.findActiveByFromPartyId(PARTY_ID, TODAY))
+                    .thenReturn(List.of(
+                            relationship(Set.of(PartyRelationshipRole.BILLING), null),
+                            relationship(Set.of(PartyRelationshipRole.APPROVER), null)));
+
+            GetCommercialAccountContactsResponse response = service.getContactsForCommercialAccount(
+                    PARTY_ID, List.of(PartyRelationshipRole.APPROVER), "ACTIVE");
+
+            assertThat(response.getContacts()).hasSize(1);
+            assertThat(response.getContacts().get(0).getRoles()).containsExactly(PartyRelationshipRole.APPROVER);
+        }
+
+        @Test
+        void acceptsAPersonPartyIdAsWellAsACommercialOne() {
+            when(partyRepository.existsById(PARTY_ID)).thenReturn(false);
+            when(personRepository.existsById(PARTY_ID)).thenReturn(true);
+            when(partyRelationshipRepository.findActiveByFromPartyId(PARTY_ID, TODAY))
+                    .thenReturn(List.of());
+
+            assertThat(service.getContactsForCommercialAccount(PARTY_ID, null, null)
+                            .getContacts())
+                    .isEmpty();
+        }
+
+        @Test
+        void failsWhenNoPartyOfEitherKindExists() {
+            when(partyRepository.existsById(PARTY_ID)).thenReturn(false);
+            when(personRepository.existsById(PARTY_ID)).thenReturn(false);
+
+            assertThatThrownBy(() -> service.getContactsForCommercialAccount(PARTY_ID, null, null))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Party not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("deactivateRelationship")
+    class DeactivateRelationship {
+
+        @Test
+        void endsTheRelationshipTodayAndRepublishesTheIdentity() {
+            PartyRelationship existing = relationship(Set.of(PartyRelationshipRole.BILLING), null);
+            when(partyRelationshipRepository.findById(RELATIONSHIP_ID)).thenReturn(Optional.of(existing));
+
+            service.deactivateRelationship(RELATIONSHIP_ID, USER_ID);
+
+            assertThat(existing.getEffectiveEndDate()).isEqualTo(TODAY);
+            assertThat(existing.getUpdatedBy()).isEqualTo(USER_ID);
+            verify(partyRelationshipRepository).save(existing);
+            verify(customerFactPublisher).personIdentityChanged(PERSON_ID);
+        }
+
+        @Test
+        void failsForAnUnknownRelationship() {
+            when(partyRelationshipRepository.findById(RELATIONSHIP_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.deactivateRelationship(RELATIONSHIP_ID, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Relationship not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("designatePrimaryBillingContact")
+    class DesignatePrimaryBillingContact {
+
+        @Test
+        void promotesTheRelationshipAndDemotesTheIncumbent() {
+            PartyRelationship existing = relationship(Set.of(PartyRelationshipRole.BILLING), null);
+            when(partyRelationshipRepository.findById(RELATIONSHIP_ID)).thenReturn(Optional.of(existing));
+
+            service.designatePrimaryBillingContact(PARTY_ID, RELATIONSHIP_ID, USER_ID);
+
+            assertThat(existing.isPrimaryBillingContact()).isTrue();
+            assertThat(existing.getUpdatedBy()).isEqualTo(USER_ID);
+            verify(partyRelationshipRepository).demoteExistingPrimaryBillingContact(PARTY_ID, RELATIONSHIP_ID);
+        }
+
+        @Test
+        void refusesARelationshipBelongingToAnotherParty() {
+            PartyRelationship foreign = relationship(Set.of(PartyRelationshipRole.BILLING), null);
+            CommercialParty otherParty = new CommercialParty();
+            otherParty.setPartyId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f2aff"));
+            foreign.setFromParty(otherParty);
+            when(partyRelationshipRepository.findById(RELATIONSHIP_ID)).thenReturn(Optional.of(foreign));
+
+            assertThatThrownBy(() -> service.designatePrimaryBillingContact(PARTY_ID, RELATIONSHIP_ID, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("does not belong to party");
+        }
+
+        @Test
+        void refusesARelationshipWithoutTheBillingRole() {
+            when(partyRelationshipRepository.findById(RELATIONSHIP_ID))
+                    .thenReturn(Optional.of(relationship(Set.of(PartyRelationshipRole.APPROVER), null)));
+
+            assertThatThrownBy(() -> service.designatePrimaryBillingContact(PARTY_ID, RELATIONSHIP_ID, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("must have BILLING role");
+        }
+
+        @Test
+        void refusesARelationshipThatHasAlreadyEnded() {
+            when(partyRelationshipRepository.findById(RELATIONSHIP_ID))
+                    .thenReturn(
+                            Optional.of(relationship(Set.of(PartyRelationshipRole.BILLING), LocalDate.of(2026, 2, 1))));
+
+            assertThatThrownBy(() -> service.designatePrimaryBillingContact(PARTY_ID, RELATIONSHIP_ID, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Cannot designate inactive relationship");
+        }
+
+        @Test
+        void failsForAnUnknownRelationship() {
+            when(partyRelationshipRepository.findById(RELATIONSHIP_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.designatePrimaryBillingContact(PARTY_ID, RELATIONSHIP_ID, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Relationship not found");
+        }
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/PersonServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/PersonServiceImplTest.java
@@ -1,0 +1,409 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.customer.internal.dto.CreatePersonRequest;
+import com.positivity.customer.internal.dto.CreatePersonResponse;
+import com.positivity.customer.internal.dto.GetPersonResponse;
+import com.positivity.customer.internal.entity.CommercialParty;
+import com.positivity.customer.internal.entity.PartyRelationship;
+import com.positivity.customer.internal.entity.PersonParty;
+import com.positivity.customer.internal.enums.ContactPointType;
+import com.positivity.customer.internal.enums.PreferredContactMethod;
+import com.positivity.customer.internal.repository.PartyRelationshipRepository;
+import com.positivity.customer.internal.repository.PersonPartyRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * CRM person records (#111, #684): pos-customer keeps only the thin link to the canonical
+ * person, while names and contact points are resolved from pos-people (ADR-0015 I2). An invalid
+ * email must persist nothing anywhere, including in pos-people.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PersonServiceImpl")
+class PersonServiceImplTest {
+
+    private static final UUID PERSON_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3a01");
+    private static final UUID PERSON_PARTY_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3a02");
+    private static final UUID ACCOUNT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3a03");
+    private static final UUID USER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3a04");
+    private static final LocalDate TODAY = LocalDate.of(2026, 3, 1);
+
+    @Mock
+    private PersonPartyRepository personRepository;
+
+    @Mock
+    private PartyRelationshipRepository partyRelationshipRepository;
+
+    @Mock
+    private PersonDirectoryService personDirectoryService;
+
+    @Mock
+    private CustomerFactPublisher customerFactPublisher;
+
+    private PersonServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PersonServiceImpl(
+                personRepository,
+                partyRelationshipRepository,
+                personDirectoryService,
+                Clock.fixed(Instant.parse("2026-03-01T12:00:00Z"), ZoneOffset.UTC),
+                customerFactPublisher);
+        when(personDirectoryService.resolveOrCreatePersonId(any(), any(), any(), any()))
+                .thenReturn(PERSON_ID);
+        when(personRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.empty());
+        when(personRepository.save(any())).thenAnswer(invocation -> {
+            PersonParty person = invocation.getArgument(0);
+            person.setPartyId(PERSON_PARTY_ID);
+            return person;
+        });
+        when(partyRelationshipRepository.findActiveByToPersonPartyId(any(), any()))
+                .thenReturn(List.of());
+        when(personDirectoryService.fetchPersonIdentitiesQuietly(any())).thenReturn(Map.of());
+    }
+
+    private static PersonParty personParty() {
+        PersonParty person = new PersonParty();
+        person.setPartyId(PERSON_PARTY_ID);
+        person.setPersonId(PERSON_ID);
+        person.setPreferredContactMethod(PreferredContactMethod.EMAIL);
+        return person;
+    }
+
+    private static CreatePersonRequest.CreatePersonRequestBuilder request() {
+        return CreatePersonRequest.builder()
+                .firstName(" Jane ")
+                .lastName(" Smith ")
+                .preferredContactMethod(PreferredContactMethod.EMAIL);
+    }
+
+    private static PersonDirectoryService.PersonIdentity identity(
+            List<PersonDirectoryService.ContactPoint> contactPoints) {
+        return new PersonDirectoryService.PersonIdentity(
+                PERSON_ID, "Jane", "Smith", "jane@example.invalid", contactPoints);
+    }
+
+    @Nested
+    @DisplayName("createPerson")
+    class CreatePerson {
+
+        @Test
+        void linksTheCanonicalPersonAndWritesContactPointsToPosPeople() {
+            CreatePersonResponse response = service.createPerson(
+                    request()
+                            .emails(List.of(CreatePersonRequest.EmailInput.builder()
+                                    .value("Jane@Example.Invalid")
+                                    .isPrimary(true)
+                                    .build()))
+                            .phones(List.of(CreatePersonRequest.PhoneInput.builder()
+                                    .value(" 555-0100 ")
+                                    .isPrimary(true)
+                                    .build()))
+                            .build(),
+                    USER_ID);
+
+            ArgumentCaptor<PersonParty> saved = ArgumentCaptor.forClass(PersonParty.class);
+            verify(personRepository).save(saved.capture());
+            assertThat(saved.getValue().getPersonId()).isEqualTo(PERSON_ID);
+            assertThat(saved.getValue().getCustomerNumber()).startsWith("CUST-PER-");
+            verify(customerFactPublisher).partyChanged(saved.getValue());
+
+            ArgumentCaptor<List<PersonDirectoryService.ContactPointUpsert>> contactPoints = ArgumentCaptor.captor();
+            verify(personDirectoryService)
+                    .setContactPoints(org.mockito.ArgumentMatchers.eq(PERSON_ID), contactPoints.capture());
+            assertThat(contactPoints.getValue()).hasSize(2);
+            // Emails are lower-cased before they leave pos-customer.
+            assertThat(contactPoints.getValue().get(0).value()).isEqualTo("jane@example.invalid");
+            assertThat(contactPoints.getValue().get(0).contactType()).isEqualTo(ContactPointType.EMAIL.name());
+            assertThat(contactPoints.getValue().get(1).value()).isEqualTo("555-0100");
+            // A phone with no explicit type defaults to mobile.
+            assertThat(contactPoints.getValue().get(1).contactType()).isEqualTo(ContactPointType.PHONE_MOBILE.name());
+            assertThat(response.getPersonId()).isEqualTo(PERSON_ID);
+        }
+
+        @Test
+        void reusesAnExistingPersonPartyForTheSameCanonicalPerson() {
+            when(personRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(personParty()));
+
+            CreatePersonResponse response = service.createPerson(request().build(), USER_ID);
+
+            assertThat(response.getPersonId()).isEqualTo(PERSON_ID);
+            verify(personRepository, never()).save(any());
+            verify(personDirectoryService, never()).setContactPoints(any(), any());
+        }
+
+        @Test
+        void keepsAnExplicitPhoneType() {
+            service.createPerson(
+                    request()
+                            .phones(List.of(CreatePersonRequest.PhoneInput.builder()
+                                    .value("555-0100")
+                                    .type(ContactPointType.PHONE_WORK)
+                                    .build()))
+                            .build(),
+                    USER_ID);
+
+            ArgumentCaptor<List<PersonDirectoryService.ContactPointUpsert>> contactPoints = ArgumentCaptor.captor();
+            verify(personDirectoryService).setContactPoints(any(), contactPoints.capture());
+            assertThat(contactPoints.getValue().get(0).contactType()).isEqualTo(ContactPointType.PHONE_WORK.name());
+        }
+
+        @Test
+        void resolvesTheCanonicalPersonByTheFlaggedPrimaryContacts() {
+            service.createPerson(
+                    request()
+                            .emails(List.of(
+                                    CreatePersonRequest.EmailInput.builder()
+                                            .value("secondary@example.invalid")
+                                            .build(),
+                                    CreatePersonRequest.EmailInput.builder()
+                                            .value("primary@example.invalid")
+                                            .isPrimary(true)
+                                            .build()))
+                            .phones(List.of(
+                                    CreatePersonRequest.PhoneInput.builder()
+                                            .value("555-0199")
+                                            .build(),
+                                    CreatePersonRequest.PhoneInput.builder()
+                                            .value("555-0100")
+                                            .isPrimary(true)
+                                            .build()))
+                            .build(),
+                    USER_ID);
+
+            verify(personDirectoryService)
+                    .resolveOrCreatePersonId("primary@example.invalid", "555-0100", "Smith", "Jane");
+        }
+
+        @Test
+        void fallsBackToTheFirstContactWhenNoneIsFlaggedPrimary() {
+            service.createPerson(
+                    request()
+                            .emails(List.of(CreatePersonRequest.EmailInput.builder()
+                                    .value("first@example.invalid")
+                                    .build()))
+                            .phones(List.of(CreatePersonRequest.PhoneInput.builder()
+                                    .value("555-0199")
+                                    .build()))
+                            .build(),
+                    USER_ID);
+
+            verify(personDirectoryService)
+                    .resolveOrCreatePersonId("first@example.invalid", "555-0199", "Smith", "Jane");
+        }
+
+        @Test
+        void resolvesOnNameAloneWhenNoContactsAreSupplied() {
+            service.createPerson(request().build(), USER_ID);
+
+            verify(personDirectoryService).resolveOrCreatePersonId(null, null, "Smith", "Jane");
+        }
+
+        @Test
+        void persistsNothingAnywhereWhenAnEmailIsMalformed() {
+            CreatePersonRequest request = request()
+                    .emails(List.of(CreatePersonRequest.EmailInput.builder()
+                            .value("not-an-email")
+                            .build()))
+                    .build();
+
+            assertThatThrownBy(() -> service.createPerson(request, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Invalid email format");
+            verifyNoInteractions(personRepository, customerFactPublisher);
+            verify(personDirectoryService, never()).resolveOrCreatePersonId(any(), any(), any(), any());
+        }
+
+        @Test
+        void refusesABlankEmailValue() {
+            CreatePersonRequest request = request()
+                    .emails(List.of(
+                            CreatePersonRequest.EmailInput.builder().value("  ").build()))
+                    .build();
+
+            assertThatThrownBy(() -> service.createPerson(request, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Email value is required");
+        }
+
+        @Test
+        void refusesARequestWithNoFirstName() {
+            CreatePersonRequest request = request().firstName("  ").build();
+
+            assertThatThrownBy(() -> service.createPerson(request, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("firstName is required");
+        }
+
+        @Test
+        void refusesARequestWithNoLastName() {
+            CreatePersonRequest request = request().lastName(null).build();
+
+            assertThatThrownBy(() -> service.createPerson(request, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("lastName is required");
+        }
+
+        @Test
+        void refusesARequestWithNoPreferredContactMethod() {
+            CreatePersonRequest request = request().preferredContactMethod(null).build();
+
+            assertThatThrownBy(() -> service.createPerson(request, USER_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("preferredContactMethod is required");
+        }
+    }
+
+    @Nested
+    @DisplayName("getPerson")
+    class GetPerson {
+
+        @Test
+        void joinsTheCrmLinkToTheCanonicalIdentityAndItsCommercialAccounts() {
+            when(personRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(personParty()));
+            when(personDirectoryService.fetchPersonIdentitiesQuietly(Set.of(PERSON_ID)))
+                    .thenReturn(Map.of(
+                            PERSON_ID,
+                            identity(List.of(
+                                    new PersonDirectoryService.ContactPoint("EMAIL", "jane@example.invalid", true)))));
+            PartyRelationship relationship = new PartyRelationship();
+            CommercialParty account = new CommercialParty();
+            account.setPartyId(ACCOUNT_ID);
+            relationship.setFromParty(account);
+            when(partyRelationshipRepository.findActiveByToPersonPartyId(PERSON_PARTY_ID, TODAY))
+                    .thenReturn(List.of(relationship, relationship));
+
+            GetPersonResponse response = service.getPerson(PERSON_ID);
+
+            assertThat(response.getFirstName()).isEqualTo("Jane");
+            assertThat(response.getDisplayName()).isEqualTo("Jane Smith");
+            assertThat(response.getContactPoints()).hasSize(1);
+            assertThat(response.getContactPoints().get(0).getContactType()).isEqualTo(ContactPointType.EMAIL);
+            assertThat(response.isCommercialContact()).isTrue();
+            // Two relationships against the same account still count as one account.
+            assertThat(response.getCommercialAccountCount()).isEqualTo(1);
+        }
+
+        @Test
+        void servesTheLinkWithNoNamesWhenPosPeopleHasNothingForThePerson() {
+            when(personRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(personParty()));
+
+            GetPersonResponse response = service.getPerson(PERSON_ID);
+
+            assertThat(response.getFirstName()).isNull();
+            assertThat(response.getDisplayName()).isNull();
+            assertThat(response.getContactPoints()).isEmpty();
+            assertThat(response.isCommercialContact()).isFalse();
+        }
+
+        @Test
+        void dropsAContactTypeThePosCustomerEnumDoesNotKnow() {
+            when(personRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(personParty()));
+            when(personDirectoryService.fetchPersonIdentitiesQuietly(Set.of(PERSON_ID)))
+                    .thenReturn(Map.of(
+                            PERSON_ID,
+                            identity(List.of(
+                                    new PersonDirectoryService.ContactPoint("CARRIER_PIGEON", "coop 3", false),
+                                    new PersonDirectoryService.ContactPoint(null, "unknown", false)))));
+
+            GetPersonResponse response = service.getPerson(PERSON_ID);
+
+            assertThat(response.getContactPoints())
+                    .hasSize(2)
+                    .allSatisfy(cp -> assertThat(cp.getContactType()).isNull());
+        }
+
+        @Test
+        void failsForAPersonWithNoCrmLink() {
+            when(personRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getPerson(PERSON_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Person not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("searchPersons")
+    class SearchPersons {
+
+        @Test
+        void keepsOnlyDirectoryMatchesThatHaveACrmLink() {
+            when(personDirectoryService.searchPersons("smith"))
+                    .thenReturn(List.of(
+                            identity(List.of()),
+                            new PersonDirectoryService.PersonIdentity(
+                                    UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3aff"),
+                                    "Rob",
+                                    "Smith",
+                                    null,
+                                    List.of())));
+            when(personRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(personParty()));
+
+            List<GetPersonResponse> matches = service.searchPersons("smith", null, null, 20, 0);
+
+            assertThat(matches).hasSize(1);
+            assertThat(matches.get(0).getPersonId()).isEqualTo(PERSON_ID);
+        }
+
+        @Test
+        void searchesOnTheFirstNonBlankCriterion() {
+            when(personDirectoryService.searchPersons("jane@example.invalid")).thenReturn(List.of());
+
+            service.searchPersons("  ", "jane@example.invalid", "555-0100", 20, 0);
+
+            verify(personDirectoryService).searchPersons("jane@example.invalid");
+        }
+
+        @Test
+        void returnsNothingWhenNoCriterionIsSupplied() {
+            assertThat(service.searchPersons(null, null, "  ", 20, 0)).isEmpty();
+            verify(personDirectoryService, never()).searchPersons(any());
+        }
+
+        @Test
+        void appliesTheRequestedPageWindow() {
+            when(personDirectoryService.searchPersons("smith")).thenReturn(List.of(identity(List.of())));
+            when(personRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(personParty()));
+
+            assertThat(service.searchPersons("smith", null, null, 20, 1)).isEmpty();
+            assertThat(service.searchPersons("smith", null, null, 1, 0)).hasSize(1);
+        }
+
+        @Test
+        void defaultsTheLegacySingleTermSearchToTheFirstTwentyMatches() {
+            when(personDirectoryService.searchPersons("smith")).thenReturn(List.of());
+
+            assertThat(service.searchPersons("smith")).isEmpty();
+            verify(personDirectoryService).searchPersons("smith");
+        }
+    }
+}

--- a/pos-documents/src/test/java/com/positivity/documents/internal/service/TemplateServiceTest.java
+++ b/pos-documents/src/test/java/com/positivity/documents/internal/service/TemplateServiceTest.java
@@ -1,0 +1,256 @@
+package com.positivity.documents.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.positivity.documents.internal.config.PdfConfiguration;
+import com.positivity.documents.internal.exception.TemplateNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.AbstractResource;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.DescriptiveResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Template resolution and the small mustache-like binder used for rendered documents:
+ * {@code ${path}} substitution plus {@code {{#each}}} / {@code {{#if}}} blocks.
+ */
+@DisplayName("TemplateService")
+class TemplateServiceTest {
+
+    private static final String BASE_PATH = "classpath:/templates";
+
+    /** Serves one canned template body and records every path the service asked for. */
+    private static final class StubResourceLoader implements ResourceLoader {
+
+        private final Map<String, String> bodies = new LinkedHashMap<>();
+        private final java.util.List<String> requestedPaths = new java.util.ArrayList<>();
+
+        private StubResourceLoader with(String path, String body) {
+            bodies.put(path, body);
+            return this;
+        }
+
+        @Override
+        public Resource getResource(String location) {
+            requestedPaths.add(location);
+            String body = bodies.get(location);
+            if (body == null) {
+                return new DescriptiveResource("missing " + location);
+            }
+            return new ByteArrayResource(body.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public ClassLoader getClassLoader() {
+            return ClassUtils.getDefaultClassLoader();
+        }
+    }
+
+    private static TemplateService service(StubResourceLoader loader, String basePath) {
+        return new TemplateService(loader, new PdfConfiguration(100_000, basePath, 1_000));
+    }
+
+    @Nested
+    @DisplayName("resolveTemplate")
+    class ResolveTemplate {
+
+        @Test
+        void loadsTheNamedTemplateFromTheConfiguredBasePath() {
+            StubResourceLoader loader = new StubResourceLoader().with(BASE_PATH + "/INVOICE_A4.html", "<p>hello</p>");
+
+            assertThat(service(loader, BASE_PATH).resolveTemplate("INVOICE_A4")).isEqualTo("<p>hello</p>");
+        }
+
+        @Test
+        void fallsBackToTheDefaultTemplateForABlankOrMissingId() {
+            StubResourceLoader loader = new StubResourceLoader()
+                    .with(BASE_PATH + "/" + TemplateService.DEFAULT_TEMPLATE_ID + ".html", "<p>default</p>");
+            TemplateService service = service(loader, BASE_PATH);
+
+            assertThat(service.resolveTemplate(null)).isEqualTo("<p>default</p>");
+            assertThat(service.resolveTemplate("   ")).isEqualTo("<p>default</p>");
+        }
+
+        @Test
+        void trimsSurroundingWhitespaceFromTheTemplateId() {
+            StubResourceLoader loader = new StubResourceLoader().with(BASE_PATH + "/INVOICE_A4.html", "<p>hello</p>");
+
+            assertThat(service(loader, BASE_PATH).resolveTemplate("  INVOICE_A4  "))
+                    .isEqualTo("<p>hello</p>");
+        }
+
+        @Test
+        void toleratesATrailingSlashOnTheConfiguredBasePath() {
+            StubResourceLoader loader = new StubResourceLoader().with(BASE_PATH + "/INVOICE_A4.html", "<p>hello</p>");
+
+            assertThat(service(loader, BASE_PATH + "/").resolveTemplate("INVOICE_A4"))
+                    .isEqualTo("<p>hello</p>");
+        }
+
+        @Test
+        void readsEachTemplateOnlyOnce() {
+            StubResourceLoader loader = new StubResourceLoader().with(BASE_PATH + "/INVOICE_A4.html", "<p>hello</p>");
+            TemplateService service = service(loader, BASE_PATH);
+
+            service.resolveTemplate("INVOICE_A4");
+            service.resolveTemplate("INVOICE_A4");
+
+            assertThat(loader.requestedPaths).hasSize(1);
+        }
+
+        @Test
+        void rejectsATemplateIdThatCouldEscapeTheBasePath() {
+            StubResourceLoader loader = new StubResourceLoader();
+            TemplateService service = service(loader, BASE_PATH);
+
+            assertThatThrownBy(() -> service.resolveTemplate("../../etc/passwd"))
+                    .isInstanceOf(TemplateNotFoundException.class)
+                    .hasMessageContaining("Template not found");
+            // The traversal attempt never reaches the resource loader at all.
+            assertThat(loader.requestedPaths).isEmpty();
+        }
+
+        @Test
+        void rejectsALowercaseTemplateId() {
+            TemplateService service = service(new StubResourceLoader(), BASE_PATH);
+
+            assertThatThrownBy(() -> service.resolveTemplate("invoice")).isInstanceOf(TemplateNotFoundException.class);
+        }
+
+        @Test
+        void failsWhenTheTemplateFileIsNotThere() {
+            TemplateService service = service(new StubResourceLoader(), BASE_PATH);
+
+            assertThatThrownBy(() -> service.resolveTemplate("INVOICE_A4"))
+                    .isInstanceOf(TemplateNotFoundException.class)
+                    .hasMessageContaining("INVOICE_A4");
+        }
+
+        @Test
+        void failsWhenTheTemplateCannotBeRead() {
+            ResourceLoader unreadable = new ResourceLoader() {
+                @Override
+                public Resource getResource(String location) {
+                    return new AbstractResource() {
+                        @Override
+                        public boolean exists() {
+                            return true;
+                        }
+
+                        @Override
+                        public String getDescription() {
+                            return "unreadable template";
+                        }
+
+                        @Override
+                        public InputStream getInputStream() throws IOException {
+                            throw new IOException("disk error");
+                        }
+                    };
+                }
+
+                @Override
+                public ClassLoader getClassLoader() {
+                    return ClassUtils.getDefaultClassLoader();
+                }
+            };
+            TemplateService service = new TemplateService(unreadable, new PdfConfiguration(100_000, BASE_PATH, 1_000));
+
+            assertThatThrownBy(() -> service.resolveTemplate("INVOICE_A4"))
+                    .isInstanceOf(TemplateNotFoundException.class)
+                    .hasMessageContaining("Failed to load template");
+        }
+    }
+
+    @Nested
+    @DisplayName("bindTemplate")
+    class BindTemplate {
+
+        private final TemplateService service = service(new StubResourceLoader(), BASE_PATH);
+
+        @Test
+        void substitutesTopLevelAndNestedVariables() {
+            String bound = service.bindTemplate(
+                    "Hello ${name}, order ${order.number}", Map.of("name", "Jane", "order", Map.of("number", "SO-1")));
+
+            assertThat(bound).isEqualTo("Hello Jane, order SO-1");
+        }
+
+        @Test
+        void rendersAnUnknownPathAsTheEmptyString() {
+            String bound = service.bindTemplate("Hello ${missing} ${order.missing} ${name.deep}", Map.of("name", "x"));
+
+            assertThat(bound).isEqualTo("Hello   ");
+        }
+
+        @Test
+        void expandsAnEachBlockOverAListOfScalars() {
+            String bound =
+                    service.bindTemplate("{{#each items}}[${this}]{{/each}}", Map.of("items", List.of("a", "b")));
+
+            assertThat(bound).isEqualTo("[a][b]");
+        }
+
+        @Test
+        void expandsAnEachBlockOverAListOfMaps() {
+            String bound = service.bindTemplate(
+                    "{{#each lines}}${this.sku}=${this.qty};{{/each}}",
+                    Map.of("lines", List.of(Map.of("sku", "SKU-1", "qty", 2), Map.of("sku", "SKU-2", "qty", 3))));
+
+            assertThat(bound).isEqualTo("SKU-1=2;SKU-2=3;");
+        }
+
+        @Test
+        void rendersAnEachBlockAsEmptyWhenThePathIsNotACollection() {
+            assertThat(service.bindTemplate("{{#each items}}x{{/each}}", Map.of("items", "not-a-list")))
+                    .isEmpty();
+            assertThat(service.bindTemplate("{{#each items}}x{{/each}}", Map.of()))
+                    .isEmpty();
+        }
+
+        @Test
+        void keepsAnIfBlockWhoseValueIsTruthy() {
+            assertThat(service.bindTemplate("{{#if show}}visible{{/if}}", Map.of("show", true)))
+                    .isEqualTo("visible");
+            assertThat(service.bindTemplate("{{#if note}}visible{{/if}}", Map.of("note", "anything")))
+                    .isEqualTo("visible");
+        }
+
+        @Test
+        void dropsAnIfBlockWhoseValueIsFalseyBlankOrAbsent() {
+            assertThat(service.bindTemplate("{{#if show}}visible{{/if}}", Map.of("show", false)))
+                    .isEmpty();
+            assertThat(service.bindTemplate("{{#if note}}visible{{/if}}", Map.of("note", "  ")))
+                    .isEmpty();
+            assertThat(service.bindTemplate("{{#if note}}visible{{/if}}", Map.of()))
+                    .isEmpty();
+        }
+
+        @Test
+        void substitutesVariablesInsideASurvivingIfBlock() {
+            String bound =
+                    service.bindTemplate("{{#if show}}Hello ${name}{{/if}}", Map.of("show", true, "name", "Jane"));
+
+            assertThat(bound).isEqualTo("Hello Jane");
+        }
+
+        @Test
+        void escapesDollarSignsInSubstitutedValues() {
+            // A value containing $ or \ must not be re-interpreted as a replacement reference.
+            String bound = service.bindTemplate("total=${amount}", Map.of("amount", "$5\\0"));
+
+            assertThat(bound).isEqualTo("total=$5\\0");
+        }
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PutawayValidationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PutawayValidationServiceImplTest.java
@@ -1,0 +1,483 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.positivity.inventory.internal.dto.PutawayExecutionRequest;
+import com.positivity.inventory.internal.dto.ValidationResult;
+import com.positivity.inventory.internal.enums.OverrideReasonCode;
+import com.positivity.inventory.internal.exception.InsufficientPermissionException;
+import com.positivity.inventory.internal.exception.LocationAtCapacityException;
+import com.positivity.inventory.internal.exception.LocationNotValidForSkuException;
+import com.positivity.inventory.internal.exception.NoOnHandAtSourceLocationException;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.PutawayRuleRepository;
+import com.positivity.inventory.internal.repository.ReplenishmentPolicyRepository;
+import com.positivity.inventory.internal.security.PutawayPermissions;
+import com.positivity.security.common.GatewaySecurityConstants;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Putaway validation: a destination must be enabled for the SKU and have room for it, and both
+ * checks may only be overridden with the matching permission plus reason, justification and — for
+ * capacity — an approver, while an overfill beyond the 10% tolerance is refused outright.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PutawayValidationServiceImpl")
+class PutawayValidationServiceImplTest {
+
+    private static final UUID SOURCE_LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f9a01");
+    private static final UUID DESTINATION_LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f9a02");
+    private static final String SKU = "SKU-1";
+
+    @Mock
+    private InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
+
+    @Mock
+    private PutawayRuleRepository putawayRuleRepository;
+
+    @Mock
+    private ReplenishmentPolicyRepository replenishmentPolicyRepository;
+
+    @Mock
+    private StorageLocationValidationService storageLocationValidationService;
+
+    private PutawayValidationServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PutawayValidationServiceImpl(
+                inventoryLedgerEntryRepository,
+                putawayRuleRepository,
+                replenishmentPolicyRepository,
+                storageLocationValidationService);
+        when(putawayRuleRepository.existsByDestinationLocationIdAndIsEnabledTrue(DESTINATION_LOCATION_ID))
+                .thenReturn(true);
+        when(replenishmentPolicyRepository.existsByItemSKU(SKU)).thenReturn(true);
+        when(replenishmentPolicyRepository.existsByItemSKUAndLocationId(SKU, DESTINATION_LOCATION_ID))
+                .thenReturn(true);
+        when(storageLocationValidationService.getStorageLocationValidation(anyString()))
+                .thenReturn(locationValidation(true, true, 100));
+        when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
+                        eq(DESTINATION_LOCATION_ID), any(List.class)))
+                .thenReturn(0);
+        when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
+                        eq(SKU), eq(SOURCE_LOCATION_ID), any(List.class)))
+                .thenReturn(50);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private static StorageLocationValidationService.StorageLocationValidation locationValidation(
+            boolean exists, boolean active, Integer maxUnitCapacity) {
+        StorageLocationValidationService.StorageLocationValidation validation =
+                new StorageLocationValidationService.StorageLocationValidation();
+        validation.setStorageLocationId(DESTINATION_LOCATION_ID);
+        validation.setExists(exists);
+        validation.setActive(active);
+        validation.setMaxUnitCapacity(maxUnitCapacity);
+        return validation;
+    }
+
+    private static void authenticateWith(String... authorities) {
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                "jane.smith",
+                "n/a",
+                java.util.Arrays.stream(authorities)
+                        .map(SimpleGrantedAuthority::new)
+                        .toList());
+        token.setDetails(Map.of(GatewaySecurityConstants.DETAIL_USERNAME, "jane.smith"));
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    private static PutawayExecutionRequest request(int quantity) {
+        PutawayExecutionRequest request = new PutawayExecutionRequest();
+        request.setSkuId(SKU);
+        request.setSourceLocationId(SOURCE_LOCATION_ID);
+        request.setDestinationLocationId(DESTINATION_LOCATION_ID);
+        request.setQuantity(quantity);
+        return request;
+    }
+
+    private static List<String> errorCodes(ValidationResult result) {
+        return result.getErrors().stream()
+                .map(ValidationResult.ValidationError::getErrorCode)
+                .toList();
+    }
+
+    private static List<String> warningCodes(ValidationResult result) {
+        return result.getWarnings().stream()
+                .map(ValidationResult.ValidationWarning::getCode)
+                .toList();
+    }
+
+    @Nested
+    @DisplayName("validateLocationCompatibility")
+    class ValidateLocationCompatibility {
+
+        @Test
+        void acceptsAnEnabledLocationThatIsConfiguredForTheSku() {
+            assertThat(service.validateLocationCompatibility(DESTINATION_LOCATION_ID, SKU)
+                            .isValid())
+                    .isTrue();
+        }
+
+        @Test
+        void refusesALocationThatIsNotEnabledForPutaway() {
+            when(putawayRuleRepository.existsByDestinationLocationIdAndIsEnabledTrue(DESTINATION_LOCATION_ID))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> service.validateLocationCompatibility(DESTINATION_LOCATION_ID, SKU))
+                    .isInstanceOf(LocationNotValidForSkuException.class)
+                    .hasMessageContaining("not enabled for putaway");
+        }
+
+        @Test
+        void refusesASkuWithNoReplenishmentPolicy() {
+            when(replenishmentPolicyRepository.existsByItemSKU(SKU)).thenReturn(false);
+
+            assertThatThrownBy(() -> service.validateLocationCompatibility(DESTINATION_LOCATION_ID, SKU))
+                    .isInstanceOf(LocationNotValidForSkuException.class)
+                    .hasMessageContaining("not configured in replenishment policies");
+        }
+
+        @Test
+        void refusesASkuThatIsNotAllowedAtTheDestination() {
+            when(replenishmentPolicyRepository.existsByItemSKUAndLocationId(SKU, DESTINATION_LOCATION_ID))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> service.validateLocationCompatibility(DESTINATION_LOCATION_ID, SKU))
+                    .isInstanceOf(LocationNotValidForSkuException.class)
+                    .hasMessageContaining("not allowed at destination");
+        }
+    }
+
+    @Nested
+    @DisplayName("validateLocationCapacity")
+    class ValidateLocationCapacity {
+
+        @Test
+        void acceptsAPutawayWellInsideTheLimitWithNoWarning() {
+            ValidationResult result = service.validateLocationCapacity(DESTINATION_LOCATION_ID, 10);
+
+            assertThat(result.isValid()).isTrue();
+            assertThat(result.getWarnings()).isEmpty();
+        }
+
+        @Test
+        void warnsWhenTheProjectedFillIsWithinTenPercentOfTheLimit() {
+            ValidationResult result = service.validateLocationCapacity(DESTINATION_LOCATION_ID, 95);
+
+            assertThat(result.isValid()).isTrue();
+            assertThat(warningCodes(result)).containsExactly("CAPACITY_NEAR_LIMIT");
+        }
+
+        @Test
+        void refusesAPutawayThatExactlyFillsTheLocation() {
+            assertThatThrownBy(() -> service.validateLocationCapacity(DESTINATION_LOCATION_ID, 100))
+                    .isInstanceOf(LocationAtCapacityException.class);
+        }
+
+        @Test
+        void warnsRatherThanFailsForAnOverfillInsideTheTolerance() {
+            ValidationResult result = service.validateLocationCapacity(DESTINATION_LOCATION_ID, 105);
+
+            assertThat(result.isValid()).isTrue();
+            assertThat(warningCodes(result)).containsExactly("CAPACITY_NEAR_LIMIT");
+        }
+
+        @Test
+        void refusesAnOverfillBeyondTheTolerance() {
+            assertThatThrownBy(() -> service.validateLocationCapacity(DESTINATION_LOCATION_ID, 120))
+                    .isInstanceOf(LocationAtCapacityException.class);
+        }
+
+        @Test
+        void refusesALocationWithNoConfiguredCapacity() {
+            when(storageLocationValidationService.getStorageLocationValidation(anyString()))
+                    .thenReturn(locationValidation(true, true, null));
+            when(replenishmentPolicyRepository.sumMaximumQuantityByLocationId(DESTINATION_LOCATION_ID))
+                    .thenReturn(null);
+
+            assertThatThrownBy(() -> service.validateLocationCapacity(DESTINATION_LOCATION_ID, 1))
+                    .isInstanceOf(LocationAtCapacityException.class);
+        }
+
+        @Test
+        void fallsBackToTheReplenishmentPolicyMaximumWhenTheBinDeclaresNone() {
+            when(storageLocationValidationService.getStorageLocationValidation(anyString()))
+                    .thenReturn(locationValidation(true, true, 0));
+            when(replenishmentPolicyRepository.sumMaximumQuantityByLocationId(DESTINATION_LOCATION_ID))
+                    .thenReturn(200);
+
+            assertThat(service.validateLocationCapacity(DESTINATION_LOCATION_ID, 10)
+                            .isValid())
+                    .isTrue();
+        }
+
+        @Test
+        void refusesADestinationThatDoesNotExistOrIsInactive() {
+            when(storageLocationValidationService.getStorageLocationValidation(anyString()))
+                    .thenReturn(locationValidation(false, false, 100));
+            assertThatThrownBy(() -> service.validateLocationCapacity(DESTINATION_LOCATION_ID, 1))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("does not exist");
+
+            when(storageLocationValidationService.getStorageLocationValidation(anyString()))
+                    .thenReturn(locationValidation(true, false, 100));
+            assertThatThrownBy(() -> service.validateLocationCapacity(DESTINATION_LOCATION_ID, 1))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("inactive");
+        }
+
+        @Test
+        void countsExistingStockTowardTheLimit() {
+            when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
+                            eq(DESTINATION_LOCATION_ID), any(List.class)))
+                    .thenReturn(95);
+
+            assertThatThrownBy(() -> service.validateLocationCapacity(DESTINATION_LOCATION_ID, 20))
+                    .isInstanceOf(LocationAtCapacityException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("validateSourceOnHand")
+    class ValidateSourceOnHand {
+
+        @Test
+        void acceptsASourceHoldingEnoughStock() {
+            assertThat(service.validateSourceOnHand(SOURCE_LOCATION_ID, SKU, 10).isValid())
+                    .isTrue();
+        }
+
+        @Test
+        void refusesASourceWithNothingOnHand() {
+            when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
+                            eq(SKU), eq(SOURCE_LOCATION_ID), any(List.class)))
+                    .thenReturn(0);
+
+            assertThatThrownBy(() -> service.validateSourceOnHand(SOURCE_LOCATION_ID, SKU, 10))
+                    .isInstanceOf(NoOnHandAtSourceLocationException.class);
+        }
+
+        @Test
+        void reportsAShortfallRatherThanThrowing() {
+            when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
+                            eq(SKU), eq(SOURCE_LOCATION_ID), any(List.class)))
+                    .thenReturn(4);
+
+            ValidationResult result = service.validateSourceOnHand(SOURCE_LOCATION_ID, SKU, 10);
+
+            assertThat(result.isValid()).isFalse();
+            assertThat(errorCodes(result)).containsExactly("INSUFFICIENT_QUANTITY");
+        }
+    }
+
+    @Nested
+    @DisplayName("validatePutawayExecution")
+    class ValidatePutawayExecution {
+
+        @Test
+        void acceptsAStraightforwardPutaway() {
+            ValidationResult result = service.validatePutawayExecution(request(10));
+
+            assertThat(result.isValid()).isTrue();
+            assertThat(result.getWarnings()).isEmpty();
+        }
+
+        @Test
+        void collectsASourceShortfallAsAnError() {
+            when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
+                            eq(SKU), eq(SOURCE_LOCATION_ID), any(List.class)))
+                    .thenReturn(4);
+
+            ValidationResult result = service.validatePutawayExecution(request(10));
+
+            assertThat(errorCodes(result)).contains("INSUFFICIENT_QUANTITY");
+        }
+
+        @Test
+        void refusesACompatibilityOverrideWithoutThePermission() {
+            PutawayExecutionRequest request = request(10);
+            request.setOverrideLocationCompatibility(true);
+            authenticateWith();
+
+            assertThatThrownBy(() -> service.validatePutawayExecution(request))
+                    .isInstanceOf(InsufficientPermissionException.class);
+        }
+
+        @Test
+        void requiresAReasonAndJustificationOnACompatibilityOverride() {
+            PutawayExecutionRequest request = request(10);
+            request.setOverrideLocationCompatibility(true);
+            authenticateWith(PutawayPermissions.OVERRIDE_LOCATION_COMPATIBILITY);
+
+            ValidationResult result = service.validatePutawayExecution(request);
+
+            assertThat(errorCodes(result))
+                    .contains(
+                            "COMPATIBILITY_OVERRIDE_REASON_REQUIRED", "COMPATIBILITY_OVERRIDE_JUSTIFICATION_REQUIRED");
+        }
+
+        @Test
+        void recordsAnAuthorizedCompatibilityOverrideAsAWarning() {
+            PutawayExecutionRequest request = request(10);
+            request.setOverrideLocationCompatibility(true);
+            request.setOverrideReasonCode(OverrideReasonCode.CAPACITY_OVERRIDE);
+            request.setOverrideJustification("no alternative bin available");
+            authenticateWith(PutawayPermissions.OVERRIDE_LOCATION_COMPATIBILITY);
+
+            ValidationResult result = service.validatePutawayExecution(request);
+
+            assertThat(result.isValid()).isTrue();
+            assertThat(warningCodes(result)).contains("COMPATIBILITY_OVERRIDDEN");
+        }
+
+        @Test
+        void turnsAMissingSourceIntoAReconciliationWarningWhenCompatibilityIsOverridden() {
+            when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
+                            eq(SKU), eq(SOURCE_LOCATION_ID), any(List.class)))
+                    .thenReturn(0);
+            PutawayExecutionRequest request = request(10);
+            request.setOverrideLocationCompatibility(true);
+            request.setOverrideReasonCode(OverrideReasonCode.CAPACITY_OVERRIDE);
+            request.setOverrideJustification("stock physically present");
+            authenticateWith(PutawayPermissions.OVERRIDE_LOCATION_COMPATIBILITY);
+
+            ValidationResult result = service.validatePutawayExecution(request);
+
+            assertThat(warningCodes(result)).contains("SOURCE_RECONCILIATION_NEEDED");
+        }
+
+        @Test
+        void stillRefusesAMissingSourceWhenNothingIsOverridden() {
+            when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
+                            eq(SKU), eq(SOURCE_LOCATION_ID), any(List.class)))
+                    .thenReturn(0);
+            PutawayExecutionRequest request = request(10);
+
+            assertThatThrownBy(() -> service.validatePutawayExecution(request))
+                    .isInstanceOf(NoOnHandAtSourceLocationException.class);
+        }
+
+        @Test
+        void refusesACapacityOverrideWithoutThePermission() {
+            PutawayExecutionRequest request = request(10);
+            request.setOverrideCapacity(true);
+            authenticateWith();
+
+            assertThatThrownBy(() -> service.validatePutawayExecution(request))
+                    .isInstanceOf(InsufficientPermissionException.class);
+        }
+
+        @Test
+        void requiresAnApproverOnACapacityOverride() {
+            PutawayExecutionRequest request = request(10);
+            request.setOverrideCapacity(true);
+            request.setOverrideReasonCode(OverrideReasonCode.CAPACITY_OVERRIDE);
+            request.setOverrideJustification("peak season");
+            authenticateWith(PutawayPermissions.OVERRIDE_LOCATION_CAPACITY);
+
+            ValidationResult result = service.validatePutawayExecution(request);
+
+            assertThat(errorCodes(result)).contains("CAPACITY_OVERRIDE_APPROVAL_REQUIRED");
+        }
+
+        @Test
+        void recordsAnAuthorizedCapacityOverrideAsAWarning() {
+            PutawayExecutionRequest request = request(10);
+            request.setOverrideCapacity(true);
+            request.setOverrideReasonCode(OverrideReasonCode.CAPACITY_OVERRIDE);
+            request.setOverrideJustification("peak season");
+            request.setApprovedBy("ops.manager");
+            authenticateWith(PutawayPermissions.OVERRIDE_LOCATION_CAPACITY);
+
+            ValidationResult result = service.validatePutawayExecution(request);
+
+            assertThat(result.isValid()).isTrue();
+            assertThat(warningCodes(result)).contains("CAPACITY_OVERRIDDEN");
+        }
+
+        @Test
+        void refusesACapacityOverrideThatBlowsPastTheTolerance() {
+            PutawayExecutionRequest request = request(150);
+            request.setOverrideCapacity(true);
+            request.setOverrideReasonCode(OverrideReasonCode.CAPACITY_OVERRIDE);
+            request.setOverrideJustification("peak season");
+            request.setApprovedBy("ops.manager");
+            authenticateWith(PutawayPermissions.OVERRIDE_LOCATION_CAPACITY);
+
+            ValidationResult result = service.validatePutawayExecution(request);
+
+            assertThat(errorCodes(result)).contains("CAPACITY_OVERRIDE_EXCEEDS_TOLERANCE");
+        }
+
+        @Test
+        void reportsThatToleranceCannotBeJudgedWithoutAConfiguredCapacity() {
+            when(storageLocationValidationService.getStorageLocationValidation(anyString()))
+                    .thenReturn(locationValidation(true, true, null));
+            when(replenishmentPolicyRepository.sumMaximumQuantityByLocationId(DESTINATION_LOCATION_ID))
+                    .thenReturn(0);
+            PutawayExecutionRequest request = request(10);
+            request.setOverrideCapacity(true);
+            request.setOverrideReasonCode(OverrideReasonCode.CAPACITY_OVERRIDE);
+            request.setOverrideJustification("peak season");
+            request.setApprovedBy("ops.manager");
+            authenticateWith(PutawayPermissions.OVERRIDE_LOCATION_CAPACITY);
+
+            ValidationResult result = service.validatePutawayExecution(request);
+
+            assertThat(errorCodes(result)).contains("CAPACITY_OVERRIDE_TOLERANCE_UNCHECKABLE");
+        }
+
+        @Test
+        void carriesCapacityWarningsThroughWhenNothingIsOverridden() {
+            ValidationResult result = service.validatePutawayExecution(request(95));
+
+            assertThat(warningCodes(result)).contains("CAPACITY_NEAR_LIMIT");
+        }
+    }
+
+    @Nested
+    @DisplayName("no-collaborator constructor")
+    class NoCollaboratorConstructor {
+
+        @Test
+        void degradesToPassThroughValidationWhenNothingIsWired() {
+            PutawayValidationServiceImpl bare = new PutawayValidationServiceImpl();
+
+            assertThat(bare.validateLocationCompatibility(DESTINATION_LOCATION_ID, SKU)
+                            .isValid())
+                    .isTrue();
+            assertThat(bare.validateLocationCapacity(DESTINATION_LOCATION_ID, 10)
+                            .isValid())
+                    .isTrue();
+            assertThat(bare.validateSourceOnHand(SOURCE_LOCATION_ID, SKU, 10).isValid())
+                    .isTrue();
+        }
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/TransferOrderServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/TransferOrderServiceImplTest.java
@@ -1,0 +1,698 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.inventory.TransferOrderUpdatedV1;
+import com.positivity.inventory.internal.dto.transfer.CreateTransferOrderRequest;
+import com.positivity.inventory.internal.dto.transfer.DispatchTransferOrderRequest;
+import com.positivity.inventory.internal.dto.transfer.ReceiveTransferOrderRequest;
+import com.positivity.inventory.internal.dto.transfer.ShortCloseTransferOrderRequest;
+import com.positivity.inventory.internal.dto.transfer.TransferOrderLineRequest;
+import com.positivity.inventory.internal.dto.transfer.TransferOrderResponse;
+import com.positivity.inventory.internal.dto.transfer.TransferQuantityLineRequest;
+import com.positivity.inventory.internal.entity.ExtStorageLocationReplica;
+import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.LocationRefEntity;
+import com.positivity.inventory.internal.entity.TransferOrder;
+import com.positivity.inventory.internal.entity.TransferOrderLine;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import com.positivity.inventory.internal.enums.ScrapReasonCode;
+import com.positivity.inventory.internal.enums.TransferOrderStatus;
+import com.positivity.inventory.internal.enums.TransferShortCloseDisposition;
+import com.positivity.inventory.internal.exception.LocationNotFoundException;
+import com.positivity.inventory.internal.exception.TransferLocationNotEligibleException;
+import com.positivity.inventory.internal.exception.TransferOrderNotFoundException;
+import com.positivity.inventory.internal.exception.TransferQuantityExceededException;
+import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRepository;
+import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import com.positivity.inventory.internal.repository.LocationRefRepository;
+import com.positivity.inventory.internal.repository.TransferOrderRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Sort;
+
+/**
+ * Transfer-order lifecycle (odoo-parity C1/C3, #1035/#1039): site eligibility gates every
+ * movement, dispatch and receive post conserving ledger pairs, and short-close resolves the
+ * in-transit remainder as either a loss or a return to the source.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("TransferOrderServiceImpl")
+class TransferOrderServiceImplTest {
+
+    private static final UUID ORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f1a01");
+    private static final UUID SOURCE_SITE = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f1a02");
+    private static final UUID DESTINATION_SITE = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f1a03");
+    private static final UUID SOURCE_BIN = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f1a04");
+    private static final UUID LINE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f1a05");
+    private static final UUID LOT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f1a06");
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final String SKU = "SKU-1";
+
+    @Mock
+    private TransferOrderRepository transferOrderRepository;
+
+    @Mock
+    private LocationRefRepository locationRefRepository;
+
+    @Mock
+    private ExtStorageLocationReplicaRepository storageLocationRepository;
+
+    @Mock
+    private LedgerPostingService ledgerPostingService;
+
+    @Mock
+    private InventoryLedgerEntryRepository ledgerRepository;
+
+    @Mock
+    private InventoryFactPublisher inventoryFactPublisher;
+
+    @Mock
+    private InventoryLotOutboundService lotOutboundService;
+
+    private TransferOrderServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = newService(false);
+        stubEligibleSite(SOURCE_SITE);
+        stubEligibleSite(DESTINATION_SITE);
+        when(transferOrderRepository.save(any())).thenAnswer(invocation -> {
+            TransferOrder order = invocation.getArgument(0);
+            if (order.getTransferOrderId() == null) {
+                order.setTransferOrderId(ORDER_ID);
+            }
+            return order;
+        });
+        when(ledgerPostingService.postAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(ledgerRepository.calculateOnHandQuantityAtLocation(anyString(), any(UUID.class)))
+                .thenReturn(50);
+        when(storageLocationRepository.findById(any())).thenReturn(Optional.empty());
+        when(lotOutboundService.resolveOutboundLot(anyString(), any())).thenReturn(null);
+    }
+
+    private TransferOrderServiceImpl newService(boolean approvalRequired) {
+        return new TransferOrderServiceImpl(
+                transferOrderRepository,
+                locationRefRepository,
+                storageLocationRepository,
+                ledgerPostingService,
+                ledgerRepository,
+                inventoryFactPublisher,
+                lotOutboundService,
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                approvalRequired);
+    }
+
+    private void stubEligibleSite(UUID siteId) {
+        stubSite(siteId, "ACTIVE");
+    }
+
+    private void stubSite(UUID siteId, String status) {
+        LocationRefEntity site = new LocationRefEntity();
+        site.setLocationId(siteId);
+        site.setStatus(status);
+        when(locationRefRepository.findByLocationId(siteId)).thenReturn(Optional.of(site));
+    }
+
+    private static CreateTransferOrderRequest createRequest() {
+        return CreateTransferOrderRequest.builder()
+                .sourceLocationId(SOURCE_SITE)
+                .destinationLocationId(DESTINATION_SITE)
+                .notes("restock")
+                .lines(List.of(TransferOrderLineRequest.builder()
+                        .sku(SKU)
+                        .requestedQty(10)
+                        .build()))
+                .build();
+    }
+
+    private TransferOrder order(TransferOrderStatus status, int requested, int dispatched, int received) {
+        TransferOrderLine line = TransferOrderLine.builder()
+                .lineId(LINE_ID)
+                .lineNumber(1)
+                .sku(SKU)
+                .requestedQty(requested)
+                .dispatchedQty(dispatched)
+                .receivedQty(received)
+                .build();
+        TransferOrder order = TransferOrder.builder()
+                .transferOrderId(ORDER_ID)
+                .sourceLocationId(SOURCE_SITE)
+                .destinationLocationId(DESTINATION_SITE)
+                .status(status)
+                .lines(new ArrayList<>())
+                .build();
+        order.addLine(line);
+        when(transferOrderRepository.findById(ORDER_ID)).thenReturn(Optional.of(order));
+        return order;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<InventoryLedgerEntry> postedEntries() {
+        ArgumentCaptor<List<InventoryLedgerEntry>> captor = ArgumentCaptor.forClass(List.class);
+        verify(ledgerPostingService).postAll(captor.capture());
+        return captor.getValue();
+    }
+
+    @Nested
+    @DisplayName("createTransferOrder")
+    class CreateTransferOrder {
+
+        @Test
+        void opensADraftOrderWithNumberedLinesAndPublishesTheFact() {
+            TransferOrderResponse response = service.createTransferOrder(createRequest());
+
+            assertThat(response.getStatus()).isEqualTo(TransferOrderStatus.DRAFT);
+            assertThat(response.getSourceLocationId()).isEqualTo(SOURCE_SITE);
+            assertThat(response.getLines()).hasSize(1);
+            assertThat(response.getLines().get(0).getLineNumber()).isEqualTo(1);
+            assertThat(response.getLines().get(0).getRequestedQty()).isEqualTo(10);
+            assertThat(response.getNotes()).isEqualTo("restock");
+            assertThat(response.getCreatedBy()).isEqualTo("system");
+
+            ArgumentCaptor<TransferOrderUpdatedV1> fact = ArgumentCaptor.forClass(TransferOrderUpdatedV1.class);
+            verify(inventoryFactPublisher).recordTransferOrderUpdated(fact.capture());
+            assertThat(fact.getValue().status()).isEqualTo("DRAFT");
+            assertThat(fact.getValue().lines()).hasSize(1);
+        }
+
+        @Test
+        void refusesATransferFromASiteToItself() {
+            CreateTransferOrderRequest request = CreateTransferOrderRequest.builder()
+                    .sourceLocationId(SOURCE_SITE)
+                    .destinationLocationId(SOURCE_SITE)
+                    .lines(List.of())
+                    .build();
+
+            assertThatThrownBy(() -> service.createTransferOrder(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("must be different sites");
+        }
+
+        @Test
+        void refusesAnUnknownSite() {
+            when(locationRefRepository.findByLocationId(SOURCE_SITE)).thenReturn(Optional.empty());
+            CreateTransferOrderRequest request = createRequest();
+
+            assertThatThrownBy(() -> service.createTransferOrder(request))
+                    .isInstanceOf(LocationNotFoundException.class);
+        }
+
+        @Test
+        void refusesASiteThatIsNotActive() {
+            stubSite(DESTINATION_SITE, "INACTIVE");
+            CreateTransferOrderRequest request = createRequest();
+
+            assertThatThrownBy(() -> service.createTransferOrder(request))
+                    .isInstanceOf(TransferLocationNotEligibleException.class);
+        }
+
+        @Test
+        void refusesABinThatBelongsToADifferentSite() {
+            ExtStorageLocationReplica bin = new ExtStorageLocationReplica();
+            bin.setStorageLocationId(SOURCE_BIN);
+            bin.setSiteId(DESTINATION_SITE);
+            when(storageLocationRepository.findById(SOURCE_BIN)).thenReturn(Optional.of(bin));
+            CreateTransferOrderRequest request = CreateTransferOrderRequest.builder()
+                    .sourceLocationId(SOURCE_SITE)
+                    .sourceStorageLocationId(SOURCE_BIN)
+                    .destinationLocationId(DESTINATION_SITE)
+                    .lines(List.of())
+                    .build();
+
+            assertThatThrownBy(() -> service.createTransferOrder(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("belongs to site");
+        }
+
+        @Test
+        void acceptsABinTheReplicaDoesNotKnowYet() {
+            CreateTransferOrderRequest request = CreateTransferOrderRequest.builder()
+                    .sourceLocationId(SOURCE_SITE)
+                    .sourceStorageLocationId(SOURCE_BIN)
+                    .destinationLocationId(DESTINATION_SITE)
+                    .lines(List.of(TransferOrderLineRequest.builder()
+                            .sku(SKU)
+                            .requestedQty(10)
+                            .build()))
+                    .build();
+
+            assertThat(service.createTransferOrder(request).getSourceStorageLocationId())
+                    .isEqualTo(SOURCE_BIN);
+        }
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        void readsOneOrderById() {
+            order(TransferOrderStatus.DRAFT, 10, 0, 0);
+
+            assertThat(service.getTransferOrder(ORDER_ID).getTransferOrderId()).isEqualTo(ORDER_ID);
+        }
+
+        @Test
+        void failsForAnUnknownOrder() {
+            when(transferOrderRepository.findById(ORDER_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getTransferOrder(ORDER_ID))
+                    .isInstanceOf(TransferOrderNotFoundException.class);
+        }
+
+        @Test
+        void listsOrdersNewestFirstWithEveryFilterApplied() {
+            TransferOrder existing = TransferOrder.builder()
+                    .transferOrderId(ORDER_ID)
+                    .sourceLocationId(SOURCE_SITE)
+                    .destinationLocationId(DESTINATION_SITE)
+                    .status(TransferOrderStatus.DRAFT)
+                    .lines(new ArrayList<>())
+                    .build();
+            when(transferOrderRepository.findAll(
+                            any(org.springframework.data.jpa.domain.Specification.class), any(Sort.class)))
+                    .thenReturn(List.of(existing));
+
+            assertThat(service.listTransferOrders(TransferOrderStatus.DRAFT, SOURCE_SITE, DESTINATION_SITE))
+                    .hasSize(1);
+        }
+
+        @Test
+        void listsOrdersWithNoFiltersAtAll() {
+            when(transferOrderRepository.findAll(
+                            any(org.springframework.data.jpa.domain.Specification.class), any(Sort.class)))
+                    .thenReturn(List.of());
+
+            assertThat(service.listTransferOrders(null, null, null)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("approve and cancel")
+    class ApproveAndCancel {
+
+        @Test
+        void refusesToApproveWhenTheApprovalStepIsDisabled() {
+            assertThatThrownBy(() -> service.approveTransferOrder(ORDER_ID))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("approval step is disabled");
+        }
+
+        @Test
+        void approvesADraftOrderWhenTheStepIsEnabled() {
+            TransferOrderServiceImpl approving = newService(true);
+            TransferOrder draft = order(TransferOrderStatus.DRAFT, 10, 0, 0);
+
+            TransferOrderResponse response = approving.approveTransferOrder(ORDER_ID);
+
+            assertThat(draft.getStatus()).isEqualTo(TransferOrderStatus.APPROVED);
+            assertThat(response.getApprovedBy()).isEqualTo("system");
+        }
+
+        @Test
+        void refusesToApproveAnOrderThatIsNoLongerADraft() {
+            TransferOrderServiceImpl approving = newService(true);
+            order(TransferOrderStatus.DISPATCHED, 10, 10, 0);
+
+            assertThatThrownBy(() -> approving.approveTransferOrder(ORDER_ID))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Cannot approve");
+        }
+
+        @Test
+        void cancelsAnOrderThatHasNotMovedStock() {
+            TransferOrder draft = order(TransferOrderStatus.DRAFT, 10, 0, 0);
+
+            assertThat(service.cancelTransferOrder(ORDER_ID).getStatus()).isEqualTo(TransferOrderStatus.CANCELLED);
+            assertThat(draft.getStatus()).isEqualTo(TransferOrderStatus.CANCELLED);
+        }
+
+        @Test
+        void refusesToCancelOnceStockHasBeenDispatched() {
+            order(TransferOrderStatus.DISPATCHED, 10, 10, 0);
+
+            assertThatThrownBy(() -> service.cancelTransferOrder(ORDER_ID))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("short-close");
+        }
+    }
+
+    @Nested
+    @DisplayName("dispatchTransferOrder")
+    class DispatchTransferOrder {
+
+        @Test
+        void postsATransferOutForTheFullRequestedQuantityByDefault() {
+            TransferOrder draft = order(TransferOrderStatus.DRAFT, 10, 0, 0);
+
+            TransferOrderResponse response = service.dispatchTransferOrder(
+                    ORDER_ID, DispatchTransferOrderRequest.builder().build());
+
+            List<InventoryLedgerEntry> entries = postedEntries();
+            assertThat(entries).hasSize(1);
+            assertThat(entries.get(0).getEventType()).isEqualTo(InventoryLedgerEventType.TRANSFER_OUT);
+            assertThat(entries.get(0).getChangeInQuantity()).isEqualTo(-10);
+            assertThat(entries.get(0).getQuantityAfter()).isEqualTo(40);
+            assertThat(entries.get(0).getLocationId()).isEqualTo(SOURCE_SITE);
+            assertThat(entries.get(0).getToLocationId()).isEqualTo(DESTINATION_SITE);
+            assertThat(entries.get(0).getSourceTransactionId()).isEqualTo(ORDER_ID.toString());
+            assertThat(draft.getLines().get(0).getDispatchedQty()).isEqualTo(10);
+            assertThat(response.getStatus()).isEqualTo(TransferOrderStatus.DISPATCHED);
+            verify(inventoryFactPublisher).markEntries(entries);
+        }
+
+        @Test
+        void dispatchesAnExplicitPartialQuantity() {
+            order(TransferOrderStatus.DRAFT, 10, 0, 0);
+
+            service.dispatchTransferOrder(
+                    ORDER_ID,
+                    DispatchTransferOrderRequest.builder()
+                            .lines(List.of(TransferQuantityLineRequest.builder()
+                                    .lineId(LINE_ID)
+                                    .quantity(4)
+                                    .build()))
+                            .build());
+
+            assertThat(postedEntries().get(0).getChangeInQuantity()).isEqualTo(-4);
+        }
+
+        @Test
+        void pinsTheResolvedLotOnTheLineSoBothEndsPostTheSameLot() {
+            order(TransferOrderStatus.DRAFT, 10, 0, 0);
+            when(lotOutboundService.resolveOutboundLot(SKU, "LOT-A")).thenReturn(LOT_ID);
+
+            TransferOrderResponse response = service.dispatchTransferOrder(
+                    ORDER_ID,
+                    DispatchTransferOrderRequest.builder()
+                            .lines(List.of(TransferQuantityLineRequest.builder()
+                                    .lineId(LINE_ID)
+                                    .quantity(10)
+                                    .lotNumber("LOT-A")
+                                    .build()))
+                            .build());
+
+            assertThat(response.getLines().get(0).getLotId()).isEqualTo(LOT_ID);
+            assertThat(response.getLines().get(0).getLotNumber()).isEqualTo("LOT-A");
+            assertThat(postedEntries().get(0).getLotId()).isEqualTo(LOT_ID);
+        }
+
+        @Test
+        void refusesToDispatchMoreThanWasRequested() {
+            order(TransferOrderStatus.DRAFT, 10, 0, 0);
+            DispatchTransferOrderRequest request = DispatchTransferOrderRequest.builder()
+                    .lines(List.of(TransferQuantityLineRequest.builder()
+                            .lineId(LINE_ID)
+                            .quantity(11)
+                            .build()))
+                    .build();
+
+            assertThatThrownBy(() -> service.dispatchTransferOrder(ORDER_ID, request))
+                    .isInstanceOf(TransferQuantityExceededException.class);
+            verify(ledgerPostingService, never()).postAll(any());
+        }
+
+        @Test
+        void refusesAnUnknownLineIdInTheRequest() {
+            order(TransferOrderStatus.DRAFT, 10, 0, 0);
+            DispatchTransferOrderRequest request = DispatchTransferOrderRequest.builder()
+                    .lines(List.of(TransferQuantityLineRequest.builder()
+                            .lineId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f1aff"))
+                            .quantity(1)
+                            .build()))
+                    .build();
+
+            assertThatThrownBy(() -> service.dispatchTransferOrder(ORDER_ID, request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Unknown transfer order line");
+        }
+
+        @Test
+        void refusesADuplicateLineIdInTheRequest() {
+            order(TransferOrderStatus.DRAFT, 10, 0, 0);
+            TransferQuantityLineRequest line = TransferQuantityLineRequest.builder()
+                    .lineId(LINE_ID)
+                    .quantity(1)
+                    .build();
+            DispatchTransferOrderRequest request = DispatchTransferOrderRequest.builder()
+                    .lines(List.of(line, line))
+                    .build();
+
+            assertThatThrownBy(() -> service.dispatchTransferOrder(ORDER_ID, request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Duplicate transfer order line");
+        }
+
+        @Test
+        void refusesToDispatchAnOrderInTheWrongStatus() {
+            order(TransferOrderStatus.RECEIVED, 10, 10, 10);
+            DispatchTransferOrderRequest request =
+                    DispatchTransferOrderRequest.builder().build();
+
+            assertThatThrownBy(() -> service.dispatchTransferOrder(ORDER_ID, request))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Cannot dispatch");
+        }
+
+        @Test
+        void tellsTheCallerToApproveFirstWhenTheApprovalStepIsOn() {
+            TransferOrderServiceImpl approving = newService(true);
+            order(TransferOrderStatus.DRAFT, 10, 0, 0);
+            DispatchTransferOrderRequest request =
+                    DispatchTransferOrderRequest.builder().build();
+
+            assertThatThrownBy(() -> approving.dispatchTransferOrder(ORDER_ID, request))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("approval is required before dispatch");
+        }
+
+        @Test
+        void postsAgainstTheBinWhenTheOrderPinsOne() {
+            TransferOrder draft = order(TransferOrderStatus.DRAFT, 10, 0, 0);
+            draft.setSourceStorageLocationId(SOURCE_BIN);
+
+            service.dispatchTransferOrder(
+                    ORDER_ID, DispatchTransferOrderRequest.builder().build());
+
+            assertThat(postedEntries().get(0).getLocationId()).isEqualTo(SOURCE_BIN);
+        }
+    }
+
+    @Nested
+    @DisplayName("receiveTransferOrder")
+    class ReceiveTransferOrder {
+
+        @Test
+        void postsATransferInForTheWholeOutstandingQuantity() {
+            TransferOrder dispatched = order(TransferOrderStatus.DISPATCHED, 10, 10, 0);
+
+            TransferOrderResponse response = service.receiveTransferOrder(
+                    ORDER_ID, ReceiveTransferOrderRequest.builder().build());
+
+            List<InventoryLedgerEntry> entries = postedEntries();
+            assertThat(entries).hasSize(1);
+            assertThat(entries.get(0).getEventType()).isEqualTo(InventoryLedgerEventType.TRANSFER_IN);
+            assertThat(entries.get(0).getChangeInQuantity()).isEqualTo(10);
+            assertThat(entries.get(0).getLocationId()).isEqualTo(DESTINATION_SITE);
+            assertThat(dispatched.getLines().get(0).getReceivedQty()).isEqualTo(10);
+            assertThat(response.getStatus()).isEqualTo(TransferOrderStatus.RECEIVED);
+        }
+
+        @Test
+        void marksThePartialReceiptWithoutClosingTheOrder() {
+            order(TransferOrderStatus.DISPATCHED, 10, 10, 0);
+
+            TransferOrderResponse response = service.receiveTransferOrder(
+                    ORDER_ID,
+                    ReceiveTransferOrderRequest.builder()
+                            .lines(List.of(TransferQuantityLineRequest.builder()
+                                    .lineId(LINE_ID)
+                                    .quantity(6)
+                                    .build()))
+                            .build());
+
+            assertThat(response.getStatus()).isEqualTo(TransferOrderStatus.PARTIALLY_RECEIVED);
+            assertThat(response.getLines().get(0).getReceivedQty()).isEqualTo(6);
+        }
+
+        @Test
+        void postsNothingForALineWithNothingLeftToReceive() {
+            order(TransferOrderStatus.PARTIALLY_RECEIVED, 10, 10, 10);
+
+            service.receiveTransferOrder(
+                    ORDER_ID, ReceiveTransferOrderRequest.builder().build());
+
+            assertThat(postedEntries()).isEmpty();
+        }
+
+        @Test
+        void refusesToReceiveMoreThanIsInTransit() {
+            order(TransferOrderStatus.DISPATCHED, 10, 10, 8);
+            ReceiveTransferOrderRequest request = ReceiveTransferOrderRequest.builder()
+                    .lines(List.of(TransferQuantityLineRequest.builder()
+                            .lineId(LINE_ID)
+                            .quantity(3)
+                            .build()))
+                    .build();
+
+            assertThatThrownBy(() -> service.receiveTransferOrder(ORDER_ID, request))
+                    .isInstanceOf(TransferQuantityExceededException.class);
+        }
+
+        @Test
+        void refusesToReceiveAnOrderThatWasNeverDispatched() {
+            order(TransferOrderStatus.DRAFT, 10, 0, 0);
+            ReceiveTransferOrderRequest request =
+                    ReceiveTransferOrderRequest.builder().build();
+
+            assertThatThrownBy(() -> service.receiveTransferOrder(ORDER_ID, request))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Cannot receive");
+        }
+    }
+
+    @Nested
+    @DisplayName("shortCloseTransferOrder")
+    class ShortCloseTransferOrder {
+
+        private ShortCloseTransferOrderRequest shortClose(TransferShortCloseDisposition disposition) {
+            return ShortCloseTransferOrderRequest.builder()
+                    .disposition(disposition)
+                    .reason("carrier loss")
+                    .notes("claim filed")
+                    .build();
+        }
+
+        @Test
+        void writesOffALostRemainderAsAConstructiveArrivalPairedWithAScrap() {
+            when(ledgerRepository.findLatestUnitCostByStockItemAndEventType(any(), any(), any()))
+                    .thenReturn(List.of(new BigDecimal("12.50")));
+            TransferOrder dispatched = order(TransferOrderStatus.DISPATCHED, 10, 10, 4);
+
+            TransferOrderResponse response = service.shortCloseTransferOrder(
+                    ORDER_ID, shortClose(TransferShortCloseDisposition.LOST_IN_TRANSIT));
+
+            List<InventoryLedgerEntry> entries = postedEntries();
+            assertThat(entries).hasSize(2);
+            assertThat(entries.get(0).getEventType()).isEqualTo(InventoryLedgerEventType.TRANSFER_IN);
+            assertThat(entries.get(0).getChangeInQuantity()).isEqualTo(6);
+            assertThat(entries.get(1).getEventType()).isEqualTo(InventoryLedgerEventType.SCRAP_OUT);
+            assertThat(entries.get(1).getChangeInQuantity()).isEqualTo(-6);
+            assertThat(entries.get(1).getReasonCode()).isEqualTo(ScrapReasonCode.LOST.name());
+            assertThat(entries.get(1).getUnitCost()).isEqualByComparingTo("12.50");
+            assertThat(entries.get(1).getNotes()).isEqualTo("claim filed");
+            assertThat(dispatched.getShortClosedAt()).isEqualTo(NOW);
+            assertThat(response.getStatus()).isEqualTo(TransferOrderStatus.SHORT_CLOSED);
+            assertThat(response.getShortCloseReason()).isEqualTo("carrier loss");
+        }
+
+        @Test
+        void fallsBackToTheLatestKnownUnitCostWhenThereIsNoGoodsReceipt() {
+            when(ledgerRepository.findLatestUnitCostByStockItemAndEventType(any(), any(), any()))
+                    .thenReturn(List.of());
+            when(ledgerRepository.findLatestUnitCostByStockItem(any(), any()))
+                    .thenReturn(List.of(new BigDecimal("9.00")));
+            order(TransferOrderStatus.DISPATCHED, 10, 10, 0);
+
+            service.shortCloseTransferOrder(ORDER_ID, shortClose(TransferShortCloseDisposition.LOST_IN_TRANSIT));
+
+            assertThat(postedEntries().get(1).getUnitCost()).isEqualByComparingTo("9.00");
+        }
+
+        @Test
+        void leavesTheScrapCostUnsetWhenTheSkuHasNoCostHistory() {
+            when(ledgerRepository.findLatestUnitCostByStockItemAndEventType(any(), any(), any()))
+                    .thenReturn(List.of());
+            when(ledgerRepository.findLatestUnitCostByStockItem(any(), any())).thenReturn(List.of());
+            order(TransferOrderStatus.DISPATCHED, 10, 10, 0);
+
+            service.shortCloseTransferOrder(ORDER_ID, shortClose(TransferShortCloseDisposition.LOST_IN_TRANSIT));
+
+            assertThat(postedEntries().get(1).getUnitCost()).isNull();
+        }
+
+        @Test
+        void returnsTheRemainderToTheSourceAsAThreeEntryShape() {
+            order(TransferOrderStatus.PARTIALLY_RECEIVED, 10, 10, 7);
+
+            service.shortCloseTransferOrder(ORDER_ID, shortClose(TransferShortCloseDisposition.RETURNED_TO_SOURCE));
+
+            List<InventoryLedgerEntry> entries = postedEntries();
+            assertThat(entries).hasSize(3);
+            assertThat(entries.get(0).getEventType()).isEqualTo(InventoryLedgerEventType.TRANSFER_IN);
+            assertThat(entries.get(0).getLocationId()).isEqualTo(DESTINATION_SITE);
+            assertThat(entries.get(1).getEventType()).isEqualTo(InventoryLedgerEventType.TRANSFER_OUT);
+            assertThat(entries.get(1).getLocationId()).isEqualTo(DESTINATION_SITE);
+            assertThat(entries.get(1).getToLocationId()).isEqualTo(SOURCE_SITE);
+            assertThat(entries.get(2).getEventType()).isEqualTo(InventoryLedgerEventType.TRANSFER_IN);
+            assertThat(entries.get(2).getLocationId()).isEqualTo(SOURCE_SITE);
+            assertThat(entries.get(2).getChangeInQuantity()).isEqualTo(3);
+        }
+
+        @Test
+        void revalidatesTheSourceOnlyForAReturn() {
+            stubSite(SOURCE_SITE, "INACTIVE");
+            order(TransferOrderStatus.DISPATCHED, 10, 10, 0);
+            ShortCloseTransferOrderRequest request = shortClose(TransferShortCloseDisposition.RETURNED_TO_SOURCE);
+
+            assertThatThrownBy(() -> service.shortCloseTransferOrder(ORDER_ID, request))
+                    .isInstanceOf(TransferLocationNotEligibleException.class);
+        }
+
+        @Test
+        void resolvesALossEvenWhenTheSourceHasSinceBeenDeactivated() {
+            stubSite(SOURCE_SITE, "INACTIVE");
+            order(TransferOrderStatus.DISPATCHED, 10, 10, 0);
+
+            assertThat(service.shortCloseTransferOrder(
+                                    ORDER_ID, shortClose(TransferShortCloseDisposition.LOST_IN_TRANSIT))
+                            .getStatus())
+                    .isEqualTo(TransferOrderStatus.SHORT_CLOSED);
+        }
+
+        @Test
+        void refusesToShortCloseAnOrderWithNothingOutstanding() {
+            order(TransferOrderStatus.DISPATCHED, 10, 10, 10);
+            ShortCloseTransferOrderRequest request = shortClose(TransferShortCloseDisposition.LOST_IN_TRANSIT);
+
+            assertThatThrownBy(() -> service.shortCloseTransferOrder(ORDER_ID, request))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("no outstanding in-transit remainder");
+        }
+
+        @Test
+        void refusesToShortCloseAnOrderThatWasNeverDispatched() {
+            order(TransferOrderStatus.DRAFT, 10, 0, 0);
+            ShortCloseTransferOrderRequest request = shortClose(TransferShortCloseDisposition.LOST_IN_TRANSIT);
+
+            assertThatThrownBy(() -> service.shortCloseTransferOrder(ORDER_ID, request))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Cannot short-close");
+        }
+    }
+}

--- a/pos-location/src/test/java/com/positivity/location/internal/service/InventoryManifestListenerTest.java
+++ b/pos-location/src/test/java/com/positivity/location/internal/service/InventoryManifestListenerTest.java
@@ -1,0 +1,170 @@
+package com.positivity.location.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.ReconciliationManifestV1;
+import com.positivity.location.internal.repository.ProcessedEventRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Consumer-side reconciliation of the inventory replica (ADR-0044 §4, #899): a matching manifest
+ * is silent, a mismatch increments {@code replica.drift} and asks the owner to replay the window.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("InventoryManifestListener")
+class InventoryManifestListenerTest {
+
+    private static final Instant WINDOW_START = Instant.parse("2026-03-01T00:00:00Z");
+    private static final Instant WINDOW_END = Instant.parse("2026-03-01T01:00:00Z");
+    private static final String COMMANDS_TOPIC = "inventory.commands.v1";
+    private static final List<String> EVENT_IDS =
+            List.of("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee01", "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee02");
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private MeterRegistry meterRegistry;
+    private InventoryManifestListener listener;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        listener = newListener(meterRegistry);
+    }
+
+    private InventoryManifestListener newListener(MeterRegistry registry) {
+        InventoryManifestListener created = new InventoryManifestListener(
+                processedEventRepository, kafkaTemplate, objectMapper, objectProviderOf(registry));
+        ReflectionTestUtils.setField(created, "locationCommandsTopic", COMMANDS_TOPIC);
+        return created;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ObjectProvider<MeterRegistry> objectProviderOf(MeterRegistry registry) {
+        ObjectProvider<MeterRegistry> provider = org.mockito.Mockito.mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(registry);
+        return provider;
+    }
+
+    private String envelope(long eventCount, String checksum) {
+        ReconciliationManifestV1 manifest = new ReconciliationManifestV1(
+                WINDOW_START, WINDOW_END, eventCount, checksum, Map.of("inventory.stock.changed", eventCount));
+        return objectMapper.writeValueAsString(Map.of("payload", manifest));
+    }
+
+    private double driftCount() {
+        return meterRegistry
+                .get("replica.drift")
+                .tag("owner", "inventory")
+                .counter()
+                .count();
+    }
+
+    @Test
+    void staysSilentWhenTheReplicaMatchesTheManifest() {
+        when(processedEventRepository.findEventIdsInRange(anyString(), anyString(), anyString()))
+                .thenReturn(EVENT_IDS);
+
+        listener.onManifest(envelope(EVENT_IDS.size(), ReconciliationManifestV1.checksumOf(EVENT_IDS)));
+
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+        assertThat(driftCount()).isZero();
+    }
+
+    @Test
+    void requestsAReplayWhenTheCountDoesNotMatch() {
+        when(processedEventRepository.findEventIdsInRange(anyString(), anyString(), anyString()))
+                .thenReturn(List.of(EVENT_IDS.get(0)));
+
+        listener.onManifest(envelope(EVENT_IDS.size(), ReconciliationManifestV1.checksumOf(EVENT_IDS)));
+
+        ArgumentCaptor<String> command = ArgumentCaptor.forClass(String.class);
+        verify(kafkaTemplate).send(eq(COMMANDS_TOPIC), eq(WINDOW_START.toString()), command.capture());
+        assertThat(command.getValue()).contains("inventory.outbox.replay-requested");
+        assertThat(command.getValue()).contains(WINDOW_START.toString()).contains(WINDOW_END.toString());
+        assertThat(driftCount()).isEqualTo(1.0d);
+    }
+
+    @Test
+    void requestsAReplayWhenTheChecksumDoesNotMatch() {
+        when(processedEventRepository.findEventIdsInRange(anyString(), anyString(), anyString()))
+                .thenReturn(EVENT_IDS);
+
+        listener.onManifest(
+                envelope(EVENT_IDS.size(), "0000000000000000000000000000000000000000000000000000000000000000"));
+
+        verify(kafkaTemplate).send(eq(COMMANDS_TOPIC), anyString(), anyString());
+        assertThat(driftCount()).isEqualTo(1.0d);
+    }
+
+    @Test
+    void scopesTheLocalRecountToTheInventoryOwnerAndTheManifestWindow() {
+        when(processedEventRepository.findEventIdsInRange(anyString(), anyString(), anyString()))
+                .thenReturn(EVENT_IDS);
+
+        listener.onManifest(envelope(EVENT_IDS.size(), ReconciliationManifestV1.checksumOf(EVENT_IDS)));
+
+        verify(processedEventRepository).findEventIdsInRange(eq("inventory"), anyString(), anyString());
+    }
+
+    @Test
+    void dropsAnUnparseableManifestWithoutTouchingTheReplica() {
+        listener.onManifest("not json at all");
+
+        verify(processedEventRepository, never()).findEventIdsInRange(any(), any(), any());
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void survivesAFailureToPublishTheReplayRequest() {
+        when(processedEventRepository.findEventIdsInRange(anyString(), anyString(), anyString()))
+                .thenReturn(List.of());
+        org.mockito.Mockito.doThrow(new IllegalStateException("broker down"))
+                .when(kafkaTemplate)
+                .send(anyString(), anyString(), anyString());
+
+        listener.onManifest(envelope(EVENT_IDS.size(), ReconciliationManifestV1.checksumOf(EVENT_IDS)));
+
+        // The drift metric still fired; the next manifest re-detects the gap.
+        assertThat(driftCount()).isEqualTo(1.0d);
+    }
+
+    @Test
+    void worksWithoutAMeterRegistry() {
+        InventoryManifestListener noMetrics = newListener(null);
+        when(processedEventRepository.findEventIdsInRange(anyString(), anyString(), anyString()))
+                .thenReturn(List.of());
+
+        noMetrics.onManifest(envelope(EVENT_IDS.size(), ReconciliationManifestV1.checksumOf(EVENT_IDS)));
+
+        verify(kafkaTemplate).send(eq(COMMANDS_TOPIC), anyString(), anyString());
+    }
+}

--- a/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/service/PersonServiceImplTest.java
+++ b/pos-people-contact/src/test/java/com/positivity/peoplecontact/internal/service/PersonServiceImplTest.java
@@ -1,0 +1,453 @@
+package com.positivity.peoplecontact.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.peoplecontact.internal.dto.Person;
+import com.positivity.peoplecontact.internal.dto.ResolvePersonRequest;
+import com.positivity.peoplecontact.internal.dto.ResolvePersonResponse;
+import com.positivity.peoplecontact.internal.entity.PersonContactPoint;
+import com.positivity.peoplecontact.internal.enums.ContactPointType;
+import com.positivity.peoplecontact.internal.enums.PartyType;
+import com.positivity.peoplecontact.internal.exception.PersonHasLinkedUsersException;
+import com.positivity.peoplecontact.internal.repository.PartyPostalAddressRepository;
+import com.positivity.peoplecontact.internal.repository.PersonContactPointRepository;
+import com.positivity.peoplecontact.internal.repository.PersonRepository;
+import com.positivity.peoplecontact.internal.repository.UserPersonLinkRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Person authority behaviour (ADR-0015 I2, ADR-0044 §6): identity reads join emails, phones and
+ * the security-owned username; {@code resolvePerson} scores candidates before falling back to a
+ * create; and deletion refuses to orphan a linked user.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PersonServiceImpl")
+class PersonServiceImplTest {
+
+    private static final UUID PERSON_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fdd01");
+    private static final UUID OTHER_PERSON_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fdd02");
+    private static final int DEFAULT_THRESHOLD = 30;
+
+    @Mock
+    private PersonRepository personRepository;
+
+    @Mock
+    private PersonContactPointRepository personContactPointRepository;
+
+    @Mock
+    private PartyPostalAddressRepository partyPostalAddressRepository;
+
+    @Mock
+    private UserPersonLinkRepository userPersonLinkRepository;
+
+    @Mock
+    private PeopleContactEventPublisher eventPublisher;
+
+    @Mock
+    private PersonWorkPhoneService workPhoneService;
+
+    @Mock
+    private PersonEmailService emailService;
+
+    @Mock
+    private PersonUsernameService usernameService;
+
+    private PersonServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PersonServiceImpl(
+                personRepository,
+                personContactPointRepository,
+                partyPostalAddressRepository,
+                userPersonLinkRepository,
+                eventPublisher,
+                workPhoneService,
+                emailService,
+                usernameService);
+        ReflectionTestUtils.setField(service, "defaultMatchingThreshold", DEFAULT_THRESHOLD);
+        when(emailService.getEmails(any())).thenReturn(new PersonEmailService.EmailPair(null, null));
+        when(workPhoneService.getWorkPhones(any(UUID.class))).thenReturn(List.of());
+        when(usernameService.usernamesByPersonId(any())).thenReturn(Map.of());
+        when(personRepository.save(any())).thenAnswer(invocation -> {
+            com.positivity.peoplecontact.internal.entity.Person entity = invocation.getArgument(0);
+            if (entity.getId() == null) {
+                entity.setId(PERSON_ID);
+            }
+            return entity;
+        });
+        when(partyPostalAddressRepository.findByPartyTypeAndPartyId(PartyType.PERSON, PERSON_ID))
+                .thenReturn(Optional.empty());
+    }
+
+    private static com.positivity.peoplecontact.internal.entity.Person entity(
+            UUID id, String firstName, String lastName) {
+        com.positivity.peoplecontact.internal.entity.Person person =
+                new com.positivity.peoplecontact.internal.entity.Person();
+        person.setId(id);
+        person.setFirstName(firstName);
+        person.setLastName(lastName);
+        person.setUpdatedAt(Instant.parse("2026-03-01T12:00:00Z"));
+        return person;
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        void attachesTheSecurityOwnedUsernameToEveryDirectoryRow() {
+            when(personRepository.findAll(any(Specification.class)))
+                    .thenReturn(List.of(entity(PERSON_ID, "Jane", "Smith")));
+            when(usernameService.usernamesByPersonId(List.of(PERSON_ID))).thenReturn(Map.of(PERSON_ID, "jane.smith"));
+            when(emailService.getEmails(PERSON_ID))
+                    .thenReturn(new PersonEmailService.EmailPair("jane@example.invalid", "j2@example.invalid"));
+            when(workPhoneService.getWorkPhones(PERSON_ID)).thenReturn(List.of("5550100"));
+
+            List<Person> people = service.getAllPeople("smith");
+
+            assertThat(people).hasSize(1);
+            assertThat(people.get(0).getUsername()).isEqualTo("jane.smith");
+            assertThat(people.get(0).getPrimaryEmail()).isEqualTo("jane@example.invalid");
+            assertThat(people.get(0).getSecondaryEmail()).isEqualTo("j2@example.invalid");
+            assertThat(people.get(0).getPhoneNumbers()).containsExactly("5550100");
+        }
+
+        @Test
+        void readsASinglePersonWithTheirUsername() {
+            when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(entity(PERSON_ID, "Jane", "Smith")));
+            when(usernameService.usernameForPerson(PERSON_ID)).thenReturn("jane.smith");
+
+            Person person = service.getPersonById(PERSON_ID).orElseThrow();
+
+            assertThat(person.getFirstName()).isEqualTo("Jane");
+            assertThat(person.getUsername()).isEqualTo("jane.smith");
+        }
+
+        @Test
+        void returnsEmptyForAnUnknownPerson() {
+            when(personRepository.findById(PERSON_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.getPersonById(PERSON_ID)).isEmpty();
+        }
+
+        @Test
+        void batchesContactPointsWhenReadingSeveralPeople() {
+            List<UUID> ids = List.of(PERSON_ID, OTHER_PERSON_ID);
+            when(personRepository.findAllById(ids))
+                    .thenReturn(List.of(entity(PERSON_ID, "Jane", "Smith"), entity(OTHER_PERSON_ID, "Rob", "Smith")));
+            when(personContactPointRepository.findByPersonIdIn(ids))
+                    .thenReturn(List.of(PersonContactPoint.builder()
+                            .personId(PERSON_ID)
+                            .contactType(ContactPointType.EMAIL)
+                            .value("jane@example.invalid")
+                            .isPrimary(true)
+                            .build()));
+            when(usernameService.usernamesByPersonId(ids)).thenReturn(Map.of(PERSON_ID, "jane.smith"));
+
+            List<Person> people = service.getPeopleByIds(ids);
+
+            assertThat(people).hasSize(2);
+            assertThat(people.get(0).getContactPoints()).hasSize(1);
+            assertThat(people.get(0).getContactPoints().get(0).getValue()).isEqualTo("jane@example.invalid");
+            assertThat(people.get(0).getContactPoints().get(0).isPrimary()).isTrue();
+            // A person with no contact points gets an empty list, not null.
+            assertThat(people.get(1).getContactPoints()).isEmpty();
+            assertThat(people.get(1).getUsername()).isNull();
+        }
+
+        @Test
+        void readsNothingForAnEmptyIdSet() {
+            assertThat(service.getPeopleByIds(List.of())).isEmpty();
+            verify(personRepository, never()).findAllById(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("replaceContactPoints")
+    class ReplaceContactPoints {
+
+        @Test
+        void replacesTheStoredSetAndPublishesTheUpdate() {
+            when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(entity(PERSON_ID, "Jane", "Smith")));
+            Person.ContactPointDto contactPoint = new Person.ContactPointDto();
+            contactPoint.setContactType(ContactPointType.EMAIL);
+            contactPoint.setValue("jane@example.invalid");
+            contactPoint.setPrimary(true);
+
+            service.replaceContactPoints(PERSON_ID, List.of(contactPoint));
+
+            verify(personContactPointRepository).deleteByPersonId(PERSON_ID);
+            ArgumentCaptor<List<PersonContactPoint>> saved = ArgumentCaptor.captor();
+            verify(personContactPointRepository).saveAll(saved.capture());
+            assertThat(saved.getValue()).hasSize(1);
+            assertThat(saved.getValue().get(0).getValue()).isEqualTo("jane@example.invalid");
+            verify(eventPublisher).publishPersonUpdated(any(), any(), any());
+        }
+
+        @Test
+        void clearsTheSetWithoutPublishingWhenGivenNothingToStore() {
+            service.replaceContactPoints(PERSON_ID, List.of());
+
+            verify(personContactPointRepository).deleteByPersonId(PERSON_ID);
+            verify(personContactPointRepository, never()).saveAll(any());
+            verify(eventPublisher, never()).publishPersonUpdated(any(), any(), any());
+        }
+
+        @Test
+        void dropsContactPointsMissingATypeOrAValue() {
+            when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(entity(PERSON_ID, "Jane", "Smith")));
+            Person.ContactPointDto noType = new Person.ContactPointDto();
+            noType.setValue("jane@example.invalid");
+            Person.ContactPointDto noValue = new Person.ContactPointDto();
+            noValue.setContactType(ContactPointType.EMAIL);
+
+            service.replaceContactPoints(PERSON_ID, List.of(noType, noValue));
+
+            ArgumentCaptor<List<PersonContactPoint>> saved = ArgumentCaptor.captor();
+            verify(personContactPointRepository).saveAll(saved.capture());
+            assertThat(saved.getValue()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("savePerson")
+    class SavePerson {
+
+        @Test
+        void persistsNamesLocallyAndDelegatesContactsToTheirOwnServices() {
+            when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(entity(PERSON_ID, "Jane", "Smith")));
+            when(usernameService.usernameForPerson(PERSON_ID)).thenReturn("jane.smith");
+            Person request = new Person();
+            request.setFirstName("Jane");
+            request.setLastName("Smith");
+            request.setPrimaryEmail("jane@example.invalid");
+            request.setPhoneNumbers(List.of("5550100"));
+
+            Person saved = service.savePerson(request);
+
+            verify(workPhoneService).replaceWorkPhones(PERSON_ID, List.of("5550100"));
+            verify(emailService).replaceEmails(PERSON_ID, "jane@example.invalid", null);
+            verify(eventPublisher).publishPersonUpdated(any(), any(), any());
+            assertThat(saved.getUsername()).isEqualTo("jane.smith");
+        }
+
+        @Test
+        void treatsMissingPhoneNumbersAsAnEmptyList() {
+            when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(entity(PERSON_ID, "Jane", "Smith")));
+            Person request = new Person();
+            request.setFirstName("Jane");
+
+            service.savePerson(request);
+
+            verify(workPhoneService).replaceWorkPhones(PERSON_ID, List.of());
+        }
+    }
+
+    @Nested
+    @DisplayName("resolvePerson")
+    class ResolvePerson {
+
+        @Test
+        void matchesAnExistingPersonOnEmailAlone() {
+            when(emailService.findPersonIdsByEmail("jane@example.invalid")).thenReturn(List.of(PERSON_ID));
+            when(personRepository.findAllById(List.of(PERSON_ID)))
+                    .thenReturn(List.of(entity(PERSON_ID, "Jane", "Smith")));
+            when(emailService.getEmails(PERSON_ID))
+                    .thenReturn(new PersonEmailService.EmailPair("jane@example.invalid", null));
+
+            ResolvePersonResponse response = service.resolvePerson(ResolvePersonRequest.builder()
+                    .email("  Jane@Example.Invalid ")
+                    .build());
+
+            assertThat(response.isMatchedExisting()).isTrue();
+            assertThat(response.getPersonId()).isEqualTo(PERSON_ID);
+            assertThat(response.getScore()).isEqualTo(60);
+            assertThat(response.getThresholdApplied()).isEqualTo(DEFAULT_THRESHOLD);
+            assertThat(response.getMatchedBy()).containsExactly("EMAIL");
+            verify(personRepository, never()).save(any());
+        }
+
+        @Test
+        void addsUpEverySignalThatPointsAtTheSamePerson() {
+            when(emailService.findPersonIdsByEmail("jane@example.invalid")).thenReturn(List.of(PERSON_ID));
+            when(workPhoneService.findPersonIdsByWorkPhone("+15550100")).thenReturn(List.of(PERSON_ID));
+            when(personRepository.findAllById(List.of(PERSON_ID)))
+                    .thenReturn(List.of(entity(PERSON_ID, "Jane", "Smith")));
+            when(personRepository.findByLastNameIgnoreCase("Smith"))
+                    .thenReturn(List.of(entity(PERSON_ID, "Jane", "Smith")));
+            when(personRepository.findByFirstNameIgnoreCase("Jane"))
+                    .thenReturn(List.of(entity(PERSON_ID, "Jane", "Smith")));
+
+            ResolvePersonResponse response = service.resolvePerson(ResolvePersonRequest.builder()
+                    .email("jane@example.invalid")
+                    .phone("+1 (555) 0100")
+                    .lastName("Smith")
+                    .firstName("Jane")
+                    .build());
+
+            assertThat(response.getScore()).isEqualTo(100);
+            assertThat(response.getMatchedBy()).containsExactly("EMAIL", "PHONE", "LAST_NAME", "FIRST_NAME");
+        }
+
+        @Test
+        void createsAPersonWhenTheBestCandidateIsBelowTheThreshold() {
+            when(personRepository.findByLastNameIgnoreCase("Smith"))
+                    .thenReturn(List.of(entity(OTHER_PERSON_ID, "Rob", "Smith")));
+            when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(entity(PERSON_ID, null, "Smith")));
+
+            ResolvePersonResponse response = service.resolvePerson(
+                    ResolvePersonRequest.builder().lastName("Smith").build());
+
+            // LAST_NAME alone scores 10, under the default threshold of 30.
+            assertThat(response.isMatchedExisting()).isFalse();
+            assertThat(response.getScore()).isZero();
+            assertThat(response.getMatchedBy()).containsExactly("CREATED");
+            verify(workPhoneService).replaceWorkPhones(PERSON_ID, List.of());
+            verify(emailService).replaceEmails(PERSON_ID, null, null);
+        }
+
+        @Test
+        void carriesTheNormalizedPhoneOntoANewlyCreatedPerson() {
+            when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(entity(PERSON_ID, "Jane", null)));
+
+            ResolvePersonResponse response = service.resolvePerson(ResolvePersonRequest.builder()
+                    .firstName("Jane")
+                    .phone("555-0100")
+                    .build());
+
+            assertThat(response.isMatchedExisting()).isFalse();
+            assertThat(response.getPhoneNumbers()).containsExactly("5550100");
+            verify(workPhoneService).replaceWorkPhones(PERSON_ID, List.of("5550100"));
+        }
+
+        @Test
+        void honoursAnExplicitThresholdOverride() {
+            when(personRepository.findByLastNameIgnoreCase("Smith"))
+                    .thenReturn(List.of(entity(PERSON_ID, "Jane", "Smith")));
+
+            ResolvePersonResponse response = service.resolvePerson(ResolvePersonRequest.builder()
+                    .lastName("Smith")
+                    .threshold(5)
+                    .build());
+
+            assertThat(response.isMatchedExisting()).isTrue();
+            assertThat(response.getThresholdApplied()).isEqualTo(5);
+        }
+
+        @Test
+        void clampsANegativeThresholdToZero() {
+            when(personRepository.findByLastNameIgnoreCase("Smith"))
+                    .thenReturn(List.of(entity(PERSON_ID, "Jane", "Smith")));
+
+            assertThat(service.resolvePerson(ResolvePersonRequest.builder()
+                                    .lastName("Smith")
+                                    .threshold(-10)
+                                    .build())
+                            .getThresholdApplied())
+                    .isZero();
+        }
+
+        @Test
+        void picksTheHigherScoringCandidateWhenSeveralMatch() {
+            when(emailService.findPersonIdsByEmail("jane@example.invalid")).thenReturn(List.of(PERSON_ID));
+            when(personRepository.findAllById(List.of(PERSON_ID)))
+                    .thenReturn(List.of(entity(PERSON_ID, "Jane", "Smith")));
+            when(personRepository.findByLastNameIgnoreCase("Smith"))
+                    .thenReturn(List.of(entity(OTHER_PERSON_ID, "Rob", "Smith")));
+
+            ResolvePersonResponse response = service.resolvePerson(ResolvePersonRequest.builder()
+                    .email("jane@example.invalid")
+                    .lastName("Smith")
+                    .build());
+
+            assertThat(response.getPersonId()).isEqualTo(PERSON_ID);
+            assertThat(response.getScore()).isEqualTo(60);
+        }
+
+        @Test
+        void ignoresAPhoneThatCarriesNoDigits() {
+            when(personRepository.findById(PERSON_ID)).thenReturn(Optional.of(entity(PERSON_ID, "Jane", null)));
+
+            ResolvePersonResponse response = service.resolvePerson(ResolvePersonRequest.builder()
+                    .firstName("Jane")
+                    .phone("---")
+                    .build());
+
+            assertThat(response.getPhoneNumbers()).isEmpty();
+        }
+
+        @Test
+        void refusesARequestWithNoIdentifyingFieldAtAll() {
+            ResolvePersonRequest request = ResolvePersonRequest.builder()
+                    .email("   ")
+                    .phone(null)
+                    .lastName("")
+                    .build();
+
+            assertThatThrownBy(() -> service.resolvePerson(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("At least one of email, phone, lastName, or firstName");
+        }
+    }
+
+    @Nested
+    @DisplayName("deletePerson")
+    class DeletePerson {
+
+        @Test
+        void removesContactPointsAndTheAddressBeforePublishingTheDeletion() {
+            when(userPersonLinkRepository.existsByPerson_Id(PERSON_ID)).thenReturn(false);
+
+            service.deletePerson(PERSON_ID);
+
+            verify(personContactPointRepository).deleteByPersonId(PERSON_ID);
+            verify(partyPostalAddressRepository).deleteByPartyTypeAndPartyId(PartyType.PERSON, PERSON_ID);
+            verify(personRepository).deleteById(PERSON_ID);
+            verify(personRepository).flush();
+            verify(eventPublisher).publishPersonDeleted(PERSON_ID);
+        }
+
+        @Test
+        void refusesToDeleteAPersonWithALinkedUser() {
+            when(userPersonLinkRepository.existsByPerson_Id(PERSON_ID)).thenReturn(true);
+
+            assertThatThrownBy(() -> service.deletePerson(PERSON_ID)).isInstanceOf(PersonHasLinkedUsersException.class);
+            verify(personRepository, never()).deleteById(any(UUID.class));
+        }
+
+        @Test
+        void turnsALinkCreatedDuringTheDeleteIntoTheSameConflict() {
+            when(userPersonLinkRepository.existsByPerson_Id(PERSON_ID)).thenReturn(false);
+            org.mockito.Mockito.doThrow(new DataIntegrityViolationException("fk violation"))
+                    .when(personRepository)
+                    .flush();
+
+            assertThatThrownBy(() -> service.deletePerson(PERSON_ID)).isInstanceOf(PersonHasLinkedUsersException.class);
+            verify(eventPublisher, never()).publishPersonDeleted(any());
+        }
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/controller/PeopleExceptionHandlerTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/controller/PeopleExceptionHandlerTest.java
@@ -1,0 +1,190 @@
+package com.positivity.people.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.people.internal.exception.NotFoundException;
+import com.positivity.people.internal.exception.PersonNotFoundException;
+import com.positivity.people.internal.exception.SemanticValidationException;
+import com.positivity.people.internal.exception.WorkSessionNotFoundException;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Status mapping for the People API's error envelope. Routing and binding failures must not
+ * surface as 500s (#820), and no handler may echo user-controlled request data.
+ */
+@DisplayName("PeopleExceptionHandler")
+class PeopleExceptionHandlerTest {
+
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final UUID PERSON_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4e01");
+
+    private final PeopleExceptionHandler handler = new PeopleExceptionHandler(Clock.fixed(NOW, ZoneOffset.UTC));
+
+    private static void assertStatusAndTimestamp(ProblemDetail problem, HttpStatus expectedStatus) {
+        assertThat(problem.getStatus()).isEqualTo(expectedStatus.value());
+        assertThat(problem.getProperties()).containsEntry("timestamp", NOW);
+    }
+
+    @Test
+    void mapsAMissingPersonToNotFound() {
+        ProblemDetail problem = handler.handlePersonNotFound(new PersonNotFoundException(PERSON_ID));
+
+        assertStatusAndTimestamp(problem, HttpStatus.NOT_FOUND);
+        assertThat(problem.getDetail()).contains(PERSON_ID.toString());
+    }
+
+    @Test
+    void mapsADomainNotFoundToNotFound() {
+        assertStatusAndTimestamp(handler.handleNotFound(new NotFoundException("no such thing")), HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void mapsAMissingWorkSessionToNotFound() {
+        assertStatusAndTimestamp(
+                handler.handleWorkSessionNotFound(new WorkSessionNotFoundException("no session")),
+                HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void mapsAMissingEntityToNotFound() {
+        assertStatusAndTimestamp(
+                handler.handleEntityNotFound(new EntityNotFoundException("gone")), HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void mapsAnIllegalArgumentToBadRequest() {
+        ProblemDetail problem = handler.handleIllegalArgument(new IllegalArgumentException("bad input"));
+
+        assertStatusAndTimestamp(problem, HttpStatus.BAD_REQUEST);
+        assertThat(problem.getDetail()).isEqualTo("bad input");
+    }
+
+    @Test
+    void mapsAnIllegalStateToConflict() {
+        assertStatusAndTimestamp(handler.handleIllegalState(new IllegalStateException("dup")), HttpStatus.CONFLICT);
+    }
+
+    @Test
+    void mapsASemanticValidationFailureToUnprocessableContent() {
+        assertStatusAndTimestamp(
+                handler.handleSemanticValidation(new SemanticValidationException("bad dates")),
+                HttpStatus.UNPROCESSABLE_CONTENT);
+    }
+
+    @Test
+    void mapsAnAccessDenialToForbidden() {
+        assertStatusAndTimestamp(handler.handleAccessDenied(new AccessDeniedException("nope")), HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void mapsAnUnroutablePathToNotFoundWithoutEchoingIt() {
+        ProblemDetail problem = handler.handleNoEndpoint();
+
+        assertStatusAndTimestamp(problem, HttpStatus.NOT_FOUND);
+        assertThat(problem.getDetail()).isEqualTo("No endpoint for the requested path");
+    }
+
+    @Test
+    void mapsATypeMismatchToBadRequestNamingOnlyTheParameter() throws Exception {
+        MethodArgumentTypeMismatchException mismatch = new MethodArgumentTypeMismatchException(
+                "not-a-uuid", UUID.class, "employeeId", methodParameter(), new IllegalArgumentException("nope"));
+
+        ProblemDetail problem = handler.handleTypeMismatch(mismatch);
+
+        assertStatusAndTimestamp(problem, HttpStatus.BAD_REQUEST);
+        assertThat(problem.getDetail()).isEqualTo("Invalid value for parameter 'employeeId'");
+        // The offending value is user input and must not be reflected back (S5131).
+        assertThat(problem.getDetail()).doesNotContain("not-a-uuid");
+    }
+
+    @Test
+    void mapsAMissingParameterToBadRequest() {
+        ProblemDetail problem =
+                handler.handleMissingParameter(new MissingServletRequestParameterException("locationId", "UUID"));
+
+        assertStatusAndTimestamp(problem, HttpStatus.BAD_REQUEST);
+        assertThat(problem.getDetail()).isEqualTo("Missing required parameter 'locationId'");
+    }
+
+    @Test
+    void mapsABeanValidationFailureToBadRequest() throws Exception {
+        MethodArgumentNotValidException invalid = new MethodArgumentNotValidException(
+                methodParameter(), new BeanPropertyBindingResult(new Object(), "request"));
+
+        ProblemDetail problem = handler.handleValidation(invalid);
+
+        assertStatusAndTimestamp(problem, HttpStatus.BAD_REQUEST);
+        assertThat(problem.getDetail()).isEqualTo("Validation failed");
+    }
+
+    @Test
+    void mapsMalformedJsonToABadRequestBodyCarryingTheRequestPath() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/v1/people/employees");
+
+        ResponseEntity<Map<String, Object>> response = handler.handleHttpMessageNotReadable(
+                new HttpMessageNotReadableException("boom", (org.springframework.http.HttpInputMessage) null), request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody())
+                .containsEntry("timestamp", NOW)
+                .containsEntry("status", HttpStatus.BAD_REQUEST.value())
+                .containsEntry("error", "Bad Request")
+                .containsEntry("path", "/v1/people/employees")
+                .containsEntry("message", "Malformed JSON request");
+    }
+
+    @Test
+    void keepsTheStatusAndReasonOfAResponseStatusException() {
+        ProblemDetail problem =
+                handler.handleResponseStatusException(new ResponseStatusException(HttpStatus.CONFLICT, "already open"));
+
+        assertStatusAndTimestamp(problem, HttpStatus.CONFLICT);
+        assertThat(problem.getDetail()).isEqualTo("already open");
+    }
+
+    @Test
+    void fallsBackToTheExceptionMessageWhenAResponseStatusExceptionCarriesNoReason() {
+        ProblemDetail problem =
+                handler.handleResponseStatusException(new ResponseStatusException(HttpStatus.BAD_GATEWAY));
+
+        assertStatusAndTimestamp(problem, HttpStatus.BAD_GATEWAY);
+        assertThat(problem.getDetail()).isNotBlank();
+    }
+
+    @Test
+    void hidesTheDetailOfAnUnexpectedFailure() {
+        ProblemDetail problem = handler.handleUnexpectedException(new RuntimeException("connection string leaked"));
+
+        assertStatusAndTimestamp(problem, HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(problem.getDetail()).isEqualTo("Internal server error");
+    }
+
+    /** Any real method parameter works: the handlers only read the exception's own fields. */
+    private static MethodParameter methodParameter() throws NoSuchMethodException {
+        return new MethodParameter(PeopleExceptionHandlerTest.class.getDeclaredMethod("sample", String.class), 0);
+    }
+
+    @SuppressWarnings("unused")
+    private static void sample(String value) {
+        // Signature-only holder for MethodParameter.
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/service/AttendanceDiscrepancyReportTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/AttendanceDiscrepancyReportTest.java
@@ -1,0 +1,343 @@
+package com.positivity.people.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.positivity.people.internal.dto.AttendanceDiscrepancyReportResponse;
+import com.positivity.people.internal.dto.AttendanceReportKey;
+import com.positivity.people.internal.entity.ExtJobTimeReplica;
+import com.positivity.people.internal.entity.ExtPersonReplica;
+import com.positivity.people.internal.entity.TimeEntry;
+import com.positivity.people.internal.repository.ExtJobTimeReplicaRepository;
+import com.positivity.people.internal.repository.ExtPersonReplicaRepository;
+import com.positivity.people.internal.repository.TimeEntryRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Attendance-versus-job-time discrepancy report (ADR-0044 §6, #875): attendance minutes are
+ * bucketed into local dates, job minutes come from the {@code ext_workorder_job_time} replica,
+ * and a row is flagged when the gap exceeds the resolved threshold.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PeopleReportsServiceImpl.getAttendanceDiscrepancyReport")
+class AttendanceDiscrepancyReportTest {
+
+    private static final UUID PERSON_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d01");
+    private static final UUID OTHER_PERSON_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d02");
+    private static final UUID LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d03");
+    private static final LocalDate DAY = LocalDate.of(2026, 3, 2);
+    private static final String TIMEZONE = "UTC";
+    private static final String ACTOR = "svc-reports";
+
+    @Mock
+    private TimeEntryRepository timeEntryRepository;
+
+    @Mock
+    private ExtPersonReplicaRepository extPersonReplicaRepository;
+
+    @Mock
+    private ExtJobTimeReplicaRepository extJobTimeReplicaRepository;
+
+    @Mock
+    private LocationReferenceService locationReferenceService;
+
+    @Mock
+    private TimekeepingThresholdCache timekeepingThresholdCache;
+
+    @Mock
+    private TimekeepingThresholdCache.ThresholdResolverContext thresholdContext;
+
+    private PeopleReportsServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PeopleReportsServiceImpl(
+                timeEntryRepository,
+                extPersonReplicaRepository,
+                extJobTimeReplicaRepository,
+                locationReferenceService,
+                timekeepingThresholdCache,
+                Clock.fixed(Instant.parse("2026-03-02T20:00:00Z"), ZoneOffset.UTC));
+        when(timekeepingThresholdCache.createContext(any(), any())).thenReturn(thresholdContext);
+        when(thresholdContext.resolveThresholdMinutes(any(), any())).thenReturn(30);
+    }
+
+    private static TimeEntry attendance(UUID personId, Instant startAt, Instant endAt) {
+        TimeEntry entry = new TimeEntry();
+        entry.setTimeEntryId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4dff"));
+        entry.setPersonId(personId);
+        entry.setLocationId(LOCATION_ID);
+        entry.setAttendanceStartAt(startAt);
+        entry.setAttendanceEndAt(endAt);
+        return entry;
+    }
+
+    private static ExtJobTimeReplica jobTime(UUID technicianId, Instant endAtUtc, int minutes) {
+        ExtJobTimeReplica row = new ExtJobTimeReplica();
+        row.setLaborEntryId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4dfe"));
+        row.setTechnicianId(technicianId);
+        row.setLocationId(LOCATION_ID);
+        row.setEndAtUtc(endAtUtc);
+        row.setMinutes(minutes);
+        return row;
+    }
+
+    private void stubAttendance(List<TimeEntry> entries) {
+        when(timeEntryRepository.findAttendanceOverlappingWindow(any(), any(), any(), anyList(), anyBoolean()))
+                .thenReturn(entries);
+    }
+
+    private void stubJobTime(List<ExtJobTimeReplica> rows) {
+        when(extJobTimeReplicaRepository.findForReportWindow(any(), any(), any(), anyList(), anyBoolean()))
+                .thenReturn(rows);
+    }
+
+    private List<AttendanceDiscrepancyReportResponse> report(boolean flaggedOnly) {
+        return service.getAttendanceDiscrepancyReport(
+                DAY, DAY, TIMEZONE, LOCATION_ID, List.of(), flaggedOnly, ACTOR, "corr-1");
+    }
+
+    @Test
+    void reportsTheGapBetweenAttendanceAndJobMinutes() {
+        stubAttendance(List.of(
+                attendance(PERSON_ID, Instant.parse("2026-03-02T13:00:00Z"), Instant.parse("2026-03-02T21:00:00Z"))));
+        stubJobTime(List.of(jobTime(PERSON_ID, Instant.parse("2026-03-02T20:00:00Z"), 300)));
+        ExtPersonReplica person = new ExtPersonReplica();
+        person.setPersonId(PERSON_ID);
+        person.setFirstName("Jane");
+        person.setLastName("Smith");
+        when(extPersonReplicaRepository.findAllById(Set.of(PERSON_ID))).thenReturn(List.of(person));
+
+        List<AttendanceDiscrepancyReportResponse> rows = report(false);
+
+        assertThat(rows).hasSize(1);
+        AttendanceDiscrepancyReportResponse row = rows.get(0);
+        assertThat(row.getTechnicianId()).isEqualTo(PERSON_ID.toString());
+        assertThat(row.getTechnicianName()).isEqualTo("Jane Smith");
+        assertThat(row.getReportDate()).isEqualTo(DAY);
+        assertThat(row.getTotalAttendanceHours()).isEqualTo(8.0d);
+        assertThat(row.getTotalJobHours()).isEqualTo(5.0d);
+        assertThat(row.getDiscrepancyHours()).isEqualTo(3.0d);
+        assertThat(row.getThresholdApplied()).isEqualTo(30);
+        assertThat(row.isFlagged()).isTrue();
+    }
+
+    @Test
+    void leavesARowUnflaggedWhenTheGapIsInsideTheThreshold() {
+        stubAttendance(List.of(
+                attendance(PERSON_ID, Instant.parse("2026-03-02T13:00:00Z"), Instant.parse("2026-03-02T21:00:00Z"))));
+        stubJobTime(List.of(jobTime(PERSON_ID, Instant.parse("2026-03-02T20:00:00Z"), 470)));
+
+        assertThat(report(false).get(0).isFlagged()).isFalse();
+    }
+
+    @Test
+    void dropsUnflaggedRowsWhenOnlyFlaggedOnesWereAskedFor() {
+        stubAttendance(List.of(
+                attendance(PERSON_ID, Instant.parse("2026-03-02T13:00:00Z"), Instant.parse("2026-03-02T21:00:00Z"))));
+        stubJobTime(List.of(jobTime(PERSON_ID, Instant.parse("2026-03-02T20:00:00Z"), 470)));
+
+        assertThat(report(true)).isEmpty();
+    }
+
+    @Test
+    void fallsBackToTheTechnicianIdWhenTheReplicaHasNoName() {
+        stubAttendance(List.of(
+                attendance(PERSON_ID, Instant.parse("2026-03-02T13:00:00Z"), Instant.parse("2026-03-02T21:00:00Z"))));
+        stubJobTime(List.of());
+        ExtPersonReplica nameless = new ExtPersonReplica();
+        nameless.setPersonId(PERSON_ID);
+        when(extPersonReplicaRepository.findAllById(any(Iterable.class))).thenReturn(List.of(nameless));
+
+        assertThat(report(false).get(0).getTechnicianName()).isEqualTo(PERSON_ID.toString());
+    }
+
+    @Test
+    void keepsAJobTimeOnlyTechnicianWithZeroAttendance() {
+        stubAttendance(List.of());
+        stubJobTime(List.of(jobTime(OTHER_PERSON_ID, Instant.parse("2026-03-02T20:00:00Z"), 120)));
+
+        List<AttendanceDiscrepancyReportResponse> rows = report(false);
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getTotalAttendanceHours()).isZero();
+        assertThat(rows.get(0).getTotalJobHours()).isEqualTo(2.0d);
+        assertThat(rows.get(0).getDiscrepancyHours()).isEqualTo(-2.0d);
+        assertThat(rows.get(0).isFlagged()).isTrue();
+    }
+
+    @Test
+    void splitsAnOvernightShiftAcrossTheTwoLocalDatesItCovers() {
+        stubAttendance(List.of(
+                attendance(PERSON_ID, Instant.parse("2026-03-02T22:00:00Z"), Instant.parse("2026-03-03T06:00:00Z"))));
+        stubJobTime(List.of());
+
+        List<AttendanceDiscrepancyReportResponse> rows = service.getAttendanceDiscrepancyReport(
+                DAY, DAY.plusDays(1), TIMEZONE, LOCATION_ID, List.of(), false, ACTOR, null);
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0).getReportDate()).isEqualTo(DAY);
+        assertThat(rows.get(0).getTotalAttendanceHours()).isEqualTo(2.0d);
+        assertThat(rows.get(1).getReportDate()).isEqualTo(DAY.plusDays(1));
+        assertThat(rows.get(1).getTotalAttendanceHours()).isEqualTo(6.0d);
+    }
+
+    @Test
+    void clipsAttendanceToTheRequestedWindow() {
+        // The shift starts the day before the window and ends inside it.
+        stubAttendance(List.of(
+                attendance(PERSON_ID, Instant.parse("2026-03-01T20:00:00Z"), Instant.parse("2026-03-02T04:00:00Z"))));
+        stubJobTime(List.of());
+
+        assertThat(report(false).get(0).getTotalAttendanceHours()).isEqualTo(4.0d);
+    }
+
+    @Test
+    void treatsAnOpenShiftAsRunningUntilNow() {
+        stubAttendance(List.of(attendance(PERSON_ID, Instant.parse("2026-03-02T13:00:00Z"), null)));
+        stubJobTime(List.of());
+
+        // The clock is fixed at 20:00Z, so the open shift counts seven hours, not the whole day.
+        assertThat(report(false).get(0).getTotalAttendanceHours()).isEqualTo(7.0d);
+    }
+
+    @Test
+    void ignoresAnAttendanceRowMissingTheDimensionsItWouldBeBucketedBy() {
+        TimeEntry noPerson =
+                attendance(null, Instant.parse("2026-03-02T13:00:00Z"), Instant.parse("2026-03-02T21:00:00Z"));
+        TimeEntry noLocation =
+                attendance(PERSON_ID, Instant.parse("2026-03-02T13:00:00Z"), Instant.parse("2026-03-02T21:00:00Z"));
+        noLocation.setLocationId(null);
+        TimeEntry noStart = attendance(PERSON_ID, null, Instant.parse("2026-03-02T21:00:00Z"));
+        stubAttendance(List.of(noPerson, noLocation, noStart));
+        stubJobTime(List.of());
+
+        assertThat(report(false)).isEmpty();
+    }
+
+    @Test
+    void ignoresAnAttendanceRowThatEndsBeforeItStarts() {
+        stubAttendance(List.of(
+                attendance(PERSON_ID, Instant.parse("2026-03-02T21:00:00Z"), Instant.parse("2026-03-02T13:00:00Z"))));
+        stubJobTime(List.of());
+
+        assertThat(report(false)).isEmpty();
+    }
+
+    @Test
+    void ignoresJobTimeWhoseLocalDateFallsOutsideTheRequestedRange() {
+        stubAttendance(List.of());
+        stubJobTime(List.of(
+                jobTime(PERSON_ID, Instant.parse("2026-03-01T20:00:00Z"), 60),
+                jobTime(PERSON_ID, Instant.parse("2026-03-04T20:00:00Z"), 60)));
+
+        assertThat(report(false)).isEmpty();
+    }
+
+    @Test
+    void sumsRepeatedJobTimeRowsForTheSameTechnicianAndDay() {
+        stubAttendance(List.of());
+        stubJobTime(List.of(
+                jobTime(PERSON_ID, Instant.parse("2026-03-02T14:00:00Z"), 60),
+                jobTime(PERSON_ID, Instant.parse("2026-03-02T18:00:00Z"), 90)));
+
+        assertThat(report(false).get(0).getTotalJobHours()).isEqualTo(2.5d);
+    }
+
+    @Test
+    void returnsNothingWhenNeitherSourceHasRowsInTheWindow() {
+        stubAttendance(List.of());
+        stubJobTime(List.of());
+
+        assertThat(report(false)).isEmpty();
+    }
+
+    @Test
+    void bucketsAttendanceByTheRequestedTimezoneRatherThanUtc() {
+        // 03:00Z on 3 March is still 2 March in New York, so the minutes land on the 2nd.
+        stubAttendance(List.of(
+                attendance(PERSON_ID, Instant.parse("2026-03-03T01:00:00Z"), Instant.parse("2026-03-03T03:00:00Z"))));
+        stubJobTime(List.of());
+
+        List<AttendanceDiscrepancyReportResponse> rows = service.getAttendanceDiscrepancyReport(
+                DAY, DAY, "America/New_York", LOCATION_ID, List.of(), false, ACTOR, null);
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getReportDate()).isEqualTo(DAY);
+        assertThat(rows.get(0).getTotalAttendanceHours()).isEqualTo(2.0d);
+    }
+
+    @Test
+    void scopesTheReadToTheRequestedTechniciansWhenSomeAreNamed() {
+        service.getAttendanceDiscrepancyReport(DAY, DAY, TIMEZONE, LOCATION_ID, List.of(PERSON_ID), false, ACTOR, null);
+
+        org.mockito.Mockito.verify(timeEntryRepository)
+                .findAttendanceOverlappingWindow(any(), any(), eq(LOCATION_ID), eq(List.of(PERSON_ID)), eq(false));
+        org.mockito.Mockito.verify(extJobTimeReplicaRepository)
+                .findForReportWindow(any(), any(), eq(LOCATION_ID), eq(List.of(PERSON_ID)), eq(false));
+    }
+
+    @Test
+    void rejectsAnInvertedDateRange() {
+        assertThatThrownBy(() -> service.getAttendanceDiscrepancyReport(
+                        DAY, DAY.minusDays(1), TIMEZONE, LOCATION_ID, List.of(), false, ACTOR, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("endDate must be on or after startDate");
+    }
+
+    @Test
+    void rejectsATimezoneThatIsNotAnIanaZone() {
+        assertThatThrownBy(() -> service.getAttendanceDiscrepancyReport(
+                        DAY, DAY, "Mars/Olympus", LOCATION_ID, List.of(), false, ACTOR, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("timezone must be a valid IANA timezone");
+    }
+
+    @Test
+    void survivesANonUuidTechnicianIdentifierWhenLoadingNames() {
+        // A key whose technician id is not a UUID cannot be looked up; the report still renders.
+        stubAttendance(List.of());
+        stubJobTime(List.of());
+        when(timekeepingThresholdCache.createContext(any(), any())).thenAnswer(invocation -> {
+            Set<AttendanceReportKey> keys = invocation.getArgument(0);
+            assertThat(keys).isNotNull();
+            return thresholdContext;
+        });
+
+        assertThat(service.getAttendanceDiscrepancyReport(DAY, DAY, TIMEZONE, null, List.of(), false, "ab", null))
+                .isEmpty();
+    }
+
+    @Test
+    void acceptsAZoneOffsetAsWellAsARegionId() {
+        stubAttendance(List.of(
+                attendance(PERSON_ID, Instant.parse("2026-03-02T13:00:00Z"), Instant.parse("2026-03-02T21:00:00Z"))));
+        stubJobTime(List.of());
+
+        List<AttendanceDiscrepancyReportResponse> rows = service.getAttendanceDiscrepancyReport(
+                DAY, DAY, ZoneId.of("UTC").getId(), null, List.of(), false, ACTOR, null);
+
+        assertThat(rows).hasSize(1);
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/service/EmployeeServiceImplTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/EmployeeServiceImplTest.java
@@ -1,0 +1,603 @@
+package com.positivity.people.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.peoplecontact.PersonUpsertRequestedV1;
+import com.positivity.people.internal.config.PeopleEventPublisher;
+import com.positivity.people.internal.dto.CreateEmployeeRequest;
+import com.positivity.people.internal.dto.DisableEmployeeRequestDto;
+import com.positivity.people.internal.dto.EmployeeContactInfoDto;
+import com.positivity.people.internal.dto.EmployeeIdentityDto;
+import com.positivity.people.internal.dto.EmployeeProfileDto;
+import com.positivity.people.internal.dto.UpdateEmployeeRequest;
+import com.positivity.people.internal.entity.Employee;
+import com.positivity.people.internal.entity.EmployeeOffboardingRetry;
+import com.positivity.people.internal.entity.ExtPersonReplica;
+import com.positivity.people.internal.enums.AssignmentTerminationPolicy;
+import com.positivity.people.internal.enums.DuplicatePolicy;
+import com.positivity.people.internal.enums.EmployeeStatus;
+import com.positivity.people.internal.exception.PersonNotFoundException;
+import com.positivity.people.internal.exception.SemanticValidationException;
+import com.positivity.people.internal.repository.EmployeeOffboardingRetryRepository;
+import com.positivity.people.internal.repository.EmployeeRepository;
+import com.positivity.people.internal.repository.ExtPersonReplicaRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Employment lifecycle unit coverage (ADR-0044 §6 Phase 3.2, #875): identity writes leave as
+ * upsert commands, employment attributes stay local, and every mutation publishes a fact.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("EmployeeServiceImpl")
+class EmployeeServiceImplTest {
+
+    private static final UUID PERSON_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01");
+    private static final UUID OTHER_PERSON_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02");
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @Mock
+    private ExtPersonReplicaRepository extPersonReplicaRepository;
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @Mock
+    private EmployeeOffboardingRetryRepository offboardingRetryRepository;
+
+    @Mock
+    private PeopleEventPublisher peopleEventPublisher;
+
+    private EmployeeServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new EmployeeServiceImpl(
+                CLOCK,
+                extPersonReplicaRepository,
+                employeeRepository,
+                offboardingRetryRepository,
+                peopleEventPublisher);
+        when(employeeRepository.save(any(Employee.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    private static CreateEmployeeRequest createRequest() {
+        CreateEmployeeRequest request = new CreateEmployeeRequest();
+        request.setFirstName("Jane");
+        request.setLastName("Smith");
+        request.setPreferredName("Janie");
+        request.setEmployeeNumber("EMP-0001");
+        request.setStatus(EmployeeStatus.ACTIVE);
+        request.setHireDate(LocalDate.of(2026, 1, 15));
+        return request;
+    }
+
+    private static UpdateEmployeeRequest updateRequest() {
+        UpdateEmployeeRequest request = new UpdateEmployeeRequest();
+        request.setFirstName("Jane");
+        request.setLastName("Smith");
+        request.setEmployeeNumber("EMP-0001");
+        request.setStatus(EmployeeStatus.ACTIVE);
+        request.setHireDate(LocalDate.of(2026, 1, 15));
+        return request;
+    }
+
+    private static EmployeeContactInfoDto contact(String email, String primaryPhone, String secondaryPhone) {
+        EmployeeContactInfoDto contactInfo = new EmployeeContactInfoDto();
+        contactInfo.setPrimaryEmail(email);
+        contactInfo.setPrimaryPhone(primaryPhone);
+        contactInfo.setSecondaryPhone(secondaryPhone);
+        return contactInfo;
+    }
+
+    private static Employee employee(EmployeeStatus status) {
+        return Employee.builder()
+                .id(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4aaa"))
+                .personId(PERSON_ID)
+                .employeeNumber("EMP-0001")
+                .status(status)
+                .hireDate(LocalDate.of(2026, 1, 15))
+                .statusEffectiveAt(Instant.parse("2026-01-15T00:00:00Z"))
+                .build();
+    }
+
+    private static ExtPersonReplica replica() {
+        ExtPersonReplica person = new ExtPersonReplica();
+        person.setPersonId(PERSON_ID);
+        person.setFirstName("Jane");
+        person.setLastName("Smith");
+        person.setPreferredName("Janie");
+        person.setPrimaryEmail("jane@example.com");
+        person.setPersonCreatedAt(Instant.parse("2026-01-01T00:00:00Z"));
+        person.setPersonUpdatedAt(Instant.parse("2026-02-01T00:00:00Z"));
+        return person;
+    }
+
+    @Nested
+    @DisplayName("resolveByEmployeeNumber")
+    class ResolveByEmployeeNumber {
+
+        @Test
+        void mapsAnActiveEmployeeToItsIdentity() {
+            when(employeeRepository.findByEmployeeNumberIgnoreCase("EMP-0001"))
+                    .thenReturn(Optional.of(employee(EmployeeStatus.ACTIVE)));
+
+            Optional<EmployeeIdentityDto> identity = service.resolveByEmployeeNumber("EMP-0001");
+
+            assertThat(identity).isPresent();
+            assertThat(identity.get().getPersonId()).isEqualTo(PERSON_ID);
+            assertThat(identity.get().getEmployeeNumber()).isEqualTo("EMP-0001");
+            assertThat(identity.get().getStatus()).isEqualTo("ACTIVE");
+            assertThat(identity.get().isActive()).isTrue();
+        }
+
+        @Test
+        void reportsANonActiveEmployeeAsInactive() {
+            when(employeeRepository.findByEmployeeNumberIgnoreCase("EMP-0001"))
+                    .thenReturn(Optional.of(employee(EmployeeStatus.ON_LEAVE)));
+
+            assertThat(service.resolveByEmployeeNumber("EMP-0001").orElseThrow().isActive())
+                    .isFalse();
+        }
+
+        @Test
+        void tolueratesAnEmployeeRowWithNoStatus() {
+            Employee employee = employee(EmployeeStatus.ACTIVE);
+            employee.setStatus(null);
+            when(employeeRepository.findByEmployeeNumberIgnoreCase("EMP-0001")).thenReturn(Optional.of(employee));
+
+            EmployeeIdentityDto identity =
+                    service.resolveByEmployeeNumber("EMP-0001").orElseThrow();
+
+            assertThat(identity.getStatus()).isNull();
+            assertThat(identity.isActive()).isFalse();
+        }
+
+        @Test
+        void returnsEmptyWhenNoEmployeeCarriesTheNumber() {
+            when(employeeRepository.findByEmployeeNumberIgnoreCase("EMP-9999")).thenReturn(Optional.empty());
+
+            assertThat(service.resolveByEmployeeNumber("EMP-9999")).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("createEmployee")
+    class CreateEmployee {
+
+        @Test
+        void sendsTheIdentityUpsertAndSavesTheEmploymentRow() {
+            CreateEmployeeRequest request = createRequest();
+            request.setContactInfo(contact("  jane@example.com ", "555-0100", "  "));
+
+            EmployeeProfileDto profile = service.createEmployee(request);
+
+            ArgumentCaptor<PersonUpsertRequestedV1> command = ArgumentCaptor.forClass(PersonUpsertRequestedV1.class);
+            verify(peopleEventPublisher).requestPersonUpsert(command.capture());
+            assertThat(command.getValue().firstName()).isEqualTo("Jane");
+            assertThat(command.getValue().primaryEmail()).isEqualTo("jane@example.com");
+            // Blank secondary phone is dropped rather than travelling as an empty string.
+            assertThat(command.getValue().workPhones()).containsExactly("555-0100");
+
+            ArgumentCaptor<Employee> saved = ArgumentCaptor.forClass(Employee.class);
+            verify(employeeRepository).save(saved.capture());
+            assertThat(saved.getValue().getPersonId())
+                    .isEqualTo(command.getValue().personId());
+            assertThat(saved.getValue().getStatus()).isEqualTo(EmployeeStatus.ACTIVE);
+            assertThat(saved.getValue().getStatusEffectiveAt()).isEqualTo(NOW);
+            verify(peopleEventPublisher).publishEmployeeUpdated(saved.getValue());
+
+            // The response echoes the request identity: the replica has not caught up yet.
+            assertThat(profile.getId()).isEqualTo(command.getValue().personId());
+            assertThat(profile.getPreferredName()).isEqualTo("Janie");
+            assertThat(profile.getEmployeeNumber()).isEqualTo("EMP-0001");
+            assertThat(profile.getWarnings()).isEmpty();
+        }
+
+        @Test
+        void sendsNoPhonesWhenTheRequestCarriesNoContactInfo() {
+            service.createEmployee(createRequest());
+
+            ArgumentCaptor<PersonUpsertRequestedV1> command = ArgumentCaptor.forClass(PersonUpsertRequestedV1.class);
+            verify(peopleEventPublisher).requestPersonUpsert(command.capture());
+            assertThat(command.getValue().workPhones()).isEmpty();
+            assertThat(command.getValue().primaryEmail()).isNull();
+        }
+
+        @Test
+        void rejectsATerminationDateBeforeTheHireDate() {
+            CreateEmployeeRequest request = createRequest();
+            request.setTerminationDate(LocalDate.of(2026, 1, 14));
+
+            assertThatThrownBy(() -> service.createEmployee(request))
+                    .isInstanceOf(SemanticValidationException.class)
+                    .hasMessageContaining("terminationDate");
+
+            verifyNoInteractions(peopleEventPublisher);
+        }
+
+        @Test
+        void rejectsADuplicateEmployeeNumberUnderTheStrictPolicy() {
+            when(employeeRepository.existsByEmployeeNumberIgnoreCase("EMP-0001"))
+                    .thenReturn(true);
+
+            CreateEmployeeRequest request = createRequest();
+
+            assertThatThrownBy(() -> service.createEmployee(request))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("STRICT");
+
+            verify(employeeRepository, never()).save(any());
+        }
+
+        @Test
+        void rejectsADuplicatePrimaryEmailUnderTheStrictPolicy() {
+            CreateEmployeeRequest request = createRequest();
+            request.setContactInfo(contact("jane@example.com", null, null));
+            when(extPersonReplicaRepository.findByPrimaryEmailIgnoreCase("jane@example.com"))
+                    .thenReturn(List.of(replica()));
+
+            assertThatThrownBy(() -> service.createEmployee(request)).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void rejectsADuplicatePhoneUnderTheStrictPolicy() {
+            CreateEmployeeRequest request = createRequest();
+            request.setContactInfo(contact(null, null, "555-0199"));
+            when(extPersonReplicaRepository.findByPrimaryPhoneOrSecondaryPhone("555-0199", "555-0199"))
+                    .thenReturn(List.of(replica()));
+
+            assertThatThrownBy(() -> service.createEmployee(request)).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void acceptsADuplicateWithAWarningUnderTheBalancedPolicy() {
+            CreateEmployeeRequest request = createRequest();
+            request.setDuplicatePolicy(DuplicatePolicy.BALANCED);
+            when(employeeRepository.existsByEmployeeNumberIgnoreCase("EMP-0001"))
+                    .thenReturn(true);
+
+            EmployeeProfileDto profile = service.createEmployee(request);
+
+            assertThat(profile.getWarnings()).anyMatch(warning -> warning.contains("BALANCED"));
+            verify(employeeRepository).save(any(Employee.class));
+        }
+
+        @Test
+        void warnsOnAnAmbiguousNameMatchUnderTheBalancedPolicy() {
+            CreateEmployeeRequest request = createRequest();
+            request.setDuplicatePolicy(DuplicatePolicy.BALANCED);
+            when(extPersonReplicaRepository.findByLastNameIgnoreCase("Smith")).thenReturn(List.of(replica()));
+
+            EmployeeProfileDto profile = service.createEmployee(request);
+
+            assertThat(profile.getWarnings()).containsExactly("Ambiguous duplicate match detected by name similarity");
+        }
+
+        @Test
+        void doesNotTreatABlankNameAsAnAmbiguousMatch() {
+            CreateEmployeeRequest request = createRequest();
+            request.setDuplicatePolicy(DuplicatePolicy.BALANCED);
+            request.setFirstName("  ");
+
+            assertThat(service.createEmployee(request).getWarnings()).isEmpty();
+            verifyNoInteractions(extPersonReplicaRepository);
+        }
+
+        @Test
+        void treatsANullDuplicatePolicyAsStrict() {
+            CreateEmployeeRequest request = createRequest();
+            request.setDuplicatePolicy(null);
+            when(employeeRepository.existsByEmployeeNumberIgnoreCase("EMP-0001"))
+                    .thenReturn(true);
+
+            assertThatThrownBy(() -> service.createEmployee(request)).isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getEmployee")
+    class GetEmployee {
+
+        @Test
+        void servesIdentityFromTheReplicaAndEmploymentFromTheLocalRow() {
+            when(extPersonReplicaRepository.findById(PERSON_ID)).thenReturn(Optional.of(replica()));
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(employee(EmployeeStatus.ACTIVE)));
+
+            EmployeeProfileDto profile = service.getEmployee(PERSON_ID);
+
+            assertThat(profile.getFirstName()).isEqualTo("Jane");
+            assertThat(profile.getStatus()).isEqualTo(EmployeeStatus.ACTIVE);
+            assertThat(profile.getContactInfo().getPrimaryEmail()).isEqualTo("jane@example.com");
+            assertThat(profile.getCreatedAt()).isEqualTo(Instant.parse("2026-01-01T00:00:00Z"));
+            assertThat(profile.getUpdatedAt()).isEqualTo(Instant.parse("2026-02-01T00:00:00Z"));
+        }
+
+        @Test
+        void servesAnEmploymentRowWhoseReplicaHasNotCaughtUp() {
+            when(extPersonReplicaRepository.findById(PERSON_ID)).thenReturn(Optional.empty());
+            Employee employee = employee(EmployeeStatus.ACTIVE);
+            employee.setCreatedAt(NOW);
+            employee.setUpdatedAt(NOW);
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(employee));
+
+            EmployeeProfileDto profile = service.getEmployee(PERSON_ID);
+
+            assertThat(profile.getFirstName()).isNull();
+            assertThat(profile.getContactInfo()).isNull();
+            assertThat(profile.getCreatedAt()).isEqualTo(NOW);
+            assertThat(profile.getUpdatedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        void servesAReplicaRowWithNoEmploymentRecordYet() {
+            when(extPersonReplicaRepository.findById(PERSON_ID)).thenReturn(Optional.of(replica()));
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.empty());
+
+            EmployeeProfileDto profile = service.getEmployee(PERSON_ID);
+
+            assertThat(profile.getEmployeeNumber()).isNull();
+            assertThat(profile.getStatus()).isNull();
+            assertThat(profile.getFirstName()).isEqualTo("Jane");
+        }
+
+        @Test
+        void omitsContactInfoWhenTheReplicaCarriesNoContactValues() {
+            ExtPersonReplica person = replica();
+            person.setPrimaryEmail("  ");
+            when(extPersonReplicaRepository.findById(PERSON_ID)).thenReturn(Optional.of(person));
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.getEmployee(PERSON_ID).getContactInfo()).isNull();
+        }
+
+        @Test
+        void failsWhenNeitherTheReplicaNorAnEmploymentRowExists() {
+            when(extPersonReplicaRepository.findById(PERSON_ID)).thenReturn(Optional.empty());
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getEmployee(PERSON_ID)).isInstanceOf(PersonNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateEmployee")
+    class UpdateEmployee {
+
+        @Test
+        void restampsStatusEffectiveAtOnlyWhenTheStatusChanges() {
+            Employee existing = employee(EmployeeStatus.ACTIVE);
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(existing));
+
+            UpdateEmployeeRequest request = updateRequest();
+            request.setStatus(EmployeeStatus.ON_LEAVE);
+
+            service.updateEmployee(PERSON_ID, request);
+
+            ArgumentCaptor<Employee> saved = ArgumentCaptor.forClass(Employee.class);
+            verify(employeeRepository).save(saved.capture());
+            assertThat(saved.getValue().getStatus()).isEqualTo(EmployeeStatus.ON_LEAVE);
+            assertThat(saved.getValue().getStatusEffectiveAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        void leavesStatusEffectiveAtAloneWhenTheStatusIsUnchanged() {
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(employee(EmployeeStatus.ACTIVE)));
+
+            service.updateEmployee(PERSON_ID, updateRequest());
+
+            ArgumentCaptor<Employee> saved = ArgumentCaptor.forClass(Employee.class);
+            verify(employeeRepository).save(saved.capture());
+            assertThat(saved.getValue().getStatusEffectiveAt()).isEqualTo(Instant.parse("2026-01-15T00:00:00Z"));
+        }
+
+        @Test
+        void createsTheEmploymentRowWhenOnlyTheReplicaKnowsThePerson() {
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.empty());
+            when(extPersonReplicaRepository.existsById(PERSON_ID)).thenReturn(true);
+
+            EmployeeProfileDto profile = service.updateEmployee(PERSON_ID, updateRequest());
+
+            ArgumentCaptor<Employee> saved = ArgumentCaptor.forClass(Employee.class);
+            verify(employeeRepository).save(saved.capture());
+            assertThat(saved.getValue().getPersonId()).isEqualTo(PERSON_ID);
+            assertThat(profile.getId()).isEqualTo(PERSON_ID);
+        }
+
+        @Test
+        void failsWhenNeitherTheReplicaNorAnEmploymentRowExists() {
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.empty());
+            when(extPersonReplicaRepository.existsById(PERSON_ID)).thenReturn(false);
+
+            UpdateEmployeeRequest request = updateRequest();
+
+            assertThatThrownBy(() -> service.updateEmployee(PERSON_ID, request))
+                    .isInstanceOf(PersonNotFoundException.class);
+        }
+
+        @Test
+        void rejectsATerminationDateBeforeTheHireDate() {
+            UpdateEmployeeRequest request = updateRequest();
+            request.setTerminationDate(LocalDate.of(2020, 1, 1));
+
+            assertThatThrownBy(() -> service.updateEmployee(PERSON_ID, request))
+                    .isInstanceOf(SemanticValidationException.class);
+        }
+
+        @Test
+        void ignoresTheEmployeesOwnRowWhenScanningForDuplicates() {
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(employee(EmployeeStatus.ACTIVE)));
+            when(employeeRepository.existsByEmployeeNumberIgnoreCaseAndPersonIdNot("EMP-0001", PERSON_ID))
+                    .thenReturn(false);
+            // The replica row for this very person must not count as somebody else's email.
+            when(extPersonReplicaRepository.findByPrimaryEmailIgnoreCase("jane@example.com"))
+                    .thenReturn(List.of(replica()));
+
+            UpdateEmployeeRequest request = updateRequest();
+            request.setContactInfo(contact("jane@example.com", null, null));
+
+            assertThat(service.updateEmployee(PERSON_ID, request).getWarnings()).isEmpty();
+        }
+
+        @Test
+        void rejectsAnEmployeeNumberAlreadyHeldBySomeoneElse() {
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(employee(EmployeeStatus.ACTIVE)));
+            when(employeeRepository.existsByEmployeeNumberIgnoreCaseAndPersonIdNot("EMP-0001", PERSON_ID))
+                    .thenReturn(true);
+
+            UpdateEmployeeRequest request = updateRequest();
+
+            assertThatThrownBy(() -> service.updateEmployee(PERSON_ID, request))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void countsAnotherPersonsNameAsAnAmbiguousMatch() {
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(employee(EmployeeStatus.ACTIVE)));
+            ExtPersonReplica other = replica();
+            other.setPersonId(OTHER_PERSON_ID);
+            when(extPersonReplicaRepository.findByLastNameIgnoreCase("Smith")).thenReturn(List.of(other));
+
+            UpdateEmployeeRequest request = updateRequest();
+            request.setDuplicatePolicy(DuplicatePolicy.BALANCED);
+
+            assertThat(service.updateEmployee(PERSON_ID, request).getWarnings())
+                    .containsExactly("Ambiguous duplicate match detected by name similarity");
+        }
+    }
+
+    @Nested
+    @DisplayName("disableEmployee")
+    class DisableEmployee {
+
+        private DisableEmployeeRequestDto disableRequest(AssignmentTerminationPolicy policy) {
+            DisableEmployeeRequestDto request = new DisableEmployeeRequestDto();
+            request.setDisableReason("Voluntary resignation");
+            request.setAssignmentPolicy(policy);
+            request.setAssignmentEndDate(LocalDate.of(2026, 3, 31));
+            return request;
+        }
+
+        @Test
+        void movesAnActiveEmployeeToDisabledAndPublishesTheFact() {
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(employee(EmployeeStatus.ACTIVE)));
+            when(extPersonReplicaRepository.findById(PERSON_ID)).thenReturn(Optional.of(replica()));
+
+            EmployeeProfileDto profile =
+                    service.disableEmployee(PERSON_ID, disableRequest(AssignmentTerminationPolicy.IMMEDIATE));
+
+            ArgumentCaptor<Employee> saved = ArgumentCaptor.forClass(Employee.class);
+            verify(employeeRepository).save(saved.capture());
+            assertThat(saved.getValue().getStatus()).isEqualTo(EmployeeStatus.DISABLED);
+            assertThat(saved.getValue().getStatusEffectiveAt()).isEqualTo(NOW);
+            verify(peopleEventPublisher).publishEmployeeUpdated(saved.getValue());
+            verifyNoInteractions(offboardingRetryRepository);
+            assertThat(profile.getStatus()).isEqualTo(EmployeeStatus.DISABLED);
+            assertThat(profile.getFirstName()).isEqualTo("Jane");
+        }
+
+        @Test
+        void acceptsTheGracePeriodPolicy() {
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(employee(EmployeeStatus.ACTIVE)));
+            when(extPersonReplicaRepository.findById(PERSON_ID)).thenReturn(Optional.empty());
+
+            EmployeeProfileDto profile =
+                    service.disableEmployee(PERSON_ID, disableRequest(AssignmentTerminationPolicy.GRACE_PERIOD));
+
+            assertThat(profile.getStatus()).isEqualTo(EmployeeStatus.DISABLED);
+            verifyNoInteractions(offboardingRetryRepository);
+        }
+
+        @Test
+        void queuesARetryWhenTheDownstreamOffboardingActionFails() {
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.of(employee(EmployeeStatus.ACTIVE)));
+            when(extPersonReplicaRepository.findById(PERSON_ID)).thenReturn(Optional.empty());
+
+            // The downstream action reads the end date; a failure there must not undo the disable.
+            DisableEmployeeRequestDto request = new DisableEmployeeRequestDto() {
+                @Override
+                public LocalDate getAssignmentEndDate() {
+                    throw new IllegalStateException("assignment service unavailable");
+                }
+            };
+            request.setAssignmentPolicy(AssignmentTerminationPolicy.GRACE_PERIOD);
+            request.setDisableReason("Voluntary resignation");
+
+            EmployeeProfileDto profile = service.disableEmployee(PERSON_ID, request);
+
+            assertThat(profile.getStatus()).isEqualTo(EmployeeStatus.DISABLED);
+            ArgumentCaptor<EmployeeOffboardingRetry> retry = ArgumentCaptor.forClass(EmployeeOffboardingRetry.class);
+            verify(offboardingRetryRepository).save(retry.capture());
+            assertThat(retry.getValue().getEmployeeId()).isEqualTo(PERSON_ID);
+            assertThat(retry.getValue().getAssignmentPolicy()).isEqualTo(AssignmentTerminationPolicy.GRACE_PERIOD);
+            assertThat(retry.getValue().getFailureReason()).contains("assignment service unavailable");
+            assertThat(retry.getValue().getAttempts()).isZero();
+            assertThat(retry.getValue().getNextAttemptAt()).isEqualTo(NOW.plusSeconds(300));
+            assertThat(retry.getValue().getActorId()).isEqualTo("system");
+        }
+
+        @Test
+        void failsWhenTheEmployeeDoesNotExist() {
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.empty());
+            DisableEmployeeRequestDto request = disableRequest(AssignmentTerminationPolicy.IMMEDIATE);
+
+            assertThatThrownBy(() -> service.disableEmployee(PERSON_ID, request))
+                    .isInstanceOf(PersonNotFoundException.class);
+        }
+
+        @Test
+        void rejectsAnAlreadyDisabledEmployee() {
+            when(employeeRepository.findByPersonId(PERSON_ID))
+                    .thenReturn(Optional.of(employee(EmployeeStatus.DISABLED)));
+            DisableEmployeeRequestDto request = disableRequest(AssignmentTerminationPolicy.IMMEDIATE);
+
+            assertThatThrownBy(() -> service.disableEmployee(PERSON_ID, request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("already DISABLED or TERMINATED");
+        }
+
+        @Test
+        void rejectsATerminatedEmployee() {
+            when(employeeRepository.findByPersonId(PERSON_ID))
+                    .thenReturn(Optional.of(employee(EmployeeStatus.TERMINATED)));
+            DisableEmployeeRequestDto request = disableRequest(AssignmentTerminationPolicy.IMMEDIATE);
+
+            assertThatThrownBy(() -> service.disableEmployee(PERSON_ID, request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void rejectsAnEmployeeThatIsNeitherActiveNorAlreadyDisabled() {
+            when(employeeRepository.findByPersonId(PERSON_ID))
+                    .thenReturn(Optional.of(employee(EmployeeStatus.SUSPENDED)));
+            DisableEmployeeRequestDto request = disableRequest(AssignmentTerminationPolicy.IMMEDIATE);
+
+            assertThatThrownBy(() -> service.disableEmployee(PERSON_ID, request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Only ACTIVE employees can be disabled");
+        }
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/service/StaffingAssignmentLifecycleTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/StaffingAssignmentLifecycleTest.java
@@ -1,0 +1,399 @@
+package com.positivity.people.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.people.internal.config.PeopleEventPublisher;
+import com.positivity.people.internal.dto.CreateStaffingAssignmentRequest;
+import com.positivity.people.internal.dto.StaffingAssignmentResponse;
+import com.positivity.people.internal.dto.UpdateStaffingAssignmentRequest;
+import com.positivity.people.internal.entity.Employee;
+import com.positivity.people.internal.entity.EmployeeLocationAssignment;
+import com.positivity.people.internal.entity.ExtPersonReplica;
+import com.positivity.people.internal.enums.AssignmentStatus;
+import com.positivity.people.internal.enums.EmployeeStatus;
+import com.positivity.people.internal.repository.EmployeeLocationAssignmentRepository;
+import com.positivity.people.internal.repository.EmployeeRepository;
+import com.positivity.people.internal.repository.ExtPersonReplicaRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Staffing assignment reads, updates and endings. Creation's primary-flag defaulting is covered
+ * by {@code com.positivity.people.service.StaffingAssignmentServiceTest}; this class covers the
+ * rest of the lifecycle — overlap conflicts, person/location validation, primary demotion on
+ * update, and ending an open-ended assignment.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("StaffingAssignmentServiceImpl lifecycle")
+class StaffingAssignmentLifecycleTest {
+
+    private static final Instant NOW = Instant.parse("2026-03-01T10:00:00Z");
+    private static final LocalDate TODAY = LocalDate.of(2026, 3, 1);
+    private static final UUID PERSON_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f6a01");
+    private static final UUID LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f6a02");
+    private static final UUID ASSIGNMENT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f6a03");
+    private static final UUID OTHER_ASSIGNMENT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f6a04");
+    private static final String ACTOR = "test.user";
+
+    @Mock
+    private EmployeeLocationAssignmentRepository repository;
+
+    @Mock
+    private ExtPersonReplicaRepository extPersonReplicaRepository;
+
+    @Mock
+    private PeopleEventPublisher peopleEventPublisher;
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @Mock
+    private LocationReferenceService locationReferenceService;
+
+    private StaffingAssignmentServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new StaffingAssignmentServiceImpl(
+                repository,
+                extPersonReplicaRepository,
+                peopleEventPublisher,
+                employeeRepository,
+                locationReferenceService,
+                Clock.fixed(NOW, ZoneOffset.UTC));
+
+        when(extPersonReplicaRepository.findById(PERSON_ID))
+                .thenReturn(Optional.of(ExtPersonReplica.builder()
+                        .personId(PERSON_ID)
+                        .aggregateVersion(0)
+                        .updatedAt(NOW)
+                        .build()));
+        when(employeeRepository.findByPersonId(PERSON_ID))
+                .thenReturn(Optional.of(Employee.builder()
+                        .personId(PERSON_ID)
+                        .status(EmployeeStatus.ACTIVE)
+                        .build()));
+        when(locationReferenceService.isLocationActive(LOCATION_ID)).thenReturn(true);
+        when(repository.save(any(EmployeeLocationAssignment.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private static EmployeeLocationAssignment assignment(UUID id, LocalDate from, LocalDate to, boolean primary) {
+        return EmployeeLocationAssignment.builder()
+                .id(id)
+                .employee(Employee.builder().personId(PERSON_ID).build())
+                .locationId(LOCATION_ID)
+                .role("TECHNICIAN")
+                .isPrimary(primary)
+                .effectiveFrom(from)
+                .effectiveTo(to)
+                .status(AssignmentStatus.ACTIVE)
+                .createdBy(ACTOR)
+                .build();
+    }
+
+    private static UpdateStaffingAssignmentRequest updateRequest(LocalDate from, LocalDate to, boolean primary) {
+        return new UpdateStaffingAssignmentRequest(PERSON_ID, LOCATION_ID, "TECHNICIAN", primary, from, to);
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        void listsEveryAssignmentHeldByAPerson() {
+            when(repository.findByEmployee_PersonId(PERSON_ID))
+                    .thenReturn(List.of(assignment(ASSIGNMENT_ID, TODAY, null, true)));
+
+            List<StaffingAssignmentResponse> assignments = service.findByPersonId(PERSON_ID);
+
+            assertThat(assignments).hasSize(1);
+            assertThat(assignments.get(0).getAssignmentId()).isEqualTo(ASSIGNMENT_ID);
+            assertThat(assignments.get(0).getPersonId()).isEqualTo(PERSON_ID);
+            assertThat(assignments.get(0).getLocationId()).isEqualTo(LOCATION_ID);
+            assertThat(assignments.get(0).isPrimary()).isTrue();
+            assertThat(assignments.get(0).getRole()).isEqualTo("TECHNICIAN");
+            assertThat(assignments.get(0).getStatus()).isEqualTo(AssignmentStatus.ACTIVE);
+            assertThat(assignments.get(0).getCreatedBy()).isEqualTo(ACTOR);
+        }
+
+        @Test
+        void asksForTheAssignmentsActiveOnTodaysDate() {
+            when(repository.findActiveByPersonIdAndDate(PERSON_ID, TODAY))
+                    .thenReturn(List.of(assignment(ASSIGNMENT_ID, TODAY, null, true)));
+
+            assertThat(service.findActiveByPersonId(PERSON_ID)).hasSize(1);
+            verify(repository).findActiveByPersonIdAndDate(PERSON_ID, TODAY);
+        }
+
+        @Test
+        void findsASingleAssignmentById() {
+            when(repository.findById(ASSIGNMENT_ID))
+                    .thenReturn(Optional.of(assignment(ASSIGNMENT_ID, TODAY, null, false)));
+
+            assertThat(service.findById(ASSIGNMENT_ID)).isPresent();
+        }
+
+        @Test
+        void returnsEmptyForAnUnknownAssignmentId() {
+            when(repository.findById(ASSIGNMENT_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.findById(ASSIGNMENT_ID)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("create validation")
+    class CreateValidation {
+
+        private CreateStaffingAssignmentRequest createRequest() {
+            return new CreateStaffingAssignmentRequest(
+                    PERSON_ID, LOCATION_ID, "TECHNICIAN", false, LocalDate.of(2026, 3, 1), null);
+        }
+
+        @Test
+        void refusesAnOverlappingAssignmentForTheSamePersonLocationAndRole() {
+            when(repository.existsOverlapping(any(), any(), any(), any(), any()))
+                    .thenReturn(true);
+            CreateStaffingAssignmentRequest request = createRequest();
+
+            assertThatThrownBy(() -> service.create(request, ACTOR))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("overlapping assignment");
+            verify(repository, never()).save(any());
+        }
+
+        @Test
+        void refusesAnAssignmentForAPersonTheReplicaDoesNotKnow() {
+            when(extPersonReplicaRepository.findById(PERSON_ID)).thenReturn(Optional.empty());
+            CreateStaffingAssignmentRequest request = createRequest();
+
+            assertThatThrownBy(() -> service.create(request, ACTOR))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Person not found");
+        }
+
+        @Test
+        void refusesAnAssignmentForANonActiveEmployee() {
+            when(employeeRepository.findByPersonId(PERSON_ID))
+                    .thenReturn(Optional.of(Employee.builder()
+                            .personId(PERSON_ID)
+                            .status(EmployeeStatus.DISABLED)
+                            .build()));
+            CreateStaffingAssignmentRequest request = createRequest();
+
+            assertThatThrownBy(() -> service.create(request, ACTOR))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("not active");
+        }
+
+        @Test
+        void refusesAnAssignmentForAPersonWithNoEmploymentRow() {
+            when(employeeRepository.findByPersonId(PERSON_ID)).thenReturn(Optional.empty());
+            CreateStaffingAssignmentRequest request = createRequest();
+
+            assertThatThrownBy(() -> service.create(request, ACTOR))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("not active");
+        }
+
+        @Test
+        void refusesAnAssignmentToAnInactiveLocation() {
+            when(locationReferenceService.isLocationActive(LOCATION_ID)).thenReturn(false);
+            CreateStaffingAssignmentRequest request = createRequest();
+
+            assertThatThrownBy(() -> service.create(request, ACTOR))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Location not found or inactive");
+        }
+
+        @Test
+        void demotesTheOverlappingPrimaryToTheDayBeforeTheNewOne() {
+            EmployeeLocationAssignment existingPrimary =
+                    assignment(OTHER_ASSIGNMENT_ID, LocalDate.of(2026, 1, 1), null, true);
+            when(repository.findFirstByEmployee_PersonIdAndIsPrimaryTrueAndStatus(PERSON_ID, AssignmentStatus.ACTIVE))
+                    .thenReturn(Optional.of(existingPrimary));
+
+            CreateStaffingAssignmentRequest request = new CreateStaffingAssignmentRequest(
+                    PERSON_ID, LOCATION_ID, "SERVICE_ADVISOR", true, LocalDate.of(2026, 3, 1), null);
+            service.create(request, ACTOR);
+
+            assertThat(existingPrimary.getEffectiveTo()).isEqualTo(LocalDate.of(2026, 2, 28));
+            assertThat(existingPrimary.getStatus()).isEqualTo(AssignmentStatus.ENDED);
+        }
+
+        @Test
+        void clampsTheDemotionDateToTheExistingPrimarysOwnStart() {
+            // The new primary starts on the same day the old one did, so it cannot be demoted
+            // to the day before — that would put its end before its start.
+            EmployeeLocationAssignment existingPrimary =
+                    assignment(OTHER_ASSIGNMENT_ID, LocalDate.of(2026, 3, 1), null, true);
+            when(repository.findFirstByEmployee_PersonIdAndIsPrimaryTrueAndStatus(PERSON_ID, AssignmentStatus.ACTIVE))
+                    .thenReturn(Optional.of(existingPrimary));
+
+            CreateStaffingAssignmentRequest request = new CreateStaffingAssignmentRequest(
+                    PERSON_ID, LOCATION_ID, "SERVICE_ADVISOR", true, LocalDate.of(2026, 3, 1), null);
+            service.create(request, ACTOR);
+
+            assertThat(existingPrimary.getEffectiveTo()).isEqualTo(LocalDate.of(2026, 3, 1));
+        }
+
+        @Test
+        void leavesANonOverlappingPrimaryAlone() {
+            EmployeeLocationAssignment pastPrimary =
+                    assignment(OTHER_ASSIGNMENT_ID, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31), true);
+            when(repository.findFirstByEmployee_PersonIdAndIsPrimaryTrueAndStatus(PERSON_ID, AssignmentStatus.ACTIVE))
+                    .thenReturn(Optional.of(pastPrimary));
+
+            CreateStaffingAssignmentRequest request = new CreateStaffingAssignmentRequest(
+                    PERSON_ID, LOCATION_ID, "SERVICE_ADVISOR", true, LocalDate.of(2026, 3, 1), null);
+            service.create(request, ACTOR);
+
+            assertThat(pastPrimary.getStatus()).isEqualTo(AssignmentStatus.ACTIVE);
+            assertThat(pastPrimary.getEffectiveTo()).isEqualTo(LocalDate.of(2026, 1, 31));
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    class Update {
+
+        @Test
+        void rewritesTheAssignmentAndPublishesTheFact() {
+            EmployeeLocationAssignment existing = assignment(ASSIGNMENT_ID, LocalDate.of(2026, 1, 1), null, false);
+            when(repository.findById(ASSIGNMENT_ID)).thenReturn(Optional.of(existing));
+
+            Optional<StaffingAssignmentResponse> response = service.update(
+                    ASSIGNMENT_ID, updateRequest(LocalDate.of(2026, 3, 1), LocalDate.of(2026, 12, 31), false), ACTOR);
+
+            assertThat(response).isPresent();
+            assertThat(existing.getEffectiveFrom()).isEqualTo(LocalDate.of(2026, 3, 1));
+            assertThat(existing.getEffectiveTo()).isEqualTo(LocalDate.of(2026, 12, 31));
+            verify(peopleEventPublisher).publishStaffingAssignmentUpdated(existing);
+        }
+
+        @Test
+        void returnsEmptyForAnUnknownAssignment() {
+            when(repository.findById(ASSIGNMENT_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.update(ASSIGNMENT_ID, updateRequest(TODAY, null, false), ACTOR))
+                    .isEmpty();
+            // The person/location checks are skipped entirely for a missing assignment.
+            verify(extPersonReplicaRepository, never()).findById(any());
+        }
+
+        @Test
+        void refusesAnUpdateThatWouldOverlapAnotherAssignment() {
+            when(repository.findById(ASSIGNMENT_ID))
+                    .thenReturn(Optional.of(assignment(ASSIGNMENT_ID, TODAY, null, false)));
+            when(repository.existsOverlappingExcludingId(any(), any(), any(), any(), any(), any()))
+                    .thenReturn(true);
+            UpdateStaffingAssignmentRequest request = updateRequest(TODAY, null, false);
+
+            assertThatThrownBy(() -> service.update(ASSIGNMENT_ID, request, ACTOR))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("overlapping assignment");
+        }
+
+        @Test
+        void demotesADifferentOverlappingPrimaryWhenPromotingThisOne() {
+            when(repository.findById(ASSIGNMENT_ID))
+                    .thenReturn(Optional.of(assignment(ASSIGNMENT_ID, TODAY, null, false)));
+            EmployeeLocationAssignment otherPrimary =
+                    assignment(OTHER_ASSIGNMENT_ID, LocalDate.of(2026, 1, 1), null, true);
+            when(repository.findFirstByEmployee_PersonIdAndIsPrimaryTrueAndStatus(PERSON_ID, AssignmentStatus.ACTIVE))
+                    .thenReturn(Optional.of(otherPrimary));
+
+            service.update(ASSIGNMENT_ID, updateRequest(LocalDate.of(2026, 3, 1), null, true), ACTOR);
+
+            assertThat(otherPrimary.getStatus()).isEqualTo(AssignmentStatus.ENDED);
+            assertThat(otherPrimary.getEffectiveTo()).isEqualTo(LocalDate.of(2026, 2, 28));
+        }
+
+        @Test
+        void doesNotDemoteTheAssignmentBeingUpdated() {
+            EmployeeLocationAssignment self = assignment(ASSIGNMENT_ID, LocalDate.of(2026, 1, 1), null, true);
+            when(repository.findById(ASSIGNMENT_ID)).thenReturn(Optional.of(self));
+            when(repository.findFirstByEmployee_PersonIdAndIsPrimaryTrueAndStatus(PERSON_ID, AssignmentStatus.ACTIVE))
+                    .thenReturn(Optional.of(self));
+
+            service.update(ASSIGNMENT_ID, updateRequest(LocalDate.of(2026, 3, 1), null, true), ACTOR);
+
+            assertThat(self.getStatus()).isEqualTo(AssignmentStatus.ACTIVE);
+        }
+
+        @Test
+        void leavesANonOverlappingPrimaryAloneOnUpdate() {
+            when(repository.findById(ASSIGNMENT_ID))
+                    .thenReturn(Optional.of(assignment(ASSIGNMENT_ID, TODAY, null, false)));
+            EmployeeLocationAssignment pastPrimary =
+                    assignment(OTHER_ASSIGNMENT_ID, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31), true);
+            when(repository.findFirstByEmployee_PersonIdAndIsPrimaryTrueAndStatus(PERSON_ID, AssignmentStatus.ACTIVE))
+                    .thenReturn(Optional.of(pastPrimary));
+
+            service.update(ASSIGNMENT_ID, updateRequest(LocalDate.of(2026, 3, 1), null, true), ACTOR);
+
+            assertThat(pastPrimary.getStatus()).isEqualTo(AssignmentStatus.ACTIVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("end")
+    class End {
+
+        @Test
+        void closesAnOpenEndedAssignmentAtToday() {
+            EmployeeLocationAssignment open = assignment(ASSIGNMENT_ID, LocalDate.of(2026, 1, 1), null, true);
+            when(repository.findById(ASSIGNMENT_ID)).thenReturn(Optional.of(open));
+
+            service.end(ASSIGNMENT_ID);
+
+            assertThat(open.getStatus()).isEqualTo(AssignmentStatus.ENDED);
+            assertThat(open.getEffectiveTo()).isEqualTo(TODAY);
+            verify(peopleEventPublisher).publishStaffingAssignmentUpdated(open);
+        }
+
+        @Test
+        void keepsAnAlreadyScheduledEndDate() {
+            EmployeeLocationAssignment scheduled =
+                    assignment(ASSIGNMENT_ID, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 6, 30), true);
+            when(repository.findById(ASSIGNMENT_ID)).thenReturn(Optional.of(scheduled));
+
+            service.end(ASSIGNMENT_ID);
+
+            assertThat(scheduled.getEffectiveTo()).isEqualTo(LocalDate.of(2026, 6, 30));
+        }
+
+        @Test
+        void failsWhenTheAssignmentDoesNotExist() {
+            when(repository.findById(ASSIGNMENT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.end(ASSIGNMENT_ID))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Assignment not found")
+                    .extracting(exception -> ((ResponseStatusException) exception).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/service/TimeEntryExceptionIntakeTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/TimeEntryExceptionIntakeTest.java
@@ -1,0 +1,301 @@
+package com.positivity.people.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.people.internal.dto.TimeEntryExceptionRequest;
+import com.positivity.people.internal.dto.TimeEntryExceptionResponse;
+import com.positivity.people.internal.entity.TimeEntryAudit;
+import com.positivity.people.internal.enums.ExceptionSeverity;
+import com.positivity.people.internal.enums.ExceptionStatus;
+import com.positivity.people.internal.repository.TimeEntryAuditRepository;
+import com.positivity.people.internal.repository.TimeEntryExceptionRepository;
+import com.positivity.security.common.GatewaySecurityConstants;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Exception intake and listing. Resolution and acknowledgement flows are covered by
+ * {@code com.positivity.people.service.TimeEntryExceptionServiceTest}; this class covers
+ * creation, the read side, and the audit-write failure paths that must not fail the action.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("TimeEntryExceptionServiceImpl intake")
+class TimeEntryExceptionIntakeTest {
+
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final UUID EXCEPTION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f8a01");
+    private static final String EMPLOYEE_ID = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f8a02";
+    private static final String ACTOR = "jane.smith";
+
+    @Mock
+    private TimeEntryExceptionRepository exceptionRepository;
+
+    @Mock
+    private TimeEntryAuditRepository auditRepository;
+
+    private TimeEntryExceptionServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TimeEntryExceptionServiceImpl(
+                exceptionRepository, auditRepository, Clock.fixed(NOW, ZoneOffset.UTC));
+        when(exceptionRepository.save(any())).thenAnswer(invocation -> {
+            com.positivity.people.internal.entity.TimeEntryException entity = invocation.getArgument(0);
+            if (entity.getExceptionId() == null) {
+                entity.setExceptionId(EXCEPTION_ID);
+            }
+            return entity;
+        });
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(ACTOR, "n/a", List.of());
+        token.setDetails(Map.of(GatewaySecurityConstants.DETAIL_USERNAME, ACTOR));
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private static TimeEntryExceptionRequest request(String severity) {
+        TimeEntryExceptionRequest request = new TimeEntryExceptionRequest();
+        request.setEmployeeId(EMPLOYEE_ID);
+        request.setExceptionCode("MISSING_PUNCH_OUT");
+        request.setSeverity(severity);
+        request.setTimeEntryId("TE-1");
+        request.setResolutionNotes("Detected by nightly sweep");
+        return request;
+    }
+
+    private static com.positivity.people.internal.entity.TimeEntryException entity(ExceptionStatus status) {
+        com.positivity.people.internal.entity.TimeEntryException exception =
+                new com.positivity.people.internal.entity.TimeEntryException();
+        exception.setExceptionId(EXCEPTION_ID);
+        exception.setEmployeeId(EMPLOYEE_ID);
+        exception.setWorkDate(LocalDate.of(2026, 3, 1));
+        exception.setExceptionCode("MISSING_PUNCH_OUT");
+        exception.setSeverity(ExceptionSeverity.BLOCKING);
+        exception.setStatus(status);
+        exception.setTimeEntryId("TE-1");
+        exception.setDetectedAt(NOW);
+        return exception;
+    }
+
+    @Nested
+    @DisplayName("createException")
+    class CreateException {
+
+        @Test
+        void opensTheExceptionAndStampsTheDetectionTime() {
+            TimeEntryExceptionResponse response = service.createException(request("BLOCKING"));
+
+            ArgumentCaptor<com.positivity.people.internal.entity.TimeEntryException> saved = ArgumentCaptor.captor();
+            verify(exceptionRepository).save(saved.capture());
+            assertThat(saved.getValue().getStatus()).isEqualTo(ExceptionStatus.OPEN);
+            assertThat(saved.getValue().getSeverity()).isEqualTo(ExceptionSeverity.BLOCKING);
+            assertThat(saved.getValue().getDetectedAt()).isEqualTo(NOW);
+            assertThat(saved.getValue().getExceptionCode()).isEqualTo("MISSING_PUNCH_OUT");
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.getMessage()).isEqualTo("created");
+            assertThat(response.getExceptionId()).isEqualTo(EXCEPTION_ID);
+        }
+
+        @Test
+        void keepsACallerSuppliedDetectionTime() {
+            TimeEntryExceptionRequest request = request("WARNING");
+            request.setDetectedAt(OffsetDateTime.parse("2026-02-28T09:30:00Z"));
+
+            service.createException(request);
+
+            ArgumentCaptor<com.positivity.people.internal.entity.TimeEntryException> saved = ArgumentCaptor.captor();
+            verify(exceptionRepository).save(saved.capture());
+            assertThat(saved.getValue().getDetectedAt()).isEqualTo(Instant.parse("2026-02-28T09:30:00Z"));
+        }
+
+        @Test
+        void downgradesAnUnrecognisedSeverityToWarningRatherThanFailing() {
+            service.createException(request("CATASTROPHIC"));
+
+            ArgumentCaptor<com.positivity.people.internal.entity.TimeEntryException> saved = ArgumentCaptor.captor();
+            verify(exceptionRepository).save(saved.capture());
+            assertThat(saved.getValue().getSeverity()).isEqualTo(ExceptionSeverity.WARNING);
+        }
+
+        @Test
+        void leavesSeverityUnsetWhenTheRequestOmitsIt() {
+            service.createException(request(null));
+
+            ArgumentCaptor<com.positivity.people.internal.entity.TimeEntryException> saved = ArgumentCaptor.captor();
+            verify(exceptionRepository).save(saved.capture());
+            assertThat(saved.getValue().getSeverity()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("listByEmployee")
+    class ListByEmployee {
+
+        @Test
+        void mapsTheEmployeesExceptionsToTheirDtoShape() {
+            when(exceptionRepository.findByEmployeeId(EMPLOYEE_ID)).thenReturn(List.of(entity(ExceptionStatus.OPEN)));
+
+            List<com.positivity.people.internal.dto.TimeEntryException> exceptions =
+                    service.listByEmployee(EMPLOYEE_ID);
+
+            assertThat(exceptions).hasSize(1);
+            assertThat(exceptions.get(0).getExceptionId()).isEqualTo(EXCEPTION_ID);
+            assertThat(exceptions.get(0).getEmployeeId()).isEqualTo(EMPLOYEE_ID);
+            assertThat(exceptions.get(0).getWorkDate()).isEqualTo(LocalDate.of(2026, 3, 1));
+            assertThat(exceptions.get(0).getSeverity()).isEqualTo(ExceptionSeverity.BLOCKING);
+            assertThat(exceptions.get(0).getStatus()).isEqualTo(ExceptionStatus.OPEN);
+            assertThat(exceptions.get(0).getTimeEntryId()).isEqualTo("TE-1");
+            assertThat(exceptions.get(0).getDetectedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        void readsEveryExceptionWhenNoEmployeeIsNamed() {
+            when(exceptionRepository.findAll()).thenReturn(List.of(entity(ExceptionStatus.ACKNOWLEDGED)));
+
+            assertThat(service.listByEmployee(null)).hasSize(1);
+            verify(exceptionRepository).findAll();
+        }
+    }
+
+    @Nested
+    @DisplayName("audit resilience")
+    class AuditResilience {
+
+        @Test
+        void completesTheActionEvenWhenTheAuditWriteFails() {
+            when(exceptionRepository.findById(EXCEPTION_ID)).thenReturn(Optional.of(entity(ExceptionStatus.OPEN)));
+            doThrow(new IllegalStateException("audit store down"))
+                    .when(auditRepository)
+                    .save(any(TimeEntryAudit.class));
+
+            service.actionException(EXCEPTION_ID, ExceptionStatus.ACKNOWLEDGED, "seen", "corr-1");
+
+            verify(exceptionRepository).save(any());
+        }
+
+        @Test
+        void recordsAnEmptyTimeEntryIdOnTheAuditRowWhenTheExceptionHasNone() {
+            com.positivity.people.internal.entity.TimeEntryException detached = entity(ExceptionStatus.OPEN);
+            detached.setTimeEntryId(null);
+            when(exceptionRepository.findById(EXCEPTION_ID)).thenReturn(Optional.of(detached));
+
+            service.actionException(EXCEPTION_ID, ExceptionStatus.ACKNOWLEDGED, null, null);
+
+            ArgumentCaptor<TimeEntryAudit> audit = ArgumentCaptor.forClass(TimeEntryAudit.class);
+            verify(auditRepository).save(audit.capture());
+            assertThat(audit.getValue().getTimeEntryId()).isEmpty();
+            assertThat(audit.getValue().getAction()).isEqualTo("EXCEPTION_ACKNOWLEDGED");
+            assertThat(audit.getValue().getActorId()).isEqualTo(ACTOR);
+        }
+
+        @Test
+        void stillDeniesTheResolveWhenTheDenialAuditWriteFails() {
+            when(exceptionRepository.findById(EXCEPTION_ID)).thenReturn(Optional.of(entity(ExceptionStatus.OPEN)));
+            doThrow(new IllegalStateException("audit store down"))
+                    .when(auditRepository)
+                    .save(any(TimeEntryAudit.class));
+
+            assertThatThrownBy(() -> service.resolveException(EXCEPTION_ID, Set.of(), null, null, "corr-1"))
+                    .isInstanceOf(org.springframework.security.access.AccessDeniedException.class);
+        }
+
+        @Test
+        void treatsAMissingPermissionSetAsADenial() {
+            when(exceptionRepository.findById(EXCEPTION_ID)).thenReturn(Optional.of(entity(ExceptionStatus.OPEN)));
+
+            assertThatThrownBy(() -> service.resolveException(EXCEPTION_ID, null, null, null, null))
+                    .isInstanceOf(org.springframework.security.access.AccessDeniedException.class);
+        }
+
+        @Test
+        void acceptsTheAdminPermissionAsWellAsTheSpecificOne() {
+            com.positivity.people.internal.entity.TimeEntryException open = entity(ExceptionStatus.OPEN);
+            when(exceptionRepository.findById(EXCEPTION_ID)).thenReturn(Optional.of(open));
+
+            service.resolveException(EXCEPTION_ID, Set.of("admin"), "fixed", null, "corr-1");
+
+            assertThat(open.getStatus()).isEqualTo(ExceptionStatus.RESOLVED);
+            assertThat(open.getResolvedBy()).isEqualTo(ACTOR);
+            assertThat(open.getResolvedAt()).isEqualTo(NOW);
+            assertThat(open.getResolutionNotes()).isEqualTo("fixed");
+        }
+
+        @Test
+        void appliesAnExplicitResolutionAction() {
+            com.positivity.people.internal.entity.TimeEntryException open = entity(ExceptionStatus.OPEN);
+            when(exceptionRepository.findById(EXCEPTION_ID)).thenReturn(Optional.of(open));
+
+            service.resolveException(EXCEPTION_ID, Set.of("admin"), null, "WAIVED", null);
+
+            assertThat(open.getStatus()).isEqualTo(ExceptionStatus.WAIVED);
+        }
+
+        @Test
+        void fallsBackToResolvedForAnUnknownResolutionAction() {
+            com.positivity.people.internal.entity.TimeEntryException open = entity(ExceptionStatus.OPEN);
+            when(exceptionRepository.findById(EXCEPTION_ID)).thenReturn(Optional.of(open));
+
+            service.resolveException(EXCEPTION_ID, Set.of("admin"), null, "NOT_A_STATUS", null);
+
+            assertThat(open.getStatus()).isEqualTo(ExceptionStatus.RESOLVED);
+        }
+
+        @Test
+        void failsWhenTheExceptionDoesNotExist() {
+            when(exceptionRepository.findById(EXCEPTION_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.resolveException(EXCEPTION_ID, Set.of("admin"), null, null, null))
+                    .isInstanceOf(EntityNotFoundException.class);
+            assertThatThrownBy(() -> service.actionException(EXCEPTION_ID, ExceptionStatus.ACKNOWLEDGED, null, null))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+
+        @Test
+        void refusesToActionAnAlreadyWaivedException() {
+            when(exceptionRepository.findById(EXCEPTION_ID)).thenReturn(Optional.of(entity(ExceptionStatus.WAIVED)));
+
+            assertThatThrownBy(() -> service.actionException(EXCEPTION_ID, ExceptionStatus.ACKNOWLEDGED, null, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("WAIVED");
+        }
+
+        @Test
+        void failsWhenThereIsNoAuthenticatedActor() {
+            SecurityContextHolder.clearContext();
+
+            assertThatThrownBy(() -> service.actionException(EXCEPTION_ID, ExceptionStatus.ACKNOWLEDGED, null, null))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/service/TimekeepingApprovalServiceImplTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/TimekeepingApprovalServiceImplTest.java
@@ -1,0 +1,324 @@
+package com.positivity.people.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.people.internal.dto.ApprovalPersonDto;
+import com.positivity.people.internal.dto.TimePeriodApprovalDto;
+import com.positivity.people.internal.dto.TimePeriodDecisionResponse;
+import com.positivity.people.internal.dto.TimePeriodDto;
+import com.positivity.people.internal.dto.TimekeepingEntryDto;
+import com.positivity.people.internal.entity.Employee;
+import com.positivity.people.internal.entity.ExtPersonReplica;
+import com.positivity.people.internal.entity.TimePeriod;
+import com.positivity.people.internal.entity.TimekeepingEntry;
+import com.positivity.people.internal.enums.ApprovalStatus;
+import com.positivity.people.internal.repository.EmployeeRepository;
+import com.positivity.people.internal.repository.ExtPersonReplicaRepository;
+import com.positivity.people.internal.repository.TimePeriodRepository;
+import com.positivity.people.internal.repository.TimekeepingEntryRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Timekeeping approval reads and period-wide approve/reject decisions. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TimekeepingApprovalServiceImpl")
+class TimekeepingApprovalServiceImplTest {
+
+    private static final UUID PERSON_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01");
+    private static final UUID OTHER_PERSON_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b02");
+    private static final UUID PERIOD_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b03");
+    private static final UUID TENANT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b04");
+
+    private static final Instant PERIOD_START = Instant.parse("2026-03-01T00:00:00Z");
+    // The window is inclusive of the whole end day, so it closes at the start of the next day.
+    private static final Instant PERIOD_END = Instant.parse("2026-03-16T00:00:00Z");
+
+    @Mock
+    private TimekeepingEntryRepository timekeepingEntryRepository;
+
+    @Mock
+    private TimePeriodRepository timePeriodRepository;
+
+    @Mock
+    private ExtPersonReplicaRepository extPersonReplicaRepository;
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @InjectMocks
+    private TimekeepingApprovalServiceImpl service;
+
+    private static TimePeriod period() {
+        TimePeriod period = new TimePeriod();
+        period.setTimePeriodId(PERIOD_ID);
+        period.setTenantId(TENANT_ID);
+        period.setStartDate(LocalDate.of(2026, 3, 1));
+        period.setEndDate(LocalDate.of(2026, 3, 15));
+        return period;
+    }
+
+    private static ExtPersonReplica person(UUID personId, String firstName, String preferredName) {
+        ExtPersonReplica replica = new ExtPersonReplica();
+        replica.setPersonId(personId);
+        replica.setFirstName(firstName);
+        replica.setPreferredName(preferredName);
+        replica.setLastName("Smith");
+        return replica;
+    }
+
+    private static TimekeepingEntry entry(ApprovalStatus status) {
+        TimekeepingEntry entry = new TimekeepingEntry();
+        entry.setTimekeepingEntryId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4bff"));
+        entry.setEmployeeId(PERSON_ID);
+        entry.setSessionStartTime(Instant.parse("2026-03-02T13:00:00Z"));
+        entry.setSessionEndTime(Instant.parse("2026-03-02T21:00:00Z"));
+        entry.setApprovalStatus(status);
+        entry.setAssociatedWorkOrderId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4bfe"));
+        return entry;
+    }
+
+    private void stubPeriodEntries(List<TimekeepingEntry> entries) {
+        when(timePeriodRepository.findById(PERIOD_ID)).thenReturn(Optional.of(period()));
+        when(timekeepingEntryRepository
+                        .findByEmployeeIdAndSessionStartTimeGreaterThanEqualAndSessionEndTimeLessThanEqual(
+                                PERSON_ID, PERIOD_START, PERIOD_END))
+                .thenReturn(entries);
+    }
+
+    @Nested
+    @DisplayName("listApprovalPeople")
+    class ListApprovalPeople {
+
+        @Test
+        void joinsReplicaIdentityToTheLocalEmployeeNumber() {
+            when(timekeepingEntryRepository.findDistinctEmployeeIds()).thenReturn(List.of(PERSON_ID, OTHER_PERSON_ID));
+            when(extPersonReplicaRepository.findAllById(List.of(PERSON_ID, OTHER_PERSON_ID)))
+                    .thenReturn(List.of(person(PERSON_ID, "Jane", "Janie"), person(OTHER_PERSON_ID, "Robert", null)));
+            when(employeeRepository.findByPersonIdIn(List.of(PERSON_ID, OTHER_PERSON_ID)))
+                    .thenReturn(List.of(Employee.builder()
+                            .personId(PERSON_ID)
+                            .employeeNumber("EMP-0001")
+                            .build()));
+
+            List<ApprovalPersonDto> people = service.listApprovalPeople();
+
+            assertThat(people).hasSize(2);
+            // Preferred name wins over the given name when one is on file.
+            assertThat(people.get(0).getDisplayName()).isEqualTo("Janie Smith");
+            assertThat(people.get(0).getEmployeeNumber()).isEqualTo("EMP-0001");
+            assertThat(people.get(1).getDisplayName()).isEqualTo("Robert Smith");
+            // No employment row means no employee number, not a failed read.
+            assertThat(people.get(1).getEmployeeNumber()).isNull();
+        }
+
+        @Test
+        void fallsBackToThePersonIdWhenNoNameIsOnFile() {
+            when(timekeepingEntryRepository.findDistinctEmployeeIds()).thenReturn(List.of(PERSON_ID));
+            when(extPersonReplicaRepository.findAllById(List.of(PERSON_ID)))
+                    .thenReturn(List.of(person(PERSON_ID, null, "  ")));
+            when(employeeRepository.findByPersonIdIn(List.of(PERSON_ID))).thenReturn(List.of());
+
+            assertThat(service.listApprovalPeople().get(0).getDisplayName()).isEqualTo(PERSON_ID.toString());
+        }
+
+        @Test
+        void returnsEmptyWithoutTouchingTheReplicaWhenNoEntriesExist() {
+            when(timekeepingEntryRepository.findDistinctEmployeeIds()).thenReturn(List.of());
+
+            assertThat(service.listApprovalPeople()).isEmpty();
+            verifyNoInteractions(extPersonReplicaRepository, employeeRepository);
+        }
+    }
+
+    @Nested
+    @DisplayName("listTimePeriods")
+    class ListTimePeriods {
+
+        @Test
+        void scopesToTheTenantWhenOneIsGiven() {
+            when(timePeriodRepository.findAllByTenantIdOrderByStartDateDesc(TENANT_ID))
+                    .thenReturn(List.of(period()));
+
+            List<TimePeriodDto> periods = service.listTimePeriods(TENANT_ID);
+
+            assertThat(periods).hasSize(1);
+            assertThat(periods.get(0).getTimePeriodId()).isEqualTo(PERIOD_ID);
+            assertThat(periods.get(0).getStartDate()).isEqualTo(LocalDate.of(2026, 3, 1));
+            assertThat(periods.get(0).getEndDate()).isEqualTo(LocalDate.of(2026, 3, 15));
+        }
+
+        @Test
+        void readsEveryPeriodWhenNoTenantIsGiven() {
+            when(timePeriodRepository.findAll()).thenReturn(List.of(period()));
+
+            assertThat(service.listTimePeriods(null)).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("listTimekeepingEntries")
+    class ListTimekeepingEntries {
+
+        @Test
+        void mapsEntriesInsideTheWholePeriodIncludingItsLastDay() {
+            stubPeriodEntries(List.of(entry(ApprovalStatus.PENDING_APPROVAL)));
+
+            List<TimekeepingEntryDto> entries = service.listTimekeepingEntries(PERSON_ID, PERIOD_ID);
+
+            assertThat(entries).hasSize(1);
+            assertThat(entries.get(0).getEmployeeId()).isEqualTo(PERSON_ID);
+            assertThat(entries.get(0).getApprovalStatus()).isEqualTo(ApprovalStatus.PENDING_APPROVAL);
+            assertThat(entries.get(0).getSessionEndTime()).isEqualTo(Instant.parse("2026-03-02T21:00:00Z"));
+        }
+
+        @Test
+        void failsWhenThePeriodDoesNotExist() {
+            when(timePeriodRepository.findById(PERIOD_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.listTimekeepingEntries(PERSON_ID, PERIOD_ID))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessageContaining(PERIOD_ID.toString());
+        }
+    }
+
+    @Nested
+    @DisplayName("getTimePeriodApproval")
+    class GetTimePeriodApproval {
+
+        @Test
+        void reportsPendingWhileAnyEntryIsStillPending() {
+            stubPeriodEntries(List.of(
+                    entry(ApprovalStatus.PENDING_APPROVAL),
+                    entry(ApprovalStatus.APPROVED),
+                    entry(ApprovalStatus.REJECTED)));
+
+            TimePeriodApprovalDto approval = service.getTimePeriodApproval(PERSON_ID, PERIOD_ID);
+
+            assertThat(approval.getOverallStatus()).isEqualTo(ApprovalStatus.PENDING_APPROVAL);
+            assertThat(approval.getTotalCount()).isEqualTo(3);
+            assertThat(approval.getPendingCount()).isEqualTo(1);
+            assertThat(approval.getApprovedCount()).isEqualTo(1);
+            assertThat(approval.getRejectedCount()).isEqualTo(1);
+        }
+
+        @Test
+        void reportsRejectedWhenNothingIsPendingAndSomethingWasRejected() {
+            stubPeriodEntries(List.of(entry(ApprovalStatus.APPROVED), entry(ApprovalStatus.REJECTED)));
+
+            assertThat(service.getTimePeriodApproval(PERSON_ID, PERIOD_ID).getOverallStatus())
+                    .isEqualTo(ApprovalStatus.REJECTED);
+        }
+
+        @Test
+        void reportsApprovedWhenEveryEntryIsApproved() {
+            stubPeriodEntries(List.of(entry(ApprovalStatus.APPROVED)));
+
+            assertThat(service.getTimePeriodApproval(PERSON_ID, PERIOD_ID).getOverallStatus())
+                    .isEqualTo(ApprovalStatus.APPROVED);
+        }
+
+        @Test
+        void treatsAnEmptyPeriodAsApproved() {
+            stubPeriodEntries(List.of());
+
+            TimePeriodApprovalDto approval = service.getTimePeriodApproval(PERSON_ID, PERIOD_ID);
+
+            assertThat(approval.getTotalCount()).isZero();
+            assertThat(approval.getOverallStatus()).isEqualTo(ApprovalStatus.APPROVED);
+        }
+
+        @Test
+        void failsWhenThePeriodDoesNotExist() {
+            when(timePeriodRepository.findById(PERIOD_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getTimePeriodApproval(PERSON_ID, PERIOD_ID))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("approvePeriod / rejectPeriod")
+    class PeriodDecisions {
+
+        private void stubPendingEntries(List<TimekeepingEntry> pending) {
+            when(timePeriodRepository.findById(PERIOD_ID)).thenReturn(Optional.of(period()));
+            when(timekeepingEntryRepository
+                            .findByEmployeeIdAndApprovalStatusAndSessionStartTimeGreaterThanEqualAndSessionEndTimeLessThanEqual(
+                                    eq(PERSON_ID), eq(ApprovalStatus.PENDING_APPROVAL), any(), any()))
+                    .thenReturn(pending);
+        }
+
+        @Test
+        void approvesEveryPendingEntryInThePeriod() {
+            TimekeepingEntry pending = entry(ApprovalStatus.PENDING_APPROVAL);
+            stubPendingEntries(List.of(pending));
+
+            TimePeriodDecisionResponse response = service.approvePeriod(PERIOD_ID, PERSON_ID);
+
+            assertThat(pending.getApprovalStatus()).isEqualTo(ApprovalStatus.APPROVED);
+            assertThat(response.getStatus()).isEqualTo("APPROVED");
+            assertThat(response.getProcessedCount()).isEqualTo(1);
+            assertThat(response.getPersonId()).isEqualTo(PERSON_ID);
+            verify(timekeepingEntryRepository).saveAll(List.of(pending));
+        }
+
+        @Test
+        void reportsZeroProcessedWhenNothingIsPending() {
+            stubPendingEntries(List.of());
+
+            assertThat(service.approvePeriod(PERIOD_ID, PERSON_ID).getProcessedCount())
+                    .isZero();
+        }
+
+        @Test
+        void rejectsEveryPendingEntryAndStampsTheReason() {
+            TimekeepingEntry pending = entry(ApprovalStatus.PENDING_APPROVAL);
+            stubPendingEntries(List.of(pending));
+
+            TimePeriodDecisionResponse response = service.rejectPeriod(PERIOD_ID, PERSON_ID, "missing break");
+
+            assertThat(pending.getApprovalStatus()).isEqualTo(ApprovalStatus.REJECTED);
+            assertThat(pending.getCorrectionReason()).isEqualTo("missing break");
+            assertThat(response.getStatus()).isEqualTo("REJECTED");
+            assertThat(response.getProcessedCount()).isEqualTo(1);
+
+            ArgumentCaptor<List<TimekeepingEntry>> saved = ArgumentCaptor.captor();
+            verify(timekeepingEntryRepository).saveAll(saved.capture());
+            assertThat(saved.getValue()).containsExactly(pending);
+        }
+
+        @Test
+        void approveFailsWhenThePeriodDoesNotExist() {
+            when(timePeriodRepository.findById(PERIOD_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.approvePeriod(PERIOD_ID, PERSON_ID))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+
+        @Test
+        void rejectFailsWhenThePeriodDoesNotExist() {
+            when(timePeriodRepository.findById(PERIOD_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.rejectPeriod(PERIOD_ID, PERSON_ID, "why"))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+}

--- a/pos-people/src/test/java/com/positivity/people/internal/service/TimekeepingThresholdCacheTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/TimekeepingThresholdCacheTest.java
@@ -1,0 +1,285 @@
+package com.positivity.people.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.people.internal.dto.AttendanceReportKey;
+import com.positivity.people.internal.entity.TimekeepingPolicy;
+import com.positivity.people.internal.enums.TimekeepingPolicyScopeType;
+import com.positivity.people.internal.repository.TimekeepingPolicyRepository;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Threshold resolution for the attendance discrepancy report: location policy beats global,
+ * global beats the built-in default, and preloading is what keeps the per-row lookup off the
+ * database.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("TimekeepingThresholdCache")
+class TimekeepingThresholdCacheTest {
+
+    private static final UUID LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4c01");
+    private static final UUID OTHER_LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4c02");
+    private static final LocalDate REPORT_DATE = LocalDate.of(2026, 3, 2);
+    private static final ZoneId ZONE = ZoneId.of("America/New_York");
+    private static final int DEFAULT_THRESHOLD_MINUTES = 30;
+
+    @Mock
+    private TimekeepingPolicyRepository timekeepingPolicyRepository;
+
+    private static TimekeepingPolicy policy(
+            TimekeepingPolicyScopeType scopeType, UUID scopeId, Integer thresholdMinutes) {
+        TimekeepingPolicy policy = new TimekeepingPolicy();
+        policy.setTimekeepingPolicyId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4cff"));
+        policy.setScopeType(scopeType);
+        policy.setScopeId(scopeId);
+        policy.setJobTimeDiscrepancyThresholdMinutes(thresholdMinutes);
+        policy.setUpdatedAt(Instant.parse("2026-01-01T00:00:00Z"));
+        return policy;
+    }
+
+    /**
+     * {@code TimekeepingPolicy.setUpdatedAt} is a deliberate no-op — the column is owned by
+     * {@code @LastModifiedDate} auditing, which writes the field reflectively — so a test that
+     * needs a specific audit stamp has to write the field the same way.
+     */
+    private static void setUpdatedAt(TimekeepingPolicy policy, Instant updatedAt) {
+        ReflectionTestUtils.setField(policy, "updatedAt", updatedAt);
+    }
+
+    private static AttendanceReportKey key(String locationId) {
+        return new AttendanceReportKey("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4cee", locationId, REPORT_DATE);
+    }
+
+    private TimekeepingThresholdCache cache(boolean preloadLocations, boolean preloadGlobals) {
+        return new TimekeepingThresholdCache(timekeepingPolicyRepository, 4096, preloadLocations, preloadGlobals);
+    }
+
+    @Nested
+    @DisplayName("resolveThresholdMinutes")
+    class ResolveThresholdMinutes {
+
+        @Test
+        void prefersTheLocationPolicyOverTheGlobalOne() {
+            when(timekeepingPolicyRepository.findByScopeType(TimekeepingPolicyScopeType.GLOBAL))
+                    .thenReturn(List.of(policy(TimekeepingPolicyScopeType.GLOBAL, null, 45)));
+            when(timekeepingPolicyRepository.findByScopeTypeAndScopeIdIn(
+                            TimekeepingPolicyScopeType.LOCATION, Set.of(LOCATION_ID)))
+                    .thenReturn(List.of(policy(TimekeepingPolicyScopeType.LOCATION, LOCATION_ID, 15)));
+
+            var context = cache(true, true).createContext(Set.of(key(LOCATION_ID.toString())), ZONE);
+
+            assertThat(context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE))
+                    .isEqualTo(15);
+        }
+
+        @Test
+        void fallsBackToTheGlobalPolicyWhenTheLocationHasNone() {
+            when(timekeepingPolicyRepository.findByScopeType(TimekeepingPolicyScopeType.GLOBAL))
+                    .thenReturn(List.of(policy(TimekeepingPolicyScopeType.GLOBAL, null, 45)));
+            when(timekeepingPolicyRepository.findByScopeTypeAndScopeIdIn(
+                            TimekeepingPolicyScopeType.LOCATION, Set.of(LOCATION_ID)))
+                    .thenReturn(List.of());
+
+            var context = cache(true, true).createContext(Set.of(key(LOCATION_ID.toString())), ZONE);
+
+            assertThat(context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE))
+                    .isEqualTo(45);
+        }
+
+        @Test
+        void fallsBackToTheBuiltInDefaultWhenNoPolicyApplies() {
+            var context = cache(true, true).createContext(Set.of(key(LOCATION_ID.toString())), ZONE);
+
+            assertThat(context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE))
+                    .isEqualTo(DEFAULT_THRESHOLD_MINUTES);
+        }
+
+        @Test
+        void ignoresANegativeOrMissingThresholdOnAnOtherwiseEffectivePolicy() {
+            when(timekeepingPolicyRepository.findByScopeTypeAndScopeIdIn(
+                            TimekeepingPolicyScopeType.LOCATION, Set.of(LOCATION_ID)))
+                    .thenReturn(List.of(policy(TimekeepingPolicyScopeType.LOCATION, LOCATION_ID, -5)));
+
+            var context = cache(true, true).createContext(Set.of(key(LOCATION_ID.toString())), ZONE);
+
+            assertThat(context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE))
+                    .isEqualTo(DEFAULT_THRESHOLD_MINUTES);
+        }
+
+        @Test
+        void ignoresAGlobalPolicyCarryingNoThreshold() {
+            when(timekeepingPolicyRepository.findByScopeType(TimekeepingPolicyScopeType.GLOBAL))
+                    .thenReturn(List.of(policy(TimekeepingPolicyScopeType.GLOBAL, null, null)));
+
+            var context = cache(true, true).createContext(Set.of(key(LOCATION_ID.toString())), ZONE);
+
+            assertThat(context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE))
+                    .isEqualTo(DEFAULT_THRESHOLD_MINUTES);
+        }
+
+        @Test
+        void skipsAPolicyWhoseEffectiveWindowDoesNotCoverTheReportDate() {
+            TimekeepingPolicy expired = policy(TimekeepingPolicyScopeType.LOCATION, LOCATION_ID, 5);
+            expired.setEffectiveEndAt(Instant.parse("2026-01-31T00:00:00Z"));
+            TimekeepingPolicy notYetStarted = policy(TimekeepingPolicyScopeType.LOCATION, LOCATION_ID, 7);
+            notYetStarted.setEffectiveStartAt(Instant.parse("2026-12-01T00:00:00Z"));
+            when(timekeepingPolicyRepository.findByScopeTypeAndScopeIdIn(
+                            TimekeepingPolicyScopeType.LOCATION, Set.of(LOCATION_ID)))
+                    .thenReturn(List.of(expired, notYetStarted));
+
+            var context = cache(true, true).createContext(Set.of(key(LOCATION_ID.toString())), ZONE);
+
+            assertThat(context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE))
+                    .isEqualTo(DEFAULT_THRESHOLD_MINUTES);
+        }
+
+        @Test
+        void picksTheMostRecentlyUpdatedEffectivePolicy() {
+            TimekeepingPolicy older = policy(TimekeepingPolicyScopeType.LOCATION, LOCATION_ID, 10);
+            setUpdatedAt(older, Instant.parse("2026-01-01T00:00:00Z"));
+            TimekeepingPolicy newer = policy(TimekeepingPolicyScopeType.LOCATION, LOCATION_ID, 20);
+            setUpdatedAt(newer, Instant.parse("2026-02-01T00:00:00Z"));
+            when(timekeepingPolicyRepository.findByScopeTypeAndScopeIdIn(
+                            TimekeepingPolicyScopeType.LOCATION, Set.of(LOCATION_ID)))
+                    .thenReturn(List.of(older, newer));
+
+            var context = cache(true, true).createContext(Set.of(key(LOCATION_ID.toString())), ZONE);
+
+            assertThat(context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE))
+                    .isEqualTo(20);
+        }
+
+        @Test
+        void breaksATieOnUpdatedAtWithTheLatestEffectiveStart() {
+            TimekeepingPolicy earlierStart = policy(TimekeepingPolicyScopeType.LOCATION, LOCATION_ID, 10);
+            earlierStart.setEffectiveStartAt(Instant.parse("2026-01-01T00:00:00Z"));
+            TimekeepingPolicy laterStart = policy(TimekeepingPolicyScopeType.LOCATION, LOCATION_ID, 20);
+            laterStart.setEffectiveStartAt(Instant.parse("2026-02-01T00:00:00Z"));
+            when(timekeepingPolicyRepository.findByScopeTypeAndScopeIdIn(
+                            TimekeepingPolicyScopeType.LOCATION, Set.of(LOCATION_ID)))
+                    .thenReturn(List.of(earlierStart, laterStart));
+
+            var context = cache(true, true).createContext(Set.of(key(LOCATION_ID.toString())), ZONE);
+
+            assertThat(context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE))
+                    .isEqualTo(20);
+        }
+
+        @Test
+        void treatsANonUuidLocationAsGlobalOnly() {
+            when(timekeepingPolicyRepository.findByScopeType(TimekeepingPolicyScopeType.GLOBAL))
+                    .thenReturn(List.of(policy(TimekeepingPolicyScopeType.GLOBAL, null, 45)));
+
+            var context = cache(true, true).createContext(Set.of(key("not-a-uuid")), ZONE);
+
+            assertThat(context.resolveThresholdMinutes("not-a-uuid", REPORT_DATE))
+                    .isEqualTo(45);
+            // No location ids to preload means no location query at all.
+            verify(timekeepingPolicyRepository, never())
+                    .findByScopeTypeAndScopeIdIn(
+                            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+        }
+
+        @Test
+        void answersRepeatedLookupsFromItsOwnCache() {
+            when(timekeepingPolicyRepository.findByScopeType(TimekeepingPolicyScopeType.GLOBAL))
+                    .thenReturn(List.of(policy(TimekeepingPolicyScopeType.GLOBAL, null, 45)));
+
+            var context = cache(false, false).createContext(Set.of(key(LOCATION_ID.toString())), ZONE);
+
+            assertThat(context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE))
+                    .isEqualTo(45);
+            assertThat(context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE))
+                    .isEqualTo(45);
+
+            // Preloading is off, so the first miss queries; the second call must not.
+            verify(timekeepingPolicyRepository, times(1))
+                    .findByScopeTypeAndScopeId(TimekeepingPolicyScopeType.LOCATION, LOCATION_ID);
+            verify(timekeepingPolicyRepository, times(1)).findByScopeType(TimekeepingPolicyScopeType.GLOBAL);
+        }
+
+        @Test
+        void evictsTheEldestEntryOnceTheCacheIsFull() {
+            TimekeepingThresholdCache oneEntryCache =
+                    new TimekeepingThresholdCache(timekeepingPolicyRepository, 1, false, false);
+            var context = oneEntryCache.createContext(Set.of(key(LOCATION_ID.toString())), ZONE);
+
+            context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE);
+            context.resolveThresholdMinutes(OTHER_LOCATION_ID.toString(), REPORT_DATE);
+            context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE);
+
+            // The first location was evicted by the second, so it is queried twice.
+            verify(timekeepingPolicyRepository, times(2))
+                    .findByScopeTypeAndScopeId(TimekeepingPolicyScopeType.LOCATION, LOCATION_ID);
+        }
+
+        @Test
+        void treatsANonPositiveCacheSizeAsTheBuiltInMaximum() {
+            TimekeepingThresholdCache zeroSized =
+                    new TimekeepingThresholdCache(timekeepingPolicyRepository, 0, false, false);
+            var context = zeroSized.createContext(Set.of(key(LOCATION_ID.toString())), ZONE);
+
+            context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE);
+            context.resolveThresholdMinutes(OTHER_LOCATION_ID.toString(), REPORT_DATE);
+            context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE);
+
+            verify(timekeepingPolicyRepository, times(1))
+                    .findByScopeTypeAndScopeId(TimekeepingPolicyScopeType.LOCATION, LOCATION_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("createContext")
+    class CreateContext {
+
+        @Test
+        void groupsPreloadedLocationPoliciesByScopeAndDropsScopelessRows() {
+            TimekeepingPolicy scopeless = policy(TimekeepingPolicyScopeType.LOCATION, null, 5);
+            when(timekeepingPolicyRepository.findByScopeTypeAndScopeIdIn(
+                            TimekeepingPolicyScopeType.LOCATION, Set.of(LOCATION_ID, OTHER_LOCATION_ID)))
+                    .thenReturn(List.of(scopeless, policy(TimekeepingPolicyScopeType.LOCATION, LOCATION_ID, 12)));
+
+            var context = cache(true, true)
+                    .createContext(Set.of(key(LOCATION_ID.toString()), key(OTHER_LOCATION_ID.toString())), ZONE);
+
+            assertThat(context.resolveThresholdMinutes(LOCATION_ID.toString(), REPORT_DATE))
+                    .isEqualTo(12);
+            assertThat(context.resolveThresholdMinutes(OTHER_LOCATION_ID.toString(), REPORT_DATE))
+                    .isEqualTo(DEFAULT_THRESHOLD_MINUTES);
+        }
+
+        @Test
+        void queriesNothingUpFrontWhenPreloadingIsDisabled() {
+            cache(false, false).createContext(Set.of(key(LOCATION_ID.toString())), ZONE);
+
+            verifyNoInteractions(timekeepingPolicyRepository);
+        }
+
+        @Test
+        void skipsTheLocationPreloadWhenNoKeyCarriesAUuidLocation() {
+            cache(true, false).createContext(Set.of(key("not-a-uuid")), ZONE);
+
+            verifyNoInteractions(timekeepingPolicyRepository);
+        }
+    }
+}

--- a/pos-price/src/test/java/com/positivity/price/internal/service/PriceQuoteServiceImplTest.java
+++ b/pos-price/src/test/java/com/positivity/price/internal/service/PriceQuoteServiceImplTest.java
@@ -1,0 +1,230 @@
+package com.positivity.price.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.price.internal.dto.PriceQuoteRequest;
+import com.positivity.price.internal.dto.PriceQuoteResponse;
+import com.positivity.price.internal.dto.PricingBreakdownEntry;
+import com.positivity.price.internal.entity.CustomerTierPricingRule;
+import com.positivity.price.internal.entity.LocationPriceOverride;
+import com.positivity.price.internal.entity.ProductBasePrice;
+import com.positivity.price.internal.exception.BasePriceUnavailableException;
+import com.positivity.price.internal.repository.CustomerTierPricingRuleRepository;
+import com.positivity.price.internal.repository.LocationPriceOverrideRepository;
+import com.positivity.price.internal.repository.ProductBasePriceRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Contextual price quoting (#51): the base price is the MSRP, a location override replaces it,
+ * and a customer-tier rule discounts whatever survived — each step recorded in the breakdown.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PriceQuoteServiceImpl")
+class PriceQuoteServiceImplTest {
+
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fff01");
+    private static final UUID LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fff02");
+    private static final UUID TIER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fff03");
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+
+    @Mock
+    private ProductBasePriceRepository productPriceRepository;
+
+    @Mock
+    private LocationPriceOverrideRepository locationOverrideRepository;
+
+    @Mock
+    private CustomerTierPricingRuleRepository customerTierPricingRuleRepository;
+
+    private PriceQuoteServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PriceQuoteServiceImpl(
+                productPriceRepository,
+                locationOverrideRepository,
+                customerTierPricingRuleRepository,
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                "usd");
+        when(locationOverrideRepository.findActiveAt(any(), any(), any(), any()))
+                .thenReturn(Optional.empty());
+        when(customerTierPricingRuleRepository.findActiveAt(any(), any(), any()))
+                .thenReturn(Optional.empty());
+    }
+
+    private static PriceQuoteRequest request(int quantity) {
+        PriceQuoteRequest request = new PriceQuoteRequest();
+        request.setProductId(PRODUCT_ID);
+        request.setQuantity(quantity);
+        request.setLocationId(LOCATION_ID);
+        request.setCustomerTierId(TIER_ID);
+        return request;
+    }
+
+    private void stubBasePrice(String msrp, String currency) {
+        ProductBasePrice basePrice = new ProductBasePrice();
+        basePrice.setProductId(PRODUCT_ID);
+        basePrice.setMsrp(new BigDecimal(msrp));
+        basePrice.setCurrency(currency);
+        when(productPriceRepository.findActiveAt(eq(PRODUCT_ID), any(), any())).thenReturn(Optional.of(basePrice));
+    }
+
+    private void stubLocationOverride(String overridePrice) {
+        LocationPriceOverride override = new LocationPriceOverride();
+        override.setProductId(PRODUCT_ID);
+        override.setLocationId(LOCATION_ID);
+        override.setOverridePrice(new BigDecimal(overridePrice));
+        override.setCurrency("USD");
+        when(locationOverrideRepository.findActiveAt(eq(PRODUCT_ID), eq(LOCATION_ID), any(), any()))
+                .thenReturn(Optional.of(override));
+    }
+
+    private void stubTierRule(String discountRate) {
+        CustomerTierPricingRule rule = new CustomerTierPricingRule();
+        rule.setProductId(PRODUCT_ID);
+        rule.setCustomerTierId(TIER_ID);
+        rule.setDiscountRate(new BigDecimal(discountRate));
+        when(customerTierPricingRuleRepository.findActiveAt(eq(PRODUCT_ID), eq(TIER_ID), any()))
+                .thenReturn(Optional.of(rule));
+    }
+
+    @Test
+    void quotesTheMsrpWhenNoOverrideOrTierRuleApplies() {
+        stubBasePrice("100.00", "USD");
+
+        PriceQuoteResponse response = service.calculatePrice(request(2));
+
+        assertThat(response.getProductId()).isEqualTo(PRODUCT_ID);
+        assertThat(response.getQuantity()).isEqualTo(2);
+        assertThat(response.getMsrp().getAmount()).isEqualByComparingTo("100.00");
+        assertThat(response.getUnitPrice().getAmount()).isEqualByComparingTo("100.00");
+        assertThat(response.getExtendedPrice().getAmount()).isEqualByComparingTo("200.00");
+        assertThat(response.getPriceSource()).isEqualTo("MSRP_FALLBACK");
+        assertThat(response.getWarnings()).isEmpty();
+        assertThat(response.getPricingBreakdown())
+                .extracting(PricingBreakdownEntry::getRuleName)
+                .containsExactly("BASE_PRICE");
+    }
+
+    @Test
+    void lettsALocationOverrideReplaceTheMsrp() {
+        stubBasePrice("100.00", "USD");
+        stubLocationOverride("90.00");
+
+        PriceQuoteResponse response = service.calculatePrice(request(1));
+
+        assertThat(response.getUnitPrice().getAmount()).isEqualByComparingTo("90.00");
+        assertThat(response.getPriceSource()).isEqualTo("CALCULATED");
+        assertThat(response.getPricingBreakdown())
+                .extracting(PricingBreakdownEntry::getRuleName)
+                .containsExactly("BASE_PRICE", "LOCATION_OVERRIDE");
+        assertThat(response.getPricingBreakdown().get(1).getAdjustment().getAmount())
+                .isEqualByComparingTo("-10.00");
+        assertThat(response.getPricingBreakdown().get(1).getResultingValue().getAmount())
+                .isEqualByComparingTo("90.00");
+        assertThat(response.getPricingBreakdown().get(1).getRuleType()).isEqualTo("LOCATION_OVERRIDE");
+    }
+
+    @Test
+    void appliesTheTierDiscountToTheMsrpWhenThereIsNoOverride() {
+        stubBasePrice("100.00", "USD");
+        stubTierRule("0.10");
+
+        PriceQuoteResponse response = service.calculatePrice(request(1));
+
+        assertThat(response.getUnitPrice().getAmount()).isEqualByComparingTo("90.00");
+        assertThat(response.getPriceSource()).isEqualTo("CALCULATED");
+        assertThat(response.getPricingBreakdown())
+                .extracting(PricingBreakdownEntry::getRuleName)
+                .containsExactly("BASE_PRICE", "CUSTOMER_TIER_DISCOUNT");
+    }
+
+    @Test
+    void appliesTheTierDiscountOnTopOfALocationOverride() {
+        stubBasePrice("100.00", "USD");
+        stubLocationOverride("80.00");
+        stubTierRule("0.25");
+
+        PriceQuoteResponse response = service.calculatePrice(request(3));
+
+        // 80 - 25% = 60, times three lines.
+        assertThat(response.getUnitPrice().getAmount()).isEqualByComparingTo("60.00");
+        assertThat(response.getExtendedPrice().getAmount()).isEqualByComparingTo("180.00");
+        assertThat(response.getPricingBreakdown())
+                .extracting(PricingBreakdownEntry::getRuleName)
+                .containsExactly("BASE_PRICE", "LOCATION_OVERRIDE", "CUSTOMER_TIER_DISCOUNT");
+    }
+
+    @Test
+    void roundsTheUnitPriceToTwoPlacesHalfEven() {
+        stubBasePrice("100.00", "USD");
+        stubTierRule("0.125");
+
+        // 100 − 12.5% = 87.50 exactly; a third of a cent would round to the even neighbour.
+        assertThat(service.calculatePrice(request(1)).getUnitPrice().getAmount())
+                .isEqualByComparingTo("87.50");
+    }
+
+    @Test
+    void quotesInTheRequestedCurrencyUppercased() {
+        stubBasePrice("100.00", "CAD");
+        PriceQuoteRequest request = request(1);
+        request.setCurrency("cad");
+
+        PriceQuoteResponse response = service.calculatePrice(request);
+
+        assertThat(response.getMsrp().getCurrency()).isEqualTo("CAD");
+        verify(productPriceRepository).findActiveAt(PRODUCT_ID, "CAD", NOW);
+    }
+
+    @Test
+    void fallsBackToTheConfiguredCurrencyWhenTheRequestNamesNone() {
+        stubBasePrice("100.00", "USD");
+
+        service.calculatePrice(request(1));
+
+        // The configured default is lower-cased in configuration and normalized on construction.
+        verify(productPriceRepository).findActiveAt(PRODUCT_ID, "USD", NOW);
+    }
+
+    @Test
+    void quotesAsOfTheRequestedTimestampRatherThanNow() {
+        stubBasePrice("100.00", "USD");
+        Instant asOf = Instant.parse("2026-02-01T00:00:00Z");
+        PriceQuoteRequest request = request(1);
+        request.setEffectiveTimestamp(asOf);
+
+        service.calculatePrice(request);
+
+        verify(productPriceRepository).findActiveAt(PRODUCT_ID, "USD", asOf);
+        verify(locationOverrideRepository).findActiveAt(PRODUCT_ID, LOCATION_ID, "USD", asOf);
+        verify(customerTierPricingRuleRepository).findActiveAt(PRODUCT_ID, TIER_ID, asOf);
+    }
+
+    @Test
+    void failsWhenNoBasePriceIsActiveForTheProduct() {
+        when(productPriceRepository.findActiveAt(any(), any(), any())).thenReturn(Optional.empty());
+        PriceQuoteRequest request = request(1);
+
+        assertThatThrownBy(() -> service.calculatePrice(request)).isInstanceOf(BasePriceUnavailableException.class);
+    }
+}

--- a/pos-price/src/test/java/com/positivity/price/internal/service/PriceQuoteServiceImplTest.java
+++ b/pos-price/src/test/java/com/positivity/price/internal/service/PriceQuoteServiceImplTest.java
@@ -126,7 +126,7 @@ class PriceQuoteServiceImplTest {
     }
 
     @Test
-    void lettsALocationOverrideReplaceTheMsrp() {
+    void letsALocationOverrideReplaceTheMsrp() {
         stubBasePrice("100.00", "USD");
         stubLocationOverride("90.00");
 

--- a/pos-price/src/test/java/com/positivity/price/internal/service/PricingSnapshotServiceImplTest.java
+++ b/pos-price/src/test/java/com/positivity/price/internal/service/PricingSnapshotServiceImplTest.java
@@ -1,0 +1,102 @@
+package com.positivity.price.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.price.internal.dto.PricingSnapshotCreateRequest;
+import com.positivity.price.internal.dto.PricingSnapshotResponse;
+import com.positivity.price.internal.entity.PricingSnapshot;
+import com.positivity.price.internal.exception.SnapshotNotFoundException;
+import com.positivity.price.internal.repository.PricingSnapshotRepository;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Immutable pricing snapshots (#50): what was written is exactly what is read back. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PricingSnapshotServiceImpl")
+class PricingSnapshotServiceImplTest {
+
+    private static final UUID SNAPSHOT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f0a01");
+    private static final Instant CREATED_AT = Instant.parse("2026-03-01T12:00:00Z");
+
+    @Mock
+    private PricingSnapshotRepository pricingSnapshotRepository;
+
+    @InjectMocks
+    private PricingSnapshotServiceImpl service;
+
+    private static PricingSnapshotCreateRequest createRequest() {
+        PricingSnapshotCreateRequest request = new PricingSnapshotCreateRequest();
+        request.setSourceContext("ORDER");
+        request.setItemIdentifier("SKU-1");
+        request.setQuantity(4);
+        request.setPrices("{\"unit\":\"19.99\"}");
+        request.setAppliedRules("[\"CUSTOMER_TIER\"]");
+        request.setPolicyVersion("2026.03");
+        return request;
+    }
+
+    @Test
+    void storesEveryFieldOfTheSnapshotAndReturnsItsId() {
+        when(pricingSnapshotRepository.save(any())).thenAnswer(invocation -> {
+            PricingSnapshot snapshot = invocation.getArgument(0);
+            snapshot.setSnapshotId(SNAPSHOT_ID);
+            return snapshot;
+        });
+
+        UUID snapshotId = service.createSnapshot(createRequest());
+
+        assertThat(snapshotId).isEqualTo(SNAPSHOT_ID);
+        ArgumentCaptor<PricingSnapshot> saved = ArgumentCaptor.forClass(PricingSnapshot.class);
+        verify(pricingSnapshotRepository).save(saved.capture());
+        assertThat(saved.getValue().getSourceContext()).isEqualTo("ORDER");
+        assertThat(saved.getValue().getItemIdentifier()).isEqualTo("SKU-1");
+        assertThat(saved.getValue().getQuantity()).isEqualTo(4);
+        assertThat(saved.getValue().getPrices()).isEqualTo("{\"unit\":\"19.99\"}");
+        assertThat(saved.getValue().getAppliedRules()).isEqualTo("[\"CUSTOMER_TIER\"]");
+        assertThat(saved.getValue().getPolicyVersion()).isEqualTo("2026.03");
+    }
+
+    @Test
+    void readsBackTheStoredSnapshotUnchanged() {
+        PricingSnapshot snapshot = new PricingSnapshot();
+        snapshot.setSnapshotId(SNAPSHOT_ID);
+        snapshot.setCreatedAt(CREATED_AT);
+        snapshot.setSourceContext("ORDER");
+        snapshot.setItemIdentifier("SKU-1");
+        snapshot.setQuantity(4);
+        snapshot.setPrices("{\"unit\":\"19.99\"}");
+        snapshot.setAppliedRules("[\"CUSTOMER_TIER\"]");
+        snapshot.setPolicyVersion("2026.03");
+        when(pricingSnapshotRepository.findById(SNAPSHOT_ID)).thenReturn(Optional.of(snapshot));
+
+        PricingSnapshotResponse response = service.getSnapshot(SNAPSHOT_ID);
+
+        assertThat(response.getSnapshotId()).isEqualTo(SNAPSHOT_ID);
+        assertThat(response.getCreatedAt()).isEqualTo(CREATED_AT);
+        assertThat(response.getSourceContext()).isEqualTo("ORDER");
+        assertThat(response.getItemIdentifier()).isEqualTo("SKU-1");
+        assertThat(response.getQuantity()).isEqualTo(4);
+        assertThat(response.getPrices()).isEqualTo("{\"unit\":\"19.99\"}");
+        assertThat(response.getAppliedRules()).isEqualTo("[\"CUSTOMER_TIER\"]");
+        assertThat(response.getPolicyVersion()).isEqualTo("2026.03");
+    }
+
+    @Test
+    void failsForASnapshotThatWasNeverWritten() {
+        when(pricingSnapshotRepository.findById(SNAPSHOT_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getSnapshot(SNAPSHOT_ID)).isInstanceOf(SnapshotNotFoundException.class);
+    }
+}

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/JsonAccessDeniedHandlerTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/JsonAccessDeniedHandlerTest.java
@@ -1,0 +1,173 @@
+package com.positivity.securityservice.internal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.positivity.securityservice.internal.dto.AuditLogEventRequest;
+import com.positivity.securityservice.service.AuditEventService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.authorization.AuthorizationResult;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Access-denied responses (AUTH-009): Spring Security's ExceptionTranslationFilter runs before
+ * the controller advice, so this handler owns the 403 body and the PermissionDenied audit event.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("JsonAccessDeniedHandler")
+class JsonAccessDeniedHandlerTest {
+
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final String URI = "/v1/users/00000000-0000-0000-0000-000000000001";
+
+    @Mock
+    private AuditEventService auditEventService;
+
+    @Mock
+    private ObjectProvider<AuditEventService> auditEventServiceProvider;
+
+    private JsonAccessDeniedHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        when(auditEventServiceProvider.getIfAvailable()).thenReturn(auditEventService);
+        handler = new JsonAccessDeniedHandler(
+                new ObjectMapper(), Clock.fixed(NOW, ZoneOffset.UTC), auditEventServiceProvider);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private static MockHttpServletRequest request() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", URI);
+        request.setRequestURI(URI);
+        return request;
+    }
+
+    private static void authenticateAs(String username) {
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(username, "n/a", List.of()));
+    }
+
+    private static AuthorizationDeniedException authorizationDenied() {
+        return new AuthorizationDeniedException("Access Denied", (AuthorizationResult) () -> false);
+    }
+
+    @Test
+    void writesTheForbiddenEnvelopeWithoutLeakingTheDeniedRule() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(request(), response, new AccessDeniedException("needs security:user:delete"));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(response.getContentType()).isEqualTo("application/json;charset=UTF-8");
+        assertThat(response.getContentAsString()).contains("FORBIDDEN").contains("Access denied");
+        assertThat(response.getContentAsString()).contains(NOW.toString());
+        assertThat(response.getContentAsString()).doesNotContain("security:user:delete");
+    }
+
+    @Test
+    void keepsACallerSuppliedCorrelationId() throws Exception {
+        MockHttpServletRequest request = request();
+        request.addHeader("X-Correlation-Id", "abc-123");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(request, response, new AccessDeniedException("denied"));
+
+        assertThat(response.getContentAsString()).contains("abc-123");
+    }
+
+    @Test
+    void mintsACorrelationIdWhenTheCallerSendsNone() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(request(), response, new AccessDeniedException("denied"));
+
+        assertThat(response.getContentAsString()).contains("correlationId");
+    }
+
+    @Test
+    void recordsAnAuditEventOnlyForAnAuthorizationDenial() throws Exception {
+        authenticateAs("jane.smith");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(request(), response, authorizationDenied());
+
+        ArgumentCaptor<AuditLogEventRequest> audit = ArgumentCaptor.forClass(AuditLogEventRequest.class);
+        verify(auditEventService).createEvent(audit.capture());
+        assertThat(audit.getValue().getEventType()).isEqualTo("PermissionDenied");
+        assertThat(audit.getValue().getActorId()).isEqualTo("jane.smith");
+        assertThat(audit.getValue().getEntityId()).isEqualTo(URI);
+    }
+
+    @Test
+    void recordsNoAuditEventForAPlainAccessDenial() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(request(), response, new AccessDeniedException("denied"));
+
+        verify(auditEventService, never()).createEvent(any());
+    }
+
+    @Test
+    void attributesTheAuditEventToTheSystemWhenNobodyIsAuthenticated() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(request(), response, authorizationDenied());
+
+        ArgumentCaptor<AuditLogEventRequest> audit = ArgumentCaptor.forClass(AuditLogEventRequest.class);
+        verify(auditEventService).createEvent(audit.capture());
+        assertThat(audit.getValue().getActorId()).isEqualTo("system");
+    }
+
+    @Test
+    void stillWritesTheForbiddenBodyWhenNoAuditServiceIsWired() throws Exception {
+        when(auditEventServiceProvider.getIfAvailable()).thenReturn(null);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(request(), response, authorizationDenied());
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
+    void stillWritesTheForbiddenBodyWhenTheAuditWriteFails() throws Exception {
+        doThrow(new IllegalStateException("audit store down"))
+                .when(auditEventService)
+                .createEvent(any());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(request(), response, authorizationDenied());
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(response.getContentAsString()).contains("FORBIDDEN");
+    }
+}

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/security/PermissionRegistrationSecretFilterTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/security/PermissionRegistrationSecretFilterTest.java
@@ -1,0 +1,171 @@
+package com.positivity.securityservice.internal.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Shared-secret gate on permission registration: only a POST to the register endpoints is
+ * checked, the comparison is constant-time, and a rejection returns the standard error envelope
+ * rather than falling through to the chain.
+ */
+@DisplayName("PermissionRegistrationSecretFilter")
+class PermissionRegistrationSecretFilterTest {
+
+    private static final String SECRET = "s3cr3t-value";
+    private static final String SECRET_HEADER = "X-Permissions-Api-Secret";
+    private static final String REGISTER_PATH = "/v1/permissions/register";
+    private static final String ALIAS_PATH = "/v1/users/permissions/register";
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private PermissionRegistrationSecretFilter filter(String expectedSecret) {
+        return new PermissionRegistrationSecretFilter(expectedSecret, Clock.fixed(NOW, ZoneOffset.UTC), objectMapper);
+    }
+
+    private static MockHttpServletRequest request(String method, String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+        request.setRequestURI(path);
+        return request;
+    }
+
+    @Test
+    void authenticatesTheRegistrationServiceWhenTheSecretMatches() throws Exception {
+        MockHttpServletRequest request = request("POST", REGISTER_PATH);
+        request.addHeader(SECRET_HEADER, SECRET);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter(SECRET).doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getName())
+                .isEqualTo("permission-registration-service");
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getAuthorities())
+                .extracting(Object::toString)
+                .containsExactly("security:permission:register");
+    }
+
+    @Test
+    void guardsTheAliasPathAsWell() throws Exception {
+        MockHttpServletRequest request = request("POST", ALIAS_PATH);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter(SECRET).doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void rejectsAMissingOrWrongSecretWithTheErrorEnvelope() throws Exception {
+        MockHttpServletRequest request = request("POST", REGISTER_PATH);
+        request.addHeader(SECRET_HEADER, "not-the-secret");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter(SECRET).doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(response.getContentType()).isEqualTo("application/json;charset=UTF-8");
+        assertThat(response.getContentAsString()).contains("INVALID_PERMISSION_REGISTRATION_SECRET");
+        assertThat(response.getContentAsString()).contains(NOW.toString());
+        verify(chain, never()).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void rejectsTheCallWhenNoSecretIsConfiguredAtAll() throws Exception {
+        MockHttpServletRequest request = request("POST", REGISTER_PATH);
+        request.addHeader(SECRET_HEADER, SECRET);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter("  ").doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(response.getContentAsString()).contains("PERMISSION_REGISTRATION_SECRET_MISSING");
+    }
+
+    @Test
+    void keepsACallerSuppliedCorrelationIdOnTheRejection() throws Exception {
+        MockHttpServletRequest request = request("POST", REGISTER_PATH);
+        request.addHeader("X-Correlation-Id", "abc-123");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter(SECRET).doFilter(request, response, mock(FilterChain.class));
+
+        assertThat(response.getContentAsString()).contains("abc-123");
+    }
+
+    @Test
+    void mintsACorrelationIdWhenTheCallerSendsABlankOne() throws Exception {
+        MockHttpServletRequest request = request("POST", REGISTER_PATH);
+        request.addHeader("X-Correlation-Id", "   ");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter(SECRET).doFilter(request, response, mock(FilterChain.class));
+
+        assertThat(response.getContentAsString()).contains("correlationId");
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    void letsAnyOtherPathThroughUnchecked() throws Exception {
+        MockHttpServletRequest request = request("POST", "/v1/users");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter(SECRET).doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void letsSafeMethodsOnTheGuardedPathThrough() throws Exception {
+        for (String method : new String[] {"GET", "HEAD", "OPTIONS"}) {
+            MockHttpServletRequest request = request(method, REGISTER_PATH);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            FilterChain chain = mock(FilterChain.class);
+
+            filter(SECRET).doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+        }
+    }
+
+    @Test
+    void letsANonPostWriteMethodThroughToTheNormalSecurityChain() throws Exception {
+        MockHttpServletRequest request = request("DELETE", REGISTER_PATH);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter(SECRET).doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/service/SelfRegistrationReviewServiceImplTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/service/SelfRegistrationReviewServiceImplTest.java
@@ -1,0 +1,258 @@
+package com.positivity.securityservice.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.securityservice.internal.dto.CrmMatchSummaryDto;
+import com.positivity.securityservice.internal.dto.ResolveSelfRegistrationReviewCaseRequest;
+import com.positivity.securityservice.internal.dto.SelfRegistrationReviewCaseCreateRequest;
+import com.positivity.securityservice.internal.dto.SelfRegistrationReviewCaseResponse;
+import com.positivity.securityservice.internal.entity.SelfRegistrationReviewCase;
+import com.positivity.securityservice.internal.enums.SelfRegistrationCaseStatus;
+import com.positivity.securityservice.internal.enums.SelfRegistrationCaseType;
+import com.positivity.securityservice.internal.exception.SelfRegistrationReviewCaseNotFoundException;
+import com.positivity.securityservice.internal.repository.SelfRegistrationReviewCaseRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Self-registration review queue: a blocked registration opens a case carrying the CRM match
+ * evidence, cases are listed by any combination of status and type, and resolving one stamps the
+ * acting administrator.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("SelfRegistrationReviewServiceImpl")
+class SelfRegistrationReviewServiceImplTest {
+
+    private static final UUID CASE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01");
+    private static final UUID PERSON_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02");
+    private static final UUID LINKED_USER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03");
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+
+    @Mock
+    private SelfRegistrationReviewCaseRepository selfRegistrationReviewCaseRepository;
+
+    private SelfRegistrationReviewServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SelfRegistrationReviewServiceImpl(
+                selfRegistrationReviewCaseRepository, Clock.fixed(NOW, ZoneOffset.UTC));
+        when(selfRegistrationReviewCaseRepository.save(any())).thenAnswer(invocation -> {
+            SelfRegistrationReviewCase reviewCase = invocation.getArgument(0);
+            if (reviewCase.getId() == null) {
+                reviewCase.setId(CASE_ID);
+            }
+            return reviewCase;
+        });
+    }
+
+    private static SelfRegistrationReviewCaseCreateRequest.SelfRegistrationReviewCaseCreateRequestBuilder request() {
+        return SelfRegistrationReviewCaseCreateRequest.builder()
+                .caseType(SelfRegistrationCaseType.IDENTITY_REVIEW)
+                .reasonCode("DUPLICATE_IDENTITY")
+                .reasonMessage("Multiple persons matched the submitted email")
+                .email("jane.smith@example.invalid")
+                .requestedUsername("jane.smith")
+                .personId(PERSON_ID)
+                .linkedUserId(LINKED_USER_ID)
+                .notes("opened by the registration flow");
+    }
+
+    private static SelfRegistrationReviewCase reviewCase(
+            SelfRegistrationCaseType caseType, SelfRegistrationCaseStatus status, Instant createdAt) {
+        SelfRegistrationReviewCase reviewCase = new SelfRegistrationReviewCase();
+        reviewCase.setId(CASE_ID);
+        reviewCase.setCaseType(caseType);
+        reviewCase.setStatus(status);
+        reviewCase.setReasonCode("DUPLICATE_IDENTITY");
+        reviewCase.setEmail("jane.smith@example.invalid");
+        reviewCase.setPersonId(PERSON_ID);
+        reviewCase.setCreatedAt(createdAt);
+        return reviewCase;
+    }
+
+    @Nested
+    @DisplayName("openCase")
+    class OpenCase {
+
+        @Test
+        void opensTheCaseWithTheSubmittedIdentityDetails() {
+            UUID caseId = service.openCase(request().build());
+
+            ArgumentCaptor<SelfRegistrationReviewCase> saved =
+                    ArgumentCaptor.forClass(SelfRegistrationReviewCase.class);
+            verify(selfRegistrationReviewCaseRepository).save(saved.capture());
+            assertThat(saved.getValue().getStatus()).isEqualTo(SelfRegistrationCaseStatus.OPEN);
+            assertThat(saved.getValue().getCaseType()).isEqualTo(SelfRegistrationCaseType.IDENTITY_REVIEW);
+            assertThat(saved.getValue().getEmail()).isEqualTo("jane.smith@example.invalid");
+            assertThat(saved.getValue().getRequestedUsername()).isEqualTo("jane.smith");
+            assertThat(saved.getValue().getPersonId()).isEqualTo(PERSON_ID);
+            assertThat(saved.getValue().getLinkedUserId()).isEqualTo(LINKED_USER_ID);
+            assertThat(caseId).isEqualTo(CASE_ID);
+        }
+
+        @Test
+        void copiesTheCrmMatchEvidenceOntoTheCase() {
+            service.openCase(request()
+                    .crmMatchSummary(CrmMatchSummaryDto.builder()
+                            .candidateCount(3)
+                            .sharedIdentityCandidateCount(2)
+                            .exactEmailMatch(true)
+                            .exactPhoneMatch(false)
+                            .exactNameMatch(true)
+                            .build())
+                    .build());
+
+            ArgumentCaptor<SelfRegistrationReviewCase> saved =
+                    ArgumentCaptor.forClass(SelfRegistrationReviewCase.class);
+            verify(selfRegistrationReviewCaseRepository).save(saved.capture());
+            assertThat(saved.getValue().getCrmCandidateCount()).isEqualTo(3);
+            assertThat(saved.getValue().getCrmSharedIdentityCandidateCount()).isEqualTo(2);
+            assertThat(saved.getValue().getCrmExactEmailMatch()).isTrue();
+            assertThat(saved.getValue().getCrmExactPhoneMatch()).isFalse();
+            assertThat(saved.getValue().getCrmExactNameMatch()).isTrue();
+        }
+
+        @Test
+        void leavesTheCrmColumnsUnsetWhenNoMatchSummaryIsSupplied() {
+            service.openCase(request().build());
+
+            ArgumentCaptor<SelfRegistrationReviewCase> saved =
+                    ArgumentCaptor.forClass(SelfRegistrationReviewCase.class);
+            verify(selfRegistrationReviewCaseRepository).save(saved.capture());
+            assertThat(saved.getValue().getCrmCandidateCount()).isNull();
+            assertThat(saved.getValue().getCrmExactEmailMatch()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("listCases")
+    class ListCases {
+
+        @Test
+        void listsEveryCaseNewestFirstWhenNoFilterIsGiven() {
+            SelfRegistrationReviewCase older = reviewCase(
+                    SelfRegistrationCaseType.IDENTITY_REVIEW,
+                    SelfRegistrationCaseStatus.OPEN,
+                    Instant.parse("2026-01-01T00:00:00Z"));
+            SelfRegistrationReviewCase newer = reviewCase(
+                    SelfRegistrationCaseType.ACCOUNT_RECOVERY,
+                    SelfRegistrationCaseStatus.RESOLVED,
+                    Instant.parse("2026-02-01T00:00:00Z"));
+            when(selfRegistrationReviewCaseRepository.findAll()).thenReturn(List.of(older, newer));
+
+            List<SelfRegistrationReviewCaseResponse> cases = service.listCases(null, null);
+
+            assertThat(cases).hasSize(2);
+            assertThat(cases.get(0).caseType()).isEqualTo(SelfRegistrationCaseType.ACCOUNT_RECOVERY);
+        }
+
+        @Test
+        void delegatesTheCombinedFilterToTheRepository() {
+            when(selfRegistrationReviewCaseRepository.findByCaseTypeAndStatusOrderByCreatedAtDesc(
+                            SelfRegistrationCaseType.IDENTITY_REVIEW, SelfRegistrationCaseStatus.OPEN))
+                    .thenReturn(List.of(reviewCase(
+                            SelfRegistrationCaseType.IDENTITY_REVIEW, SelfRegistrationCaseStatus.OPEN, NOW)));
+
+            assertThat(service.listCases(SelfRegistrationCaseStatus.OPEN, SelfRegistrationCaseType.IDENTITY_REVIEW))
+                    .hasSize(1);
+        }
+
+        @Test
+        void delegatesTheStatusOnlyFilterToTheRepository() {
+            when(selfRegistrationReviewCaseRepository.findByStatusOrderByCreatedAtDesc(SelfRegistrationCaseStatus.OPEN))
+                    .thenReturn(List.of(reviewCase(
+                            SelfRegistrationCaseType.IDENTITY_REVIEW, SelfRegistrationCaseStatus.OPEN, NOW)));
+
+            assertThat(service.listCases(SelfRegistrationCaseStatus.OPEN, null)).hasSize(1);
+        }
+
+        @Test
+        void filtersByTypeInMemoryWhenNoStatusIsGiven() {
+            when(selfRegistrationReviewCaseRepository.findAll())
+                    .thenReturn(List.of(
+                            reviewCase(
+                                    SelfRegistrationCaseType.IDENTITY_REVIEW,
+                                    SelfRegistrationCaseStatus.OPEN,
+                                    Instant.parse("2026-01-01T00:00:00Z")),
+                            reviewCase(
+                                    SelfRegistrationCaseType.ACCOUNT_RECOVERY,
+                                    SelfRegistrationCaseStatus.OPEN,
+                                    Instant.parse("2026-02-01T00:00:00Z"))));
+
+            List<SelfRegistrationReviewCaseResponse> cases =
+                    service.listCases(null, SelfRegistrationCaseType.ACCOUNT_RECOVERY);
+
+            assertThat(cases).hasSize(1);
+            assertThat(cases.get(0).caseType()).isEqualTo(SelfRegistrationCaseType.ACCOUNT_RECOVERY);
+        }
+    }
+
+    @Nested
+    @DisplayName("getCase and resolveCase")
+    class GetAndResolve {
+
+        @Test
+        void mapsTheStoredCaseOntoItsResponse() {
+            SelfRegistrationReviewCase stored =
+                    reviewCase(SelfRegistrationCaseType.IDENTITY_REVIEW, SelfRegistrationCaseStatus.OPEN, NOW);
+            stored.setCrmCandidateCount(2);
+            when(selfRegistrationReviewCaseRepository.findById(CASE_ID)).thenReturn(Optional.of(stored));
+
+            SelfRegistrationReviewCaseResponse response = service.getCase(CASE_ID);
+
+            assertThat(response.caseId()).isEqualTo(CASE_ID);
+            assertThat(response.email()).isEqualTo("jane.smith@example.invalid");
+            assertThat(response.personId()).isEqualTo(PERSON_ID);
+            assertThat(response.crmCandidateCount()).isEqualTo(2);
+            assertThat(response.status()).isEqualTo(SelfRegistrationCaseStatus.OPEN);
+        }
+
+        @Test
+        void stampsTheResolvingAdministratorAndTheirNotes() {
+            SelfRegistrationReviewCase stored =
+                    reviewCase(SelfRegistrationCaseType.IDENTITY_REVIEW, SelfRegistrationCaseStatus.OPEN, NOW);
+            when(selfRegistrationReviewCaseRepository.findById(CASE_ID)).thenReturn(Optional.of(stored));
+
+            SelfRegistrationReviewCaseResponse response = service.resolveCase(
+                    CASE_ID,
+                    new ResolveSelfRegistrationReviewCaseRequest("Recovered the existing account"),
+                    "admin.user");
+
+            assertThat(stored.getStatus()).isEqualTo(SelfRegistrationCaseStatus.RESOLVED);
+            assertThat(stored.getResolvedAt()).isEqualTo(NOW);
+            assertThat(stored.getResolvedBy()).isEqualTo("admin.user");
+            assertThat(response.resolutionNotes()).isEqualTo("Recovered the existing account");
+        }
+
+        @Test
+        void failsForACaseThatDoesNotExist() {
+            when(selfRegistrationReviewCaseRepository.findById(CASE_ID)).thenReturn(Optional.empty());
+            ResolveSelfRegistrationReviewCaseRequest request = new ResolveSelfRegistrationReviewCaseRequest("notes");
+
+            assertThatThrownBy(() -> service.getCase(CASE_ID))
+                    .isInstanceOf(SelfRegistrationReviewCaseNotFoundException.class);
+            assertThatThrownBy(() -> service.resolveCase(CASE_ID, request, "admin.user"))
+                    .isInstanceOf(SelfRegistrationReviewCaseNotFoundException.class);
+        }
+    }
+}

--- a/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/controller/GlobalExceptionHandlerTest.java
+++ b/pos-shop-manager/src/test/java/com/positivity/shopmanager/internal/controller/GlobalExceptionHandlerTest.java
@@ -1,0 +1,242 @@
+package com.positivity.shopmanager.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.shared.error.ApiError;
+import com.positivity.shopmanager.internal.exception.AppointmentNotFoundException;
+import com.positivity.shopmanager.internal.exception.AppointmentStateException;
+import com.positivity.shopmanager.internal.exception.AppointmentValidationException;
+import com.positivity.shopmanager.internal.exception.CrmCustomerNotFoundException;
+import com.positivity.shopmanager.internal.exception.CrmUnavailableException;
+import com.positivity.shopmanager.internal.exception.CrmVehicleNotFoundException;
+import com.positivity.shopmanager.internal.exception.LocationNotFoundException;
+import com.positivity.shopmanager.internal.exception.ResourceNotFoundException;
+import com.positivity.shopmanager.internal.exception.SourceNotEligibleException;
+import com.positivity.shopmanager.internal.exception.VehicleCustomerMismatchException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * Shop-manager error envelope (docs/ERROR_ENVELOPE.md): each domain failure gets its own code and
+ * status, and the correlation id comes from {@code X-Correlation-Id} when the caller sends a
+ * usable one.
+ */
+@DisplayName("GlobalExceptionHandler")
+class GlobalExceptionHandlerTest {
+
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final UUID CUSTOMER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fcc01");
+    private static final UUID VEHICLE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fcc02");
+    private static final UUID APPOINTMENT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fcc03");
+    private static final UUID LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fcc04");
+    private static final UUID CORRELATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fcc05");
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler(Clock.fixed(NOW, ZoneOffset.UTC));
+
+    private static MockHttpServletRequest request() {
+        return new MockHttpServletRequest("GET", "/v1/shop-manager/appointments");
+    }
+
+    private static MockHttpServletRequest requestWithCorrelationId(String value) {
+        MockHttpServletRequest request = request();
+        request.addHeader("X-Correlation-Id", value);
+        return request;
+    }
+
+    private static void assertEnvelope(ResponseEntity<ApiError> response, HttpStatus status, String code) {
+        assertThat(response.getStatusCode()).isEqualTo(status);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code()).isEqualTo(code);
+        assertThat(response.getBody().status()).isEqualTo(status.value());
+        assertThat(response.getBody().timestamp()).isEqualTo(NOW.toString());
+        assertThat(response.getBody().correlationId()).isNotBlank();
+    }
+
+    @Test
+    void mapsAMissingCrmCustomerToNotFound() {
+        assertEnvelope(
+                handler.handleCustomerNotFound(new CrmCustomerNotFoundException(CUSTOMER_ID), request()),
+                HttpStatus.NOT_FOUND,
+                "CUSTOMER_NOT_FOUND");
+    }
+
+    @Test
+    void mapsAMissingCrmVehicleToNotFound() {
+        assertEnvelope(
+                handler.handleVehicleNotFound(new CrmVehicleNotFoundException(VEHICLE_ID), request()),
+                HttpStatus.NOT_FOUND,
+                "VEHICLE_NOT_FOUND");
+    }
+
+    @Test
+    void mapsAVehicleThatBelongsToSomebodyElseToConflict() {
+        assertEnvelope(
+                handler.handleVehicleCustomerMismatch(
+                        new VehicleCustomerMismatchException(VEHICLE_ID, CUSTOMER_ID), request()),
+                HttpStatus.CONFLICT,
+                "VEHICLE_CUSTOMER_MISMATCH");
+    }
+
+    @Test
+    void mapsAnAppointmentValidationFailureToBadRequest() {
+        ResponseEntity<ApiError> response = handler.handleAppointmentValidation(
+                new AppointmentValidationException("slot is in the past"), request());
+
+        assertEnvelope(response, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
+        assertThat(response.getBody().message()).isEqualTo("slot is in the past");
+    }
+
+    @Test
+    void mapsAnIneligibleSourceToUnprocessableContentKeepingItsOwnCode() {
+        ResponseEntity<ApiError> response = handler.handleSourceNotEligible(
+                new SourceNotEligibleException(
+                        "ESTIMATE_NOT_ELIGIBLE", "Estimate is not approved", "ESTIMATE", "EST-1", "DRAFT"),
+                request());
+
+        assertEnvelope(response, HttpStatus.UNPROCESSABLE_CONTENT, "ESTIMATE_NOT_ELIGIBLE");
+    }
+
+    @Test
+    void fallsBackToAGenericCodeWhenTheIneligibleSourceCarriesNone() {
+        ResponseEntity<ApiError> response = handler.handleSourceNotEligible(
+                new SourceNotEligibleException(null, "Not eligible", "ESTIMATE", "EST-1", "DRAFT"), request());
+
+        assertEnvelope(response, HttpStatus.UNPROCESSABLE_CONTENT, "SOURCE_NOT_ELIGIBLE");
+    }
+
+    @Test
+    void mapsAnIllegalAppointmentTransitionToConflict() {
+        assertEnvelope(
+                handler.handleAppointmentState(new AppointmentStateException("already checked in"), request()),
+                HttpStatus.CONFLICT,
+                "INVALID_APPOINTMENT_STATE");
+    }
+
+    @Test
+    void mapsAMissingAppointmentToNotFound() {
+        assertEnvelope(
+                handler.handleAppointmentNotFound(new AppointmentNotFoundException(APPOINTMENT_ID), request()),
+                HttpStatus.NOT_FOUND,
+                "APPOINTMENT_NOT_FOUND");
+    }
+
+    @Test
+    void mapsAMissingLocationToNotFound() {
+        assertEnvelope(
+                handler.handleLocationNotFound(new LocationNotFoundException(LOCATION_ID), request()),
+                HttpStatus.NOT_FOUND,
+                "LOCATION_NOT_FOUND");
+    }
+
+    @Test
+    void mapsAMissingResourceToNotFound() {
+        assertEnvelope(
+                handler.handleResourceNotFound(new ResourceNotFoundException("BAY-3"), request()),
+                HttpStatus.NOT_FOUND,
+                "RESOURCE_NOT_FOUND");
+    }
+
+    @Test
+    void reportsEveryRejectedFieldOnAValidationFailure() throws Exception {
+        BindingResult bindingResult = new BeanPropertyBindingResult(new Object(), "request");
+        bindingResult.rejectValue(null, "NotNull", "startAt is required");
+        bindingResult.addError(new org.springframework.validation.FieldError(
+                "request", "locationId", null, false, null, null, "locationId is required"));
+        bindingResult.addError(
+                new org.springframework.validation.FieldError("request", "customerId", null, false, null, null, null));
+
+        ResponseEntity<ApiError> response = handler.handleMethodArgumentNotValid(
+                new MethodArgumentNotValidException(methodParameter(), bindingResult), request());
+
+        assertEnvelope(response, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR");
+        assertThat(response.getBody().message()).isEqualTo("Request validation failed");
+        assertThat(response.getBody().fieldErrors())
+                .extracting(ApiError.FieldError::field)
+                .contains("locationId", "customerId");
+        // A rejection with no message still names the field rather than dropping it.
+        assertThat(response.getBody().fieldErrors())
+                .extracting(ApiError.FieldError::message)
+                .contains("invalid value");
+    }
+
+    @Test
+    void mapsAnUnreachableCrmToServiceUnavailable() {
+        assertEnvelope(
+                handler.handleCrmUnavailable(new ResourceAccessException("connect timed out"), request()),
+                HttpStatus.SERVICE_UNAVAILABLE,
+                "CRM_UNAVAILABLE");
+        assertEnvelope(
+                handler.handleCrmUnavailable(new RestClientException("502"), request()),
+                HttpStatus.SERVICE_UNAVAILABLE,
+                "CRM_UNAVAILABLE");
+    }
+
+    @Test
+    void mapsTheDomainCrmUnavailableExceptionToServiceUnavailable() {
+        ResponseEntity<ApiError> response = handler.handleCrmUnavailable(
+                new CrmUnavailableException("crm down", new IllegalStateException("boom")), request());
+
+        assertEnvelope(response, HttpStatus.SERVICE_UNAVAILABLE, "CRM_UNAVAILABLE");
+        // The upstream failure detail is not echoed to the caller.
+        assertThat(response.getBody().message()).isEqualTo("CRM service is unavailable");
+    }
+
+    @Test
+    void mapsAnUnimplementedOperationToNotImplemented() {
+        assertEnvelope(
+                handler.handleNotImplemented(new UnsupportedOperationException("not yet"), request()),
+                HttpStatus.NOT_IMPLEMENTED,
+                "NOT_IMPLEMENTED");
+    }
+
+    @Test
+    void mapsAnIllegalArgumentToBadRequest() {
+        assertEnvelope(
+                handler.handleIllegalArgument(new IllegalArgumentException("bad id"), request()),
+                HttpStatus.BAD_REQUEST,
+                "INVALID_REQUEST");
+    }
+
+    @Test
+    void keepsACallerSuppliedCorrelationId() {
+        ResponseEntity<ApiError> response = handler.handleAppointmentNotFound(
+                new AppointmentNotFoundException(APPOINTMENT_ID),
+                requestWithCorrelationId("  " + CORRELATION_ID + "  "));
+
+        assertThat(response.getBody().correlationId()).isEqualTo(CORRELATION_ID.toString());
+    }
+
+    @Test
+    void mintsACorrelationIdWhenTheCallerSendsAnUnusableOne() {
+        ResponseEntity<ApiError> malformed = handler.handleAppointmentNotFound(
+                new AppointmentNotFoundException(APPOINTMENT_ID), requestWithCorrelationId("not-a-uuid"));
+        ResponseEntity<ApiError> blank = handler.handleAppointmentNotFound(
+                new AppointmentNotFoundException(APPOINTMENT_ID), requestWithCorrelationId("   "));
+
+        assertThat(malformed.getBody().correlationId()).isNotBlank().isNotEqualTo("not-a-uuid");
+        assertThat(blank.getBody().correlationId()).isNotBlank();
+    }
+
+    /** Any real method parameter works: the handler only reads the binding result. */
+    private static MethodParameter methodParameter() throws NoSuchMethodException {
+        return new MethodParameter(GlobalExceptionHandlerTest.class.getDeclaredMethod("sample", String.class), 0);
+    }
+
+    @SuppressWarnings("unused")
+    private static void sample(String value) {
+        // Signature-only holder for MethodParameter.
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/controller/EstimateControllerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/controller/EstimateControllerTest.java
@@ -1,0 +1,779 @@
+package com.positivity.workorder.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.dto.ApproveEstimateRequest;
+import com.positivity.workorder.internal.dto.CreateEstimateRequest;
+import com.positivity.workorder.internal.dto.EstimateItemResponse;
+import com.positivity.workorder.internal.dto.EstimateResponse;
+import com.positivity.workorder.internal.dto.EstimateSnapshotResponse;
+import com.positivity.workorder.internal.dto.EstimateSummaryResponse;
+import com.positivity.workorder.internal.dto.WorkorderResponse;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.exception.PromotionValidationException;
+import com.positivity.workorder.service.EstimateService;
+import com.positivity.workorder.service.IdempotencyService;
+import com.positivity.workorder.service.WorkorderService;
+import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Estimate endpoints: the controller owns status mapping and the Idempotency-Key replay contract,
+ * while every business rule lives in {@code EstimateService}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("EstimateController")
+class EstimateControllerTest {
+
+    private static final UUID ESTIMATE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a01");
+    private static final UUID CUSTOMER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a02");
+    private static final UUID VEHICLE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a03");
+    private static final UUID LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a04");
+    private static final UUID ITEM_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a05");
+    private static final UUID WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a06");
+    private static final UUID OTHER_WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a07");
+    private static final String IDEMPOTENCY_KEY = "estimate-key-1";
+    private static final String CREATE_OPERATION = "estimate.create";
+    private static final String PROMOTE_OPERATION = "estimate.promote";
+
+    @Mock
+    private EstimateService estimateService;
+
+    @Mock
+    private WorkorderService workorderService;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    @InjectMocks
+    private EstimateController controller;
+
+    private Workorder workorder;
+
+    @BeforeEach
+    void setUp() {
+        workorder = new Workorder();
+        workorder.setId(WORKORDER_ID);
+        workorder.setEstimateId(ESTIMATE_ID);
+        workorder.setCustomerId(CUSTOMER_ID);
+    }
+
+    private static EstimateResponse estimate() {
+        return EstimateResponse.builder()
+                .id(ESTIMATE_ID)
+                .estimateNumber("EST-0001")
+                .customerId(CUSTOMER_ID)
+                .vehicleId(VEHICLE_ID)
+                .locationId(LOCATION_ID)
+                .status("DRAFT")
+                .subtotal(new BigDecimal("100.00"))
+                .taxAmount(new BigDecimal("8.00"))
+                .total(new BigDecimal("108.00"))
+                .build();
+    }
+
+    private static CreateEstimateRequest createRequest() {
+        return CreateEstimateRequest.builder()
+                .customerId(CUSTOMER_ID)
+                .vehicleId(VEHICLE_ID)
+                .locationId(LOCATION_ID)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        void listsEveryEstimate() {
+            when(estimateService.getAllEstimates()).thenReturn(List.of(estimate()));
+
+            assertThat(controller.getAllEstimates()).hasSize(1);
+        }
+
+        @Test
+        void servesOneEstimateById() {
+            when(estimateService.getEstimateById(ESTIMATE_ID)).thenReturn(Optional.of(estimate()));
+
+            ResponseEntity<EstimateResponse> response = controller.getEstimateById(ESTIMATE_ID);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getEstimateNumber()).isEqualTo("EST-0001");
+        }
+
+        @Test
+        void reportsNotFoundForAnUnknownEstimate() {
+            when(estimateService.getEstimateById(ESTIMATE_ID)).thenReturn(Optional.empty());
+
+            assertThat(controller.getEstimateById(ESTIMATE_ID).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        void listsACustomersEstimates() {
+            when(estimateService.getEstimatesByCustomer(CUSTOMER_ID)).thenReturn(List.of(estimate()));
+
+            assertThat(controller.getEstimatesByCustomer(CUSTOMER_ID)).hasSize(1);
+        }
+
+        @Test
+        void servesTheShopAliasFromTheSameLocationLookup() {
+            when(estimateService.getEstimatesByLocation(LOCATION_ID)).thenReturn(List.of(estimate()));
+
+            assertThat(controller.getEstimatesByShop(LOCATION_ID)).hasSize(1);
+            assertThat(controller.getEstimatesByLocation(LOCATION_ID)).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("createEstimate")
+    class CreateEstimate {
+
+        @Test
+        void createsTheEstimateAndReportsCreated() {
+            when(estimateService.createEstimate(any(), anyString())).thenReturn(estimate());
+
+            ResponseEntity<Object> response = controller.createEstimate(createRequest(), null);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+            assertThat(response.getBody()).isInstanceOf(EstimateResponse.class);
+            verify(idempotencyService, never()).registerKey(anyString(), anyString(), any());
+        }
+
+        @Test
+        void registersTheIdempotencyKeyAgainstTheNewEstimate() {
+            when(estimateService.createEstimate(any(), anyString())).thenReturn(estimate());
+
+            controller.createEstimate(createRequest(), IDEMPOTENCY_KEY);
+
+            verify(idempotencyService).registerKey(CREATE_OPERATION, IDEMPOTENCY_KEY, ESTIMATE_ID);
+        }
+
+        @Test
+        void toleratesAConcurrentRegistrationOfTheSameKey() {
+            when(estimateService.createEstimate(any(), anyString())).thenReturn(estimate());
+            doThrow(new DataIntegrityViolationException("duplicate key"))
+                    .when(idempotencyService)
+                    .registerKey(CREATE_OPERATION, IDEMPOTENCY_KEY, ESTIMATE_ID);
+
+            assertThat(controller
+                            .createEstimate(createRequest(), IDEMPOTENCY_KEY)
+                            .getStatusCode())
+                    .isEqualTo(HttpStatus.CREATED);
+        }
+
+        @Test
+        void replaysTheOriginalEstimateForAKnownIdempotencyKey() {
+            when(idempotencyService.getExistingWorkorderId(CREATE_OPERATION, IDEMPOTENCY_KEY))
+                    .thenReturn(Optional.of(ESTIMATE_ID));
+            when(estimateService.getEstimateById(ESTIMATE_ID)).thenReturn(Optional.of(estimate()));
+
+            ResponseEntity<Object> response = controller.createEstimate(createRequest(), IDEMPOTENCY_KEY);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+            verify(estimateService, never()).createEstimate(any(), anyString());
+        }
+
+        @Test
+        void reportsAConflictWhenTheReplayedEstimateNoLongerExists() {
+            when(idempotencyService.getExistingWorkorderId(CREATE_OPERATION, IDEMPOTENCY_KEY))
+                    .thenReturn(Optional.of(ESTIMATE_ID));
+            when(estimateService.getEstimateById(ESTIMATE_ID)).thenReturn(Optional.empty());
+
+            ResponseEntity<Object> response = controller.createEstimate(createRequest(), IDEMPOTENCY_KEY);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+            assertThat(response.getBody()).isEqualTo(Map.of("code", "CONFLICT"));
+        }
+
+        @Test
+        void ignoresABlankIdempotencyKey() {
+            when(estimateService.createEstimate(any(), anyString())).thenReturn(estimate());
+
+            controller.createEstimate(createRequest(), "   ");
+
+            verify(idempotencyService, never()).getExistingWorkorderId(anyString(), anyString());
+            verify(idempotencyService, never()).registerKey(anyString(), anyString(), any());
+        }
+
+        @Test
+        void reportsAValidationErrorForAnIllegalArgument() {
+            when(estimateService.createEstimate(any(), anyString()))
+                    .thenThrow(new IllegalArgumentException("customerId is required"));
+
+            ResponseEntity<Object> response = controller.createEstimate(createRequest(), null);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(response.getBody()).isEqualTo(Map.of("code", "VALIDATION_ERROR"));
+        }
+
+        @Test
+        void reportsAConflictForAnIllegalStateOrIntegrityFailure() {
+            doThrow(new IllegalStateException("totals do not add up"))
+                    .when(estimateService)
+                    .createEstimate(any(), anyString());
+            assertThat(controller.createEstimate(createRequest(), null).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT);
+
+            doThrow(new DataIntegrityViolationException("duplicate estimate number"))
+                    .when(estimateService)
+                    .createEstimate(any(), anyString());
+            assertThat(controller.createEstimate(createRequest(), null).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT);
+        }
+
+        @Test
+        void reportsAnInternalErrorForAnythingElse() {
+            when(estimateService.createEstimate(any(), anyString())).thenThrow(new RuntimeException("boom"));
+
+            assertThat(controller.createEstimate(createRequest(), null).getStatusCode())
+                    .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Nested
+    @DisplayName("patchEstimateStatus")
+    class PatchEstimateStatus {
+
+        @Test
+        void delegatesADeclineTargetToTheDeclineFlowWithNoReason() {
+            when(estimateService.declineEstimate(ESTIMATE_ID, null)).thenReturn(estimate());
+
+            ResponseEntity<Object> response = controller.patchEstimateStatus(ESTIMATE_ID, Map.of("status", "DECLINED"));
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(estimateService).declineEstimate(ESTIMATE_ID, null);
+        }
+
+        @Test
+        void delegatesADraftTargetToTheReopenFlow() {
+            when(estimateService.reopenEstimate(ESTIMATE_ID)).thenReturn(estimate());
+
+            assertThat(controller
+                            .patchEstimateStatus(ESTIMATE_ID, Map.of("status", "DRAFT"))
+                            .getStatusCode())
+                    .isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        void refusesAnyOtherTargetStatus() {
+            ResponseEntity<Object> response = controller.patchEstimateStatus(ESTIMATE_ID, Map.of("status", "APPROVED"));
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+            assertThat(response.getBody()).isEqualTo(Map.of("code", "CONFLICT"));
+        }
+
+        @Test
+        void rejectsAMissingOrNonStringStatus() {
+            assertThat(controller.patchEstimateStatus(ESTIMATE_ID, Map.of()).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(controller
+                            .patchEstimateStatus(ESTIMATE_ID, Map.of("status", 42))
+                            .getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(controller
+                            .patchEstimateStatus(ESTIMATE_ID, Map.of("status", "  "))
+                            .getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @Test
+        void rejectsAStatusThatIsNotAKnownValue() {
+            ResponseEntity<Object> response =
+                    controller.patchEstimateStatus(ESTIMATE_ID, Map.of("status", "NOT_A_STATUS"));
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(response.getBody()).isEqualTo(Map.of("code", "VALIDATION_ERROR"));
+        }
+
+        @Test
+        void mapsADelegatedFailureOntoTheRightStatus() {
+            doThrow(new IllegalArgumentException("no such estimate"))
+                    .when(estimateService)
+                    .declineEstimate(ESTIMATE_ID, null);
+            assertThat(controller
+                            .patchEstimateStatus(ESTIMATE_ID, Map.of("status", "DECLINED"))
+                            .getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+
+            doThrow(new IllegalStateException("expired")).when(estimateService).reopenEstimate(ESTIMATE_ID);
+            assertThat(controller
+                            .patchEstimateStatus(ESTIMATE_ID, Map.of("status", "DRAFT"))
+                            .getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT);
+        }
+    }
+
+    @Nested
+    @DisplayName("decline, reopen, submit and approve")
+    class Transitions {
+
+        @Test
+        void declinesWithTheSuppliedReason() {
+            when(estimateService.declineEstimate(ESTIMATE_ID, "too expensive")).thenReturn(estimate());
+
+            assertThat(controller.declineEstimate(ESTIMATE_ID, "too expensive").getStatusCode())
+                    .isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        void reportsBadRequestWhenADeclineIsNotAllowed() {
+            when(estimateService.declineEstimate(any(), any()))
+                    .thenThrow(new IllegalStateException("already declined"));
+
+            assertThat(controller.declineEstimate(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @Test
+        void reopensADeclinedEstimate() {
+            when(estimateService.reopenEstimate(ESTIMATE_ID)).thenReturn(estimate());
+
+            assertThat(controller.reopenEstimate(ESTIMATE_ID).getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        void reportsBadRequestWhenAReopenIsNotAllowed() {
+            when(estimateService.reopenEstimate(ESTIMATE_ID)).thenThrow(new IllegalStateException("expired"));
+
+            assertThat(controller.reopenEstimate(ESTIMATE_ID).getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @Test
+        void submitsForApprovalUnderTheAuthenticatedUser() {
+            when(estimateService.submitForApproval(eq(ESTIMATE_ID), anyString()))
+                    .thenReturn(estimate());
+
+            assertThat(controller.submitForApproval(ESTIMATE_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.OK);
+            verify(estimateService).submitForApproval(ESTIMATE_ID, "SYSTEM");
+        }
+
+        @Test
+        void mapsSubmissionFailuresOntoNotFoundOrBadRequest() {
+            doThrow(new EntityNotFoundException("gone")).when(estimateService).submitForApproval(any(), anyString());
+            assertThat(controller.submitForApproval(ESTIMATE_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new IllegalStateException("not a draft"))
+                    .when(estimateService)
+                    .submitForApproval(any(), anyString());
+            assertThat(controller.submitForApproval(ESTIMATE_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @Test
+        void passesEverySignatureFieldThroughOnApproval() {
+            ApproveEstimateRequest request = ApproveEstimateRequest.builder()
+                    .customerId(CUSTOMER_ID)
+                    .signatureData("base64-signature")
+                    .signerName("Jane Customer")
+                    .notes("approved")
+                    .purchaseOrderNumber("PO-12345")
+                    .build();
+            when(estimateService.approveEstimate(
+                            ESTIMATE_ID,
+                            CUSTOMER_ID,
+                            "base64-signature",
+                            "image/png",
+                            "Jane Customer",
+                            "approved",
+                            "PO-12345",
+                            null))
+                    .thenReturn(estimate());
+
+            assertThat(controller.approveEstimate(ESTIMATE_ID, request).getStatusCode())
+                    .isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        void mapsApprovalFailuresOntoNotFoundOrBadRequest() {
+            ApproveEstimateRequest request =
+                    ApproveEstimateRequest.builder().customerId(CUSTOMER_ID).build();
+            doThrow(new EntityNotFoundException("gone"))
+                    .when(estimateService)
+                    .approveEstimate(any(), any(), any(), any(), any(), any(), any(), any());
+            assertThat(controller.approveEstimate(ESTIMATE_ID, request).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new IllegalStateException("PO required"))
+                    .when(estimateService)
+                    .approveEstimate(any(), any(), any(), any(), any(), any(), any(), any());
+            assertThat(controller.approveEstimate(ESTIMATE_ID, request).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("promoteEstimateToWorkorder")
+    class PromoteEstimateToWorkorder {
+
+        @Test
+        void promotesAnApprovedEstimateIntoANewWorkorder() {
+            when(workorderService.createWorkorder(ESTIMATE_ID, null)).thenReturn(workorder);
+
+            ResponseEntity<WorkorderResponse> response = controller.promoteEstimateToWorkorder(ESTIMATE_ID, null);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getId()).isEqualTo(WORKORDER_ID);
+        }
+
+        @Test
+        void replaysTheOriginalWorkorderForAKnownIdempotencyKey() {
+            when(idempotencyService.getExistingWorkorderId(PROMOTE_OPERATION, IDEMPOTENCY_KEY))
+                    .thenReturn(Optional.of(WORKORDER_ID));
+            when(workorderService.getWorkorderById(WORKORDER_ID)).thenReturn(Optional.of(workorder));
+
+            ResponseEntity<WorkorderResponse> response =
+                    controller.promoteEstimateToWorkorder(ESTIMATE_ID, IDEMPOTENCY_KEY);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(workorderService, never()).createWorkorder(any(UUID.class), any());
+        }
+
+        @Test
+        void reportsAnInternalErrorWhenTheReplayedWorkorderIsMissing() {
+            when(idempotencyService.getExistingWorkorderId(PROMOTE_OPERATION, IDEMPOTENCY_KEY))
+                    .thenReturn(Optional.of(WORKORDER_ID));
+            when(workorderService.getWorkorderById(WORKORDER_ID)).thenReturn(Optional.empty());
+
+            assertThat(controller
+                            .promoteEstimateToWorkorder(ESTIMATE_ID, IDEMPOTENCY_KEY)
+                            .getStatusCode())
+                    .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        @Test
+        void registersTheIdempotencyKeyAgainstTheNewWorkorder() {
+            when(workorderService.createWorkorder(ESTIMATE_ID, null)).thenReturn(workorder);
+
+            controller.promoteEstimateToWorkorder(ESTIMATE_ID, IDEMPOTENCY_KEY);
+
+            verify(idempotencyService).registerKey(PROMOTE_OPERATION, IDEMPOTENCY_KEY, WORKORDER_ID);
+        }
+
+        @Test
+        void servesTheWinnersWorkorderWhenTwoRequestsRaceOnTheSameKey() {
+            when(workorderService.createWorkorder(ESTIMATE_ID, null)).thenReturn(workorder);
+            doThrow(new DataIntegrityViolationException("duplicate key"))
+                    .when(idempotencyService)
+                    .registerKey(PROMOTE_OPERATION, IDEMPOTENCY_KEY, WORKORDER_ID);
+            when(idempotencyService.getExistingWorkorderId(PROMOTE_OPERATION, IDEMPOTENCY_KEY))
+                    .thenReturn(Optional.empty(), Optional.of(OTHER_WORKORDER_ID));
+            Workorder winner = new Workorder();
+            winner.setId(OTHER_WORKORDER_ID);
+            when(workorderService.getWorkorderById(OTHER_WORKORDER_ID)).thenReturn(Optional.of(winner));
+
+            ResponseEntity<WorkorderResponse> response =
+                    controller.promoteEstimateToWorkorder(ESTIMATE_ID, IDEMPOTENCY_KEY);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getId()).isEqualTo(OTHER_WORKORDER_ID);
+        }
+
+        @Test
+        void keepsItsOwnWorkorderWhenTheDuplicateKeyPointsAtTheSameOne() {
+            when(workorderService.createWorkorder(ESTIMATE_ID, null)).thenReturn(workorder);
+            doThrow(new DataIntegrityViolationException("duplicate key"))
+                    .when(idempotencyService)
+                    .registerKey(PROMOTE_OPERATION, IDEMPOTENCY_KEY, WORKORDER_ID);
+            when(idempotencyService.getExistingWorkorderId(PROMOTE_OPERATION, IDEMPOTENCY_KEY))
+                    .thenReturn(Optional.empty(), Optional.of(WORKORDER_ID));
+
+            ResponseEntity<WorkorderResponse> response =
+                    controller.promoteEstimateToWorkorder(ESTIMATE_ID, IDEMPOTENCY_KEY);
+
+            assertThat(response.getBody().getId()).isEqualTo(WORKORDER_ID);
+        }
+
+        @Test
+        void answersAnAlreadyPromotedEstimateWithItsExistingWorkorder() {
+            when(workorderService.createWorkorder(ESTIMATE_ID, null))
+                    .thenThrow(new PromotionValidationException(
+                            PromotionValidationException.PromotionErrorCode.ALREADY_PROMOTED,
+                            "already promoted",
+                            WORKORDER_ID));
+            when(workorderService.getWorkorderById(WORKORDER_ID)).thenReturn(Optional.of(workorder));
+
+            ResponseEntity<WorkorderResponse> response = controller.promoteEstimateToWorkorder(ESTIMATE_ID, null);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getId()).isEqualTo(WORKORDER_ID);
+        }
+
+        @Test
+        void fallsBackToAConflictWhenTheAlreadyPromotedWorkorderCannotBeLoaded() {
+            when(workorderService.createWorkorder(ESTIMATE_ID, null))
+                    .thenThrow(new PromotionValidationException(
+                            PromotionValidationException.PromotionErrorCode.ALREADY_PROMOTED,
+                            "already promoted",
+                            WORKORDER_ID));
+            when(workorderService.getWorkorderById(WORKORDER_ID)).thenReturn(Optional.empty());
+
+            assertThat(controller.promoteEstimateToWorkorder(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT);
+        }
+
+        @Test
+        void reportsAConflictForAnyOtherPromotionValidationFailure() {
+            when(workorderService.createWorkorder(ESTIMATE_ID, null))
+                    .thenThrow(new PromotionValidationException(
+                            PromotionValidationException.PromotionErrorCode.APPROVAL_EXPIRED, "approval expired"));
+
+            assertThat(controller.promoteEstimateToWorkorder(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT);
+        }
+
+        @Test
+        void mapsMissingEstimatesAndBadArgumentsOntoTheirOwnStatuses() {
+            doThrow(new EntityNotFoundException("gone")).when(workorderService).createWorkorder(ESTIMATE_ID, null);
+            assertThat(controller.promoteEstimateToWorkorder(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new IllegalArgumentException("bad estimate"))
+                    .when(workorderService)
+                    .createWorkorder(ESTIMATE_ID, null);
+            assertThat(controller.promoteEstimateToWorkorder(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+
+            doThrow(new RuntimeException("boom")).when(workorderService).createWorkorder(ESTIMATE_ID, null);
+            assertThat(controller.promoteEstimateToWorkorder(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Nested
+    @DisplayName("items, totals and documents")
+    class ItemsAndDocuments {
+
+        private static EstimateItemResponse item() {
+            return EstimateItemResponse.builder()
+                    .id(ITEM_ID)
+                    .estimateId(ESTIMATE_ID)
+                    .description("Mount and balance")
+                    .build();
+        }
+
+        @Test
+        void deletesAnEstimate() {
+            assertThat(controller.deleteEstimate(ESTIMATE_ID).getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+            verify(estimateService).deleteEstimate(ESTIMATE_ID);
+        }
+
+        @Test
+        void addsAnItemUnderTheAuthenticatedUser() {
+            when(estimateService.addEstimateItem(eq(ESTIMATE_ID), any(), anyString()))
+                    .thenReturn(item());
+
+            assertThat(controller.addEstimateItem(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        void mapsAResponseStatusExceptionFromTheAddPathOntoItsOwnStatus() {
+            doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "no estimate"))
+                    .when(estimateService)
+                    .addEstimateItem(any(), any(), anyString());
+            assertThat(controller.addEstimateItem(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "bad item"))
+                    .when(estimateService)
+                    .addEstimateItem(any(), any(), anyString());
+            assertThat(controller.addEstimateItem(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @Test
+        void mapsTheOtherAddFailuresOntoNotFoundBadRequestAndConflict() {
+            doThrow(new EntityNotFoundException("gone"))
+                    .when(estimateService)
+                    .addEstimateItem(any(), any(), anyString());
+            assertThat(controller.addEstimateItem(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new IllegalArgumentException("bad quantity"))
+                    .when(estimateService)
+                    .addEstimateItem(any(), any(), anyString());
+            assertThat(controller.addEstimateItem(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+
+            doThrow(new IllegalStateException("estimate is locked"))
+                    .when(estimateService)
+                    .addEstimateItem(any(), any(), anyString());
+            assertThat(controller.addEstimateItem(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT);
+        }
+
+        @Test
+        void updatesAnItem() {
+            when(estimateService.updateEstimateItem(eq(ESTIMATE_ID), eq(ITEM_ID), any()))
+                    .thenReturn(item());
+
+            assertThat(controller.updateEstimateItem(ESTIMATE_ID, ITEM_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        void mapsUpdateFailuresOntoNotFoundBadRequestAndConflict() {
+            doThrow(new EntityNotFoundException("gone")).when(estimateService).updateEstimateItem(any(), any(), any());
+            assertThat(controller.updateEstimateItem(ESTIMATE_ID, ITEM_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new IllegalArgumentException("bad quantity"))
+                    .when(estimateService)
+                    .updateEstimateItem(any(), any(), any());
+            assertThat(controller.updateEstimateItem(ESTIMATE_ID, ITEM_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+
+            doThrow(new IllegalStateException("estimate is locked"))
+                    .when(estimateService)
+                    .updateEstimateItem(any(), any(), any());
+            assertThat(controller.updateEstimateItem(ESTIMATE_ID, ITEM_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT);
+        }
+
+        @Test
+        void deletesAnItem() {
+            assertThat(controller.deleteEstimateItem(ESTIMATE_ID, ITEM_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.NO_CONTENT);
+            verify(estimateService).deleteEstimateItem(ESTIMATE_ID, ITEM_ID);
+        }
+
+        @Test
+        void mapsItemDeleteFailuresOntoNotFoundAndConflict() {
+            doThrow(new IllegalArgumentException("no item"))
+                    .when(estimateService)
+                    .deleteEstimateItem(ESTIMATE_ID, ITEM_ID);
+            assertThat(controller.deleteEstimateItem(ESTIMATE_ID, ITEM_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new IllegalStateException("estimate is locked"))
+                    .when(estimateService)
+                    .deleteEstimateItem(ESTIMATE_ID, ITEM_ID);
+            assertThat(controller.deleteEstimateItem(ESTIMATE_ID, ITEM_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT);
+        }
+
+        @Test
+        void returnsTheRecalculatedTotalsAlongsideTheEstimate() {
+            when(estimateService.calculateEstimateTaxesAndTotals(eq(ESTIMATE_ID), anyString()))
+                    .thenReturn(estimate());
+
+            ResponseEntity<Map<String, Object>> response = controller.calculateEstimateTotals(ESTIMATE_ID);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody())
+                    .containsKey("estimate")
+                    .containsEntry("subtotal", new BigDecimal("100.00"))
+                    .containsEntry("taxAmount", new BigDecimal("8.00"))
+                    .containsEntry("total", new BigDecimal("108.00"));
+        }
+
+        @Test
+        void mapsCalculationFailuresOntoNotFoundAndConflict() {
+            doThrow(new IllegalArgumentException("no estimate"))
+                    .when(estimateService)
+                    .calculateEstimateTaxesAndTotals(any(), anyString());
+            assertThat(controller.calculateEstimateTotals(ESTIMATE_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new IllegalStateException("no items"))
+                    .when(estimateService)
+                    .calculateEstimateTaxesAndTotals(any(), anyString());
+            assertThat(controller.calculateEstimateTotals(ESTIMATE_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT);
+        }
+
+        @Test
+        void servesTheCustomerFacingSummary() {
+            when(estimateService.getEstimateSummary(ESTIMATE_ID))
+                    .thenReturn(EstimateSummaryResponse.builder().build());
+
+            assertThat(controller.getEstimateSummary(ESTIMATE_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        void reportsNotFoundWhenTheSummaryHasNoEstimate() {
+            when(estimateService.getEstimateSummary(ESTIMATE_ID)).thenThrow(new IllegalArgumentException("gone"));
+
+            assertThat(controller.getEstimateSummary(ESTIMATE_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        void servesThePdfAsAnAttachment() {
+            when(estimateService.generateEstimatePdf(ESTIMATE_ID)).thenReturn(new byte[] {1, 2, 3});
+
+            ResponseEntity<byte[]> response = controller.generateEstimatePdf(ESTIMATE_ID);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getHeaders().getFirst("Content-Disposition"))
+                    .contains("estimate-" + ESTIMATE_ID + ".pdf");
+            assertThat(response.getBody()).hasSize(3);
+        }
+
+        @Test
+        void reportsNotFoundForAPdfOfAnUnknownEstimateAndBadGatewayOnRenderFailure() {
+            doThrow(new IllegalArgumentException("gone")).when(estimateService).generateEstimatePdf(ESTIMATE_ID);
+            assertThat(controller.generateEstimatePdf(ESTIMATE_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new RuntimeException("renderer down")).when(estimateService).generateEstimatePdf(ESTIMATE_ID);
+            assertThat(controller.generateEstimatePdf(ESTIMATE_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_GATEWAY);
+        }
+
+        @Test
+        void createsASnapshotUnderTheAuthenticatedUser() {
+            when(estimateService.createEstimateSnapshot(eq(ESTIMATE_ID), anyString(), eq("before revision")))
+                    .thenReturn(EstimateSnapshotResponse.builder().build());
+
+            assertThat(controller
+                            .createEstimateSnapshot(ESTIMATE_ID, "before revision")
+                            .getStatusCode())
+                    .isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        void mapsSnapshotFailuresOntoNotFoundAndConflict() {
+            doThrow(new IllegalArgumentException("gone"))
+                    .when(estimateService)
+                    .createEstimateSnapshot(any(), anyString(), any());
+            assertThat(controller.createEstimateSnapshot(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new IllegalStateException("snapshot exists"))
+                    .when(estimateService)
+                    .createEstimateSnapshot(any(), anyString(), any());
+            assertThat(controller.createEstimateSnapshot(ESTIMATE_ID, null).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT);
+        }
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/controller/WorkexecTimeTrackingControllerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/controller/WorkexecTimeTrackingControllerTest.java
@@ -1,0 +1,357 @@
+package com.positivity.workorder.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.security.common.GatewaySecurityConstants;
+import com.positivity.security.common.MissingPersonIdException;
+import com.positivity.workorder.internal.dto.WorkexecJobTimeTotalResponse;
+import com.positivity.workorder.internal.dto.WorkexecLaborPerformedRequest;
+import com.positivity.workorder.internal.dto.WorkexecLaborPerformedResponse;
+import com.positivity.workorder.internal.dto.WorkexecTimerEntryResponse;
+import com.positivity.workorder.internal.dto.WorkexecTimerStartRequest;
+import com.positivity.workorder.internal.dto.WorkexecTimerStopResponse;
+import com.positivity.workorder.service.WorkexecTimeTrackingService;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Workexec time-tracking endpoints: the mechanic is always the authenticated caller, replays are
+ * flagged with {@code Idempotency-Replayed}, and every service failure gets its own status.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("WorkexecTimeTrackingController")
+class WorkexecTimeTrackingControllerTest {
+
+    private static final UUID MECHANIC_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f8a01");
+    private static final UUID WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f8a02");
+    private static final UUID LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f8a03");
+    private static final UUID ENTRY_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f8a04");
+    private static final LocalDate START_DATE = LocalDate.of(2026, 3, 1);
+    private static final LocalDate END_DATE = LocalDate.of(2026, 3, 2);
+    private static final String IDEMPOTENCY_KEY = "workexec-key-1";
+
+    @Mock
+    private WorkexecTimeTrackingService service;
+
+    @InjectMocks
+    private WorkexecTimeTrackingController controller;
+
+    @BeforeEach
+    void authenticateTheMechanic() {
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken("jane.smith", "n/a", List.of());
+        token.setDetails(Map.of(
+                GatewaySecurityConstants.DETAIL_USERNAME,
+                "jane.smith",
+                GatewaySecurityConstants.DETAIL_USER_ID,
+                MECHANIC_ID));
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private static void authenticateWithoutAUserId() {
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken("jane.smith", "n/a", List.of());
+        token.setDetails(Map.of(GatewaySecurityConstants.DETAIL_USERNAME, "jane.smith"));
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    private static WorkexecTimeTrackingService.TimerEntry timerEntry(LocalDateTime endTime) {
+        return new WorkexecTimeTrackingService.TimerEntry(
+                ENTRY_ID,
+                MECHANIC_ID,
+                WORKORDER_ID,
+                null,
+                "BRAKE_JOB",
+                LocalDateTime.of(2026, 3, 1, 8, 0),
+                endTime,
+                endTime == null ? null : 3600L,
+                endTime == null ? "ACTIVE" : "COMPLETED");
+    }
+
+    private static WorkexecLaborPerformedRequest laborRequest() {
+        return WorkexecLaborPerformedRequest.builder()
+                .workorderId(WORKORDER_ID)
+                .technicianId(MECHANIC_ID)
+                .performedAt(Instant.parse("2026-03-01T15:00:00Z"))
+                .labor(WorkexecLaborPerformedRequest.LaborQuantity.builder()
+                        .quantity(new BigDecimal("1.5"))
+                        .unit("HOURS")
+                        .build())
+                .source(WorkexecLaborPerformedRequest.SourceReference.builder()
+                        .system("shopmgr")
+                        .sourceReferenceId("ref-1")
+                        .build())
+                .build();
+    }
+
+    private static WorkexecTimeTrackingService.LaborPerformedResult laborResult(boolean replayed) {
+        return new WorkexecTimeTrackingService.LaborPerformedResult(
+                new WorkexecTimeTrackingService.LaborPerformedResponse(
+                        ENTRY_ID,
+                        WORKORDER_ID,
+                        MECHANIC_ID,
+                        Instant.parse("2026-03-01T15:00:00Z"),
+                        new BigDecimal("1.50"),
+                        "HOURS",
+                        "shopmgr",
+                        "ref-1"),
+                replayed);
+    }
+
+    @Nested
+    @DisplayName("getJobTimeTotals")
+    class GetJobTimeTotals {
+
+        @Test
+        void mapsTheAggregatedTotalsOntoTheirResponse() {
+            when(service.getJobTimeTotals(any(), any(), any(), any(), any()))
+                    .thenReturn(List.of(
+                            new WorkexecTimeTrackingService.JobTimeTotal(MECHANIC_ID, LOCATION_ID, START_DATE, 210)));
+
+            ResponseEntity<Object> response =
+                    controller.getJobTimeTotals(START_DATE, END_DATE, "UTC", LOCATION_ID, List.of(MECHANIC_ID));
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            @SuppressWarnings("unchecked")
+            List<WorkexecJobTimeTotalResponse> body = (List<WorkexecJobTimeTotalResponse>) response.getBody();
+            assertThat(body).hasSize(1);
+            assertThat(body.get(0).getTotalJobMinutes()).isEqualTo(210);
+            assertThat(body.get(0).getTechnicianId()).isEqualTo(MECHANIC_ID);
+        }
+
+        @Test
+        void treatsAMissingTechnicianFilterAsNoFilter() {
+            when(service.getJobTimeTotals(any(), any(), any(), any(), any())).thenReturn(List.of());
+
+            controller.getJobTimeTotals(START_DATE, END_DATE, "UTC", null, null);
+
+            verify(service).getJobTimeTotals(eq(START_DATE), eq(END_DATE), any(), eq(null), eq(List.of()));
+        }
+
+        @Test
+        void rejectsATimezoneThatIsNotAZoneId() {
+            ResponseEntity<Object> response =
+                    controller.getJobTimeTotals(START_DATE, END_DATE, "Mars/Olympus", null, null);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(response.getBody().toString()).contains("Invalid timezone value");
+        }
+
+        @Test
+        void rejectsAnInvertedDateRange() {
+            ResponseEntity<Object> response = controller.getJobTimeTotals(END_DATE, START_DATE, "UTC", null, null);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(response.getBody().toString()).contains("endDate must be on or after startDate");
+        }
+    }
+
+    @Nested
+    @DisplayName("createLaborPerformed")
+    class CreateLaborPerformed {
+
+        @Test
+        void reportsCreatedForANewLaborPosting() {
+            when(service.recordLaborPerformed(any(), anyString())).thenReturn(laborResult(false));
+
+            ResponseEntity<Object> response =
+                    controller.createLaborPerformed(laborRequest(), IDEMPOTENCY_KEY, "corr-1");
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+            assertThat(response.getHeaders().getFirst("X-Correlation-Id")).isEqualTo("corr-1");
+            assertThat(response.getHeaders().getFirst("Idempotency-Replayed")).isNull();
+            assertThat(((WorkexecLaborPerformedResponse) response.getBody()).getQuantity())
+                    .isEqualByComparingTo("1.50");
+        }
+
+        @Test
+        void flagsAReplayWithItsOwnHeaderAndAnOkStatus() {
+            when(service.recordLaborPerformed(any(), anyString())).thenReturn(laborResult(true));
+
+            ResponseEntity<Object> response = controller.createLaborPerformed(laborRequest(), IDEMPOTENCY_KEY, null);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getHeaders().getFirst("Idempotency-Replayed")).isEqualTo("true");
+            assertThat(response.getHeaders().getFirst("X-Correlation-Id")).isNull();
+        }
+
+        @Test
+        void requiresAnIdempotencyKey() {
+            ResponseEntity<Object> response = controller.createLaborPerformed(laborRequest(), "  ", null);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(response.getBody().toString()).contains("Idempotency-Key header is required");
+            verify(service, never()).recordLaborPerformed(any(), anyString());
+        }
+
+        @Test
+        void mapsEveryServiceFailureOntoItsOwnStatus() {
+            doThrow(new NoSuchElementException("Workorder not found"))
+                    .when(service)
+                    .recordLaborPerformed(any(), anyString());
+            assertThat(controller
+                            .createLaborPerformed(laborRequest(), IDEMPOTENCY_KEY, null)
+                            .getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new WorkexecTimeTrackingService.WorkexecConflictException(
+                            "WORKEXEC_CONFLICT_WORKORDER_STATE", "cancelled"))
+                    .when(service)
+                    .recordLaborPerformed(any(), anyString());
+            ResponseEntity<Object> conflict = controller.createLaborPerformed(laborRequest(), IDEMPOTENCY_KEY, null);
+            assertThat(conflict.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+            assertThat(conflict.getBody().toString()).contains("WORKEXEC_CONFLICT_WORKORDER_STATE");
+
+            doThrow(new IllegalArgumentException("labor.unit must be HOURS"))
+                    .when(service)
+                    .recordLaborPerformed(any(), anyString());
+            assertThat(controller
+                            .createLaborPerformed(laborRequest(), IDEMPOTENCY_KEY, null)
+                            .getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("timers")
+    class Timers {
+
+        @Test
+        void listsTheAuthenticatedMechanicsActiveTimers() {
+            when(service.getActiveTimers(MECHANIC_ID)).thenReturn(List.of(timerEntry(null)));
+
+            ResponseEntity<Object> response = controller.getActiveTimerEntries();
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            @SuppressWarnings("unchecked")
+            List<WorkexecTimerEntryResponse> body = (List<WorkexecTimerEntryResponse>) response.getBody();
+            assertThat(body).hasSize(1);
+            assertThat(body.get(0).getStatus()).isEqualTo("ACTIVE");
+            assertThat(body.get(0).getLaborCode()).isEqualTo("BRAKE_JOB");
+        }
+
+        @Test
+        void startsATimerAndReportsCreated() {
+            when(service.startTimer(eq(MECHANIC_ID), any(), any()))
+                    .thenReturn(new WorkexecTimeTrackingService.TimerStartResult(timerEntry(null), false));
+
+            ResponseEntity<Object> response = controller.startTimer(
+                    IDEMPOTENCY_KEY,
+                    WorkexecTimerStartRequest.builder()
+                            .workorderId(WORKORDER_ID)
+                            .laborCode("BRAKE_JOB")
+                            .build());
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+            assertThat(response.getHeaders().getFirst("Idempotency-Replayed")).isNull();
+        }
+
+        @Test
+        void flagsAReplayedTimerStart() {
+            when(service.startTimer(eq(MECHANIC_ID), any(), any()))
+                    .thenReturn(new WorkexecTimeTrackingService.TimerStartResult(timerEntry(null), true));
+
+            ResponseEntity<Object> response = controller.startTimer(
+                    IDEMPOTENCY_KEY,
+                    WorkexecTimerStartRequest.builder()
+                            .workorderId(WORKORDER_ID)
+                            .build());
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getHeaders().getFirst("Idempotency-Replayed")).isEqualTo("true");
+        }
+
+        @Test
+        void mapsTimerStartFailuresOntoNotFoundAndConflict() {
+            WorkexecTimerStartRequest request = WorkexecTimerStartRequest.builder()
+                    .workorderId(WORKORDER_ID)
+                    .build();
+
+            doThrow(new NoSuchElementException("Workorder not found"))
+                    .when(service)
+                    .startTimer(any(), any(), any());
+            assertThat(controller.startTimer(null, request).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new WorkexecTimeTrackingService.WorkexecConflictException(
+                            "TIMER_ALREADY_ACTIVE", "already running"))
+                    .when(service)
+                    .startTimer(any(), any(), any());
+            ResponseEntity<Object> conflict = controller.startTimer(null, request);
+            assertThat(conflict.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+            assertThat(conflict.getBody().toString()).contains("TIMER_ALREADY_ACTIVE");
+        }
+
+        @Test
+        void stopsEveryTimerAndReturnsThem() {
+            when(service.stopTimers(MECHANIC_ID)).thenReturn(List.of(timerEntry(LocalDateTime.of(2026, 3, 1, 9, 0))));
+
+            ResponseEntity<Object> response = controller.stopTimers();
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(((WorkexecTimerStopResponse) response.getBody()).getStopped())
+                    .hasSize(1);
+        }
+
+        @Test
+        void reportsAConflictWhenNoTimerIsRunning() {
+            doThrow(new WorkexecTimeTrackingService.WorkexecConflictException("NO_ACTIVE_TIMER", "nothing running"))
+                    .when(service)
+                    .stopTimers(MECHANIC_ID);
+
+            ResponseEntity<Object> response = controller.stopTimers();
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+            assertThat(response.getBody().toString()).contains("NO_ACTIVE_TIMER");
+        }
+
+        @Test
+        void surfacesAContextWithoutAUuidUserIdRatherThanGuessingAMechanic() {
+            // SecurityContextHelper is fail-fast here: a gateway-authenticated request always
+            // carries a UUID user id, so a missing one is an integration fault, not a 400.
+            authenticateWithoutAUserId();
+            WorkexecTimerStartRequest request = WorkexecTimerStartRequest.builder()
+                    .workorderId(WORKORDER_ID)
+                    .build();
+
+            assertThatThrownBy(() -> controller.getActiveTimerEntries()).isInstanceOf(MissingPersonIdException.class);
+            assertThatThrownBy(() -> controller.startTimer(null, request)).isInstanceOf(MissingPersonIdException.class);
+            assertThatThrownBy(() -> controller.stopTimers()).isInstanceOf(MissingPersonIdException.class);
+            verify(service, never()).getActiveTimers(any());
+        }
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/controller/WorkorderControllerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/controller/WorkorderControllerTest.java
@@ -1,0 +1,406 @@
+package com.positivity.workorder.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.shared.dto.CountResponse;
+import com.positivity.shared.dto.InvoiceGenerationResponse;
+import com.positivity.workorder.internal.dto.ApproveWorkorderRequest;
+import com.positivity.workorder.internal.dto.CompleteWorkorderRequest;
+import com.positivity.workorder.internal.dto.CompleteWorkorderResponse;
+import com.positivity.workorder.internal.dto.CreateWorkorderRequest;
+import com.positivity.workorder.internal.dto.ReopenWorkorderRequest;
+import com.positivity.workorder.internal.dto.ReopenWorkorderResponse;
+import com.positivity.workorder.internal.dto.WorkorderItemCompletionResponse;
+import com.positivity.workorder.internal.dto.WorkorderResponse;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.service.WorkorderStateMachine;
+import com.positivity.workorder.service.WorkorderCountService;
+import com.positivity.workorder.service.WorkorderInvoiceService;
+import com.positivity.workorder.service.WorkorderService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Workorder endpoints: reads project the entity, writes delegate to the service, and each
+ * failure mode gets its own status — a missing workorder is a 404, an illegal transition a 400.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("WorkorderController")
+class WorkorderControllerTest {
+
+    private static final UUID WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3faa11");
+    private static final UUID ESTIMATE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3faa12");
+    private static final UUID CUSTOMER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3faa13");
+    private static final UUID SERVICE_LINE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3faa14");
+    private static final UUID PART_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3faa15");
+    private static final UUID INVOICE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3faa16");
+
+    @Mock
+    private WorkorderService workorderService;
+
+    @Mock
+    private WorkorderInvoiceService workorderInvoiceService;
+
+    @Mock
+    private WorkorderCountService workorderCountService;
+
+    @InjectMocks
+    private WorkorderController controller;
+
+    private Workorder workorder;
+
+    @BeforeEach
+    void setUp() {
+        workorder = new Workorder();
+        workorder.setId(WORKORDER_ID);
+        workorder.setEstimateId(ESTIMATE_ID);
+        workorder.setCustomerId(CUSTOMER_ID);
+        workorder.setStatus(WorkorderStatus.DRAFT);
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        void listsEveryWorkorder() {
+            when(workorderService.getAllWorkorders()).thenReturn(List.of(workorder));
+
+            List<WorkorderResponse> responses = controller.getAllWorkorders();
+
+            assertThat(responses).hasSize(1);
+            assertThat(responses.get(0).getId()).isEqualTo(WORKORDER_ID);
+        }
+
+        @Test
+        void servesOneWorkorderById() {
+            when(workorderService.getWorkorderById(WORKORDER_ID)).thenReturn(Optional.of(workorder));
+
+            ResponseEntity<WorkorderResponse> response = controller.getWorkorderById(WORKORDER_ID);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getId()).isEqualTo(WORKORDER_ID);
+        }
+
+        @Test
+        void reportsNotFoundForAnUnknownWorkorder() {
+            when(workorderService.getWorkorderById(WORKORDER_ID)).thenReturn(Optional.empty());
+
+            assertThat(controller.getWorkorderById(WORKORDER_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        void countsTheExplicitlyRequestedStatuses() {
+            CountResponse expected = new CountResponse(3, List.of());
+            when(workorderCountService.countByStatuses(Set.of(WorkorderStatus.DRAFT)))
+                    .thenReturn(expected);
+
+            assertThat(controller.countWorkorders(false, Set.of(WorkorderStatus.DRAFT)))
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void countsOnlyOpenStatusesWhenAskedTo() {
+            when(workorderCountService.countByStatuses(WorkorderStatus.getOpenStatuses()))
+                    .thenReturn(new CountResponse(2, List.of()));
+
+            assertThat(controller.countWorkorders(true, null).total()).isEqualTo(2);
+        }
+
+        @Test
+        void countsEveryStatusWhenNeitherFilterIsGiven() {
+            when(workorderCountService.countByStatuses(null)).thenReturn(new CountResponse(9, List.of()));
+
+            assertThat(controller.countWorkorders(false, Set.of()).total()).isEqualTo(9);
+            verify(workorderCountService, org.mockito.Mockito.atLeastOnce()).countByStatuses(null);
+        }
+
+        @Test
+        void servesTheTransitionAndSnapshotHistories() {
+            when(workorderService.getTransitionHistory(WORKORDER_ID)).thenReturn(List.of());
+            when(workorderService.getSnapshotHistory(WORKORDER_ID)).thenReturn(List.of());
+
+            assertThat(controller.getTransitionHistory(WORKORDER_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.OK);
+            assertThat(controller.getSnapshotHistory(WORKORDER_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.OK);
+        }
+    }
+
+    @Nested
+    @DisplayName("create and delete")
+    class CreateAndDelete {
+
+        @Test
+        void createsAWorkorderThroughTheIdempotentServicePath() {
+            when(workorderService.createWorkorderWithIdempotency(ESTIMATE_ID, CUSTOMER_ID, "key-1"))
+                    .thenReturn(workorder);
+
+            ResponseEntity<WorkorderResponse> response = controller.createWorkorder(
+                    CreateWorkorderRequest.builder()
+                            .estimateId(ESTIMATE_ID)
+                            .customerId(CUSTOMER_ID)
+                            .build(),
+                    "key-1");
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getId()).isEqualTo(WORKORDER_ID);
+        }
+
+        @Test
+        void deletesAWorkorder() {
+            assertThat(controller.deleteWorkorder(WORKORDER_ID).getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+            verify(workorderService).deleteWorkorder(WORKORDER_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("approve, complete and reopen")
+    class Lifecycle {
+
+        @Test
+        void approvesAWorkorderWithItsCapturedSignature() {
+            when(workorderService.approveWorkorder(
+                            WORKORDER_ID, CUSTOMER_ID, "sig", "image/png", "Jane Customer", "ok"))
+                    .thenReturn(workorder);
+
+            ResponseEntity<WorkorderResponse> response = controller.approveWorkorder(
+                    WORKORDER_ID,
+                    ApproveWorkorderRequest.builder()
+                            .customerId(CUSTOMER_ID)
+                            .signatureData("sig")
+                            .signerName("Jane Customer")
+                            .notes("ok")
+                            .build());
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        void reportsBadRequestWhenAnApprovalIsNotAllowed() {
+            ApproveWorkorderRequest request =
+                    ApproveWorkorderRequest.builder().customerId(CUSTOMER_ID).build();
+            doThrow(new IllegalStateException("not a draft"))
+                    .when(workorderService)
+                    .approveWorkorder(any(), any(), any(), any(), any(), any());
+
+            assertThat(controller.approveWorkorder(WORKORDER_ID, request).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @Test
+        void completesAWorkorderAndReportsBothStatuses() {
+            when(workorderService.getCurrentWorkorderStatus(WORKORDER_ID)).thenReturn("WORK_IN_PROGRESS");
+
+            ResponseEntity<CompleteWorkorderResponse> response = controller.completeWorkorder(
+                    WORKORDER_ID,
+                    CompleteWorkorderRequest.builder()
+                            .completionNotes("all done")
+                            .build());
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getPreviousStatus()).isEqualTo("WORK_IN_PROGRESS");
+            assertThat(response.getBody().getCurrentStatus()).isEqualTo("COMPLETED");
+            verify(workorderService).completeWorkorder(WORKORDER_ID, "system", "all done");
+        }
+
+        @Test
+        void mapsCompletionFailuresOntoBadRequestAndNotFound() {
+            CompleteWorkorderRequest request =
+                    CompleteWorkorderRequest.builder().build();
+
+            doThrow(new IllegalStateException("open change requests"))
+                    .when(workorderService)
+                    .completeWorkorder(any(), anyString(), any());
+            assertThat(controller.completeWorkorder(WORKORDER_ID, request).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+
+            doThrow(new IllegalArgumentException("no such workorder"))
+                    .when(workorderService)
+                    .completeWorkorder(any(), anyString(), any());
+            assertThat(controller.completeWorkorder(WORKORDER_ID, request).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        void reportsTheCompletionPreconditions() {
+            when(workorderService.getCompletionPreconditions(WORKORDER_ID))
+                    .thenReturn(new WorkorderStateMachine.CompletionPreconditions(
+                            WORKORDER_ID,
+                            "WORK_IN_PROGRESS",
+                            false,
+                            List.of("all parts installed"),
+                            List.of("2 open change requests"),
+                            2,
+                            1,
+                            0,
+                            false,
+                            true));
+
+            ResponseEntity<?> response = controller.getCompletionPreconditions(WORKORDER_ID);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().toString()).contains("2 open change requests");
+        }
+
+        @Test
+        void reportsNotFoundForPreconditionsOfAnUnknownWorkorder() {
+            doThrow(new IllegalArgumentException("no such workorder"))
+                    .when(workorderService)
+                    .getCompletionPreconditions(WORKORDER_ID);
+
+            assertThat(controller.getCompletionPreconditions(WORKORDER_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        void reopensACompletedWorkorder() {
+            when(workorderService.reopenCompletedWorkorder(eq(WORKORDER_ID), anyString(), eq("more work")))
+                    .thenReturn(new WorkorderService.ReopenResult(
+                            WORKORDER_ID, "COMPLETED", true, Instant.parse("2026-03-01T12:00:00Z")));
+
+            ResponseEntity<ReopenWorkorderResponse> response = controller.reopenWorkorder(
+                    WORKORDER_ID,
+                    ReopenWorkorderRequest.builder().reopenReason("more work").build());
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getIsReopened()).isTrue();
+            assertThat(response.getBody().getMessage()).isEqualTo("Workorder reopened successfully");
+        }
+
+        @Test
+        void mapsReopenFailuresOntoNotFoundAndBadRequest() {
+            ReopenWorkorderRequest request =
+                    ReopenWorkorderRequest.builder().reopenReason("more work").build();
+
+            doThrow(new IllegalArgumentException("no such workorder"))
+                    .when(workorderService)
+                    .reopenCompletedWorkorder(any(), anyString(), any());
+            assertThat(controller.reopenWorkorder(WORKORDER_ID, request).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new IllegalStateException("not completed"))
+                    .when(workorderService)
+                    .reopenCompletedWorkorder(any(), anyString(), any());
+            ResponseEntity<ReopenWorkorderResponse> badRequest = controller.reopenWorkorder(WORKORDER_ID, request);
+            assertThat(badRequest.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(badRequest.getBody().getMessage()).isEqualTo("not completed");
+        }
+    }
+
+    @Nested
+    @DisplayName("invoice and item completion")
+    class InvoiceAndItems {
+
+        @Test
+        void reportsAcceptedWhileInvoiceGenerationIsStillPending() {
+            when(workorderInvoiceService.generateInvoice(WORKORDER_ID, "key-1"))
+                    .thenReturn(InvoiceGenerationResponse.builder()
+                            .workorderId(WORKORDER_ID)
+                            .status(WorkorderInvoiceService.STATUS_PENDING)
+                            .build());
+
+            assertThat(controller.generateInvoice(WORKORDER_ID, "key-1").getStatusCode())
+                    .isEqualTo(HttpStatus.ACCEPTED);
+        }
+
+        @Test
+        void reportsOkOnceTheInvoiceExists() {
+            when(workorderInvoiceService.generateInvoice(WORKORDER_ID, null))
+                    .thenReturn(InvoiceGenerationResponse.builder()
+                            .workorderId(WORKORDER_ID)
+                            .invoiceId(INVOICE_ID)
+                            .status("GENERATED")
+                            .build());
+
+            ResponseEntity<InvoiceGenerationResponse> response = controller.generateInvoice(WORKORDER_ID, null);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getInvoiceId()).isEqualTo(INVOICE_ID);
+        }
+
+        @Test
+        void completesAServiceLine() {
+            when(workorderService.completeServiceItem(eq(WORKORDER_ID), eq(SERVICE_LINE_ID), anyString()))
+                    .thenReturn(WorkorderItemCompletionResponse.builder()
+                            .workorderId(WORKORDER_ID)
+                            .itemId(SERVICE_LINE_ID)
+                            .build());
+
+            assertThat(controller
+                            .completeServiceItem(WORKORDER_ID, SERVICE_LINE_ID)
+                            .getStatusCode())
+                    .isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        void mapsServiceLineFailuresOntoNotFoundAndBadRequest() {
+            doThrow(new IllegalArgumentException("no such line"))
+                    .when(workorderService)
+                    .completeServiceItem(any(), any(), anyString());
+            assertThat(controller
+                            .completeServiceItem(WORKORDER_ID, SERVICE_LINE_ID)
+                            .getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new IllegalStateException("line is cancelled"))
+                    .when(workorderService)
+                    .completeServiceItem(any(), any(), anyString());
+            assertThat(controller
+                            .completeServiceItem(WORKORDER_ID, SERVICE_LINE_ID)
+                            .getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @Test
+        void completesAPartLine() {
+            when(workorderService.completePartItem(eq(WORKORDER_ID), eq(PART_ID), anyString()))
+                    .thenReturn(WorkorderItemCompletionResponse.builder()
+                            .workorderId(WORKORDER_ID)
+                            .itemId(PART_ID)
+                            .build());
+
+            assertThat(controller.completePartItem(WORKORDER_ID, PART_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        void mapsPartLineFailuresOntoNotFoundAndBadRequest() {
+            doThrow(new IllegalArgumentException("no such part"))
+                    .when(workorderService)
+                    .completePartItem(any(), any(), anyString());
+            assertThat(controller.completePartItem(WORKORDER_ID, PART_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+
+            doThrow(new IllegalStateException("part is cancelled"))
+                    .when(workorderService)
+                    .completePartItem(any(), any(), anyString());
+            assertThat(controller.completePartItem(WORKORDER_ID, PART_ID).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/ChangeRequestServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/ChangeRequestServiceImplTest.java
@@ -1,0 +1,629 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.security.common.GatewaySecurityConstants;
+import com.positivity.workorder.internal.dto.CreateChangeRequestDTO;
+import com.positivity.workorder.internal.entity.ApprovalRecord;
+import com.positivity.workorder.internal.entity.ChangeRequest;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderPart;
+import com.positivity.workorder.internal.entity.WorkorderServiceLine;
+import com.positivity.workorder.internal.enums.WorkorderItemStatus;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.repository.ApprovalRecordRepository;
+import com.positivity.workorder.internal.repository.ChangeRequestRepository;
+import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
+import com.positivity.workorder.service.IdempotencyService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Change requests: they may only be raised against work in progress, emergency items must carry
+ * photo or written evidence, and every advisor decision writes an approval record and pushes the
+ * attached items to their next status.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ChangeRequestServiceImpl")
+class ChangeRequestServiceImplTest {
+
+    private static final UUID WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fcc11");
+    private static final UUID CHANGE_REQUEST_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fcc12");
+    private static final UUID SERVICE_ENTITY_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fcc13");
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fcc14");
+    private static final UUID APPROVER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fcc15");
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final LocalDateTime NOW_LOCAL = LocalDateTime.ofInstant(NOW, ZoneOffset.UTC);
+
+    @Mock
+    private ChangeRequestRepository changeRequestRepository;
+
+    @Mock
+    private WorkorderRepository workOrderRepository;
+
+    @Mock
+    private WorkorderServiceRepository workOrderServiceRepository;
+
+    @Mock
+    private WorkorderPartRepository workOrderPartRepository;
+
+    @Mock
+    private ApprovalRecordRepository approvalRecordRepository;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    @Mock
+    private RestClient documentServiceRestClient;
+
+    private ChangeRequestServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ChangeRequestServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                changeRequestRepository,
+                workOrderRepository,
+                workOrderServiceRepository,
+                workOrderPartRepository,
+                approvalRecordRepository,
+                idempotencyService,
+                documentServiceRestClient,
+                new ObjectMapper());
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken("jane.smith", "n/a", List.of());
+        token.setDetails(Map.of(GatewaySecurityConstants.DETAIL_USERNAME, "jane.smith"));
+        SecurityContextHolder.getContext().setAuthentication(token);
+
+        when(changeRequestRepository.save(any())).thenAnswer(invocation -> {
+            ChangeRequest changeRequest = invocation.getArgument(0);
+            if (changeRequest.getId() == null) {
+                changeRequest.setId(CHANGE_REQUEST_ID);
+            }
+            return changeRequest;
+        });
+        when(workOrderServiceRepository.findByChangeRequest_Id(any())).thenReturn(List.of());
+        when(workOrderPartRepository.findByChangeRequest_Id(any())).thenReturn(List.of());
+        // The document service is unreachable in a unit test; the PDF step is best-effort and
+        // must not fail the change request.
+        when(documentServiceRestClient.post()).thenThrow(new IllegalStateException("document service unavailable"));
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private static Workorder workorder(WorkorderStatus status) {
+        Workorder workorder = new Workorder();
+        workorder.setId(WORKORDER_ID);
+        workorder.setStatus(status);
+        return workorder;
+    }
+
+    private void stubWorkorder(WorkorderStatus status) {
+        when(workOrderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(workorder(status)));
+    }
+
+    private static CreateChangeRequestDTO.CreateChangeRequestDTOBuilder dto() {
+        return CreateChangeRequestDTO.builder()
+                .workorderId(WORKORDER_ID)
+                .description("Rear rotors are scored")
+                .services(List.of(CreateChangeRequestDTO.WorkorderItemDTO.builder()
+                        .serviceEntityId(SERVICE_ENTITY_ID)
+                        .build()));
+    }
+
+    private static ChangeRequest changeRequest(ChangeRequest.ChangeRequestStatus status) {
+        return ChangeRequest.builder()
+                .id(CHANGE_REQUEST_ID)
+                .workorder(workorder(WorkorderStatus.WORK_IN_PROGRESS))
+                .requestedByUserId("jane.smith")
+                .description("Rear rotors are scored")
+                .status(status)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("createChangeRequest")
+    class CreateChangeRequest {
+
+        @Test
+        void opensTheRequestForAdvisorReviewAndAttachesItsItems() {
+            stubWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+
+            ChangeRequest created =
+                    service.createChangeRequest(dto().parts(List.of(CreateChangeRequestDTO.WorkorderItemDTO.builder()
+                                    .productEntityId(PRODUCT_ID)
+                                    .quantity(2)
+                                    .build()))
+                            .build());
+
+            assertThat(created.getStatus()).isEqualTo(ChangeRequest.ChangeRequestStatus.AWAITING_ADVISOR_REVIEW);
+            assertThat(created.getRequestedByUserId()).isEqualTo("jane.smith");
+            assertThat(created.getRequestedAt()).isEqualTo(NOW_LOCAL);
+
+            ArgumentCaptor<WorkorderServiceLine> savedService = ArgumentCaptor.forClass(WorkorderServiceLine.class);
+            verify(workOrderServiceRepository).save(savedService.capture());
+            assertThat(savedService.getValue().getStatus()).isEqualTo(WorkorderItemStatus.PENDING_APPROVAL);
+            assertThat(savedService.getValue().getServiceEntityId()).isEqualTo(SERVICE_ENTITY_ID);
+
+            ArgumentCaptor<WorkorderPart> savedPart = ArgumentCaptor.forClass(WorkorderPart.class);
+            verify(workOrderPartRepository).save(savedPart.capture());
+            assertThat(savedPart.getValue().getStatus()).isEqualTo(WorkorderItemStatus.PENDING_APPROVAL);
+            assertThat(savedPart.getValue().getQuantity()).isEqualByComparingTo("2");
+        }
+
+        @Test
+        void survivesAnUnreachableDocumentServiceWithoutAPdfReference() {
+            stubWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+
+            assertThat(service.createChangeRequest(dto().build()).getSupplementalEstimatePdfId())
+                    .isNull();
+        }
+
+        @Test
+        void requiresADescription() {
+            CreateChangeRequestDTO request = dto().description("  ").build();
+
+            assertThatThrownBy(() -> service.createChangeRequest(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Description is required");
+        }
+
+        @Test
+        void requiresAtLeastOneServiceOrPart() {
+            CreateChangeRequestDTO request =
+                    dto().services(List.of()).parts(List.of()).build();
+
+            assertThatThrownBy(() -> service.createChangeRequest(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("At least one service or part");
+        }
+
+        @Test
+        void failsForAnUnknownWorkorder() {
+            when(workOrderRepository.findById(WORKORDER_ID)).thenReturn(Optional.empty());
+            CreateChangeRequestDTO request = dto().build();
+
+            assertThatThrownBy(() -> service.createChangeRequest(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Work order not found");
+        }
+
+        @Test
+        void refusesAWorkorderThatIsNotInProgress() {
+            stubWorkorder(WorkorderStatus.COMPLETED);
+            CreateChangeRequestDTO request = dto().build();
+
+            assertThatThrownBy(() -> service.createChangeRequest(request))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("WORK_IN_PROGRESS");
+        }
+    }
+
+    @Nested
+    @DisplayName("emergency documentation")
+    class EmergencyDocumentation {
+
+        @Test
+        void refusesAnEmergencyExceptionWithNoEmergencyItems() {
+            stubWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+            CreateChangeRequestDTO request = dto().isEmergencyException(true)
+                    .exceptionReason("brake failure")
+                    .build();
+
+            assertThatThrownBy(() -> service.createChangeRequest(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("no items are marked as emergency/safety");
+        }
+
+        @Test
+        void requiresPhotoEvidenceOrAnExplicitPhotoNotPossibleFlag() {
+            stubWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+            CreateChangeRequestDTO request = dto().isEmergencyException(true)
+                    .services(List.of(CreateChangeRequestDTO.WorkorderItemDTO.builder()
+                            .serviceEntityId(SERVICE_ENTITY_ID)
+                            .isEmergencySafety(true)
+                            .build()))
+                    .build();
+
+            assertThatThrownBy(() -> service.createChangeRequest(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("photo evidence");
+        }
+
+        @Test
+        void requiresNotesWhenNoPhotoIsPossible() {
+            stubWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+            CreateChangeRequestDTO request = dto().isEmergencyException(true)
+                    .services(List.of(CreateChangeRequestDTO.WorkorderItemDTO.builder()
+                            .serviceEntityId(SERVICE_ENTITY_ID)
+                            .isEmergencySafety(true)
+                            .photoNotPossible(true)
+                            .build()))
+                    .build();
+
+            assertThatThrownBy(() -> service.createChangeRequest(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("notes explaining the situation");
+        }
+
+        @Test
+        void acceptsAnEmergencyItemWithAPhoto() {
+            stubWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+
+            ChangeRequest created = service.createChangeRequest(dto().isEmergencyException(true)
+                    .exceptionReason("brake failure")
+                    .services(List.of(CreateChangeRequestDTO.WorkorderItemDTO.builder()
+                            .serviceEntityId(SERVICE_ENTITY_ID)
+                            .isEmergencySafety(true)
+                            .photoEvidenceUrl("https://example.invalid/rotor.jpg")
+                            .build()))
+                    .build());
+
+            assertThat(created.getIsEmergencyException()).isTrue();
+            assertThat(created.getExceptionReason()).isEqualTo("brake failure");
+        }
+
+        @Test
+        void acceptsAnEmergencyPartWithNotesInsteadOfAPhoto() {
+            stubWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+
+            assertThat(service.createChangeRequest(dto().isEmergencyException(true)
+                            .services(List.of())
+                            .parts(List.of(CreateChangeRequestDTO.WorkorderItemDTO.builder()
+                                    .productEntityId(PRODUCT_ID)
+                                    .isEmergencySafety(true)
+                                    .photoNotPossible(true)
+                                    .emergencyNotes("bay lighting too poor to photograph")
+                                    .build()))
+                            .build()))
+                    .isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("createChangeRequestWithIdempotency")
+    class CreateWithIdempotency {
+
+        @Test
+        void replaysTheOriginalRequestForAKnownKey() {
+            when(idempotencyService.getExistingChangeRequestId(anyString(), anyString()))
+                    .thenReturn(Optional.of(CHANGE_REQUEST_ID));
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID))
+                    .thenReturn(Optional.of(changeRequest(ChangeRequest.ChangeRequestStatus.AWAITING_ADVISOR_REVIEW)));
+
+            ChangeRequest replayed = service.createChangeRequestWithIdempotency(dto().build(), "cr-key-1");
+
+            assertThat(replayed.getId()).isEqualTo(CHANGE_REQUEST_ID);
+            verify(workOrderRepository, never()).findById(any());
+        }
+
+        @Test
+        void failsWhenTheReplayedRequestIsGone() {
+            when(idempotencyService.getExistingChangeRequestId(anyString(), anyString()))
+                    .thenReturn(Optional.of(CHANGE_REQUEST_ID));
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID)).thenReturn(Optional.empty());
+            CreateChangeRequestDTO request = dto().build();
+
+            assertThatThrownBy(() -> service.createChangeRequestWithIdempotency(request, "cr-key-1"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("non-existent change request");
+        }
+
+        @Test
+        void createsNormallyWhenNoKeyIsSupplied() {
+            stubWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+
+            assertThat(service.createChangeRequestWithIdempotency(dto().build(), "  "))
+                    .isNotNull();
+            verify(idempotencyService, never()).getExistingChangeRequestId(anyString(), anyString());
+            verify(idempotencyService, never()).markKeyProcessedForChangeRequest(anyString(), anyString(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("advisor decisions")
+    class AdvisorDecisions {
+
+        @Test
+        void approvalRecordsTheDecisionAndReleasesTheItems() {
+            ChangeRequest pending = changeRequest(ChangeRequest.ChangeRequestStatus.AWAITING_ADVISOR_REVIEW);
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID)).thenReturn(Optional.of(pending));
+            WorkorderServiceLine line = WorkorderServiceLine.builder()
+                    .status(WorkorderItemStatus.PENDING_APPROVAL)
+                    .build();
+            when(workOrderServiceRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID))
+                    .thenReturn(List.of(line));
+
+            ChangeRequest approved = service.approveChangeRequest(CHANGE_REQUEST_ID, APPROVER_ID, "go ahead");
+
+            assertThat(approved.getStatus()).isEqualTo(ChangeRequest.ChangeRequestStatus.APPROVED);
+            assertThat(approved.getApprovedBy()).isEqualTo("jane.smith");
+            assertThat(approved.getApprovedAt()).isEqualTo(NOW_LOCAL);
+            assertThat(line.getStatus()).isEqualTo(WorkorderItemStatus.READY_TO_EXECUTE);
+
+            ArgumentCaptor<ApprovalRecord> record = ArgumentCaptor.forClass(ApprovalRecord.class);
+            verify(approvalRecordRepository).save(record.capture());
+            assertThat(record.getValue().getResolutionStatus()).isEqualTo(ApprovalRecord.ResolutionStatus.APPROVED);
+            assertThat(record.getValue().getApprovalNote()).isEqualTo("go ahead");
+        }
+
+        @Test
+        void declineCancelsTheAttachedItems() {
+            ChangeRequest pending = changeRequest(ChangeRequest.ChangeRequestStatus.AWAITING_ADVISOR_REVIEW);
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID)).thenReturn(Optional.of(pending));
+            WorkorderPart part = WorkorderPart.builder()
+                    .status(WorkorderItemStatus.PENDING_APPROVAL)
+                    .build();
+            when(workOrderPartRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID))
+                    .thenReturn(List.of(part));
+
+            ChangeRequest declined = service.declineChangeRequest(CHANGE_REQUEST_ID, "customer declined");
+
+            assertThat(declined.getStatus()).isEqualTo(ChangeRequest.ChangeRequestStatus.DECLINED);
+            assertThat(declined.getDeclinedAt()).isEqualTo(NOW_LOCAL);
+            assertThat(part.getStatus()).isEqualTo(WorkorderItemStatus.CANCELLED);
+
+            ArgumentCaptor<ApprovalRecord> record = ArgumentCaptor.forClass(ApprovalRecord.class);
+            verify(approvalRecordRepository).save(record.capture());
+            assertThat(record.getValue().getResolutionStatus()).isEqualTo(ApprovalRecord.ResolutionStatus.REJECTED);
+        }
+
+        @Test
+        void bothDecisionsRequireANote() {
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID))
+                    .thenReturn(Optional.of(changeRequest(ChangeRequest.ChangeRequestStatus.AWAITING_ADVISOR_REVIEW)));
+
+            assertThatThrownBy(() -> service.approveChangeRequest(CHANGE_REQUEST_ID, APPROVER_ID, "  "))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Approval note is required");
+            assertThatThrownBy(() -> service.declineChangeRequest(CHANGE_REQUEST_ID, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Approval note is required");
+        }
+
+        @Test
+        void bothDecisionsRefuseARequestThatIsNoLongerPending() {
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID))
+                    .thenReturn(Optional.of(changeRequest(ChangeRequest.ChangeRequestStatus.APPROVED)));
+
+            assertThatThrownBy(() -> service.approveChangeRequest(CHANGE_REQUEST_ID, APPROVER_ID, "note"))
+                    .isInstanceOf(IllegalStateException.class);
+            assertThatThrownBy(() -> service.declineChangeRequest(CHANGE_REQUEST_ID, "note"))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void bothDecisionsFailForAnUnknownRequest() {
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.approveChangeRequest(CHANGE_REQUEST_ID, APPROVER_ID, "note"))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> service.declineChangeRequest(CHANGE_REQUEST_ID, "note"))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> service.applyEmergencyOverride(CHANGE_REQUEST_ID, "reason"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void emergencyOverrideApprovesWithAnExceptionAndItsReason() {
+            ChangeRequest pending = changeRequest(ChangeRequest.ChangeRequestStatus.AWAITING_ADVISOR_REVIEW);
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID)).thenReturn(Optional.of(pending));
+
+            ChangeRequest overridden = service.applyEmergencyOverride(CHANGE_REQUEST_ID, "brake failure");
+
+            assertThat(overridden.getStatus()).isEqualTo(ChangeRequest.ChangeRequestStatus.APPROVED_WITH_EXCEPTION);
+            assertThat(overridden.getIsEmergencyException()).isTrue();
+            assertThat(overridden.getExceptionReason()).isEqualTo("brake failure");
+
+            ArgumentCaptor<ApprovalRecord> record = ArgumentCaptor.forClass(ApprovalRecord.class);
+            verify(approvalRecordRepository).save(record.capture());
+            assertThat(record.getValue().getResolutionStatus())
+                    .isEqualTo(ApprovalRecord.ResolutionStatus.APPROVED_WITH_EXCEPTION);
+        }
+
+        @Test
+        void emergencyOverrideRequiresAReasonAndAPendingRequest() {
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID))
+                    .thenReturn(Optional.of(changeRequest(ChangeRequest.ChangeRequestStatus.AWAITING_ADVISOR_REVIEW)));
+            assertThatThrownBy(() -> service.applyEmergencyOverride(CHANGE_REQUEST_ID, "  "))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Exception reason is required");
+
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID))
+                    .thenReturn(Optional.of(changeRequest(ChangeRequest.ChangeRequestStatus.DECLINED)));
+            assertThatThrownBy(() -> service.applyEmergencyOverride(CHANGE_REQUEST_ID, "brake failure"))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void everyDecisionRequiresAnAuthenticatedActor() {
+            SecurityContextHolder.clearContext();
+
+            assertThatThrownBy(() -> service.approveChangeRequest(CHANGE_REQUEST_ID, APPROVER_ID, "note"))
+                    .isInstanceOf(IllegalStateException.class);
+            assertThatThrownBy(() -> service.declineChangeRequest(CHANGE_REQUEST_ID, "note"))
+                    .isInstanceOf(IllegalStateException.class);
+            assertThatThrownBy(() -> service.applyEmergencyOverride(CHANGE_REQUEST_ID, "reason"))
+                    .isInstanceOf(IllegalStateException.class);
+            verify(changeRequestRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("denial acknowledgment and close gating")
+    class DenialAndClosing {
+
+        @Test
+        void acknowledgesDenialOnEveryEmergencyItem() {
+            ChangeRequest declined = changeRequest(ChangeRequest.ChangeRequestStatus.DECLINED);
+            declined.setIsEmergencyException(true);
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID)).thenReturn(Optional.of(declined));
+            WorkorderServiceLine emergencyService =
+                    WorkorderServiceLine.builder().isEmergencySafety(true).build();
+            WorkorderServiceLine routineService =
+                    WorkorderServiceLine.builder().isEmergencySafety(false).build();
+            WorkorderPart emergencyPart =
+                    WorkorderPart.builder().isEmergencySafety(true).build();
+            when(workOrderServiceRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID))
+                    .thenReturn(List.of(emergencyService, routineService));
+            when(workOrderPartRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID))
+                    .thenReturn(List.of(emergencyPart));
+
+            service.recordCustomerDenialAcknowledgment(CHANGE_REQUEST_ID);
+
+            assertThat(emergencyService.getCustomerDenialAcknowledged()).isTrue();
+            assertThat(routineService.getCustomerDenialAcknowledged()).isNotEqualTo(true);
+            assertThat(emergencyPart.getCustomerDenialAcknowledged()).isTrue();
+        }
+
+        @Test
+        void refusesAcknowledgmentForANonEmergencyOrStillOpenRequest() {
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID))
+                    .thenReturn(Optional.of(changeRequest(ChangeRequest.ChangeRequestStatus.DECLINED)));
+            assertThatThrownBy(() -> service.recordCustomerDenialAcknowledgment(CHANGE_REQUEST_ID))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("not marked as emergency/safety");
+
+            ChangeRequest stillOpen = changeRequest(ChangeRequest.ChangeRequestStatus.AWAITING_ADVISOR_REVIEW);
+            stillOpen.setIsEmergencyException(true);
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID)).thenReturn(Optional.of(stillOpen));
+            assertThatThrownBy(() -> service.recordCustomerDenialAcknowledgment(CHANGE_REQUEST_ID))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("must be declined");
+        }
+
+        @Test
+        void blocksClosingWhileAnEmergencyDenialIsUnacknowledged() {
+            ChangeRequest declined = changeRequest(ChangeRequest.ChangeRequestStatus.DECLINED);
+            declined.setIsEmergencyException(true);
+            when(changeRequestRepository.findByWorkorder_IdAndStatus(
+                            WORKORDER_ID, ChangeRequest.ChangeRequestStatus.DECLINED))
+                    .thenReturn(List.of(declined));
+            when(workOrderServiceRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID))
+                    .thenReturn(List.of(WorkorderServiceLine.builder()
+                            .isEmergencySafety(true)
+                            .build()));
+
+            assertThat(service.canCloseWorkorder(WORKORDER_ID)).isFalse();
+        }
+
+        @Test
+        void allowsClosingOnceEveryEmergencyDenialIsAcknowledged() {
+            ChangeRequest declined = changeRequest(ChangeRequest.ChangeRequestStatus.DECLINED);
+            declined.setIsEmergencyException(true);
+            when(changeRequestRepository.findByWorkorder_IdAndStatus(
+                            WORKORDER_ID, ChangeRequest.ChangeRequestStatus.DECLINED))
+                    .thenReturn(List.of(declined));
+            when(workOrderServiceRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID))
+                    .thenReturn(List.of(WorkorderServiceLine.builder()
+                            .isEmergencySafety(true)
+                            .customerDenialAcknowledged(true)
+                            .build()));
+            when(workOrderPartRepository.findByChangeRequest_Id(CHANGE_REQUEST_ID))
+                    .thenReturn(List.of(WorkorderPart.builder()
+                            .isEmergencySafety(true)
+                            .customerDenialAcknowledged(true)
+                            .build()));
+
+            assertThat(service.canCloseWorkorder(WORKORDER_ID)).isTrue();
+        }
+
+        @Test
+        void ignoresNonEmergencyDeclinesWhenGatingTheClose() {
+            when(changeRequestRepository.findByWorkorder_IdAndStatus(
+                            WORKORDER_ID, ChangeRequest.ChangeRequestStatus.DECLINED))
+                    .thenReturn(List.of(changeRequest(ChangeRequest.ChangeRequestStatus.DECLINED)));
+
+            assertThat(service.canCloseWorkorder(WORKORDER_ID)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        void reportsOnlyApprovalGatedPendingRequests() {
+            ChangeRequest gated = changeRequest(ChangeRequest.ChangeRequestStatus.AWAITING_ADVISOR_REVIEW);
+            ChangeRequest ungated = changeRequest(ChangeRequest.ChangeRequestStatus.AWAITING_ADVISOR_REVIEW);
+            ungated.setIsApprovalGated(false);
+            when(changeRequestRepository.findByWorkorder_IdAndStatus(
+                            WORKORDER_ID, ChangeRequest.ChangeRequestStatus.AWAITING_ADVISOR_REVIEW))
+                    .thenReturn(List.of(gated, ungated));
+
+            assertThat(service.hasPendingApprovalGatedRequests(WORKORDER_ID)).isTrue();
+            assertThat(service.getPendingApprovalGatedRequests(WORKORDER_ID)).containsExactly(gated);
+        }
+
+        @Test
+        void reportsNoPendingGateWhenEveryRequestIsUngated() {
+            ChangeRequest ungated = changeRequest(ChangeRequest.ChangeRequestStatus.AWAITING_ADVISOR_REVIEW);
+            ungated.setIsApprovalGated(false);
+            when(changeRequestRepository.findByWorkorder_IdAndStatus(
+                            WORKORDER_ID, ChangeRequest.ChangeRequestStatus.AWAITING_ADVISOR_REVIEW))
+                    .thenReturn(List.of(ungated));
+
+            assertThat(service.hasPendingApprovalGatedRequests(WORKORDER_ID)).isFalse();
+            assertThat(service.getPendingApprovalGatedRequests(WORKORDER_ID)).isEmpty();
+        }
+
+        @Test
+        void listsAWorkordersChangeRequests() {
+            when(changeRequestRepository.findByWorkorder_Id(WORKORDER_ID))
+                    .thenReturn(List.of(changeRequest(ChangeRequest.ChangeRequestStatus.APPROVED)));
+
+            assertThat(service.getChangeRequestsByWorkorder(WORKORDER_ID)).hasSize(1);
+        }
+
+        @Test
+        void readsOneChangeRequestById() {
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID))
+                    .thenReturn(Optional.of(changeRequest(ChangeRequest.ChangeRequestStatus.APPROVED)));
+
+            assertThat(service.getChangeRequestById(CHANGE_REQUEST_ID).getId()).isEqualTo(CHANGE_REQUEST_ID);
+        }
+
+        @Test
+        void failsForAnUnknownChangeRequestId() {
+            when(changeRequestRepository.findById(CHANGE_REQUEST_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getChangeRequestById(CHANGE_REQUEST_ID))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Change request not found");
+        }
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateApprovalLifecycleTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateApprovalLifecycleTest.java
@@ -1,0 +1,915 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.client.DocumentClient;
+import com.positivity.workorder.internal.client.TaxClient;
+import com.positivity.workorder.internal.dto.CreateEstimateFromAppointmentRequest;
+import com.positivity.workorder.internal.dto.CreateEstimateFromAppointmentResponse;
+import com.positivity.workorder.internal.dto.EstimateResponse;
+import com.positivity.workorder.internal.dto.EstimateSnapshotResponse;
+import com.positivity.workorder.internal.dto.EstimateSummaryResponse;
+import com.positivity.workorder.internal.dto.LineItemApprovalDto;
+import com.positivity.workorder.internal.entity.ApprovalConfiguration;
+import com.positivity.workorder.internal.entity.Estimate;
+import com.positivity.workorder.internal.entity.EstimateItem;
+import com.positivity.workorder.internal.entity.EstimateItemType;
+import com.positivity.workorder.internal.entity.EstimateSnapshot;
+import com.positivity.workorder.internal.enums.ApprovalStatus;
+import com.positivity.workorder.internal.enums.EstimateStatus;
+import com.positivity.workorder.internal.repository.ApprovalConfigurationRepository;
+import com.positivity.workorder.internal.repository.EstimateItemRepository;
+import com.positivity.workorder.internal.repository.EstimateRepository;
+import com.positivity.workorder.internal.repository.EstimateSnapshotRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.service.BillingRulesClientService;
+import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Estimate approval lifecycle: submit for approval (CAP:003 issue #168), selective line-item
+ * approval (CAP:003), purchase-order enforcement for commercial accounts (CAP:092 story #98),
+ * decline / reopen inside the configured expiry window, approval-window expiration
+ * (CAP:003 issue #204), snapshots, PDF rendering, and estimate creation from an appointment.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("EstimateServiceImpl approval lifecycle")
+class EstimateApprovalLifecycleTest {
+
+    private static final UUID ESTIMATE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3311");
+    private static final UUID CUSTOMER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3312");
+    private static final UUID OTHER_CUSTOMER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3313");
+    private static final UUID VEHICLE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3314");
+    private static final UUID LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3315");
+    private static final UUID CONFIG_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3316");
+    private static final UUID ITEM_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3317");
+    private static final UUID OTHER_ITEM_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3318");
+    private static final UUID APPOINTMENT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f3319");
+    private static final UUID SNAPSHOT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f331a");
+
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final LocalDateTime NOW_LOCAL = LocalDateTime.ofInstant(NOW, ZoneOffset.UTC);
+
+    @Mock
+    private EstimateRepository estimateRepository;
+
+    @Mock
+    private EstimateItemRepository estimateItemRepository;
+
+    @Mock
+    private EstimateSnapshotRepository estimateSnapshotRepository;
+
+    @Mock
+    private ApprovalConfigurationRepository approvalConfigurationRepository;
+
+    @Mock
+    private WorkorderRepository workOrderRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private BillingRulesClientService billingRulesClientService;
+
+    @Mock
+    private TaxClient taxClient;
+
+    @Mock
+    private LocationReferenceService locationReferenceService;
+
+    @Mock
+    private PeopleAvailabilityLocalService peopleAvailabilityLocalService;
+
+    @Mock
+    private DocumentClient documentClient;
+
+    @Mock
+    private CustomerReferenceService customerReferenceService;
+
+    @Mock
+    private VehicleReferenceService vehicleReferenceService;
+
+    @Mock
+    private EstimateFactPublisher estimateFactPublisher;
+
+    private EstimateServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new EstimateServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                estimateRepository,
+                estimateItemRepository,
+                estimateSnapshotRepository,
+                approvalConfigurationRepository,
+                workOrderRepository,
+                eventPublisher,
+                billingRulesClientService,
+                taxClient,
+                locationReferenceService,
+                peopleAvailabilityLocalService,
+                documentClient,
+                new ObjectMapper(),
+                customerReferenceService,
+                vehicleReferenceService,
+                estimateFactPublisher);
+
+        when(estimateRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(estimateItemRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(estimateItemRepository.findByEstimate_IdAndDeletedFalse(ESTIMATE_ID))
+                .thenReturn(List.of());
+        when(estimateSnapshotRepository.save(any())).thenAnswer(invocation -> {
+            EstimateSnapshot snapshot = invocation.getArgument(0);
+            if (snapshot.getId() == null) {
+                // The snapshot id is assigned by the persistence provider and has no setter.
+                ReflectionTestUtils.setField(snapshot, "id", SNAPSHOT_ID);
+            }
+            return snapshot;
+        });
+        when(billingRulesClientService.isPurchaseOrderRequired(any())).thenReturn(false);
+    }
+
+    private Estimate estimate(EstimateStatus status) {
+        return Estimate.builder()
+                .id(ESTIMATE_ID)
+                .estimateNumber("EST-0001")
+                .status(status)
+                .customerId(CUSTOMER_ID)
+                .vehicleId(VEHICLE_ID)
+                .locationId(LOCATION_ID)
+                .subtotal(new BigDecimal("100.00"))
+                .taxAmount(new BigDecimal("8.25"))
+                .total(new BigDecimal("108.25"))
+                .currencyUomId("USD")
+                .build();
+    }
+
+    private void givenEstimate(Estimate estimate) {
+        when(estimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.of(estimate));
+    }
+
+    private EstimateItem item(UUID id, EstimateItemType type) {
+        return EstimateItem.builder()
+                .id(id)
+                .estimate(new Estimate(ESTIMATE_ID))
+                .itemType(type)
+                .description(type == EstimateItemType.PART ? "Brake pad set" : "Brake replacement")
+                .quantity(new BigDecimal("2"))
+                .unitPrice(new BigDecimal("25.00"))
+                .lineTotal(new BigDecimal("50.00"))
+                .approvalStatus(ApprovalStatus.PENDING_APPROVAL)
+                .build();
+    }
+
+    private void givenItems(EstimateItem... items) {
+        when(estimateItemRepository.findByEstimate_IdAndDeletedFalse(ESTIMATE_ID))
+                .thenReturn(List.of(items));
+    }
+
+    private void givenApprovalConfiguration(ApprovalConfiguration configuration) {
+        when(approvalConfigurationRepository.findById(CONFIG_ID)).thenReturn(Optional.of(configuration));
+    }
+
+    @Nested
+    @DisplayName("approveEstimate")
+    class ApproveEstimate {
+
+        @Test
+        @DisplayName("stamps approval on a PENDING_APPROVAL estimate")
+        void approvesPendingEstimate() {
+            givenEstimate(estimate(EstimateStatus.PENDING_APPROVAL));
+
+            EstimateResponse response = service.approveEstimate(ESTIMATE_ID, CUSTOMER_ID);
+
+            assertThat(response.getStatus()).isEqualTo("APPROVED");
+            assertThat(response.getApprovedAt()).isEqualTo(NOW_LOCAL);
+            assertThat(response.getApprovedBy()).isEqualTo(CUSTOMER_ID);
+            verify(estimateFactPublisher).markChanged(ESTIMATE_ID);
+        }
+
+        @Test
+        @DisplayName("refuses an estimate that is not awaiting approval")
+        void rejectsNonPendingEstimate() {
+            givenEstimate(estimate(EstimateStatus.DRAFT));
+
+            assertThatThrownBy(() -> service.approveEstimate(ESTIMATE_ID, CUSTOMER_ID))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Estimate cannot be approved in current state: DRAFT");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown estimate")
+        void rejectsUnknownEstimate() {
+            when(estimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.approveEstimate(ESTIMATE_ID, CUSTOMER_ID))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessageContaining("Estimate not found");
+        }
+
+        @Test
+        @DisplayName("captures the signature payload on the approved estimate")
+        void capturesSignature() {
+            givenEstimate(estimate(EstimateStatus.PENDING_APPROVAL));
+
+            EstimateResponse response = service.approveEstimate(
+                    ESTIMATE_ID, CUSTOMER_ID, "base64-signature", "image/png", "Jane Smith", "approved in bay");
+
+            assertThat(response.getStatus()).isEqualTo("APPROVED");
+            assertThat(response.getSignatureData()).isEqualTo("base64-signature");
+            assertThat(response.getSignatureMimeType()).isEqualTo("image/png");
+            assertThat(response.getSignerName()).isEqualTo("Jane Smith");
+            assertThat(response.getApprovalNotes()).isEqualTo("approved in bay");
+        }
+
+        @Test
+        @DisplayName("refuses an approval attempted by a different customer")
+        void rejectsCustomerMismatch() {
+            givenEstimate(estimate(EstimateStatus.PENDING_APPROVAL));
+
+            assertThatThrownBy(() -> service.approveEstimate(
+                            ESTIMATE_ID, OTHER_CUSTOMER_ID, "sig", "image/png", "Someone Else", null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Customer ID mismatch");
+        }
+
+        @Test
+        @DisplayName("records the purchase order when the account requires one")
+        void recordsPurchaseOrder() {
+            givenEstimate(estimate(EstimateStatus.PENDING_APPROVAL));
+            when(billingRulesClientService.isPurchaseOrderRequired(String.valueOf(CUSTOMER_ID)))
+                    .thenReturn(true);
+
+            EstimateResponse response = service.approveEstimate(
+                    ESTIMATE_ID, CUSTOMER_ID, "sig", "image/png", "Jane Smith", null, "PO-4711");
+
+            assertThat(response.getPurchaseOrderNumber()).isEqualTo("PO-4711");
+            assertThat(response.getStatus()).isEqualTo("APPROVED");
+        }
+
+        @Test
+        @DisplayName("refuses approval when a required purchase order is missing or blank")
+        void rejectsMissingPurchaseOrder() {
+            givenEstimate(estimate(EstimateStatus.PENDING_APPROVAL));
+            when(billingRulesClientService.isPurchaseOrderRequired(String.valueOf(CUSTOMER_ID)))
+                    .thenReturn(true);
+
+            assertThatThrownBy(() -> service.approveEstimate(
+                            ESTIMATE_ID, CUSTOMER_ID, "sig", "image/png", "Jane Smith", null, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Purchase order number is required for this customer account");
+
+            assertThatThrownBy(() -> service.approveEstimate(
+                            ESTIMATE_ID, CUSTOMER_ID, "sig", "image/png", "Jane Smith", null, "   "))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Purchase order number is required for this customer account");
+            verify(estimateRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("approves every line item when no selective decisions are supplied")
+        void approvesAllItemsByDefault() {
+            givenEstimate(estimate(EstimateStatus.PENDING_APPROVAL));
+            EstimateItem part = item(ITEM_ID, EstimateItemType.PART);
+            EstimateItem labor = item(OTHER_ITEM_ID, EstimateItemType.LABOR);
+            givenItems(part, labor);
+
+            service.approveEstimate(ESTIMATE_ID, CUSTOMER_ID, "sig", "image/png", "Jane Smith", null);
+
+            assertThat(part.getApprovalStatus()).isEqualTo(ApprovalStatus.APPROVED);
+            assertThat(part.getApprovalTimestamp()).isEqualTo(NOW_LOCAL);
+            assertThat(labor.getApprovalStatus()).isEqualTo(ApprovalStatus.APPROVED);
+        }
+
+        @Test
+        @DisplayName("applies selective approvals and declines with a reason")
+        void appliesSelectiveApprovals() {
+            givenEstimate(estimate(EstimateStatus.PENDING_APPROVAL));
+            EstimateItem approved = item(ITEM_ID, EstimateItemType.PART);
+            EstimateItem declined = item(OTHER_ITEM_ID, EstimateItemType.LABOR);
+            givenItems(approved, declined);
+
+            service.approveEstimate(
+                    ESTIMATE_ID,
+                    CUSTOMER_ID,
+                    "sig",
+                    "image/png",
+                    "Jane Smith",
+                    null,
+                    null,
+                    List.of(
+                            LineItemApprovalDto.builder()
+                                    .lineItemId(ITEM_ID)
+                                    .approved(true)
+                                    .notes("go ahead")
+                                    .build(),
+                            LineItemApprovalDto.builder()
+                                    .lineItemId(OTHER_ITEM_ID)
+                                    .approved(false)
+                                    .rejectionReason("second opinion wanted")
+                                    .build()));
+
+            assertThat(approved.getApprovalStatus()).isEqualTo(ApprovalStatus.APPROVED);
+            assertThat(approved.getApprovalNotes()).isEqualTo("go ahead");
+            assertThat(approved.getApprovalTimestamp()).isEqualTo(NOW_LOCAL);
+
+            assertThat(declined.getApprovalStatus()).isEqualTo(ApprovalStatus.DECLINED);
+            assertThat(declined.getRejectionReason()).isEqualTo("second opinion wanted");
+        }
+
+        @Test
+        @DisplayName("implicitly approves items left out of the selective decision list")
+        void implicitlyApprovesUndecidedItems() {
+            givenEstimate(estimate(EstimateStatus.PENDING_APPROVAL));
+            EstimateItem decided = item(ITEM_ID, EstimateItemType.PART);
+            EstimateItem undecided = item(OTHER_ITEM_ID, EstimateItemType.LABOR);
+            givenItems(decided, undecided);
+
+            service.approveEstimate(
+                    ESTIMATE_ID,
+                    CUSTOMER_ID,
+                    "sig",
+                    "image/png",
+                    "Jane Smith",
+                    null,
+                    null,
+                    List.of(LineItemApprovalDto.builder()
+                            .lineItemId(ITEM_ID)
+                            .approved(true)
+                            .build()));
+
+            assertThat(undecided.getApprovalStatus()).isEqualTo(ApprovalStatus.APPROVED);
+            assertThat(undecided.getApprovalNotes()).isNull();
+        }
+
+        @Test
+        @DisplayName("treats an empty selective decision list as approve-all")
+        void emptyApprovalListApprovesAll() {
+            givenEstimate(estimate(EstimateStatus.PENDING_APPROVAL));
+            EstimateItem part = item(ITEM_ID, EstimateItemType.PART);
+            givenItems(part);
+
+            service.approveEstimate(ESTIMATE_ID, CUSTOMER_ID, "sig", "image/png", "Jane Smith", null, null, List.of());
+
+            assertThat(part.getApprovalStatus()).isEqualTo(ApprovalStatus.APPROVED);
+        }
+    }
+
+    @Nested
+    @DisplayName("declineEstimate and reopenEstimate")
+    class DeclineAndReopen {
+
+        @Test
+        @DisplayName("declines and sets the expiry from the approval configuration")
+        void declinesWithConfiguredExpiry() {
+            Estimate estimate = estimate(EstimateStatus.PENDING_APPROVAL);
+            estimate.setApprovalConfigurationId(CONFIG_ID);
+            givenEstimate(estimate);
+            givenApprovalConfiguration(
+                    ApprovalConfiguration.builder().declineExpiryDays(14).build());
+
+            EstimateResponse response = service.declineEstimate(ESTIMATE_ID, "too expensive");
+
+            assertThat(response.getStatus()).isEqualTo("DECLINED");
+            assertThat(response.getExpiresAt()).isEqualTo(NOW_LOCAL.plusDays(14));
+            assertThat(estimate.getDeclineReason()).isEqualTo("too expensive");
+            assertThat(estimate.getDeclinedAt()).isEqualTo(NOW_LOCAL);
+            verify(estimateFactPublisher).markChanged(ESTIMATE_ID);
+        }
+
+        @Test
+        @DisplayName("falls back to the 30-day default when no configuration is linked")
+        void declinesWithDefaultExpiry() {
+            givenEstimate(estimate(EstimateStatus.DRAFT));
+
+            EstimateResponse response = service.declineEstimate(ESTIMATE_ID, "changed mind");
+
+            assertThat(response.getExpiresAt()).isEqualTo(NOW_LOCAL.plusDays(30));
+        }
+
+        @Test
+        @DisplayName("refuses to decline an estimate in a terminal state")
+        void rejectsUndeclinableEstimate() {
+            givenEstimate(estimate(EstimateStatus.EXPIRED));
+
+            assertThatThrownBy(() -> service.declineEstimate(ESTIMATE_ID, "reason"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Estimate cannot be declined in current state: EXPIRED");
+        }
+
+        @Test
+        @DisplayName("rejects declining an unknown estimate")
+        void rejectsUnknownEstimate() {
+            when(estimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.declineEstimate(ESTIMATE_ID, "reason"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Estimate not found");
+        }
+
+        @Test
+        @DisplayName("reopens a declined estimate inside the expiry window and clears the decline")
+        void reopensWithinWindow() {
+            Estimate estimate = estimate(EstimateStatus.DECLINED);
+            estimate.setDeclinedAt(NOW_LOCAL.minusDays(3));
+            estimate.setDeclineReason("too expensive");
+            estimate.setExpiresAt(NOW_LOCAL.plusDays(27));
+            givenEstimate(estimate);
+
+            EstimateResponse response = service.reopenEstimate(ESTIMATE_ID);
+
+            assertThat(response.getStatus()).isEqualTo("DRAFT");
+            assertThat(response.getExpiresAt()).isNull();
+            assertThat(estimate.getDeclinedAt()).isNull();
+            assertThat(estimate.getDeclineReason()).isNull();
+        }
+
+        @Test
+        @DisplayName("refuses to reopen once the expiry window has passed")
+        void rejectsReopenAfterWindow() {
+            Estimate estimate = estimate(EstimateStatus.DECLINED);
+            estimate.setDeclinedAt(NOW_LOCAL.minusDays(45));
+            givenEstimate(estimate);
+
+            assertThatThrownBy(() -> service.reopenEstimate(ESTIMATE_ID))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("either not declined or expiry period has passed");
+        }
+
+        @Test
+        @DisplayName("refuses to reopen an estimate that was never declined")
+        void rejectsReopenOfNonDeclined() {
+            givenEstimate(estimate(EstimateStatus.DRAFT));
+
+            assertThatThrownBy(() -> service.reopenEstimate(ESTIMATE_ID))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("either not declined or expiry period has passed");
+        }
+
+        @Test
+        @DisplayName("fails when the linked approval configuration is missing")
+        void failsOnMissingConfiguration() {
+            Estimate estimate = estimate(EstimateStatus.DECLINED);
+            estimate.setApprovalConfigurationId(CONFIG_ID);
+            estimate.setDeclinedAt(NOW_LOCAL.minusDays(1));
+            givenEstimate(estimate);
+            when(approvalConfigurationRepository.findById(CONFIG_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.reopenEstimate(ESTIMATE_ID))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Approval configuration not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("submitForApproval")
+    class SubmitForApproval {
+
+        @BeforeEach
+        void seedCompleteEstimate() {
+            givenItems(item(ITEM_ID, EstimateItemType.PART));
+        }
+
+        @Test
+        @DisplayName("snapshots the estimate and moves it to PENDING_APPROVAL")
+        void submitsDraft() {
+            givenEstimate(estimate(EstimateStatus.DRAFT));
+
+            EstimateResponse response = service.submitForApproval(ESTIMATE_ID, "jane.smith");
+
+            assertThat(response.getStatus()).isEqualTo("PENDING_APPROVAL");
+            assertThat(response.getSubmittedAt()).isEqualTo(NOW_LOCAL);
+            assertThat(response.getSubmittedBy()).isEqualTo("jane.smith");
+
+            ArgumentCaptor<EstimateSnapshot> captor = ArgumentCaptor.forClass(EstimateSnapshot.class);
+            verify(estimateSnapshotRepository).save(captor.capture());
+            assertThat(captor.getValue().getCapturedById()).isEqualTo("jane.smith");
+            assertThat(captor.getValue().getNotes()).isEqualTo("Submitted for customer approval");
+            assertThat(captor.getValue().getSnapshotData()).contains("EST-0001");
+        }
+
+        @Test
+        @DisplayName("sets the expiry from the configured approval window")
+        void appliesApprovalWindow() {
+            Estimate estimate = estimate(EstimateStatus.DRAFT);
+            estimate.setApprovalConfigurationId(CONFIG_ID);
+            givenEstimate(estimate);
+            givenApprovalConfiguration(
+                    ApprovalConfiguration.builder().approvalWindowDays(7).build());
+
+            assertThat(service.submitForApproval(ESTIMATE_ID, "jane.smith").getExpiresAt())
+                    .isEqualTo(NOW_LOCAL.plusDays(7));
+        }
+
+        @Test
+        @DisplayName("leaves the expiry unset when the configuration has no approval window")
+        void noApprovalWindowLeavesExpiryUnset() {
+            Estimate estimate = estimate(EstimateStatus.DRAFT);
+            estimate.setApprovalConfigurationId(CONFIG_ID);
+            givenEstimate(estimate);
+            givenApprovalConfiguration(
+                    ApprovalConfiguration.builder().approvalWindowDays(0).build());
+
+            assertThat(service.submitForApproval(ESTIMATE_ID, "jane.smith").getExpiresAt())
+                    .isNull();
+        }
+
+        @Test
+        @DisplayName("refuses an estimate that is not a draft")
+        void rejectsNonDraft() {
+            givenEstimate(estimate(EstimateStatus.PENDING_APPROVAL));
+
+            assertThatThrownBy(() -> service.submitForApproval(ESTIMATE_ID, "jane.smith"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("must be in DRAFT state, current state: PENDING_APPROVAL");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown estimate")
+        void rejectsUnknownEstimate() {
+            when(estimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.submitForApproval(ESTIMATE_ID, "jane.smith"))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("refuses an estimate with no customer")
+        void rejectsMissingCustomer() {
+            Estimate estimate = estimate(EstimateStatus.DRAFT);
+            estimate.setCustomerId(null);
+            givenEstimate(estimate);
+
+            assertThatThrownBy(() -> service.submitForApproval(ESTIMATE_ID, "jane.smith"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Cannot submit estimate - no customer assigned");
+        }
+
+        @Test
+        @DisplayName("refuses an estimate with no vehicle")
+        void rejectsMissingVehicle() {
+            Estimate estimate = estimate(EstimateStatus.DRAFT);
+            estimate.setVehicleId(null);
+            givenEstimate(estimate);
+
+            assertThatThrownBy(() -> service.submitForApproval(ESTIMATE_ID, "jane.smith"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Cannot submit estimate - no vehicle assigned");
+        }
+
+        @Test
+        @DisplayName("refuses an estimate with no line items")
+        void rejectsMissingLineItems() {
+            givenEstimate(estimate(EstimateStatus.DRAFT));
+            when(estimateItemRepository.findByEstimate_IdAndDeletedFalse(ESTIMATE_ID))
+                    .thenReturn(List.of());
+
+            assertThatThrownBy(() -> service.submitForApproval(ESTIMATE_ID, "jane.smith"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Cannot submit estimate - no line items added");
+        }
+
+        @Test
+        @DisplayName("refuses an estimate whose totals have not been calculated")
+        void rejectsUncalculatedTotals() {
+            Estimate estimate = estimate(EstimateStatus.DRAFT);
+            estimate.setSubtotal(null);
+            givenEstimate(estimate);
+
+            assertThatThrownBy(() -> service.submitForApproval(ESTIMATE_ID, "jane.smith"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("totals not calculated");
+
+            estimate.setSubtotal(BigDecimal.ZERO);
+            assertThatThrownBy(() -> service.submitForApproval(ESTIMATE_ID, "jane.smith"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("totals not calculated");
+        }
+    }
+
+    @Nested
+    @DisplayName("expirePendingApprovals")
+    class ExpirePendingApprovals {
+
+        @Test
+        @DisplayName("marks every overdue estimate EXPIRED and returns the count")
+        void expiresOverdueEstimates() {
+            Estimate overdue = estimate(EstimateStatus.PENDING_APPROVAL);
+            overdue.setExpiresAt(NOW_LOCAL.minusDays(1));
+            when(estimateRepository.findByStatusAndExpiresAtBefore(EstimateStatus.PENDING_APPROVAL, NOW_LOCAL))
+                    .thenReturn(List.of(overdue));
+
+            assertThat(service.expirePendingApprovals()).isEqualTo(1);
+            assertThat(overdue.getStatus()).isEqualTo(EstimateStatus.EXPIRED);
+            assertThat(overdue.getDeclinedAt()).isEqualTo(NOW_LOCAL);
+            assertThat(overdue.getDeclineReason()).contains("Approval window expired");
+            verify(estimateFactPublisher).markChanged(ESTIMATE_ID);
+        }
+
+        @Test
+        @DisplayName("returns zero when nothing is overdue")
+        void noOverdueEstimates() {
+            when(estimateRepository.findByStatusAndExpiresAtBefore(EstimateStatus.PENDING_APPROVAL, NOW_LOCAL))
+                    .thenReturn(List.of());
+
+            assertThat(service.expirePendingApprovals()).isZero();
+            verify(estimateRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("keeps going and reports only the successes when one estimate fails to expire")
+        void countsOnlySuccessfulExpirations() {
+            Estimate healthy = estimate(EstimateStatus.PENDING_APPROVAL);
+            Estimate broken = estimate(EstimateStatus.PENDING_APPROVAL);
+            broken.setId(null);
+            when(estimateRepository.findByStatusAndExpiresAtBefore(EstimateStatus.PENDING_APPROVAL, NOW_LOCAL))
+                    .thenReturn(List.of(broken, healthy));
+            when(estimateRepository.save(broken)).thenThrow(new IllegalStateException("optimistic lock"));
+
+            assertThat(service.expirePendingApprovals()).isEqualTo(1);
+            assertThat(healthy.getStatus()).isEqualTo(EstimateStatus.EXPIRED);
+        }
+    }
+
+    @Nested
+    @DisplayName("summary, PDF, and snapshots")
+    class SummaryPdfAndSnapshots {
+
+        @Test
+        @DisplayName("groups the summary line items by type")
+        void buildsSummary() {
+            givenEstimate(estimate(EstimateStatus.PENDING_APPROVAL));
+            givenItems(item(ITEM_ID, EstimateItemType.PART), item(OTHER_ITEM_ID, EstimateItemType.LABOR));
+
+            EstimateSummaryResponse summary = service.getEstimateSummary(ESTIMATE_ID);
+
+            assertThat(summary.getEstimateNumber()).isEqualTo("EST-0001");
+            assertThat(summary.getPartItems()).hasSize(1);
+            assertThat(summary.getLaborItems()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("rejects a summary for an unknown estimate")
+        void rejectsUnknownSummary() {
+            when(estimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getEstimateSummary(ESTIMATE_ID))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Estimate not found");
+        }
+
+        @Test
+        @DisplayName("renders a Markdown document with parts, labor, and totals tables")
+        void rendersPdfMarkdown() {
+            Estimate estimate = estimate(EstimateStatus.APPROVED);
+            estimate.setExpiresAt(NOW_LOCAL.plusDays(10));
+            givenEstimate(estimate);
+            givenItems(item(ITEM_ID, EstimateItemType.PART), item(OTHER_ITEM_ID, EstimateItemType.LABOR));
+            when(documentClient.renderPdf(any())).thenReturn("pdf-bytes".getBytes(StandardCharsets.UTF_8));
+
+            assertThat(service.generateEstimatePdf(ESTIMATE_ID)).asString().isEqualTo("pdf-bytes");
+
+            ArgumentCaptor<String> markdown = ArgumentCaptor.forClass(String.class);
+            verify(documentClient).renderPdf(markdown.capture());
+            assertThat(markdown.getValue())
+                    .contains("# Estimate EST-0001")
+                    .contains("**Status:** APPROVED")
+                    .contains("**Expires:**")
+                    .contains("## Parts")
+                    .contains("Brake pad set")
+                    .contains("## Labor")
+                    .contains("Brake replacement")
+                    .contains("| **Subtotal** | 100.00 |")
+                    .contains("| **Tax** | 8.25 |")
+                    .contains("| **Total** | 108.25 |")
+                    .contains("*Currency: USD*");
+        }
+
+        @Test
+        @DisplayName("omits empty sections and defaults missing amounts to zero")
+        void rendersMarkdownWithoutOptionalSections() {
+            Estimate estimate = estimate(EstimateStatus.DRAFT);
+            estimate.setExpiresAt(null);
+            estimate.setSubtotal(null);
+            estimate.setTaxAmount(null);
+            estimate.setTotal(null);
+            estimate.setCurrencyUomId(null);
+            givenEstimate(estimate);
+            EstimateItem bare = item(ITEM_ID, EstimateItemType.PART);
+            bare.setDescription(null);
+            bare.setQuantity(null);
+            bare.setUnitPrice(null);
+            givenItems(bare);
+            when(documentClient.renderPdf(any())).thenReturn(new byte[0]);
+
+            service.generateEstimatePdf(ESTIMATE_ID);
+
+            ArgumentCaptor<String> markdown = ArgumentCaptor.forClass(String.class);
+            verify(documentClient).renderPdf(markdown.capture());
+            assertThat(markdown.getValue())
+                    .doesNotContain("**Expires:**")
+                    .doesNotContain("## Labor")
+                    .doesNotContain("*Currency:")
+                    .contains("| — | 1 | 0.00 | 0.00 |")
+                    .contains("| **Subtotal** | 0.00 |");
+        }
+
+        @Test
+        @DisplayName("rejects a PDF request for an unknown estimate")
+        void rejectsUnknownPdf() {
+            when(estimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.generateEstimatePdf(ESTIMATE_ID))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("serializes the estimate and its items into the snapshot")
+        void createsSnapshot() {
+            givenEstimate(estimate(EstimateStatus.PENDING_APPROVAL));
+            givenItems(item(ITEM_ID, EstimateItemType.PART));
+
+            EstimateSnapshotResponse response =
+                    service.createEstimateSnapshot(ESTIMATE_ID, "jane.smith", "before revision");
+
+            assertThat(response.getId()).isEqualTo(SNAPSHOT_ID);
+            assertThat(response.getCapturedById()).isEqualTo("jane.smith");
+            assertThat(response.getNotes()).isEqualTo("before revision");
+            assertThat(response.getStatus()).isEqualTo(EstimateStatus.PENDING_APPROVAL);
+            assertThat(response.getSnapshotData()).contains("EST-0001").contains("Brake pad set");
+        }
+
+        @Test
+        @DisplayName("rejects a snapshot for an unknown estimate")
+        void rejectsUnknownSnapshot() {
+            when(estimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.createEstimateSnapshot(ESTIMATE_ID, "jane.smith", null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Estimate not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("createEstimateFromAppointment")
+    class CreateFromAppointment {
+
+        private CreateEstimateFromAppointmentRequest request() {
+            return CreateEstimateFromAppointmentRequest.builder()
+                    .appointmentId(APPOINTMENT_ID)
+                    .customerId(CUSTOMER_ID)
+                    .vehicleId(VEHICLE_ID)
+                    .locationId(LOCATION_ID)
+                    .idempotencyKey(UUID.randomUUID())
+                    .build();
+        }
+
+        @Test
+        @DisplayName("creates a DRAFT estimate carrying the appointment reference")
+        void createsEstimate() {
+            when(estimateRepository.findByAppointmentId(APPOINTMENT_ID)).thenReturn(Optional.empty());
+            when(estimateRepository.save(any())).thenAnswer(invocation -> {
+                Estimate saved = invocation.getArgument(0);
+                saved.setId(ESTIMATE_ID);
+                return saved;
+            });
+
+            CreateEstimateFromAppointmentResponse response = service.createEstimateFromAppointment(request());
+
+            assertThat(response.isCreated()).isTrue();
+            assertThat(response.getEstimateId()).isEqualTo(ESTIMATE_ID);
+            assertThat(response.getStatus()).isEqualTo(EstimateStatus.DRAFT.name());
+            verify(estimateFactPublisher).markChanged(ESTIMATE_ID);
+        }
+
+        @Test
+        @DisplayName("returns the existing estimate for a replayed appointment")
+        void replaysExistingEstimate() {
+            Estimate existing = estimate(EstimateStatus.PENDING_APPROVAL);
+            when(estimateRepository.findByAppointmentId(APPOINTMENT_ID)).thenReturn(Optional.of(existing));
+
+            CreateEstimateFromAppointmentResponse response = service.createEstimateFromAppointment(request());
+
+            assertThat(response.isCreated()).isFalse();
+            assertThat(response.getEstimateId()).isEqualTo(ESTIMATE_ID);
+            assertThat(response.getStatus()).isEqualTo(EstimateStatus.PENDING_APPROVAL.name());
+            verify(estimateRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("reports DRAFT for a replayed estimate whose status was never set")
+        void replaysStatuslessEstimate() {
+            Estimate existing = estimate(EstimateStatus.DRAFT);
+            existing.setStatus(null);
+            when(estimateRepository.findByAppointmentId(APPOINTMENT_ID)).thenReturn(Optional.of(existing));
+
+            assertThat(service.createEstimateFromAppointment(request()).getStatus())
+                    .isEqualTo(EstimateStatus.DRAFT.name());
+        }
+
+        @Test
+        @DisplayName("requires both an appointment and a customer")
+        void requiresIdentifiers() {
+            CreateEstimateFromAppointmentRequest noAppointment = request();
+            noAppointment.setAppointmentId(null);
+            assertThatThrownBy(() -> service.createEstimateFromAppointment(noAppointment))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("appointmentId is required");
+
+            CreateEstimateFromAppointmentRequest noCustomer = request();
+            noCustomer.setCustomerId(null);
+            assertThatThrownBy(() -> service.createEstimateFromAppointment(noCustomer))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("customerId is required");
+        }
+    }
+
+    @Nested
+    @DisplayName("reads and configuration lookup")
+    class ReadsAndConfiguration {
+
+        @Test
+        @DisplayName("maps every estimate list query through the response DTO")
+        void listQueries() {
+            List<Estimate> estimates = List.of(estimate(EstimateStatus.DRAFT));
+            when(estimateRepository.findAll()).thenReturn(estimates);
+            when(estimateRepository.findByCustomerId(CUSTOMER_ID)).thenReturn(estimates);
+            when(estimateRepository.findByLocationId(LOCATION_ID)).thenReturn(estimates);
+
+            assertThat(service.getAllEstimates())
+                    .singleElement()
+                    .satisfies(
+                            response -> assertThat(response.getEstimateNumber()).isEqualTo("EST-0001"));
+            assertThat(service.getEstimatesByCustomer(CUSTOMER_ID)).hasSize(1);
+            assertThat(service.getEstimatesByLocation(LOCATION_ID)).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("returns an estimate by id, or empty when it does not exist")
+        void findsById() {
+            givenEstimate(estimate(EstimateStatus.DRAFT));
+            assertThat(service.getEstimateById(ESTIMATE_ID)).isPresent();
+
+            when(estimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.empty());
+            assertThat(service.getEstimateById(ESTIMATE_ID)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("returns the highest-priority applicable approval configuration")
+        void returnsHighestPriorityConfiguration() {
+            ApprovalConfiguration first =
+                    ApprovalConfiguration.builder().id(CONFIG_ID).priority(10).build();
+            when(approvalConfigurationRepository.findApplicableConfigurations(LOCATION_ID, CUSTOMER_ID))
+                    .thenReturn(List.of(
+                            first, ApprovalConfiguration.builder().priority(1).build()));
+
+            assertThat(service.getApprovalConfiguration(LOCATION_ID, CUSTOMER_ID))
+                    .isSameAs(first);
+        }
+
+        @Test
+        @DisplayName("returns null when no configuration applies")
+        void returnsNullConfiguration() {
+            when(approvalConfigurationRepository.findApplicableConfigurations(LOCATION_ID, CUSTOMER_ID))
+                    .thenReturn(List.of());
+
+            assertThat(service.getApprovalConfiguration(LOCATION_ID, CUSTOMER_ID))
+                    .isNull();
+        }
+
+        @Test
+        @DisplayName("deletes an estimate by id")
+        void deletesEstimate() {
+            service.deleteEstimate(ESTIMATE_ID);
+
+            verify(estimateRepository).deleteById(ESTIMATE_ID);
+        }
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/IdempotencyServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/IdempotencyServiceImplTest.java
@@ -1,0 +1,366 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.entity.IdempotencyKey;
+import com.positivity.workorder.internal.repository.IdempotencyKeyRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Idempotency keys are scoped by operation, so the same client key used for two different
+ * operations never collides, and a key past its 24-hour window no longer replays.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("IdempotencyServiceImpl")
+class IdempotencyServiceImplTest {
+
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final Instant NOT_EXPIRED = NOW.plusSeconds(3600);
+    private static final Instant EXPIRED = NOW.minusSeconds(3600);
+    private static final Instant EXPECTED_EXPIRY = NOW.plusSeconds(24 * 3600);
+    private static final String KEY = "client-key-1";
+    private static final UUID WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f6a01");
+    private static final UUID CHANGE_REQUEST_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f6a02");
+    private static final UUID LABOR_ENTRY_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f6a03");
+    private static final UUID PART_USAGE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f6a04");
+    private static final UUID PART_ADJUSTMENT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f6a05");
+    private static final UUID INVOICE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f6a06");
+
+    @Mock
+    private IdempotencyKeyRepository repository;
+
+    private IdempotencyServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new IdempotencyServiceImpl(repository, Clock.fixed(NOW, ZoneOffset.UTC));
+    }
+
+    private static IdempotencyKey key(Instant expiresAt) {
+        IdempotencyKey key = new IdempotencyKey();
+        key.setKeyValue("scoped");
+        key.setExpiresAt(expiresAt);
+        return key;
+    }
+
+    private void stubKey(String scopedKey, IdempotencyKey stored) {
+        when(repository.findByKeyValue(scopedKey)).thenReturn(Optional.ofNullable(stored));
+    }
+
+    private IdempotencyKey savedKey() {
+        ArgumentCaptor<IdempotencyKey> saved = ArgumentCaptor.forClass(IdempotencyKey.class);
+        verify(repository).save(saved.capture());
+        return saved.getValue();
+    }
+
+    @Nested
+    @DisplayName("workorder keys")
+    class WorkorderKeys {
+
+        @Test
+        void replaysTheWorkorderBehindALiveKey() {
+            IdempotencyKey stored = key(NOT_EXPIRED);
+            stored.setWorkorderId(WORKORDER_ID);
+            stubKey("workorder.default:" + KEY, stored);
+
+            assertThat(service.getExistingWorkorderId(KEY)).contains(WORKORDER_ID);
+        }
+
+        @Test
+        void scopesTheLookupToTheNamedOperation() {
+            IdempotencyKey stored = key(NOT_EXPIRED);
+            stored.setWorkorderId(WORKORDER_ID);
+            stubKey("estimate.promote:" + KEY, stored);
+
+            assertThat(service.getExistingWorkorderId("estimate.promote", KEY)).contains(WORKORDER_ID);
+            // The same client key under the default scope is a different key entirely.
+            assertThat(service.getExistingWorkorderId(KEY)).isEmpty();
+        }
+
+        @Test
+        void ignoresAnExpiredKey() {
+            IdempotencyKey stored = key(EXPIRED);
+            stored.setWorkorderId(WORKORDER_ID);
+            stubKey("workorder.default:" + KEY, stored);
+
+            assertThat(service.getExistingWorkorderId(KEY)).isEmpty();
+        }
+
+        @Test
+        void returnsEmptyWhenNoKeyWasEverRegistered() {
+            stubKey("workorder.default:" + KEY, null);
+
+            assertThat(service.getExistingWorkorderId(KEY)).isEmpty();
+        }
+
+        @Test
+        void registersTheKeyWithATwentyFourHourWindow() {
+            service.registerKey(KEY, WORKORDER_ID);
+
+            IdempotencyKey saved = savedKey();
+            assertThat(saved.getKeyValue()).isEqualTo("workorder.default:" + KEY);
+            assertThat(saved.getWorkorderId()).isEqualTo(WORKORDER_ID);
+            assertThat(saved.getExpiresAt()).isEqualTo(EXPECTED_EXPIRY);
+        }
+
+        @Test
+        void registersAnOperationScopedKey() {
+            service.registerKey("estimate.promote", KEY, WORKORDER_ID);
+
+            assertThat(savedKey().getKeyValue()).isEqualTo("estimate.promote:" + KEY);
+        }
+    }
+
+    @Nested
+    @DisplayName("change-request keys")
+    class ChangeRequestKeys {
+
+        @Test
+        void replaysTheChangeRequestBehindALiveKey() {
+            IdempotencyKey stored = key(NOT_EXPIRED);
+            stored.setChangeRequestId(CHANGE_REQUEST_ID);
+            stubKey("change-request.default:" + KEY, stored);
+
+            assertThat(service.getExistingChangeRequestId(KEY)).contains(CHANGE_REQUEST_ID);
+            assertThat(service.getExistingChangeRequestId("change-request.default", KEY))
+                    .contains(CHANGE_REQUEST_ID);
+        }
+
+        @Test
+        void ignoresALiveKeyThatCarriesNoChangeRequest() {
+            stubKey("change-request.default:" + KEY, key(NOT_EXPIRED));
+
+            assertThat(service.getExistingChangeRequestId(KEY)).isEmpty();
+        }
+
+        @Test
+        void ignoresAnExpiredKey() {
+            IdempotencyKey stored = key(EXPIRED);
+            stored.setChangeRequestId(CHANGE_REQUEST_ID);
+            stubKey("change-request.default:" + KEY, stored);
+
+            assertThat(service.getExistingChangeRequestId(KEY)).isEmpty();
+        }
+
+        @Test
+        void marksTheKeyProcessedForTheChangeRequest() {
+            service.markKeyProcessedForChangeRequest(KEY, CHANGE_REQUEST_ID);
+
+            IdempotencyKey saved = savedKey();
+            assertThat(saved.getKeyValue()).isEqualTo("change-request.default:" + KEY);
+            assertThat(saved.getChangeRequestId()).isEqualTo(CHANGE_REQUEST_ID);
+            assertThat(saved.getWorkorderId()).isNull();
+            assertThat(saved.getExpiresAt()).isEqualTo(EXPECTED_EXPIRY);
+        }
+
+        @Test
+        void marksAnOperationScopedKeyProcessed() {
+            service.markKeyProcessedForChangeRequest("change-request.create", KEY, CHANGE_REQUEST_ID);
+
+            assertThat(savedKey().getKeyValue()).isEqualTo("change-request.create:" + KEY);
+        }
+    }
+
+    @Nested
+    @DisplayName("labor keys")
+    class LaborKeys {
+
+        @Test
+        void replaysTheLaborEntryBehindALiveKey() {
+            IdempotencyKey stored = key(NOT_EXPIRED);
+            stored.setLaborEntryId(LABOR_ENTRY_ID);
+            stubKey("labor.default:" + KEY, stored);
+
+            assertThat(service.getExistingLaborEntryId(KEY)).contains(LABOR_ENTRY_ID);
+            assertThat(service.getExistingLaborEntryId("labor.default", KEY)).contains(LABOR_ENTRY_ID);
+        }
+
+        @Test
+        void ignoresAnExpiredOrEmptyKey() {
+            IdempotencyKey expired = key(EXPIRED);
+            expired.setLaborEntryId(LABOR_ENTRY_ID);
+            stubKey("labor.default:" + KEY, expired);
+            assertThat(service.getExistingLaborEntryId(KEY)).isEmpty();
+
+            stubKey("labor.default:" + KEY, key(NOT_EXPIRED));
+            assertThat(service.getExistingLaborEntryId(KEY)).isEmpty();
+        }
+
+        @Test
+        void registersTheLaborKeyWithItsCreationStamp() {
+            service.registerLaborKey(KEY, LABOR_ENTRY_ID);
+
+            IdempotencyKey saved = savedKey();
+            assertThat(saved.getKeyValue()).isEqualTo("labor.default:" + KEY);
+            assertThat(saved.getLaborEntryId()).isEqualTo(LABOR_ENTRY_ID);
+            assertThat(saved.getCreatedAt()).isEqualTo(NOW);
+            assertThat(saved.getExpiresAt()).isEqualTo(EXPECTED_EXPIRY);
+        }
+
+        @Test
+        void registersAnOperationScopedLaborKey() {
+            service.registerLaborKey("labor.log", KEY, LABOR_ENTRY_ID);
+
+            assertThat(savedKey().getKeyValue()).isEqualTo("labor.log:" + KEY);
+        }
+    }
+
+    @Nested
+    @DisplayName("part usage, part adjustment and invoice keys")
+    class OtherKeys {
+
+        @Test
+        void replaysThePartUsageEventBehindALiveKey() {
+            IdempotencyKey stored = key(NOT_EXPIRED);
+            stored.setPartUsageEventId(PART_USAGE_ID);
+            stubKey("part-usage.default:" + KEY, stored);
+
+            assertThat(service.getExistingPartUsageEventId(KEY)).contains(PART_USAGE_ID);
+            assertThat(service.getExistingPartUsageEventId("part-usage.default", KEY))
+                    .contains(PART_USAGE_ID);
+        }
+
+        @Test
+        void ignoresAnExpiredOrEmptyPartUsageKey() {
+            IdempotencyKey expired = key(EXPIRED);
+            expired.setPartUsageEventId(PART_USAGE_ID);
+            stubKey("part-usage.default:" + KEY, expired);
+            assertThat(service.getExistingPartUsageEventId(KEY)).isEmpty();
+
+            stubKey("part-usage.default:" + KEY, key(NOT_EXPIRED));
+            assertThat(service.getExistingPartUsageEventId(KEY)).isEmpty();
+        }
+
+        @Test
+        void marksTheKeyProcessedForPartUsage() {
+            service.markKeyProcessedForPartUsage(KEY, PART_USAGE_ID);
+
+            IdempotencyKey saved = savedKey();
+            assertThat(saved.getKeyValue()).isEqualTo("part-usage.default:" + KEY);
+            assertThat(saved.getPartUsageEventId()).isEqualTo(PART_USAGE_ID);
+        }
+
+        @Test
+        void marksAnOperationScopedPartUsageKey() {
+            service.markKeyProcessedForPartUsage("part-usage.record", KEY, PART_USAGE_ID);
+
+            assertThat(savedKey().getKeyValue()).isEqualTo("part-usage.record:" + KEY);
+        }
+
+        @Test
+        void replaysThePartAdjustmentEventBehindALiveKey() {
+            IdempotencyKey stored = key(NOT_EXPIRED);
+            stored.setPartAdjustmentEventId(PART_ADJUSTMENT_ID);
+            stubKey("part-adjustment.default:" + KEY, stored);
+
+            assertThat(service.getExistingPartAdjustmentEventId(KEY)).contains(PART_ADJUSTMENT_ID);
+            assertThat(service.getExistingPartAdjustmentEventId("part-adjustment.default", KEY))
+                    .contains(PART_ADJUSTMENT_ID);
+        }
+
+        @Test
+        void ignoresAnExpiredOrEmptyPartAdjustmentKey() {
+            IdempotencyKey expired = key(EXPIRED);
+            expired.setPartAdjustmentEventId(PART_ADJUSTMENT_ID);
+            stubKey("part-adjustment.default:" + KEY, expired);
+            assertThat(service.getExistingPartAdjustmentEventId(KEY)).isEmpty();
+
+            stubKey("part-adjustment.default:" + KEY, key(NOT_EXPIRED));
+            assertThat(service.getExistingPartAdjustmentEventId(KEY)).isEmpty();
+        }
+
+        @Test
+        void marksTheKeyProcessedForAPartAdjustment() {
+            service.markKeyProcessedForPartAdjustment(KEY, PART_ADJUSTMENT_ID);
+
+            IdempotencyKey saved = savedKey();
+            assertThat(saved.getKeyValue()).isEqualTo("part-adjustment.default:" + KEY);
+            assertThat(saved.getPartAdjustmentEventId()).isEqualTo(PART_ADJUSTMENT_ID);
+        }
+
+        @Test
+        void marksAnOperationScopedPartAdjustmentKey() {
+            service.markKeyProcessedForPartAdjustment("part-adjustment.post", KEY, PART_ADJUSTMENT_ID);
+
+            assertThat(savedKey().getKeyValue()).isEqualTo("part-adjustment.post:" + KEY);
+        }
+
+        @Test
+        void replaysTheInvoiceBehindALiveKey() {
+            IdempotencyKey stored = key(NOT_EXPIRED);
+            stored.setInvoiceId(INVOICE_ID);
+            stubKey("invoice.default:" + KEY, stored);
+
+            assertThat(service.getExistingInvoiceId(KEY)).contains(INVOICE_ID);
+            assertThat(service.getExistingInvoiceId("invoice.default", KEY)).contains(INVOICE_ID);
+        }
+
+        @Test
+        void ignoresAnExpiredOrEmptyInvoiceKey() {
+            IdempotencyKey expired = key(EXPIRED);
+            expired.setInvoiceId(INVOICE_ID);
+            stubKey("invoice.default:" + KEY, expired);
+            assertThat(service.getExistingInvoiceId(KEY)).isEmpty();
+
+            stubKey("invoice.default:" + KEY, key(NOT_EXPIRED));
+            assertThat(service.getExistingInvoiceId(KEY)).isEmpty();
+        }
+
+        @Test
+        void registersTheInvoiceKey() {
+            service.registerInvoiceKey(KEY, INVOICE_ID);
+
+            IdempotencyKey saved = savedKey();
+            assertThat(saved.getKeyValue()).isEqualTo("invoice.default:" + KEY);
+            assertThat(saved.getInvoiceId()).isEqualTo(INVOICE_ID);
+            assertThat(saved.getCreatedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        void registersAnOperationScopedInvoiceKey() {
+            service.registerInvoiceKey("invoice.generate", KEY, INVOICE_ID);
+
+            assertThat(savedKey().getKeyValue()).isEqualTo("invoice.generate:" + KEY);
+        }
+    }
+
+    @Test
+    void reportsHowManyExpiredKeysWereRemoved() {
+        when(repository.deleteExpiredKeys(NOW)).thenReturn(7);
+
+        assertThat(service.cleanupExpiredKeys()).isEqualTo(7);
+        verify(repository).deleteExpiredKeys(NOW);
+    }
+
+    @Test
+    void neverConfusesKeysAcrossEntityTypes() {
+        IdempotencyKey workorderOnly = key(NOT_EXPIRED);
+        workorderOnly.setWorkorderId(WORKORDER_ID);
+        when(repository.findByKeyValue(any())).thenReturn(Optional.of(workorderOnly));
+
+        assertThat(service.getExistingWorkorderId(KEY)).contains(WORKORDER_ID);
+        assertThat(service.getExistingChangeRequestId(KEY)).isEmpty();
+        assertThat(service.getExistingLaborEntryId(KEY)).isEmpty();
+        assertThat(service.getExistingPartUsageEventId(KEY)).isEmpty();
+        assertThat(service.getExistingPartAdjustmentEventId(KEY)).isEmpty();
+        assertThat(service.getExistingInvoiceId(KEY)).isEmpty();
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/TechnicianAssignmentServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/TechnicianAssignmentServiceImplTest.java
@@ -1,0 +1,327 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.entity.TechnicianAssignment;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.exception.WorkorderNotFoundException;
+import com.positivity.workorder.internal.repository.TechnicianAssignmentRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Technician assignment: assignment is only allowed from APPROVED / ASSIGNED / WORK_IN_PROGRESS,
+ * the first assignment from APPROVED drives the workorder to ASSIGNED, and every superseded
+ * assignment is retained as history with {@code current} cleared.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("TechnicianAssignmentServiceImpl")
+class TechnicianAssignmentServiceImplTest {
+
+    private static final UUID WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f2211");
+    private static final UUID TECHNICIAN_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f2212");
+    private static final UUID OTHER_TECHNICIAN_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f2213");
+    private static final Long ASSIGNMENT_ID = 4711L;
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final LocalDateTime NOW_LOCAL = LocalDateTime.ofInstant(NOW, ZoneOffset.UTC);
+
+    @Mock
+    private TechnicianAssignmentRepository assignmentRepository;
+
+    @Mock
+    private WorkorderRepository workorderRepository;
+
+    @Mock
+    private WorkorderStateMachine stateMachine;
+
+    private TechnicianAssignmentServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TechnicianAssignmentServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC), assignmentRepository, workorderRepository, stateMachine);
+
+        when(assignmentRepository.save(any())).thenAnswer(invocation -> {
+            TechnicianAssignment assignment = invocation.getArgument(0);
+            if (assignment.getId() == null) {
+                assignment.setId(ASSIGNMENT_ID);
+            }
+            return assignment;
+        });
+        when(assignmentRepository.findByWorkorder_IdAndCurrentTrue(WORKORDER_ID))
+                .thenReturn(Optional.empty());
+    }
+
+    private void givenWorkorder(WorkorderStatus status) {
+        Workorder workorder = new Workorder();
+        workorder.setId(WORKORDER_ID);
+        workorder.setStatus(status);
+        when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(workorder));
+    }
+
+    private TechnicianAssignment currentAssignment(UUID technicianId) {
+        return TechnicianAssignment.builder()
+                .id(ASSIGNMENT_ID)
+                .workorder(new Workorder(WORKORDER_ID))
+                .technicianId(technicianId)
+                .assignedBy("dispatch")
+                .assignedAt(NOW_LOCAL.minusHours(3))
+                .current(true)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("assignTechnician")
+    class AssignTechnician {
+
+        @Test
+        @DisplayName("creates a current assignment stamped with the clock")
+        void createsAssignment() {
+            givenWorkorder(WorkorderStatus.APPROVED);
+
+            TechnicianAssignment assignment =
+                    service.assignTechnician(WORKORDER_ID, TECHNICIAN_ID, "dispatch", "morning bay");
+
+            assertThat(assignment.getTechnicianId()).isEqualTo(TECHNICIAN_ID);
+            assertThat(assignment.getAssignedBy()).isEqualTo("dispatch");
+            assertThat(assignment.getAssignedAt()).isEqualTo(NOW_LOCAL);
+            assertThat(assignment.getNotes()).isEqualTo("morning bay");
+            assertThat(assignment.getCurrent()).isTrue();
+            assertThat(assignment.getWorkorder().getId()).isEqualTo(WORKORDER_ID);
+        }
+
+        @Test
+        @DisplayName("drives an APPROVED workorder to ASSIGNED")
+        void transitionsApprovedWorkorder() {
+            givenWorkorder(WorkorderStatus.APPROVED);
+
+            service.assignTechnician(WORKORDER_ID, TECHNICIAN_ID, "dispatch", null);
+
+            verify(stateMachine)
+                    .transitionWorkorder(WORKORDER_ID, WorkorderStatus.ASSIGNED, "dispatch", "Technician assigned");
+        }
+
+        @Test
+        @DisplayName("leaves an already-ASSIGNED workorder in place")
+        void doesNotRetransitionAssignedWorkorder() {
+            givenWorkorder(WorkorderStatus.ASSIGNED);
+
+            service.assignTechnician(WORKORDER_ID, TECHNICIAN_ID, "dispatch", null);
+
+            verify(stateMachine, never()).transitionWorkorder(any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("leaves a WORK_IN_PROGRESS workorder in place")
+        void doesNotRetransitionInProgressWorkorder() {
+            givenWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+
+            service.assignTechnician(WORKORDER_ID, TECHNICIAN_ID, "dispatch", null);
+
+            verify(stateMachine, never()).transitionWorkorder(any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("supersedes the existing assignment instead of deleting it")
+        void supersedesExistingAssignment() {
+            givenWorkorder(WorkorderStatus.ASSIGNED);
+            TechnicianAssignment existing = currentAssignment(OTHER_TECHNICIAN_ID);
+            when(assignmentRepository.findByWorkorder_IdAndCurrentTrue(WORKORDER_ID))
+                    .thenReturn(Optional.of(existing));
+
+            service.assignTechnician(WORKORDER_ID, TECHNICIAN_ID, "dispatch", null);
+
+            assertThat(existing.getCurrent()).isFalse();
+            assertThat(existing.getUnassignedAt()).isEqualTo(NOW_LOCAL);
+            assertThat(existing.getReassignmentReason()).isEqualTo("Reassigned to different technician");
+
+            ArgumentCaptor<TechnicianAssignment> captor = ArgumentCaptor.forClass(TechnicianAssignment.class);
+            verify(assignmentRepository, org.mockito.Mockito.times(2)).save(captor.capture());
+            assertThat(captor.getAllValues().get(0)).isSameAs(existing);
+            assertThat(captor.getAllValues().get(1).getTechnicianId()).isEqualTo(TECHNICIAN_ID);
+        }
+
+        @Test
+        @DisplayName("rejects an unknown workorder")
+        void rejectsUnknownWorkorder() {
+            when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.assignTechnician(WORKORDER_ID, TECHNICIAN_ID, "dispatch", null))
+                    .isInstanceOf(WorkorderNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("rejects a workorder in a status that does not allow assignment")
+        void rejectsIneligibleStatus() {
+            givenWorkorder(WorkorderStatus.COMPLETED);
+
+            assertThatThrownBy(() -> service.assignTechnician(WORKORDER_ID, TECHNICIAN_ID, "dispatch", null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Current status: COMPLETED");
+            verify(assignmentRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("reassignTechnician")
+    class ReassignTechnician {
+
+        @Test
+        @DisplayName("closes the current assignment with the supplied reason and opens a new one")
+        void reassigns() {
+            givenWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+            TechnicianAssignment existing = currentAssignment(OTHER_TECHNICIAN_ID);
+            when(assignmentRepository.findByWorkorder_IdAndCurrentTrue(WORKORDER_ID))
+                    .thenReturn(Optional.of(existing));
+
+            TechnicianAssignment created = service.reassignTechnician(
+                    WORKORDER_ID, TECHNICIAN_ID, "supervisor", "called out sick", "swap to bay 2");
+
+            assertThat(existing.getCurrent()).isFalse();
+            assertThat(existing.getUnassignedAt()).isEqualTo(NOW_LOCAL);
+            assertThat(existing.getReassignmentReason()).isEqualTo("called out sick");
+
+            assertThat(created.getTechnicianId()).isEqualTo(TECHNICIAN_ID);
+            assertThat(created.getAssignedBy()).isEqualTo("supervisor");
+            assertThat(created.getReassignmentReason()).isEqualTo("called out sick");
+            assertThat(created.getNotes()).isEqualTo("swap to bay 2");
+            assertThat(created.getCurrent()).isTrue();
+        }
+
+        @Test
+        @DisplayName("keeps the prior reason when none is supplied")
+        void keepsPriorReasonWhenReasonOmitted() {
+            givenWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+            TechnicianAssignment existing = currentAssignment(OTHER_TECHNICIAN_ID);
+            when(assignmentRepository.findByWorkorder_IdAndCurrentTrue(WORKORDER_ID))
+                    .thenReturn(Optional.of(existing));
+
+            service.reassignTechnician(WORKORDER_ID, TECHNICIAN_ID, "supervisor", null, null);
+
+            assertThat(existing.getCurrent()).isFalse();
+            assertThat(existing.getReassignmentReason()).isNull();
+        }
+
+        @Test
+        @DisplayName("never transitions the workorder status")
+        void doesNotTransitionWorkorder() {
+            givenWorkorder(WorkorderStatus.APPROVED);
+            when(assignmentRepository.findByWorkorder_IdAndCurrentTrue(WORKORDER_ID))
+                    .thenReturn(Optional.of(currentAssignment(OTHER_TECHNICIAN_ID)));
+
+            service.reassignTechnician(WORKORDER_ID, TECHNICIAN_ID, "supervisor", "reason", null);
+
+            verify(stateMachine, never()).transitionWorkorder(any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("refuses to reassign a workorder that has no current assignment")
+        void rejectsWithoutCurrentAssignment() {
+            givenWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+
+            assertThatThrownBy(
+                            () -> service.reassignTechnician(WORKORDER_ID, TECHNICIAN_ID, "supervisor", "reason", null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("no current technician assignment");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown workorder and an ineligible status")
+        void rejectsUnresolvableTargets() {
+            when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.empty());
+            assertThatThrownBy(
+                            () -> service.reassignTechnician(WORKORDER_ID, TECHNICIAN_ID, "supervisor", "reason", null))
+                    .isInstanceOf(WorkorderNotFoundException.class);
+
+            givenWorkorder(WorkorderStatus.CANCELLED);
+            assertThatThrownBy(
+                            () -> service.reassignTechnician(WORKORDER_ID, TECHNICIAN_ID, "supervisor", "reason", null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Current status: CANCELLED");
+        }
+    }
+
+    @Nested
+    @DisplayName("reads")
+    class Reads {
+
+        @Test
+        @DisplayName("exposes the current assignment when one exists")
+        void currentAssignmentIsExposed() {
+            TechnicianAssignment existing = currentAssignment(TECHNICIAN_ID);
+            when(assignmentRepository.findByWorkorder_IdAndCurrentTrue(WORKORDER_ID))
+                    .thenReturn(Optional.of(existing));
+
+            assertThat(service.getCurrentAssignment(WORKORDER_ID)).contains(existing);
+        }
+
+        @Test
+        @DisplayName("returns empty when the workorder is unassigned")
+        void noCurrentAssignment() {
+            assertThat(service.getCurrentAssignment(WORKORDER_ID)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("returns the assignment history newest first")
+        void historyIsDelegated() {
+            TechnicianAssignment newest = currentAssignment(TECHNICIAN_ID);
+            TechnicianAssignment older = currentAssignment(OTHER_TECHNICIAN_ID);
+            when(assignmentRepository.findByWorkorder_IdOrderByAssignedAtDesc(WORKORDER_ID))
+                    .thenReturn(List.of(newest, older));
+
+            assertThat(service.getAssignmentHistory(WORKORDER_ID)).containsExactly(newest, older);
+        }
+
+        @Test
+        @DisplayName("reads the previous technician from the second-newest assignment")
+        void previousTechnicianFromHistory() {
+            when(assignmentRepository.findByWorkorder_IdOrderByAssignedAtDesc(WORKORDER_ID))
+                    .thenReturn(List.of(currentAssignment(TECHNICIAN_ID), currentAssignment(OTHER_TECHNICIAN_ID)));
+
+            assertThat(service.getPreviousTechnicianId(WORKORDER_ID)).contains(OTHER_TECHNICIAN_ID);
+        }
+
+        @Test
+        @DisplayName("has no previous technician after a single assignment")
+        void noPreviousTechnician() {
+            when(assignmentRepository.findByWorkorder_IdOrderByAssignedAtDesc(WORKORDER_ID))
+                    .thenReturn(List.of(currentAssignment(TECHNICIAN_ID)));
+
+            assertThat(service.getPreviousTechnicianId(WORKORDER_ID)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("reports the workorder status, or fails when the workorder is unknown")
+        void workorderStatus() {
+            givenWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+            assertThat(service.getWorkorderStatus(WORKORDER_ID)).isEqualTo(WorkorderStatus.WORK_IN_PROGRESS);
+
+            when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.empty());
+            assertThatThrownBy(() -> service.getWorkorderStatus(WORKORDER_ID))
+                    .isInstanceOf(WorkorderNotFoundException.class);
+        }
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkexecTimeTrackingServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkexecTimeTrackingServiceImplTest.java
@@ -1,0 +1,639 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.security.common.GatewaySecurityConstants;
+import com.positivity.workorder.internal.entity.TechnicianAssignment;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderLaborEntry;
+import com.positivity.workorder.internal.entity.WorkorderServiceLine;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.repository.TechnicianAssignmentRepository;
+import com.positivity.workorder.internal.repository.WorkorderLaborEntryRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
+import com.positivity.workorder.service.IdempotencyService;
+import com.positivity.workorder.service.WorkexecTimeTrackingService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Workexec time tracking: job-time totals bucket finalized labor into local dates, labor
+ * postings and timer starts replay on their idempotency key, and attributing a timer to anyone
+ * other than yourself or the current assignee needs the on-behalf authority plus a reason.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("WorkexecTimeTrackingServiceImpl")
+class WorkexecTimeTrackingServiceImplTest {
+
+    private static final UUID WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7a01");
+    private static final UUID TECHNICIAN_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7a02");
+    private static final UUID OTHER_TECHNICIAN_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7a03");
+    private static final UUID LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7a04");
+    private static final UUID SERVICE_LINE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7a05");
+    private static final UUID ENTRY_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7a06");
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final String IDEMPOTENCY_KEY = "workexec-key-1";
+    private static final String ON_BEHALF_AUTHORITY = "workorder:labor:add_on_behalf";
+
+    @Mock
+    private WorkorderRepository workorderRepository;
+
+    @Mock
+    private WorkorderLaborEntryRepository laborEntryRepository;
+
+    @Mock
+    private WorkorderServiceRepository workorderServiceRepository;
+
+    @Mock
+    private TechnicianAssignmentRepository technicianAssignmentRepository;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    private WorkexecTimeTrackingServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkexecTimeTrackingServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                workorderRepository,
+                laborEntryRepository,
+                workorderServiceRepository,
+                technicianAssignmentRepository,
+                idempotencyService);
+        when(laborEntryRepository.save(any())).thenAnswer(invocation -> {
+            WorkorderLaborEntry entry = invocation.getArgument(0);
+            if (entry.getId() == null) {
+                entry.setId(ENTRY_ID);
+            }
+            return entry;
+        });
+        when(workorderServiceRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(workorderServiceRepository.findByWorkOrder_Id(WORKORDER_ID)).thenReturn(List.of(serviceLine()));
+        when(idempotencyService.getExistingLaborEntryId(anyString(), anyString()))
+                .thenReturn(Optional.empty());
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private static void authenticateAs(String username, String... authorities) {
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                username,
+                "n/a",
+                java.util.Arrays.stream(authorities)
+                        .map(SimpleGrantedAuthority::new)
+                        .toList());
+        token.setDetails(Map.of(GatewaySecurityConstants.DETAIL_USERNAME, username));
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    private static Workorder workorder(WorkorderStatus status) {
+        Workorder workorder = new Workorder();
+        workorder.setId(WORKORDER_ID);
+        workorder.setShopId(LOCATION_ID);
+        workorder.setStatus(status);
+        return workorder;
+    }
+
+    private static WorkorderServiceLine serviceLine() {
+        return WorkorderServiceLine.builder()
+                .id(SERVICE_LINE_ID)
+                .workOrder(workorder(WorkorderStatus.APPROVED))
+                .build();
+    }
+
+    private static WorkorderLaborEntry laborEntry(LocalDateTime start, LocalDateTime end, String hours) {
+        return WorkorderLaborEntry.builder()
+                .id(ENTRY_ID)
+                .workorder(workorder(WorkorderStatus.COMPLETED))
+                .workorderService(serviceLine())
+                .technicianId(TECHNICIAN_ID)
+                .startTime(start)
+                .endTime(end)
+                .hoursWorked(hours == null ? null : new BigDecimal(hours))
+                .notes("BRAKE_JOB")
+                .createdBy("system")
+                .build();
+    }
+
+    private void stubWorkorder(WorkorderStatus status) {
+        when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(workorder(status)));
+    }
+
+    private WorkorderLaborEntry savedEntry() {
+        ArgumentCaptor<WorkorderLaborEntry> saved = ArgumentCaptor.forClass(WorkorderLaborEntry.class);
+        verify(laborEntryRepository).save(saved.capture());
+        return saved.getValue();
+    }
+
+    @Nested
+    @DisplayName("getJobTimeTotals")
+    class GetJobTimeTotals {
+
+        private List<WorkexecTimeTrackingService.JobTimeTotal> totals(
+                ZoneId zone, UUID locationFilter, List<UUID> technicianFilter) {
+            return service.getJobTimeTotals(
+                    LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 2), zone, locationFilter, technicianFilter);
+        }
+
+        @Test
+        void sumsLaborMinutesPerTechnicianLocationAndLocalDate() {
+            when(laborEntryRepository.findFinalizedByEndTimeBetween(any(), any(), any()))
+                    .thenReturn(List.of(
+                            laborEntry(LocalDateTime.of(2026, 3, 1, 8, 0), LocalDateTime.of(2026, 3, 1, 10, 0), "2.0"),
+                            laborEntry(
+                                    LocalDateTime.of(2026, 3, 1, 13, 0), LocalDateTime.of(2026, 3, 1, 14, 30), "1.5")));
+
+            List<WorkexecTimeTrackingService.JobTimeTotal> totals = totals(ZoneOffset.UTC, null, List.of());
+
+            assertThat(totals).hasSize(1);
+            assertThat(totals.get(0).technicianId()).isEqualTo(TECHNICIAN_ID);
+            assertThat(totals.get(0).locationId()).isEqualTo(LOCATION_ID);
+            assertThat(totals.get(0).localDate()).isEqualTo(LocalDate.of(2026, 3, 1));
+            assertThat(totals.get(0).totalJobMinutes()).isEqualTo(210);
+        }
+
+        @Test
+        void bucketsByTheRequestedTimezoneRatherThanUtc() {
+            // 02:00Z on 2 March is still 1 March in New York.
+            when(laborEntryRepository.findFinalizedByEndTimeBetween(any(), any(), any()))
+                    .thenReturn(List.of(
+                            laborEntry(LocalDateTime.of(2026, 3, 2, 1, 0), LocalDateTime.of(2026, 3, 2, 2, 0), "1.0")));
+
+            List<WorkexecTimeTrackingService.JobTimeTotal> totals =
+                    totals(ZoneId.of("America/New_York"), null, List.of());
+
+            assertThat(totals).hasSize(1);
+            assertThat(totals.get(0).localDate()).isEqualTo(LocalDate.of(2026, 3, 1));
+        }
+
+        @Test
+        void dropsEntriesOutsideTheRequestedWindow() {
+            when(laborEntryRepository.findFinalizedByEndTimeBetween(any(), any(), any()))
+                    .thenReturn(List.of(
+                            laborEntry(LocalDateTime.of(2026, 2, 28, 8, 0), LocalDateTime.of(2026, 2, 28, 9, 0), "1.0"),
+                            laborEntry(LocalDateTime.of(2026, 3, 3, 8, 0), LocalDateTime.of(2026, 3, 3, 9, 0), "1.0")));
+
+            assertThat(totals(ZoneOffset.UTC, null, List.of())).isEmpty();
+        }
+
+        @Test
+        void dropsAnEntryThatWasNeverFinished() {
+            when(laborEntryRepository.findFinalizedByEndTimeBetween(any(), any(), any()))
+                    .thenReturn(List.of(laborEntry(LocalDateTime.of(2026, 3, 1, 8, 0), null, "1.0")));
+
+            assertThat(totals(ZoneOffset.UTC, null, List.of())).isEmpty();
+        }
+
+        @Test
+        void filtersToTheRequestedTechnicians() {
+            when(laborEntryRepository.findFinalizedByEndTimeBetween(any(), any(), any()))
+                    .thenReturn(List.of(
+                            laborEntry(LocalDateTime.of(2026, 3, 1, 8, 0), LocalDateTime.of(2026, 3, 1, 9, 0), "1.0")));
+
+            assertThat(totals(ZoneOffset.UTC, null, List.of(OTHER_TECHNICIAN_ID)))
+                    .isEmpty();
+            assertThat(totals(ZoneOffset.UTC, null, List.of(TECHNICIAN_ID))).hasSize(1);
+        }
+
+        @Test
+        void filtersToTheRequestedLocation() {
+            WorkorderLaborEntry entry =
+                    laborEntry(LocalDateTime.of(2026, 3, 1, 8, 0), LocalDateTime.of(2026, 3, 1, 9, 0), "1.0");
+            when(laborEntryRepository.findFinalizedByEndTimeBetween(any(), any(), any()))
+                    .thenReturn(List.of(entry));
+
+            assertThat(totals(ZoneOffset.UTC, LOCATION_ID, List.of())).hasSize(1);
+            assertThat(totals(ZoneOffset.UTC, OTHER_TECHNICIAN_ID, List.of())).isEmpty();
+        }
+
+        @Test
+        void dropsAnEntryWithNoLocationWhenALocationFilterIsApplied() {
+            WorkorderLaborEntry entry =
+                    laborEntry(LocalDateTime.of(2026, 3, 1, 8, 0), LocalDateTime.of(2026, 3, 1, 9, 0), "1.0");
+            entry.getWorkorder().setShopId(null);
+            when(laborEntryRepository.findFinalizedByEndTimeBetween(any(), any(), any()))
+                    .thenReturn(List.of(entry));
+
+            assertThat(totals(ZoneOffset.UTC, LOCATION_ID, List.of())).isEmpty();
+        }
+
+        @Test
+        void ordersTheResultByDateThenTechnician() {
+            WorkorderLaborEntry laterDay =
+                    laborEntry(LocalDateTime.of(2026, 3, 2, 8, 0), LocalDateTime.of(2026, 3, 2, 9, 0), "1.0");
+            WorkorderLaborEntry earlierDay =
+                    laborEntry(LocalDateTime.of(2026, 3, 1, 8, 0), LocalDateTime.of(2026, 3, 1, 9, 0), "1.0");
+            when(laborEntryRepository.findFinalizedByEndTimeBetween(any(), any(), any()))
+                    .thenReturn(List.of(laterDay, earlierDay));
+
+            List<WorkexecTimeTrackingService.JobTimeTotal> totals = totals(ZoneOffset.UTC, null, List.of());
+
+            assertThat(totals).hasSize(2);
+            assertThat(totals.get(0).localDate()).isEqualTo(LocalDate.of(2026, 3, 1));
+        }
+    }
+
+    @Nested
+    @DisplayName("recordLaborPerformed")
+    class RecordLaborPerformed {
+
+        private WorkexecTimeTrackingService.LaborPerformedRequest request(String quantity, String unit) {
+            return new WorkexecTimeTrackingService.LaborPerformedRequest(
+                    WORKORDER_ID,
+                    TECHNICIAN_ID,
+                    Instant.parse("2026-03-01T15:00:00Z"),
+                    new WorkexecTimeTrackingService.LaborQuantity(
+                            quantity == null ? null : new BigDecimal(quantity), unit),
+                    new WorkexecTimeTrackingService.SourceReference("shopmgr", "ref-1"));
+        }
+
+        @Test
+        void postsTheLaborEntryBackdatedByTheHoursWorked() {
+            stubWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+
+            WorkexecTimeTrackingService.LaborPerformedResult result =
+                    service.recordLaborPerformed(request("1.5", "HOURS"), IDEMPOTENCY_KEY);
+
+            WorkorderLaborEntry saved = savedEntry();
+            assertThat(saved.getEndTime()).isEqualTo(LocalDateTime.of(2026, 3, 1, 15, 0));
+            assertThat(saved.getStartTime()).isEqualTo(LocalDateTime.of(2026, 3, 1, 13, 30));
+            assertThat(saved.getHoursWorked()).isEqualByComparingTo("1.50");
+            assertThat(saved.getNotes()).isEqualTo("sourceSystem=shopmgr;sourceReferenceId=ref-1");
+            assertThat(result.replayed()).isFalse();
+            assertThat(result.response().sourceSystem()).isEqualTo("shopmgr");
+            verify(idempotencyService)
+                    .registerLaborKey(anyString(), org.mockito.ArgumentMatchers.eq(IDEMPOTENCY_KEY), any());
+        }
+
+        @Test
+        void replaysTheOriginalEntryForAKnownIdempotencyKey() {
+            when(idempotencyService.getExistingLaborEntryId(anyString(), anyString()))
+                    .thenReturn(Optional.of(ENTRY_ID));
+            when(laborEntryRepository.findById(ENTRY_ID))
+                    .thenReturn(Optional.of(laborEntry(
+                            LocalDateTime.of(2026, 3, 1, 13, 30), LocalDateTime.of(2026, 3, 1, 15, 0), "1.50")));
+
+            WorkexecTimeTrackingService.LaborPerformedResult result =
+                    service.recordLaborPerformed(request("1.5", "HOURS"), IDEMPOTENCY_KEY);
+
+            assertThat(result.replayed()).isTrue();
+            verify(laborEntryRepository, never()).save(any());
+        }
+
+        @Test
+        void failsWhenTheReplayedEntryIsGone() {
+            when(idempotencyService.getExistingLaborEntryId(anyString(), anyString()))
+                    .thenReturn(Optional.of(ENTRY_ID));
+            when(laborEntryRepository.findById(ENTRY_ID)).thenReturn(Optional.empty());
+            WorkexecTimeTrackingService.LaborPerformedRequest request = request("1.5", "HOURS");
+
+            assertThatThrownBy(() -> service.recordLaborPerformed(request, IDEMPOTENCY_KEY))
+                    .isInstanceOf(NoSuchElementException.class);
+        }
+
+        @Test
+        void failsForAnUnknownWorkorder() {
+            when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.empty());
+            WorkexecTimeTrackingService.LaborPerformedRequest request = request("1.5", "HOURS");
+
+            assertThatThrownBy(() -> service.recordLaborPerformed(request, IDEMPOTENCY_KEY))
+                    .isInstanceOf(NoSuchElementException.class);
+        }
+
+        @Test
+        void refusesLaborOnACancelledWorkorder() {
+            stubWorkorder(WorkorderStatus.CANCELLED);
+            WorkexecTimeTrackingService.LaborPerformedRequest request = request("1.5", "HOURS");
+
+            assertThatThrownBy(() -> service.recordLaborPerformed(request, IDEMPOTENCY_KEY))
+                    .isInstanceOf(WorkexecTimeTrackingService.WorkexecConflictException.class);
+        }
+
+        @Test
+        void refusesLaborOnACompletedWorkorderUnlessItWasReopened() {
+            Workorder completed = workorder(WorkorderStatus.COMPLETED);
+            when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(completed));
+            WorkexecTimeTrackingService.LaborPerformedRequest request = request("1.5", "HOURS");
+
+            assertThatThrownBy(() -> service.recordLaborPerformed(request, IDEMPOTENCY_KEY))
+                    .isInstanceOf(WorkexecTimeTrackingService.WorkexecConflictException.class);
+
+            completed.setIsReopened(true);
+            assertThat(service.recordLaborPerformed(request, IDEMPOTENCY_KEY)).isNotNull();
+        }
+
+        @Test
+        void refusesAUnitOtherThanHours() {
+            stubWorkorder(WorkorderStatus.APPROVED);
+            WorkexecTimeTrackingService.LaborPerformedRequest request = request("1.5", "MINUTES");
+
+            assertThatThrownBy(() -> service.recordLaborPerformed(request, IDEMPOTENCY_KEY))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("labor.unit must be HOURS");
+        }
+
+        @Test
+        void refusesANonPositiveOrMissingQuantity() {
+            stubWorkorder(WorkorderStatus.APPROVED);
+
+            assertThatThrownBy(() -> service.recordLaborPerformed(request("0", "HOURS"), IDEMPOTENCY_KEY))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> service.recordLaborPerformed(request(null, "HOURS"), IDEMPOTENCY_KEY))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void createsAServiceLineWhenTheWorkorderHasNoneYet() {
+            stubWorkorder(WorkorderStatus.APPROVED);
+            when(workorderServiceRepository.findByWorkOrder_Id(WORKORDER_ID)).thenReturn(List.of());
+
+            service.recordLaborPerformed(request("1.0", "HOURS"), IDEMPOTENCY_KEY);
+
+            ArgumentCaptor<WorkorderServiceLine> created = ArgumentCaptor.forClass(WorkorderServiceLine.class);
+            verify(workorderServiceRepository).save(created.capture());
+            assertThat(created.getValue().getDescription()).isEqualTo("Workexec auto-created labor service");
+        }
+    }
+
+    @Nested
+    @DisplayName("startTimer")
+    class StartTimer {
+
+        /**
+         * The timer stamps {@code createdBy} from the security context, so a realistic caller is
+         * always authenticated — the gateway guarantees it for every timer endpoint.
+         */
+        @BeforeEach
+        void authenticateTheActor() {
+            authenticateAs("jane.smith");
+        }
+
+        private WorkexecTimeTrackingService.TimerStartRequest request(UUID technicianId, String reason) {
+            return new WorkexecTimeTrackingService.TimerStartRequest(
+                    WORKORDER_ID, null, "BRAKE_JOB", technicianId, reason);
+        }
+
+        @Test
+        void startsATimerForTheActorThemselves() {
+            stubWorkorder(WorkorderStatus.APPROVED);
+            when(laborEntryRepository.findByTechnicianIdAndEndTimeIsNullOrderByStartTimeDesc(TECHNICIAN_ID))
+                    .thenReturn(List.of());
+
+            WorkexecTimeTrackingService.TimerStartResult result =
+                    service.startTimer(TECHNICIAN_ID, request(null, null), null);
+
+            WorkorderLaborEntry saved = savedEntry();
+            assertThat(saved.getTechnicianId()).isEqualTo(TECHNICIAN_ID);
+            assertThat(saved.getActedByUserId()).isNull();
+            assertThat(saved.getOnBehalfReason()).isNull();
+            assertThat(saved.getHoursWorked()).isEqualByComparingTo("0");
+            assertThat(result.replayed()).isFalse();
+            assertThat(result.response().status()).isEqualTo("ACTIVE");
+        }
+
+        @Test
+        void defaultsAttributionToTheCurrentAssigneeAndRecordsTheInitiator() {
+            stubWorkorder(WorkorderStatus.ASSIGNED);
+            TechnicianAssignment assignment = new TechnicianAssignment();
+            assignment.setTechnicianId(OTHER_TECHNICIAN_ID);
+            when(technicianAssignmentRepository.findByWorkorder_IdAndCurrentTrue(WORKORDER_ID))
+                    .thenReturn(Optional.of(assignment));
+            when(laborEntryRepository.findByTechnicianIdAndEndTimeIsNullOrderByStartTimeDesc(OTHER_TECHNICIAN_ID))
+                    .thenReturn(List.of());
+
+            service.startTimer(TECHNICIAN_ID, request(null, null), null);
+
+            WorkorderLaborEntry saved = savedEntry();
+            assertThat(saved.getTechnicianId()).isEqualTo(OTHER_TECHNICIAN_ID);
+            assertThat(saved.getActedByUserId()).isEqualTo(TECHNICIAN_ID);
+            // The default-attribution path is not an on-behalf action, so no reason is recorded.
+            assertThat(saved.getOnBehalfReason()).isNull();
+        }
+
+        @Test
+        void requiresTheOnBehalfAuthorityToTrackAThirdTechnician() {
+            stubWorkorder(WorkorderStatus.APPROVED);
+            authenticateAs("jane.smith");
+
+            WorkexecTimeTrackingService.TimerStartRequest request = request(OTHER_TECHNICIAN_ID, "covering the shift");
+
+            assertThatThrownBy(() -> service.startTimer(TECHNICIAN_ID, request, null))
+                    .isInstanceOf(AccessDeniedException.class);
+        }
+
+        @Test
+        void requiresAReasonForAnOnBehalfTimer() {
+            stubWorkorder(WorkorderStatus.APPROVED);
+            authenticateAs("jane.smith", ON_BEHALF_AUTHORITY);
+
+            WorkexecTimeTrackingService.TimerStartRequest request = request(OTHER_TECHNICIAN_ID, "  ");
+
+            assertThatThrownBy(() -> service.startTimer(TECHNICIAN_ID, request, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("reason is required");
+        }
+
+        @Test
+        void recordsTheReasonOnAnAuthorizedOnBehalfTimer() {
+            stubWorkorder(WorkorderStatus.APPROVED);
+            authenticateAs("jane.smith", ON_BEHALF_AUTHORITY);
+            when(laborEntryRepository.findByTechnicianIdAndEndTimeIsNullOrderByStartTimeDesc(OTHER_TECHNICIAN_ID))
+                    .thenReturn(List.of());
+
+            service.startTimer(TECHNICIAN_ID, request(OTHER_TECHNICIAN_ID, "covering the shift"), null);
+
+            WorkorderLaborEntry saved = savedEntry();
+            assertThat(saved.getTechnicianId()).isEqualTo(OTHER_TECHNICIAN_ID);
+            assertThat(saved.getOnBehalfReason()).isEqualTo("covering the shift");
+            assertThat(saved.getActedByUserId()).isEqualTo(TECHNICIAN_ID);
+            assertThat(saved.getCreatedBy()).isEqualTo("jane.smith");
+        }
+
+        @Test
+        void refusesASecondTimerForTheSameTrackedTechnician() {
+            stubWorkorder(WorkorderStatus.APPROVED);
+            when(laborEntryRepository.findByTechnicianIdAndEndTimeIsNullOrderByStartTimeDesc(TECHNICIAN_ID))
+                    .thenReturn(List.of(laborEntry(LocalDateTime.of(2026, 3, 1, 8, 0), null, "0")));
+            WorkexecTimeTrackingService.TimerStartRequest request = request(null, null);
+
+            assertThatThrownBy(() -> service.startTimer(TECHNICIAN_ID, request, null))
+                    .isInstanceOf(WorkexecTimeTrackingService.WorkexecConflictException.class)
+                    .hasMessageContaining("active timer");
+        }
+
+        @Test
+        void refusesATimerOnAWorkorderThatIsNotEligible() {
+            stubWorkorder(WorkorderStatus.COMPLETED);
+            WorkexecTimeTrackingService.TimerStartRequest request = request(null, null);
+
+            assertThatThrownBy(() -> service.startTimer(TECHNICIAN_ID, request, null))
+                    .isInstanceOf(WorkexecTimeTrackingService.WorkexecConflictException.class)
+                    .hasMessageContaining("timer-eligible");
+        }
+
+        @Test
+        void failsForAnUnknownWorkorder() {
+            when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.empty());
+            WorkexecTimeTrackingService.TimerStartRequest request = request(null, null);
+
+            assertThatThrownBy(() -> service.startTimer(TECHNICIAN_ID, request, null))
+                    .isInstanceOf(NoSuchElementException.class);
+        }
+
+        @Test
+        void replaysTheOriginalTimerForAKnownIdempotencyKey() {
+            when(idempotencyService.getExistingLaborEntryId(anyString(), anyString()))
+                    .thenReturn(Optional.of(ENTRY_ID));
+            when(laborEntryRepository.findById(ENTRY_ID))
+                    .thenReturn(Optional.of(laborEntry(LocalDateTime.of(2026, 3, 1, 8, 0), null, "0")));
+
+            WorkexecTimeTrackingService.TimerStartResult result =
+                    service.startTimer(TECHNICIAN_ID, request(null, null), IDEMPOTENCY_KEY);
+
+            assertThat(result.replayed()).isTrue();
+            verify(laborEntryRepository, never()).save(any());
+        }
+
+        @Test
+        void failsWhenTheReplayedTimerIsGone() {
+            when(idempotencyService.getExistingLaborEntryId(anyString(), anyString()))
+                    .thenReturn(Optional.of(ENTRY_ID));
+            when(laborEntryRepository.findById(ENTRY_ID)).thenReturn(Optional.empty());
+            WorkexecTimeTrackingService.TimerStartRequest request = request(null, null);
+
+            assertThatThrownBy(() -> service.startTimer(TECHNICIAN_ID, request, IDEMPOTENCY_KEY))
+                    .isInstanceOf(NoSuchElementException.class);
+        }
+
+        @Test
+        void ignoresABlankIdempotencyKey() {
+            stubWorkorder(WorkorderStatus.APPROVED);
+
+            service.startTimer(TECHNICIAN_ID, request(null, null), "   ");
+
+            verify(idempotencyService, never()).registerLaborKey(anyString(), anyString(), any());
+        }
+
+        @Test
+        void pinsAnExplicitWorkorderItemAndRejectsOneFromAnotherWorkorder() {
+            stubWorkorder(WorkorderStatus.APPROVED);
+            when(workorderServiceRepository.findById(SERVICE_LINE_ID)).thenReturn(Optional.of(serviceLine()));
+
+            service.startTimer(
+                    TECHNICIAN_ID,
+                    new WorkexecTimeTrackingService.TimerStartRequest(
+                            WORKORDER_ID, SERVICE_LINE_ID, "BRAKE_JOB", null, null),
+                    null);
+            assertThat(savedEntry().getWorkorderServiceId()).isEqualTo(SERVICE_LINE_ID);
+        }
+
+        @Test
+        void refusesAWorkorderItemThatBelongsToAnotherWorkorder() {
+            stubWorkorder(WorkorderStatus.APPROVED);
+            Workorder otherWorkorder = new Workorder();
+            otherWorkorder.setId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7aff"));
+            WorkorderServiceLine foreign = WorkorderServiceLine.builder()
+                    .id(SERVICE_LINE_ID)
+                    .workOrder(otherWorkorder)
+                    .build();
+            when(workorderServiceRepository.findById(SERVICE_LINE_ID)).thenReturn(Optional.of(foreign));
+            WorkexecTimeTrackingService.TimerStartRequest request = new WorkexecTimeTrackingService.TimerStartRequest(
+                    WORKORDER_ID, SERVICE_LINE_ID, "BRAKE_JOB", null, null);
+
+            assertThatThrownBy(() -> service.startTimer(TECHNICIAN_ID, request, null))
+                    .isInstanceOf(WorkexecTimeTrackingService.WorkexecConflictException.class)
+                    .hasMessageContaining("does not belong");
+        }
+
+        @Test
+        void failsForAWorkorderItemThatDoesNotExist() {
+            stubWorkorder(WorkorderStatus.APPROVED);
+            when(workorderServiceRepository.findById(SERVICE_LINE_ID)).thenReturn(Optional.empty());
+            WorkexecTimeTrackingService.TimerStartRequest request = new WorkexecTimeTrackingService.TimerStartRequest(
+                    WORKORDER_ID, SERVICE_LINE_ID, "BRAKE_JOB", null, null);
+
+            assertThatThrownBy(() -> service.startTimer(TECHNICIAN_ID, request, null))
+                    .isInstanceOf(NoSuchElementException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getActiveTimers and stopTimers")
+    class ActiveAndStop {
+
+        @Test
+        void listsTimersTheActorTracksOrInitiated() {
+            when(laborEntryRepository.findActiveByTechnicianOrActor(TECHNICIAN_ID))
+                    .thenReturn(List.of(laborEntry(LocalDateTime.of(2026, 3, 1, 8, 0), null, "0")));
+
+            List<WorkexecTimeTrackingService.TimerEntry> timers = service.getActiveTimers(TECHNICIAN_ID);
+
+            assertThat(timers).hasSize(1);
+            assertThat(timers.get(0).status()).isEqualTo("ACTIVE");
+            assertThat(timers.get(0).durationInSeconds()).isNull();
+            assertThat(timers.get(0).laborCode()).isEqualTo("BRAKE_JOB");
+        }
+
+        @Test
+        void stopsEveryTimerTheActorCanReach() {
+            WorkorderLaborEntry active = laborEntry(LocalDateTime.of(2026, 3, 1, 8, 0), null, "0");
+            when(laborEntryRepository.findActiveByTechnicianOrActor(TECHNICIAN_ID))
+                    .thenReturn(List.of(active));
+            when(laborEntryRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            List<WorkexecTimeTrackingService.TimerEntry> stopped = service.stopTimers(TECHNICIAN_ID);
+
+            assertThat(active.getEndTime()).isNotNull();
+            assertThat(stopped).hasSize(1);
+            assertThat(stopped.get(0).status()).isEqualTo("COMPLETED");
+            assertThat(stopped.get(0).durationInSeconds()).isNotNull();
+        }
+
+        @Test
+        void refusesToStopWhenNothingIsRunning() {
+            when(laborEntryRepository.findActiveByTechnicianOrActor(TECHNICIAN_ID))
+                    .thenReturn(List.of());
+
+            assertThatThrownBy(() -> service.stopTimers(TECHNICIAN_ID))
+                    .isInstanceOf(WorkexecTimeTrackingService.WorkexecConflictException.class)
+                    .hasMessageContaining("No active timer");
+        }
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderLaborServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderLaborServiceImplTest.java
@@ -1,0 +1,460 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderLaborEntry;
+import com.positivity.workorder.internal.entity.WorkorderServiceLine;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.repository.WorkorderLaborEntryRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
+import com.positivity.workorder.service.IdempotencyService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Labor recording (CAP-005 story #159): a session may only be opened while the workorder is in a
+ * labor-eligible status, only one session may be open per service line, and stopping derives
+ * hours worked from the elapsed duration unless they are adjusted manually.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("WorkorderLaborServiceImpl")
+class WorkorderLaborServiceImplTest {
+
+    private static final UUID WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f1111");
+    private static final UUID SERVICE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f1112");
+    private static final UUID TECHNICIAN_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f1113");
+    private static final UUID ENTRY_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f1114");
+    private static final UUID OTHER_WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f1115");
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+
+    private static final String START_OPERATION = "labor.start";
+    private static final String STOP_OPERATION = "labor.stop";
+    private static final String ADJUST_OPERATION = "labor.adjust";
+
+    @Mock
+    private WorkorderLaborEntryRepository laborRepository;
+
+    @Mock
+    private WorkorderRepository workorderRepository;
+
+    @Mock
+    private WorkorderServiceRepository workorderServiceRepository;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    private WorkorderLaborServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkorderLaborServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                laborRepository,
+                workorderRepository,
+                workorderServiceRepository,
+                idempotencyService);
+
+        when(idempotencyService.getExistingLaborEntryId(anyString(), anyString()))
+                .thenReturn(Optional.empty());
+        when(laborRepository.save(any())).thenAnswer(invocation -> {
+            WorkorderLaborEntry entry = invocation.getArgument(0);
+            if (entry.getId() == null) {
+                entry.setId(ENTRY_ID);
+            }
+            return entry;
+        });
+        when(laborRepository.findByWorkorderService_IdAndEndTimeIsNull(SERVICE_ID))
+                .thenReturn(Optional.empty());
+    }
+
+    private static Workorder workorder(WorkorderStatus status) {
+        Workorder workorder = new Workorder();
+        workorder.setId(WORKORDER_ID);
+        workorder.setStatus(status);
+        return workorder;
+    }
+
+    private void givenWorkorder(WorkorderStatus status) {
+        when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(workorder(status)));
+    }
+
+    private void givenServiceLine(UUID owningWorkorderId) {
+        WorkorderServiceLine line = new WorkorderServiceLine();
+        line.setId(SERVICE_ID);
+        if (owningWorkorderId != null) {
+            Workorder owner = new Workorder();
+            owner.setId(owningWorkorderId);
+            line.setWorkOrder(owner);
+        }
+        when(workorderServiceRepository.findById(SERVICE_ID)).thenReturn(Optional.of(line));
+    }
+
+    private WorkorderLaborEntry openEntry(LocalDateTime startTime) {
+        WorkorderServiceLine line = new WorkorderServiceLine();
+        line.setId(SERVICE_ID);
+        return WorkorderLaborEntry.builder()
+                .id(ENTRY_ID)
+                .workorder(workorder(WorkorderStatus.WORK_IN_PROGRESS))
+                .workorderService(line)
+                .technicianId(TECHNICIAN_ID)
+                .startTime(startTime)
+                .hoursWorked(BigDecimal.ZERO)
+                .createdBy("jane.smith")
+                .createdAt(NOW)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("startLaborSession")
+    class StartLaborSession {
+
+        @Test
+        @DisplayName("opens a session stamped with the clock and zero hours")
+        void startsSession() {
+            givenWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+            givenServiceLine(WORKORDER_ID);
+
+            WorkorderLaborEntry entry =
+                    service.startLaborSession(WORKORDER_ID, SERVICE_ID, TECHNICIAN_ID, "brake job", "jane.smith", null);
+
+            assertThat(entry.getTechnicianId()).isEqualTo(TECHNICIAN_ID);
+            assertThat(entry.getStartTime()).isEqualTo(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC));
+            assertThat(entry.getHoursWorked()).isEqualByComparingTo("0");
+            assertThat(entry.getNotes()).isEqualTo("brake job");
+            assertThat(entry.getCreatedBy()).isEqualTo("jane.smith");
+            assertThat(entry.isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("allows every labor-eligible workorder status")
+        void allowsEligibleStatuses() {
+            givenServiceLine(WORKORDER_ID);
+            for (WorkorderStatus status : List.of(
+                    WorkorderStatus.ASSIGNED,
+                    WorkorderStatus.WORK_IN_PROGRESS,
+                    WorkorderStatus.AWAITING_PARTS,
+                    WorkorderStatus.AWAITING_APPROVAL)) {
+                givenWorkorder(status);
+
+                assertThat(service.startLaborSession(WORKORDER_ID, SERVICE_ID, TECHNICIAN_ID, null, "jane.smith", null))
+                        .isNotNull();
+            }
+        }
+
+        @Test
+        @DisplayName("refuses a workorder in a status that does not allow labor")
+        void rejectsIneligibleStatus() {
+            givenWorkorder(WorkorderStatus.COMPLETED);
+
+            assertThatThrownBy(() -> service.startLaborSession(
+                            WORKORDER_ID, SERVICE_ID, TECHNICIAN_ID, null, "jane.smith", null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Cannot start labor on workorder with status COMPLETED");
+        }
+
+        @Test
+        @DisplayName("refuses a second open session on the same service line")
+        void rejectsConcurrentSession() {
+            givenWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+            when(laborRepository.findByWorkorderService_IdAndEndTimeIsNull(SERVICE_ID))
+                    .thenReturn(Optional.of(openEntry(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC))));
+
+            assertThatThrownBy(() -> service.startLaborSession(
+                            WORKORDER_ID, SERVICE_ID, TECHNICIAN_ID, null, "jane.smith", null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Active labor session already exists");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown workorder")
+        void rejectsUnknownWorkorder() {
+            when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.startLaborSession(
+                            WORKORDER_ID, SERVICE_ID, TECHNICIAN_ID, null, "jane.smith", null))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Workorder not found");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown service line")
+        void rejectsUnknownServiceLine() {
+            givenWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+            when(workorderServiceRepository.findById(SERVICE_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.startLaborSession(
+                            WORKORDER_ID, SERVICE_ID, TECHNICIAN_ID, null, "jane.smith", null))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Workorder service not found");
+        }
+
+        @Test
+        @DisplayName("rejects a service line owned by another workorder")
+        void rejectsForeignServiceLine() {
+            givenWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+            givenServiceLine(OTHER_WORKORDER_ID);
+
+            assertThatThrownBy(() -> service.startLaborSession(
+                            WORKORDER_ID, SERVICE_ID, TECHNICIAN_ID, null, "jane.smith", null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("does not belong to workorder");
+        }
+
+        @Test
+        @DisplayName("rejects a detached service line")
+        void rejectsDetachedServiceLine() {
+            givenWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+            givenServiceLine(null);
+
+            assertThatThrownBy(() -> service.startLaborSession(
+                            WORKORDER_ID, SERVICE_ID, TECHNICIAN_ID, null, "jane.smith", null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("does not belong to workorder");
+        }
+
+        @Test
+        @DisplayName("registers the idempotency key under the start operation")
+        void registersIdempotencyKey() {
+            givenWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+            givenServiceLine(WORKORDER_ID);
+
+            service.startLaborSession(WORKORDER_ID, SERVICE_ID, TECHNICIAN_ID, null, "jane.smith", "start-key");
+
+            verify(idempotencyService).registerLaborKey(START_OPERATION, "start-key", ENTRY_ID);
+        }
+
+        @Test
+        @DisplayName("replays the recorded entry when the idempotency key was already used")
+        void replaysExistingEntry() {
+            WorkorderLaborEntry existing = openEntry(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC));
+            when(idempotencyService.getExistingLaborEntryId(START_OPERATION, "start-key"))
+                    .thenReturn(Optional.of(ENTRY_ID));
+            when(laborRepository.findById(ENTRY_ID)).thenReturn(Optional.of(existing));
+
+            assertThat(service.startLaborSession(
+                            WORKORDER_ID, SERVICE_ID, TECHNICIAN_ID, null, "jane.smith", "start-key"))
+                    .isSameAs(existing);
+            verify(laborRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("fails when the replayed entry has vanished")
+        void failsWhenReplayedEntryMissing() {
+            when(idempotencyService.getExistingLaborEntryId(START_OPERATION, "start-key"))
+                    .thenReturn(Optional.of(ENTRY_ID));
+            when(laborRepository.findById(ENTRY_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.startLaborSession(
+                            WORKORDER_ID, SERVICE_ID, TECHNICIAN_ID, null, "jane.smith", "start-key"))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Labor entry not found");
+        }
+
+        @Test
+        @DisplayName("treats a blank idempotency key as absent")
+        void blankKeyIsNotIdempotent() {
+            givenWorkorder(WorkorderStatus.WORK_IN_PROGRESS);
+            givenServiceLine(WORKORDER_ID);
+
+            service.startLaborSession(WORKORDER_ID, SERVICE_ID, TECHNICIAN_ID, null, "jane.smith", " ");
+
+            verify(idempotencyService, never()).getExistingLaborEntryId(anyString(), anyString());
+            verify(idempotencyService, never()).registerLaborKey(anyString(), anyString(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("stopLaborSession")
+    class StopLaborSession {
+
+        @Test
+        @DisplayName("closes the session and derives hours from the elapsed duration")
+        void stopsSession() {
+            LocalDateTime start = LocalDateTime.ofInstant(NOW, ZoneOffset.UTC).minusMinutes(90);
+            WorkorderLaborEntry entry = openEntry(start);
+            when(laborRepository.findById(ENTRY_ID)).thenReturn(Optional.of(entry));
+
+            WorkorderLaborEntry stopped = service.stopLaborSession(ENTRY_ID, null);
+
+            assertThat(stopped.getEndTime()).isEqualTo(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC));
+            assertThat(stopped.getHoursWorked()).isEqualByComparingTo("1.50");
+            assertThat(stopped.isActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("refuses to stop a session that is already closed")
+        void rejectsAlreadyStopped() {
+            LocalDateTime start = LocalDateTime.ofInstant(NOW, ZoneOffset.UTC).minusHours(2);
+            WorkorderLaborEntry entry = openEntry(start);
+            entry.stop(start.plusHours(1));
+            when(laborRepository.findById(ENTRY_ID)).thenReturn(Optional.of(entry));
+
+            assertThatThrownBy(() -> service.stopLaborSession(ENTRY_ID, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Labor session already stopped");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown entry")
+        void rejectsUnknownEntry() {
+            when(laborRepository.findById(ENTRY_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.stopLaborSession(ENTRY_ID, null))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Labor entry not found");
+        }
+
+        @Test
+        @DisplayName("registers the idempotency key under the stop operation")
+        void registersIdempotencyKey() {
+            when(laborRepository.findById(ENTRY_ID))
+                    .thenReturn(Optional.of(openEntry(
+                            LocalDateTime.ofInstant(NOW, ZoneOffset.UTC).minusMinutes(30))));
+
+            service.stopLaborSession(ENTRY_ID, "stop-key");
+
+            verify(idempotencyService).registerLaborKey(STOP_OPERATION, "stop-key", ENTRY_ID);
+        }
+
+        @Test
+        @DisplayName("replays the recorded entry when the idempotency key was already used")
+        void replaysExistingEntry() {
+            WorkorderLaborEntry existing = openEntry(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC));
+            when(idempotencyService.getExistingLaborEntryId(STOP_OPERATION, "stop-key"))
+                    .thenReturn(Optional.of(ENTRY_ID));
+            when(laborRepository.findById(ENTRY_ID)).thenReturn(Optional.of(existing));
+
+            assertThat(service.stopLaborSession(ENTRY_ID, "stop-key")).isSameAs(existing);
+            verify(laborRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("fails when the replayed entry has vanished")
+        void failsWhenReplayedEntryMissing() {
+            when(idempotencyService.getExistingLaborEntryId(STOP_OPERATION, "stop-key"))
+                    .thenReturn(Optional.of(ENTRY_ID));
+            when(laborRepository.findById(ENTRY_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.stopLaborSession(ENTRY_ID, "stop-key"))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Labor entry not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("adjustLaborHours")
+    class AdjustLaborHours {
+
+        @Test
+        @DisplayName("overwrites hours worked and records the reason")
+        void adjustsHours() {
+            WorkorderLaborEntry entry = openEntry(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC));
+            when(laborRepository.findById(ENTRY_ID)).thenReturn(Optional.of(entry));
+
+            WorkorderLaborEntry adjusted =
+                    service.adjustLaborHours(ENTRY_ID, new BigDecimal("2.25"), "customer disputed", "jane.smith", null);
+
+            assertThat(adjusted.getHoursWorked()).isEqualByComparingTo("2.25");
+            assertThat(adjusted.getAdjustmentReason()).isEqualTo("customer disputed");
+
+            ArgumentCaptor<WorkorderLaborEntry> captor = ArgumentCaptor.forClass(WorkorderLaborEntry.class);
+            verify(laborRepository).save(captor.capture());
+            assertThat(captor.getValue()).isSameAs(entry);
+        }
+
+        @Test
+        @DisplayName("rejects negative hours")
+        void rejectsNegativeHours() {
+            when(laborRepository.findById(ENTRY_ID))
+                    .thenReturn(Optional.of(openEntry(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC))));
+
+            assertThatThrownBy(
+                            () -> service.adjustLaborHours(ENTRY_ID, new BigDecimal("-1"), "typo", "jane.smith", null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Hours worked cannot be negative");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown entry")
+        void rejectsUnknownEntry() {
+            when(laborRepository.findById(ENTRY_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.adjustLaborHours(ENTRY_ID, BigDecimal.ONE, "reason", "jane.smith", null))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Labor entry not found");
+        }
+
+        @Test
+        @DisplayName("registers the idempotency key under the adjust operation")
+        void registersIdempotencyKey() {
+            when(laborRepository.findById(ENTRY_ID))
+                    .thenReturn(Optional.of(openEntry(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC))));
+
+            service.adjustLaborHours(ENTRY_ID, BigDecimal.ONE, "reason", "jane.smith", "adjust-key");
+
+            verify(idempotencyService).registerLaborKey(ADJUST_OPERATION, "adjust-key", ENTRY_ID);
+        }
+
+        @Test
+        @DisplayName("replays the recorded entry when the idempotency key was already used")
+        void replaysExistingEntry() {
+            WorkorderLaborEntry existing = openEntry(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC));
+            when(idempotencyService.getExistingLaborEntryId(ADJUST_OPERATION, "adjust-key"))
+                    .thenReturn(Optional.of(ENTRY_ID));
+            when(laborRepository.findById(ENTRY_ID)).thenReturn(Optional.of(existing));
+
+            assertThat(service.adjustLaborHours(ENTRY_ID, BigDecimal.ONE, "reason", "jane.smith", "adjust-key"))
+                    .isSameAs(existing);
+            verify(laborRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("fails when the replayed entry has vanished")
+        void failsWhenReplayedEntryMissing() {
+            when(idempotencyService.getExistingLaborEntryId(ADJUST_OPERATION, "adjust-key"))
+                    .thenReturn(Optional.of(ENTRY_ID));
+            when(laborRepository.findById(ENTRY_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                            service.adjustLaborHours(ENTRY_ID, BigDecimal.ONE, "reason", "jane.smith", "adjust-key"))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Labor entry not found");
+        }
+    }
+
+    @Test
+    @DisplayName("labor history is delegated to the repository, newest first")
+    void returnsLaborHistory() {
+        WorkorderLaborEntry entry = openEntry(LocalDateTime.ofInstant(NOW, ZoneOffset.UTC));
+        when(laborRepository.findByWorkorder_IdOrderByStartTimeDesc(WORKORDER_ID))
+                .thenReturn(List.of(entry));
+
+        assertThat(service.getLaborHistory(WORKORDER_ID)).containsExactly(entry);
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImplTest.java
@@ -1,0 +1,613 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.security.common.GatewaySecurityConstants;
+import com.positivity.workorder.internal.dto.WorkorderPartAdjustmentEventResponse;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderPart;
+import com.positivity.workorder.internal.entity.WorkorderPartAdjustmentEvent;
+import com.positivity.workorder.internal.enums.WorkorderItemStatus;
+import com.positivity.workorder.internal.repository.WorkorderPartAdjustmentEventRepository;
+import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.service.IdempotencyService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Part adjustments (CAP:005 story #157): substitutions, supplemental returns, and administrative
+ * quantity corrections each append an immutable adjustment event and are replayable by
+ * idempotency key.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("WorkorderPartAdjustmentServiceImpl")
+class WorkorderPartAdjustmentServiceImplTest {
+
+    private static final UUID WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee11");
+    private static final UUID OTHER_WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee12");
+    private static final UUID PART_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee13");
+    private static final UUID SUBSTITUTE_PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee14");
+    private static final UUID NEW_PART_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee15");
+    private static final UUID EVENT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee16");
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+
+    private static final String SUBSTITUTE_OPERATION = "part-adjustment.substitute";
+    private static final String RETURN_OPERATION = "part-adjustment.additional-return";
+    private static final String CORRECTION_OPERATION = "part-adjustment.correction";
+
+    @Mock
+    private WorkorderPartRepository workorderPartRepository;
+
+    @Mock
+    private WorkorderPartAdjustmentEventRepository adjustmentEventRepository;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    @Mock
+    private WorkorderFactPublisher workorderFactPublisher;
+
+    private WorkorderPartAdjustmentServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkorderPartAdjustmentServiceImpl(
+                workorderPartRepository,
+                adjustmentEventRepository,
+                idempotencyService,
+                workorderFactPublisher,
+                Clock.fixed(NOW, ZoneOffset.UTC));
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken("jane.smith", "n/a", List.of());
+        token.setDetails(Map.of(GatewaySecurityConstants.DETAIL_USERNAME, "jane.smith"));
+        SecurityContextHolder.getContext().setAuthentication(token);
+
+        when(idempotencyService.getExistingPartAdjustmentEventId(anyString(), anyString()))
+                .thenReturn(Optional.empty());
+        when(workorderPartRepository.save(any())).thenAnswer(invocation -> {
+            WorkorderPart part = invocation.getArgument(0);
+            if (part.getId() == null) {
+                part.setId(NEW_PART_ID);
+            }
+            return part;
+        });
+        when(adjustmentEventRepository.save(any())).thenAnswer(invocation -> {
+            WorkorderPartAdjustmentEvent event = invocation.getArgument(0);
+            if (event.getId() == null) {
+                event.setId(EVENT_ID);
+            }
+            return event;
+        });
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private static Workorder workorder(UUID id) {
+        Workorder workorder = new Workorder();
+        workorder.setId(id);
+        return workorder;
+    }
+
+    private WorkorderPart part(String issued, String consumed, String returned) {
+        return WorkorderPart.builder()
+                .id(PART_ID)
+                .workorder(workorder(WORKORDER_ID))
+                .description("Brake pad set")
+                .quantity(new BigDecimal("2"))
+                .unitPrice(new BigDecimal("49.99"))
+                .lineTotal(new BigDecimal("99.98"))
+                .taxCode("TX-STD")
+                .status(WorkorderItemStatus.OPEN)
+                .quantityIssued(new BigDecimal(issued))
+                .quantityConsumed(new BigDecimal(consumed))
+                .quantityReturned(new BigDecimal(returned))
+                .build();
+    }
+
+    private void givenPart(WorkorderPart part) {
+        when(workorderPartRepository.findById(PART_ID)).thenReturn(Optional.of(part));
+    }
+
+    private WorkorderPartAdjustmentEvent savedEvent() {
+        ArgumentCaptor<WorkorderPartAdjustmentEvent> captor =
+                ArgumentCaptor.forClass(WorkorderPartAdjustmentEvent.class);
+        verify(adjustmentEventRepository).save(captor.capture());
+        return captor.getValue();
+    }
+
+    private WorkorderPartAdjustmentEvent existingEvent(String type) {
+        return WorkorderPartAdjustmentEvent.builder()
+                .id(EVENT_ID)
+                .originalPart(part("2", "0", "0"))
+                .workorderId(WORKORDER_ID)
+                .adjustmentType(type)
+                .quantityAdjustment(BigDecimal.ONE)
+                .reason("replayed")
+                .performedBy("jane.smith")
+                .performedAt(NOW)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("substitutePartLine")
+    class SubstitutePartLine {
+
+        @Test
+        @DisplayName("mirrors the original line onto a new part and records a SUBSTITUTION event")
+        void substitutesPart() {
+            WorkorderPart original = part("2", "0", "0");
+            givenPart(original);
+
+            WorkorderPartAdjustmentEventResponse response = service.substitutePartLine(
+                    WORKORDER_ID, PART_ID, SUBSTITUTE_PRODUCT_ID, "OUT_OF_STOCK", null, "supplier backorder");
+
+            ArgumentCaptor<WorkorderPart> partCaptor = ArgumentCaptor.forClass(WorkorderPart.class);
+            verify(workorderPartRepository).save(partCaptor.capture());
+            WorkorderPart substitute = partCaptor.getValue();
+            assertThat(substitute.getProductEntityId()).isEqualTo(SUBSTITUTE_PRODUCT_ID);
+            assertThat(substitute.getDescription()).isEqualTo("Brake pad set (Substitute)");
+            assertThat(substitute.getQuantity()).isEqualByComparingTo("2");
+            assertThat(substitute.getUnitPrice()).isEqualByComparingTo("49.99");
+            assertThat(substitute.getLineTotal()).isEqualByComparingTo("99.98");
+            assertThat(substitute.getTaxCode()).isEqualTo("TX-STD");
+            assertThat(substitute.getStatus()).isEqualTo(WorkorderItemStatus.OPEN);
+            assertThat(substitute.getQuantityIssued()).isEqualByComparingTo("0");
+
+            assertThat(response.getAdjustmentType()).isEqualTo("SUBSTITUTION");
+            assertThat(response.getSubstitutedWithPartId()).isEqualTo(NEW_PART_ID);
+            assertThat(response.getQuantityAdjustment()).isEqualByComparingTo("0");
+            assertThat(response.getReason()).isEqualTo("OUT_OF_STOCK");
+            assertThat(response.getNotes()).isEqualTo("supplier backorder");
+            assertThat(response.getPerformedBy()).isEqualTo("jane.smith");
+            assertThat(response.getPerformedAt()).isEqualTo(NOW);
+            assertThat(response.getOriginalPartId()).isEqualTo(PART_ID);
+            assertThat(response.getOriginalPartDescription()).isEqualTo("Brake pad set");
+            assertThat(response.getSubstitutedWithPartDescription()).isNull();
+
+            verify(workorderFactPublisher).markChanged(WORKORDER_ID);
+        }
+
+        @Test
+        @DisplayName("leaves the original part in place for history")
+        void keepsOriginalPart() {
+            WorkorderPart original = part("2", "0", "0");
+            givenPart(original);
+
+            service.substitutePartLine(WORKORDER_ID, PART_ID, SUBSTITUTE_PRODUCT_ID, "OUT_OF_STOCK", null, null);
+
+            verify(workorderPartRepository, never()).delete(any());
+            assertThat(savedEvent().getOriginalPart()).isSameAs(original);
+        }
+
+        @Test
+        @DisplayName("registers the idempotency key under the substitute operation")
+        void registersIdempotencyKey() {
+            givenPart(part("2", "0", "0"));
+
+            service.substitutePartLine(WORKORDER_ID, PART_ID, SUBSTITUTE_PRODUCT_ID, "OUT_OF_STOCK", "sub-key", null);
+
+            verify(idempotencyService).markKeyProcessedForPartAdjustment(SUBSTITUTE_OPERATION, "sub-key", EVENT_ID);
+        }
+
+        @Test
+        @DisplayName("replays the recorded event when the idempotency key was already used")
+        void replaysExistingEvent() {
+            when(idempotencyService.getExistingPartAdjustmentEventId(SUBSTITUTE_OPERATION, "sub-key"))
+                    .thenReturn(Optional.of(EVENT_ID));
+            when(adjustmentEventRepository.findById(EVENT_ID)).thenReturn(Optional.of(existingEvent("SUBSTITUTION")));
+
+            WorkorderPartAdjustmentEventResponse response = service.substitutePartLine(
+                    WORKORDER_ID, PART_ID, SUBSTITUTE_PRODUCT_ID, "OUT_OF_STOCK", "sub-key", null);
+
+            assertThat(response.getId()).isEqualTo(EVENT_ID);
+            assertThat(response.getReason()).isEqualTo("replayed");
+            verify(adjustmentEventRepository, never()).save(any());
+            verify(workorderPartRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("fails when the replayed event has vanished")
+        void failsWhenReplayedEventMissing() {
+            when(idempotencyService.getExistingPartAdjustmentEventId(SUBSTITUTE_OPERATION, "sub-key"))
+                    .thenReturn(Optional.of(EVENT_ID));
+            when(adjustmentEventRepository.findById(EVENT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.substitutePartLine(
+                            WORKORDER_ID, PART_ID, SUBSTITUTE_PRODUCT_ID, "OUT_OF_STOCK", "sub-key", null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Adjustment event not found");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown original part")
+        void rejectsUnknownPart() {
+            when(workorderPartRepository.findById(PART_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.substitutePartLine(
+                            WORKORDER_ID, PART_ID, SUBSTITUTE_PRODUCT_ID, "OUT_OF_STOCK", null, null))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Original part not found");
+        }
+
+        @Test
+        @DisplayName("rejects a part that belongs to a different workorder")
+        void rejectsForeignPart() {
+            WorkorderPart foreign = part("2", "0", "0");
+            foreign.setWorkorder(workorder(OTHER_WORKORDER_ID));
+            givenPart(foreign);
+
+            assertThatThrownBy(() -> service.substitutePartLine(
+                            WORKORDER_ID, PART_ID, SUBSTITUTE_PRODUCT_ID, "OUT_OF_STOCK", null, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("does not belong to workorder");
+        }
+
+        @Test
+        @DisplayName("refuses to substitute a part that has already been consumed")
+        void rejectsConsumedPart() {
+            givenPart(part("2", "1", "0"));
+
+            assertThatThrownBy(() -> service.substitutePartLine(
+                            WORKORDER_ID, PART_ID, SUBSTITUTE_PRODUCT_ID, "OUT_OF_STOCK", null, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Cannot substitute part that has already been consumed");
+        }
+
+        @Test
+        @DisplayName("refuses to substitute a part with itself")
+        void rejectsSelfSubstitution() {
+            givenPart(part("2", "0", "0"));
+
+            assertThatThrownBy(() ->
+                            service.substitutePartLine(WORKORDER_ID, PART_ID, PART_ID, "OUT_OF_STOCK", null, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Substitute part must be different from original part");
+        }
+
+        @Test
+        @DisplayName("fails when the part is orphaned from any workorder")
+        void failsWhenPartHasNoWorkorder() {
+            WorkorderPart orphan = part("2", "0", "0");
+            orphan.setWorkorder(null);
+            orphan.setWorkOrderService(null);
+            givenPart(orphan);
+
+            assertThatThrownBy(() -> service.substitutePartLine(
+                            WORKORDER_ID, PART_ID, SUBSTITUTE_PRODUCT_ID, "OUT_OF_STOCK", null, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Part has no workorder reference");
+        }
+
+        @Test
+        @DisplayName("fails when the security context is empty")
+        void failsWithoutAuthenticatedUser() {
+            SecurityContextHolder.clearContext();
+
+            assertThatThrownBy(() -> service.substitutePartLine(
+                            WORKORDER_ID, PART_ID, SUBSTITUTE_PRODUCT_ID, "OUT_OF_STOCK", null, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Security context has no Authentication");
+        }
+    }
+
+    @Nested
+    @DisplayName("returnUnusedQuantity")
+    class ReturnUnusedQuantity {
+
+        @Test
+        @DisplayName("records a negative ADDITIONAL_RETURN adjustment and grows the returned total")
+        void returnsQuantity() {
+            WorkorderPart part = part("5", "2", "1");
+            givenPart(part);
+
+            WorkorderPartAdjustmentEventResponse response = service.returnUnusedQuantity(
+                    WORKORDER_ID, PART_ID, new BigDecimal("2"), "CUSTOMER_DECLINED", null, "left on shelf");
+
+            assertThat(part.getQuantityReturned()).isEqualByComparingTo("3");
+            assertThat(response.getAdjustmentType()).isEqualTo("ADDITIONAL_RETURN");
+            assertThat(response.getQuantityAdjustment()).isEqualByComparingTo("-2");
+            assertThat(response.getSubstitutedWithPartId()).isNull();
+            assertThat(response.getNotes()).isEqualTo("left on shelf");
+            verify(workorderFactPublisher).markChanged(WORKORDER_ID);
+        }
+
+        @Test
+        @DisplayName("allows returning exactly the available quantity")
+        void allowsReturningAllAvailable() {
+            WorkorderPart part = part("5", "2", "1");
+            givenPart(part);
+
+            service.returnUnusedQuantity(WORKORDER_ID, PART_ID, new BigDecimal("2"), "reason", null, null);
+
+            assertThat(part.getQuantityReturned()).isEqualByComparingTo("3");
+        }
+
+        @Test
+        @DisplayName("rejects a return beyond issued minus consumed minus already returned")
+        void rejectsOverReturn() {
+            givenPart(part("5", "2", "1"));
+
+            assertThatThrownBy(() -> service.returnUnusedQuantity(
+                            WORKORDER_ID, PART_ID, new BigDecimal("2.5"), "reason", null, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("exceeds available quantity");
+            verify(adjustmentEventRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("rejects a non-positive quantity")
+        void rejectsNonPositiveQuantity() {
+            assertThatThrownBy(
+                            () -> service.returnUnusedQuantity(WORKORDER_ID, PART_ID, BigDecimal.ZERO, "r", null, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Return quantity must be positive");
+        }
+
+        @Test
+        @DisplayName("registers the idempotency key under the additional-return operation")
+        void registersIdempotencyKey() {
+            givenPart(part("5", "0", "0"));
+
+            service.returnUnusedQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "reason", "ret-key", null);
+
+            verify(idempotencyService).markKeyProcessedForPartAdjustment(RETURN_OPERATION, "ret-key", EVENT_ID);
+        }
+
+        @Test
+        @DisplayName("replays the recorded event when the idempotency key was already used")
+        void replaysExistingEvent() {
+            when(idempotencyService.getExistingPartAdjustmentEventId(RETURN_OPERATION, "ret-key"))
+                    .thenReturn(Optional.of(EVENT_ID));
+            when(adjustmentEventRepository.findById(EVENT_ID))
+                    .thenReturn(Optional.of(existingEvent("ADDITIONAL_RETURN")));
+
+            assertThat(service.returnUnusedQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "reason", "ret-key", null)
+                            .getAdjustmentType())
+                    .isEqualTo("ADDITIONAL_RETURN");
+            verify(workorderPartRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("fails when the replayed event has vanished")
+        void failsWhenReplayedEventMissing() {
+            when(idempotencyService.getExistingPartAdjustmentEventId(RETURN_OPERATION, "ret-key"))
+                    .thenReturn(Optional.of(EVENT_ID));
+            when(adjustmentEventRepository.findById(EVENT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.returnUnusedQuantity(
+                            WORKORDER_ID, PART_ID, BigDecimal.ONE, "reason", "ret-key", null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Adjustment event not found");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown part and a foreign part")
+        void rejectsUnresolvableTargets() {
+            when(workorderPartRepository.findById(PART_ID)).thenReturn(Optional.empty());
+            assertThatThrownBy(
+                            () -> service.returnUnusedQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "r", null, null))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Part not found");
+
+            WorkorderPart foreign = part("5", "0", "0");
+            foreign.setWorkorder(workorder(OTHER_WORKORDER_ID));
+            givenPart(foreign);
+            assertThatThrownBy(
+                            () -> service.returnUnusedQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "r", null, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("does not belong to workorder");
+        }
+
+        @Test
+        @DisplayName("fails when the security context is empty")
+        void failsWithoutAuthenticatedUser() {
+            SecurityContextHolder.clearContext();
+
+            assertThatThrownBy(
+                            () -> service.returnUnusedQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "r", null, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Security context has no Authentication");
+        }
+    }
+
+    @Nested
+    @DisplayName("correctPartQuantity")
+    class CorrectPartQuantity {
+
+        @Test
+        @DisplayName("raises the authorized quantity and recomputes the line total")
+        void correctsUpwards() {
+            WorkorderPart part = part("0", "0", "0");
+            givenPart(part);
+
+            WorkorderPartAdjustmentEventResponse response = service.correctPartQuantity(
+                    WORKORDER_ID, PART_ID, new BigDecimal("5"), "DATA_ENTRY_ERROR", null, "counted again");
+
+            assertThat(part.getQuantity()).isEqualByComparingTo("5");
+            assertThat(part.getLineTotal()).isEqualByComparingTo("249.95");
+            assertThat(response.getAdjustmentType()).isEqualTo("CORRECTION");
+            assertThat(response.getQuantityAdjustment()).isEqualByComparingTo("3");
+            assertThat(response.getSubstitutedWithPartId()).isNull();
+            verify(workorderFactPublisher).markChanged(WORKORDER_ID);
+        }
+
+        @Test
+        @DisplayName("records a negative adjustment when the quantity is corrected downwards")
+        void correctsDownwards() {
+            WorkorderPart part = part("0", "0", "0");
+            givenPart(part);
+
+            WorkorderPartAdjustmentEventResponse response =
+                    service.correctPartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "reason", null, null);
+
+            assertThat(response.getQuantityAdjustment()).isEqualByComparingTo("-1");
+            assertThat(part.getLineTotal()).isEqualByComparingTo("49.99");
+        }
+
+        @Test
+        @DisplayName("leaves the line total untouched when the part has no unit price")
+        void skipsLineTotalWithoutUnitPrice() {
+            WorkorderPart part = part("0", "0", "0");
+            part.setUnitPrice(null);
+            part.setLineTotal(new BigDecimal("99.98"));
+            givenPart(part);
+
+            service.correctPartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("4"), "reason", null, null);
+
+            assertThat(part.getQuantity()).isEqualByComparingTo("4");
+            assertThat(part.getLineTotal()).isEqualByComparingTo("99.98");
+        }
+
+        @Test
+        @DisplayName("rejects a non-positive new quantity")
+        void rejectsNonPositiveQuantity() {
+            assertThatThrownBy(
+                            () -> service.correctPartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ZERO, "r", null, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("New quantity must be positive");
+            assertThatThrownBy(() ->
+                            service.correctPartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("-3"), "r", null, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("New quantity must be positive");
+        }
+
+        @Test
+        @DisplayName("registers the idempotency key under the correction operation")
+        void registersIdempotencyKey() {
+            givenPart(part("0", "0", "0"));
+
+            service.correctPartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("3"), "reason", "corr-key", null);
+
+            verify(idempotencyService).markKeyProcessedForPartAdjustment(CORRECTION_OPERATION, "corr-key", EVENT_ID);
+        }
+
+        @Test
+        @DisplayName("replays the recorded event when the idempotency key was already used")
+        void replaysExistingEvent() {
+            when(idempotencyService.getExistingPartAdjustmentEventId(CORRECTION_OPERATION, "corr-key"))
+                    .thenReturn(Optional.of(EVENT_ID));
+            when(adjustmentEventRepository.findById(EVENT_ID)).thenReturn(Optional.of(existingEvent("CORRECTION")));
+
+            assertThat(service.correctPartQuantity(
+                                    WORKORDER_ID, PART_ID, new BigDecimal("3"), "reason", "corr-key", null)
+                            .getAdjustmentType())
+                    .isEqualTo("CORRECTION");
+            verify(workorderPartRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("fails when the replayed event has vanished")
+        void failsWhenReplayedEventMissing() {
+            when(idempotencyService.getExistingPartAdjustmentEventId(CORRECTION_OPERATION, "corr-key"))
+                    .thenReturn(Optional.of(EVENT_ID));
+            when(adjustmentEventRepository.findById(EVENT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.correctPartQuantity(
+                            WORKORDER_ID, PART_ID, new BigDecimal("3"), "reason", "corr-key", null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Adjustment event not found");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown part and a foreign part")
+        void rejectsUnresolvableTargets() {
+            when(workorderPartRepository.findById(PART_ID)).thenReturn(Optional.empty());
+            assertThatThrownBy(
+                            () -> service.correctPartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "r", null, null))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Part not found");
+
+            WorkorderPart foreign = part("0", "0", "0");
+            foreign.setWorkorder(workorder(OTHER_WORKORDER_ID));
+            givenPart(foreign);
+            assertThatThrownBy(
+                            () -> service.correctPartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "r", null, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("does not belong to workorder");
+        }
+
+        @Test
+        @DisplayName("fails when the security context is empty")
+        void failsWithoutAuthenticatedUser() {
+            SecurityContextHolder.clearContext();
+
+            assertThatThrownBy(
+                            () -> service.correctPartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "r", null, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Security context has no Authentication");
+        }
+    }
+
+    @Nested
+    @DisplayName("adjustment history")
+    class AdjustmentHistory {
+
+        @Test
+        @DisplayName("maps the workorder's adjustment events newest first")
+        void mapsWorkorderHistory() {
+            when(adjustmentEventRepository.findByWorkorderIdOrderByPerformedAtDesc(WORKORDER_ID))
+                    .thenReturn(List.of(existingEvent("CORRECTION"), existingEvent("SUBSTITUTION")));
+
+            List<WorkorderPartAdjustmentEventResponse> history = service.getAdjustmentHistory(WORKORDER_ID);
+
+            assertThat(history)
+                    .extracting(WorkorderPartAdjustmentEventResponse::getAdjustmentType)
+                    .containsExactly("CORRECTION", "SUBSTITUTION");
+        }
+
+        @Test
+        @DisplayName("maps a single part's adjustment events")
+        void mapsPartHistory() {
+            when(adjustmentEventRepository.findByOriginalPartIdOrderByPerformedAtDesc(PART_ID))
+                    .thenReturn(List.of(existingEvent("ADDITIONAL_RETURN")));
+
+            assertThat(service.getPartAdjustmentHistory(PART_ID))
+                    .singleElement()
+                    .satisfies(response -> {
+                        assertThat(response.getAdjustmentType()).isEqualTo("ADDITIONAL_RETURN");
+                        assertThat(response.getOriginalPartId()).isEqualTo(PART_ID);
+                        assertThat(response.getOriginalPartDescription()).isEqualTo("Brake pad set");
+                    });
+        }
+
+        @Test
+        @DisplayName("returns an empty history when nothing has been adjusted")
+        void emptyHistory() {
+            when(adjustmentEventRepository.findByWorkorderIdOrderByPerformedAtDesc(WORKORDER_ID))
+                    .thenReturn(List.of());
+
+            assertThat(service.getAdjustmentHistory(WORKORDER_ID)).isEmpty();
+        }
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImplTest.java
@@ -1,0 +1,650 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.security.common.GatewaySecurityConstants;
+import com.positivity.workorder.internal.dto.WorkorderPartUsageEventResponse;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderPart;
+import com.positivity.workorder.internal.entity.WorkorderPartUsageEvent;
+import com.positivity.workorder.internal.entity.WorkorderServiceLine;
+import com.positivity.workorder.internal.exception.WorkorderNotFoundException;
+import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.internal.repository.WorkorderPartUsageEventRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.service.IdempotencyService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Parts usage tracking (CAP:005 story #158): issue / consume / return move quantities on a
+ * workorder part line, each operation guarded by its own idempotency namespace and by the
+ * issued &gt;= consumed + returned invariant.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("WorkorderPartUsageServiceImpl")
+class WorkorderPartUsageServiceImplTest {
+
+    private static final UUID WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fdd11");
+    private static final UUID OTHER_WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fdd12");
+    private static final UUID PART_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fdd13");
+    private static final UUID EVENT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fdd14");
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+
+    private static final String ISSUE_OPERATION = "part-usage.issue";
+    private static final String CONSUME_OPERATION = "part-usage.consume";
+    private static final String RETURN_OPERATION = "part-usage.return";
+
+    @Mock
+    private WorkorderRepository workorderRepository;
+
+    @Mock
+    private WorkorderPartRepository workorderPartRepository;
+
+    @Mock
+    private WorkorderPartUsageEventRepository usageEventRepository;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    @Mock
+    private WorkorderFactPublisher workorderFactPublisher;
+
+    private WorkorderPartUsageServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkorderPartUsageServiceImpl(
+                workorderRepository,
+                workorderPartRepository,
+                usageEventRepository,
+                idempotencyService,
+                workorderFactPublisher,
+                Clock.fixed(NOW, ZoneOffset.UTC));
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken("jane.smith", "n/a", List.of());
+        token.setDetails(Map.of(GatewaySecurityConstants.DETAIL_USERNAME, "jane.smith"));
+        SecurityContextHolder.getContext().setAuthentication(token);
+
+        when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(workorder(WORKORDER_ID)));
+        when(idempotencyService.getExistingPartUsageEventId(anyString(), anyString()))
+                .thenReturn(Optional.empty());
+        when(usageEventRepository.save(any())).thenAnswer(invocation -> {
+            WorkorderPartUsageEvent event = invocation.getArgument(0);
+            if (event.getId() == null) {
+                // The entity's id is assigned by the persistence provider and has no setter.
+                ReflectionTestUtils.setField(event, "id", EVENT_ID);
+            }
+            return event;
+        });
+        when(workorderPartRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private static Workorder workorder(UUID id) {
+        Workorder workorder = new Workorder();
+        workorder.setId(id);
+        return workorder;
+    }
+
+    /** A part attached directly to the workorder, with the supplied issued/consumed/returned totals. */
+    private WorkorderPart part(String issued, String consumed, String returned) {
+        return WorkorderPart.builder()
+                .id(PART_ID)
+                .workorder(workorder(WORKORDER_ID))
+                .description("Oil filter")
+                .quantity(new BigDecimal("2"))
+                .unitPrice(new BigDecimal("12.50"))
+                .lineTotal(new BigDecimal("25.00"))
+                .quantityIssued(new BigDecimal(issued))
+                .quantityConsumed(new BigDecimal(consumed))
+                .quantityReturned(new BigDecimal(returned))
+                .build();
+    }
+
+    private void givenPart(WorkorderPart part) {
+        when(workorderPartRepository.findById(PART_ID)).thenReturn(Optional.of(part));
+    }
+
+    @Nested
+    @DisplayName("issuePartQuantity")
+    class IssuePartQuantity {
+
+        @Test
+        @DisplayName("records an ISSUE event and adds to the issued total")
+        void issuesQuantity() {
+            WorkorderPart part = part("0", "0", "0");
+            givenPart(part);
+
+            WorkorderPartUsageEvent event = service.issuePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("2"), null);
+
+            assertThat(event.getEventType()).isEqualTo("ISSUE");
+            assertThat(event.getQuantity()).isEqualByComparingTo("2");
+            assertThat(event.getPerformedBy()).isEqualTo("jane.smith");
+            assertThat(event.getPerformedAt()).isEqualTo(NOW);
+            assertThat(event.getWorkorderId()).isEqualTo(WORKORDER_ID);
+            assertThat(part.getQuantityIssued()).isEqualByComparingTo("2");
+            verify(workorderPartRepository).save(part);
+            verify(workorderFactPublisher).markChanged(WORKORDER_ID);
+        }
+
+        @Test
+        @DisplayName("adds to a non-zero issued total rather than replacing it")
+        void accumulatesIssuedQuantity() {
+            WorkorderPart part = part("3", "1", "0");
+            givenPart(part);
+
+            service.issuePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("1.5"), null);
+
+            assertThat(part.getQuantityIssued()).isEqualByComparingTo("4.5");
+        }
+
+        @Test
+        @DisplayName("registers the idempotency key under the issue operation")
+        void registersIdempotencyKey() {
+            givenPart(part("0", "0", "0"));
+
+            service.issuePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "issue-key-1");
+
+            verify(idempotencyService).markKeyProcessedForPartUsage(ISSUE_OPERATION, "issue-key-1", EVENT_ID);
+        }
+
+        @Test
+        @DisplayName("replays the recorded event when the idempotency key was already used")
+        void replaysExistingEvent() {
+            WorkorderPartUsageEvent existing = WorkorderPartUsageEvent.builder()
+                    .id(EVENT_ID)
+                    .workorderPart(part("0", "0", "0"))
+                    .workorderId(WORKORDER_ID)
+                    .eventType("ISSUE")
+                    .quantity(BigDecimal.ONE)
+                    .performedBy("jane.smith")
+                    .performedAt(NOW)
+                    .build();
+            when(idempotencyService.getExistingPartUsageEventId(ISSUE_OPERATION, "issue-key-1"))
+                    .thenReturn(Optional.of(EVENT_ID));
+            when(usageEventRepository.findById(EVENT_ID)).thenReturn(Optional.of(existing));
+
+            WorkorderPartUsageEvent event =
+                    service.issuePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "issue-key-1");
+
+            assertThat(event).isSameAs(existing);
+            verify(usageEventRepository, never()).save(any());
+            verify(workorderPartRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("fails when the replayed event has vanished")
+        void failsWhenReplayedEventMissing() {
+            when(idempotencyService.getExistingPartUsageEventId(ISSUE_OPERATION, "issue-key-1"))
+                    .thenReturn(Optional.of(EVENT_ID));
+            when(usageEventRepository.findById(EVENT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.issuePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "issue-key-1"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Event not found");
+        }
+
+        @Test
+        @DisplayName("treats a blank idempotency key as absent")
+        void blankKeyIsNotIdempotent() {
+            givenPart(part("0", "0", "0"));
+
+            service.issuePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "   ");
+
+            verify(idempotencyService, never()).getExistingPartUsageEventId(anyString(), anyString());
+            verify(idempotencyService, never()).markKeyProcessedForPartUsage(anyString(), anyString(), any());
+            verify(usageEventRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("rejects a zero or negative quantity")
+        void rejectsNonPositiveQuantity() {
+            assertThatThrownBy(() -> service.issuePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ZERO, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Quantity must be positive");
+            assertThatThrownBy(() -> service.issuePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("-1"), null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Quantity must be positive");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown workorder")
+        void rejectsUnknownWorkorder() {
+            when(workorderRepository.findById(OTHER_WORKORDER_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.issuePartQuantity(OTHER_WORKORDER_ID, PART_ID, BigDecimal.ONE, null))
+                    .isInstanceOf(WorkorderNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("rejects an unknown part line")
+        void rejectsUnknownPart() {
+            when(workorderPartRepository.findById(PART_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.issuePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Part not found");
+        }
+
+        @Test
+        @DisplayName("rejects a part that belongs to a different workorder")
+        void rejectsPartFromAnotherWorkorder() {
+            WorkorderPart foreign = part("0", "0", "0");
+            foreign.setWorkorder(workorder(OTHER_WORKORDER_ID));
+            givenPart(foreign);
+
+            assertThatThrownBy(() -> service.issuePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("does not belong to workorder");
+        }
+
+        @Test
+        @DisplayName("fails when the part is orphaned from any workorder")
+        void failsWhenPartHasNoWorkorder() {
+            WorkorderPart orphan = part("0", "0", "0");
+            orphan.setWorkorder(null);
+            orphan.setWorkOrderService(null);
+            givenPart(orphan);
+
+            assertThatThrownBy(() -> service.issuePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Part has no associated workorder");
+        }
+
+        @Test
+        @DisplayName("fails when the security context is empty")
+        void failsWithoutAuthenticatedUser() {
+            SecurityContextHolder.clearContext();
+
+            assertThatThrownBy(() -> service.issuePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Security context has no Authentication");
+        }
+    }
+
+    @Nested
+    @DisplayName("consumePartQuantity")
+    class ConsumePartQuantity {
+
+        @Test
+        @DisplayName("records a CONSUME event and adds to the consumed total")
+        void consumesQuantity() {
+            WorkorderPart part = part("4", "1", "0");
+            givenPart(part);
+
+            WorkorderPartUsageEvent event =
+                    service.consumePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("2"), null);
+
+            assertThat(event.getEventType()).isEqualTo("CONSUME");
+            assertThat(part.getQuantityConsumed()).isEqualByComparingTo("3");
+            verify(workorderFactPublisher).markChanged(WORKORDER_ID);
+        }
+
+        @Test
+        @DisplayName("allows consuming exactly the issued quantity")
+        void allowsConsumingAllIssued() {
+            WorkorderPart part = part("4", "1", "0");
+            givenPart(part);
+
+            service.consumePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("3"), null);
+
+            assertThat(part.getQuantityConsumed()).isEqualByComparingTo("4");
+        }
+
+        @Test
+        @DisplayName("rejects consumption beyond the issued quantity")
+        void rejectsOverConsumption() {
+            givenPart(part("4", "1", "0"));
+
+            assertThatThrownBy(() -> service.consumePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("3.5"), null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Consumption exceeds issued quantity");
+            verify(usageEventRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("rejects a non-positive quantity")
+        void rejectsNonPositiveQuantity() {
+            assertThatThrownBy(() -> service.consumePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ZERO, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Quantity must be positive");
+        }
+
+        @Test
+        @DisplayName("registers the idempotency key under the consume operation")
+        void registersIdempotencyKey() {
+            givenPart(part("4", "0", "0"));
+
+            service.consumePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "consume-key-1");
+
+            verify(idempotencyService).markKeyProcessedForPartUsage(CONSUME_OPERATION, "consume-key-1", EVENT_ID);
+        }
+
+        @Test
+        @DisplayName("replays the recorded event when the idempotency key was already used")
+        void replaysExistingEvent() {
+            WorkorderPartUsageEvent existing = WorkorderPartUsageEvent.builder()
+                    .id(EVENT_ID)
+                    .workorderPart(part("0", "0", "0"))
+                    .workorderId(WORKORDER_ID)
+                    .eventType("ISSUE")
+                    .quantity(BigDecimal.ONE)
+                    .performedBy("jane.smith")
+                    .performedAt(NOW)
+                    .build();
+            when(idempotencyService.getExistingPartUsageEventId(CONSUME_OPERATION, "consume-key-1"))
+                    .thenReturn(Optional.of(EVENT_ID));
+            when(usageEventRepository.findById(EVENT_ID)).thenReturn(Optional.of(existing));
+
+            assertThat(service.consumePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "consume-key-1"))
+                    .isSameAs(existing);
+        }
+
+        @Test
+        @DisplayName("fails when the replayed event has vanished")
+        void failsWhenReplayedEventMissing() {
+            when(idempotencyService.getExistingPartUsageEventId(CONSUME_OPERATION, "consume-key-1"))
+                    .thenReturn(Optional.of(EVENT_ID));
+            when(usageEventRepository.findById(EVENT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(
+                            () -> service.consumePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "consume-key-1"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Event not found");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown workorder, unknown part, and a foreign part")
+        void rejectsUnresolvableTargets() {
+            when(workorderRepository.findById(OTHER_WORKORDER_ID)).thenReturn(Optional.empty());
+            assertThatThrownBy(() -> service.consumePartQuantity(OTHER_WORKORDER_ID, PART_ID, BigDecimal.ONE, null))
+                    .isInstanceOf(WorkorderNotFoundException.class);
+
+            when(workorderPartRepository.findById(PART_ID)).thenReturn(Optional.empty());
+            assertThatThrownBy(() -> service.consumePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Part not found");
+
+            WorkorderPart foreign = part("4", "0", "0");
+            foreign.setWorkorder(workorder(OTHER_WORKORDER_ID));
+            givenPart(foreign);
+            assertThatThrownBy(() -> service.consumePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("does not belong to workorder");
+        }
+
+        @Test
+        @DisplayName("fails when the security context is empty")
+        void failsWithoutAuthenticatedUser() {
+            SecurityContextHolder.clearContext();
+
+            assertThatThrownBy(() -> service.consumePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Security context has no Authentication");
+        }
+    }
+
+    @Nested
+    @DisplayName("returnPartQuantity")
+    class ReturnPartQuantity {
+
+        @Test
+        @DisplayName("records a RETURN event and adds to the returned total")
+        void returnsQuantity() {
+            WorkorderPart part = part("5", "2", "1");
+            givenPart(part);
+
+            WorkorderPartUsageEvent event =
+                    service.returnPartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("2"), null);
+
+            assertThat(event.getEventType()).isEqualTo("RETURN");
+            assertThat(part.getQuantityReturned()).isEqualByComparingTo("3");
+            verify(workorderFactPublisher).markChanged(WORKORDER_ID);
+        }
+
+        @Test
+        @DisplayName("rejects a return beyond issued minus consumed minus already returned")
+        void rejectsOverReturn() {
+            givenPart(part("5", "2", "1"));
+
+            assertThatThrownBy(() -> service.returnPartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("2.5"), null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Return quantity exceeds available");
+            verify(usageEventRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("rejects a non-positive quantity")
+        void rejectsNonPositiveQuantity() {
+            assertThatThrownBy(() -> service.returnPartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("-2"), null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Quantity must be positive");
+        }
+
+        @Test
+        @DisplayName("registers the idempotency key under the return operation")
+        void registersIdempotencyKey() {
+            givenPart(part("5", "0", "0"));
+
+            service.returnPartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "return-key-1");
+
+            verify(idempotencyService).markKeyProcessedForPartUsage(RETURN_OPERATION, "return-key-1", EVENT_ID);
+        }
+
+        @Test
+        @DisplayName("replays the recorded event when the idempotency key was already used")
+        void replaysExistingEvent() {
+            WorkorderPartUsageEvent existing = WorkorderPartUsageEvent.builder()
+                    .id(EVENT_ID)
+                    .workorderPart(part("0", "0", "0"))
+                    .workorderId(WORKORDER_ID)
+                    .eventType("ISSUE")
+                    .quantity(BigDecimal.ONE)
+                    .performedBy("jane.smith")
+                    .performedAt(NOW)
+                    .build();
+            when(idempotencyService.getExistingPartUsageEventId(RETURN_OPERATION, "return-key-1"))
+                    .thenReturn(Optional.of(EVENT_ID));
+            when(usageEventRepository.findById(EVENT_ID)).thenReturn(Optional.of(existing));
+
+            assertThat(service.returnPartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "return-key-1"))
+                    .isSameAs(existing);
+        }
+
+        @Test
+        @DisplayName("fails when the replayed event has vanished")
+        void failsWhenReplayedEventMissing() {
+            when(idempotencyService.getExistingPartUsageEventId(RETURN_OPERATION, "return-key-1"))
+                    .thenReturn(Optional.of(EVENT_ID));
+            when(usageEventRepository.findById(EVENT_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.returnPartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "return-key-1"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Event not found");
+        }
+
+        @Test
+        @DisplayName("rejects an unknown workorder, unknown part, and a foreign part")
+        void rejectsUnresolvableTargets() {
+            when(workorderRepository.findById(OTHER_WORKORDER_ID)).thenReturn(Optional.empty());
+            assertThatThrownBy(() -> service.returnPartQuantity(OTHER_WORKORDER_ID, PART_ID, BigDecimal.ONE, null))
+                    .isInstanceOf(WorkorderNotFoundException.class);
+
+            when(workorderPartRepository.findById(PART_ID)).thenReturn(Optional.empty());
+            assertThatThrownBy(() -> service.returnPartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Part not found");
+
+            WorkorderPart foreign = part("5", "0", "0");
+            foreign.setWorkorder(workorder(OTHER_WORKORDER_ID));
+            givenPart(foreign);
+            assertThatThrownBy(() -> service.returnPartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("does not belong to workorder");
+        }
+
+        @Test
+        @DisplayName("fails when the security context is empty")
+        void failsWithoutAuthenticatedUser() {
+            SecurityContextHolder.clearContext();
+
+            assertThatThrownBy(() -> service.returnPartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Security context has no Authentication");
+        }
+    }
+
+    @Nested
+    @DisplayName("usage history")
+    class UsageHistory {
+
+        private WorkorderPartUsageEvent event(String type, String quantity) {
+            WorkorderPart part = part("5", "1", "0");
+            return WorkorderPartUsageEvent.builder()
+                    .id(EVENT_ID)
+                    .workorderPart(part)
+                    .workorderId(WORKORDER_ID)
+                    .eventType(type)
+                    .quantity(new BigDecimal(quantity))
+                    .performedBy("jane.smith")
+                    .performedAt(NOW)
+                    .notes("shelf stock")
+                    .build();
+        }
+
+        @Test
+        @DisplayName("maps a part's events to responses")
+        void mapsPartHistory() {
+            givenPart(part("5", "1", "0"));
+            when(usageEventRepository.findByWorkorderPartIdOrderByPerformedAtDesc(PART_ID))
+                    .thenReturn(List.of(event("ISSUE", "5"), event("CONSUME", "1")));
+
+            List<WorkorderPartUsageEventResponse> history = service.getUsageHistory(WORKORDER_ID, PART_ID);
+
+            assertThat(history).hasSize(2);
+            WorkorderPartUsageEventResponse first = history.get(0);
+            assertThat(first.getEventType()).isEqualTo("ISSUE");
+            assertThat(first.getQuantity()).isEqualByComparingTo("5");
+            assertThat(first.getWorkorderPartId()).isEqualTo(PART_ID);
+            assertThat(first.getWorkorderId()).isEqualTo(WORKORDER_ID);
+            assertThat(first.getPerformedBy()).isEqualTo("jane.smith");
+            assertThat(first.getPerformedAt()).isEqualTo(NOW);
+            assertThat(first.getNotes()).isEqualTo("shelf stock");
+            assertThat(first.getPartDescription()).isEqualTo("Oil filter");
+        }
+
+        @Test
+        @DisplayName("resolves the owning workorder through the parent service line")
+        void resolvesWorkorderThroughServiceLine() {
+            WorkorderServiceLine line = new WorkorderServiceLine();
+            line.setWorkOrder(workorder(WORKORDER_ID));
+            WorkorderPart serviceLinked = part("5", "1", "0");
+            serviceLinked.setWorkorder(null);
+            serviceLinked.setWorkOrderService(line);
+            givenPart(serviceLinked);
+            when(usageEventRepository.findByWorkorderPartIdOrderByPerformedAtDesc(PART_ID))
+                    .thenReturn(List.of(event("ISSUE", "5")));
+
+            assertThat(service.getUsageHistory(WORKORDER_ID, PART_ID)).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("rejects history for an unknown workorder, unknown part, or foreign part")
+        void rejectsUnresolvableTargets() {
+            when(workorderRepository.findById(OTHER_WORKORDER_ID)).thenReturn(Optional.empty());
+            assertThatThrownBy(() -> service.getUsageHistory(OTHER_WORKORDER_ID, PART_ID))
+                    .isInstanceOf(WorkorderNotFoundException.class);
+
+            when(workorderPartRepository.findById(PART_ID)).thenReturn(Optional.empty());
+            assertThatThrownBy(() -> service.getUsageHistory(WORKORDER_ID, PART_ID))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Part not found");
+
+            WorkorderPart foreign = part("5", "0", "0");
+            foreign.setWorkorder(workorder(OTHER_WORKORDER_ID));
+            givenPart(foreign);
+            assertThatThrownBy(() -> service.getUsageHistory(WORKORDER_ID, PART_ID))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("does not belong to workorder");
+        }
+
+        @Test
+        @DisplayName("maps every event on the workorder")
+        void mapsWorkorderHistory() {
+            when(usageEventRepository.findByWorkorderIdOrderByPerformedAtDesc(WORKORDER_ID))
+                    .thenReturn(List.of(event("RETURN", "2")));
+
+            List<WorkorderPartUsageEventResponse> history = service.getAllUsageHistory(WORKORDER_ID);
+
+            assertThat(history).singleElement().satisfies(response -> {
+                assertThat(response.getEventType()).isEqualTo("RETURN");
+                assertThat(response.getQuantity()).isEqualByComparingTo("2");
+            });
+        }
+
+        @Test
+        @DisplayName("rejects workorder-wide history for an unknown workorder")
+        void rejectsUnknownWorkorder() {
+            when(workorderRepository.findById(OTHER_WORKORDER_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getAllUsageHistory(OTHER_WORKORDER_ID))
+                    .isInstanceOf(WorkorderNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("returns an empty history when nothing has been recorded")
+        void emptyHistory() {
+            when(usageEventRepository.findByWorkorderIdOrderByPerformedAtDesc(WORKORDER_ID))
+                    .thenReturn(List.of());
+
+            assertThat(service.getAllUsageHistory(WORKORDER_ID)).isEmpty();
+        }
+    }
+
+    @Test
+    @DisplayName("issue, consume, and return use separate idempotency namespaces")
+    void operationsUseSeparateIdempotencyNamespaces() {
+        givenPart(part("10", "0", "0"));
+
+        service.issuePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "shared-key");
+        service.consumePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "shared-key");
+        service.returnPartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, "shared-key");
+
+        verify(idempotencyService).getExistingPartUsageEventId(eq(ISSUE_OPERATION), eq("shared-key"));
+        verify(idempotencyService).getExistingPartUsageEventId(eq(CONSUME_OPERATION), eq("shared-key"));
+        verify(idempotencyService).getExistingPartUsageEventId(eq(RETURN_OPERATION), eq("shared-key"));
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderSubstitutionServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderSubstitutionServiceImplTest.java
@@ -1,0 +1,341 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.security.common.GatewaySecurityConstants;
+import com.positivity.workorder.internal.dto.WorkorderPartAdjustmentEventResponse;
+import com.positivity.workorder.internal.entity.WorkOrderPartSubstitution;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderPart;
+import com.positivity.workorder.internal.entity.WorkorderPartAdjustmentEvent;
+import com.positivity.workorder.internal.entity.WorkorderServiceLine;
+import com.positivity.workorder.internal.enums.PriceLockStatus;
+import com.positivity.workorder.internal.enums.SubstitutionStatus;
+import com.positivity.workorder.internal.repository.WorkOrderPartSubstitutionRepository;
+import com.positivity.workorder.internal.repository.WorkorderPartAdjustmentEventRepository;
+import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.service.IdempotencyService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Part substitution (#49): the original line is price-locked and flagged, a mirrored substitute
+ * line is created, and an immutable substitution record captures the pricing snapshot.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("WorkorderSubstitutionServiceImpl")
+class WorkorderSubstitutionServiceImplTest {
+
+    private static final UUID WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb11");
+    private static final UUID ORIGINAL_PART_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb12");
+    private static final UUID SUBSTITUTE_PART_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb13");
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb14");
+    private static final UUID NEW_PART_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb15");
+    private static final UUID EVENT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb16");
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final String IDEMPOTENCY_KEY = "substitution-key-1";
+
+    @Mock
+    private WorkorderPartRepository workorderPartRepository;
+
+    @Mock
+    private WorkOrderPartSubstitutionRepository substitutionRepository;
+
+    @Mock
+    private WorkorderPartAdjustmentEventRepository adjustmentEventRepository;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    @Mock
+    private WorkorderFactPublisher workorderFactPublisher;
+
+    private WorkorderSubstitutionServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkorderSubstitutionServiceImpl(
+                workorderPartRepository,
+                substitutionRepository,
+                adjustmentEventRepository,
+                idempotencyService,
+                new ObjectMapper(),
+                workorderFactPublisher,
+                Clock.fixed(NOW, ZoneOffset.UTC));
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken("jane.smith", "n/a", List.of());
+        token.setDetails(Map.of(GatewaySecurityConstants.DETAIL_USERNAME, "jane.smith"));
+        SecurityContextHolder.getContext().setAuthentication(token);
+
+        when(workorderPartRepository.save(any())).thenAnswer(invocation -> {
+            WorkorderPart part = invocation.getArgument(0);
+            if (part.getId() == null) {
+                part.setId(NEW_PART_ID);
+            }
+            return part;
+        });
+        when(adjustmentEventRepository.save(any())).thenAnswer(invocation -> {
+            WorkorderPartAdjustmentEvent event = invocation.getArgument(0);
+            if (event.getId() == null) {
+                event.setId(EVENT_ID);
+            }
+            return event;
+        });
+        when(idempotencyService.getExistingPartAdjustmentEventId(anyString(), anyString()))
+                .thenReturn(Optional.empty());
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private static WorkorderPart originalPart(String consumed) {
+        Workorder workorder = new Workorder();
+        workorder.setId(WORKORDER_ID);
+        return WorkorderPart.builder()
+                .id(ORIGINAL_PART_ID)
+                .workorder(workorder)
+                .productEntityId(PRODUCT_ID)
+                .description("Brake pad set")
+                .quantity(new BigDecimal("1"))
+                .unitPrice(new BigDecimal("49.99"))
+                .lineTotal(new BigDecimal("49.99"))
+                .quantityConsumed(new BigDecimal(consumed))
+                .build();
+    }
+
+    private WorkorderPartAdjustmentEventResponse substitute() {
+        return service.substitutePartLine(
+                WORKORDER_ID, ORIGINAL_PART_ID, SUBSTITUTE_PART_ID, "OUT_OF_STOCK", null, "supplier backorder");
+    }
+
+    @Test
+    void locksTheOriginalLineAndMirrorsItAsTheSubstitute() {
+        when(workorderPartRepository.findById(ORIGINAL_PART_ID)).thenReturn(Optional.of(originalPart("0")));
+
+        WorkorderPartAdjustmentEventResponse response = substitute();
+
+        ArgumentCaptor<WorkorderPart> saved = ArgumentCaptor.forClass(WorkorderPart.class);
+        verify(workorderPartRepository, org.mockito.Mockito.times(2)).save(saved.capture());
+        WorkorderPart original = saved.getAllValues().get(0);
+        assertThat(original.getIsSubstituted()).isTrue();
+        assertThat(original.getPriceLockStatus()).isEqualTo(PriceLockStatus.LOCKED);
+        assertThat(original.getOriginalProductId()).isEqualTo(PRODUCT_ID);
+
+        WorkorderPart substitute = saved.getAllValues().get(1);
+        assertThat(substitute.getProductEntityId()).isEqualTo(SUBSTITUTE_PART_ID);
+        assertThat(substitute.getDescription()).isEqualTo("Brake pad set (Substitute)");
+        assertThat(substitute.getUnitPrice()).isEqualByComparingTo("49.99");
+        assertThat(substitute.getQuantityConsumed()).isEqualByComparingTo("0");
+        assertThat(substitute.getPriceLockStatus()).isEqualTo(PriceLockStatus.LOCKED);
+
+        assertThat(response.getAdjustmentType()).isEqualTo("SUBSTITUTION");
+        assertThat(response.getPerformedBy()).isEqualTo("jane.smith");
+        assertThat(response.getPerformedAt()).isEqualTo(NOW);
+        assertThat(response.getNotes()).isEqualTo("supplier backorder");
+        verify(workorderFactPublisher, org.mockito.Mockito.times(2)).markChanged(WORKORDER_ID);
+    }
+
+    @Test
+    void recordsAnImmutableSubstitutionWithItsPricingSnapshot() {
+        when(workorderPartRepository.findById(ORIGINAL_PART_ID)).thenReturn(Optional.of(originalPart("0")));
+
+        substitute();
+
+        ArgumentCaptor<WorkOrderPartSubstitution> record = ArgumentCaptor.forClass(WorkOrderPartSubstitution.class);
+        verify(substitutionRepository).save(record.capture());
+        assertThat(record.getValue().getSelectedBy()).isEqualTo("jane.smith");
+        assertThat(record.getValue().getSelectedAt()).isEqualTo(NOW);
+        assertThat(record.getValue().getReasonCode()).isEqualTo("OUT_OF_STOCK");
+        assertThat(record.getValue().getStatus()).isEqualTo(SubstitutionStatus.APPLIED);
+        assertThat(record.getValue().getOriginalPartNumberSnapshot()).isEqualTo("Brake pad set");
+        assertThat(record.getValue().getPricingSnapshot()).contains("49.99");
+    }
+
+    @Test
+    void resolvesTheOriginalProductFromANonInventoryLineWhenThereIsNoProductId() {
+        WorkorderPart part = originalPart("0");
+        part.setProductEntityId(null);
+        part.setNonInventoryProductEntityId(SUBSTITUTE_PART_ID);
+        when(workorderPartRepository.findById(ORIGINAL_PART_ID)).thenReturn(Optional.of(part));
+
+        service.substitutePartLine(WORKORDER_ID, ORIGINAL_PART_ID, PRODUCT_ID, "OUT_OF_STOCK", null, null);
+
+        assertThat(part.getOriginalProductId()).isEqualTo(SUBSTITUTE_PART_ID);
+    }
+
+    @Test
+    void fallsBackToThePartIdWhenNeitherProductReferenceIsSet() {
+        WorkorderPart part = originalPart("0");
+        part.setProductEntityId(null);
+        when(workorderPartRepository.findById(ORIGINAL_PART_ID)).thenReturn(Optional.of(part));
+
+        substitute();
+
+        assertThat(part.getOriginalProductId()).isEqualTo(ORIGINAL_PART_ID);
+    }
+
+    @Test
+    void keepsAnAlreadyRecordedOriginalProductReference() {
+        WorkorderPart part = originalPart("0");
+        part.setOriginalProductId(SUBSTITUTE_PART_ID);
+        when(workorderPartRepository.findById(ORIGINAL_PART_ID)).thenReturn(Optional.of(part));
+
+        substitute();
+
+        assertThat(part.getOriginalProductId()).isEqualTo(SUBSTITUTE_PART_ID);
+    }
+
+    @Test
+    void resolvesTheWorkorderThroughTheServiceLineWhenThePartHasNoDirectLink() {
+        Workorder workorder = new Workorder();
+        workorder.setId(WORKORDER_ID);
+        WorkorderPart part = originalPart("0");
+        part.setWorkorder(null);
+        part.setWorkOrderService(
+                WorkorderServiceLine.builder().workOrder(workorder).build());
+        when(workorderPartRepository.findById(ORIGINAL_PART_ID)).thenReturn(Optional.of(part));
+
+        assertThat(substitute()).isNotNull();
+    }
+
+    @Test
+    void refusesAPartThatBelongsToAnotherWorkorder() {
+        WorkorderPart part = originalPart("0");
+        part.getWorkorder().setId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbbff"));
+        when(workorderPartRepository.findById(ORIGINAL_PART_ID)).thenReturn(Optional.of(part));
+
+        assertThatThrownBy(this::substitute)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("does not belong to workorder");
+    }
+
+    @Test
+    void refusesToSubstituteAPartThatHasAlreadyBeenConsumed() {
+        when(workorderPartRepository.findById(ORIGINAL_PART_ID)).thenReturn(Optional.of(originalPart("1")));
+
+        assertThatThrownBy(this::substitute)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already been consumed");
+    }
+
+    @Test
+    void refusesASubstituteThatIsTheSamePart() {
+        when(workorderPartRepository.findById(ORIGINAL_PART_ID)).thenReturn(Optional.of(originalPart("0")));
+
+        assertThatThrownBy(() -> service.substitutePartLine(
+                        WORKORDER_ID, ORIGINAL_PART_ID, ORIGINAL_PART_ID, "OUT_OF_STOCK", null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be different");
+    }
+
+    @Test
+    void failsForAPartThatDoesNotExist() {
+        when(workorderPartRepository.findById(ORIGINAL_PART_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(this::substitute).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void requiresAnAuthenticatedActor() {
+        SecurityContextHolder.clearContext();
+
+        // SecurityContextHelper is fail-fast: an unauthenticated call never reaches the
+        // substitution logic at all.
+        assertThatThrownBy(this::substitute).isInstanceOf(IllegalStateException.class);
+        verify(workorderPartRepository, never()).save(any());
+    }
+
+    @Test
+    void registersTheIdempotencyKeyAgainstTheAdjustmentEvent() {
+        when(workorderPartRepository.findById(ORIGINAL_PART_ID)).thenReturn(Optional.of(originalPart("0")));
+
+        service.substitutePartLine(
+                WORKORDER_ID, ORIGINAL_PART_ID, SUBSTITUTE_PART_ID, "OUT_OF_STOCK", IDEMPOTENCY_KEY, null);
+
+        verify(idempotencyService)
+                .markKeyProcessedForPartAdjustment(
+                        anyString(), org.mockito.ArgumentMatchers.eq(IDEMPOTENCY_KEY), any());
+    }
+
+    @Test
+    void replaysTheOriginalAdjustmentEventForAKnownIdempotencyKey() {
+        when(idempotencyService.getExistingPartAdjustmentEventId(anyString(), anyString()))
+                .thenReturn(Optional.of(EVENT_ID));
+        when(adjustmentEventRepository.findById(EVENT_ID))
+                .thenReturn(Optional.of(WorkorderPartAdjustmentEvent.builder()
+                        .id(EVENT_ID)
+                        .originalPart(originalPart("0"))
+                        .workorderId(WORKORDER_ID)
+                        .adjustmentType("SUBSTITUTION")
+                        .substitutedWithPartId(NEW_PART_ID)
+                        .quantityAdjustment(BigDecimal.ZERO)
+                        .reason("OUT_OF_STOCK")
+                        .performedBy("jane.smith")
+                        .performedAt(NOW)
+                        .build()));
+        when(workorderPartRepository.findById(NEW_PART_ID))
+                .thenReturn(Optional.of(WorkorderPart.builder()
+                        .id(NEW_PART_ID)
+                        .description("Brake pad set (Substitute)")
+                        .build()));
+
+        WorkorderPartAdjustmentEventResponse response = service.substitutePartLine(
+                WORKORDER_ID, ORIGINAL_PART_ID, SUBSTITUTE_PART_ID, "OUT_OF_STOCK", IDEMPOTENCY_KEY, null);
+
+        assertThat(response.getId()).isEqualTo(EVENT_ID);
+        assertThat(response.getSubstitutedWithPartDescription()).isEqualTo("Brake pad set (Substitute)");
+        verify(substitutionRepository, never()).save(any());
+    }
+
+    @Test
+    void failsWhenTheReplayedAdjustmentEventIsGone() {
+        when(idempotencyService.getExistingPartAdjustmentEventId(anyString(), anyString()))
+                .thenReturn(Optional.of(EVENT_ID));
+        when(adjustmentEventRepository.findById(EVENT_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.substitutePartLine(
+                        WORKORDER_ID, ORIGINAL_PART_ID, SUBSTITUTE_PART_ID, "OUT_OF_STOCK", IDEMPOTENCY_KEY, null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Adjustment event not found");
+    }
+
+    @Test
+    void ignoresABlankIdempotencyKey() {
+        when(workorderPartRepository.findById(ORIGINAL_PART_ID)).thenReturn(Optional.of(originalPart("0")));
+
+        service.substitutePartLine(WORKORDER_ID, ORIGINAL_PART_ID, SUBSTITUTE_PART_ID, "OUT_OF_STOCK", "  ", null);
+
+        verify(idempotencyService, never()).getExistingPartAdjustmentEventId(anyString(), anyString());
+        verify(idempotencyService, never()).markKeyProcessedForPartAdjustment(anyString(), anyString(), any());
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — build/CI health, not a capability story
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: cross-cutting (`pos-catalog`, `pos-customer`, `pos-documents`, `pos-inventory`, `pos-location`, `pos-people`, `pos-people-contact`, `pos-price`, `pos-security-service`, `pos-shop-manager`, `pos-workorder`)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Not applicable — no contract-relevant files changed. The diff is 37 new files, all under `src/test/java`, with zero production changes (`git diff --stat origin/main...HEAD` reports insertions only). No controllers, DTOs, `*Request`/`*Response` types, events, `openapi.yaml`, or validation/error models were touched, so no `BACKEND_CONTRACT_GUIDE.md` entry applies.

## Contract Chain (when a Controller changed)
No controller changed; the items below are not applicable.
- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope

**What changed:** 37 new unit-test classes that lift eleven modules back above their per-module JaCoCo `jacoco.line.min` / `jacoco.branch.min` floors. No production code is modified.

**Why:** The nightly coverage ratchet was failing with 19 violations across 11 modules. The root cause is a measurement mismatch rather than a regression in test quality:

- The ratchet step in `.github/workflows/ci.yml` runs `verify -DskipITs`, so only Surefire (`*Test.java`) contributes to the JaCoCo bundle.
- The floors recorded in `docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md` §6 were measured on a run that *included* the Failsafe suites (`*IT.java` / `*ITCase.java`).

Behaviour covered only by the contract/integration suites therefore never counted toward the floors. This PR closes the gap by adding genuine unit coverage for that behaviour, rather than by lowering the floors.

Highlights by module:

- **pos-workorder** (the largest gap — line 0.65 → 0.78, branch 0.50 → 0.63): the estimate approval lifecycle (submit-for-approval, selective line-item approval, purchase-order enforcement, decline/reopen windows, approval expiration, snapshots, PDF markdown, create-from-appointment), change requests and emergency documentation, part usage and part adjustments, labor sessions, technician assignment, workexec time tracking, part substitution, idempotency keys, and the estimate/workorder controllers.
- **pos-people**: employee resolve/create/update/disable with duplicate policies and offboarding retry queueing, timekeeping approval and threshold caching, attendance discrepancy reporting, staffing assignment lifecycle, time-entry exception intake, and the exception handler.
- **pos-catalog**: location price overrides, product lifecycle, MSRP, item cost, and catalog item queries.
- **pos-security-service**: the self-registration review queue, the permission-registration secret filter, and the JSON access-denied handler.
- **pos-inventory**: the transfer-order lifecycle including both short-close ledger shapes, plus putaway validation.
- **pos-customer**, **pos-price**, **pos-people-contact**, **pos-documents**, **pos-location**, **pos-shop-manager**: person and party-relationship services, price quotes and pricing snapshots, person matching/scoring and the linked-user delete guard, template rendering, the inventory manifest listener, and the global exception handler.

## Tests
- [x] Unit tests added/updated — 37 new classes; this PR is entirely test code
- [ ] Integration tests added/updated — unchanged by design; the ratchet does not measure them
- [ ] Provider behavioral contract tests added/updated — unchanged

**How to run** — reproduce the ratchet exactly as CI does:

```bash
./mvnw -pl pos-catalog,pos-customer,pos-documents,pos-inventory,pos-location,\
pos-people-contact,pos-people,pos-price,pos-security-service,pos-shop-manager,pos-workorder \
  verify -DskipITs -Darchunit.skipTests=true -Djacoco.check.haltOnFailure=false
```

Every module clears both floors, with no `Rule violated for bundle` lines in the output:

| module | line (floor) | branch (floor) |
|---|---|---|
| pos-catalog | 0.780 (0.75) | 0.623 (0.54) |
| pos-customer | 0.824 (0.81) | 0.696 (0.66) |
| pos-documents | 0.729 (0.70) | 0.750 (—) |
| pos-inventory | 0.797 (0.79) | 0.638 (0.63) |
| pos-location | 0.781 (0.76) | 0.661 (—) |
| pos-people-contact | 0.728 (0.65) | 0.622 (0.50) |
| pos-people | 0.784 (0.74) | 0.717 (0.58) |
| pos-price | 0.944 (0.89) | 0.804 (—) |
| pos-security-service | 0.771 (0.76) | 0.666 (0.66) |
| pos-shop-manager | 0.799 (0.78) | 0.635 (0.62) |
| pos-workorder | 0.776 (0.73) | 0.629 (0.55) |

Spotless, Checkstyle, and SpotBugs all pass on the touched modules.

## Risk & Rollback
- Risk level: **Low** — test-only diff; no production code, configuration, migration, or coverage floor is modified.
- Rollback plan: revert the five commits on this branch. No runtime behaviour changes, so no deploy or data considerations.

## Notes for reviewers

A few pre-existing production observations surfaced while writing these tests. None are fixed here — they are all outside the scope of a coverage PR, and each is flagged so it can be triaged separately:

- `PeopleExceptionHandler.determineHttpStatus` is dead private code with no caller.
- `WorkexecTimeTrackingController.resolveAuthenticatedMechanicId()` has an unreachable null branch — `SecurityContextHelper.getCurrentUserIdAsUuid()` throws rather than returning empty.
- `TimekeepingPolicy.setCreatedAt` / `setUpdatedAt` silently discard their argument, so tests must set those audit fields reflectively.
- `SecurityContextHelper.getCurrentUsername()` never returns an empty `Optional` (it throws), which makes every `orElseThrow(() -> new IllegalStateException("Missing authenticated username"))` in pos-workorder unreachable.

Structurally, the floors and the gate still disagree about what they measure. Reconciling that — either by re-deriving the §6 baseline from a unit-only run, or by having the ratchet job include the Failsafe suites — would stop this class of failure recurring. Happy to follow up on whichever direction you prefer.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch was pre-assigned as `claude/unit-test-coverage-gaps-qhdok2`
- [ ] PR title starts with `[CAP:<cap-id>]` — no capability id; this is CI health work
- [ ] Links to parent + child issues are present — no tracking issue exists for the ratchet failure
- [x] Contract guide updated (when contract semantics changed) — n/a, no contract semantics changed
- [ ] Required CI checks passing — pending this run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9EcuvmxZu9k32ekEiHXZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9EcuvmxZu9k32ekEiHXZX)_