### PR TITLE
[CAP:320] feat(order): transmit approved purchase orders to the supplier and consume the results (#1330)

### DIFF
--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,9 +1,9 @@
-generatedAt: "2026-08-15T22:48:58.528605+00:00"
+generatedAt: "2026-08-16T01:59:02.334307+00:00"
 root: "."
 summary:
   manifestCount: 22
-  permissionCount: 424
-  uniquePermissionCount: 424
+  permissionCount: 425
+  uniquePermissionCount: 425
   duplicatePermissionNameCount: 0
   parseIssueCount: 0
 manifests:
@@ -522,7 +522,7 @@ manifests:
     domain: "order"
     serviceName: "pos-order"
     version: "1.0"
-    permissionCount: 29
+    permissionCount: 30
     permissions:
       - name: "order:order:view"
         description: "View orders"
@@ -582,6 +582,8 @@ manifests:
         description: "Create or revise a purchase order (DRAFT state)"
       - name: "order:purchase_order:approve"
         description: "Approve or cancel a purchase order"
+      - name: "order:purchase_order:transmit"
+        description: "Send an approved purchase order to its vendor"
   - module: "pos-people"
     path: "pos-people/src/main/resources/permissions.yaml"
     domain: "people"
@@ -2452,6 +2454,12 @@ permissions:
     source: "pos-order/src/main/resources/permissions.yaml"
   - name: "order:purchase_order:create"
     description: "Create or revise a purchase order (DRAFT state)"
+    domain: "order"
+    serviceName: "pos-order"
+    module: "pos-order"
+    source: "pos-order/src/main/resources/permissions.yaml"
+  - name: "order:purchase_order:transmit"
+    description: "Send an approved purchase order to its vendor"
     domain: "order"
     serviceName: "pos-order"
     module: "pos-order"

--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -919,6 +919,8 @@ paths:
     $ref: ../../pos-order/openapi.yaml#/paths/~1v1~1orders~1purchase-orders~1{poId}~1cancel
   /v1/orders/purchase-orders/{poId}/revisions:
     $ref: ../../pos-order/openapi.yaml#/paths/~1v1~1orders~1purchase-orders~1{poId}~1revisions
+  /v1/orders/purchase-orders/{poId}/transmit:
+    $ref: ../../pos-order/openapi.yaml#/paths/~1v1~1orders~1purchase-orders~1{poId}~1transmit
   /v1/orders/sessions:
     $ref: ../../pos-order/openapi.yaml#/paths/~1v1~1orders~1sessions
   /v1/orders/sessions/current:

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 49;
+    public static final int CATALOG_VERSION = 50;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -542,7 +542,10 @@ public final class GatewayPermissionCatalog {
         // ── New batch (bits 456–458) ──────────────────────────────────────────
         "PERM_order:purchase_order:approve", // 456
         "PERM_order:purchase_order:create", // 457
-        "PERM_order:purchase_order:view" // 458
+        "PERM_order:purchase_order:view", // 458
+
+        // ── New batch (bits 459–459) ──────────────────────────────────────────
+        "PERM_order:purchase_order:transmit" // 459
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,9 +1142,9 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 49")
+    @DisplayName("CATALOG_VERSION is 50")
     void catalogVersionMatchesCurrent() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(49);
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(50);
     }
 
     @Test
@@ -1303,8 +1303,12 @@ class SecurityGatewayConfigTest {
         assertThat(GatewayPermissionCatalog.authorityForBit(456)).isEqualTo("PERM_order:purchase_order:approve");
         assertThat(GatewayPermissionCatalog.authorityForBit(457)).isEqualTo("PERM_order:purchase_order:create");
         assertThat(GatewayPermissionCatalog.authorityForBit(458)).isEqualTo("PERM_order:purchase_order:view");
+        // Sending an approved order to the vendor (CAP-320 #1330). Separate from approval because
+        // they are different acts: approving commits the spend, transmitting puts it in front of a
+        // supplier who will act on it.
+        assertThat(GatewayPermissionCatalog.authorityForBit(459)).isEqualTo("PERM_order:purchase_order:transmit");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(459)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(460)).isNull();
     }
 
     @Test

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierOrderReviewRequiredV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierOrderReviewRequiredV1.java
@@ -1,0 +1,62 @@
+package com.positivity.domainevents.supplier;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A transmission has stopped and needs a person, published on {@code supplier.events.v1}
+ * (CAP-320 #1330, ADR-0052 §3/§4).
+ *
+ * <h2>Why this is not an outcome, and why it is still published</h2>
+ *
+ * pos-supplier deliberately publishes no confirmation or rejection when an intent escalates to
+ * {@code MANUAL_REVIEW}: it does not know whether the vendor received the order, and saying either
+ * would be an assertion nobody has made. That reasoning is why this event says neither.
+ *
+ * <p>What it does say is that the transmission has stopped and will not move again on its own.
+ * Without it the ordering domain sees a request that looks in flight, indistinguishable from one
+ * genuinely in progress — so a buyer waiting on goods waits on something that is not coming, and
+ * the only record of why lives in a transmission log they have no reason to open. "Still open" and
+ * "stuck pending a human" are different facts, and the second is the one somebody has to act on.
+ *
+ * <p>Deliberately carries no advice about what to do. Resolution is an operator's judgement made
+ * against evidence pos-supplier holds (ADR-0052 §4), and a hint here would be this service
+ * guessing at the very thing it escalated because it could not determine.
+ *
+ * @param transmissionIntentId the intent that stopped
+ * @param purchaseOrderId      the purchase order it was transmitting
+ * @param vendorProfileId      vendor profile the transmission was addressed to
+ * @param supplierRef          that profile's alias, as at the time of the transmission
+ * @param documentId           the vendor document id derived for this intent, which an operator
+ *                             quotes to the vendor when asking whether it arrived
+ * @param detail               why it escalated, as recorded for the operator; free text, never a
+ *                             code to branch on
+ * @param escalatedAt          when it stopped
+ */
+public record SupplierOrderReviewRequiredV1(
+        @NonNull UUID transmissionIntentId,
+        @NonNull UUID purchaseOrderId,
+        @NonNull UUID vendorProfileId,
+        @NonNull String supplierRef,
+        @NonNull String documentId,
+        @Nullable String detail,
+        @NonNull Instant escalatedAt) {
+
+    /** Event type of this payload on {@code supplier.events.v1}. */
+    public static final String EVENT_TYPE = "supplier.order.reviewrequired";
+
+    /** Payload schema version; additive changes only within v1 (ADR-0044 §3). */
+    public static final int SCHEMA_VERSION = 1;
+
+    public SupplierOrderReviewRequiredV1 {
+        Objects.requireNonNull(transmissionIntentId, "transmissionIntentId must not be null");
+        Objects.requireNonNull(purchaseOrderId, "purchaseOrderId must not be null");
+        Objects.requireNonNull(vendorProfileId, "vendorProfileId must not be null");
+        Objects.requireNonNull(supplierRef, "supplierRef must not be null");
+        Objects.requireNonNull(documentId, "documentId must not be null");
+        Objects.requireNonNull(escalatedAt, "escalatedAt must not be null");
+    }
+}

--- a/pos-order/openapi.yaml
+++ b/pos-order/openapi.yaml
@@ -792,7 +792,7 @@ paths:
 
         Required inputs: none; vendorId, status, currency and locationId narrow the result, and standard page, size and sort parameters control pagination.
 
-        Emits an INVENTORY_PURCHASE_ORDER_LIST audit event; no stock state changes, this is a read-only projection.
+        Emits an ORDER_PURCHASE_ORDER_LIST audit event; no stock state changes, this is a read-only projection.
 
         Returns 200 with an empty page when nothing matches, so an empty result is not an error condition.
 
@@ -839,7 +839,7 @@ paths:
 
         Required inputs: vendorId (UUID), poDate, currency (ISO 4217) and lines (non-empty), each naming lineNumber, description and unitCostMinor plus either quantity in base UoM or the documentUom/documentQuantity pair; tax is derived from the configured default rate.
 
-        Emits an INVENTORY_PURCHASE_ORDER_CREATE event; no stock, ledger or vendor-side state is touched.
+        Emits an ORDER_PURCHASE_ORDER_CREATE event; no stock, ledger or vendor-side state is touched.
 
         Returns 400 when a line''s quantity is missing without the document-UoM pair, and 422 when a documentUom has no conversion path to the product''s base UoM.
 
@@ -892,6 +892,53 @@ paths:
         - order:purchase_order:create
       x-required-permissions:
       - order:purchase_order:create
+  /v1/orders/purchase-orders/{poId}/transmit:
+    post:
+      tags:
+      - Purchase Orders
+      summary: Transmit Purchase Order To Vendor
+      description: 'Sends an approved purchase order to the supplier named on it, asking pos-supplier to transmit it and report back what the vendor says.
+
+        Use this tool to actually place an order with a vendor; do not use approvePurchaseOrder for this, which commits the spend internally and sends nothing to anyone.
+
+        Preconditions: the order must be APPROVED or PARTIALLY_RECEIVED, must name a supplierRef, must have no transmission already in flight or awaiting review, and every line must carry an article code the vendor would recognise.
+
+        Required inputs: poId (UUIDv7) path parameter; there is no request body, because what is sent is the order as it stands.
+
+        Emits an ORDER_PURCHASE_ORDER_TRANSMIT event and queues a supplier order command; the vendor''s answer arrives later and appears on the order''s transmission state and timeline.
+
+        Returns 404 when the purchase order does not exist, and 422 with a code naming the obstacle when the order cannot be sent: SUPPLIER_REF_MISSING, PURCHASE_ORDER_NOT_APPROVED, TRANSMISSION_IN_FLIGHT, TRANSMISSION_AWAITING_REVIEW, ARTICLE_NOT_IDENTIFIABLE or FRACTIONAL_QUANTITY.
+
+        '
+      operationId: transmitPurchaseOrder
+      parameters:
+      - name: poId
+        in: path
+        description: Purchase order id (UUIDv7)
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '202':
+          description: Transmission requested
+        '404':
+          description: Purchase order not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '422':
+          description: The order cannot be transmitted as it stands
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - order:purchase_order:transmit
+      x-required-permissions:
+      - order:purchase_order:transmit
   /v1/orders/purchase-orders/{poId}/revisions:
     post:
       tags:
@@ -905,7 +952,7 @@ paths:
 
         Required inputs: poId (UUIDv7) path parameter plus poDate, revisionReason and the full replacement lines list, because every line is replaced rather than merged; paymentTermsId, expectedDeliveryDate, shipToLocationId, requestedBy and comment overwrite the stored values even when omitted.
 
-        Emits an INVENTORY_PURCHASE_ORDER_REVISE event carrying the field-level delta and the revision reason.
+        Emits an ORDER_PURCHASE_ORDER_REVISE event carrying the field-level delta and the revision reason.
 
         Returns 404 when the purchase order does not exist, and 422 when a line''s documentUom has no conversion path to the product''s base UoM.
 
@@ -989,7 +1036,7 @@ paths:
 
         Required inputs: poId (UUIDv7) path parameter; there is no request body and no confirmation flag.
 
-        Emits an INVENTORY_PURCHASE_ORDER_CANCEL event, and when the order was APPROVED or PARTIALLY_RECEIVED it also records one expected-supply-dropped fact per SKU with remaining open quantity, removing the order from the supply projection.
+        Emits an ORDER_PURCHASE_ORDER_CANCEL event and publishes the order''s new state; a cancelled order is no longer counted as incoming supply by the modules that track it.
 
         Returns 404 when the purchase order does not exist, and 409 when it is FULLY_RECEIVED or CLOSED.
 
@@ -1046,7 +1093,7 @@ paths:
 
         Required inputs: poId (UUIDv7) path parameter and a JSON body where approvalNotes is optional, so an empty object is acceptable.
 
-        Emits an INVENTORY_PURCHASE_ORDER_APPROVE event; the order becomes eligible for ASNs, goods receipts and receiving sessions.
+        Emits an ORDER_PURCHASE_ORDER_APPROVE event; the order becomes eligible for ASNs, goods receipts and receiving sessions.
 
         Returns 404 when the purchase order does not exist, and 409 when it is not in DRAFT status.
 
@@ -2045,7 +2092,7 @@ paths:
 
         Required inputs: poId (UUIDv7) path parameter; there is no request body.
 
-        Emits an INVENTORY_PURCHASE_ORDER_GET audit event; no stock state changes, this is a read-only projection.
+        Emits an ORDER_PURCHASE_ORDER_GET audit event; no stock state changes, this is a read-only projection.
 
         Returns 404 when no purchase order exists for the supplied id.
 

--- a/pos-order/src/main/java/com/positivity/order/internal/config/EventTypes.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/config/EventTypes.java
@@ -147,5 +147,9 @@ public final class EventTypes {
                     .build(),
             EventTypeRegistration.write("ORDER_PURCHASE_ORDER_CANCEL", "Cancel a purchase order")
                     .apiVersion("1")
+                    .build(),
+            EventTypeRegistration.write(
+                            "ORDER_PURCHASE_ORDER_TRANSMIT", "Send an approved purchase order to its vendor")
+                    .apiVersion("1")
                     .build());
 }

--- a/pos-order/src/main/java/com/positivity/order/internal/controller/PurchaseOrderController.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/controller/PurchaseOrderController.java
@@ -7,6 +7,7 @@ import com.positivity.order.internal.dto.purchaseorder.ListPurchaseOrdersRequest
 import com.positivity.order.internal.dto.purchaseorder.PurchaseOrderResponse;
 import com.positivity.order.internal.dto.purchaseorder.RevisePurchaseOrderRequest;
 import com.positivity.order.internal.security.PurchaseOrderPermissions;
+import com.positivity.order.internal.service.PurchaseOrderTransmissionService;
 import com.positivity.order.service.PurchaseOrderService;
 import com.positivity.security.common.SecurityContextHelper;
 import com.positivity.shared.error.ApiError;
@@ -41,6 +42,7 @@ public class PurchaseOrderController {
     private static final String NO_CURRENT_USER = "No current user";
 
     private final PurchaseOrderService purchaseOrderService;
+    private final PurchaseOrderTransmissionService purchaseOrderTransmissionService;
 
     @PostMapping
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -62,7 +64,7 @@ public class PurchaseOrderController {
                     Required inputs: vendorId (UUID), poDate, currency (ISO 4217) and lines (non-empty), each \
                     naming lineNumber, description and unitCostMinor plus either quantity in base UoM or the \
                     documentUom/documentQuantity pair; tax is derived from the configured default rate.
-                    Emits an INVENTORY_PURCHASE_ORDER_CREATE event; no stock, ledger or vendor-side state is \
+                    Emits an ORDER_PURCHASE_ORDER_CREATE event; no stock, ledger or vendor-side state is \
                     touched.
                     Returns 400 when a line's quantity is missing without the document-UoM pair, and 422 when a \
                     documentUom has no conversion path to the product's base UoM.
@@ -127,7 +129,7 @@ public class PurchaseOrderController {
                     vendor, status, currency or ship-to location.
                     Preconditions: the purchase order must exist.
                     Required inputs: poId (UUIDv7) path parameter; there is no request body.
-                    Emits an INVENTORY_PURCHASE_ORDER_GET audit event; no stock state changes, this is a \
+                    Emits an ORDER_PURCHASE_ORDER_GET audit event; no stock state changes, this is a \
                     read-only projection.
                     Returns 404 when no purchase order exists for the supplied id.
                     """,
@@ -169,7 +171,7 @@ public class PurchaseOrderController {
                     Preconditions: none; every filter is optional and an unfiltered call pages over all orders.
                     Required inputs: none; vendorId, status, currency and locationId narrow the result, and \
                     standard page, size and sort parameters control pagination.
-                    Emits an INVENTORY_PURCHASE_ORDER_LIST audit event; no stock state changes, this is a \
+                    Emits an ORDER_PURCHASE_ORDER_LIST audit event; no stock state changes, this is a \
                     read-only projection.
                     Returns 200 with an empty page when nothing matches, so an empty result is not an error \
                     condition.
@@ -204,7 +206,7 @@ public class PurchaseOrderController {
                     conflict.
                     Required inputs: poId (UUIDv7) path parameter and a JSON body where approvalNotes is optional, \
                     so an empty object is acceptable.
-                    Emits an INVENTORY_PURCHASE_ORDER_APPROVE event; the order becomes eligible for ASNs, goods \
+                    Emits an ORDER_PURCHASE_ORDER_APPROVE event; the order becomes eligible for ASNs, goods \
                     receipts and receiving sessions.
                     Returns 404 when the purchase order does not exist, and 409 when it is not in DRAFT status.
                     """,
@@ -281,7 +283,7 @@ public class PurchaseOrderController {
                     replacement lines list, because every line is replaced rather than merged; paymentTermsId, \
                     expectedDeliveryDate, shipToLocationId, requestedBy and comment overwrite the stored values \
                     even when omitted.
-                    Emits an INVENTORY_PURCHASE_ORDER_REVISE event carrying the field-level delta and the \
+                    Emits an ORDER_PURCHASE_ORDER_REVISE event carrying the field-level delta and the \
                     revision reason.
                     Returns 404 when the purchase order does not exist, and 422 when a line's documentUom has no \
                     conversion path to the product's base UoM.
@@ -355,9 +357,8 @@ public class PurchaseOrderController {
                     other status, including DRAFT, may be cancelled.
                     Required inputs: poId (UUIDv7) path parameter; there is no request body and no confirmation \
                     flag.
-                    Emits an INVENTORY_PURCHASE_ORDER_CANCEL event, and when the order was APPROVED or \
-                    PARTIALLY_RECEIVED it also records one expected-supply-dropped fact per SKU with remaining \
-                    open quantity, removing the order from the supply projection.
+                    Emits an ORDER_PURCHASE_ORDER_CANCEL event and publishes the order's new state; a cancelled \
+                    order is no longer counted as incoming supply by the modules that track it.
                     Returns 404 when the purchase order does not exist, and 409 when it is FULLY_RECEIVED or \
                     CLOSED.
                     """,
@@ -386,5 +387,48 @@ public class PurchaseOrderController {
         String actorUserId = SecurityContextHelper.getCurrentUsername()
                 .orElseThrow(() -> new IllegalStateException(NO_CURRENT_USER));
         return ResponseEntity.ok(purchaseOrderService.cancelPurchaseOrder(poId, actorUserId));
+    }
+
+    @PostMapping("/{poId}/transmit")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"order:purchase_order:transmit"})
+    @PreAuthorize("hasAuthority('" + PurchaseOrderPermissions.PURCHASE_ORDER_TRANSMIT + "')")
+    @EmitEvent(id = "ORDER_PURCHASE_ORDER_TRANSMIT", apiVersion = "1")
+    @Operation(
+            operationId = "transmitPurchaseOrder",
+            summary = "Transmit Purchase Order To Vendor",
+            description = """
+                    Sends an approved purchase order to the supplier named on it, asking pos-supplier to \
+                    transmit it and report back what the vendor says.
+                    Use this tool to actually place an order with a vendor; do not use approvePurchaseOrder for \
+                    this, which commits the spend internally and sends nothing to anyone.
+                    Preconditions: the order must be APPROVED or PARTIALLY_RECEIVED, must name a supplierRef, \
+                    must have no transmission already in flight or awaiting review, and every line must carry an \
+                    article code the vendor would recognise.
+                    Required inputs: poId (UUIDv7) path parameter; there is no request body, because what is sent \
+                    is the order as it stands.
+                    Emits an ORDER_PURCHASE_ORDER_TRANSMIT event and queues a supplier order command; the vendor's \
+                    answer arrives later and appears on the order's transmission state and timeline.
+                    Returns 404 when the purchase order does not exist, and 422 with a code naming the obstacle \
+                    when the order cannot be sent: SUPPLIER_REF_MISSING, PURCHASE_ORDER_NOT_APPROVED, \
+                    TRANSMISSION_IN_FLIGHT, TRANSMISSION_AWAITING_REVIEW, ARTICLE_NOT_IDENTIFIABLE or \
+                    FRACTIONAL_QUANTITY.
+                    """,
+            tags = {"Purchase Orders"})
+    @ApiResponse(responseCode = "202", description = "Transmission requested")
+    @ApiResponse(
+            responseCode = "404",
+            description = "Purchase order not found",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "The order cannot be transmitted as it stands",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<Void> transmitPurchaseOrder(
+            @Parameter(description = "Purchase order id (UUIDv7)", required = true) @PathVariable UUID poId) {
+        purchaseOrderTransmissionService.requestTransmission(
+                poId, SecurityContextHelper.getCurrentUsername().orElse(NO_CURRENT_USER));
+        return ResponseEntity.accepted().build();
     }
 }

--- a/pos-order/src/main/java/com/positivity/order/internal/controller/PurchaseOrderExceptionHandler.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/controller/PurchaseOrderExceptionHandler.java
@@ -1,0 +1,100 @@
+package com.positivity.order.internal.controller;
+
+import com.positivity.order.internal.exception.PurchaseOrderNotFoundException;
+import com.positivity.order.internal.exception.PurchaseOrderNotTransmittableException;
+import com.positivity.order.internal.exception.UomConversionUndefinedException;
+import com.positivity.shared.error.ApiError;
+import com.positivity.shared.id.UUIDv7Generator;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Turns purchase-order failures into the {@code ApiError} envelope its endpoints promise.
+ *
+ * <h2>Why this exists</h2>
+ *
+ * pos-order scopes its advices per controller, and the purchase-order controller arrived without
+ * one when the aggregate moved here (#1334). Its endpoints have documented 404 and 409 responses
+ * since then and would have produced neither: every one of these exceptions fell through to the
+ * default handler and came back as a 500 with a body no client could read. Callers were being
+ * promised a contract that did not exist.
+ *
+ * <p>The transmission codes are surfaced individually rather than collapsed into one "cannot
+ * transmit" message, because each names a different thing for somebody to go and fix — a missing
+ * supplier profile, an article without a code, a send already in flight — and a caller that cannot
+ * tell them apart cannot act on any of them.
+ */
+@RestControllerAdvice(assignableTypes = PurchaseOrderController.class)
+@RequiredArgsConstructor
+@Slf4j
+public class PurchaseOrderExceptionHandler {
+
+    private static final String X_CORRELATION_ID = "X-Correlation-Id";
+    private final Clock clock;
+
+    @ExceptionHandler(PurchaseOrderNotFoundException.class)
+    public ResponseEntity<ApiError> handleNotFound(PurchaseOrderNotFoundException ex, HttpServletRequest request) {
+        return respond(HttpStatus.NOT_FOUND, "PURCHASE_ORDER_NOT_FOUND", ex.getMessage(), request);
+    }
+
+    /**
+     * The order cannot be sent as it stands.
+     *
+     * <p>422 rather than 409: the request is understood and the order exists, but its current
+     * content or state makes sending it wrong. The exception's own code travels through, so a
+     * caller can distinguish "add a supplier" from "wait for the answer to the last send".
+     */
+    @ExceptionHandler(PurchaseOrderNotTransmittableException.class)
+    public ResponseEntity<ApiError> handleNotTransmittable(
+            PurchaseOrderNotTransmittableException ex, HttpServletRequest request) {
+        return respond(HttpStatus.UNPROCESSABLE_ENTITY, ex.getErrorCode(), ex.getMessage(), request);
+    }
+
+    /** A line keyed in a unit with no conversion to base; never a silent 1:1 assumption. */
+    @ExceptionHandler(UomConversionUndefinedException.class)
+    public ResponseEntity<ApiError> handleUomConversionUndefined(
+            UomConversionUndefinedException ex, HttpServletRequest request) {
+        return respond(HttpStatus.UNPROCESSABLE_ENTITY, ex.getErrorCode(), ex.getMessage(), request);
+    }
+
+    /** Lifecycle refusals: approving a non-draft, cancelling a received order. */
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiError> handleInvalidState(IllegalStateException ex, HttpServletRequest request) {
+        return respond(HttpStatus.CONFLICT, "PURCHASE_ORDER_INVALID_STATE", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiError> handleIllegalArgument(IllegalArgumentException ex, HttpServletRequest request) {
+        log.warn("Invalid purchase-order request", ex);
+        return respond(HttpStatus.BAD_REQUEST, "PURCHASE_ORDER_BAD_REQUEST", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiError> handleAccessDenied(AccessDeniedException ex, HttpServletRequest request) {
+        return respond(HttpStatus.FORBIDDEN, "PURCHASE_ORDER_FORBIDDEN", ex.getMessage(), request);
+    }
+
+    private ResponseEntity<ApiError> respond(
+            HttpStatus status, String code, String message, HttpServletRequest request) {
+        String correlationId = correlationId(request);
+        return ResponseEntity.status(status)
+                .header(X_CORRELATION_ID, correlationId)
+                .body(ApiError.of(
+                        code, message, status.value(), Instant.now(clock).toString(), correlationId));
+    }
+
+    private static String correlationId(HttpServletRequest request) {
+        String header = request.getHeader(X_CORRELATION_ID);
+        return (header != null && !header.isBlank())
+                ? header
+                : UUIDv7Generator.generate().toString();
+    }
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/entity/ExtProductCode.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/entity/ExtProductCode.java
@@ -3,6 +3,7 @@ package com.positivity.order.internal.entity;
 import com.positivity.shared.id.UUIDv7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
@@ -14,6 +15,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * A product's identity code as catalog states it (CAP-320 #1330, ADR-0044 R3).
@@ -27,6 +29,7 @@ import org.springframework.data.annotation.LastModifiedDate;
  * second a replica that has not caught up and will fix itself.
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(
         name = "ext_product_code",
         indexes = @Index(name = "idx_ext_product_code_lookup", columnList = "code_type, code"))

--- a/pos-order/src/main/java/com/positivity/order/internal/entity/ExtProductCode.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/entity/ExtProductCode.java
@@ -1,0 +1,64 @@
+package com.positivity.order.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Generator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A product's identity code as catalog states it (CAP-320 #1330, ADR-0044 R3).
+ *
+ * <p>This is what lets a purchase-order line name an article the vendor recognises. Purchase-order
+ * lines carry our own product ids, which mean nothing to a supplier; the EAN is the shared name.
+ *
+ * <p>A cleared code is stored as a null {@code code} rather than by removing the row, because
+ * "this product carries no code" and "this module has never heard of this product" are different
+ * answers and send a buyer to different places — the first is a gap in catalog to be filled, the
+ * second a replica that has not caught up and will fix itself.
+ */
+@Entity
+@Table(
+        name = "ext_product_code",
+        indexes = @Index(name = "idx_ext_product_code_lookup", columnList = "code_type, code"))
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExtProductCode {
+
+    /** pos-catalog's product id, replicated verbatim; never generated here. */
+    @Id
+    @Column(name = "product_id", nullable = false)
+    private UUID productId;
+
+    /** e.g. {@code EAN}. Null when the product carries no code. */
+    @Column(name = "code_type", length = 16)
+    private String codeType;
+
+    @Column(name = "code", length = 64)
+    private String code;
+
+    @Column(name = "aggregate_version", nullable = false)
+    private long aggregateVersion;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    /**
+     * Explicit dependency hook for the ArchUnit UUIDv7 rule (ADR-0013): the product id IS a
+     * UUIDv7 minted by pos-catalog; this replica stores it verbatim.
+     */
+    @Transient
+    public Class<?> uuidv7Dependency() {
+        return UUIDv7Generator.class;
+    }
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/entity/ExtProductCode.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/entity/ExtProductCode.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
 
 /**
  * A product's identity code as catalog states it (CAP-320 #1330, ADR-0044 R3).
@@ -50,6 +51,13 @@ public class ExtProductCode {
     @Column(name = "aggregate_version", nullable = false)
     private long aggregateVersion;
 
+    /**
+     * When this replica last changed, maintained by auditing (ADR-0024).
+     *
+     * <p>Ours rather than catalog's: it says when we last heard, which is the question asked when a
+     * product's code looks wrong and somebody needs to know whether this row is stale.
+     */
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 

--- a/pos-order/src/main/java/com/positivity/order/internal/entity/PurchaseOrderEntity.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/entity/PurchaseOrderEntity.java
@@ -1,6 +1,7 @@
 package com.positivity.order.internal.entity;
 
 import com.positivity.order.internal.enums.PurchaseOrderStatus;
+import com.positivity.order.internal.enums.TransmissionState;
 import com.positivity.shared.id.UUIDv7Id;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -119,6 +120,62 @@ public class PurchaseOrderEntity {
     @LastModifiedBy
     @Column(name = "updated_by")
     private String updatedBy;
+
+    // ── Transmission to the vendor (CAP-320 #1330) ───────────────────────────
+
+    /**
+     * The vendor as pos-supplier knows it: its profile alias, chosen when the order is raised.
+     *
+     * <p>{@code vendorId} cannot serve. It holds a manufacturer or distributor id from
+     * pos-inventory's normalized feeds, which bears no relationship to a supplier profile. Who to
+     * send to is therefore recorded as an ordering decision rather than inferred from something
+     * that does not mean what it would need to mean. An order without one is not transmittable.
+     */
+    @Column(name = "supplier_ref", length = 100)
+    private String supplierRef;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "transmission_state", nullable = false, length = 32)
+    @Builder.Default
+    private TransmissionState transmissionState = TransmissionState.NOT_TRANSMITTED;
+
+    @Column(name = "transmission_intent_id")
+    private UUID transmissionIntentId;
+
+    @Column(name = "vendor_document_id")
+    private String vendorDocumentId;
+
+    @Column(name = "supplier_order_number")
+    private String supplierOrderNumber;
+
+    @Column(name = "transmission_rejection_reason", length = 64)
+    private String transmissionRejectionReason;
+
+    @Column(name = "transmission_vendor_reason", length = 1024)
+    private String transmissionVendorReason;
+
+    @Column(name = "transmission_requested_at")
+    private Instant transmissionRequestedAt;
+
+    /**
+     * The vendor's clock as last reported. A result older than this is ignored, which is what makes
+     * an out-of-order arrival harmless rather than a regression to a state already left behind.
+     */
+    @Column(name = "transmission_observed_at")
+    private Instant transmissionObservedAt;
+
+    /**
+     * How many times this order has been transmitted. Distinguishes a first send from a re-order,
+     * which decides whether the next request is {@code INITIAL} or {@code REPLACEMENT} — nothing in
+     * the payload lets pos-supplier tell them apart, and getting it wrong is a second lorry.
+     */
+    @Column(name = "transmission_count", nullable = false)
+    @Builder.Default
+    private Integer transmissionCount = 0;
+
+    /** The order's version as last transmitted; a later one makes the next request a REVISION. */
+    @Column(name = "transmitted_version_number")
+    private Integer transmittedVersionNumber;
 
     @OneToMany(mappedBy = "purchaseOrder", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Builder.Default

--- a/pos-order/src/main/java/com/positivity/order/internal/entity/PurchaseOrderTransmissionEvent.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/entity/PurchaseOrderTransmissionEvent.java
@@ -50,7 +50,13 @@ public class PurchaseOrderTransmissionEvent {
     @Column(name = "transmission_intent_id")
     private UUID transmissionIntentId;
 
-    /** {@code CONFIRMED}, {@code REJECTED} or {@code STATUS_CHANGED}. */
+    /**
+     * {@code CONFIRMED}, {@code REJECTED}, {@code STATUS_CHANGED} or {@code REVIEW_REQUIRED}.
+     *
+     * <p>The last is not a vendor answer at all — it records that the transmission stopped and
+     * needs a person — but it belongs on the same timeline, because "nothing happened next, and
+     * here is why" is part of the story of the order.
+     */
     @Column(name = "event_type", nullable = false, length = 64)
     private String eventType;
 

--- a/pos-order/src/main/java/com/positivity/order/internal/entity/PurchaseOrderTransmissionEvent.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/entity/PurchaseOrderTransmissionEvent.java
@@ -1,0 +1,83 @@
+package com.positivity.order.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * One thing the vendor said about a purchase order (CAP-320 #1330).
+ *
+ * <h2>A timeline, not a current value</h2>
+ *
+ * "Confirmed, then despatched, then delivery slipped a week" is what a buyer chasing an order
+ * actually needs, and each step carries dates the previous one did not. Collapsing that to the
+ * latest status would answer "where is it?" and lose "what happened to it?", which is the question
+ * asked when an order goes wrong.
+ *
+ * <p>Rows are appended in the order the events were <em>heard</em> and read in the order the vendor
+ * <em>observed</em> them, so a status that arrives late still sits in the right place on the
+ * timeline rather than at the end of it.
+ */
+@Entity
+@Table(name = "purchase_order_transmission_event")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PurchaseOrderTransmissionEvent {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "event_id")
+    private UUID eventId;
+
+    @Column(name = "purchase_order_id", nullable = false)
+    private UUID purchaseOrderId;
+
+    @Column(name = "transmission_intent_id")
+    private UUID transmissionIntentId;
+
+    /** {@code CONFIRMED}, {@code REJECTED} or {@code STATUS_CHANGED}. */
+    @Column(name = "event_type", nullable = false, length = 64)
+    private String eventType;
+
+    /** The vendor-reported status on a status change; null on a confirmation or rejection. */
+    @Column(name = "status", length = 32)
+    private String status;
+
+    @Column(name = "vendor_document_id")
+    private String vendorDocumentId;
+
+    @Column(name = "supplier_order_number")
+    private String supplierOrderNumber;
+
+    @Column(name = "vendor_reason", length = 1024)
+    private String vendorReason;
+
+    @Column(name = "despatch_date")
+    private LocalDate despatchDate;
+
+    @Column(name = "estimated_delivery_date")
+    private LocalDate estimatedDeliveryDate;
+
+    /** The vendor's clock: when it says this happened. Orders the timeline. */
+    @Column(name = "observed_at", nullable = false)
+    private Instant observedAt;
+
+    /** Ours: when we heard it. Kept apart from {@code observedAt} so a late arrival is visible. */
+    @Column(name = "recorded_at", nullable = false)
+    private Instant recordedAt;
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/enums/TransmissionState.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/enums/TransmissionState.java
@@ -1,0 +1,33 @@
+package com.positivity.order.internal.enums;
+
+/**
+ * Where a purchase order's transmission to its vendor has got to (CAP-320 #1330, ADR-0052).
+ *
+ * <p>This domain's own state, not a mirror of pos-supplier's intent ledger. The buyer looks at the
+ * order; a state that exists only in the transmission log is a state the buyer cannot see.
+ */
+public enum TransmissionState {
+    /** Never sent. The starting state, and the state a rejected order returns to on re-request. */
+    NOT_TRANSMITTED,
+
+    /**
+     * Sent, no answer yet. Re-requesting from here is refused: a blind re-send is how one purchase
+     * order becomes two deliveries (ADR-0052).
+     */
+    REQUESTED,
+
+    /** The vendor accepted it. */
+    CONFIRMED,
+
+    /** The vendor refused it. Re-ordering is this domain's job, as a fresh request. */
+    REJECTED,
+
+    /**
+     * pos-supplier could not establish whether the vendor received it, and an operator must decide.
+     *
+     * <p>Not an outcome — that is precisely why it matters here. An order in this state has no
+     * answer and must not be re-sent on a guess, so the buyer needs to see it rather than watch a
+     * request sit in REQUESTED forever with nothing to explain it.
+     */
+    MANUAL_REVIEW
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/enums/TransmissionState.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/enums/TransmissionState.java
@@ -7,7 +7,13 @@ package com.positivity.order.internal.enums;
  * order; a state that exists only in the transmission log is a state the buyer cannot see.
  */
 public enum TransmissionState {
-    /** Never sent. The starting state, and the state a rejected order returns to on re-request. */
+    /**
+     * Never sent.
+     *
+     * <p>Only ever the starting state. A re-request from {@code REJECTED} moves straight to
+     * {@code REQUESTED} rather than passing back through here — an order that has been sent once
+     * has a transmission history, and returning it to "never sent" would erase that.
+     */
     NOT_TRANSMITTED,
 
     /**

--- a/pos-order/src/main/java/com/positivity/order/internal/exception/PurchaseOrderNotTransmittableException.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/exception/PurchaseOrderNotTransmittableException.java
@@ -1,0 +1,102 @@
+package com.positivity.order.internal.exception;
+
+import java.util.List;
+
+/**
+ * Thrown when a purchase order cannot be sent to its vendor (CAP-320 #1330).
+ *
+ * <p>Every case here is a refusal to guess. A transmission that goes out with the wrong vendor,
+ * the wrong article, or a second time is not an error the system notices later — it is a delivery
+ * that arrives wrong, or twice, and the first anyone knows of it is the lorry.
+ */
+public class PurchaseOrderNotTransmittableException extends RuntimeException {
+
+    private final String errorCode;
+
+    private PurchaseOrderNotTransmittableException(String errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    /** The order names no supplier profile, so there is nobody to send it to. */
+    public static PurchaseOrderNotTransmittableException noSupplierRef() {
+        return new PurchaseOrderNotTransmittableException(
+                "SUPPLIER_REF_MISSING",
+                "SUPPLIER_REF_MISSING: the purchase order names no supplier profile, so it cannot be transmitted");
+    }
+
+    /** Only an approved order may be sent; a draft is not yet a commitment. */
+    public static PurchaseOrderNotTransmittableException notApproved(String status) {
+        return new PurchaseOrderNotTransmittableException(
+                "PURCHASE_ORDER_NOT_APPROVED",
+                "PURCHASE_ORDER_NOT_APPROVED: an order in " + status + " has not been committed to and cannot be sent");
+    }
+
+    /**
+     * A transmission is already in flight.
+     *
+     * <p>Refused here rather than left to pos-supplier's active-intent guard, which is a backstop
+     * and not the design. A blind re-send is how one purchase order becomes two deliveries
+     * (ADR-0052), and the domain that knows why the order exists is the one that must decline.
+     */
+    public static PurchaseOrderNotTransmittableException alreadyInFlight() {
+        return new PurchaseOrderNotTransmittableException(
+                "TRANSMISSION_IN_FLIGHT",
+                "TRANSMISSION_IN_FLIGHT: this order has already been sent and no answer has come back yet;"
+                        + " re-sending it would risk a second delivery");
+    }
+
+    /** An operator must settle the previous transmission before another can be raised. */
+    public static PurchaseOrderNotTransmittableException awaitingManualReview() {
+        return new PurchaseOrderNotTransmittableException(
+                "TRANSMISSION_AWAITING_REVIEW",
+                "TRANSMISSION_AWAITING_REVIEW: whether the vendor received the previous send is unresolved;"
+                        + " it must be settled before this order is sent again");
+    }
+
+    /**
+     * One or more lines name no article the vendor could recognise.
+     *
+     * <p>The whole order is refused rather than the lines being withheld. Withholding would send a
+     * order that silently differs from the one on screen, and the gap would surface as a short
+     * delivery weeks later; refusing surfaces it now, to the person who can fix the article data.
+     */
+    public static PurchaseOrderNotTransmittableException articlesNotIdentifiable(List<Integer> lineNumbers) {
+        return new PurchaseOrderNotTransmittableException(
+                "ARTICLE_NOT_IDENTIFIABLE",
+                "ARTICLE_NOT_IDENTIFIABLE: line(s) " + lineNumbers
+                        + " carry no article code the vendor would recognise; the order was not sent");
+    }
+
+    /**
+     * A line's quantity is not a whole number.
+     *
+     * <p>The order command carries an integer quantity, so a fractional line cannot be stated to
+     * the vendor at all. Rounding it would order an amount nobody asked for — and be discovered as
+     * a delivery of the wrong size — so the order is refused and the buyer decides.
+     */
+    public static PurchaseOrderNotTransmittableException fractionalQuantity(List<Integer> lineNumbers) {
+        return new PurchaseOrderNotTransmittableException(
+                "FRACTIONAL_QUANTITY",
+                "FRACTIONAL_QUANTITY: line(s) " + lineNumbers
+                        + " carry a quantity that is not a whole number, which the vendor order cannot express;"
+                        + " the order was not sent");
+    }
+
+    /**
+     * The deployment has no event publishing wired, so nothing can reach the vendor.
+     *
+     * <p>Raised rather than quietly doing nothing. A publisher that silently no-ops would leave the
+     * order marked as sent and the buyer waiting on goods nobody ever asked for.
+     */
+    public static PurchaseOrderNotTransmittableException publishingUnavailable() {
+        return new PurchaseOrderNotTransmittableException(
+                "TRANSMISSION_UNAVAILABLE",
+                "TRANSMISSION_UNAVAILABLE: this deployment cannot send orders to vendors, so the order was"
+                        + " not sent and has not been marked as sent");
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/repository/ExtProductCodeRepository.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/repository/ExtProductCodeRepository.java
@@ -1,0 +1,7 @@
+package com.positivity.order.internal.repository;
+
+import com.positivity.order.internal.entity.ExtProductCode;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExtProductCodeRepository extends JpaRepository<ExtProductCode, UUID> {}

--- a/pos-order/src/main/java/com/positivity/order/internal/repository/PurchaseOrderTransmissionEventRepository.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/repository/PurchaseOrderTransmissionEventRepository.java
@@ -1,0 +1,12 @@
+package com.positivity.order.internal.repository;
+
+import com.positivity.order.internal.entity.PurchaseOrderTransmissionEvent;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PurchaseOrderTransmissionEventRepository extends JpaRepository<PurchaseOrderTransmissionEvent, UUID> {
+
+    /** The order's timeline, in the sequence the vendor observed rather than the one we heard. */
+    List<PurchaseOrderTransmissionEvent> findByPurchaseOrderIdOrderByObservedAtAsc(UUID purchaseOrderId);
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/security/PurchaseOrderPermissions.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/security/PurchaseOrderPermissions.java
@@ -20,6 +20,15 @@ public final class PurchaseOrderPermissions {
     public static final String PURCHASE_ORDER_CREATE = "order:purchase_order:create";
     public static final String PURCHASE_ORDER_APPROVE = "order:purchase_order:approve";
 
+    /**
+     * Sending an approved order to the vendor.
+     *
+     * <p>Separate from approval because they are different acts by different people: approving
+     * commits the business to the spend, transmitting puts it in front of a supplier who will act
+     * on it. A shop may well let a buyer do the first and not the second.
+     */
+    public static final String PURCHASE_ORDER_TRANSMIT = "order:purchase_order:transmit";
+
     private PurchaseOrderPermissions() {
         // Utility class
     }

--- a/pos-order/src/main/java/com/positivity/order/internal/service/ProductEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/ProductEventsListener.java
@@ -111,7 +111,6 @@ public class ProductEventsListener {
                 .codeType(trimToNull(payload.path("productCodeType").stringValue(null)))
                 .code(trimToNull(payload.path("productCode").stringValue(null)))
                 .aggregateVersion(aggregateVersion)
-                .updatedAt(Instant.now(clock))
                 .build());
     }
 

--- a/pos-order/src/main/java/com/positivity/order/internal/service/ProductEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/ProductEventsListener.java
@@ -2,8 +2,10 @@ package com.positivity.order.internal.service;
 
 import com.positivity.domainevents.catalog.ProductUpdatedV1;
 import com.positivity.order.internal.entity.ExtProduct;
+import com.positivity.order.internal.entity.ExtProductCode;
 import com.positivity.order.internal.entity.ExtProductUomReplica;
 import com.positivity.order.internal.entity.ProcessedEvent;
+import com.positivity.order.internal.repository.ExtProductCodeRepository;
 import com.positivity.order.internal.repository.ExtProductRepository;
 import com.positivity.order.internal.repository.ExtProductUomReplicaRepository;
 import com.positivity.order.internal.repository.ProcessedEventRepository;
@@ -39,6 +41,7 @@ public class ProductEventsListener {
     private final ProcessedEventRepository processedEventRepository;
     private final ExtProductRepository extProductRepository;
     private final ExtProductUomReplicaRepository extProductUomReplicaRepository;
+    private final ExtProductCodeRepository extProductCodeRepository;
 
     @KafkaListener(
             topics = "${pos.order.kafka.catalog-events-topic:catalog.events.v1}",
@@ -99,6 +102,25 @@ public class ProductEventsListener {
         extProductRepository.save(replica);
 
         applyUomConversions(productId, payload);
+
+        // The product's identity code, which is what lets a purchase-order line name an article the
+        // vendor recognises (CAP-320 #1330). A cleared code is stored as null rather than by
+        // deleting the row, so "carries no code" stays distinguishable from "never replicated".
+        extProductCodeRepository.save(ExtProductCode.builder()
+                .productId(productId)
+                .codeType(trimToNull(payload.path("productCodeType").stringValue(null)))
+                .code(trimToNull(payload.path("productCode").stringValue(null)))
+                .aggregateVersion(aggregateVersion)
+                .updatedAt(Instant.now(clock))
+                .build());
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     /**

--- a/pos-order/src/main/java/com/positivity/order/internal/service/PurchaseOrderTransmissionService.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/PurchaseOrderTransmissionService.java
@@ -1,0 +1,269 @@
+package com.positivity.order.internal.service;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.DomainTopics;
+import com.positivity.domainevents.supplier.SupplierOrderRequestedLine;
+import com.positivity.domainevents.supplier.SupplierOrderRequestedV1;
+import com.positivity.order.internal.config.OutboxEventWriter;
+import com.positivity.order.internal.entity.ExtProductCode;
+import com.positivity.order.internal.entity.PurchaseOrderEntity;
+import com.positivity.order.internal.entity.PurchaseOrderLineEntity;
+import com.positivity.order.internal.enums.PurchaseOrderStatus;
+import com.positivity.order.internal.enums.TransmissionState;
+import com.positivity.order.internal.exception.PurchaseOrderNotFoundException;
+import com.positivity.order.internal.exception.PurchaseOrderNotTransmittableException;
+import com.positivity.order.internal.repository.ExtProductCodeRepository;
+import com.positivity.order.internal.repository.PurchaseOrderRepository;
+import com.positivity.shared.id.UUIDv7Generator;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Sends an approved purchase order to its vendor (CAP-320 #1330, ADR-0052).
+ *
+ * <h2>Why this domain refuses rather than relying on the far side</h2>
+ *
+ * pos-supplier will never re-send an order and offers no operation to make it, deliberately: a
+ * blind re-send is how one purchase order becomes two deliveries. The consequence lands here.
+ * Re-ordering is this domain's job, and so is declining to order twice — pos-supplier's
+ * active-intent guard is a backstop, not the design. Every refusal below is a refusal to guess,
+ * because the cost of guessing is not an error message but a lorry.
+ *
+ * <h2>intentType is a statement only this domain can make</h2>
+ *
+ * Nothing in the payload lets pos-supplier tell a revision from a redelivery. {@code INITIAL},
+ * {@code REVISION} and {@code REPLACEMENT} are distinguished by why the order is being sent, which
+ * is knowledge the order itself holds: whether it has been sent before, and whether it has changed
+ * since. Defaulting it would be asserting something untrue about a delivery.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PurchaseOrderTransmissionService {
+
+    private static final String SOURCE = "pos-order";
+
+    /** The code type the vendor understands as an article identifier. */
+    private static final String EAN = "EAN";
+
+    private final PurchaseOrderRepository purchaseOrderRepository;
+    private final ExtProductCodeRepository extProductCodeRepository;
+    /**
+     * Optional because the outbox is not wired in every deployment — but unlike a fact publisher,
+     * absence here is fatal rather than inert. Silently publishing nothing would leave the order
+     * marked as sent and a buyer waiting on goods nobody ever ordered.
+     */
+    private final org.springframework.beans.factory.ObjectProvider<OutboxEventWriter> outboxEventWriter;
+
+    private final Clock clock;
+
+    /**
+     * Asks pos-supplier to transmit the order, publishing in the transaction that records the
+     * request.
+     *
+     * <p>Outbox rather than a direct publish, so a command can never describe an order that rolled
+     * back: {@code supplier.commands.v1} has one consumer group keyed on event id alone, and a
+     * duplicate publication is not harmless.
+     */
+    @Transactional
+    public void requestTransmission(@NonNull UUID purchaseOrderId, @NonNull String actorId) {
+        PurchaseOrderEntity order = purchaseOrderRepository
+                .findById(purchaseOrderId)
+                .orElseThrow(() -> new PurchaseOrderNotFoundException(purchaseOrderId));
+
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            throw PurchaseOrderNotTransmittableException.publishingUnavailable();
+        }
+
+        guardTransmittable(order);
+        List<SupplierOrderRequestedLine> lines = resolveLines(order);
+        SupplierOrderRequestedV1.IntentType intentType = intentTypeFor(order);
+
+        Instant now = Instant.now(clock);
+
+        order.setTransmissionState(TransmissionState.REQUESTED);
+        // The intent id is deliberately not set here. pos-supplier mints it on consuming the
+        // command, which is what makes a redelivered command a no-op rather than a second physical
+        // order (ADR-0052 §1). It arrives back on the result events, and is recorded then.
+        order.setTransmissionRequestedAt(now);
+        order.setTransmissionCount(order.getTransmissionCount() == null ? 1 : order.getTransmissionCount() + 1);
+        order.setTransmittedVersionNumber(order.getVersionNumber());
+        // Cleared, not kept: a previous refusal explains the order's last state, not this one, and
+        // a stale reason beside a fresh request reads as though the vendor has refused it again.
+        order.setTransmissionRejectionReason(null);
+        order.setTransmissionVendorReason(null);
+        purchaseOrderRepository.save(order);
+
+        writer.publish(
+                DomainTopics.commands("supplier"),
+                new DomainEventEnvelope<>(
+                        UUIDv7Generator.generate(),
+                        SupplierOrderRequestedV1.EVENT_TYPE,
+                        SupplierOrderRequestedV1.SCHEMA_VERSION,
+                        order.getPurchaseOrderId(),
+                        order.getVersionNumber() == null
+                                ? 0L
+                                : order.getVersionNumber().longValue(),
+                        now,
+                        SOURCE,
+                        null,
+                        actorId,
+                        new SupplierOrderRequestedV1(
+                                order.getPurchaseOrderId(),
+                                // The order's own revision. Together with intentType it is what
+                                // pos-supplier enforces intent uniqueness on, so re-sending this
+                                // exact command creates no second intent while a genuine revision
+                                // does — by construction rather than by our care.
+                                revisionOf(order),
+                                intentType,
+                                order.getSupplierRef(),
+                                order.getShipToLocationId(),
+                                order.getPoNumber(),
+                                lines)));
+
+        log.info(
+                "Requested transmission of purchase order {} to {} as {} (attempt {})",
+                order.getPurchaseOrderId(),
+                order.getSupplierRef(),
+                intentType,
+                order.getTransmissionCount());
+    }
+
+    private static void guardTransmittable(PurchaseOrderEntity order) {
+        if (order.getSupplierRef() == null || order.getSupplierRef().isBlank()) {
+            throw PurchaseOrderNotTransmittableException.noSupplierRef();
+        }
+        // A draft is not a commitment. Sending one would put an order in front of a vendor that
+        // nobody inside has yet agreed to place.
+        if (order.getStatus() != PurchaseOrderStatus.APPROVED
+                && order.getStatus() != PurchaseOrderStatus.PARTIALLY_RECEIVED) {
+            throw PurchaseOrderNotTransmittableException.notApproved(
+                    order.getStatus() == null
+                            ? "an unknown state"
+                            : order.getStatus().name());
+        }
+        switch (order.getTransmissionState()) {
+            case REQUESTED -> throw PurchaseOrderNotTransmittableException.alreadyInFlight();
+            case MANUAL_REVIEW -> throw PurchaseOrderNotTransmittableException.awaitingManualReview();
+            default -> {
+                // NOT_TRANSMITTED, CONFIRMED and REJECTED may all be sent: the first is a first
+                // send, and the other two are a revision and a re-order respectively.
+            }
+        }
+    }
+
+    /**
+     * The order's lines as articles the vendor can recognise.
+     *
+     * <p>A line whose article cannot be identified refuses the whole transmission. Withholding it
+     * instead would send an order that silently differs from the one on screen, and the difference
+     * would surface as a short delivery weeks later rather than as a question now.
+     */
+    private List<SupplierOrderRequestedLine> resolveLines(PurchaseOrderEntity order) {
+        List<SupplierOrderRequestedLine> resolved = new ArrayList<>();
+        List<Integer> unidentifiable = new ArrayList<>();
+        List<Integer> fractional = new ArrayList<>();
+
+        for (PurchaseOrderLineEntity line : order.getLines().stream()
+                .sorted(Comparator.comparing(
+                        PurchaseOrderLineEntity::getLineNumber, Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList()) {
+            String ean = eanFor(line);
+            if (ean == null) {
+                unidentifiable.add(line.getLineNumber());
+                continue;
+            }
+            // What is still owed, not what was originally ordered: a revision sent after a part
+            // delivery must ask for the remainder, or the vendor ships the whole order again.
+            BigDecimal quantity =
+                    line.getOpenQuantityDecimal() == null ? line.getQuantityDecimal() : line.getOpenQuantityDecimal();
+            Integer whole = wholeUnits(quantity);
+            if (whole == null) {
+                fractional.add(line.getLineNumber());
+                continue;
+            }
+            resolved.add(new SupplierOrderRequestedLine(
+                    line.getLineNumber() == null ? 0 : line.getLineNumber(),
+                    ean,
+                    null,
+                    whole,
+                    order.getExpectedDeliveryDate()));
+        }
+
+        if (!unidentifiable.isEmpty()) {
+            throw PurchaseOrderNotTransmittableException.articlesNotIdentifiable(unidentifiable);
+        }
+        if (!fractional.isEmpty()) {
+            throw PurchaseOrderNotTransmittableException.fractionalQuantity(fractional);
+        }
+        return resolved;
+    }
+
+    /** The quantity as whole units, or null when it cannot be stated as one. */
+    private static Integer wholeUnits(BigDecimal quantity) {
+        if (quantity == null) {
+            return null;
+        }
+        try {
+            return quantity.intValueExact();
+        } catch (ArithmeticException e) {
+            return null;
+        }
+    }
+
+    /** The revision this command transmits; the order's version, floored at zero. */
+    private static int revisionOf(PurchaseOrderEntity order) {
+        return order.getVersionNumber() == null ? 0 : Math.max(0, order.getVersionNumber());
+    }
+
+    private String eanFor(PurchaseOrderLineEntity line) {
+        if (line.getSkuId() == null) {
+            return null;
+        }
+        return extProductCodeRepository
+                .findById(line.getSkuId())
+                .filter(code -> EAN.equalsIgnoreCase(code.getCodeType()))
+                .map(ExtProductCode::getCode)
+                .filter(code -> !code.isBlank())
+                .orElse(null);
+    }
+
+    /**
+     * Why this order is being sent, stated from the order's own history.
+     *
+     * <ul>
+     *   <li>Never sent → {@code INITIAL}.
+     *   <li>Sent, and changed since → {@code REVISION}: the vendor holds an older version of an
+     *       order it has acknowledged, and this corrects it.
+     *   <li>Sent, refused, unchanged → {@code REPLACEMENT}: the previous send terminated without
+     *       the vendor taking the order, so this is a fresh one rather than a correction.
+     * </ul>
+     *
+     * <p>{@code SPLIT} is not derived. Splitting an order across vendors or deliveries is a
+     * decision nobody has made here, and inferring it from a partial send would claim the buyer
+     * intended something they did not.
+     */
+    private static SupplierOrderRequestedV1.IntentType intentTypeFor(PurchaseOrderEntity order) {
+        if (order.getTransmissionCount() == null || order.getTransmissionCount() == 0) {
+            return SupplierOrderRequestedV1.IntentType.INITIAL;
+        }
+        boolean changedSinceLastSend = order.getTransmittedVersionNumber() == null
+                || order.getVersionNumber() == null
+                || order.getVersionNumber() > order.getTransmittedVersionNumber();
+        if (changedSinceLastSend) {
+            return SupplierOrderRequestedV1.IntentType.REVISION;
+        }
+        return SupplierOrderRequestedV1.IntentType.REPLACEMENT;
+    }
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/service/SupplierOrderResultListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/SupplierOrderResultListener.java
@@ -1,0 +1,372 @@
+package com.positivity.order.internal.service;
+
+import com.positivity.domainevents.supplier.SupplierOrderConfirmedV1;
+import com.positivity.domainevents.supplier.SupplierOrderRejectedV1;
+import com.positivity.domainevents.supplier.SupplierOrderReviewRequiredV1;
+import com.positivity.domainevents.supplier.SupplierOrderStatusChangedV1;
+import com.positivity.domainevents.supplier.SupplierOrderStatusDespatch;
+import com.positivity.domainevents.supplier.SupplierOrderStatusLine;
+import com.positivity.domainevents.supplier.SupplierOrderStatusSchedule;
+import com.positivity.order.internal.entity.ProcessedEvent;
+import com.positivity.order.internal.entity.PurchaseOrderEntity;
+import com.positivity.order.internal.entity.PurchaseOrderTransmissionEvent;
+import com.positivity.order.internal.enums.TransmissionState;
+import com.positivity.order.internal.repository.ProcessedEventRepository;
+import com.positivity.order.internal.repository.PurchaseOrderRepository;
+import com.positivity.order.internal.repository.PurchaseOrderTransmissionEventRepository;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Hears what the vendor said about a purchase order (CAP-320 #1330, ADR-0044 §4).
+ *
+ * <h2>Why the order records this and not only the transmission log</h2>
+ *
+ * A buyer chasing a delivery looks at the order. Leaving the vendor's answer in pos-supplier's
+ * intent ledger would mean the only place the answer exists is a place the buyer has no reason to
+ * open, so the order carries its own state and its own timeline.
+ *
+ * <h2>Late answers must not undo settled ones</h2>
+ *
+ * Status observations are polled, so they arrive out of order more often than not — a slow reply
+ * about an earlier observation can land after a newer one. The order's current state therefore
+ * moves only on an observation newer than the one already applied, while the timeline keeps every
+ * observation and orders it by the vendor's clock. "Where is it?" stays correct and "what happened
+ * to it?" stays complete, which one field alone cannot do.
+ *
+ * <p>Confirmations and rejections are outcomes rather than observations and are applied whenever
+ * they arrive: a vendor that has decided has decided, and a status poll from before that decision
+ * must not overwrite it.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.order.kafka", name = "enabled", havingValue = "true")
+public class SupplierOrderResultListener {
+
+    /** Producing domain, per the repo-wide {@code processed_events} convention. */
+    static final String OWNER = "supplier";
+
+    private final java.time.Clock clock;
+    private final ObjectMapper objectMapper;
+    private final ProcessedEventRepository processedEventRepository;
+    private final PurchaseOrderRepository purchaseOrderRepository;
+    private final PurchaseOrderTransmissionEventRepository transmissionEventRepository;
+
+    @KafkaListener(
+            topics = "${pos.order.kafka.supplier-events-topic:supplier.events.v1}",
+            groupId = "${pos.order.kafka.supplier-events-consumer-group:pos-order-supplier-events}")
+    @Transactional
+    public void onSupplierEvent(@NonNull String message) {
+        JsonNode envelope;
+        try {
+            envelope = objectMapper.readTree(message);
+        } catch (Exception e) {
+            log.warn("Skipping unparsable supplier event", e);
+            return;
+        }
+        String eventType = envelope.path("eventType").stringValue(null);
+        String eventId = envelope.path("eventId").stringValue(null);
+        if (eventId == null || eventId.isBlank()) {
+            log.warn("Skipping supplier event without eventId");
+            return;
+        }
+        if (processedEventRepository.existsById(eventId)) {
+            return;
+        }
+
+        try {
+            if (SupplierOrderConfirmedV1.EVENT_TYPE.equals(eventType)) {
+                applyConfirmed(envelope);
+            } else if (SupplierOrderRejectedV1.EVENT_TYPE.equals(eventType)) {
+                applyRejected(envelope);
+            } else if (SupplierOrderStatusChangedV1.EVENT_TYPE.equals(eventType)) {
+                applyStatusChanged(envelope);
+            } else if (SupplierOrderReviewRequiredV1.EVENT_TYPE.equals(eventType)) {
+                applyReviewRequired(envelope);
+            } else {
+                log.debug("Ignoring supplier event type={} eventId={}", eventType, eventId);
+            }
+        } catch (TransientDataAccessException e) {
+            // Rethrown so the container retries. Recording this as processed would leave the buyer
+            // looking at an order that says it is still waiting for an answer the vendor has
+            // already given, with nothing left to correct it.
+            throw e;
+        } catch (Exception e) {
+            log.warn("Skipping malformed supplier event eventId={}", eventId, e);
+        }
+
+        processedEventRepository.save(ProcessedEvent.builder()
+                .eventId(eventId)
+                .owner(OWNER)
+                .processedAt(Instant.now(clock))
+                .build());
+    }
+
+    private void applyConfirmed(JsonNode envelope) {
+        SupplierOrderConfirmedV1 fact =
+                objectMapper.treeToValue(envelope.path("payload"), SupplierOrderConfirmedV1.class);
+        PurchaseOrderEntity order = orderFor(fact.purchaseOrderId());
+        if (order == null) {
+            return;
+        }
+
+        order.setTransmissionState(TransmissionState.CONFIRMED);
+        order.setTransmissionIntentId(fact.transmissionIntentId());
+        order.setVendorDocumentId(fact.documentId());
+        order.setSupplierOrderNumber(fact.supplierOrderNumber());
+        order.setTransmissionRejectionReason(null);
+        order.setTransmissionVendorReason(null);
+        order.setTransmissionObservedAt(fact.confirmedAt());
+        purchaseOrderRepository.save(order);
+
+        record(
+                fact.purchaseOrderId(),
+                fact.transmissionIntentId(),
+                "CONFIRMED",
+                null,
+                fact.documentId(),
+                fact.supplierOrderNumber(),
+                null,
+                null,
+                null,
+                fact.confirmedAt());
+
+        log.info(
+                "Purchase order {} confirmed by {} as {}",
+                fact.purchaseOrderId(),
+                fact.supplierRef(),
+                fact.supplierOrderNumber());
+    }
+
+    private void applyRejected(JsonNode envelope) {
+        SupplierOrderRejectedV1 fact =
+                objectMapper.treeToValue(envelope.path("payload"), SupplierOrderRejectedV1.class);
+        PurchaseOrderEntity order = orderFor(fact.purchaseOrderId());
+        if (order == null) {
+            return;
+        }
+
+        order.setTransmissionState(TransmissionState.REJECTED);
+        order.setTransmissionIntentId(fact.transmissionIntentId());
+        order.setVendorDocumentId(fact.documentId());
+        order.setTransmissionRejectionReason(fact.reason().name());
+        order.setTransmissionVendorReason(fact.vendorReason());
+        order.setTransmissionObservedAt(fact.rejectedAt());
+        purchaseOrderRepository.save(order);
+
+        record(
+                fact.purchaseOrderId(),
+                fact.transmissionIntentId(),
+                "REJECTED",
+                fact.reason().name(),
+                fact.documentId(),
+                null,
+                fact.vendorReason(),
+                null,
+                null,
+                fact.rejectedAt());
+
+        // Deliberately not re-sent. Getting the goods means a fresh request from this domain, which
+        // pos-supplier mints as a new intent with a new document id — a re-send here would be the
+        // blind retry ADR-0052 exists to make impossible.
+        log.info("Purchase order {} rejected by {}: {}", fact.purchaseOrderId(), fact.supplierRef(), fact.reason());
+    }
+
+    /**
+     * The transmission has stopped and needs a person.
+     *
+     * <p>Recorded because a buyer waiting on goods otherwise sees a request that looks in flight
+     * and is indistinguishable from one genuinely in progress. This is not an outcome — nobody
+     * knows yet whether the vendor has the order — so the order is not moved toward confirmed or
+     * rejected, only marked as stopped.
+     */
+    private void applyReviewRequired(JsonNode envelope) {
+        SupplierOrderReviewRequiredV1 fact =
+                objectMapper.treeToValue(envelope.path("payload"), SupplierOrderReviewRequiredV1.class);
+        PurchaseOrderEntity order = orderFor(fact.purchaseOrderId());
+        if (order == null) {
+            return;
+        }
+
+        // An order the vendor has already answered is not dragged back into limbo by a late
+        // escalation about an earlier attempt.
+        if (order.getTransmissionState() == TransmissionState.CONFIRMED
+                || order.getTransmissionState() == TransmissionState.REJECTED) {
+            log.debug("Ignoring review-required for {}: already answered", fact.purchaseOrderId());
+            return;
+        }
+
+        order.setTransmissionState(TransmissionState.MANUAL_REVIEW);
+        order.setTransmissionIntentId(fact.transmissionIntentId());
+        order.setVendorDocumentId(fact.documentId());
+        order.setTransmissionVendorReason(fact.detail());
+        order.setTransmissionObservedAt(fact.escalatedAt());
+        purchaseOrderRepository.save(order);
+
+        record(
+                fact.purchaseOrderId(),
+                fact.transmissionIntentId(),
+                "REVIEW_REQUIRED",
+                null,
+                fact.documentId(),
+                null,
+                fact.detail(),
+                null,
+                null,
+                fact.escalatedAt());
+
+        log.warn(
+                "Purchase order {} transmission stopped pending review (document {}): {}",
+                fact.purchaseOrderId(),
+                fact.documentId(),
+                fact.detail());
+    }
+
+    private void applyStatusChanged(JsonNode envelope) {
+        SupplierOrderStatusChangedV1 fact =
+                objectMapper.treeToValue(envelope.path("payload"), SupplierOrderStatusChangedV1.class);
+        PurchaseOrderEntity order = orderFor(fact.purchaseOrderId());
+        if (order == null) {
+            return;
+        }
+
+        // Every observation joins the timeline, however late. It is the order's *current* state
+        // that must not go backwards.
+        record(
+                fact.purchaseOrderId(),
+                fact.transmissionIntentId(),
+                "STATUS_CHANGED",
+                fact.status().name(),
+                fact.documentId(),
+                fact.supplierOrderNumber(),
+                fact.vendorReason(),
+                earliestDespatchDate(fact),
+                earliestDeliveryDate(fact),
+                fact.observedAt());
+
+        if (isStale(order, fact.observedAt())) {
+            log.debug(
+                    "Status observation for {} at {} is older than the applied {}; timeline only",
+                    fact.purchaseOrderId(),
+                    fact.observedAt(),
+                    order.getTransmissionObservedAt());
+            return;
+        }
+        // An outcome already reached is not revisited by a poll. A vendor that has confirmed or
+        // refused has decided, and a status observation is a weaker statement than a decision.
+        if (order.getTransmissionState() == TransmissionState.CONFIRMED
+                || order.getTransmissionState() == TransmissionState.REJECTED) {
+            order.setTransmissionObservedAt(fact.observedAt());
+            order.setSupplierOrderNumber(
+                    fact.supplierOrderNumber() == null ? order.getSupplierOrderNumber() : fact.supplierOrderNumber());
+            purchaseOrderRepository.save(order);
+            return;
+        }
+
+        order.setTransmissionIntentId(fact.transmissionIntentId());
+        order.setVendorDocumentId(fact.documentId());
+        order.setSupplierOrderNumber(fact.supplierOrderNumber());
+        order.setTransmissionObservedAt(fact.observedAt());
+        order.setTransmissionState(stateFor(fact.status(), order.getTransmissionState()));
+        purchaseOrderRepository.save(order);
+    }
+
+    /**
+     * The order's state after a vendor status observation.
+     *
+     * <p>{@code NOT_FOUND} deliberately does not move the order out of {@code REQUESTED}. The
+     * vendor saying it has never heard of the document is exactly the ambiguity ADR-0052 refuses
+     * to resolve automatically — it may mean the send never landed, or that the vendor has not
+     * caught up. Treating it as a refusal would invite a re-order for goods that may already be
+     * on their way.
+     */
+    private static TransmissionState stateFor(SupplierOrderStatusChangedV1.Status status, TransmissionState current) {
+        return switch (status) {
+            case CONFIRMED -> TransmissionState.CONFIRMED;
+            case REJECTED -> TransmissionState.REJECTED;
+            case IN_PROGRESS, NOT_FOUND -> current;
+        };
+    }
+
+    private boolean isStale(PurchaseOrderEntity order, Instant observedAt) {
+        return order.getTransmissionObservedAt() != null
+                && observedAt != null
+                && observedAt.isBefore(order.getTransmissionObservedAt());
+    }
+
+    /** The soonest despatch the vendor has stated across the order's lines, if any. */
+    private static @Nullable LocalDate earliestDespatchDate(SupplierOrderStatusChangedV1 fact) {
+        return fact.lines().stream()
+                .map(SupplierOrderStatusLine::schedules)
+                .flatMap(java.util.List::stream)
+                .map(SupplierOrderStatusSchedule::despatches)
+                .flatMap(java.util.List::stream)
+                .map(SupplierOrderStatusDespatch::despatchDate)
+                .filter(java.util.Objects::nonNull)
+                .min(Comparator.naturalOrder())
+                .orElse(null);
+    }
+
+    /** The soonest delivery the vendor has scheduled across the order's lines, if any. */
+    private static @Nullable LocalDate earliestDeliveryDate(SupplierOrderStatusChangedV1 fact) {
+        return fact.lines().stream()
+                .map(SupplierOrderStatusLine::schedules)
+                .flatMap(java.util.List::stream)
+                .map(SupplierOrderStatusSchedule::deliveryDate)
+                .filter(java.util.Objects::nonNull)
+                .min(Comparator.naturalOrder())
+                .orElse(null);
+    }
+
+    private @Nullable PurchaseOrderEntity orderFor(UUID purchaseOrderId) {
+        Optional<PurchaseOrderEntity> order = purchaseOrderRepository.findById(purchaseOrderId);
+        if (order.isEmpty()) {
+            // pos-supplier only ever answers a command this domain sent, so an unknown order means
+            // a data problem rather than a race worth retrying.
+            log.warn("Supplier result references unknown purchase order {}", purchaseOrderId);
+        }
+        return order.orElse(null);
+    }
+
+    @SuppressWarnings("java:S107")
+    private void record(
+            UUID purchaseOrderId,
+            UUID intentId,
+            String eventType,
+            String status,
+            String documentId,
+            String supplierOrderNumber,
+            String vendorReason,
+            LocalDate despatchDate,
+            LocalDate estimatedDeliveryDate,
+            Instant observedAt) {
+        transmissionEventRepository.save(PurchaseOrderTransmissionEvent.builder()
+                .purchaseOrderId(purchaseOrderId)
+                .transmissionIntentId(intentId)
+                .eventType(eventType)
+                .status(status)
+                .vendorDocumentId(documentId)
+                .supplierOrderNumber(supplierOrderNumber)
+                .vendorReason(vendorReason)
+                .despatchDate(despatchDate)
+                .estimatedDeliveryDate(estimatedDeliveryDate)
+                .observedAt(observedAt == null ? Instant.now(clock) : observedAt)
+                .recordedAt(Instant.now(clock))
+                .build());
+    }
+}

--- a/pos-order/src/main/resources/db/migration/V16__purchase_order_transmission.sql
+++ b/pos-order/src/main/resources/db/migration/V16__purchase_order_transmission.sql
@@ -1,0 +1,71 @@
+-- CAP-320 #1330: transmitting an approved purchase order to its vendor, and hearing back.
+--
+-- pos-supplier can already mint an intent, send a C1.0 order, poll C1.1 status and escalate a
+-- stuck send. Nothing asked it to and nothing heard the answers. These columns are the order's
+-- half of that conversation.
+
+-- The vendor as pos-supplier knows it: its profile alias, chosen when the order is raised.
+--
+-- vendor_id cannot serve. It holds a manufacturer or distributor id from pos-inventory's
+-- normalized feeds, which has no relationship to a supplier profile — so who to send to is
+-- recorded as an ordering decision rather than inferred later from something that does not mean
+-- what it would need to mean. An order with no supplier_ref is simply not transmittable.
+ALTER TABLE purchase_order ADD COLUMN supplier_ref varchar(100);
+
+-- Where the transmission has got to, from this domain's point of view.
+--
+-- NOT_TRANSMITTED, REQUESTED, CONFIRMED, REJECTED, MANUAL_REVIEW. Deliberately this domain's own
+-- state and not a mirror of pos-supplier's intent ledger: the buyer looks at the order, and a
+-- state that only exists in the transmission log is a state the buyer cannot see.
+ALTER TABLE purchase_order ADD COLUMN transmission_state varchar(32) NOT NULL DEFAULT 'NOT_TRANSMITTED';
+
+-- The intent pos-supplier minted for the current transmission, echoed back on every result event.
+ALTER TABLE purchase_order ADD COLUMN transmission_intent_id uuid;
+
+-- The vendor document id pos-supplier derived, and the vendor's own order number once it gives one.
+ALTER TABLE purchase_order ADD COLUMN vendor_document_id varchar(255);
+ALTER TABLE purchase_order ADD COLUMN supplier_order_number varchar(255);
+
+-- Why the vendor refused, when it did.
+ALTER TABLE purchase_order ADD COLUMN transmission_rejection_reason varchar(64);
+ALTER TABLE purchase_order ADD COLUMN transmission_vendor_reason varchar(1024);
+
+-- When the transmission was requested, and when it last changed. observed_at is the vendor's
+-- clock as reported; a result older than what is already applied is ignored, which is what makes
+-- an out-of-order arrival harmless rather than a regression.
+ALTER TABLE purchase_order ADD COLUMN transmission_requested_at timestamp(6) with time zone;
+ALTER TABLE purchase_order ADD COLUMN transmission_observed_at timestamp(6) with time zone;
+
+-- How many times this order has been transmitted. Distinguishes a first send from a re-order,
+-- which is what decides whether the next request is INITIAL or REPLACEMENT — pos-supplier cannot
+-- tell them apart from the payload, and getting it wrong is a second lorry rather than a 400.
+ALTER TABLE purchase_order ADD COLUMN transmission_count integer NOT NULL DEFAULT 0;
+
+-- The version of the order as last transmitted. A later revision of an order the vendor already
+-- holds is a REVISION; without this there is nothing to compare against and every re-send would
+-- look like a first one.
+ALTER TABLE purchase_order ADD COLUMN transmitted_version_number integer;
+
+CREATE INDEX idx_purchase_order_transmission_intent ON purchase_order (transmission_intent_id);
+
+-- What the vendor said, in the order it was heard.
+--
+-- A timeline rather than a current-value column, because "confirmed, then despatched, then
+-- delivered late" is the thing a buyer chasing an order actually needs, and each step carries
+-- dates the previous one did not.
+CREATE TABLE purchase_order_transmission_event (
+    event_id                uuid PRIMARY KEY,
+    purchase_order_id       uuid NOT NULL REFERENCES purchase_order (purchase_order_id),
+    transmission_intent_id  uuid,
+    event_type              varchar(64) NOT NULL,
+    status                  varchar(32),
+    vendor_document_id      varchar(255),
+    supplier_order_number   varchar(255),
+    vendor_reason           varchar(1024),
+    despatch_date           date,
+    estimated_delivery_date date,
+    observed_at             timestamp(6) with time zone NOT NULL,
+    recorded_at             timestamp(6) with time zone NOT NULL
+);
+
+CREATE INDEX idx_po_transmission_event_order ON purchase_order_transmission_event (purchase_order_id, observed_at);

--- a/pos-order/src/main/resources/db/migration/V17__ext_product_code.sql
+++ b/pos-order/src/main/resources/db/migration/V17__ext_product_code.sql
@@ -1,0 +1,20 @@
+-- CAP-320 #1330: the product's identity code, so a transmitted line can name an article the
+-- vendor recognises.
+--
+-- Purchase-order lines carry skuId. The vendor has never heard of our ids and needs an EAN. The
+-- code is catalog's to state, so it arrives on catalog.product.updated like every other product
+-- fact rather than being fetched (ADR-0044 R1/R3).
+--
+-- A cleared code is stored as null rather than by deleting the row. "This product carries no code"
+-- and "this module has never heard of this product" are different answers, and a buyer told the
+-- wrong one looks in the wrong place: the first is a data gap in catalog, the second is a replica
+-- that has not caught up and will fix itself.
+CREATE TABLE ext_product_code (
+    product_id        uuid PRIMARY KEY,
+    code_type         varchar(16),
+    code              varchar(64),
+    aggregate_version bigint NOT NULL,
+    updated_at        timestamp(6) with time zone NOT NULL
+);
+
+CREATE INDEX idx_ext_product_code_lookup ON ext_product_code (code_type, code);

--- a/pos-order/src/main/resources/permissions.yaml
+++ b/pos-order/src/main/resources/permissions.yaml
@@ -60,3 +60,5 @@ permissions:
     description: "Create or revise a purchase order (DRAFT state)"
   - name: "order:purchase_order:approve"
     description: "Approve or cancel a purchase order"
+  - name: "order:purchase_order:transmit"
+    description: "Send an approved purchase order to its vendor"

--- a/pos-order/src/test/java/com/positivity/order/PurchaseOrderErrorContractTest.java
+++ b/pos-order/src/test/java/com/positivity/order/PurchaseOrderErrorContractTest.java
@@ -1,0 +1,120 @@
+package com.positivity.order;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.order.internal.exception.PurchaseOrderNotFoundException;
+import com.positivity.order.internal.exception.PurchaseOrderNotTransmittableException;
+import com.positivity.order.internal.service.PurchaseOrderTransmissionService;
+import com.positivity.order.service.PurchaseOrderService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * The purchase-order endpoints return the errors they advertise (CAP-320 #1330).
+ *
+ * <h2>Why this test exists</h2>
+ *
+ * The endpoints have documented 404 and 409 responses since the aggregate moved here (#1334), and
+ * returned neither. pos-order scopes its exception advices per controller and the purchase-order
+ * controller arrived without one, so every one of these failures fell through to the default
+ * handler and came back as a 500 with a body no client could parse.
+ *
+ * <p>Nothing caught it because the service-level tests assert the exception is thrown, which it
+ * was — the gap was entirely between the exception and the wire. So this test works the other way
+ * round: it drives the HTTP surface and asserts the status and the envelope a caller was promised.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("Purchase-order endpoints return the errors they document (#1330)")
+class PurchaseOrderErrorContractTest extends BaseContractIntegrationTest {
+
+    private static final UUID PO_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4f01");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PurchaseOrderService purchaseOrderService;
+
+    @MockitoBean
+    private PurchaseOrderTransmissionService purchaseOrderTransmissionService;
+
+    @Test
+    @DisplayName("an unknown order is a 404 carrying the error envelope, not a 500")
+    void unknownOrderIsNotFound() throws Exception {
+        when(purchaseOrderService.getPurchaseOrder(any())).thenThrow(new PurchaseOrderNotFoundException(PO_ID));
+
+        mockMvc.perform(withGatewayAuth(get("/v1/orders/purchase-orders/{poId}", PO_ID), "order:purchase_order:view"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("PURCHASE_ORDER_NOT_FOUND"))
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.correlationId").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("an order already in flight is a 422 naming the obstacle")
+    void inFlightTransmissionIsUnprocessable() throws Exception {
+        doThrow(PurchaseOrderNotTransmittableException.alreadyInFlight())
+                .when(purchaseOrderTransmissionService)
+                .requestTransmission(any(), any());
+
+        // The specific code matters more than the status: a caller that cannot tell "already sent"
+        // from "no supplier" cannot act on either, and both are things somebody must go and fix.
+        mockMvc.perform(withGatewayAuth(
+                        post("/v1/orders/purchase-orders/{poId}/transmit", PO_ID), "order:purchase_order:transmit"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("TRANSMISSION_IN_FLIGHT"));
+    }
+
+    @Test
+    @DisplayName("an unidentifiable article is a 422 naming the lines to fix")
+    void unidentifiableArticleIsUnprocessable() throws Exception {
+        doThrow(PurchaseOrderNotTransmittableException.articlesNotIdentifiable(List.of(2, 5)))
+                .when(purchaseOrderTransmissionService)
+                .requestTransmission(any(), any());
+
+        mockMvc.perform(withGatewayAuth(
+                        post("/v1/orders/purchase-orders/{poId}/transmit", PO_ID), "order:purchase_order:transmit"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value("ARTICLE_NOT_IDENTIFIABLE"))
+                // The buyer has to know which lines, or the message tells them nothing actionable.
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("[2, 5]")));
+    }
+
+    @Test
+    @DisplayName("a lifecycle refusal is a 409, as the approve and cancel endpoints document")
+    void invalidLifecycleTransitionIsConflict() throws Exception {
+        when(purchaseOrderService.cancelPurchaseOrder(any(), any()))
+                .thenThrow(new IllegalStateException("Cannot cancel a fully received or closed purchase order"));
+
+        mockMvc.perform(withGatewayAuth(
+                        post("/v1/orders/purchase-orders/{poId}/cancel", PO_ID), "order:purchase_order:approve"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PURCHASE_ORDER_INVALID_STATE"));
+    }
+
+    @Test
+    @DisplayName("a transmit request without the transmit authority is refused")
+    void transmitRequiresItsOwnAuthority() throws Exception {
+        // Approving commits the spend; transmitting puts the order in front of a supplier who will
+        // act on it. A shop may well grant one and not the other.
+        mockMvc.perform(withGatewayAuth(
+                        post("/v1/orders/purchase-orders/{poId}/transmit", PO_ID), "order:purchase_order:approve"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/service/ProductVehicleLocationReplicaTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/ProductVehicleLocationReplicaTest.java
@@ -14,6 +14,7 @@ import com.positivity.order.internal.entity.ExtLocation;
 import com.positivity.order.internal.entity.ExtProduct;
 import com.positivity.order.internal.entity.ExtVehicle;
 import com.positivity.order.internal.repository.ExtLocationRepository;
+import com.positivity.order.internal.repository.ExtProductCodeRepository;
 import com.positivity.order.internal.repository.ExtProductRepository;
 import com.positivity.order.internal.repository.ExtProductUomReplicaRepository;
 import com.positivity.order.internal.repository.ExtVehicleRepository;
@@ -71,6 +72,9 @@ class ProductVehicleLocationReplicaTest {
     private ExtProductUomReplicaRepository extProductUomReplicaRepository;
 
     @Mock
+    private ExtProductCodeRepository extProductCodeRepository;
+
+    @Mock
     private ExtVehicleRepository extVehicleRepository;
 
     @Mock
@@ -94,7 +98,8 @@ class ProductVehicleLocationReplicaTest {
                     objectMapper,
                     processedEventRepository,
                     extProductRepository,
-                    extProductUomReplicaRepository);
+                    extProductUomReplicaRepository,
+                    extProductCodeRepository);
         }
 
         private String envelope(long version, String active) {

--- a/pos-order/src/test/java/com/positivity/order/internal/service/PurchaseOrderTransmissionServiceTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/PurchaseOrderTransmissionServiceTest.java
@@ -1,0 +1,313 @@
+package com.positivity.order.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.supplier.SupplierOrderRequestedV1;
+import com.positivity.order.internal.config.OutboxEventWriter;
+import com.positivity.order.internal.entity.ExtProductCode;
+import com.positivity.order.internal.entity.PurchaseOrderEntity;
+import com.positivity.order.internal.entity.PurchaseOrderLineEntity;
+import com.positivity.order.internal.enums.PurchaseOrderStatus;
+import com.positivity.order.internal.enums.TransmissionState;
+import com.positivity.order.internal.exception.PurchaseOrderNotTransmittableException;
+import com.positivity.order.internal.repository.ExtProductCodeRepository;
+import com.positivity.order.internal.repository.PurchaseOrderRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Sending a purchase order to its vendor (CAP-320 #1330, ADR-0052).
+ *
+ * <p>Almost every test here is about a refusal, which is the shape of the problem: pos-supplier
+ * will never re-send an order and offers no operation to make it, so the judgement about whether
+ * to send at all lives here. The cost of getting it wrong is not an error message — it is a second
+ * lorry, or a delivery of the wrong goods, discovered weeks later at a loading bay.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PurchaseOrderTransmissionService — sending an order to its vendor (#1330)")
+class PurchaseOrderTransmissionServiceTest {
+
+    private static final UUID PO_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d01");
+    private static final UUID SKU_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d02");
+    private static final UUID SITE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d03");
+    private static final Instant NOW = Instant.parse("2026-08-16T09:00:00Z");
+    private static final String ACTOR = "buyer-1";
+
+    @Mock
+    private PurchaseOrderRepository purchaseOrderRepository;
+
+    @Mock
+    private ExtProductCodeRepository extProductCodeRepository;
+
+    @Mock
+    private OutboxEventWriter outboxEventWriter;
+
+    @Mock
+    private org.springframework.beans.factory.ObjectProvider<OutboxEventWriter> outboxProvider;
+
+    private PurchaseOrderTransmissionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PurchaseOrderTransmissionService(
+                purchaseOrderRepository, extProductCodeRepository, outboxProvider, Clock.fixed(NOW, ZoneOffset.UTC));
+        when(outboxProvider.getIfAvailable()).thenReturn(outboxEventWriter);
+        when(extProductCodeRepository.findById(SKU_ID))
+                .thenReturn(Optional.of(ExtProductCode.builder()
+                        .productId(SKU_ID)
+                        .codeType("EAN")
+                        .code("5012345678900")
+                        .aggregateVersion(1L)
+                        .updatedAt(NOW)
+                        .build()));
+    }
+
+    private PurchaseOrderEntity order(PurchaseOrderStatus status, TransmissionState transmissionState) {
+        PurchaseOrderLineEntity line = PurchaseOrderLineEntity.builder()
+                .lineId(UUID.randomUUID())
+                .lineNumber(1)
+                .skuId(SKU_ID)
+                .description("Front brake rotor")
+                .quantityDecimal(BigDecimal.TEN)
+                .openQuantityDecimal(BigDecimal.TEN)
+                .unitCostMinor(5_000L)
+                .lineTotalMinor(50_000L)
+                .build();
+        PurchaseOrderEntity po = PurchaseOrderEntity.builder()
+                .purchaseOrderId(PO_ID)
+                .poNumber("0000001A")
+                .vendorId(UUID.randomUUID())
+                .supplierRef("acme-parts")
+                .status(status)
+                .transmissionState(transmissionState)
+                .transmissionCount(0)
+                .versionNumber(1)
+                .currency("USD")
+                .subtotalMinor(50_000L)
+                .taxMinor(0L)
+                .grandTotalMinor(50_000L)
+                .openBalanceMinor(50_000L)
+                .shipToLocationId(SITE_ID)
+                .expectedDeliveryDate(LocalDate.of(2026, 9, 1))
+                .lines(new ArrayList<>(List.of(line)))
+                .build();
+        line.setPurchaseOrder(po);
+        when(purchaseOrderRepository.findById(PO_ID)).thenReturn(Optional.of(po));
+        return po;
+    }
+
+    private SupplierOrderRequestedV1 published() {
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(outboxEventWriter).publish(eq("supplier.commands.v1"), captor.capture());
+        return (SupplierOrderRequestedV1) captor.getValue().payload();
+    }
+
+    @Test
+    @DisplayName("a first send is INITIAL and carries what the vendor needs")
+    void firstSendIsInitial() {
+        order(PurchaseOrderStatus.APPROVED, TransmissionState.NOT_TRANSMITTED);
+
+        service.requestTransmission(PO_ID, ACTOR);
+
+        SupplierOrderRequestedV1 command = published();
+        assertThat(command.intentType()).isEqualTo(SupplierOrderRequestedV1.IntentType.INITIAL);
+        assertThat(command.supplierRef()).isEqualTo("acme-parts");
+        assertThat(command.deliveryLocationId()).isEqualTo(SITE_ID);
+        assertThat(command.revision()).isEqualTo(1);
+        // The article is named by a code the vendor shares, never by our own product id.
+        assertThat(command.lines()).singleElement().satisfies(line -> {
+            assertThat(line.articleEan()).isEqualTo("5012345678900");
+            assertThat(line.quantity()).isEqualTo(10);
+        });
+    }
+
+    @Test
+    @DisplayName("an order changed since it was sent is a REVISION")
+    void changedSinceLastSendIsRevision() {
+        PurchaseOrderEntity po = order(PurchaseOrderStatus.APPROVED, TransmissionState.CONFIRMED);
+        po.setTransmissionCount(1);
+        po.setTransmittedVersionNumber(1);
+        po.setVersionNumber(2);
+
+        service.requestTransmission(PO_ID, ACTOR);
+
+        // The vendor holds an older version of an order it has acknowledged; this corrects it.
+        assertThat(published().intentType()).isEqualTo(SupplierOrderRequestedV1.IntentType.REVISION);
+    }
+
+    @Test
+    @DisplayName("an unchanged order sent again after a refusal is a REPLACEMENT")
+    void unchangedAfterRejectionIsReplacement() {
+        PurchaseOrderEntity po = order(PurchaseOrderStatus.APPROVED, TransmissionState.REJECTED);
+        po.setTransmissionCount(1);
+        po.setTransmittedVersionNumber(1);
+        po.setVersionNumber(1);
+
+        service.requestTransmission(PO_ID, ACTOR);
+
+        // Nothing changed about the order — the previous send simply never became an order the
+        // vendor holds, so this is a fresh one rather than a correction to one.
+        assertThat(published().intentType()).isEqualTo(SupplierOrderRequestedV1.IntentType.REPLACEMENT);
+    }
+
+    @Test
+    @DisplayName("an order already in flight is refused here, not left to the far side")
+    void inFlightIsRefused() {
+        order(PurchaseOrderStatus.APPROVED, TransmissionState.REQUESTED);
+
+        // pos-supplier's active-intent guard is a backstop. The domain that knows why the order
+        // exists is the one that must decline, because a blind re-send is a second delivery.
+        assertThatThrownBy(() -> service.requestTransmission(PO_ID, ACTOR))
+                .isInstanceOf(PurchaseOrderNotTransmittableException.class)
+                .hasMessageContaining("TRANSMISSION_IN_FLIGHT");
+        verify(outboxEventWriter, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("an order awaiting manual review is refused until a person settles it")
+    void awaitingReviewIsRefused() {
+        order(PurchaseOrderStatus.APPROVED, TransmissionState.MANUAL_REVIEW);
+
+        // Nobody knows whether the vendor has the previous send. Sending again on that ignorance
+        // is exactly the guess ADR-0052 exists to prevent.
+        assertThatThrownBy(() -> service.requestTransmission(PO_ID, ACTOR))
+                .isInstanceOf(PurchaseOrderNotTransmittableException.class)
+                .hasMessageContaining("TRANSMISSION_AWAITING_REVIEW");
+        verify(outboxEventWriter, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("a draft is refused: nobody has committed to it yet")
+    void draftIsRefused() {
+        order(PurchaseOrderStatus.DRAFT, TransmissionState.NOT_TRANSMITTED);
+
+        assertThatThrownBy(() -> service.requestTransmission(PO_ID, ACTOR))
+                .isInstanceOf(PurchaseOrderNotTransmittableException.class)
+                .hasMessageContaining("PURCHASE_ORDER_NOT_APPROVED");
+        verify(outboxEventWriter, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("an order naming no supplier profile has nobody to send to")
+    void missingSupplierRefIsRefused() {
+        PurchaseOrderEntity po = order(PurchaseOrderStatus.APPROVED, TransmissionState.NOT_TRANSMITTED);
+        po.setSupplierRef(null);
+
+        // vendorId cannot stand in: it holds a manufacturer or distributor id that bears no
+        // relationship to a supplier profile.
+        assertThatThrownBy(() -> service.requestTransmission(PO_ID, ACTOR))
+                .isInstanceOf(PurchaseOrderNotTransmittableException.class)
+                .hasMessageContaining("SUPPLIER_REF_MISSING");
+    }
+
+    @Test
+    @DisplayName("a line the vendor could not identify refuses the whole order, not just the line")
+    void unidentifiableArticleRefusesTheOrder() {
+        order(PurchaseOrderStatus.APPROVED, TransmissionState.NOT_TRANSMITTED);
+        when(extProductCodeRepository.findById(SKU_ID)).thenReturn(Optional.empty());
+
+        // Withholding the line would send an order that silently differs from the one on screen,
+        // and the difference would surface as a short delivery rather than as a question now.
+        assertThatThrownBy(() -> service.requestTransmission(PO_ID, ACTOR))
+                .isInstanceOf(PurchaseOrderNotTransmittableException.class)
+                .hasMessageContaining("ARTICLE_NOT_IDENTIFIABLE")
+                .hasMessageContaining("[1]");
+        verify(outboxEventWriter, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("a product with a code of the wrong type is not identified by it")
+    void nonEanCodeIsNotAnArticleIdentifier() {
+        order(PurchaseOrderStatus.APPROVED, TransmissionState.NOT_TRANSMITTED);
+        when(extProductCodeRepository.findById(SKU_ID))
+                .thenReturn(Optional.of(ExtProductCode.builder()
+                        .productId(SKU_ID)
+                        .codeType("INTERNAL")
+                        .code("PART-9911")
+                        .aggregateVersion(1L)
+                        .updatedAt(NOW)
+                        .build()));
+
+        // An internal code means nothing to the vendor. Sending it would name an article they
+        // cannot look up, which is a guess wearing the costume of an identifier.
+        assertThatThrownBy(() -> service.requestTransmission(PO_ID, ACTOR))
+                .isInstanceOf(PurchaseOrderNotTransmittableException.class)
+                .hasMessageContaining("ARTICLE_NOT_IDENTIFIABLE");
+    }
+
+    @Test
+    @DisplayName("a fractional quantity is refused rather than rounded")
+    void fractionalQuantityIsRefused() {
+        PurchaseOrderEntity po = order(PurchaseOrderStatus.APPROVED, TransmissionState.NOT_TRANSMITTED);
+        po.getLines().getFirst().setOpenQuantityDecimal(new BigDecimal("2.5"));
+
+        // The wire carries an integer. Rounding would order an amount nobody asked for and it
+        // would be discovered as a delivery of the wrong size.
+        assertThatThrownBy(() -> service.requestTransmission(PO_ID, ACTOR))
+                .isInstanceOf(PurchaseOrderNotTransmittableException.class)
+                .hasMessageContaining("FRACTIONAL_QUANTITY");
+    }
+
+    @Test
+    @DisplayName("a revision after a part delivery asks for the remainder, not the whole order")
+    void revisionAsksForWhatIsStillOwed() {
+        PurchaseOrderEntity po = order(PurchaseOrderStatus.PARTIALLY_RECEIVED, TransmissionState.CONFIRMED);
+        po.setTransmissionCount(1);
+        po.setTransmittedVersionNumber(1);
+        po.setVersionNumber(2);
+        po.getLines().getFirst().setOpenQuantityDecimal(new BigDecimal("4"));
+
+        service.requestTransmission(PO_ID, ACTOR);
+
+        // Asking for the ordered ten again would have the vendor ship the six already delivered a
+        // second time.
+        assertThat(published().lines().getFirst().quantity()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("the request is recorded on the order in the same transaction that publishes it")
+    void requestIsRecordedOnTheOrder() {
+        PurchaseOrderEntity po = order(PurchaseOrderStatus.APPROVED, TransmissionState.REJECTED);
+        po.setTransmissionCount(1);
+        po.setTransmissionRejectionReason("VENDOR_REJECTED");
+        po.setTransmissionVendorReason("out of stock");
+
+        service.requestTransmission(PO_ID, ACTOR);
+
+        assertThat(po.getTransmissionState()).isEqualTo(TransmissionState.REQUESTED);
+        assertThat(po.getTransmissionCount()).isEqualTo(2);
+        assertThat(po.getTransmissionRequestedAt()).isEqualTo(NOW);
+        // The previous refusal explained the order's last state, not this one. Left in place beside
+        // a fresh request it would read as though the vendor had refused again.
+        assertThat(po.getTransmissionRejectionReason()).isNull();
+        assertThat(po.getTransmissionVendorReason()).isNull();
+        // The intent id stays unset: pos-supplier mints it, which is what makes a redelivered
+        // command a no-op rather than a second physical order.
+        assertThat(po.getTransmissionIntentId()).isNull();
+        verify(purchaseOrderRepository).save(po);
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/service/ReplicaListenerContractTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/ReplicaListenerContractTest.java
@@ -18,6 +18,7 @@ import com.positivity.order.internal.repository.ExtCustomerRepository;
 import com.positivity.order.internal.repository.ExtEstimateLineRepository;
 import com.positivity.order.internal.repository.ExtEstimateRepository;
 import com.positivity.order.internal.repository.ExtLocationRepository;
+import com.positivity.order.internal.repository.ExtProductCodeRepository;
 import com.positivity.order.internal.repository.ExtProductRepository;
 import com.positivity.order.internal.repository.ExtProductUomReplicaRepository;
 import com.positivity.order.internal.repository.ExtVehicleRepository;
@@ -97,6 +98,9 @@ class ReplicaListenerContractTest {
     private ExtProductUomReplicaRepository extProductUomReplicaRepository;
 
     @Mock
+    private ExtProductCodeRepository extProductCodeRepository;
+
+    @Mock
     private ExtLocationRepository extLocationRepository;
 
     @Mock
@@ -142,7 +146,12 @@ class ReplicaListenerContractTest {
         VehicleEventsListener vehicle =
                 new VehicleEventsListener(clock, objectMapper, processedEventRepository, extVehicleRepository);
         ProductEventsListener product = new ProductEventsListener(
-                clock, objectMapper, processedEventRepository, extProductRepository, extProductUomReplicaRepository);
+                clock,
+                objectMapper,
+                processedEventRepository,
+                extProductRepository,
+                extProductUomReplicaRepository,
+                extProductCodeRepository);
         LocationEventsListener location =
                 new LocationEventsListener(clock, objectMapper, processedEventRepository, extLocationRepository);
         WorkorderEventsListener workorder = new WorkorderEventsListener(

--- a/pos-order/src/test/java/com/positivity/order/internal/service/SupplierOrderResultListenerTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/SupplierOrderResultListenerTest.java
@@ -1,0 +1,264 @@
+package com.positivity.order.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.order.internal.entity.PurchaseOrderEntity;
+import com.positivity.order.internal.entity.PurchaseOrderTransmissionEvent;
+import com.positivity.order.internal.enums.TransmissionState;
+import com.positivity.order.internal.repository.ProcessedEventRepository;
+import com.positivity.order.internal.repository.PurchaseOrderRepository;
+import com.positivity.order.internal.repository.PurchaseOrderTransmissionEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.QueryTimeoutException;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Hearing back from the vendor (CAP-320 #1330).
+ *
+ * <p>Two properties carry most of the weight. Replay must not double-count, because these events
+ * are redelivered as a matter of course. And a late status observation must not undo a settled
+ * answer — status is polled, so an old reply landing after a new one is ordinary rather than
+ * exceptional, and an order that flips back to "in progress" after the vendor confirmed it sends
+ * a buyer chasing something that has already been agreed.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("SupplierOrderResultListener — what the vendor said (#1330)")
+class SupplierOrderResultListenerTest {
+
+    private static final UUID PO_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4e01");
+    private static final UUID INTENT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4e02");
+    private static final UUID PROFILE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4e03");
+    private static final Instant NOW = Instant.parse("2026-08-16T12:00:00Z");
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private PurchaseOrderRepository purchaseOrderRepository;
+
+    @Mock
+    private PurchaseOrderTransmissionEventRepository transmissionEventRepository;
+
+    private SupplierOrderResultListener listener;
+    private PurchaseOrderEntity order;
+
+    @BeforeEach
+    void setUp() {
+        listener = new SupplierOrderResultListener(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                new ObjectMapper(),
+                processedEventRepository,
+                purchaseOrderRepository,
+                transmissionEventRepository);
+        when(processedEventRepository.existsById(any())).thenReturn(false);
+        order = PurchaseOrderEntity.builder()
+                .purchaseOrderId(PO_ID)
+                .poNumber("0000001A")
+                .transmissionState(TransmissionState.REQUESTED)
+                .transmissionCount(1)
+                .build();
+        when(purchaseOrderRepository.findById(PO_ID)).thenReturn(Optional.of(order));
+    }
+
+    private static String confirmed(String eventId, String observedAt) {
+        return """
+            {"eventId":"%s","eventType":"supplier.order.confirmed","payload":{
+              "transmissionIntentId":"%s","purchaseOrderId":"%s","vendorProfileId":"%s",
+              "supplierRef":"acme-parts","documentId":"DOC-1","supplierOrderNumber":"V-9911",
+              "source":"ORDER_RESPONSE","confirmedAt":"%s","lines":[]}}
+            """.formatted(eventId, INTENT_ID, PO_ID, PROFILE_ID, observedAt);
+    }
+
+    private static String rejected(String eventId) {
+        return """
+            {"eventId":"%s","eventType":"supplier.order.rejected","payload":{
+              "transmissionIntentId":"%s","purchaseOrderId":"%s","vendorProfileId":"%s",
+              "supplierRef":"acme-parts","documentId":"DOC-1","reason":"VENDOR_REJECTED",
+              "vendorErrorCode":"E12","vendorReason":"article discontinued",
+              "rejectedAt":"2026-08-16T11:00:00Z","lines":[]}}
+            """.formatted(eventId, INTENT_ID, PO_ID, PROFILE_ID);
+    }
+
+    private static String statusChanged(String eventId, String status, String observedAt, String deliveryDate) {
+        return """
+            {"eventId":"%s","eventType":"supplier.orderstatus.changed","payload":{
+              "transmissionIntentId":"%s","purchaseOrderId":"%s","vendorProfileId":"%s",
+              "supplierRef":"acme-parts","documentId":"DOC-1","supplierOrderNumber":"V-9911",
+              "status":"%s","vendorReason":null,"observedAt":"%s","lines":[
+                {"lineId":"1","customerLineItemNumber":"1","articleEan":"5012345678900",
+                 "supplierArticleCode":null,"buyersArticleId":null,"description":"rotor",
+                 "orderedQuantity":10,"requestedDeliveryDate":null,
+                 "schedules":[{"deliveryDate":%s,"confirmedQuantity":10,"cancelledQuantity":null,
+                   "openQuantity":null,"backorderedQuantity":null,"scheduledQuantity":null,
+                   "shippedQuantity":null,"despatches":[{"despatchDate":"2026-09-02",
+                     "despatchAdviceDocumentId":"ASN-7","despatchAdviceLineId":"1",
+                     "despatchedQuantity":10}]}],
+                 "vendorErrorCode":null,"vendorErrorText":null}]}}
+            """.formatted(eventId, INTENT_ID, PO_ID, PROFILE_ID, status, observedAt, deliveryDate);
+    }
+
+    private static String reviewRequired(String eventId) {
+        return """
+            {"eventId":"%s","eventType":"supplier.order.reviewrequired","payload":{
+              "transmissionIntentId":"%s","purchaseOrderId":"%s","vendorProfileId":"%s",
+              "supplierRef":"acme-parts","documentId":"DOC-1",
+              "detail":"send timed out with no acknowledgement",
+              "escalatedAt":"2026-08-16T10:30:00Z"}}
+            """.formatted(eventId, INTENT_ID, PO_ID, PROFILE_ID);
+    }
+
+    @Test
+    @DisplayName("a confirmation records the vendor's own reference on the order")
+    void confirmationRecordsTheVendorReference() {
+        listener.onSupplierEvent(confirmed("evt-1", "2026-08-16T11:00:00Z"));
+
+        assertThat(order.getTransmissionState()).isEqualTo(TransmissionState.CONFIRMED);
+        // The vendor's number is what an operator quotes when chasing the order; without it the
+        // only shared handle is our own, which the vendor cannot look up.
+        assertThat(order.getSupplierOrderNumber()).isEqualTo("V-9911");
+        assertThat(order.getVendorDocumentId()).isEqualTo("DOC-1");
+        assertThat(order.getTransmissionIntentId()).isEqualTo(INTENT_ID);
+    }
+
+    @Test
+    @DisplayName("a rejection records why, and does not resend")
+    void rejectionRecordsTheReason() {
+        listener.onSupplierEvent(rejected("evt-2"));
+
+        assertThat(order.getTransmissionState()).isEqualTo(TransmissionState.REJECTED);
+        assertThat(order.getTransmissionRejectionReason()).isEqualTo("VENDOR_REJECTED");
+        assertThat(order.getTransmissionVendorReason()).isEqualTo("article discontinued");
+    }
+
+    @Test
+    @DisplayName("a redelivered event changes nothing")
+    void replayIsANoOp() {
+        when(processedEventRepository.existsById("evt-1")).thenReturn(true);
+
+        listener.onSupplierEvent(confirmed("evt-1", "2026-08-16T11:00:00Z"));
+
+        verify(purchaseOrderRepository, never()).save(any());
+        verify(transmissionEventRepository, never()).save(any());
+        // Not even a second processed-event row: the guard returns before any write.
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("a status observation older than the applied one joins the timeline but not the state")
+    void staleStatusDoesNotMoveTheOrder() {
+        order.setTransmissionObservedAt(Instant.parse("2026-08-16T11:00:00Z"));
+        order.setTransmissionState(TransmissionState.REQUESTED);
+
+        listener.onSupplierEvent(statusChanged("evt-3", "CONFIRMED", "2026-08-16T09:00:00Z", "\"2026-09-05\""));
+
+        // The observation is real and belongs on the record — it just describes an earlier moment
+        // than the one already applied, so it must not move the order's current state.
+        verify(transmissionEventRepository).save(any());
+        assertThat(order.getTransmissionState()).isEqualTo(TransmissionState.REQUESTED);
+    }
+
+    @Test
+    @DisplayName("a status poll from before a decision does not undo it")
+    void statusDoesNotOverturnASettledAnswer() {
+        order.setTransmissionState(TransmissionState.CONFIRMED);
+        order.setTransmissionObservedAt(Instant.parse("2026-08-16T11:00:00Z"));
+
+        listener.onSupplierEvent(statusChanged("evt-4", "IN_PROGRESS", "2026-08-16T12:30:00Z", "null"));
+
+        // Even though this observation is newer, a vendor that has confirmed has decided; a poll is
+        // a weaker statement than a decision, and flipping back would send a buyer chasing an order
+        // that has already been agreed.
+        assertThat(order.getTransmissionState()).isEqualTo(TransmissionState.CONFIRMED);
+    }
+
+    @Test
+    @DisplayName("the timeline carries the despatch and delivery dates the vendor stated")
+    void timelineCarriesTheDates() {
+        listener.onSupplierEvent(statusChanged("evt-5", "IN_PROGRESS", "2026-08-16T12:30:00Z", "\"2026-09-05\""));
+
+        ArgumentCaptor<PurchaseOrderTransmissionEvent> captor =
+                ArgumentCaptor.forClass(PurchaseOrderTransmissionEvent.class);
+        verify(transmissionEventRepository).save(captor.capture());
+        // These are the dates a buyer actually wants: not when we asked, but when the vendor says
+        // it will ship and arrive.
+        assertThat(captor.getValue().getDespatchDate()).hasToString("2026-09-02");
+        assertThat(captor.getValue().getEstimatedDeliveryDate()).hasToString("2026-09-05");
+        assertThat(captor.getValue().getObservedAt()).isEqualTo(Instant.parse("2026-08-16T12:30:00Z"));
+        // Kept apart from observedAt, so an answer that arrived late is visibly late.
+        assertThat(captor.getValue().getRecordedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("NOT_FOUND leaves the order where it is rather than reading as a refusal")
+    void notFoundIsNotARefusal() {
+        listener.onSupplierEvent(statusChanged("evt-6", "NOT_FOUND", "2026-08-16T12:30:00Z", "null"));
+
+        // The vendor not recognising the document may mean the send never landed, or that they
+        // have not caught up. Treating it as a refusal invites a re-order for goods already coming.
+        assertThat(order.getTransmissionState()).isEqualTo(TransmissionState.REQUESTED);
+    }
+
+    @Test
+    @DisplayName("a stalled transmission is visible on the order, not only in the transmission log")
+    void reviewRequiredIsVisibleOnTheOrder() {
+        listener.onSupplierEvent(reviewRequired("evt-7"));
+
+        // Without this the buyer sees a request that looks in flight and waits on goods that are
+        // not coming, with the only explanation in a log they have no reason to open.
+        assertThat(order.getTransmissionState()).isEqualTo(TransmissionState.MANUAL_REVIEW);
+        assertThat(order.getTransmissionVendorReason()).contains("timed out");
+    }
+
+    @Test
+    @DisplayName("a late escalation does not drag an answered order back into limbo")
+    void reviewRequiredDoesNotOverturnAnAnswer() {
+        order.setTransmissionState(TransmissionState.CONFIRMED);
+
+        listener.onSupplierEvent(reviewRequired("evt-8"));
+
+        assertThat(order.getTransmissionState()).isEqualTo(TransmissionState.CONFIRMED);
+    }
+
+    @Test
+    @DisplayName("transient database trouble is retried, not swallowed")
+    void transientFailureIsRethrown() {
+        when(purchaseOrderRepository.save(any())).thenThrow(new QueryTimeoutException("statement timed out"));
+
+        assertThatThrownBy(() -> listener.onSupplierEvent(confirmed("evt-9", "2026-08-16T11:00:00Z")))
+                .isInstanceOf(QueryTimeoutException.class);
+
+        // Marking it processed would leave the buyer looking at an order that says it is still
+        // waiting for an answer the vendor has already given, with nothing left to correct it.
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("a result for an unknown order is skipped rather than stalling the partition")
+    void unknownOrderIsSkipped() {
+        when(purchaseOrderRepository.findById(PO_ID)).thenReturn(Optional.empty());
+
+        listener.onSupplierEvent(confirmed("evt-10", "2026-08-16T11:00:00Z"));
+
+        verify(purchaseOrderRepository, never()).save(any());
+        verify(processedEventRepository).save(any());
+    }
+}

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -23,7 +23,7 @@ public final class DownstreamPermissionCatalog {
      * {@code PermissionCode.CATALOG_VERSION}.
      * Updated automatically by {@code scripts/generate-permissions.py --sync}.
      */
-    public static final int CATALOG_VERSION = 49;
+    public static final int CATALOG_VERSION = 50;
 
     /**
      * Index-to-authority mapping. Entry at position N is the {@code PERM_*}-prefixed
@@ -568,7 +568,10 @@ public final class DownstreamPermissionCatalog {
         // ── New batch (bits 456–458) ──────────────────────────────────────────
         "PERM_order:purchase_order:approve", // 456
         "PERM_order:purchase_order:create", // 457
-        "PERM_order:purchase_order:view" // 458
+        "PERM_order:purchase_order:view", // 458
+
+        // ── New batch (bits 459–459) ──────────────────────────────────────────
+        "PERM_order:purchase_order:transmit" // 459
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -599,13 +599,15 @@ public enum PermissionCode {
     // ── Order (new) ────────────────────────────────────────────────────────────
     ORDER__PURCHASE_ORDER__APPROVE(456, "order:purchase_order:approve"),
     ORDER__PURCHASE_ORDER__CREATE(457, "order:purchase_order:create"),
-    ORDER__PURCHASE_ORDER__VIEW(458, "order:purchase_order:view");
+    ORDER__PURCHASE_ORDER__VIEW(458, "order:purchase_order:view"),
+    // ── Order (new) ────────────────────────────────────────────────────────────
+    ORDER__PURCHASE_ORDER__TRANSMIT(459, "order:purchase_order:transmit");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 49;
+    public static final int CATALOG_VERSION = 50;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 459;
-    private static final int EXPECTED_CATALOG_VERSION = 49;
+    private static final int EXPECTED_PERMISSION_COUNT = 460;
+    private static final int EXPECTED_CATALOG_VERSION = 50;
 
     // -------------------------------------------------------------------------
     // AC-1: Catalog size — EXPECTED_PERMISSION_COUNT entries

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/order/service/TransmissionStateWriter.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/order/service/TransmissionStateWriter.java
@@ -4,6 +4,7 @@ import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.domainevents.DomainTopics;
 import com.positivity.domainevents.supplier.SupplierOrderConfirmedV1;
 import com.positivity.domainevents.supplier.SupplierOrderRejectedV1;
+import com.positivity.domainevents.supplier.SupplierOrderReviewRequiredV1;
 import com.positivity.domainevents.supplier.SupplierOrderStatusChangedV1;
 import com.positivity.shared.id.UUIDv7Generator;
 import com.positivity.supplier.internal.domain.model.SupplierDeliverySchedule;
@@ -203,10 +204,15 @@ public class TransmissionStateWriter {
     /**
      * Escalates an intent to {@code MANUAL_REVIEW} (ADR-0052 §3/§4).
      *
-     * <p>No event is published. The transmission has no outcome yet — that is the entire meaning
-     * of this state — and telling the ordering domain "rejected" or "confirmed" here would be an
-     * assertion nobody has made. What the ordering domain sees is a transmission still open, which
-     * is the truth, until an operator resolves it.
+     * <p>No <em>outcome</em> is published, and that remains deliberate: this service does not know
+     * whether the vendor received the order, and saying "rejected" or "confirmed" here would be an
+     * assertion nobody has made.
+     *
+     * <p>The state itself is published, which is a different claim. Left silent, the ordering
+     * domain sees a request that looks in flight and is indistinguishable from one genuinely in
+     * progress — so a buyer waits on goods that are not coming, and the only record of why lives
+     * in a transmission log they have no reason to open (CAP-320 #1330). "Still open" and "stopped,
+     * pending a human" are different facts, and the second is the one somebody has to act on.
      */
     @Transactional
     public void recordManualReview(@NonNull UUID transmissionIntentId, @Nullable String detail) {
@@ -215,6 +221,7 @@ public class TransmissionStateWriter {
         intent.setStatusPollingActive(false);
         intent.setLastError(truncate(detail, 2000));
         intentRepository.save(intent);
+        publishReviewRequired(intent, detail);
         log.warn(
                 "Transmission intent {} (document {}) entered MANUAL_REVIEW: {}",
                 intent.getTransmissionIntentId(),
@@ -350,6 +357,22 @@ public class TransmissionStateWriter {
             SupplierOrderConfirmedV1.Source source,
             List<SupplierOrderResult.Line> lines) {
         publishConfirmedLines(intent, source, OrderEventMapper.toEventConfirmedLines(lines));
+    }
+
+    private void publishReviewRequired(SupplierTransmissionIntentEntity intent, String detail) {
+        SupplierOrderReviewRequiredV1 payload = new SupplierOrderReviewRequiredV1(
+                intent.getTransmissionIntentId(),
+                intent.getPurchaseOrderId(),
+                intent.getVendorProfileId(),
+                intent.getSupplierRef(),
+                intent.getDocumentId(),
+                truncate(detail, 1000),
+                Instant.now(clock));
+        publish(
+                intent,
+                SupplierOrderReviewRequiredV1.EVENT_TYPE,
+                SupplierOrderReviewRequiredV1.SCHEMA_VERSION,
+                payload);
     }
 
     private void publishConfirmedLines(

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/order/service/TransmissionStateWriter.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/order/service/TransmissionStateWriter.java
@@ -359,7 +359,7 @@ public class TransmissionStateWriter {
         publishConfirmedLines(intent, source, OrderEventMapper.toEventConfirmedLines(lines));
     }
 
-    private void publishReviewRequired(SupplierTransmissionIntentEntity intent, String detail) {
+    private void publishReviewRequired(SupplierTransmissionIntentEntity intent, @Nullable String detail) {
         SupplierOrderReviewRequiredV1 payload = new SupplierOrderReviewRequiredV1(
                 intent.getTransmissionIntentId(),
                 intent.getPurchaseOrderId(),

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/order/service/TransmissionStateWriterTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/order/service/TransmissionStateWriterTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,6 +11,7 @@ import static org.mockito.Mockito.when;
 import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.domainevents.supplier.SupplierOrderConfirmedV1;
 import com.positivity.domainevents.supplier.SupplierOrderRejectedV1;
+import com.positivity.domainevents.supplier.SupplierOrderReviewRequiredV1;
 import com.positivity.domainevents.supplier.SupplierOrderStatusChangedV1;
 import com.positivity.supplier.internal.domain.model.SupplierDeliverySchedule;
 import com.positivity.supplier.internal.domain.model.SupplierDespatch;
@@ -169,14 +169,28 @@ class TransmissionStateWriterTest {
     }
 
     @Test
-    void publishesNothingWhenATransmissionEntersManualReview() {
-        // There is no outcome yet -- that is the entire meaning of the state -- and telling the
-        // ordering domain "confirmed" or "rejected" here would assert something nobody has
-        // established.
+    void publishesTheStateButNoOutcomeWhenATransmissionEntersManualReview() {
         writer.recordManualReview(INTENT_ID, "vendor unreachable after send");
 
         assertThat(intent.getAttemptState()).isEqualTo(TransmissionAttemptState.MANUAL_REVIEW);
-        verify(outboxWriter, never()).publish(anyString(), any());
+
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(outboxWriter).publish(anyString(), captor.capture());
+
+        // There is no outcome yet -- that is the entire meaning of the state -- so nothing here
+        // says "confirmed" or "rejected", which would assert something nobody has established.
+        assertThat(captor.getValue().eventType()).isEqualTo(SupplierOrderReviewRequiredV1.EVENT_TYPE);
+        assertThat(captor.getValue().payload()).isInstanceOf(SupplierOrderReviewRequiredV1.class);
+
+        // The state itself is published, which is a different claim and a necessary one: left
+        // silent, the ordering domain sees a request indistinguishable from one still in progress,
+        // so a buyer waits on goods that are not coming and the only record of why lives in a
+        // transmission log they have no reason to open (CAP-320 #1330).
+        SupplierOrderReviewRequiredV1 payload =
+                (SupplierOrderReviewRequiredV1) captor.getValue().payload();
+        assertThat(payload.purchaseOrderId()).isEqualTo(intent.getPurchaseOrderId());
+        assertThat(payload.documentId()).isEqualTo(intent.getDocumentId());
+        assertThat(payload.detail()).contains("vendor unreachable");
     }
 
     @Test


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:320`
- Parent STORY (durion): louisburroughs/durion#375
- Child issue: louisburroughs/durion-positivity-backend#1330
- Domain: `domain:order`, `domain:positivity`

## Contract References
- Contract guide entry (durion): `domains/order/.business-rules/BACKEND_CONTRACT_GUIDE.md` → purchase-order transmission
- Produced: `supplier.order.requested` v1 on `supplier.commands.v1` (existing contract, first producer)
- Consumed: `supplier.order.confirmed`, `supplier.order.rejected`, `supplier.orderstatus.changed` (existing contracts, first consumer)
- **New**: `supplier.order.reviewrequired` v1 on `supplier.events.v1` — see "One AC needed a new contract" below

## Scope

CAP-320's supplier half was delivered and inert. pos-supplier could mint an intent, transmit a C1.0 order, poll C1.1 status, reconcile an ambiguous send and hold a stuck one for review — but **nothing asked it to and nothing heard the answers**. This is the ordering half.

### Two questions the story deferred, settled here

Neither was derivable from what existed, so both were decided explicitly.

**The vendor.** A purchase order's `vendorId` holds a manufacturer or distributor id from pos-inventory's normalized feeds. pos-supplier keys on a profile alias and publishes no profile fact, so there was nothing to map through. The order now carries `supplierRef`, chosen when it is raised — who to send to is an ordering decision recorded on the order, not something inferred later from a field that does not mean what it would need to mean.

**The article.** Lines carry our product ids, which mean nothing to a supplier, so pos-order replicates the product's identity code from catalog. A line that cannot be identified **refuses the whole transmission** rather than being withheld: withholding sends an order that silently differs from the one on screen, and the difference surfaces as a short delivery weeks later instead of as a question now. A fractional quantity is refused for the same reason — the wire carries an integer, and rounding orders an amount nobody asked for.

### Almost everything here is a refusal

That is the shape of the problem. pos-supplier will never re-send an order and offers no operation to make it (ADR-0052), so the judgement about whether to send at all lives here. An order already in flight, or awaiting a person, is declined by this domain rather than left to a downstream guard that exists as a backstop. The cost of a wrong call is not an error message — it is a second lorry, or the wrong goods, discovered at a loading bay.

`intentType` is derived from the order's own history (never sent → `INITIAL`; changed since → `REVISION`; refused and unchanged → `REPLACEMENT`), because nothing in the payload lets pos-supplier tell a revision from a redelivery. `SPLIT` is deliberately not derived: nobody has made that decision here, and inferring it would claim an intent the buyer never had.

### Hearing back

Results land on the order and on a timeline, so a buyer chasing a delivery finds the answer where they are already looking rather than in a transmission log. Status is polled, so out-of-order arrival is routine: the timeline keeps **every** observation ordered by the vendor's clock, while the order's current state moves only forward — and a poll never overturns a decision the vendor has already made. `NOT_FOUND` deliberately does not read as a refusal, because it may equally mean the vendor has not caught up, and treating it as one invites a re-order for goods already in transit.

## One AC needed a new contract

> *"A purchase order whose transmission is awaiting manual review is visibly in that state here, not only in pos-supplier's ledger."*

This could not be met as things stood. `MANUAL_REVIEW` published nothing, on sound reasoning recorded in the code: there is no outcome, and saying "confirmed" or "rejected" would assert what nobody has established.

But *"still open"* and *"stopped, pending a human"* are different facts. Left silent, the ordering domain sees a request indistinguishable from one genuinely in progress, so the buyer waits on goods that are not coming with the only explanation in a log they have no reason to open.

pos-supplier now publishes `supplier.order.reviewrequired` — carrying **no outcome** and **no advice**, since resolution is an operator's judgement against evidence this service does not have. That respects the original reasoning rather than overturning it: the objection was to asserting an outcome, and this asserts a state.

**This touches pos-supplier**, which is outside the story's stated scope of "transmission wiring". Flagged prominently because it is a cross-module change reviewers should look at deliberately. Its existing test was rewritten to assert the sharper property: a state is published, an outcome never is.

## Tests
- [x] Unit tests added/updated — `PurchaseOrderTransmissionServiceTest` (12), `SupplierOrderResultListenerTest` (11), `TransmissionStateWriterTest` (rewritten)
- [x] Integration tests added/updated — covered by the above against the real contracts
- [ ] Provider behavioral contract tests added/updated — n/a
- How to run:
  ```bash
  ./mvnw -pl pos-domain-events,pos-order,pos-supplier -am test
  ./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests,DomainWallsTest -Dsurefire.failIfNoSpecifiedTests=false test
  bash scripts/check-flyway-hygiene.sh
  ```
  pos-order 364/364, pos-supplier 928/928, pos-domain-events green, pos-archunit 13/13, security+gateway green, Flyway hygiene passes.

Every AC test is present: outbox-in-transaction, each `intentType` mapping, refusal of a duplicate in-flight request, idempotent replay of each result event, and the timeline surviving out-of-order status arrivals.

## Permissions

`order:purchase_order:transmit` takes bit 459; `CATALOG_VERSION` 49 → 50 via `--sync`. Separate from approval because they are different acts by different people — approving commits the spend, transmitting puts it in front of a supplier who will act on it, and a shop may well let a buyer do the first and not the second.

## Risk & Rollback
- Risk level: Medium — this is the first thing that will actually place orders with real vendors. The failure mode is asymmetric, which is why the design refuses rather than assumes at every fork; a refused transmission is recoverable in minutes, a duplicated one is not.
- Rollback plan: revert the commit. No data migration; the new columns default to `NOT_TRANSMITTED` and the new tables are additive. pos-supplier reverts to publishing nothing on `MANUAL_REVIEW`, which is where it started.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing — pending
- [ ] Angular SDK regenerated — deferred until backend work is complete

## By-catch

Six purchase-order endpoint descriptions still named `INVENTORY_PURCHASE_ORDER_*` events after the #1334 move — only the `@EmitEvent` ids had been renamed, not the prose. Corrected, along with a cancel description that still described pos-inventory's supply-drop behaviour.

## Follow-ups
- `supplierArticleCode` is not yet populated. Only the EAN path is wired; the vendor's own article code is known solely from PRICAT entries in pos-catalog, which is a separate replication question.
- #1329 — pos-order procurement availability.
