### PR TITLE
fix: remove dead code and make the workexec timer 400 reachable

### DIFF
--- a/pos-people/src/main/java/com/positivity/people/internal/controller/PeopleExceptionHandler.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/controller/PeopleExceptionHandler.java
@@ -156,25 +156,4 @@ public class PeopleExceptionHandler {
         problem.setProperty(TIMESTAMP_PROPERTY, Instant.now(clock));
         return problem;
     }
-
-    private HttpStatus determineHttpStatus(int statusCode) {
-
-        return switch (statusCode) {
-            case 400 -> HttpStatus.BAD_REQUEST;
-            case 401 -> HttpStatus.UNAUTHORIZED;
-            case 403 -> HttpStatus.FORBIDDEN;
-            case 404 -> HttpStatus.NOT_FOUND;
-            case 409 -> HttpStatus.CONFLICT;
-            case 503 -> HttpStatus.SERVICE_UNAVAILABLE;
-            default -> {
-                if (statusCode >= 500 && statusCode < 600) {
-                    yield HttpStatus.INTERNAL_SERVER_ERROR;
-                }
-                if (statusCode >= 400 && statusCode < 500) {
-                    yield HttpStatus.BAD_REQUEST;
-                }
-                yield HttpStatus.INTERNAL_SERVER_ERROR;
-            }
-        };
-    }
 }

--- a/pos-people/src/main/java/com/positivity/people/internal/entity/TimekeepingPolicy.java
+++ b/pos-people/src/main/java/com/positivity/people/internal/entity/TimekeepingPolicy.java
@@ -118,15 +118,17 @@ public class TimekeepingPolicy {
         this.updatedBy = updatedBy;
     }
 
+    /**
+     * {@code createdAt} and {@code updatedAt} are owned by {@link AuditingEntityListener} via
+     * {@link CreatedDate} / {@link LastModifiedDate} and are assigned on persist and update. They
+     * deliberately have no setters: the previous no-op setters accepted a value and silently threw
+     * it away, so callers believed they had stamped a timestamp when they had not.
+     */
     public Instant getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(Instant createdAt) {}
-
     public Instant getUpdatedAt() {
         return updatedAt;
     }
-
-    public void setUpdatedAt(Instant updatedAt) {}
 }

--- a/pos-people/src/test/java/com/positivity/people/ContractBehaviorIT.java
+++ b/pos-people/src/test/java/com/positivity/people/ContractBehaviorIT.java
@@ -348,7 +348,7 @@ class ContractBehaviorIT extends BaseContractIntegrationTest {
         policy.setScopeType(TimekeepingPolicyScopeType.GLOBAL);
         policy.setJobTimeDiscrepancyThresholdMinutes(thresholdMinutes);
         policy.setUpdatedBy("test");
-        policy.setUpdatedAt(Instant.parse("2026-01-01T00:00:00Z"));
+        // updatedAt is stamped by @LastModifiedDate auditing on save.
         timekeepingPolicyRepository.save(policy);
     }
 
@@ -358,7 +358,7 @@ class ContractBehaviorIT extends BaseContractIntegrationTest {
         policy.setScopeId(locationId);
         policy.setJobTimeDiscrepancyThresholdMinutes(thresholdMinutes);
         policy.setUpdatedBy("test");
-        policy.setUpdatedAt(Instant.parse("2026-01-02T00:00:00Z"));
+        // updatedAt is stamped by @LastModifiedDate auditing on save.
         timekeepingPolicyRepository.save(policy);
     }
 

--- a/pos-people/src/test/java/com/positivity/people/internal/service/TimekeepingThresholdCacheTest.java
+++ b/pos-people/src/test/java/com/positivity/people/internal/service/TimekeepingThresholdCacheTest.java
@@ -53,14 +53,14 @@ class TimekeepingThresholdCacheTest {
         policy.setScopeType(scopeType);
         policy.setScopeId(scopeId);
         policy.setJobTimeDiscrepancyThresholdMinutes(thresholdMinutes);
-        policy.setUpdatedAt(Instant.parse("2026-01-01T00:00:00Z"));
+        setUpdatedAt(policy, Instant.parse("2026-01-01T00:00:00Z"));
         return policy;
     }
 
     /**
-     * {@code TimekeepingPolicy.setUpdatedAt} is a deliberate no-op — the column is owned by
-     * {@code @LastModifiedDate} auditing, which writes the field reflectively — so a test that
-     * needs a specific audit stamp has to write the field the same way.
+     * {@code updatedAt} is owned by {@code @LastModifiedDate} auditing, which writes the field
+     * reflectively and exposes no setter, so a test that needs a specific audit stamp has to write
+     * the field the same way.
      */
     private static void setUpdatedAt(TimekeepingPolicy policy, Instant updatedAt) {
         ReflectionTestUtils.setField(policy, "updatedAt", updatedAt);

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkexecTimeTrackingController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkexecTimeTrackingController.java
@@ -356,12 +356,25 @@ public class WorkexecTimeTrackingController {
         }
     }
 
+    /**
+     * Resolve the caller's stable UUID identity, or {@code null} when the security context cannot
+     * supply one.
+     *
+     * <p>{@code SecurityContextHelper.getCurrentUserIdAsUuid()} never returns an empty
+     * {@code Optional}: a missing or malformed user id raises {@code MissingPersonIdException}, and
+     * a missing authentication or details map raises {@code IllegalStateException}. Left to
+     * propagate, both are caught by the module's {@code IllegalStateException} advice and surface as
+     * 409 CONFLICT, which contradicts the 400 these endpoints document and leaks the internal
+     * message. Catching here keeps the null-return contract that the callers — and the
+     * {@code @ApiResponse(responseCode = "400")} annotations — are written against.
+     */
     private UUID resolveAuthenticatedMechanicId() {
-        UUID mechanicId = SecurityContextHelper.getCurrentUserIdAsUuid().orElse(null);
-        if (mechanicId == null) {
-            log.warn("Missing authenticated UUID user id in security context");
+        try {
+            return SecurityContextHelper.getCurrentUserIdAsUuid().orElse(null);
+        } catch (IllegalStateException ex) {
+            log.warn("Missing authenticated UUID user id in security context: {}", ex.getMessage());
+            return null;
         }
-        return mechanicId;
     }
 
     private ResponseEntity<Object> badRequest(String code, String message) {

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/controller/WorkexecTimeTrackingControllerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/controller/WorkexecTimeTrackingControllerTest.java
@@ -1,7 +1,6 @@
 package com.positivity.workorder.internal.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -11,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.positivity.security.common.GatewaySecurityConstants;
-import com.positivity.security.common.MissingPersonIdException;
 import com.positivity.workorder.internal.dto.WorkexecJobTimeTotalResponse;
 import com.positivity.workorder.internal.dto.WorkexecLaborPerformedRequest;
 import com.positivity.workorder.internal.dto.WorkexecLaborPerformedResponse;
@@ -340,18 +338,30 @@ class WorkexecTimeTrackingControllerTest {
         }
 
         @Test
-        void surfacesAContextWithoutAUuidUserIdRatherThanGuessingAMechanic() {
-            // SecurityContextHelper is fail-fast here: a gateway-authenticated request always
-            // carries a UUID user id, so a missing one is an integration fault, not a 400.
+        void rejectsAContextWithoutAUuidUserIdAsABadRequest() {
+            // SecurityContextHelper is fail-fast: it raises MissingPersonIdException rather than
+            // returning an empty Optional. The controller catches it so the caller gets the 400
+            // these endpoints document, not the 409 the module's IllegalStateException advice
+            // would otherwise produce.
             authenticateWithoutAUserId();
             WorkexecTimerStartRequest request = WorkexecTimerStartRequest.builder()
                     .workorderId(WORKORDER_ID)
                     .build();
 
-            assertThatThrownBy(() -> controller.getActiveTimerEntries()).isInstanceOf(MissingPersonIdException.class);
-            assertThatThrownBy(() -> controller.startTimer(null, request)).isInstanceOf(MissingPersonIdException.class);
-            assertThatThrownBy(() -> controller.stopTimers()).isInstanceOf(MissingPersonIdException.class);
+            assertThat(controller.getActiveTimerEntries()).satisfies(this::isUserIdRequiredBadRequest);
+            assertThat(controller.startTimer(null, request)).satisfies(this::isUserIdRequiredBadRequest);
+            assertThat(controller.stopTimers()).satisfies(this::isUserIdRequiredBadRequest);
             verify(service, never()).getActiveTimers(any());
+            verify(service, never()).startTimer(any(), any(), any());
+            verify(service, never()).stopTimers(any());
+        }
+
+        private void isUserIdRequiredBadRequest(ResponseEntity<Object> response) {
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(response.getBody())
+                    .isEqualTo(Map.of(
+                            "code", "WORKEXEC_INVALID_REQUEST",
+                            "message", "Authenticated user id must be a valid UUID"));
         }
     }
 }


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — defect cleanup found during the coverage work in #1327
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:people`, `domain:workorder`

## Contract References (REQUIRED for backend PRs touching API/event behavior)

This PR touches a controller, so flagging it explicitly: **no contract changes here — this brings the implementation into line with the contract that is already published.**

The three workexec timer endpoints already declare `400 — Missing or invalid authenticated user id` in both their `@ApiResponse` annotations and `pos-workorder/openapi.yaml` (verified present for `/time-entries/timer/start`, `/time-entries/timer/stop`, and `/time-entries/timer/active`). The implementation was not honouring that: the missing-identity path returned **409** instead. This change makes the documented 400 actually reachable, so the published contract becomes true rather than changing.

- Contract guide entry (durion): no new entry required — the `BACKEND_CONTRACT_GUIDE.md` behaviour for these endpoints is unchanged; the code now matches it. Reviewers who want to confirm should compare the `responses` block for the three timer paths in `pos-workorder/openapi.yaml` against the diff.
- Durion contract PR (if applicable): none

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — not needed, the `@ApiResponse(responseCode = "400")` annotations were already correct
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — not needed, no schema or response-code change to emit
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — not needed, the generated surface is unchanged

## Scope

**What changed:** three defects surfaced while writing unit tests for the coverage ratchet (#1327). Two were dead code; one was returning the wrong HTTP status.

### 1. `PeopleExceptionHandler.determineHttpStatus` (pos-people) — dead code, removed

A private switch mapping upstream status codes, with no caller anywhere in the module. `pos-people-contact` has a near-identical handler where the same method *is* live (called at `PeopleExceptionHandler.java:189` via the `SecurityServiceException` overload), which is presumably where this copy originated. Deleted from pos-people only; the pos-people-contact copy is untouched.

### 2. `WorkexecTimeTrackingController.resolveAuthenticatedMechanicId` — unreachable branch masking a wrong status code

The helper read `getCurrentUserIdAsUuid().orElse(null)`, and all three timer endpoints branch on that null to return the documented 400. But `SecurityContextHelper` never returns an empty `Optional`:

- a missing or malformed user id raises `MissingPersonIdException`
- a missing authentication or details map raises `IllegalStateException`

`MissingPersonIdException extends IllegalStateException`, so both propagated to the module's `IllegalStateException` advice (`GlobalExceptionHandler.java:46`) and surfaced as **409 CONFLICT with the internal exception message in the response body**. Net effect: the three null branches were dead, the documented 400 was unreachable, and callers got a misleading status plus an internal detail leak.

The helper now catches `IllegalStateException` around that single call and returns null. The `try` block wraps only the `SecurityContextHelper` call, so the catch cannot swallow unrelated state errors, and every exception it can see means exactly "missing or invalid authenticated user id" — which is what the 400 documents.

### 3. `TimekeepingPolicy.setCreatedAt` / `setUpdatedAt` (pos-people) — silent no-ops, removed

Both accepted an `Instant` and discarded it. The fields are owned by `AuditingEntityListener` through `@CreatedDate` / `@LastModifiedDate`, so no caller should be assigning them — but a no-op setter lets a caller believe it stamped a timestamp when it did not. Removed both, so any such attempt is now a compile error.

All three call sites were in tests and all were already ineffective:
- `ContractBehaviorIT` seeded values that auditing overwrote on save — lines removed, with a comment noting where the value comes from.
- `TimekeepingThresholdCacheTest` had already grown a reflective helper to work around the no-op, but one call site still used the entity setter; it now uses the helper consistently.

**Why:** each of these is a small correctness or maintainability trap. The second is the one with user-visible impact — an API returning 409 where its own published contract promises 400.

## Tests
- [x] Unit tests added/updated — `WorkexecTimeTrackingControllerTest` previously asserted the `MissingPersonIdException` propagation (i.e. it pinned the buggy behaviour); it now asserts the 400 envelope for all three endpoints and that no service call is made
- [ ] Integration tests added/updated — `ContractBehaviorIT` edited only to drop two already-ineffective setter calls; no assertion changed
- [ ] Provider behavioral contract tests added/updated — unchanged

**How to run:**

```bash
./mvnw -pl pos-people,pos-workorder verify -DskipITs
```

Result: `BUILD SUCCESS`, zero test failures, zero `Rule violated for bundle` lines, Spotless / Checkstyle / SpotBugs clean.

Coverage nudged up in both modules, since removing dead code removes uncovered lines:

| module | line (floor) | branch (floor) |
|---|---|---|
| pos-people | 0.7870 (0.74) | 0.7313 (0.58) |
| pos-workorder | 0.7769 (0.73) | 0.6307 (0.55) |

## Risk & Rollback
- Risk level: **Low**, with one behaviour change worth a reviewer's eye: the workexec timer endpoints now return **400** instead of **409** when the security context carries no usable UUID user id. Any client that pattern-matched on the old 409 for this case would be relying on behaviour that contradicted the published OpenAPI spec. In normal operation the gateway always injects a UUID user id, so this path should not be hit at all outside an integration fault.
- The two deletions are inert: neither the dead handler method nor the no-op setters could affect runtime behaviour.
- Rollback plan: revert the single commit. No migration, configuration, or data considerations.

## Recommendation for reviewers

The 409-vs-400 mismatch existed because nothing exercised the path — the branch was unreachable, so no test could cover it, and the contract drifted unnoticed. The same shape may exist elsewhere: `SecurityContextHelper`'s `getCurrentUsername()` and `getCurrentUserIdAsUuid()` both return `Optional` but never return empty, so every `orElse(null)` / `orElseThrow(...)` against them across the codebase is dead in the same way. A follow-up worth considering is changing those two helpers to return the value directly rather than an `Optional` that is structurally never empty, which would turn each of these latent traps into a compile error. Happy to do that sweep separately if you want it — it touches several modules, so it did not belong in this PR.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch was pre-assigned as `claude/unit-test-coverage-gaps-qhdok2`
- [ ] PR title starts with `[CAP:<cap-id>]` — no capability id; defect cleanup
- [ ] Links to parent + child issues are present — no tracking issue; found during #1327
- [x] Contract guide updated (when contract semantics changed) — n/a, contract semantics unchanged; implementation corrected to match
- [ ] Required CI checks passing — pending this run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9EcuvmxZu9k32ekEiHXZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9EcuvmxZu9k32ekEiHXZX)_