### PR TITLE
[CAP:320] feat(inventory): read expected supply from an ext_purchase_order projection (#1333)

### DIFF
--- a/pos-domain-events/src/main/java/com/positivity/domainevents/order/PurchaseOrderLine.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/order/PurchaseOrderLine.java
@@ -1,0 +1,46 @@
+package com.positivity.domainevents.order;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One line of a purchase order, as carried by {@link PurchaseOrderUpdatedV1}.
+ *
+ * <p>Two quantities, and the difference between them is the contract. {@code orderedQuantity} is
+ * what was ordered and does not move as goods arrive; {@code openQuantity} is what is still
+ * outstanding and falls to zero as the line is received. Availability-to-promise sums the
+ * <em>open</em> figure, because stock already in the building is counted by the ledger and adding
+ * the ordered figure would count it twice.
+ *
+ * @param lineId           identity of the line within the order
+ * @param lineNumber       1-based position, for citing a line back to a vendor
+ * @param skuId            the stock item ordered; the key every consumer joins on
+ * @param orderedQuantity  quantity ordered; fixed once the order is approved
+ * @param openQuantity     quantity still outstanding; zero once the line is fully received
+ * @param unitCostMinor    unit cost in minor units of the order's currency, when priced
+ * @param description      line description as ordered, for display
+ */
+public record PurchaseOrderLine(
+        @NonNull UUID lineId,
+        int lineNumber,
+        @NonNull UUID skuId,
+        @NonNull BigDecimal orderedQuantity,
+        @NonNull BigDecimal openQuantity,
+        @Nullable Long unitCostMinor,
+        @Nullable String description) {
+
+    public PurchaseOrderLine {
+        Objects.requireNonNull(lineId, "lineId must not be null");
+        Objects.requireNonNull(skuId, "skuId must not be null");
+        Objects.requireNonNull(orderedQuantity, "orderedQuantity must not be null");
+        Objects.requireNonNull(openQuantity, "openQuantity must not be null");
+    }
+
+    /** Whether anything on this line is still expected to arrive. */
+    public boolean hasOutstandingSupply() {
+        return openQuantity.signum() > 0;
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/order/PurchaseOrderUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/order/PurchaseOrderUpdatedV1.java
@@ -1,0 +1,95 @@
+package com.positivity.domainevents.order;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Current state of one purchase order, published on {@code order.events.v1} (ADR-0049 §3,
+ * ADR-0044 §4).
+ *
+ * <h2>One fact, not a lifecycle</h2>
+ *
+ * There is deliberately no separate created / approved / revised / cancelled event. Every consumer
+ * of this fact wants the order's <em>current</em> state rather than the story of how it got there:
+ * availability-to-promise asks what is open now, replenishment asks whether stock is already on the
+ * way, receiving asks what was ordered. Four event types would oblige each of them to reassemble
+ * state from a stream they have no reason to follow, and would turn a missed event into a silently
+ * wrong answer instead of a merely stale one. With a single full-state fact and the stale guard on
+ * {@code aggregateVersion}, a consumer that misses an event is corrected by the next one.
+ *
+ * <h2>Who publishes it</h2>
+ *
+ * pos-order, once the purchase-order aggregate lives there (CAP-320). Until that move completes,
+ * pos-inventory publishes it — on this topic, not its own, because the contract must not change
+ * when the owner does. That is what lets the projection be built and proven against the running
+ * implementation before the aggregate moves, rather than rewiring every reader at the same moment.
+ *
+ * <h2>Supply, not stock</h2>
+ *
+ * This fact says what has been ordered and what is still outstanding. It says nothing about what is
+ * on a shelf: owned stock is pos-inventory's, computed from its ledger (ADR-0048). A consumer that
+ * adds {@code openQuantity} to on-hand is describing future supply, and one that adds
+ * {@code orderedQuantity} is counting received goods twice.
+ *
+ * @param purchaseOrderId      identity of the order; the event aggregate id
+ * @param poNumber             human-readable order number
+ * @param vendorId             vendor the order is placed with
+ * @param status               lifecycle state: DRAFT, APPROVED, PARTIALLY_RECEIVED,
+ *                             FULLY_RECEIVED, CLOSED or CANCELLED
+ * @param shipToLocationId     receiving location; the site availability is attributed to
+ * @param expectedDeliveryDate when the vendor is expected to deliver; null when undated, and an
+ *                             undated order is deliberately excluded from horizon-bounded supply
+ *                             rather than treated as arriving today
+ * @param currency             ISO 4217 currency of the order's monetary figures
+ * @param grandTotalMinor      order total in minor units, when priced
+ * @param occurredAt           when this state was reached
+ * @param lines                the order's lines; empty only for an order that has none
+ */
+public record PurchaseOrderUpdatedV1(
+        @NonNull UUID purchaseOrderId,
+        @NonNull String poNumber,
+        @NonNull UUID vendorId,
+        @NonNull String status,
+        @Nullable UUID shipToLocationId,
+        @Nullable LocalDate expectedDeliveryDate,
+        @Nullable String currency,
+        @Nullable Long grandTotalMinor,
+        @NonNull Instant occurredAt,
+        @NonNull List<PurchaseOrderLine> lines) {
+
+    /** Event type of this payload on {@code order.events.v1}. */
+    public static final String EVENT_TYPE = "purchaseorder.updated";
+
+    /** Payload schema version; additive changes only within v1 (ADR-0044 §3). */
+    public static final int SCHEMA_VERSION = 1;
+
+    /**
+     * Statuses whose outstanding quantities count as incoming supply.
+     *
+     * <p>Declared here rather than in each consumer because getting it wrong is not a local
+     * mistake: counting a {@code DRAFT} order would promise stock nobody has committed to buying,
+     * and omitting {@code PARTIALLY_RECEIVED} would lose the remainder of an order already part
+     * delivered.
+     */
+    public static final List<String> OPEN_SUPPLY_STATUSES = List.of("APPROVED", "PARTIALLY_RECEIVED");
+
+    public PurchaseOrderUpdatedV1 {
+        Objects.requireNonNull(purchaseOrderId, "purchaseOrderId must not be null");
+        Objects.requireNonNull(poNumber, "poNumber must not be null");
+        Objects.requireNonNull(vendorId, "vendorId must not be null");
+        Objects.requireNonNull(status, "status must not be null");
+        Objects.requireNonNull(occurredAt, "occurredAt must not be null");
+        Objects.requireNonNull(lines, "lines must not be null");
+        lines = List.copyOf(lines);
+    }
+
+    /** Whether this order's outstanding quantities should be counted as incoming supply. */
+    public boolean countsAsOpenSupply() {
+        return OPEN_SUPPLY_STATUSES.contains(status);
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtPurchaseOrderLineReplica.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtPurchaseOrderLineReplica.java
@@ -1,0 +1,78 @@
+package com.positivity.inventory.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Generator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import java.math.BigDecimal;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * One line of a projected purchase order.
+ *
+ * <p>Deliberately not a JPA association to {@link ExtPurchaseOrderReplica}'s owning side beyond the
+ * plain column: a projection is not an aggregate and modelling it as one invites code to navigate it
+ * as though this module owned the order.
+ */
+@Entity
+@Table(
+        name = "ext_purchase_order_line",
+        indexes = {
+            @Index(name = "idx_ext_po_line_sku", columnList = "sku_id"),
+            @Index(name = "idx_ext_po_line_order", columnList = "purchase_order_id")
+        })
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExtPurchaseOrderLineReplica {
+
+    @Id
+    @Column(name = "line_id", nullable = false)
+    private UUID lineId;
+
+    @Column(name = "purchase_order_id", nullable = false)
+    private UUID purchaseOrderId;
+
+    @Column(name = "line_number", nullable = false)
+    private int lineNumber;
+
+    @Column(name = "sku_id", nullable = false)
+    private UUID skuId;
+
+    /** What was ordered. Does not move as goods arrive. */
+    @Column(name = "ordered_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal orderedQuantity;
+
+    /**
+     * What is still outstanding.
+     *
+     * <p>This is the figure availability-to-promise sums. Stock already in the building is counted by
+     * the ledger, so adding the ordered quantity instead would count received goods twice.
+     */
+    @Column(name = "open_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal openQuantity;
+
+    @Column(name = "unit_cost_minor")
+    private Long unitCostMinor;
+
+    @Column(name = "description")
+    private String description;
+
+    /**
+     * Explicit dependency hook for the ArchUnit UUIDv7 rule (ADR-0013): the primary key IS a
+     * UUIDv7 minted by the owning module; this replica stores it verbatim. Minting one locally
+     * would break the correspondence with the order the owner published.
+     */
+    @Transient
+    public Class<?> uuidv7Dependency() {
+        return UUIDv7Generator.class;
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtPurchaseOrderLineReplica.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtPurchaseOrderLineReplica.java
@@ -47,8 +47,13 @@ public class ExtPurchaseOrderLineReplica {
     @Column(name = "sku_id", nullable = false)
     private UUID skuId;
 
-    /** What was ordered. Does not move as goods arrive. */
-    @Column(name = "ordered_quantity", nullable = false, precision = 19, scale = 4)
+    /**
+     * What was ordered. Does not move as goods arrive.
+     *
+     * <p>Precision and scale mirror the source column ({@code purchase_order_line.quantity_decimal},
+     * {@code numeric(18,6)}) so projecting a fractional quantity never rounds it.
+     */
+    @Column(name = "ordered_quantity", nullable = false, precision = 18, scale = 6)
     private BigDecimal orderedQuantity;
 
     /**
@@ -57,7 +62,7 @@ public class ExtPurchaseOrderLineReplica {
      * <p>This is the figure availability-to-promise sums. Stock already in the building is counted by
      * the ledger, so adding the ordered quantity instead would count received goods twice.
      */
-    @Column(name = "open_quantity", nullable = false, precision = 19, scale = 4)
+    @Column(name = "open_quantity", nullable = false, precision = 18, scale = 6)
     private BigDecimal openQuantity;
 
     @Column(name = "unit_cost_minor")

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtPurchaseOrderReceipt.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtPurchaseOrderReceipt.java
@@ -1,0 +1,53 @@
+package com.positivity.inventory.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Generator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * What the projection has actually applied for one order, so completeness is a query rather than an
+ * inference.
+ *
+ * <p>A replica that feeds availability-to-promise cannot only be eventually correct — it has to be
+ * able to say when it is behind. Holding the highest applied version per order means a gap between
+ * what the owner published and what was applied can be asked about directly, instead of being
+ * noticed as a quietly smaller supply figure.
+ */
+@Entity
+@Table(name = "ext_purchase_order_receipt")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExtPurchaseOrderReceipt {
+
+    @Id
+    @Column(name = "purchase_order_id", nullable = false)
+    private UUID purchaseOrderId;
+
+    /** Highest {@code aggregateVersion} applied for this order. */
+    @Column(name = "applied_version", nullable = false)
+    private long appliedVersion;
+
+    @Column(name = "applied_at", nullable = false)
+    private Instant appliedAt;
+
+    /**
+     * Explicit dependency hook for the ArchUnit UUIDv7 rule (ADR-0013): the primary key IS a
+     * UUIDv7 minted by the owning module; this replica stores it verbatim. Minting one locally
+     * would break the correspondence with the order the owner published.
+     */
+    @Transient
+    public Class<?> uuidv7Dependency() {
+        return UUIDv7Generator.class;
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtPurchaseOrderReplica.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ExtPurchaseOrderReplica.java
@@ -1,0 +1,102 @@
+package com.positivity.inventory.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Generator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Local projection of a purchase order owned by pos-order (ADR-0044 R3, ADR-0049 amendment
+ * 2026-08-15).
+ *
+ * <p>Written only by the {@code order.events.v1} consumer. Nothing else in this module may write it:
+ * a change to what was ordered belongs to the owner, and received quantities are pos-inventory's own
+ * fact kept in its own tables. The open quantity here is what the owner last said, not a number this
+ * module maintains.
+ *
+ * <p>This is not a convenience copy for a receiving screen. Availability-to-promise sums open
+ * quantities from these rows, so a missing or stale row changes what a customer is promised — and it
+ * errs optimistically, offering stock nobody ordered.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "ext_purchase_order",
+        indexes = {
+            @Index(name = "idx_ext_po_status_site", columnList = "status, ship_to_location_id"),
+            @Index(name = "idx_ext_po_expected_delivery", columnList = "expected_delivery_date")
+        })
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExtPurchaseOrderReplica {
+
+    @Id
+    @Column(name = "purchase_order_id", nullable = false)
+    private UUID purchaseOrderId;
+
+    @Column(name = "po_number", nullable = false)
+    private String poNumber;
+
+    @Column(name = "vendor_id", nullable = false)
+    private UUID vendorId;
+
+    /** DRAFT, APPROVED, PARTIALLY_RECEIVED, FULLY_RECEIVED, CLOSED or CANCELLED, as the owner said. */
+    @Column(name = "status", nullable = false, length = 32)
+    private String status;
+
+    @Column(name = "ship_to_location_id")
+    private UUID shipToLocationId;
+
+    /**
+     * Null when the order carries no promised delivery date.
+     *
+     * <p>The horizon-bounded supply query excludes undated orders rather than treating them as
+     * arriving today, so this must stay nullable and must never be defaulted on the way in.
+     */
+    @Column(name = "expected_delivery_date")
+    private LocalDate expectedDeliveryDate;
+
+    @Column(name = "currency", length = 8)
+    private String currency;
+
+    @Column(name = "grand_total_minor")
+    private Long grandTotalMinor;
+
+    /** Owner's optimistic-lock version; the stale guard compares against this. */
+    @Column(name = "aggregate_version", nullable = false)
+    @Builder.Default
+    private long aggregateVersion = 0L;
+
+    /** When the owner said this state was reached, as distinct from when we applied it. */
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    /**
+     * Explicit dependency hook for the ArchUnit UUIDv7 rule (ADR-0013): the primary key IS a
+     * UUIDv7 minted by the owning module; this replica stores it verbatim. Minting one locally
+     * would break the correspondence with the order the owner published.
+     */
+    @Transient
+    public Class<?> uuidv7Dependency() {
+        return UUIDv7Generator.class;
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ExtPurchaseOrderLineRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ExtPurchaseOrderLineRepository.java
@@ -1,0 +1,80 @@
+package com.positivity.inventory.internal.repository;
+
+import com.positivity.inventory.internal.entity.ExtPurchaseOrderLineReplica;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Supply queries over the projected purchase order.
+ *
+ * <p>These are ports of the queries that ran against the local aggregate, kept semantically
+ * identical on purpose: availability-to-promise is computed from them, and a subtle change in
+ * filtering is not a refactor, it is a different promise to a customer. The parity test compares the
+ * two implementations directly for that reason.
+ *
+ * <p>The projection stores the order's status as a string rather than the local enum, because the
+ * owner's lifecycle is the owner's to name. Callers pass
+ * {@code PurchaseOrderUpdatedV1.OPEN_SUPPLY_STATUSES} rather than assembling the list themselves.
+ */
+public interface ExtPurchaseOrderLineRepository extends JpaRepository<ExtPurchaseOrderLineReplica, UUID> {
+
+    /**
+     * Outstanding supply for one SKU: the sum of open quantities over projected orders in the given
+     * statuses, optionally restricted to one ship-to site and to a delivery-date horizon.
+     *
+     * <p>The expected delivery date lives on the order header, so the horizon bound applies at header
+     * granularity. With {@code boundByExpectedDelivery = true}, orders with a NULL expected delivery
+     * date are excluded — undated supply cannot be promised by a date; with {@code false} they are
+     * included and {@code horizonDate} is ignored. That exclusion is load-bearing and is the first
+     * thing to check if ATP parity ever drifts.
+     */
+    @Query("""
+      SELECT COALESCE(SUM(l.openQuantity), 0)
+      FROM ExtPurchaseOrderLineReplica l, ExtPurchaseOrderReplica o
+      WHERE o.purchaseOrderId = l.purchaseOrderId
+        AND l.skuId = :skuId
+        AND o.status IN :statuses
+        AND (:siteId IS NULL OR o.shipToLocationId = :siteId)
+        AND (:boundByExpectedDelivery = FALSE
+             OR (o.expectedDeliveryDate IS NOT NULL
+                 AND o.expectedDeliveryDate <= :horizonDate))
+      """)
+    BigDecimal sumOpenQuantityForSku(
+            @Param("skuId") UUID skuId,
+            @Param("statuses") Collection<String> statuses,
+            @Param("siteId") UUID siteId,
+            @Param("boundByExpectedDelivery") boolean boundByExpectedDelivery,
+            @Param("horizonDate") LocalDate horizonDate);
+
+    /**
+     * Distinct expected delivery dates of outstanding supply for one SKU within a horizon: the
+     * candidate cutoffs at which a horizon-bounded forecast can change. Undated orders are excluded,
+     * matching the bounded variant above.
+     */
+    @Query("""
+      SELECT DISTINCT o.expectedDeliveryDate
+      FROM ExtPurchaseOrderLineReplica l, ExtPurchaseOrderReplica o
+      WHERE o.purchaseOrderId = l.purchaseOrderId
+        AND l.skuId = :skuId
+        AND o.status IN :statuses
+        AND (:siteId IS NULL OR o.shipToLocationId = :siteId)
+        AND o.expectedDeliveryDate IS NOT NULL
+        AND o.expectedDeliveryDate <= :horizonDate
+      """)
+    List<LocalDate> findDistinctExpectedDeliveryDatesForSku(
+            @Param("skuId") UUID skuId,
+            @Param("statuses") Collection<String> statuses,
+            @Param("siteId") UUID siteId,
+            @Param("horizonDate") LocalDate horizonDate);
+
+    /** Lines of one projected order, for the consumer's replace-on-apply. */
+    List<ExtPurchaseOrderLineReplica> findByPurchaseOrderId(UUID purchaseOrderId);
+
+    void deleteByPurchaseOrderId(UUID purchaseOrderId);
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ExtPurchaseOrderReceiptRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ExtPurchaseOrderReceiptRepository.java
@@ -1,0 +1,8 @@
+package com.positivity.inventory.internal.repository;
+
+import com.positivity.inventory.internal.entity.ExtPurchaseOrderReceipt;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Applied-version log for the purchase-order projection (#1333). */
+public interface ExtPurchaseOrderReceiptRepository extends JpaRepository<ExtPurchaseOrderReceipt, UUID> {}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ExtPurchaseOrderRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ExtPurchaseOrderRepository.java
@@ -1,0 +1,8 @@
+package com.positivity.inventory.internal.repository;
+
+import com.positivity.inventory.internal.entity.ExtPurchaseOrderReplica;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Projected purchase orders owned by pos-order (ADR-0044 R3). Read-only outside the consumer. */
+public interface ExtPurchaseOrderRepository extends JpaRepository<ExtPurchaseOrderReplica, UUID> {}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AsnServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AsnServiceImpl.java
@@ -57,6 +57,7 @@ public class AsnServiceImpl implements AsnService {
     private final InventoryLedgerEntryRepository inventoryLedgerEntryRepository;
     private final LedgerPostingService ledgerPostingService;
     private final InventoryFactPublisher inventoryFactPublisher;
+    private final PurchaseOrderFactPublisher purchaseOrderFactPublisher;
     private final ApplicationEventPublisher eventPublisher;
     private final DocumentQuantityConverter documentQuantityConverter;
     private final InventoryLotCaptureService lotCaptureService;
@@ -296,6 +297,11 @@ public class AsnServiceImpl implements AsnService {
         purchaseOrder.setStatus(
                 nextOpenBalance == 0L ? PurchaseOrderStatus.FULLY_RECEIVED : PurchaseOrderStatus.PARTIALLY_RECEIVED);
         purchaseOrderRepository.save(purchaseOrder);
+        // This is the second path that changes a purchase order's state, and the consequential one
+        // for availability-to-promise: it is what takes an order out of open supply once it is
+        // fully received. Without the fact, the projection would go on counting a delivered order
+        // as still incoming, over-promising stock that is already on the shelf.
+        purchaseOrderFactPublisher.publish(purchaseOrder, purchaseOrder.getLines());
 
         if (asn != null) {
             applyReceiptToAsn(asn, computedLines);

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ExpectedSupplyServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ExpectedSupplyServiceImpl.java
@@ -1,10 +1,10 @@
 package com.positivity.inventory.internal.service;
 
+import com.positivity.domainevents.order.PurchaseOrderUpdatedV1;
 import com.positivity.inventory.internal.enums.AsnStatus;
-import com.positivity.inventory.internal.enums.PurchaseOrderStatus;
 import com.positivity.inventory.internal.enums.TransferOrderStatus;
 import com.positivity.inventory.internal.repository.AsnLineRepository;
-import com.positivity.inventory.internal.repository.PurchaseOrderLineRepository;
+import com.positivity.inventory.internal.repository.ExtPurchaseOrderLineRepository;
 import com.positivity.inventory.internal.repository.TransferOrderRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -26,9 +26,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ExpectedSupplyServiceImpl implements ExpectedSupplyService {
 
-    /** PO statuses whose open line quantity counts as expected supply. */
-    private static final List<PurchaseOrderStatus> OPEN_PO_STATUSES =
-            List.of(PurchaseOrderStatus.APPROVED, PurchaseOrderStatus.PARTIALLY_RECEIVED);
+    /**
+     * PO statuses whose open line quantity counts as expected supply.
+     *
+     * <p>Taken from the published contract rather than declared here, because this reads the
+     * projection now: the set that decides what counts must be the one the owning domain states,
+     * or the two drift and supply is quietly over- or under-counted.
+     */
+    private static final List<String> OPEN_PO_STATUSES = PurchaseOrderUpdatedV1.OPEN_SUPPLY_STATUSES;
 
     /** ASN statuses whose un-received remainder counts as expected supply. */
     private static final List<AsnStatus> OPEN_ASN_STATUSES =
@@ -38,7 +43,7 @@ public class ExpectedSupplyServiceImpl implements ExpectedSupplyService {
     private static final List<TransferOrderStatus> IN_TRANSIT_TRANSFER_STATUSES =
             List.of(TransferOrderStatus.DISPATCHED, TransferOrderStatus.PARTIALLY_RECEIVED);
 
-    private final PurchaseOrderLineRepository purchaseOrderLineRepository;
+    private final ExtPurchaseOrderLineRepository purchaseOrderLineRepository;
     private final AsnLineRepository asnLineRepository;
     private final TransferOrderRepository transferOrderRepository;
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PurchaseOrderFactPublisher.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PurchaseOrderFactPublisher.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
@@ -98,8 +99,11 @@ public class PurchaseOrderFactPublisher {
      *
      * <p>Zero is safe as a floor rather than a collision risk: an order with no version yet has not
      * been persisted, so no earlier fact for it can exist to be ordered against.
+     *
+     * <p>Package-private for the same reason as {@link #toFact}: the projection test support must
+     * version its rows the way production does, not with a number of its own.
      */
-    private static long versionOf(PurchaseOrderEntity order) {
+    static long versionOf(PurchaseOrderEntity order) {
         Integer version = order.getVersionNumber();
         return version == null ? 0L : version.longValue();
     }
@@ -127,7 +131,12 @@ public class PurchaseOrderFactPublisher {
     }
 
     private static PurchaseOrderLine toFactLine(PurchaseOrderLineEntity line) {
-        BigDecimal ordered = line.getQuantityDecimal() == null ? BigDecimal.ZERO : line.getQuantityDecimal();
+        // quantity_decimal is NOT NULL at the schema level and the contract requires it, so a null
+        // here is corrupt data. Publishing zero instead would quietly drop the line's supply from
+        // availability-to-promise; failing keeps the corruption loud and the caller's transaction
+        // rolled back.
+        BigDecimal ordered = Objects.requireNonNull(
+                line.getQuantityDecimal(), () -> "quantityDecimal is null on purchase-order line " + line.getLineId());
         // Open quantity is null on a line that has never been received against; it means "all of it
         // is still outstanding", not "none of it is".
         BigDecimal open = line.getOpenQuantityDecimal() == null ? ordered : line.getOpenQuantityDecimal();

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PurchaseOrderFactPublisher.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PurchaseOrderFactPublisher.java
@@ -70,17 +70,7 @@ public class PurchaseOrderFactPublisher {
             return;
         }
 
-        PurchaseOrderUpdatedV1 payload = new PurchaseOrderUpdatedV1(
-                order.getPurchaseOrderId(),
-                order.getPoNumber(),
-                order.getVendorId(),
-                order.getStatus().name(),
-                order.getShipToLocationId(),
-                order.getExpectedDeliveryDate(),
-                order.getCurrency(),
-                order.getGrandTotalMinor(),
-                Instant.now(clock),
-                lines.stream().map(PurchaseOrderFactPublisher::toFactLine).toList());
+        PurchaseOrderUpdatedV1 payload = toFact(order, lines, Instant.now(clock));
 
         writer.publish(
                 DomainTopics.events("order"),
@@ -112,6 +102,28 @@ public class PurchaseOrderFactPublisher {
     private static long versionOf(PurchaseOrderEntity order) {
         Integer version = order.getVersionNumber();
         return version == null ? 0L : version.longValue();
+    }
+
+    /**
+     * Builds the published state of one order.
+     *
+     * <p>Package-private rather than private so tests can project an aggregate through the exact
+     * mapping production uses. A test helper with its own copy of this mapping would keep passing
+     * while the real one drifted, which is the failure a parity test exists to prevent.
+     */
+    static PurchaseOrderUpdatedV1 toFact(
+            PurchaseOrderEntity order, List<PurchaseOrderLineEntity> lines, Instant occurredAt) {
+        return new PurchaseOrderUpdatedV1(
+                order.getPurchaseOrderId(),
+                order.getPoNumber(),
+                order.getVendorId(),
+                order.getStatus().name(),
+                order.getShipToLocationId(),
+                order.getExpectedDeliveryDate(),
+                order.getCurrency(),
+                order.getGrandTotalMinor(),
+                occurredAt,
+                lines.stream().map(PurchaseOrderFactPublisher::toFactLine).toList());
     }
 
     private static PurchaseOrderLine toFactLine(PurchaseOrderLineEntity line) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PurchaseOrderFactPublisher.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PurchaseOrderFactPublisher.java
@@ -1,0 +1,131 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.DomainTopics;
+import com.positivity.domainevents.order.PurchaseOrderLine;
+import com.positivity.domainevents.order.PurchaseOrderUpdatedV1;
+import com.positivity.inventory.internal.config.OutboxEventWriter;
+import com.positivity.inventory.internal.entity.PurchaseOrderEntity;
+import com.positivity.inventory.internal.entity.PurchaseOrderLineEntity;
+import com.positivity.shared.id.UUIDv7Generator;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+/**
+ * Publishes {@code purchaseorder.updated} on {@code order.events.v1} whenever a purchase order's
+ * state changes (CAP-320, ADR-0049 §3).
+ *
+ * <h2>Why pos-inventory publishes on the order domain's topic</h2>
+ *
+ * Because the aggregate is moving to pos-order and the contract must not move with it. Publishing on
+ * {@code inventory.events.v1} today would mean changing the topic — and every consumer — at the same
+ * moment the aggregate relocates, which is exactly the simultaneous rewiring this sequencing exists
+ * to avoid. Emitting the eventual owner's contract from the current owner lets the projection be
+ * built and proven against the running implementation, so the move becomes a deletion.
+ *
+ * <p>This is the one place in the module that knowingly produces on another domain's topic. It is
+ * temporary by construction: when pos-order gains the aggregate, this class is deleted rather than
+ * repointed.
+ *
+ * <h2>Full state, every time</h2>
+ *
+ * The fact carries the order and all its lines as they now stand, not a delta. A consumer that
+ * misses one is corrected by the next rather than left holding a gap it cannot detect — which
+ * matters because the principal consumer computes availability-to-promise, and a quietly missing
+ * line understates supply rather than failing loudly.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PurchaseOrderFactPublisher {
+
+    private static final String SOURCE = "pos-inventory";
+
+    /**
+     * Optional so the publisher is inert where the outbox is not wired — the same treatment
+     * {@link InventoryFactPublisher} gives it. A deployment without eventing still writes purchase
+     * orders; it simply publishes nothing.
+     */
+    private final ObjectProvider<OutboxEventWriter> outboxEventWriter;
+
+    private final Clock clock;
+
+    /**
+     * Queues the order's current state for publication, in the caller's transaction.
+     *
+     * <p>{@code aggregateVersion} is the order's own optimistic-lock version, so a consumer's stale
+     * guard compares like with like: two facts for one order are ordered by the version the database
+     * assigned, not by the clock of whichever instance emitted them.
+     */
+    public void publish(@NonNull PurchaseOrderEntity order, @NonNull List<PurchaseOrderLineEntity> lines) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+
+        PurchaseOrderUpdatedV1 payload = new PurchaseOrderUpdatedV1(
+                order.getPurchaseOrderId(),
+                order.getPoNumber(),
+                order.getVendorId(),
+                order.getStatus().name(),
+                order.getShipToLocationId(),
+                order.getExpectedDeliveryDate(),
+                order.getCurrency(),
+                order.getGrandTotalMinor(),
+                Instant.now(clock),
+                lines.stream().map(PurchaseOrderFactPublisher::toFactLine).toList());
+
+        writer.publish(
+                DomainTopics.events("order"),
+                new DomainEventEnvelope<>(
+                        UUIDv7Generator.generate(),
+                        PurchaseOrderUpdatedV1.EVENT_TYPE,
+                        PurchaseOrderUpdatedV1.SCHEMA_VERSION,
+                        order.getPurchaseOrderId(),
+                        versionOf(order),
+                        Instant.now(clock),
+                        SOURCE,
+                        null,
+                        order.getUpdatedBy(),
+                        payload));
+
+        log.debug(
+                "Queued purchaseorder.updated for {} status={} lines={}",
+                order.getPurchaseOrderId(),
+                order.getStatus(),
+                lines.size());
+    }
+
+    /**
+     * The order's optimistic-lock version, or zero before one is assigned.
+     *
+     * <p>Zero is safe as a floor rather than a collision risk: an order with no version yet has not
+     * been persisted, so no earlier fact for it can exist to be ordered against.
+     */
+    private static long versionOf(PurchaseOrderEntity order) {
+        Integer version = order.getVersionNumber();
+        return version == null ? 0L : version.longValue();
+    }
+
+    private static PurchaseOrderLine toFactLine(PurchaseOrderLineEntity line) {
+        BigDecimal ordered = line.getQuantityDecimal() == null ? BigDecimal.ZERO : line.getQuantityDecimal();
+        // Open quantity is null on a line that has never been received against; it means "all of it
+        // is still outstanding", not "none of it is".
+        BigDecimal open = line.getOpenQuantityDecimal() == null ? ordered : line.getOpenQuantityDecimal();
+        return new PurchaseOrderLine(
+                line.getLineId(),
+                line.getLineNumber() == null ? 0 : line.getLineNumber(),
+                line.getSkuId(),
+                ordered,
+                open,
+                line.getUnitCostMinor(),
+                line.getDescription());
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PurchaseOrderProjectionListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PurchaseOrderProjectionListener.java
@@ -1,0 +1,185 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.domainevents.order.PurchaseOrderLine;
+import com.positivity.domainevents.order.PurchaseOrderUpdatedV1;
+import com.positivity.inventory.internal.entity.ExtPurchaseOrderLineReplica;
+import com.positivity.inventory.internal.entity.ExtPurchaseOrderReceipt;
+import com.positivity.inventory.internal.entity.ExtPurchaseOrderReplica;
+import com.positivity.inventory.internal.entity.ProcessedEvent;
+import com.positivity.inventory.internal.repository.ExtPurchaseOrderLineRepository;
+import com.positivity.inventory.internal.repository.ExtPurchaseOrderReceiptRepository;
+import com.positivity.inventory.internal.repository.ExtPurchaseOrderRepository;
+import com.positivity.inventory.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Applies {@code purchaseorder.updated} into the {@code ext_purchase_order} projection
+ * (ADR-0044 R3/§4, CAP-320 #1333).
+ *
+ * <h2>What depends on this being right</h2>
+ *
+ * The projection is the supply side of availability-to-promise. A row that is missing or behind does
+ * not merely stale a screen — it lowers the incoming figure a customer is quoted against, which is
+ * wrong in the direction that promises stock nobody ordered. That is why this consumer keeps an
+ * applied-version log alongside the ordinary idempotency guard: staleness has to be answerable, not
+ * inferred from a number looking smaller than expected.
+ *
+ * <h2>Full state replaces, it does not merge</h2>
+ *
+ * Each fact carries the order and all its lines as they now stand, so applying one replaces the
+ * projected lines outright. Merging would leave a line the owner has deleted sitting in the replica,
+ * still counted as incoming supply, with nothing to reveal it — the failure a delta contract makes
+ * easy and a full-state contract makes impossible.
+ *
+ * <h2>Three failures, three answers</h2>
+ *
+ * <ul>
+ *   <li><strong>Redelivery</strong> — the event-id guard makes it a no-op.
+ *   <li><strong>Out-of-order arrival</strong> — the stale guard on {@code aggregateVersion} skips a
+ *       fact older than what is already applied, so a slow retry cannot resurrect a superseded state.
+ *   <li><strong>Transient database trouble</strong> — rethrown so the container retries. Recording
+ *       the event as processed here would drop an order out of supply permanently.
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.inventory.kafka", name = "enabled", havingValue = "true")
+public class PurchaseOrderProjectionListener {
+
+    /** Producing domain, per the repo-wide {@code processed_events} convention. */
+    static final String OWNER = "order";
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final ProcessedEventRepository processedEventRepository;
+    private final ExtPurchaseOrderRepository orderRepository;
+    private final ExtPurchaseOrderLineRepository lineRepository;
+    private final ExtPurchaseOrderReceiptRepository receiptRepository;
+
+    @KafkaListener(
+            topics = "${pos.inventory.kafka.order-events-topic:order.events.v1}",
+            groupId = "${pos.inventory.kafka.order-events-consumer-group:pos-inventory-order-events}")
+    @Transactional
+    public void onOrderEvent(@NonNull String message) {
+        JsonNode envelope;
+        try {
+            envelope = objectMapper.readTree(message);
+        } catch (Exception e) {
+            log.warn("Skipping unparsable order event", e);
+            return;
+        }
+        String eventType = envelope.path("eventType").stringValue(null);
+        String eventId = envelope.path("eventId").stringValue(null);
+        if (eventId == null || eventId.isBlank()) {
+            log.warn("Skipping order event without eventId");
+            return;
+        }
+        if (processedEventRepository.existsById(eventId)) {
+            return;
+        }
+
+        try {
+            if (PurchaseOrderUpdatedV1.EVENT_TYPE.equals(eventType)) {
+                apply(envelope);
+            } else {
+                log.debug("Ignoring order event type={} eventId={}", eventType, eventId);
+            }
+        } catch (TransientDataAccessException e) {
+            // Rethrown so the container retries. Recording this as processed would leave the order
+            // out of the projection permanently, and availability-to-promise would keep quoting a
+            // supply figure short by that order with nothing to show why.
+            throw e;
+        } catch (Exception e) {
+            log.warn("Skipping malformed order event eventId={}", eventId, e);
+        }
+
+        processedEventRepository.save(ProcessedEvent.builder()
+                .eventId(eventId)
+                .owner(OWNER)
+                .processedAt(Instant.now(clock))
+                .build());
+    }
+
+    private void apply(JsonNode envelope) {
+        PurchaseOrderUpdatedV1 fact = objectMapper.treeToValue(envelope.path("payload"), PurchaseOrderUpdatedV1.class);
+        long version = envelope.path("aggregateVersion").longValue(0);
+        UUID orderId = fact.purchaseOrderId();
+
+        ExtPurchaseOrderReplica existing = orderRepository.findById(orderId).orElse(null);
+        if (existing != null && existing.getAggregateVersion() > version) {
+            log.debug(
+                    "Skipping stale purchase-order fact for {}: have v{}, event v{}",
+                    orderId,
+                    existing.getAggregateVersion(),
+                    version);
+            return;
+        }
+
+        orderRepository.save(ExtPurchaseOrderReplica.builder()
+                .purchaseOrderId(orderId)
+                .poNumber(fact.poNumber())
+                .vendorId(fact.vendorId())
+                .status(fact.status())
+                .shipToLocationId(fact.shipToLocationId())
+                // Carried through exactly: an undated order stays undated, because the
+                // horizon-bounded supply query excludes it rather than treating it as arriving today.
+                .expectedDeliveryDate(fact.expectedDeliveryDate())
+                .currency(fact.currency())
+                .grandTotalMinor(fact.grandTotalMinor())
+                .aggregateVersion(version)
+                .occurredAt(fact.occurredAt())
+                .build());
+
+        // Replace rather than merge. A line the owner removed must disappear here too, or it keeps
+        // counting as incoming supply that nobody will deliver.
+        lineRepository.deleteByPurchaseOrderId(orderId);
+        for (PurchaseOrderLine line : fact.lines()) {
+            lineRepository.save(toReplica(orderId, line));
+        }
+
+        receiptRepository.save(ExtPurchaseOrderReceipt.builder()
+                .purchaseOrderId(orderId)
+                .appliedVersion(version)
+                .appliedAt(Instant.now(clock))
+                .build());
+
+        log.debug(
+                "Applied purchase-order fact for {} v{} ({} lines)",
+                orderId,
+                version,
+                fact.lines().size());
+    }
+
+    private static ExtPurchaseOrderLineReplica toReplica(UUID orderId, PurchaseOrderLine line) {
+        return ExtPurchaseOrderLineReplica.builder()
+                .lineId(line.lineId())
+                .purchaseOrderId(orderId)
+                .lineNumber(line.lineNumber())
+                .skuId(line.skuId())
+                .orderedQuantity(line.orderedQuantity())
+                .openQuantity(line.openQuantity())
+                .unitCostMinor(line.unitCostMinor())
+                .description(line.description())
+                .build();
+    }
+
+    /** Lines currently projected for one order; used by the completeness checks and by tests. */
+    @NonNull
+    public List<ExtPurchaseOrderLineReplica> projectedLines(@NonNull UUID purchaseOrderId) {
+        return lineRepository.findByPurchaseOrderId(purchaseOrderId);
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PurchaseOrderServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PurchaseOrderServiceImpl.java
@@ -53,6 +53,7 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
     private final PurchaseOrderLineRepository purchaseOrderLineRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final InventoryFactPublisher inventoryFactPublisher;
+    private final PurchaseOrderFactPublisher purchaseOrderFactPublisher;
     private final DocumentQuantityConverter documentQuantityConverter;
     private final InventoryLotCaptureService lotCaptureService;
     private final Clock clock;
@@ -92,6 +93,7 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
         purchaseOrder.setLines(lines);
 
         PurchaseOrderEntity saved = purchaseOrderRepository.save(purchaseOrder);
+        purchaseOrderFactPublisher.publish(saved, saved.getLines());
         eventPublisher.publishEvent(Map.of(
                 EVENT_TYPE,
                 "PurchaseOrderCreated",
@@ -167,6 +169,7 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
         po.setApprovalTimestamp(now);
         po.setApprovalNotes(request.getApprovalNotes());
         PurchaseOrderEntity saved = purchaseOrderRepository.save(po);
+        purchaseOrderFactPublisher.publish(saved, saved.getLines());
 
         eventPublisher.publishEvent(Map.of(
                 EVENT_TYPE,
@@ -240,6 +243,7 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
         });
 
         PurchaseOrderEntity saved = purchaseOrderRepository.save(po);
+        purchaseOrderFactPublisher.publish(saved, saved.getLines());
         eventPublisher.publishEvent(Map.of(
                 EVENT_TYPE,
                 "PurchaseOrderRevised",
@@ -270,6 +274,7 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
         PurchaseOrderStatus priorStatus = po.getStatus();
         po.setStatus(PurchaseOrderStatus.CANCELLED);
         PurchaseOrderEntity saved = purchaseOrderRepository.save(po);
+        purchaseOrderFactPublisher.publish(saved, saved.getLines());
         emitExpectedSupplyDropped(saved, priorStatus, ExpectedSupplyDroppedV1.REASON_CANCELLED);
         eventPublisher.publishEvent(Map.of(
                 EVENT_TYPE,
@@ -326,6 +331,9 @@ public class PurchaseOrderServiceImpl implements PurchaseOrderService {
                 request.getLines(), poLinesById, safeLong(po.getOpenBalanceMinor()), po.getVendorId());
         updateReceiptStatus(po, openBalanceMinor);
         purchaseOrderRepository.save(po);
+        // Receipt moves open quantities, which is supply leaving the incoming figure — the fact
+        // must go out here too or ATP keeps counting goods that have already arrived.
+        purchaseOrderFactPublisher.publish(po, po.getLines());
         publishReceiptEvent(po, actorId);
         List<ReceivePurchaseOrderResponse.ReceivePurchaseOrderLineDetail> lineDetails = buildReceiveLineDetails(po);
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockoutDeadlineCalculator.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockoutDeadlineCalculator.java
@@ -1,10 +1,10 @@
 package com.positivity.inventory.internal.service;
 
+import com.positivity.domainevents.order.PurchaseOrderUpdatedV1;
 import com.positivity.inventory.internal.enums.AsnStatus;
-import com.positivity.inventory.internal.enums.PurchaseOrderStatus;
 import com.positivity.inventory.internal.enums.ReservationStatus;
 import com.positivity.inventory.internal.repository.AsnLineRepository;
-import com.positivity.inventory.internal.repository.PurchaseOrderLineRepository;
+import com.positivity.inventory.internal.repository.ExtPurchaseOrderLineRepository;
 import com.positivity.inventory.internal.repository.ReservationRepository;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -43,15 +43,14 @@ public class StockoutDeadlineCalculator {
     // ForecastQuantityServiceImpl: candidate cutoffs must come from exactly the documents
     // the forecast counts, or the walk would evaluate at dates where nothing changes (or
     // miss dates where something does).
-    private static final List<PurchaseOrderStatus> OPEN_PO_STATUSES =
-            List.of(PurchaseOrderStatus.APPROVED, PurchaseOrderStatus.PARTIALLY_RECEIVED);
+    private static final List<String> OPEN_PO_STATUSES = PurchaseOrderUpdatedV1.OPEN_SUPPLY_STATUSES;
     private static final List<AsnStatus> OPEN_ASN_STATUSES =
             List.of(AsnStatus.LOADED, AsnStatus.READY_FOR_RECEIPT, AsnStatus.PARTIALLY_RECEIVED);
     private static final List<ReservationStatus> OPEN_RESERVATION_STATUSES =
             List.of(ReservationStatus.PENDING, ReservationStatus.PARTIALLY_FULFILLED);
 
     private final ForecastQuantityService forecastQuantityService;
-    private final PurchaseOrderLineRepository purchaseOrderLineRepository;
+    private final ExtPurchaseOrderLineRepository purchaseOrderLineRepository;
     private final AsnLineRepository asnLineRepository;
     private final ReservationRepository reservationRepository;
 

--- a/pos-inventory/src/main/resources/db/migration/V35__create_ext_purchase_order.sql
+++ b/pos-inventory/src/main/resources/db/migration/V35__create_ext_purchase_order.sql
@@ -1,0 +1,75 @@
+-- CAP-320 (#1333): local projection of the purchase order (ADR-0044 R3, ADR-0049 amendment 2026-08-15).
+--
+-- The commercial purchase order moves to pos-order. Receiving, availability-to-promise, replenishment
+-- forecasting and traceability all read it and all stay here, so they need a local read path: ADR-0044
+-- R1 forbids the synchronous call that would otherwise answer it, and R3 makes an event-fed replica
+-- the sanctioned one. This table is that replica, written only by the order.events.v1 consumer.
+--
+-- READ-ONLY BY CONSTRUCTION. No receiving flow may write ordered quantities, prices or approval state
+-- here; a change to what was ordered goes through the owner. Received quantities are pos-inventory's
+-- own fact and stay in its own tables — the open quantity below is what the owner last told us, not a
+-- number this module maintains.
+--
+-- WHY THIS IS NOT JUST A RECEIVING CONVENIENCE. ExpectedSupplyServiceImpl sums open quantity for a SKU
+-- filtered by order status and ship-to site and bounded by expected delivery date. That figure is
+-- availability-to-promise: incoming supply a customer is quoted against. A missing or stale row here
+-- does not degrade a screen, it changes a promise — and it errs optimistically, offering stock that
+-- was never ordered. Hence the completeness log alongside it rather than trust that every event
+-- arrived.
+--
+-- Written to be H2(MODE=PostgreSQL)-compatible, matching the other ext_* replicas in this module.
+
+CREATE TABLE ext_purchase_order (
+    purchase_order_id uuid NOT NULL,
+    po_number character varying(255) NOT NULL,
+    vendor_id uuid NOT NULL,
+    status character varying(32) NOT NULL,
+    ship_to_location_id uuid,
+    -- Null means the order carries no promised delivery date. The horizon-bounded supply query
+    -- deliberately excludes such orders rather than treating them as arriving today, so this column
+    -- must stay nullable and must never be defaulted on the way in.
+    expected_delivery_date date,
+    currency character varying(8),
+    grand_total_minor bigint,
+    aggregate_version bigint DEFAULT 0 NOT NULL,
+    occurred_at timestamp(6) with time zone NOT NULL,
+    updated_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT ext_purchase_order_pkey PRIMARY KEY (purchase_order_id)
+);
+
+-- The supply query filters on status and site before summing, so that pair leads the index.
+CREATE INDEX idx_ext_po_status_site ON ext_purchase_order (status, ship_to_location_id);
+CREATE INDEX idx_ext_po_expected_delivery ON ext_purchase_order (expected_delivery_date);
+
+CREATE TABLE ext_purchase_order_line (
+    line_id uuid NOT NULL,
+    purchase_order_id uuid NOT NULL,
+    line_number integer NOT NULL,
+    sku_id uuid NOT NULL,
+    -- Two quantities, and the difference is the contract. ordered_quantity is what was ordered and
+    -- does not move as goods arrive; open_quantity is what is still outstanding. ATP sums the open
+    -- figure, because stock already in the building is counted by the ledger and adding the ordered
+    -- figure would count it twice.
+    ordered_quantity numeric(19,4) NOT NULL,
+    open_quantity numeric(19,4) NOT NULL,
+    unit_cost_minor bigint,
+    description character varying(255),
+    CONSTRAINT ext_purchase_order_line_pkey PRIMARY KEY (line_id),
+    CONSTRAINT fk_ext_po_line_order FOREIGN KEY (purchase_order_id)
+        REFERENCES ext_purchase_order (purchase_order_id) ON DELETE CASCADE
+);
+
+-- The supply query starts from a SKU and joins to its orders, so sku_id leads here.
+CREATE INDEX idx_ext_po_line_sku ON ext_purchase_order_line (sku_id);
+CREATE INDEX idx_ext_po_line_order ON ext_purchase_order_line (purchase_order_id);
+
+-- Completeness, not just currency. A replica feeding a promise has to be able to say when it is
+-- missing something rather than quietly summing less. One row per order the consumer has ever seen,
+-- carrying the highest version applied, so a gap between what the owner published and what was
+-- applied is a query rather than an inference.
+CREATE TABLE ext_purchase_order_receipt (
+    purchase_order_id uuid NOT NULL,
+    applied_version bigint NOT NULL,
+    applied_at timestamp(6) with time zone NOT NULL,
+    CONSTRAINT ext_purchase_order_receipt_pkey PRIMARY KEY (purchase_order_id)
+);

--- a/pos-inventory/src/main/resources/db/migration/V35__create_ext_purchase_order.sql
+++ b/pos-inventory/src/main/resources/db/migration/V35__create_ext_purchase_order.sql
@@ -50,8 +50,12 @@ CREATE TABLE ext_purchase_order_line (
     -- does not move as goods arrive; open_quantity is what is still outstanding. ATP sums the open
     -- figure, because stock already in the building is counted by the ledger and adding the ordered
     -- figure would count it twice.
-    ordered_quantity numeric(19,4) NOT NULL,
-    open_quantity numeric(19,4) NOT NULL,
+    --
+    -- numeric(18,6) matches purchase_order_line.quantity_decimal/open_quantity_decimal exactly. A
+    -- narrower scale here would round fractional quantities on the way in and the parity comparison
+    -- against the aggregate would drift.
+    ordered_quantity numeric(18,6) NOT NULL,
+    open_quantity numeric(18,6) NOT NULL,
     unit_cost_minor bigint,
     description character varying(255),
     CONSTRAINT ext_purchase_order_line_pkey PRIMARY KEY (line_id),

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/BatchReplenishmentScanTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/BatchReplenishmentScanTest.java
@@ -56,6 +56,9 @@ class BatchReplenishmentScanTest {
     private LedgerPostingService ledgerPostingService;
 
     @Autowired
+    private PurchaseOrderProjectionTestSupport projection;
+
+    @Autowired
     private PurchaseOrderRepository purchaseOrderRepository;
 
     @Autowired
@@ -290,5 +293,7 @@ class BatchReplenishmentScanTest {
         line.setPurchaseOrder(po);
         po.getLines().add(line);
         purchaseOrderRepository.save(po);
+        // Supply is read from the projection (#1333).
+        projection.project(po);
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ForecastQuantityServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ForecastQuantityServiceImplTest.java
@@ -53,6 +53,9 @@ class ForecastQuantityServiceImplTest {
     private ExpectedSupplyService expectedSupplyService;
 
     @Autowired
+    private PurchaseOrderProjectionTestSupport projection;
+
+    @Autowired
     private PurchaseOrderRepository purchaseOrderRepository;
 
     @Autowired
@@ -321,7 +324,11 @@ class ForecastQuantityServiceImplTest {
             line.setPurchaseOrder(po);
             po.getLines().add(line);
         }
-        return purchaseOrderRepository.save(po);
+        PurchaseOrderEntity saved = purchaseOrderRepository.save(po);
+        // Supply is read from the projection, so seeding the aggregate alone would describe a
+        // state the running system never reaches (#1333).
+        projection.project(saved);
+        return saved;
     }
 
     private AsnLineEntity asnLine(PurchaseOrderEntity po, UUID skuId, String shipped, String received) {

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseOrderFactPublisherTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseOrderFactPublisherTest.java
@@ -1,0 +1,196 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.order.PurchaseOrderUpdatedV1;
+import com.positivity.inventory.internal.config.OutboxEventWriter;
+import com.positivity.inventory.internal.entity.PurchaseOrderEntity;
+import com.positivity.inventory.internal.entity.PurchaseOrderLineEntity;
+import com.positivity.inventory.internal.enums.PurchaseOrderStatus;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Purchase-order facts for the ext_purchase_order projection (#1333)")
+class PurchaseOrderFactPublisherTest {
+
+    private static final UUID PO_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01");
+    private static final UUID VENDOR_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02");
+    private static final UUID SITE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03");
+    private static final UUID SKU_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04");
+    private static final Instant NOW = Instant.parse("2026-08-15T12:00:00Z");
+    private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @Mock
+    private ObjectProvider<OutboxEventWriter> outboxProvider;
+
+    @Mock
+    private OutboxEventWriter outboxEventWriter;
+
+    private PurchaseOrderFactPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new PurchaseOrderFactPublisher(outboxProvider, CLOCK);
+        when(outboxProvider.getIfAvailable()).thenReturn(outboxEventWriter);
+    }
+
+    private static PurchaseOrderEntity order(PurchaseOrderStatus status, LocalDate expectedDelivery) {
+        PurchaseOrderEntity po = new PurchaseOrderEntity();
+        po.setPurchaseOrderId(PO_ID);
+        po.setPoNumber("PO-2026-0001");
+        po.setVendorId(VENDOR_ID);
+        po.setStatus(status);
+        po.setShipToLocationId(SITE_ID);
+        po.setExpectedDeliveryDate(expectedDelivery);
+        po.setCurrency("USD");
+        po.setGrandTotalMinor(100_000L);
+        po.setVersionNumber(3);
+        return po;
+    }
+
+    private static PurchaseOrderLineEntity line(BigDecimal ordered, BigDecimal open) {
+        PurchaseOrderLineEntity l = new PurchaseOrderLineEntity();
+        l.setLineId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a05"));
+        l.setLineNumber(1);
+        l.setSkuId(SKU_ID);
+        l.setQuantityDecimal(ordered);
+        l.setOpenQuantityDecimal(open);
+        l.setUnitCostMinor(5_000L);
+        l.setDescription("Front brake rotor");
+        return l;
+    }
+
+    private PurchaseOrderUpdatedV1 captured() {
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(outboxEventWriter).publish(eq("order.events.v1"), captor.capture());
+        return (PurchaseOrderUpdatedV1) captor.getValue().payload();
+    }
+
+    @Test
+    void publishesOnTheOrderDomainTopicNotTheInventoryOne() {
+        publisher.publish(order(PurchaseOrderStatus.APPROVED, LocalDate.of(2026, 9, 1)), List.of(line(TEN(), TEN())));
+
+        // The eventual owner's topic, emitted by the current owner. Publishing on
+        // inventory.events.v1 would mean changing the contract when the aggregate moves, which is
+        // the simultaneous rewiring this sequencing exists to avoid.
+        verify(outboxEventWriter).publish(eq("order.events.v1"), any());
+    }
+
+    @Test
+    void carriesEverythingAvailabilityToPromiseReads() {
+        publisher.publish(
+                order(PurchaseOrderStatus.APPROVED, LocalDate.of(2026, 9, 1)),
+                List.of(line(TEN(), BigDecimal.valueOf(4))));
+
+        PurchaseOrderUpdatedV1 fact = captured();
+        // ExpectedSupplyServiceImpl sums open quantity for a SKU, filtered by order status and
+        // ship-to site, bounded by expected delivery date. All five must survive the hop.
+        assertThat(fact.status()).isEqualTo("APPROVED");
+        assertThat(fact.shipToLocationId()).isEqualTo(SITE_ID);
+        assertThat(fact.expectedDeliveryDate()).isEqualTo(LocalDate.of(2026, 9, 1));
+        assertThat(fact.lines()).singleElement().satisfies(l -> {
+            assertThat(l.skuId()).isEqualTo(SKU_ID);
+            assertThat(l.openQuantity()).isEqualByComparingTo(BigDecimal.valueOf(4));
+        });
+    }
+
+    @Test
+    void keepsOrderedAndOpenQuantitiesApart() {
+        publisher.publish(
+                order(PurchaseOrderStatus.PARTIALLY_RECEIVED, LocalDate.of(2026, 9, 1)),
+                List.of(line(TEN(), BigDecimal.valueOf(4))));
+
+        // Six of ten arrived. Supply still incoming is four; summing the ordered figure instead
+        // would count the six already on the shelf a second time.
+        assertThat(captured().lines().getFirst().orderedQuantity()).isEqualByComparingTo(TEN());
+        assertThat(captured().lines().getFirst().openQuantity()).isEqualByComparingTo(BigDecimal.valueOf(4));
+    }
+
+    @Test
+    void treatsAnUnreceivedLineAsFullyOutstandingRatherThanAsNothing() {
+        PurchaseOrderLineEntity unreceived = line(TEN(), null);
+
+        publisher.publish(order(PurchaseOrderStatus.APPROVED, LocalDate.of(2026, 9, 1)), List.of(unreceived));
+
+        // A line never received against has a null open quantity. That means all of it is still
+        // coming, not none of it — defaulting to zero would silently drop the whole order from ATP.
+        assertThat(captured().lines().getFirst().openQuantity()).isEqualByComparingTo(TEN());
+    }
+
+    @Test
+    void keepsAnUndatedOrderUndatedRatherThanDatingItToday() {
+        publisher.publish(order(PurchaseOrderStatus.APPROVED, null), List.of(line(TEN(), TEN())));
+
+        // The horizon-bounded supply query deliberately excludes undated orders. Substituting a
+        // date here would pull an order with no promised delivery into every horizon.
+        assertThat(captured().expectedDeliveryDate()).isNull();
+    }
+
+    @Test
+    void keysTheEventOnTheOrderAndVersionsItByTheOptimisticLock() {
+        publisher.publish(order(PurchaseOrderStatus.APPROVED, null), List.of(line(TEN(), TEN())));
+
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(outboxEventWriter).publish(eq("order.events.v1"), captor.capture());
+        // Aggregate id keys the partition so one order's facts stay ordered; aggregateVersion is the
+        // row's own version, so a consumer's stale guard compares like with like rather than
+        // trusting whichever instance's clock emitted the event.
+        assertThat(captor.getValue().aggregateId()).isEqualTo(PO_ID);
+        assertThat(captor.getValue().aggregateVersion()).isEqualTo(3L);
+        assertThat(captor.getValue().eventType()).isEqualTo("purchaseorder.updated");
+    }
+
+    @Test
+    void marksOnlyApprovedAndPartiallyReceivedAsOpenSupply() {
+        assertThat(new PurchaseOrderUpdatedV1(
+                                PO_ID, "PO-1", VENDOR_ID, "APPROVED", SITE_ID, null, "USD", 1L, NOW, List.of())
+                        .countsAsOpenSupply())
+                .isTrue();
+        assertThat(new PurchaseOrderUpdatedV1(
+                                PO_ID, "PO-1", VENDOR_ID, "DRAFT", SITE_ID, null, "USD", 1L, NOW, List.of())
+                        .countsAsOpenSupply())
+                .isFalse();
+        // A draft counted as supply would promise stock nobody has committed to buying.
+        assertThat(new PurchaseOrderUpdatedV1(
+                                PO_ID, "PO-1", VENDOR_ID, "CANCELLED", SITE_ID, null, "USD", 1L, NOW, List.of())
+                        .countsAsOpenSupply())
+                .isFalse();
+    }
+
+    @Test
+    void publishesNothingWhereTheOutboxIsNotWired() {
+        when(outboxProvider.getIfAvailable()).thenReturn(null);
+
+        publisher.publish(order(PurchaseOrderStatus.APPROVED, null), List.of(line(TEN(), TEN())));
+
+        // A deployment without eventing still writes purchase orders; it simply publishes nothing.
+        verifyNoInteractions(outboxEventWriter);
+    }
+
+    private static BigDecimal TEN() {
+        return BigDecimal.valueOf(10);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseOrderProjectionListenerTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseOrderProjectionListenerTest.java
@@ -1,0 +1,228 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.inventory.internal.entity.ExtPurchaseOrderLineReplica;
+import com.positivity.inventory.internal.entity.ExtPurchaseOrderReceipt;
+import com.positivity.inventory.internal.entity.ExtPurchaseOrderReplica;
+import com.positivity.inventory.internal.repository.ExtPurchaseOrderLineRepository;
+import com.positivity.inventory.internal.repository.ExtPurchaseOrderReceiptRepository;
+import com.positivity.inventory.internal.repository.ExtPurchaseOrderRepository;
+import com.positivity.inventory.internal.repository.ProcessedEventRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.QueryTimeoutException;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * The projection is the supply side of availability-to-promise, so its failure modes are asserted
+ * rather than assumed (#1333, ADR-0044 §4).
+ *
+ * <p>Each test here corresponds to a way the projection can end up disagreeing with the order it
+ * mirrors. They matter in one direction more than the other: a projection that is behind
+ * over-states open supply, which promises a customer stock that was never ordered or has already
+ * been received.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PurchaseOrderProjectionListener — ext_purchase_order (#1333)")
+class PurchaseOrderProjectionListenerTest {
+
+    private static final UUID PO_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a01");
+    private static final UUID VENDOR_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a02");
+    private static final UUID SITE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03");
+    private static final UUID SKU_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04");
+    private static final UUID LINE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a05");
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private ExtPurchaseOrderRepository orderRepository;
+
+    @Mock
+    private ExtPurchaseOrderLineRepository lineRepository;
+
+    @Mock
+    private ExtPurchaseOrderReceiptRepository receiptRepository;
+
+    private PurchaseOrderProjectionListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new PurchaseOrderProjectionListener(
+                Clock.fixed(Instant.parse("2026-08-15T12:00:00Z"), ZoneOffset.UTC),
+                new ObjectMapper(),
+                processedEventRepository,
+                orderRepository,
+                lineRepository,
+                receiptRepository);
+        when(processedEventRepository.existsById(any())).thenReturn(false);
+        when(orderRepository.findById(any())).thenReturn(Optional.empty());
+    }
+
+    private static String event(String eventId, long version, String status, String openQuantity) {
+        return """
+            {
+              "eventId": "%s",
+              "eventType": "purchaseorder.updated",
+              "aggregateId": "%s",
+              "aggregateVersion": %d,
+              "payload": {
+                "purchaseOrderId": "%s",
+                "poNumber": "PO-2026-0001",
+                "vendorId": "%s",
+                "status": "%s",
+                "shipToLocationId": "%s",
+                "expectedDeliveryDate": "2026-09-01",
+                "currency": "USD",
+                "grandTotalMinor": 100000,
+                "occurredAt": "2026-08-15T12:00:00Z",
+                "lines": [
+                  {
+                    "lineId": "%s",
+                    "lineNumber": 1,
+                    "skuId": "%s",
+                    "orderedQuantity": 10,
+                    "openQuantity": %s,
+                    "unitCostMinor": 5000,
+                    "description": "Front brake rotor"
+                  }
+                ]
+              }
+            }
+            """.formatted(eventId, PO_ID, version, PO_ID, VENDOR_ID, status, SITE_ID, LINE_ID, SKU_ID, openQuantity);
+    }
+
+    @Test
+    @DisplayName("applies an order and everything availability-to-promise reads from it")
+    void appliesTheOrderAndItsLines() {
+        listener.onOrderEvent(event("evt-1", 3, "APPROVED", "4"));
+
+        ArgumentCaptor<ExtPurchaseOrderReplica> order = ArgumentCaptor.forClass(ExtPurchaseOrderReplica.class);
+        verify(orderRepository).save(order.capture());
+        // Status, site and expected date are the three filters the supply query applies; the fourth
+        // input, open quantity, lives on the line.
+        assertThat(order.getValue().getStatus()).isEqualTo("APPROVED");
+        assertThat(order.getValue().getShipToLocationId()).isEqualTo(SITE_ID);
+        assertThat(order.getValue().getExpectedDeliveryDate()).hasToString("2026-09-01");
+
+        ArgumentCaptor<ExtPurchaseOrderLineReplica> line = ArgumentCaptor.forClass(ExtPurchaseOrderLineReplica.class);
+        verify(lineRepository).save(line.capture());
+        assertThat(line.getValue().getSkuId()).isEqualTo(SKU_ID);
+        assertThat(line.getValue().getOpenQuantity()).isEqualByComparingTo(BigDecimal.valueOf(4));
+        // Ordered and open are kept apart: summing ordered would count the six already received.
+        assertThat(line.getValue().getOrderedQuantity()).isEqualByComparingTo(BigDecimal.TEN);
+    }
+
+    @Test
+    @DisplayName("records what it applied, so being behind is a query rather than an inference")
+    void recordsTheAppliedVersion() {
+        listener.onOrderEvent(event("evt-1", 7, "APPROVED", "4"));
+
+        ArgumentCaptor<ExtPurchaseOrderReceipt> receipt = ArgumentCaptor.forClass(ExtPurchaseOrderReceipt.class);
+        verify(receiptRepository).save(receipt.capture());
+        assertThat(receipt.getValue().getAppliedVersion()).isEqualTo(7L);
+        assertThat(receipt.getValue().getPurchaseOrderId()).isEqualTo(PO_ID);
+    }
+
+    @Test
+    @DisplayName("a redelivered event changes nothing")
+    void redeliveryIsANoOp() {
+        when(processedEventRepository.existsById("evt-1")).thenReturn(true);
+
+        listener.onOrderEvent(event("evt-1", 3, "APPROVED", "4"));
+
+        verify(orderRepository, never()).save(any());
+        verify(lineRepository, never()).save(any());
+        // Not even a second processed-event row: the guard returns before any write.
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("a fact older than what is applied cannot resurrect a superseded state")
+    void staleFactIsSkipped() {
+        ExtPurchaseOrderReplica applied = ExtPurchaseOrderReplica.builder()
+                .purchaseOrderId(PO_ID)
+                .aggregateVersion(9L)
+                .build();
+        when(orderRepository.findById(PO_ID)).thenReturn(Optional.of(applied));
+
+        // A slow retry of an old approval arriving after the order was fully received. Applying it
+        // would put the order back into open supply and re-promise stock already on the shelf.
+        listener.onOrderEvent(event("evt-old", 4, "APPROVED", "10"));
+
+        verify(orderRepository, never()).save(any());
+        verify(lineRepository, never()).save(any());
+        // Still marked processed: it was handled correctly by being ignored, and redelivering it
+        // would only reach the same conclusion.
+        verify(processedEventRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("lines are replaced, not merged")
+    void linesAreReplacedNotMerged() {
+        listener.onOrderEvent(event("evt-1", 3, "APPROVED", "4"));
+
+        // A line the owner deleted must disappear here too. Merging would leave it counted as
+        // incoming supply with nothing to reveal it.
+        verify(lineRepository).deleteByPurchaseOrderId(PO_ID);
+    }
+
+    @Test
+    @DisplayName("transient database trouble is retried, not swallowed")
+    void transientFailureIsRethrownAndNotMarkedProcessed() {
+        when(orderRepository.save(any())).thenThrow(new QueryTimeoutException("statement timed out"));
+
+        assertThatThrownBy(() -> listener.onOrderEvent(event("evt-1", 3, "APPROVED", "4")))
+                .isInstanceOf(QueryTimeoutException.class);
+
+        // Marking it processed here would drop the order out of the projection permanently, and
+        // availability-to-promise would keep quoting a figure short by that order with nothing to
+        // show why.
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("a malformed payload is skipped rather than stalling the partition")
+    void malformedPayloadIsSkippedAndMarkedProcessed() {
+        listener.onOrderEvent("""
+                {"eventId":"evt-bad","eventType":"purchaseorder.updated","payload":{"nonsense":true}}
+                """);
+
+        verify(orderRepository, never()).save(any());
+        // Marked processed: redelivering it would fail identically, and blocking the partition
+        // would stop every other order's facts too.
+        verify(processedEventRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("events without an id, and other domains' events, are left alone")
+    void ignoresUnusableAndUnrelatedEvents() {
+        listener.onOrderEvent("""
+                {"eventType":"purchaseorder.updated"}""");
+        listener.onOrderEvent("""
+                {"eventId":"evt-2","eventType":"order.completed","payload":{}}""");
+        listener.onOrderEvent("not json at all");
+
+        verify(orderRepository, never()).save(any());
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseOrderProjectionParityIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseOrderProjectionParityIT.java
@@ -1,0 +1,214 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.inventory.internal.entity.ExtPurchaseOrderLineReplica;
+import com.positivity.inventory.internal.entity.ExtPurchaseOrderReplica;
+import com.positivity.inventory.internal.entity.PurchaseOrderEntity;
+import com.positivity.inventory.internal.entity.PurchaseOrderLineEntity;
+import com.positivity.inventory.internal.enums.PurchaseOrderStatus;
+import com.positivity.inventory.internal.repository.ExtPurchaseOrderLineRepository;
+import com.positivity.inventory.internal.repository.ExtPurchaseOrderRepository;
+import com.positivity.inventory.internal.repository.PurchaseOrderLineRepository;
+import com.positivity.inventory.internal.repository.PurchaseOrderRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Availability-to-promise must be unchanged by the purchase-order split (#1333).
+ *
+ * <h2>Why this test exists and why it is written this way</h2>
+ *
+ * The projection replaces the local aggregate as the supply-side input to ATP. Its query was ported
+ * rather than rewritten, and "ported" is a claim, not a fact — so the claim is checked by running the
+ * old query and the new one over the same data and comparing the answers. Reading the two queries and
+ * agreeing they look alike is exactly the check that misses a changed NULL handling or an off-by-one
+ * on a horizon boundary.
+ *
+ * <p>The comparison must happen while both implementations still exist. Once the aggregate moves
+ * there is nothing left to compare against, which is why this story is sequenced before the move
+ * rather than after it.
+ *
+ * <p>Wrong ATP is not a cosmetic defect. It errs optimistically — a supply figure that is too high
+ * promises a customer stock that was never ordered.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("ATP parity between the purchase-order aggregate and its projection (#1333)")
+class PurchaseOrderProjectionParityIT {
+
+    private static final UUID SKU = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a04");
+    private static final UUID SITE_A = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a03");
+    private static final UUID SITE_B = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a09");
+    private static final LocalDate HORIZON = LocalDate.of(2026, 9, 30);
+
+    private static final List<PurchaseOrderStatus> OPEN_ENUM =
+            List.of(PurchaseOrderStatus.APPROVED, PurchaseOrderStatus.PARTIALLY_RECEIVED);
+    private static final List<String> OPEN_STRING = List.of("APPROVED", "PARTIALLY_RECEIVED");
+
+    @Autowired
+    private PurchaseOrderRepository orderRepository;
+
+    @Autowired
+    private PurchaseOrderLineRepository lineRepository;
+
+    @Autowired
+    private ExtPurchaseOrderRepository extOrderRepository;
+
+    @Autowired
+    private ExtPurchaseOrderLineRepository extLineRepository;
+
+    @BeforeEach
+    void seedBothSides() {
+        // Every case that distinguishes the two implementations, written once into both shapes.
+        seed(PurchaseOrderStatus.APPROVED, SITE_A, LocalDate.of(2026, 9, 1), "10", "10");
+        seed(PurchaseOrderStatus.PARTIALLY_RECEIVED, SITE_A, LocalDate.of(2026, 9, 15), "10", "4");
+        // Draft: committed to by nobody, must not count.
+        seed(PurchaseOrderStatus.DRAFT, SITE_A, LocalDate.of(2026, 9, 2), "50", "50");
+        // Cancelled: never arriving.
+        seed(PurchaseOrderStatus.CANCELLED, SITE_A, LocalDate.of(2026, 9, 3), "25", "25");
+        // Another site: excluded when a site filter is applied.
+        seed(PurchaseOrderStatus.APPROVED, SITE_B, LocalDate.of(2026, 9, 4), "7", "7");
+        // Undated: excluded by the bounded query, included by the unbounded one. The single most
+        // likely place for the two implementations to disagree.
+        seed(PurchaseOrderStatus.APPROVED, SITE_A, null, "3", "3");
+        // Exactly on the horizon: inclusive bound.
+        seed(PurchaseOrderStatus.APPROVED, SITE_A, HORIZON, "5", "5");
+        // Beyond the horizon.
+        seed(PurchaseOrderStatus.APPROVED, SITE_A, HORIZON.plusDays(1), "9", "9");
+        // Fully received: nothing outstanding, so it contributes zero rather than being filtered.
+        seed(PurchaseOrderStatus.PARTIALLY_RECEIVED, SITE_A, LocalDate.of(2026, 9, 5), "8", "0");
+    }
+
+    private void seed(PurchaseOrderStatus status, UUID site, LocalDate expected, String ordered, String open) {
+        UUID orderId = UUID.randomUUID();
+        UUID lineId = UUID.randomUUID();
+
+        PurchaseOrderEntity po = new PurchaseOrderEntity();
+        po.setPurchaseOrderId(orderId);
+        po.setPoNumber("PO-" + orderId.toString().substring(0, 8));
+        po.setVendorId(UUID.randomUUID());
+        po.setStatus(status);
+        po.setShipToLocationId(site);
+        po.setExpectedDeliveryDate(expected);
+        po.setCurrency("USD");
+        po.setSubtotalMinor(0L);
+        po.setTaxMinor(0L);
+        po.setGrandTotalMinor(0L);
+        po.setVersionNumber(1);
+        po.setCreatedBy("test");
+        po.setCreatedAt(Instant.now());
+        po.setUpdatedAt(Instant.now());
+
+        PurchaseOrderLineEntity line = new PurchaseOrderLineEntity();
+        line.setLineId(lineId);
+        line.setPurchaseOrder(po);
+        line.setLineNumber(1);
+        line.setSkuId(SKU);
+        line.setDescription("parity fixture");
+        line.setQuantityDecimal(new BigDecimal(ordered));
+        line.setOpenQuantityDecimal(new BigDecimal(open));
+        line.setUnitCostMinor(0L);
+        line.setLineTotalMinor(0L);
+        po.setLines(List.of(line));
+        orderRepository.save(po);
+
+        extOrderRepository.save(ExtPurchaseOrderReplica.builder()
+                .purchaseOrderId(orderId)
+                .poNumber(po.getPoNumber())
+                .vendorId(po.getVendorId())
+                .status(status.name())
+                .shipToLocationId(site)
+                .expectedDeliveryDate(expected)
+                .currency("USD")
+                .grandTotalMinor(0L)
+                .aggregateVersion(1L)
+                .occurredAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build());
+        extLineRepository.save(ExtPurchaseOrderLineReplica.builder()
+                .lineId(lineId)
+                .purchaseOrderId(orderId)
+                .lineNumber(1)
+                .skuId(SKU)
+                .orderedQuantity(new BigDecimal(ordered))
+                .openQuantity(new BigDecimal(open))
+                .unitCostMinor(0L)
+                .description("parity fixture")
+                .build());
+    }
+
+    @ParameterizedTest(name = "site={0} bounded={1}")
+    @CsvSource({
+        "A, true",
+        "A, false",
+        "B, true",
+        "B, false",
+        "NONE, true",
+        "NONE, false",
+    })
+    @DisplayName("open-supply sums are identical across every site and horizon combination")
+    void openSupplySumsMatch(String site, boolean bounded) {
+        UUID siteId = "A".equals(site) ? SITE_A : "B".equals(site) ? SITE_B : null;
+
+        BigDecimal fromAggregate = lineRepository.sumOpenQuantityForSku(SKU, OPEN_ENUM, siteId, bounded, HORIZON);
+        BigDecimal fromProjection = extLineRepository.sumOpenQuantityForSku(SKU, OPEN_STRING, siteId, bounded, HORIZON);
+
+        assertThat(fromProjection)
+                .as("projection must promise exactly what the aggregate promises")
+                .isEqualByComparingTo(fromAggregate);
+    }
+
+    @Test
+    @DisplayName("the undated order is the case that separates bounded from unbounded, in both")
+    void undatedSupplyIsExcludedByTheBoundedQueryInBothImplementations() {
+        BigDecimal aggBounded = lineRepository.sumOpenQuantityForSku(SKU, OPEN_ENUM, SITE_A, true, HORIZON);
+        BigDecimal aggUnbounded = lineRepository.sumOpenQuantityForSku(SKU, OPEN_ENUM, SITE_A, false, HORIZON);
+        BigDecimal projBounded = extLineRepository.sumOpenQuantityForSku(SKU, OPEN_STRING, SITE_A, true, HORIZON);
+        BigDecimal projUnbounded = extLineRepository.sumOpenQuantityForSku(SKU, OPEN_STRING, SITE_A, false, HORIZON);
+
+        // Both must differ between bounded and unbounded, and differ by the same amount — the undated
+        // three plus the beyond-horizon nine. Agreeing on a wrong figure would pass a naive equality
+        // check, so the shape of the difference is asserted too.
+        assertThat(aggUnbounded.subtract(aggBounded)).isEqualByComparingTo(projUnbounded.subtract(projBounded));
+        assertThat(projUnbounded).isGreaterThan(projBounded);
+    }
+
+    @Test
+    @DisplayName("candidate cutoff dates are identical")
+    void distinctDeliveryDatesMatch() {
+        List<LocalDate> fromAggregate =
+                lineRepository.findDistinctExpectedDeliveryDatesForSku(SKU, OPEN_ENUM, SITE_A, HORIZON);
+        List<LocalDate> fromProjection =
+                extLineRepository.findDistinctExpectedDeliveryDatesForSku(SKU, OPEN_STRING, SITE_A, HORIZON);
+
+        assertThat(fromProjection).containsExactlyInAnyOrderElementsOf(fromAggregate);
+    }
+
+    @Test
+    @DisplayName("a SKU nobody ordered returns zero, not null, from both")
+    void unknownSkuReturnsZeroFromBoth() {
+        UUID unknown = UUID.randomUUID();
+
+        BigDecimal fromAggregate = lineRepository.sumOpenQuantityForSku(unknown, OPEN_ENUM, null, false, HORIZON);
+        BigDecimal fromProjection = extLineRepository.sumOpenQuantityForSku(unknown, OPEN_STRING, null, false, HORIZON);
+
+        // COALESCE on both sides: a null here would become a NullPointerException in the caller, or
+        // worse, be treated as zero by one implementation and not the other.
+        assertThat(fromAggregate).isNotNull().isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(fromProjection).isNotNull().isEqualByComparingTo(fromAggregate);
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseOrderProjectionTestSupport.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseOrderProjectionTestSupport.java
@@ -46,7 +46,9 @@ public class PurchaseOrderProjectionTestSupport {
 
     /** Projects an order already held in memory, lines included. */
     public void project(PurchaseOrderEntity order) {
-        apply(PurchaseOrderFactPublisher.toFact(order, order.getLines(), Instant.now()));
+        apply(
+                PurchaseOrderFactPublisher.toFact(order, order.getLines(), Instant.now()),
+                PurchaseOrderFactPublisher.versionOf(order));
     }
 
     /**
@@ -58,7 +60,7 @@ public class PurchaseOrderProjectionTestSupport {
         purchaseOrderRepository.findById(purchaseOrderId).ifPresent(this::project);
     }
 
-    private void apply(PurchaseOrderUpdatedV1 fact) {
+    private void apply(PurchaseOrderUpdatedV1 fact, long aggregateVersion) {
         extOrderRepository.save(ExtPurchaseOrderReplica.builder()
                 .purchaseOrderId(fact.purchaseOrderId())
                 .poNumber(fact.poNumber())
@@ -68,7 +70,9 @@ public class PurchaseOrderProjectionTestSupport {
                 .expectedDeliveryDate(fact.expectedDeliveryDate())
                 .currency(fact.currency())
                 .grandTotalMinor(fact.grandTotalMinor())
-                .aggregateVersion(1L)
+                // The order's real optimistic-lock version, exactly as the publisher would stamp it
+                // — a hard-coded number here would mask version-dependent staleness behavior.
+                .aggregateVersion(aggregateVersion)
                 .occurredAt(fact.occurredAt())
                 .build());
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseOrderProjectionTestSupport.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseOrderProjectionTestSupport.java
@@ -1,0 +1,91 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.domainevents.order.PurchaseOrderLine;
+import com.positivity.domainevents.order.PurchaseOrderUpdatedV1;
+import com.positivity.inventory.internal.entity.ExtPurchaseOrderLineReplica;
+import com.positivity.inventory.internal.entity.ExtPurchaseOrderReplica;
+import com.positivity.inventory.internal.entity.PurchaseOrderEntity;
+import com.positivity.inventory.internal.repository.ExtPurchaseOrderLineRepository;
+import com.positivity.inventory.internal.repository.ExtPurchaseOrderRepository;
+import com.positivity.inventory.internal.repository.PurchaseOrderRepository;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Projects a purchase order into {@code ext_purchase_order} the way the running system would.
+ *
+ * <h2>Why tests need this at all</h2>
+ *
+ * Availability-to-promise reads the projection, not the aggregate (#1333). A test that saves a
+ * {@link PurchaseOrderEntity} and expects supply to move is describing a state the system never
+ * reaches: in production the order is published as a fact and applied by
+ * {@link PurchaseOrderProjectionListener}. Without Kafka in the test context nothing closes that
+ * loop, so this helper closes it explicitly — one call, at the point the order is saved.
+ *
+ * <h2>Why it borrows the production mapping</h2>
+ *
+ * It builds the same {@link PurchaseOrderUpdatedV1} the publisher builds, through the same
+ * package-private {@code toFact}. A helper carrying its own copy of the mapping would keep the
+ * tests green while the real one drifted — the null-open-quantity rule in particular, where
+ * "never received against" must mean "all of it is still outstanding" rather than "none of it is".
+ * Copying that rule here would let a regression in the real one go unnoticed.
+ *
+ * <p>Once the aggregate moves to pos-order (#1334) this becomes the only way these tests can seed
+ * supply, because the aggregate will no longer exist in this module.
+ */
+@Component
+@RequiredArgsConstructor
+public class PurchaseOrderProjectionTestSupport {
+
+    private final PurchaseOrderRepository purchaseOrderRepository;
+    private final ExtPurchaseOrderRepository extOrderRepository;
+    private final ExtPurchaseOrderLineRepository extLineRepository;
+
+    /** Projects an order already held in memory, lines included. */
+    public void project(PurchaseOrderEntity order) {
+        apply(PurchaseOrderFactPublisher.toFact(order, order.getLines(), Instant.now()));
+    }
+
+    /**
+     * Projects an order by id, for tests that create or mutate one through the real service or raw
+     * SQL. Transactional so the order's lazily loaded lines are readable.
+     */
+    @Transactional
+    public void project(UUID purchaseOrderId) {
+        purchaseOrderRepository.findById(purchaseOrderId).ifPresent(this::project);
+    }
+
+    private void apply(PurchaseOrderUpdatedV1 fact) {
+        extOrderRepository.save(ExtPurchaseOrderReplica.builder()
+                .purchaseOrderId(fact.purchaseOrderId())
+                .poNumber(fact.poNumber())
+                .vendorId(fact.vendorId())
+                .status(fact.status())
+                .shipToLocationId(fact.shipToLocationId())
+                .expectedDeliveryDate(fact.expectedDeliveryDate())
+                .currency(fact.currency())
+                .grandTotalMinor(fact.grandTotalMinor())
+                .aggregateVersion(1L)
+                .occurredAt(fact.occurredAt())
+                .build());
+
+        // Replace, not merge — the same rule the listener follows, so a test that re-projects an
+        // order after a change sees the change rather than both versions of it.
+        extLineRepository.deleteByPurchaseOrderId(fact.purchaseOrderId());
+        for (PurchaseOrderLine line : fact.lines()) {
+            extLineRepository.save(ExtPurchaseOrderLineReplica.builder()
+                    .lineId(line.lineId() == null ? UUID.randomUUID() : line.lineId())
+                    .purchaseOrderId(fact.purchaseOrderId())
+                    .lineNumber(line.lineNumber())
+                    .skuId(line.skuId())
+                    .orderedQuantity(line.orderedQuantity())
+                    .openQuantity(line.openQuantity())
+                    .unitCostMinor(line.unitCostMinor())
+                    .description(line.description())
+                    .build());
+        }
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseSuggestionScanTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseSuggestionScanTest.java
@@ -65,6 +65,9 @@ class PurchaseSuggestionScanTest {
     private NormalizedAvailabilityRepository normalizedAvailabilityRepository;
 
     @Autowired
+    private PurchaseOrderProjectionTestSupport projection;
+
+    @Autowired
     private PurchaseOrderService purchaseOrderService;
 
     @Autowired
@@ -278,6 +281,9 @@ class PurchaseSuggestionScanTest {
         jdbcTemplate.update(
                 "UPDATE purchase_order SET status = 'APPROVED' WHERE purchase_order_id = ?",
                 converted.getPurchaseOrderId());
+        // Approval is what turns the order into expected supply, and expected supply is read from
+        // the projection — so the approval has to reach it, as a published fact would.
+        projection.project(converted.getPurchaseOrderId());
         assertThat(replenishmentService
                         .evaluatePickFaceForReplenishment(sku, location)
                         .getStatus())
@@ -296,6 +302,9 @@ class PurchaseSuggestionScanTest {
         jdbcTemplate.update(
                 "UPDATE purchase_order_line SET open_quantity_decimal = 5 WHERE purchase_order_id = ?",
                 converted.getPurchaseOrderId());
+        // The receipt is what changes supply, and supply is read from the projection — so the
+        // change has to reach it, exactly as a published fact would in the running system.
+        projection.project(converted.getPurchaseOrderId());
         post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 15, 15);
         post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -12, 3);
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/AsnServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/AsnServiceImplTest.java
@@ -88,6 +88,9 @@ class AsnServiceImplTest {
     private LedgerPostingService ledgerPostingService;
 
     @Mock
+    private com.positivity.inventory.internal.service.PurchaseOrderFactPublisher purchaseOrderFactPublisher;
+
+    @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
     private AsnServiceImpl asnService;
@@ -104,6 +107,7 @@ class AsnServiceImplTest {
                 inventoryLedgerEntryRepository,
                 ledgerPostingService,
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
+                purchaseOrderFactPublisher,
                 applicationEventPublisher,
                 new com.positivity.inventory.internal.service.DocumentQuantityConverter(
                         org.mockito.Mockito.mock(com.positivity.inventory.internal.service.UomConversionService.class)),
@@ -519,6 +523,16 @@ class AsnServiceImplTest {
         ArgumentCaptor<AdvanceShippingNoticeEntity> captor = ArgumentCaptor.forClass(AdvanceShippingNoticeEntity.class);
         verify(asnRepository).save(captor.capture());
         assertEquals(AsnStatus.FULLY_RECEIVED, captor.getValue().getStatus());
+
+        // Receiving is what takes an order out of open supply, and this is the path that does it.
+        // Without the fact, the ext_purchase_order projection would go on counting a fully
+        // received order as still incoming, promising stock that is already on the shelf.
+        ArgumentCaptor<PurchaseOrderEntity> poCaptor = ArgumentCaptor.forClass(PurchaseOrderEntity.class);
+        verify(purchaseOrderFactPublisher).publish(poCaptor.capture(), any());
+        // A fully received ASN is not a fully received order. Every shipped unit on this ASN
+        // arrived, but the order was for 10,000 minor and only 1,000 of it has been received, so
+        // the order stays open — and the fact carries that status, not the ASN's.
+        assertEquals(PurchaseOrderStatus.PARTIALLY_RECEIVED, poCaptor.getValue().getStatus());
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/PurchaseOrderServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/PurchaseOrderServiceImplTest.java
@@ -65,6 +65,9 @@ class PurchaseOrderServiceImplTest {
     @Mock
     private com.positivity.inventory.internal.service.InventoryFactPublisher inventoryFactPublisher;
 
+    @Mock
+    private com.positivity.inventory.internal.service.PurchaseOrderFactPublisher purchaseOrderFactPublisher;
+
     private PurchaseOrderServiceImpl purchaseOrderService;
 
     private Clock fixedClock = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
@@ -76,6 +79,7 @@ class PurchaseOrderServiceImplTest {
                 purchaseOrderLineRepository,
                 eventPublisher,
                 inventoryFactPublisher,
+                purchaseOrderFactPublisher,
                 new com.positivity.inventory.internal.service.DocumentQuantityConverter(
                         org.mockito.Mockito.mock(com.positivity.inventory.internal.service.UomConversionService.class)),
                 // Lot gate answers "untracked" for every SKU in these unit tests (E1 #1038):


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:320`
- Parent STORY (durion): louisburroughs/durion#377
- Child issue: louisburroughs/durion-positivity-backend#1333
- Domain: `domain:inventory`

## Contract References
- Contract guide entry (durion): `domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` → expected supply / availability-to-promise
- New event contract: `purchaseorder.updated` v1 on `order.events.v1` (ADR-0049 §3, ADR-0044 §4)

No controller changed, so no OpenAPI or SDK regeneration is required.

## Scope

**What changed:** availability-to-promise no longer reads the purchase-order aggregate. It reads an `ext_purchase_order` projection fed by the published `purchaseorder.updated` fact.

**Why:** the purchase-order aggregate is pos-order's (ADR-0049 §2) and is moving there under CAP-320. ADR-0044 R3 makes replicas the cross-domain read path, so the read has to move off the aggregate before the aggregate moves off this module.

**The sequencing is the point.** The projection is built and proven *while both implementations still exist*. `PurchaseOrderProjectionParityIT` runs the aggregate's supply query and the ported one over identical seeded data and compares the answers across every site and horizon combination — including the undated-order case, which is the single most likely place for the two to disagree, and the fully-received line, which must contribute zero rather than be filtered out. Once the aggregate moves there is nothing left to compare against.

**A gap this surfaced.** `AsnServiceImpl` was a second path that changes a purchase order's state, and it published nothing. It is the consequential one: it is what flips an order to `FULLY_RECEIVED`/`PARTIALLY_RECEIVED`, i.e. what takes it *out* of open supply. Left unpublished, the projection would have gone on counting a delivered order as still incoming — over-promising stock already on the shelf. It now publishes.

**Failure modes the listener answers rather than assumes:**
- redelivery → the event-id guard makes it a no-op
- out-of-order arrival → the stale guard on `aggregateVersion` skips a fact older than what is applied, so a slow retry cannot resurrect a superseded state
- transient database trouble → rethrown for retry; marking it processed would drop an order out of supply permanently
- full state replaces rather than merges, so a line the owner deleted disappears here too instead of lingering as phantom supply
- `ext_purchase_order_receipt` records the highest applied version per order, so "is the projection behind?" is a query rather than an inference from a number looking smaller than expected

## Tests
- [x] Unit tests added/updated — `PurchaseOrderFactPublisherTest` (8), `PurchaseOrderProjectionListenerTest` (8), `AsnServiceImplTest` (publish-on-receipt assertion)
- [x] Integration tests added/updated — `PurchaseOrderProjectionParityIT` (9)
- [ ] Provider behavioral contract tests added/updated — n/a
- How to run:
  ```bash
  ./mvnw -pl pos-inventory -am test
  ./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests,DomainWallsTest -Dsurefire.failIfNoSpecifiedTests=false test
  ```
  pos-inventory 889/889 green; pos-archunit 13/13 green; Flyway hygiene passes.

Tests that seeded the aggregate and expected supply to move now seed the projection through `PurchaseOrderProjectionTestSupport`. It borrows the production mapping via a package-private `toFact` rather than copying it — a copy would keep these tests green while the real mapping drifted, which is exactly what the null-open-quantity rule ("never received against" means *all* of it is outstanding, not none) must not be allowed to do.

## Risk & Rollback
- Risk level: Medium — this changes the supply input to availability-to-promise. Errors here are optimistic, which is the bad direction: too much supply promises stock that was never ordered. That is why the parity test compares outputs rather than reading the two queries and judging them alike.
- Rollback plan: revert the commit. The aggregate and its queries are untouched and still present, so reverting restores the previous read path with no data migration. `ext_purchase_order*` tables can be left in place or dropped independently.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing — pending

## Follow-ups
- #1334 moves the aggregate to pos-order and deletes the pos-inventory copy, at which point `PurchaseOrderFactPublisher` is deleted rather than repointed. Four JPA `@ManyToOne` links into `PurchaseOrderEntity` (ASN, ASN line, goods receipt, PO line) must become plain UUIDs there.
