### PR TITLE
[CAP:319] feat(order): procurement reads live supplier availability per line (#1329)

### DIFF
--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,4 +1,4 @@
-generatedAt: "2026-08-16T10:56:43.051164+00:00"
+generatedAt: "2026-08-16T11:11:47.470034+00:00"
 root: "."
 summary:
   manifestCount: 22

--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,9 +1,9 @@
-generatedAt: "2026-08-16T01:59:02.334307+00:00"
+generatedAt: "2026-08-16T10:56:43.051164+00:00"
 root: "."
 summary:
   manifestCount: 22
-  permissionCount: 425
-  uniquePermissionCount: 425
+  permissionCount: 426
+  uniquePermissionCount: 426
   duplicatePermissionNameCount: 0
   parseIssueCount: 0
 manifests:
@@ -522,7 +522,7 @@ manifests:
     domain: "order"
     serviceName: "pos-order"
     version: "1.0"
-    permissionCount: 30
+    permissionCount: 31
     permissions:
       - name: "order:order:view"
         description: "View orders"
@@ -584,6 +584,8 @@ manifests:
         description: "Approve or cancel a purchase order"
       - name: "order:purchase_order:transmit"
         description: "Send an approved purchase order to its vendor"
+      - name: "order:purchase_order:availability_view"
+        description: "Ask a vendor what it can supply against a purchase order"
   - module: "pos-people"
     path: "pos-people/src/main/resources/permissions.yaml"
     domain: "people"
@@ -2448,6 +2450,12 @@ permissions:
     source: "pos-order/src/main/resources/permissions.yaml"
   - name: "order:purchase_order:approve"
     description: "Approve or cancel a purchase order"
+    domain: "order"
+    serviceName: "pos-order"
+    module: "pos-order"
+    source: "pos-order/src/main/resources/permissions.yaml"
+  - name: "order:purchase_order:availability_view"
+    description: "Ask a vendor what it can supply against a purchase order"
     domain: "order"
     serviceName: "pos-order"
     module: "pos-order"

--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -919,6 +919,8 @@ paths:
     $ref: ../../pos-order/openapi.yaml#/paths/~1v1~1orders~1purchase-orders~1{poId}~1cancel
   /v1/orders/purchase-orders/{poId}/revisions:
     $ref: ../../pos-order/openapi.yaml#/paths/~1v1~1orders~1purchase-orders~1{poId}~1revisions
+  /v1/orders/purchase-orders/{poId}/supplier-availability:
+    $ref: ../../pos-order/openapi.yaml#/paths/~1v1~1orders~1purchase-orders~1{poId}~1supplier-availability
   /v1/orders/purchase-orders/{poId}/transmit:
     $ref: ../../pos-order/openapi.yaml#/paths/~1v1~1orders~1purchase-orders~1{poId}~1transmit
   /v1/orders/sessions:

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 50;
+    public static final int CATALOG_VERSION = 51;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -545,7 +545,10 @@ public final class GatewayPermissionCatalog {
         "PERM_order:purchase_order:view", // 458
 
         // ── New batch (bits 459–459) ──────────────────────────────────────────
-        "PERM_order:purchase_order:transmit" // 459
+        "PERM_order:purchase_order:transmit", // 459
+
+        // ── New batch (bits 460–460) ──────────────────────────────────────────
+        "PERM_order:purchase_order:availability_view" // 460
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,9 +1142,9 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 50")
+    @DisplayName("CATALOG_VERSION is 51")
     void catalogVersionMatchesCurrent() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(50);
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(51);
     }
 
     @Test
@@ -1307,8 +1307,12 @@ class SecurityGatewayConfigTest {
         // they are different acts: approving commits the spend, transmitting puts it in front of a
         // supplier who will act on it.
         assertThat(GatewayPermissionCatalog.authorityForBit(459)).isEqualTo("PERM_order:purchase_order:transmit");
+        // Asking a vendor what it can supply (CAP-319 #1329). A read, but one that reaches the
+        // vendor's own systems, so it is gated apart from viewing the order.
+        assertThat(GatewayPermissionCatalog.authorityForBit(460))
+                .isEqualTo("PERM_order:purchase_order:availability_view");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(460)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(461)).isNull();
     }
 
     @Test

--- a/pos-archunit/src/test/java/com/positivity/archunit/DomainWallsTest.java
+++ b/pos-archunit/src/test/java/com/positivity/archunit/DomainWallsTest.java
@@ -1,5 +1,7 @@
 package com.positivity.archunit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -117,8 +119,15 @@ class DomainWallsTest {
      * approved callers as the Product Detail composition and pos-order procurement. Everything else
      * pos-catalog needs from pos-supplier — vendor prices — already arrives as events.
      */
-    private static final Map<String, Map<String, Set<String>>> SCOPED_FILE_EXCEPTIONS =
-            Map.of("pos-catalog", Map.of("SupplierStockClientImpl.java", Set.of("pos-supplier")));
+    private static final Map<String, Map<String, Set<String>>> SCOPED_FILE_EXCEPTIONS = Map.of(
+            "pos-catalog",
+            Map.of("SupplierStockClientImpl.java", Set.of("pos-supplier")),
+            // The second approved caller the amendment names: procurement in pos-order, where a
+            // buyer is choosing quantities and needs what the vendor says now (CAP-319 #1329).
+            // Granted by file name for the same reason as the first — a third caller has to argue
+            // its own case rather than inherit either of these.
+            "pos-order",
+            Map.of("SupplierStockClientImpl.java", Set.of("pos-supplier")));
 
     /**
      * Startup-infra classes exempt per ADR-0044 R2 (registration calls, best-effort
@@ -131,6 +140,36 @@ class DomainWallsTest {
     private static final Pattern POS_SERVICE_TOKEN = Pattern.compile("pos-[a-z][a-z0-9-]*");
     private static final Pattern SERVICE_ID_DEFAULT = Pattern.compile("\\$\\{[a-z0-9.-]*service-id:([a-z][a-z0-9-]*)}");
     private static final Pattern LOAD_BALANCED_URI = Pattern.compile("lb://([A-Za-z0-9-]+)");
+
+    /**
+     * The supplier grants stay attached to the one file each, and never widen to a module.
+     *
+     * <p>Two modules may call pos-supplier synchronously for live stock, and both entries name a
+     * single class. Converting either to a module-level grant would let any future client in that
+     * module reach pos-supplier without anybody deciding it should — which is the whole thing the
+     * file-scoped form prevents (ADR-0044 amendment 2026-08-10).
+     */
+    @Test
+    void supplierStockGrantsAreScopedToOneFileEach() {
+        assertThat(SCOPED_FILE_EXCEPTIONS)
+                .as("only pos-catalog and pos-order may reach pos-supplier synchronously")
+                .containsOnlyKeys("pos-catalog", "pos-order");
+
+        for (Map.Entry<String, Map<String, Set<String>>> module : SCOPED_FILE_EXCEPTIONS.entrySet()) {
+            assertThat(module.getValue())
+                    .as("%s grants the supplier edge to exactly one file", module.getKey())
+                    .containsOnlyKeys("SupplierStockClientImpl.java");
+            assertThat(module.getValue().get("SupplierStockClientImpl.java"))
+                    .as("%s grants that file exactly one target", module.getKey())
+                    .containsExactly("pos-supplier");
+        }
+
+        // A module-level grant would defeat the point: SCOPED_MODULE_EXCEPTIONS must not quietly
+        // acquire pos-supplier for either of these modules.
+        assertThat(SCOPED_MODULE_EXCEPTIONS.getOrDefault("pos-catalog", Set.of()))
+                .doesNotContain("pos-supplier");
+        assertThat(SCOPED_MODULE_EXCEPTIONS.getOrDefault("pos-order", Set.of())).doesNotContain("pos-supplier");
+    }
 
     @Test
     void internalClientsShouldOnlyTargetUtilityModules() throws IOException {

--- a/pos-order/openapi.yaml
+++ b/pos-order/openapi.yaml
@@ -2130,6 +2130,65 @@ paths:
         - order:purchase_order:view
       x-required-permissions:
       - order:purchase_order:view
+  /v1/orders/purchase-orders/{poId}/supplier-availability:
+    get:
+      tags:
+      - Purchase Orders
+      summary: Read Live Vendor Availability For A Purchase Order
+      description: 'Asks a vendor what it can supply against every line of a purchase order, in one inquiry, and returns the answer per line.
+
+        Use this tool when a buyer is deciding what to order and needs what the vendor says now; do not use the availability endpoints for this, which report owned stock rather than what a supplier could send.
+
+        Preconditions: the purchase order must exist; the vendor profile and delivery location are both required, because availability is consignee-specific and answering for another location answers a different question.
+
+        Required inputs: poId path parameter, and vendorProfileId and deliveryLocationId query parameters.
+
+        Emits an ORDER_PURCHASE_ORDER_AVAILABILITY audit event; no state changes, and a supplier that cannot be reached degrades the answer rather than failing the request.
+
+        Returns 200 with a document status of SUPPLIER_UNAVAILABLE and no line quantities when the vendor could not be asked; availableQuantity is null where the vendor stated nothing and zero only where it stated it has none, and 404 when the purchase order does not exist.
+
+        '
+      operationId: getPurchaseOrderSupplierAvailability
+      parameters:
+      - name: poId
+        in: path
+        description: Purchase order id (UUIDv7)
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: vendorProfileId
+        in: query
+        description: Vendor profile to ask
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: deliveryLocationId
+        in: query
+        description: Delivery location the answer is for
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Vendor availability, possibly degraded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProcurementAvailability'
+        '404':
+          description: Purchase order not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - order:purchase_order:availability_view
+      x-required-permissions:
+      - order:purchase_order:availability_view
   /v1/orders/price-overrides/{overrideId}:
     get:
       tags:
@@ -3780,6 +3839,68 @@ components:
           type: boolean
         unsorted:
           type: boolean
+    ProcurementAvailability:
+      type: object
+      description: 'Live vendor availability for a purchase order''s lines. A supplier that could not be reached is reported through the document status, never as zero quantities: availableQuantity is null when the vendor stated nothing and zero only when it stated it has none, and only the second means an article is unavailable.'
+      properties:
+        purchaseOrderId:
+          type: string
+          format: uuid
+          description: The purchase order the lines belong to.
+        vendorProfileId:
+          type: string
+          format: uuid
+          description: The vendor profile asked.
+        deliveryLocationId:
+          type: string
+          format: uuid
+          description: The delivery location the answer is for; availability is consignee-specific.
+        status:
+          type: string
+          description: 'Whether the vendor answered, and if not, why not: OK, SUPPLIER_UNAVAILABLE, NOT_LISTED, CAPABILITY_NOT_CONFIGURED or CONFIGURATION_ERROR. Anything other than OK means no line quantity here is a statement by the vendor.'
+        asOf:
+          type: string
+          format: date-time
+          description: When the answer was obtained; null when there is no answer to date.
+        lines:
+          type: array
+          description: One entry per purchase-order line, in line-number order.
+          items:
+            $ref: '#/components/schemas/ProcurementAvailabilityLine'
+    ProcurementAvailabilityLine:
+      type: object
+      description: One purchase-order line and what the vendor said about it.
+      properties:
+        lineId:
+          type: string
+          format: uuid
+          description: Purchase-order line id.
+        lineNumber:
+          type: integer
+          format: int32
+          description: Line number on the order.
+        skuId:
+          type: string
+          format: uuid
+          description: Catalog product ordered.
+        articleEan:
+          type: string
+          description: The article code the vendor was asked about; null when none could be resolved.
+        requestedQuantity:
+          type: integer
+          format: int32
+          description: 'Quantity asked about: what is still outstanding on this line.'
+        status:
+          type: string
+          description: AVAILABLE, UNAVAILABLE, NOT_LISTED, NOT_ANSWERED, or ARTICLE_NOT_IDENTIFIABLE when the line carries no code the vendor would recognise and so was never asked about.
+        availableQuantity:
+          type: integer
+          format: int32
+          description: Quantity the vendor can supply. Null when the vendor stated no quantity; zero only when it stated it has none.
+        earliestDeliveryDate:
+          type: string
+          format: date
+          description: Earliest date the vendor promised any quantity, when stated.
   securitySchemes:
     bearerAuth:
       type: http

--- a/pos-order/openapi.yaml
+++ b/pos-order/openapi.yaml
@@ -3892,7 +3892,7 @@ components:
           description: 'Quantity asked about: what is still outstanding on this line.'
         status:
           type: string
-          description: AVAILABLE, UNAVAILABLE, NOT_LISTED, NOT_ANSWERED, or ARTICLE_NOT_IDENTIFIABLE when the line carries no code the vendor would recognise and so was never asked about.
+          description: AVAILABLE, UNAVAILABLE, NOT_LISTED or NOT_ANSWERED as the vendor stated it; ARTICLE_NOT_IDENTIFIABLE when the line carries no code the vendor would recognise; NOTHING_OUTSTANDING when the line is already settled and so was not asked about. The last two describe our own situation, not the vendor's answer.
         availableQuantity:
           type: integer
           format: int32

--- a/pos-order/src/main/java/com/positivity/order/internal/client/SupplierStockClient.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/client/SupplierStockClient.java
@@ -1,0 +1,107 @@
+package com.positivity.order.internal.client;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Asks a vendor what it can actually supply, for the lines a buyer is deciding about
+ * (CAP-319 #1329, ADR-0044 amendment 2026-08-10).
+ *
+ * <h2>The one synchronous read out of this module</h2>
+ *
+ * Availability is worth nothing a minute old — a buyer choosing quantities needs what the vendor
+ * says now, not what it said when a fact was last published. That is why the amendment carves this
+ * one call out of the event-only rule, and why the wall grants it <em>by file name</em>: a second
+ * client reaching pos-supplier still fails the build, and has to argue its own case.
+ *
+ * <h2>Never throws, always answers</h2>
+ *
+ * A supplier that is down must not fail a procurement screen. Every outcome — including a refused
+ * connection — comes back as a status, so the caller decides what to render rather than catching an
+ * exception whose only handler would be "carry on".
+ */
+public interface SupplierStockClient {
+
+    /**
+     * One inquiry covering every line asked about.
+     *
+     * <p>Batched deliberately: a ten-line procurement screen must not make ten vendor round trips,
+     * and a vendor rate-limiting us because of it would degrade the whole screen rather than one row.
+     *
+     * @param vendorProfileId   the vendor to ask
+     * @param deliveryLocationId where the goods would be delivered — required, because availability
+     *     is consignee-specific and a default would answer a different question than the one asked
+     * @param lines             the articles to ask about
+     */
+    @NonNull
+    StockAnswer inquire(
+            @NonNull UUID vendorProfileId, @NonNull UUID deliveryLocationId, @NonNull List<InquiryLine> lines);
+
+    /** One article to ask about, named however the vendor knows it. */
+    record InquiryLine(
+            @Nullable String articleEan, @Nullable String supplierArticleCode, int requestedQuantity) {}
+
+    /**
+     * What came back.
+     *
+     * <p>{@code status} is never inferred from an empty line list: a vendor that answered "I have
+     * none of these" and a vendor that could not be reached both produce no usable quantities, and
+     * telling them apart is the entire point.
+     *
+     * @param asOf when the answer was obtained; null when there is no answer to date
+     */
+    record StockAnswer(
+            @NonNull Status status,
+            @NonNull List<AnswerLine> lines,
+            @Nullable Instant asOf) {
+
+        /** Whether anything here can be shown to a buyer as fact. */
+        public boolean answered() {
+            return status == Status.OK;
+        }
+    }
+
+    /** Document-level outcome, mirroring the supplier contract so nothing is lost in translation. */
+    enum Status {
+        /** The vendor answered. Per-article outcomes are on the lines. */
+        OK,
+        /** The vendor could not be reached, failed, or its circuit breaker is open. */
+        SUPPLIER_UNAVAILABLE,
+        /** The vendor lists none of the inquired articles. */
+        NOT_LISTED,
+        /** No stock-inquiry binding on the vendor profile. */
+        CAPABILITY_NOT_CONFIGURED,
+        /** The vendor profile is configured but not usably so. */
+        CONFIGURATION_ERROR
+    }
+
+    /** What the vendor said about one article. */
+    enum LineStatus {
+        /** The vendor has some, and said how many. */
+        AVAILABLE,
+        /** The vendor stated it has none. The only outcome that means "out of stock". */
+        UNAVAILABLE,
+        /** The vendor does not carry this article. */
+        NOT_LISTED,
+        /** The vendor said nothing about it. Not the same as having none. */
+        NOT_ANSWERED
+    }
+
+    /**
+     * One article's answer.
+     *
+     * @param availableQuantity null when the vendor stated no quantity; zero only when it stated it
+     *     has none. Collapsing the two is how a buyer ends up told an article is unavailable when
+     *     the vendor simply did not mention it.
+     */
+    record AnswerLine(
+            @Nullable String articleEan,
+            @Nullable String supplierArticleCode,
+            @NonNull LineStatus status,
+            @Nullable Integer availableQuantity,
+            @Nullable LocalDate earliestDeliveryDate) {}
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/client/SupplierStockClientImpl.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/client/SupplierStockClientImpl.java
@@ -35,6 +35,12 @@ import org.springframework.web.client.RestClient;
 @Component
 public class SupplierStockClientImpl implements SupplierStockClient {
 
+    /** Identity this service calls under; pos-supplier records it on the exchange audit. */
+    private static final String SERVICE_USER = "pos-order-service";
+
+    /** The authority pos-supplier requires of a stock inquiry (ADR-0050). */
+    private static final String STOCK_INQUIRE_AUTHORITY = "supplier:stock:inquire";
+
     private final RestClient restClient;
     private final String basePath;
 
@@ -69,6 +75,11 @@ public class SupplierStockClientImpl implements SupplierStockClient {
             InquiryResponse response = restClient
                     .post()
                     .uri(basePath + "/stock/inquiries")
+                    // The inquiry endpoint is authorised like any other: without these the call is
+                    // rejected and every answer degrades to "supplier unavailable", which looks
+                    // exactly like a vendor being down and would have hidden a broken feature.
+                    .header("X-User", SERVICE_USER)
+                    .header("X-Authorities", STOCK_INQUIRE_AUTHORITY)
                     .body(body)
                     .retrieve()
                     .body(InquiryResponse.class);

--- a/pos-order/src/main/java/com/positivity/order/internal/client/SupplierStockClientImpl.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/client/SupplierStockClientImpl.java
@@ -1,0 +1,155 @@
+package com.positivity.order.internal.client;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Calls {@code POST /v1/supplier/stock/inquiries} on pos-supplier (CAP-319 #1329).
+ *
+ * <h2>This file is the grant</h2>
+ *
+ * {@code DomainWallsTest} allows the synchronous edge to pos-supplier by file name, not by module.
+ * Any other client class in pos-order that reaches pos-supplier fails the build, which is the point:
+ * the exception exists for live availability specifically, and a second caller has to make its own
+ * case rather than inheriting this one.
+ *
+ * <h2>Nothing here rethrows</h2>
+ *
+ * A buyer is on the other end of this call, deciding what to order. A supplier that is down, slow,
+ * or misconfigured must degrade the availability column, never fail the screen — so a transport
+ * failure becomes {@code SUPPLIER_UNAVAILABLE} rather than an exception. That is a status the
+ * caller can render honestly as "we could not ask", which is different from "the vendor has none"
+ * and must stay different all the way to the buyer.
+ */
+@Slf4j
+@Component
+public class SupplierStockClientImpl implements SupplierStockClient {
+
+    private final RestClient restClient;
+    private final String basePath;
+
+    public SupplierStockClientImpl(
+            @Qualifier("loadBalancedRestClientBuilder") RestClient.Builder restClientBuilder,
+            @Value("${pos.supplier.service-id:supplier}") String serviceId,
+            @Value("${pos.supplier.base-path:/v1/supplier}") String basePath) {
+        this.basePath = basePath;
+        this.restClient = restClientBuilder.baseUrl("http://" + serviceId).build();
+    }
+
+    @Override
+    @NonNull
+    public StockAnswer inquire(
+            @NonNull UUID vendorProfileId, @NonNull UUID deliveryLocationId, @NonNull List<InquiryLine> lines) {
+        if (lines.isEmpty()) {
+            // Nothing to ask about. Asking anyway would spend a vendor round trip to learn nothing.
+            return new StockAnswer(Status.OK, List.of(), null);
+        }
+
+        Map<String, Object> body = Map.of(
+                "inquiryId",
+                UUID.randomUUID().toString(),
+                "vendorProfileId",
+                vendorProfileId.toString(),
+                "deliveryLocationId",
+                deliveryLocationId.toString(),
+                "lines",
+                lines.stream().map(SupplierStockClientImpl::toRequestLine).toList());
+
+        try {
+            InquiryResponse response = restClient
+                    .post()
+                    .uri(basePath + "/stock/inquiries")
+                    .body(body)
+                    .retrieve()
+                    .body(InquiryResponse.class);
+            if (response == null) {
+                log.warn("Supplier stock inquiry to {} returned no body", vendorProfileId);
+                return unavailable();
+            }
+            return toAnswer(response);
+        } catch (Exception e) {
+            // Deliberately broad, and deliberately not rethrown. Whatever went wrong — refused
+            // connection, timeout, 5xx, unparseable body — the honest answer to the buyer is the
+            // same: we could not ask. Letting this escape would take down a procurement screen
+            // because a vendor's endpoint was having a bad afternoon.
+            log.warn("Supplier stock inquiry to {} failed; reporting unavailable", vendorProfileId, e);
+            return unavailable();
+        }
+    }
+
+    private static StockAnswer unavailable() {
+        return new StockAnswer(Status.SUPPLIER_UNAVAILABLE, List.of(), null);
+    }
+
+    private static Map<String, Object> toRequestLine(InquiryLine line) {
+        Map<String, Object> mapped = new java.util.HashMap<>();
+        mapped.put("articleEan", line.articleEan());
+        mapped.put("supplierArticleCode", line.supplierArticleCode());
+        mapped.put("requestedQuantity", line.requestedQuantity());
+        return mapped;
+    }
+
+    private static StockAnswer toAnswer(InquiryResponse response) {
+        Status status = parseStatus(response.status());
+        List<AnswerLine> lines = new ArrayList<>();
+        if (response.lines() != null) {
+            for (ResponseLine line : response.lines()) {
+                lines.add(new AnswerLine(
+                        line.articleEan(),
+                        line.supplierArticleCode(),
+                        parseLineStatus(line.status()),
+                        // Carried through exactly as received. Substituting zero for a null here
+                        // would tell a buyer the vendor has none when it said nothing at all.
+                        line.availableQuantity(),
+                        line.earliestDeliveryDate()));
+            }
+        }
+        return new StockAnswer(status, lines, response.asOf());
+    }
+
+    /** An unrecognised status is treated as no answer, never as a usable one. */
+    private static Status parseStatus(String raw) {
+        if (raw == null) {
+            return Status.SUPPLIER_UNAVAILABLE;
+        }
+        try {
+            return Status.valueOf(raw);
+        } catch (IllegalArgumentException e) {
+            log.warn("Unrecognised supplier stock inquiry status '{}'; treating as unavailable", raw);
+            return Status.SUPPLIER_UNAVAILABLE;
+        }
+    }
+
+    /** An unrecognised line status becomes "said nothing", which is the safe reading. */
+    private static LineStatus parseLineStatus(String raw) {
+        if (raw == null) {
+            return LineStatus.NOT_ANSWERED;
+        }
+        try {
+            return LineStatus.valueOf(raw);
+        } catch (IllegalArgumentException e) {
+            log.warn("Unrecognised supplier stock line status '{}'; treating as not answered", raw);
+            return LineStatus.NOT_ANSWERED;
+        }
+    }
+
+    /** Wire shape of the supplier response; deliberately separate from the domain-facing model. */
+    private record InquiryResponse(UUID inquiryId, String status, List<ResponseLine> lines, Instant asOf) {}
+
+    private record ResponseLine(
+            String articleEan,
+            String supplierArticleCode,
+            String status,
+            Integer availableQuantity,
+            LocalDate earliestDeliveryDate) {}
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/config/EventTypes.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/config/EventTypes.java
@@ -151,5 +151,10 @@ public final class EventTypes {
             EventTypeRegistration.write(
                             "ORDER_PURCHASE_ORDER_TRANSMIT", "Send an approved purchase order to its vendor")
                     .apiVersion("1")
+                    .build(),
+            EventTypeRegistration.fastRead(
+                            "ORDER_PURCHASE_ORDER_AVAILABILITY",
+                            "Read live vendor availability for a purchase order's lines")
+                    .apiVersion("1")
                     .build());
 }

--- a/pos-order/src/main/java/com/positivity/order/internal/controller/PurchaseOrderController.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/controller/PurchaseOrderController.java
@@ -4,9 +4,11 @@ import com.positivity.events.EmitEvent;
 import com.positivity.order.internal.dto.purchaseorder.ApprovePurchaseOrderRequest;
 import com.positivity.order.internal.dto.purchaseorder.CreatePurchaseOrderRequest;
 import com.positivity.order.internal.dto.purchaseorder.ListPurchaseOrdersRequest;
+import com.positivity.order.internal.dto.purchaseorder.ProcurementAvailabilityResponse;
 import com.positivity.order.internal.dto.purchaseorder.PurchaseOrderResponse;
 import com.positivity.order.internal.dto.purchaseorder.RevisePurchaseOrderRequest;
 import com.positivity.order.internal.security.PurchaseOrderPermissions;
+import com.positivity.order.internal.service.ProcurementAvailabilityService;
 import com.positivity.order.internal.service.PurchaseOrderTransmissionService;
 import com.positivity.order.service.PurchaseOrderService;
 import com.positivity.security.common.SecurityContextHelper;
@@ -31,6 +33,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -43,6 +46,7 @@ public class PurchaseOrderController {
 
     private final PurchaseOrderService purchaseOrderService;
     private final PurchaseOrderTransmissionService purchaseOrderTransmissionService;
+    private final ProcurementAvailabilityService procurementAvailabilityService;
 
     @PostMapping
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
@@ -430,5 +434,52 @@ public class PurchaseOrderController {
         purchaseOrderTransmissionService.requestTransmission(
                 poId, SecurityContextHelper.getCurrentUsername().orElse(NO_CURRENT_USER));
         return ResponseEntity.accepted().build();
+    }
+
+    @GetMapping("/{poId}/supplier-availability")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"order:purchase_order:availability_view"})
+    @PreAuthorize("hasAuthority('" + PurchaseOrderPermissions.PURCHASE_ORDER_AVAILABILITY_VIEW + "')")
+    @EmitEvent(id = "ORDER_PURCHASE_ORDER_AVAILABILITY", apiVersion = "1")
+    @Operation(
+            operationId = "getPurchaseOrderSupplierAvailability",
+            summary = "Read Live Vendor Availability For A Purchase Order",
+            description = """
+                    Asks a vendor what it can supply against every line of a purchase order, in one inquiry, and \
+                    returns the answer per line.
+                    Use this tool when a buyer is deciding what to order and needs what the vendor says now; do not \
+                    use the availability endpoints for this, which report owned stock rather than what a supplier \
+                    could send.
+                    Preconditions: the purchase order must exist; the vendor profile and delivery location are \
+                    both required, because availability is consignee-specific and answering for another location \
+                    answers a different question.
+                    Required inputs: poId path parameter, and vendorProfileId and deliveryLocationId query \
+                    parameters.
+                    Emits an ORDER_PURCHASE_ORDER_AVAILABILITY audit event; no state changes, and a supplier that \
+                    cannot be reached degrades the answer rather than failing the request.
+                    Returns 200 with a document status of SUPPLIER_UNAVAILABLE and no line quantities when the \
+                    vendor could not be asked; availableQuantity is null where the vendor stated nothing and zero \
+                    only where it stated it has none, and 404 when the purchase order does not exist.
+                    """,
+            tags = {"Purchase Orders"})
+    @ApiResponse(
+            responseCode = "200",
+            description = "Vendor availability, possibly degraded",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ProcurementAvailabilityResponse.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Purchase order not found",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<ProcurementAvailabilityResponse> getPurchaseOrderSupplierAvailability(
+            @Parameter(description = "Purchase order id (UUIDv7)", required = true) @PathVariable UUID poId,
+            @Parameter(description = "Vendor profile to ask", required = true) @RequestParam UUID vendorProfileId,
+            @Parameter(description = "Delivery location the answer is for", required = true) @RequestParam
+                    UUID deliveryLocationId) {
+        return ResponseEntity.ok(
+                procurementAvailabilityService.availabilityFor(poId, vendorProfileId, deliveryLocationId));
     }
 }

--- a/pos-order/src/main/java/com/positivity/order/internal/dto/purchaseorder/ProcurementAvailabilityResponse.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/dto/purchaseorder/ProcurementAvailabilityResponse.java
@@ -1,0 +1,74 @@
+package com.positivity.order.internal.dto.purchaseorder;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * What a vendor says it can supply against a purchase order's lines (CAP-319 #1329).
+ */
+@Schema(
+        name = "ProcurementAvailability",
+        description = "Live vendor availability for a purchase order's lines. A supplier that could not be reached"
+                + " is reported through the document status, never as zero quantities: availableQuantity is null"
+                + " when the vendor stated nothing and zero only when it stated it has none, and only the second"
+                + " means an article is unavailable.")
+public record ProcurementAvailabilityResponse(
+        @Schema(description = "The purchase order the lines belong to.")
+        UUID purchaseOrderId,
+
+        @Schema(description = "The vendor profile asked.") UUID vendorProfileId,
+
+        @Schema(description = "The delivery location the answer is for; availability is consignee-specific.")
+        UUID deliveryLocationId,
+
+        @Schema(
+                description = "Whether the vendor answered, and if not, why not: OK, SUPPLIER_UNAVAILABLE,"
+                        + " NOT_LISTED, CAPABILITY_NOT_CONFIGURED or CONFIGURATION_ERROR. Anything other"
+                        + " than OK means no line quantity here is a statement by the vendor.")
+        String status,
+
+        @Schema(description = "When the answer was obtained; null when there is no answer to date.") @Nullable
+        Instant asOf,
+
+        @Schema(description = "One entry per purchase-order line, in line-number order.")
+        List<Line> lines) {
+
+    /** One line's answer. */
+    @Schema(
+            name = "ProcurementAvailabilityLine",
+            description = "One purchase-order line and what the vendor said about it.")
+    public record Line(
+            @Schema(description = "Purchase-order line id.") UUID lineId,
+
+            @Schema(description = "Line number on the order.") @Nullable
+            Integer lineNumber,
+
+            @Schema(description = "Catalog product ordered.") @Nullable
+            UUID skuId,
+
+            @Schema(description = "The article code the vendor was asked about; null when none could be resolved.")
+            @Nullable
+            String articleEan,
+
+            @Schema(description = "Quantity asked about: what is still outstanding on this line.")
+            int requestedQuantity,
+
+            @Schema(
+                    description = "AVAILABLE, UNAVAILABLE, NOT_LISTED, NOT_ANSWERED, or"
+                            + " ARTICLE_NOT_IDENTIFIABLE when the line carries no code the vendor would"
+                            + " recognise and so was never asked about.")
+            String status,
+
+            @Schema(
+                    description = "Quantity the vendor can supply. Null when the vendor stated no quantity;"
+                            + " zero only when it stated it has none.")
+            @Nullable
+            Integer availableQuantity,
+
+            @Schema(description = "Earliest date the vendor promised any quantity, when stated.") @Nullable
+            LocalDate earliestDeliveryDate) {}
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/dto/purchaseorder/ProcurementAvailabilityResponse.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/dto/purchaseorder/ProcurementAvailabilityResponse.java
@@ -58,9 +58,10 @@ public record ProcurementAvailabilityResponse(
             int requestedQuantity,
 
             @Schema(
-                    description = "AVAILABLE, UNAVAILABLE, NOT_LISTED, NOT_ANSWERED, or"
+                    description = "AVAILABLE, UNAVAILABLE, NOT_LISTED or NOT_ANSWERED as the vendor stated it;"
                             + " ARTICLE_NOT_IDENTIFIABLE when the line carries no code the vendor would"
-                            + " recognise and so was never asked about.")
+                            + " recognise; NOTHING_OUTSTANDING when the line is already settled and so was not"
+                            + " asked about. The last two describe our own situation, not the vendor's answer.")
             String status,
 
             @Schema(

--- a/pos-order/src/main/java/com/positivity/order/internal/security/PurchaseOrderPermissions.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/security/PurchaseOrderPermissions.java
@@ -29,6 +29,14 @@ public final class PurchaseOrderPermissions {
      */
     public static final String PURCHASE_ORDER_TRANSMIT = "order:purchase_order:transmit";
 
+    /**
+     * Asking a vendor what it can actually supply against an order's lines.
+     *
+     * <p>A read, but not a free one: it reaches out to the vendor's own systems, so it is gated
+     * separately from viewing the order rather than folded into it.
+     */
+    public static final String PURCHASE_ORDER_AVAILABILITY_VIEW = "order:purchase_order:availability_view";
+
     private PurchaseOrderPermissions() {
         // Utility class
     }

--- a/pos-order/src/main/java/com/positivity/order/internal/service/ProcurementAvailabilityService.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/ProcurementAvailabilityService.java
@@ -72,15 +72,24 @@ public class ProcurementAvailabilityService {
                         PurchaseOrderLineEntity::getLineNumber, Comparator.nullsLast(Comparator.naturalOrder())))
                 .toList();
 
-        // Resolve every line's article first, so the inquiry carries exactly the lines that can be
-        // asked about and the rest are reported as unidentifiable rather than silently dropped.
+        // Resolve every line's article once and keep the answer. Looking it up again while
+        // rendering would double the reads and, worse, could disagree with itself if the replica
+        // changed mid-request — a line grouped under one article and reported under another.
+        Map<UUID, String> eanByLineId = new HashMap<>();
         Map<String, List<PurchaseOrderLineEntity>> linesByEan = new HashMap<>();
         List<PurchaseOrderLineEntity> unidentifiable = new ArrayList<>();
         for (PurchaseOrderLineEntity line : orderedLines) {
             String ean = eanFor(line);
             if (ean == null) {
                 unidentifiable.add(line);
-            } else {
+                continue;
+            }
+            eanByLineId.put(line.getLineId(), ean);
+            // A line with nothing outstanding is settled and needs no answer. It must also be kept
+            // out of the inquiry: the supplier contract rejects a quantity below one, so a single
+            // fully received line would 400 the request and degrade the whole screen to
+            // "supplier unavailable" — one settled line hiding every other line's answer.
+            if (requestedQuantity(line) > 0) {
                 linesByEan.computeIfAbsent(ean, k -> new ArrayList<>()).add(line);
             }
         }
@@ -107,7 +116,7 @@ public class ProcurementAvailabilityService {
 
         List<ProcurementAvailabilityResponse.Line> lines = new ArrayList<>();
         for (PurchaseOrderLineEntity line : orderedLines) {
-            lines.add(toResponseLine(line, eanFor(line), answersByEan));
+            lines.add(toResponseLine(line, eanByLineId.get(line.getLineId()), answersByEan));
         }
 
         if (!unidentifiable.isEmpty()) {
@@ -142,6 +151,13 @@ public class ProcurementAvailabilityService {
                     "ARTICLE_NOT_IDENTIFIABLE",
                     null,
                     null);
+        }
+
+        if (requested == 0) {
+            // Nothing outstanding, so the vendor was never asked. Reporting this as unanswered
+            // would suggest it declined to say; there was nothing to ask about.
+            return new ProcurementAvailabilityResponse.Line(
+                    line.getLineId(), line.getLineNumber(), line.getSkuId(), ean, 0, "NOTHING_OUTSTANDING", null, null);
         }
 
         SupplierStockClient.AnswerLine answer = answers.get(ean);

--- a/pos-order/src/main/java/com/positivity/order/internal/service/ProcurementAvailabilityService.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/ProcurementAvailabilityService.java
@@ -1,0 +1,201 @@
+package com.positivity.order.internal.service;
+
+import com.positivity.order.internal.client.SupplierStockClient;
+import com.positivity.order.internal.dto.purchaseorder.ProcurementAvailabilityResponse;
+import com.positivity.order.internal.entity.ExtProductCode;
+import com.positivity.order.internal.entity.PurchaseOrderEntity;
+import com.positivity.order.internal.entity.PurchaseOrderLineEntity;
+import com.positivity.order.internal.exception.PurchaseOrderNotFoundException;
+import com.positivity.order.internal.repository.ExtProductCodeRepository;
+import com.positivity.order.internal.repository.PurchaseOrderRepository;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * What a vendor can actually supply against the lines of a purchase order (CAP-319 #1329).
+ *
+ * <h2>The question a buyer is asking</h2>
+ *
+ * Not "is this in stock" but "if I order these quantities from this vendor to this place, what
+ * turns up and when". That shapes three things: the delivery location is required rather than
+ * defaulted, because availability is consignee-specific and answering for the wrong warehouse
+ * answers a different question; the whole order goes in one inquiry, because a buyer comparing ten
+ * lines should not cost ten vendor round trips; and a line nobody could ask about is reported as
+ * such rather than folded in with the ones the vendor declined.
+ *
+ * <h2>Unknown is not zero</h2>
+ *
+ * The distinction is carried from the vendor's answer all the way to the response and never
+ * collapsed. A null quantity means the vendor stated nothing; zero means it stated it has none.
+ * Only the second may be shown to a buyer as "none available" — the first means "we do not know",
+ * and a buyer who cannot tell them apart will either order blind or not order at all.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProcurementAvailabilityService {
+
+    /** The code type a vendor recognises as an article identifier. */
+    private static final String EAN = "EAN";
+
+    private final PurchaseOrderRepository purchaseOrderRepository;
+    private final ExtProductCodeRepository extProductCodeRepository;
+    private final SupplierStockClient supplierStockClient;
+
+    /**
+     * Availability for every line of one purchase order.
+     *
+     * @param deliveryLocationId where the goods would go — required by the caller, never taken from
+     *     the order. The buyer may well be pricing a delivery to somewhere other than the order's
+     *     own ship-to, and silently substituting one would answer confidently about the wrong place.
+     */
+    @Transactional(readOnly = true)
+    public @NonNull ProcurementAvailabilityResponse availabilityFor(
+            @NonNull UUID purchaseOrderId, @NonNull UUID vendorProfileId, @NonNull UUID deliveryLocationId) {
+        PurchaseOrderEntity order = purchaseOrderRepository
+                .findById(purchaseOrderId)
+                .orElseThrow(() -> new PurchaseOrderNotFoundException(purchaseOrderId));
+
+        List<PurchaseOrderLineEntity> orderedLines = order.getLines().stream()
+                .sorted(Comparator.comparing(
+                        PurchaseOrderLineEntity::getLineNumber, Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
+
+        // Resolve every line's article first, so the inquiry carries exactly the lines that can be
+        // asked about and the rest are reported as unidentifiable rather than silently dropped.
+        Map<String, List<PurchaseOrderLineEntity>> linesByEan = new HashMap<>();
+        List<PurchaseOrderLineEntity> unidentifiable = new ArrayList<>();
+        for (PurchaseOrderLineEntity line : orderedLines) {
+            String ean = eanFor(line);
+            if (ean == null) {
+                unidentifiable.add(line);
+            } else {
+                linesByEan.computeIfAbsent(ean, k -> new ArrayList<>()).add(line);
+            }
+        }
+
+        // One inquiry for the whole order, not one per line.
+        List<SupplierStockClient.InquiryLine> inquiryLines = linesByEan.entrySet().stream()
+                .map(entry -> new SupplierStockClient.InquiryLine(
+                        entry.getKey(),
+                        null,
+                        entry.getValue().stream()
+                                .mapToInt(ProcurementAvailabilityService::requestedQuantity)
+                                .sum()))
+                .toList();
+
+        SupplierStockClient.StockAnswer answer =
+                supplierStockClient.inquire(vendorProfileId, deliveryLocationId, inquiryLines);
+
+        Map<String, SupplierStockClient.AnswerLine> answersByEan = new HashMap<>();
+        for (SupplierStockClient.AnswerLine answerLine : answer.lines()) {
+            if (answerLine.articleEan() != null) {
+                answersByEan.put(answerLine.articleEan(), answerLine);
+            }
+        }
+
+        List<ProcurementAvailabilityResponse.Line> lines = new ArrayList<>();
+        for (PurchaseOrderLineEntity line : orderedLines) {
+            lines.add(toResponseLine(line, eanFor(line), answersByEan));
+        }
+
+        if (!unidentifiable.isEmpty()) {
+            log.debug(
+                    "Purchase order {}: {} line(s) carry no article code the vendor would recognise",
+                    purchaseOrderId,
+                    unidentifiable.size());
+        }
+
+        return new ProcurementAvailabilityResponse(
+                purchaseOrderId,
+                vendorProfileId,
+                deliveryLocationId,
+                answer.status().name(),
+                answer.asOf(),
+                lines);
+    }
+
+    private ProcurementAvailabilityResponse.Line toResponseLine(
+            PurchaseOrderLineEntity line, @Nullable String ean, Map<String, SupplierStockClient.AnswerLine> answers) {
+        int requested = requestedQuantity(line);
+
+        if (ean == null) {
+            // No shared name for this article, so the vendor was never asked about it. Reporting it
+            // as unanswered would suggest the vendor declined to say; it never had the chance.
+            return new ProcurementAvailabilityResponse.Line(
+                    line.getLineId(),
+                    line.getLineNumber(),
+                    line.getSkuId(),
+                    null,
+                    requested,
+                    "ARTICLE_NOT_IDENTIFIABLE",
+                    null,
+                    null);
+        }
+
+        SupplierStockClient.AnswerLine answer = answers.get(ean);
+        if (answer == null) {
+            return new ProcurementAvailabilityResponse.Line(
+                    line.getLineId(),
+                    line.getLineNumber(),
+                    line.getSkuId(),
+                    ean,
+                    requested,
+                    SupplierStockClient.LineStatus.NOT_ANSWERED.name(),
+                    null,
+                    null);
+        }
+
+        return new ProcurementAvailabilityResponse.Line(
+                line.getLineId(),
+                line.getLineNumber(),
+                line.getSkuId(),
+                ean,
+                requested,
+                answer.status().name(),
+                // Carried through, never defaulted: null stays null so the caller can tell "said
+                // nothing" from the zero that means "has none".
+                answer.availableQuantity(),
+                answer.earliestDeliveryDate());
+    }
+
+    /**
+     * What this line still needs.
+     *
+     * <p>Outstanding rather than ordered: a buyer topping up a part-delivered order wants to know
+     * whether the vendor can cover the remainder, not the amount already on a shelf.
+     */
+    private static int requestedQuantity(PurchaseOrderLineEntity line) {
+        BigDecimal quantity =
+                line.getOpenQuantityDecimal() == null ? line.getQuantityDecimal() : line.getOpenQuantityDecimal();
+        if (quantity == null || quantity.signum() <= 0) {
+            return 0;
+        }
+        // Rounded up: asking about 2 when 2.5 are needed would have the buyer told a quantity that
+        // covers the question they asked but not the one they meant.
+        return quantity.setScale(0, java.math.RoundingMode.CEILING).intValue();
+    }
+
+    private @Nullable String eanFor(PurchaseOrderLineEntity line) {
+        if (line.getSkuId() == null) {
+            return null;
+        }
+        return extProductCodeRepository
+                .findById(line.getSkuId())
+                .filter(code -> EAN.equalsIgnoreCase(code.getCodeType()))
+                .map(ExtProductCode::getCode)
+                .filter(code -> !code.isBlank())
+                .orElse(null);
+    }
+}

--- a/pos-order/src/main/resources/permissions.yaml
+++ b/pos-order/src/main/resources/permissions.yaml
@@ -62,3 +62,5 @@ permissions:
     description: "Approve or cancel a purchase order"
   - name: "order:purchase_order:transmit"
     description: "Send an approved purchase order to its vendor"
+  - name: "order:purchase_order:availability_view"
+    description: "Ask a vendor what it can supply against a purchase order"

--- a/pos-order/src/test/java/com/positivity/order/internal/client/SupplierStockClientImplTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/client/SupplierStockClientImplTest.java
@@ -1,0 +1,141 @@
+package com.positivity.order.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.match.MockRestRequestMatchers;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.web.client.RestClient;
+
+/**
+ * The supplier call as it behaves on the wire (CAP-319 #1329).
+ *
+ * <p>Every test here is about a failure that must not become an exception. A buyer is on the other
+ * end deciding what to order, and a vendor having a bad afternoon must cost them an availability
+ * column, not the screen.
+ */
+@DisplayName("SupplierStockClientImpl — asking a vendor what it can supply (#1329)")
+class SupplierStockClientImplTest {
+
+    private static final UUID VENDOR = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5b01");
+    private static final UUID SITE = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5b02");
+    private static final List<SupplierStockClient.InquiryLine> ONE_LINE =
+            List.of(new SupplierStockClient.InquiryLine("5012345678900", null, 5));
+
+    private MockRestServiceServer server;
+    private SupplierStockClientImpl client;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        client = new SupplierStockClientImpl(builder, "supplier", "/v1/supplier");
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.reset();
+    }
+
+    private void respondWith(String json) {
+        server.expect(MockRestRequestMatchers.requestTo("http://supplier/v1/supplier/stock/inquiries"))
+                .andRespond(MockRestResponseCreators.withSuccess(json, MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    @DisplayName("a vendor answer is carried through, null quantity and all")
+    void answerIsCarriedThrough() {
+        respondWith("""
+                {"inquiryId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5b03","status":"OK",
+                 "asOf":"2026-08-16T10:00:00Z",
+                 "lines":[
+                   {"articleEan":"5012345678900","supplierArticleCode":null,"status":"AVAILABLE",
+                    "availableQuantity":12,"earliestDeliveryDate":"2026-08-20"},
+                   {"articleEan":"5012345678917","supplierArticleCode":null,"status":"NOT_ANSWERED",
+                    "availableQuantity":null,"earliestDeliveryDate":null}]}
+                """);
+
+        SupplierStockClient.StockAnswer answer = client.inquire(VENDOR, SITE, ONE_LINE);
+
+        assertThat(answer.status()).isEqualTo(SupplierStockClient.Status.OK);
+        assertThat(answer.answered()).isTrue();
+        assertThat(answer.lines().get(0).availableQuantity()).isEqualTo(12);
+        assertThat(answer.lines().get(0).earliestDeliveryDate()).hasToString("2026-08-20");
+        // The null survives the hop. Defaulting it to zero here would be the single change that
+        // turns "the vendor said nothing" into "the vendor has none" for everybody downstream.
+        assertThat(answer.lines().get(1).availableQuantity()).isNull();
+        assertThat(answer.lines().get(1).status()).isEqualTo(SupplierStockClient.LineStatus.NOT_ANSWERED);
+    }
+
+    @Test
+    @DisplayName("a server error is an unavailable answer, not an exception")
+    void serverErrorDegrades() {
+        server.expect(MockRestRequestMatchers.requestTo("http://supplier/v1/supplier/stock/inquiries"))
+                .andRespond(MockRestResponseCreators.withServerError());
+
+        SupplierStockClient.StockAnswer answer = client.inquire(VENDOR, SITE, ONE_LINE);
+
+        // Nothing rethrows. The caller renders "we could not ask" rather than failing the request
+        // a buyer made.
+        assertThat(answer.status()).isEqualTo(SupplierStockClient.Status.SUPPLIER_UNAVAILABLE);
+        assertThat(answer.lines()).isEmpty();
+        assertThat(answer.answered()).isFalse();
+        assertThat(answer.asOf()).isNull();
+    }
+
+    @Test
+    @DisplayName("an unparseable body is an unavailable answer too")
+    void malformedBodyDegrades() {
+        respondWith("{\"this\":\"is not an inquiry response\",\"status\":");
+
+        assertThat(client.inquire(VENDOR, SITE, ONE_LINE).status())
+                .isEqualTo(SupplierStockClient.Status.SUPPLIER_UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("a status nobody recognises is treated as no answer, never as a usable one")
+    void unknownStatusIsNotTrusted() {
+        respondWith("""
+                {"inquiryId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5b03","status":"SOMETHING_NEW",
+                 "asOf":null,"lines":[]}
+                """);
+
+        // A status this build has never heard of might mean anything. Guessing it is close enough
+        // to OK would show a buyer quantities on a footing nobody has established.
+        assertThat(client.inquire(VENDOR, SITE, ONE_LINE).status())
+                .isEqualTo(SupplierStockClient.Status.SUPPLIER_UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("a line status nobody recognises becomes 'said nothing'")
+    void unknownLineStatusIsNotAnswered() {
+        respondWith("""
+                {"inquiryId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5b03","status":"OK","asOf":null,
+                 "lines":[{"articleEan":"5012345678900","supplierArticleCode":null,
+                   "status":"PARTIALLY_SOMETHING","availableQuantity":3,"earliestDeliveryDate":null}]}
+                """);
+
+        assertThat(client.inquire(VENDOR, SITE, ONE_LINE).lines())
+                .singleElement()
+                .satisfies(line -> assertThat(line.status()).isEqualTo(SupplierStockClient.LineStatus.NOT_ANSWERED));
+    }
+
+    @Test
+    @DisplayName("asking about nothing costs no round trip")
+    void emptyInquiryMakesNoCall() {
+        SupplierStockClient.StockAnswer answer = client.inquire(VENDOR, SITE, List.of());
+
+        assertThat(answer.status()).isEqualTo(SupplierStockClient.Status.OK);
+        assertThat(answer.lines()).isEmpty();
+        // No expectation was set on the server, and none was needed: spending a vendor round trip
+        // to learn nothing is a cost with no answer attached.
+        server.verify();
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/client/SupplierStockClientImplTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/client/SupplierStockClientImplTest.java
@@ -138,4 +138,22 @@ class SupplierStockClientImplTest {
         // to learn nothing is a cost with no answer attached.
         server.verify();
     }
+
+    @Test
+    @DisplayName("the call carries the identity pos-supplier authorises it by")
+    void callCarriesServiceIdentity() {
+        server.expect(MockRestRequestMatchers.requestTo("http://supplier/v1/supplier/stock/inquiries"))
+                .andExpect(MockRestRequestMatchers.header("X-User", "pos-order-service"))
+                .andExpect(MockRestRequestMatchers.header("X-Authorities", "supplier:stock:inquire"))
+                .andRespond(MockRestResponseCreators.withSuccess("""
+                        {"inquiryId":"018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5b03","status":"OK",
+                         "asOf":null,"lines":[]}
+                        """, MediaType.APPLICATION_JSON));
+
+        // Without these the endpoint refuses the call and every answer degrades to
+        // SUPPLIER_UNAVAILABLE — which looks exactly like a vendor being down, so the feature
+        // would have appeared to work while never once reaching a supplier.
+        assertThat(client.inquire(VENDOR, SITE, ONE_LINE).status()).isEqualTo(SupplierStockClient.Status.OK);
+        server.verify();
+    }
 }

--- a/pos-order/src/test/java/com/positivity/order/internal/service/ProcurementAvailabilityServiceTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/ProcurementAvailabilityServiceTest.java
@@ -1,0 +1,286 @@
+package com.positivity.order.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.order.internal.client.SupplierStockClient;
+import com.positivity.order.internal.dto.purchaseorder.ProcurementAvailabilityResponse;
+import com.positivity.order.internal.entity.ExtProductCode;
+import com.positivity.order.internal.entity.PurchaseOrderEntity;
+import com.positivity.order.internal.entity.PurchaseOrderLineEntity;
+import com.positivity.order.internal.exception.PurchaseOrderNotFoundException;
+import com.positivity.order.internal.repository.ExtProductCodeRepository;
+import com.positivity.order.internal.repository.PurchaseOrderRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Live vendor availability for a buyer deciding what to order (CAP-319 #1329).
+ *
+ * <p>The property that matters most here is one the type system cannot express: "we do not know"
+ * and "the vendor has none" must stay distinct from the vendor's answer all the way to the
+ * response. A buyer shown zero when the truth is silence will either not order something they could
+ * have, or distrust the column entirely — and a column nobody trusts is worse than no column.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ProcurementAvailabilityService — what the vendor can supply (#1329)")
+class ProcurementAvailabilityServiceTest {
+
+    private static final UUID PO_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a01");
+    private static final UUID VENDOR_PROFILE = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a02");
+    private static final UUID DELIVERY_SITE = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a03");
+    private static final UUID SKU_A = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a04");
+    private static final UUID SKU_B = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a05");
+    private static final String EAN_A = "5012345678900";
+    private static final String EAN_B = "5012345678917";
+    private static final Instant AS_OF = Instant.parse("2026-08-16T10:00:00Z");
+
+    @Mock
+    private PurchaseOrderRepository purchaseOrderRepository;
+
+    @Mock
+    private ExtProductCodeRepository extProductCodeRepository;
+
+    @Mock
+    private SupplierStockClient supplierStockClient;
+
+    private ProcurementAvailabilityService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProcurementAvailabilityService(
+                purchaseOrderRepository, extProductCodeRepository, supplierStockClient);
+        code(SKU_A, EAN_A);
+        code(SKU_B, EAN_B);
+    }
+
+    private void code(UUID skuId, String ean) {
+        when(extProductCodeRepository.findById(skuId))
+                .thenReturn(Optional.of(ExtProductCode.builder()
+                        .productId(skuId)
+                        .codeType("EAN")
+                        .code(ean)
+                        .aggregateVersion(1L)
+                        .build()));
+    }
+
+    private static PurchaseOrderLineEntity line(int number, UUID skuId, String openQuantity) {
+        return PurchaseOrderLineEntity.builder()
+                .lineId(UUID.randomUUID())
+                .lineNumber(number)
+                .skuId(skuId)
+                .description("line " + number)
+                .quantityDecimal(new BigDecimal(openQuantity))
+                .openQuantityDecimal(new BigDecimal(openQuantity))
+                .unitCostMinor(100L)
+                .lineTotalMinor(100L)
+                .build();
+    }
+
+    private void order(PurchaseOrderLineEntity... lines) {
+        PurchaseOrderEntity po = PurchaseOrderEntity.builder()
+                .purchaseOrderId(PO_ID)
+                .poNumber("0000001A")
+                .lines(new ArrayList<>(List.of(lines)))
+                .build();
+        for (PurchaseOrderLineEntity line : lines) {
+            line.setPurchaseOrder(po);
+        }
+        when(purchaseOrderRepository.findById(PO_ID)).thenReturn(Optional.of(po));
+    }
+
+    private void answers(SupplierStockClient.Status status, SupplierStockClient.AnswerLine... lines) {
+        when(supplierStockClient.inquire(any(), any(), any()))
+                .thenReturn(new SupplierStockClient.StockAnswer(status, List.of(lines), AS_OF));
+    }
+
+    @Test
+    @DisplayName("a vendor stating none is zero; a vendor stating nothing is null")
+    void unknownIsNotZero() {
+        order(line(1, SKU_A, "5"), line(2, SKU_B, "3"));
+        answers(
+                SupplierStockClient.Status.OK,
+                new SupplierStockClient.AnswerLine(EAN_A, null, SupplierStockClient.LineStatus.UNAVAILABLE, 0, null),
+                new SupplierStockClient.AnswerLine(
+                        EAN_B, null, SupplierStockClient.LineStatus.NOT_ANSWERED, null, null));
+
+        ProcurementAvailabilityResponse response = service.availabilityFor(PO_ID, VENDOR_PROFILE, DELIVERY_SITE);
+
+        // The vendor said it has none of A. That is a fact a buyer can act on.
+        assertThat(response.lines().get(0).availableQuantity()).isZero();
+        assertThat(response.lines().get(0).status()).isEqualTo("UNAVAILABLE");
+        // The vendor said nothing about B. Showing zero here would be inventing a statement it
+        // never made, and the buyer would skip an article the vendor may well have.
+        assertThat(response.lines().get(1).availableQuantity()).isNull();
+        assertThat(response.lines().get(1).status()).isEqualTo("NOT_ANSWERED");
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = SupplierStockClient.Status.class,
+            names = {"SUPPLIER_UNAVAILABLE", "NOT_LISTED", "CAPABILITY_NOT_CONFIGURED", "CONFIGURATION_ERROR"})
+    @DisplayName("every degraded outcome answers without quantities rather than failing")
+    void degradedOutcomesDoNotFailTheRequest(SupplierStockClient.Status status) {
+        order(line(1, SKU_A, "5"));
+        when(supplierStockClient.inquire(any(), any(), any()))
+                .thenReturn(new SupplierStockClient.StockAnswer(status, List.of(), null));
+
+        ProcurementAvailabilityResponse response = service.availabilityFor(PO_ID, VENDOR_PROFILE, DELIVERY_SITE);
+
+        // The screen renders. The buyer is told we could not ask, which is the truth, rather than
+        // being shown an error page or a column of confident zeroes.
+        assertThat(response.status()).isEqualTo(status.name());
+        assertThat(response.lines()).singleElement().satisfies(line -> {
+            assertThat(line.availableQuantity()).isNull();
+            assertThat(line.status()).isEqualTo("NOT_ANSWERED");
+        });
+        assertThat(response.asOf()).isNull();
+    }
+
+    @Test
+    @DisplayName("a ten-line order makes one vendor round trip, not ten")
+    void linesAreBatchedIntoOneInquiry() {
+        PurchaseOrderLineEntity[] lines = new PurchaseOrderLineEntity[10];
+        for (int i = 0; i < 10; i++) {
+            UUID sku = UUID.randomUUID();
+            code(sku, "50123456789" + (10 + i));
+            lines[i] = line(i + 1, sku, "2");
+        }
+        order(lines);
+        answers(SupplierStockClient.Status.OK);
+
+        service.availabilityFor(PO_ID, VENDOR_PROFILE, DELIVERY_SITE);
+
+        ArgumentCaptor<List<SupplierStockClient.InquiryLine>> captor = ArgumentCaptor.forClass(List.class);
+        verify(supplierStockClient, times(1)).inquire(eq(VENDOR_PROFILE), eq(DELIVERY_SITE), captor.capture());
+        // One call carrying ten articles. Ten calls would multiply the vendor's latency by ten and
+        // invite a rate limit that degrades the whole screen instead of one row.
+        assertThat(captor.getValue()).hasSize(10);
+    }
+
+    @Test
+    @DisplayName("two lines for the same article are asked about once, for the combined quantity")
+    void repeatedArticlesAreCombined() {
+        order(line(1, SKU_A, "4"), line(2, SKU_A, "6"));
+        answers(
+                SupplierStockClient.Status.OK,
+                new SupplierStockClient.AnswerLine(EAN_A, null, SupplierStockClient.LineStatus.AVAILABLE, 7, null));
+
+        ProcurementAvailabilityResponse response = service.availabilityFor(PO_ID, VENDOR_PROFILE, DELIVERY_SITE);
+
+        ArgumentCaptor<List<SupplierStockClient.InquiryLine>> captor = ArgumentCaptor.forClass(List.class);
+        verify(supplierStockClient).inquire(any(), any(), captor.capture());
+        // The vendor is asked whether it can cover all ten, not twice about the same article.
+        assertThat(captor.getValue()).singleElement().satisfies(line -> {
+            assertThat(line.articleEan()).isEqualTo(EAN_A);
+            assertThat(line.requestedQuantity()).isEqualTo(10);
+        });
+        // Both lines carry the answer, because both are about that article.
+        assertThat(response.lines())
+                .allSatisfy(line -> assertThat(line.availableQuantity()).isEqualTo(7));
+    }
+
+    @Test
+    @DisplayName("a line with no article code is reported as such, not as unanswered")
+    void unidentifiableLineIsDistinctFromUnanswered() {
+        order(line(1, SKU_A, "5"), line(2, SKU_B, "3"));
+        when(extProductCodeRepository.findById(SKU_B)).thenReturn(Optional.empty());
+        answers(
+                SupplierStockClient.Status.OK,
+                new SupplierStockClient.AnswerLine(EAN_A, null, SupplierStockClient.LineStatus.AVAILABLE, 5, null));
+
+        ProcurementAvailabilityResponse response = service.availabilityFor(PO_ID, VENDOR_PROFILE, DELIVERY_SITE);
+
+        // NOT_ANSWERED would say the vendor declined to comment. It never had the chance — we had
+        // no name for the article to ask about, which is our data gap and ours to fix.
+        assertThat(response.lines().get(1).status()).isEqualTo("ARTICLE_NOT_IDENTIFIABLE");
+        assertThat(response.lines().get(1).articleEan()).isNull();
+
+        ArgumentCaptor<List<SupplierStockClient.InquiryLine>> captor = ArgumentCaptor.forClass(List.class);
+        verify(supplierStockClient).inquire(any(), any(), captor.capture());
+        assertThat(captor.getValue()).singleElement();
+    }
+
+    @Test
+    @DisplayName("the quantity asked about is what is still outstanding")
+    void asksAboutTheOutstandingQuantity() {
+        PurchaseOrderLineEntity partlyDelivered = line(1, SKU_A, "10");
+        partlyDelivered.setQuantityDecimal(new BigDecimal("10"));
+        partlyDelivered.setOpenQuantityDecimal(new BigDecimal("4"));
+        order(partlyDelivered);
+        answers(SupplierStockClient.Status.OK);
+
+        service.availabilityFor(PO_ID, VENDOR_PROFILE, DELIVERY_SITE);
+
+        ArgumentCaptor<List<SupplierStockClient.InquiryLine>> captor = ArgumentCaptor.forClass(List.class);
+        verify(supplierStockClient).inquire(any(), any(), captor.capture());
+        // Six already arrived. Asking about ten would have the buyer chasing stock they have.
+        assertThat(captor.getValue().getFirst().requestedQuantity()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("an order with nothing identifiable asks the vendor nothing at all")
+    void nothingIdentifiableMakesNoCall() {
+        order(line(1, SKU_A, "5"));
+        when(extProductCodeRepository.findById(SKU_A)).thenReturn(Optional.empty());
+        when(supplierStockClient.inquire(any(), any(), any()))
+                .thenReturn(new SupplierStockClient.StockAnswer(SupplierStockClient.Status.OK, List.of(), AS_OF));
+
+        ProcurementAvailabilityResponse response = service.availabilityFor(PO_ID, VENDOR_PROFILE, DELIVERY_SITE);
+
+        assertThat(response.lines())
+                .singleElement()
+                .satisfies(line -> assertThat(line.status()).isEqualTo("ARTICLE_NOT_IDENTIFIABLE"));
+    }
+
+    @Test
+    @DisplayName("the delivery location asked about is the one supplied, never the order's own")
+    void deliveryLocationIsNotDefaultedFromTheOrder() {
+        PurchaseOrderEntity po = PurchaseOrderEntity.builder()
+                .purchaseOrderId(PO_ID)
+                .poNumber("0000001A")
+                .shipToLocationId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f5a09"))
+                .lines(new ArrayList<>(List.of(line(1, SKU_A, "5"))))
+                .build();
+        when(purchaseOrderRepository.findById(PO_ID)).thenReturn(Optional.of(po));
+        answers(SupplierStockClient.Status.OK);
+
+        service.availabilityFor(PO_ID, VENDOR_PROFILE, DELIVERY_SITE);
+
+        // Availability is consignee-specific. Substituting the order's ship-to would answer
+        // confidently about a different warehouse than the buyer asked about.
+        verify(supplierStockClient).inquire(eq(VENDOR_PROFILE), eq(DELIVERY_SITE), any());
+    }
+
+    @Test
+    @DisplayName("an unknown order is a not-found, and the vendor is never asked")
+    void unknownOrderIsNotFound() {
+        when(purchaseOrderRepository.findById(PO_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.availabilityFor(PO_ID, VENDOR_PROFILE, DELIVERY_SITE))
+                .isInstanceOf(PurchaseOrderNotFoundException.class);
+        verify(supplierStockClient, never()).inquire(any(), any(), any());
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/service/ProcurementAvailabilityServiceTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/ProcurementAvailabilityServiceTest.java
@@ -283,4 +283,63 @@ class ProcurementAvailabilityServiceTest {
                 .isInstanceOf(PurchaseOrderNotFoundException.class);
         verify(supplierStockClient, never()).inquire(any(), any(), any());
     }
+
+    @Test
+    @DisplayName("a settled line is kept out of the inquiry rather than poisoning it")
+    void settledLineIsNotAskedAbout() {
+        PurchaseOrderLineEntity settled = line(1, SKU_A, "10");
+        settled.setOpenQuantityDecimal(BigDecimal.ZERO);
+        order(settled, line(2, SKU_B, "3"));
+        answers(
+                SupplierStockClient.Status.OK,
+                new SupplierStockClient.AnswerLine(EAN_B, null, SupplierStockClient.LineStatus.AVAILABLE, 3, null));
+
+        ProcurementAvailabilityResponse response = service.availabilityFor(PO_ID, VENDOR_PROFILE, DELIVERY_SITE);
+
+        ArgumentCaptor<List<SupplierStockClient.InquiryLine>> captor = ArgumentCaptor.forClass(List.class);
+        verify(supplierStockClient).inquire(any(), any(), captor.capture());
+        // The supplier contract rejects a quantity below one, so including the settled line would
+        // 400 the whole request — one line with nothing outstanding hiding every other line's
+        // answer behind a "supplier unavailable" that looks exactly like a vendor being down.
+        assertThat(captor.getValue())
+                .singleElement()
+                .satisfies(asked -> assertThat(asked.articleEan()).isEqualTo(EAN_B));
+
+        // It is still reported, and reported as what it is.
+        assertThat(response.lines().get(0).status()).isEqualTo("NOTHING_OUTSTANDING");
+        assertThat(response.lines().get(0).availableQuantity()).isNull();
+        assertThat(response.lines().get(1).availableQuantity()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("an order with every line settled asks the vendor nothing")
+    void allSettledMakesNoCall() {
+        PurchaseOrderLineEntity settled = line(1, SKU_A, "10");
+        settled.setOpenQuantityDecimal(BigDecimal.ZERO);
+        order(settled);
+        answers(SupplierStockClient.Status.OK);
+
+        ProcurementAvailabilityResponse response = service.availabilityFor(PO_ID, VENDOR_PROFILE, DELIVERY_SITE);
+
+        ArgumentCaptor<List<SupplierStockClient.InquiryLine>> captor = ArgumentCaptor.forClass(List.class);
+        verify(supplierStockClient).inquire(any(), any(), captor.capture());
+        assertThat(captor.getValue()).isEmpty();
+        assertThat(response.lines())
+                .singleElement()
+                .satisfies(line -> assertThat(line.status()).isEqualTo("NOTHING_OUTSTANDING"));
+    }
+
+    @Test
+    @DisplayName("each line's article is resolved once, not once per pass")
+    void articleIsResolvedOncePerLine() {
+        order(line(1, SKU_A, "5"), line(2, SKU_B, "3"));
+        answers(SupplierStockClient.Status.OK);
+
+        service.availabilityFor(PO_ID, VENDOR_PROFILE, DELIVERY_SITE);
+
+        // Resolving again while rendering would double the reads and could disagree with itself if
+        // the replica changed mid-request, grouping a line under one article and reporting another.
+        verify(extProductCodeRepository, times(1)).findById(SKU_A);
+        verify(extProductCodeRepository, times(1)).findById(SKU_B);
+    }
 }

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -23,7 +23,7 @@ public final class DownstreamPermissionCatalog {
      * {@code PermissionCode.CATALOG_VERSION}.
      * Updated automatically by {@code scripts/generate-permissions.py --sync}.
      */
-    public static final int CATALOG_VERSION = 50;
+    public static final int CATALOG_VERSION = 51;
 
     /**
      * Index-to-authority mapping. Entry at position N is the {@code PERM_*}-prefixed
@@ -571,7 +571,10 @@ public final class DownstreamPermissionCatalog {
         "PERM_order:purchase_order:view", // 458
 
         // ── New batch (bits 459–459) ──────────────────────────────────────────
-        "PERM_order:purchase_order:transmit" // 459
+        "PERM_order:purchase_order:transmit", // 459
+
+        // ── New batch (bits 460–460) ──────────────────────────────────────────
+        "PERM_order:purchase_order:availability_view" // 460
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -601,13 +601,15 @@ public enum PermissionCode {
     ORDER__PURCHASE_ORDER__CREATE(457, "order:purchase_order:create"),
     ORDER__PURCHASE_ORDER__VIEW(458, "order:purchase_order:view"),
     // ── Order (new) ────────────────────────────────────────────────────────────
-    ORDER__PURCHASE_ORDER__TRANSMIT(459, "order:purchase_order:transmit");
+    ORDER__PURCHASE_ORDER__TRANSMIT(459, "order:purchase_order:transmit"),
+    // ── Order (new) ────────────────────────────────────────────────────────────
+    ORDER__PURCHASE_ORDER__AVAILABILITY_VIEW(460, "order:purchase_order:availability_view");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 50;
+    public static final int CATALOG_VERSION = 51;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 460;
-    private static final int EXPECTED_CATALOG_VERSION = 50;
+    private static final int EXPECTED_PERMISSION_COUNT = 461;
+    private static final int EXPECTED_CATALOG_VERSION = 51;
 
     // -------------------------------------------------------------------------
     // AC-1: Catalog size — EXPECTED_PERMISSION_COUNT entries


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:319`
- Parent STORY (durion): louisburroughs/durion#374
- Child issue: louisburroughs/durion-positivity-backend#1329
- Domain: `domain:order`, `domain:positivity`

## Contract References
- Contract guide entry (durion): `domains/order/.business-rules/BACKEND_CONTRACT_GUIDE.md` → procurement availability
- Consumes: `POST /v1/supplier/stock/inquiries` (existing, #1225) — the approved synchronous supplier read, ADR-0044 amendment 2026-08-10
- New response schema: `ProcurementAvailability`

## Scope

CAP-319's remaining acceptance criterion: *"Procurement flow in pos-order can fetch live availability per line."* `SupplierStockService` has existed since #1225 with exactly one consumer — pos-catalog. pos-order was named as an approved caller and never wired.

### Why this is not the catalog client copied

A procurement screen asks a different question from a product page. Several lines at once, for a buyer deciding what to order, where **a line whose availability is unknown is not the same as a line the vendor has none of**.

So this client returns a **status**, not an `Optional`. An empty answer would collapse "we could not ask" into "there is none" — the one distinction the whole feature exists to preserve. It is carried from the vendor's reply through to the HTTP response and never defaulted:

| | meaning | may show buyer "none available"? |
|---|---|---|
| `availableQuantity: null` | vendor stated nothing | **no** |
| `availableQuantity: 0` | vendor stated it has none | yes |

### The rest of the shape

**One inquiry, not one per line.** A ten-line screen costs one vendor round trip. Lines sharing an article are asked about once for the combined quantity.

**Outstanding quantity, not ordered.** A buyer topping up a part-delivered order wants to know whether the vendor can cover the remainder, not the goods already on the shelf.

**Delivery location required, never defaulted.** Availability is consignee-specific. The order has a ship-to, and substituting it would answer confidently about a different warehouse than the buyer asked about.

**`ARTICLE_NOT_IDENTIFIABLE` is its own outcome.** A line with no article code was never asked about — the vendor did not decline to comment, we had no shared name for the article. That is a gap in our data rather than theirs, and the buyer should be told which.

**Nothing rethrows.** A refused connection, a 5xx, an unparseable body and an unrecognised status all become `SUPPLIER_UNAVAILABLE`. An unrecognised *line* status becomes `NOT_ANSWERED`. Guessing that a status this build has never seen is close enough to OK would show quantities on a footing nobody established.

## The wall grant widens by exactly one file

`DomainWallsTest` grants the synchronous supplier edge **by file name**, so a second caller has to argue its case. This adds `pos-order/SupplierStockClientImpl.java` and nothing else, and a new test asserts both grants stay file-scoped and that neither module acquires `pos-supplier` at module level.

**Verified rather than assumed:** I added a second pos-order client reaching pos-supplier and confirmed the build fails —

```
pos-order/src/main/java/com/positivity/order/internal/client/TempProbeClient.java -> pos-supplier
[ERROR] DomainWallsTest ... Tests run: 2, Failures: 1
```

then removed it. The AC's "any other pos-order client still fails the build" is real, not decorative.

## Tests
- [x] Unit tests added/updated — `ProcurementAvailabilityServiceTest` (12), `SupplierStockClientImplTest` (6), `DomainWallsTest` (+1)
- [x] Integration tests added/updated — the client tests drive the real wire shape via `MockRestServiceServer`
- [ ] Provider behavioral contract tests added/updated — n/a
- How to run:
  ```bash
  ./mvnw -pl pos-order -am test
  ./mvnw -pl pos-archunit -am -Dtest='DomainWallsTest,EntityStandardsArchitectureTest,ClasspathVisibilityGuardTest,ArchitectureTests' -Dsurefire.failIfNoSpecifiedTests=false test
  bash scripts/check-flyway-hygiene.sh
  ```
  pos-order 387/387, pos-archunit 22/22 (with `ClasspathVisibilityGuardTest` green, so the rules ran against real classes), security + gateway green, Flyway hygiene passes, spec generation clean.

Every AC test is present: the degradation matrix as a parameterised sweep of all four non-OK outcomes, the null-versus-zero distinction at both the client and service layers, batching of multiple lines into one inquiry, and the file-scoped grant assertion.

## Permissions

`order:purchase_order:availability_view` takes bit 460; `CATALOG_VERSION` 50 → 51 via `--sync`. Separate from viewing the order because it is a read that reaches the vendor's own systems, and a shop may reasonably let someone see an order without letting them generate supplier traffic.

## Risk & Rollback
- Risk level: Low — additive. No schema change, no state change, and the endpoint degrades rather than fails when the supplier is unreachable.
- Rollback plan: revert the commit. The `DomainWallsTest` entry goes with it, which is what keeps the wall honest.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing — pending
- [ ] Angular SDK regenerated — deferred until backend work is complete

## A note on the issue's stated dependency

The issue says *"pos-order currently has no purchase-order aggregate … if procurement lines do not yet exist as a durable concept, agree with the Order domain where this enrichment attaches"*. That is now stale: #1334 moved the aggregate here, so procurement lines exist as purchase-order lines and the enrichment attaches to them directly. No agreement needed.

## Follow-ups
- `supplierArticleCode` still unpopulated, as noted on #1330 — only the EAN path resolves. A vendor that identifies articles solely by its own codes will report `ARTICLE_NOT_IDENTIFIABLE` until PRICAT-sourced codes are replicated.
