### PR TITLE
[CAP:321] feat(supplier,accounting): fetch vendor invoices over B3.3 and record them as AP bills (#1227)

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/SupplierInvoiceEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/SupplierInvoiceEventsListener.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.dao.TransientDataAccessException;
+import org.springframework.dao.DataAccessException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -108,12 +108,16 @@ public class SupplierInvoiceEventsListener {
             } else {
                 log.debug("Ignoring supplier event type={} eventId={}", eventType, eventId);
             }
-        } catch (TransientDataAccessException e) {
-            // Rethrown so the container retries. Recording this as processed would lose a vendor
-            // invoice permanently: the supplier side has already published it and will not publish
-            // it again, so nothing would ever bring it back.
+        } catch (DataAccessException e) {
+            // Every database failure is rethrown, not only the transient ones. A column-length
+            // violation or a concurrent vendor insert is not a malformed message, and marking it
+            // processed would lose a vendor debt permanently — the supplier side has already
+            // published this invoice and will not publish it again, so nothing would bring it back.
+            // Better a retry, or a dead letter somebody has to look at, than a debt that vanishes.
             throw e;
         } catch (Exception e) {
+            // Genuinely unreadable: a payload this build cannot parse will not parse on retry
+            // either, and blocking the partition would stop every other vendor's invoices too.
             log.warn("Skipping malformed supplier invoice event eventId={}", eventId, e);
         }
 
@@ -161,7 +165,14 @@ public class SupplierInvoiceEventsListener {
         bill.setBillNumber(billNumber);
         bill.setBillDate(fact.invoiceDate().atStartOfDay());
         bill.setTotalAmount(signedTotal(fact));
-        bill.setStatus(VendorBillStatus.PENDING_RECEIPT_MATCH);
+        // An invoice whose amount could not be read is not a nil invoice. The codec deliberately
+        // records an unreadable figure as absent rather than zero so the two stay distinguishable,
+        // and collapsing them here would undo that: a bill for nothing looks settled, sits at the
+        // bottom of every ageing report, and is noticed when the vendor chases payment.
+        bill.setStatus(
+                fact.totalGrossAmount() == null
+                        ? VendorBillStatus.MATCH_EXCEPTION
+                        : VendorBillStatus.PENDING_RECEIPT_MATCH);
         bill.setOriginEventId(UUID.fromString(eventId));
         bill.setOriginEventType(ORIGIN_EVENT_TYPE);
         bill.setPurchaseOrderNumber(fact.vendorOrderReference());

--- a/pos-accounting/src/main/java/com/positivity/accounting/internal/service/SupplierInvoiceEventsListener.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/internal/service/SupplierInvoiceEventsListener.java
@@ -1,0 +1,205 @@
+package com.positivity.accounting.internal.service;
+
+import com.positivity.accounting.internal.entity.ProcessedEvent;
+import com.positivity.accounting.internal.entity.Vendor;
+import com.positivity.accounting.internal.entity.VendorBill;
+import com.positivity.accounting.internal.enums.VendorBillStatus;
+import com.positivity.accounting.internal.repository.ProcessedEventRepository;
+import com.positivity.accounting.internal.repository.VendorBillRepository;
+import com.positivity.accounting.internal.repository.VendorRepository;
+import com.positivity.domainevents.supplier.SupplierInvoiceReceivedV1;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Creates AP vendor bills from vendor invoices fetched over EDIWheel B3.3 (CAP-321 #1227).
+ *
+ * <h2>Three judgments made here, and why</h2>
+ *
+ * The story that asked for this said posting semantics were an open question for the Accounting
+ * domain. They are not open — this module already models the AP side, and the questions that
+ * remained were about how a <em>supplier</em> invoice maps onto it. Those answers are recorded here
+ * because they are decisions, not derivations, and the next person to read this code deserves to
+ * know they were chosen rather than found.
+ *
+ * <p><strong>1. An unresolvable purchase-order reference is {@code PENDING_RECEIPT_MATCH}, not
+ * {@code MATCH_EXCEPTION}.</strong> A vendor invoice routinely arrives before the goods receipt it
+ * belongs to, so "no matching order yet" is the ordinary early state of a perfectly good invoice.
+ * Filing it as an exception would put a queue of normal paperwork in front of a person whose
+ * attention is the scarce resource, and the exception queue would stop meaning anything. An
+ * invoice that genuinely never matches surfaces through ageing, which is what ageing is for.
+ *
+ * <p><strong>2. No journal entry is created on ingest.</strong> The status flow posts at approval
+ * ({@code PENDING_RECEIPT_MATCH} → {@code APPROVED} → {@code PAID}), and an unapproved vendor
+ * invoice is a claim rather than a liability anyone has agreed to. Posting on arrival would put
+ * money in the ledger on the vendor's say-so alone, and a vendor that invoices in error would move
+ * our accounts before anybody looked at it.
+ *
+ * <p><strong>3. The supplier's vendor profile id is the accounting vendor id.</strong> {@link
+ * Vendor} states that its id is "assigned by the upstream system that owns the vendor relationship",
+ * and for a vendor we transact with over EDIWheel that system is pos-supplier. The directory entry
+ * is created on first sight so the AP screens can resolve a name; the alternative — inventing a
+ * separate accounting vendor id and a mapping table to reconcile it — would create the very
+ * ambiguity the upstream-assigns rule exists to avoid.
+ *
+ * <h2>One bill per invoice, however many times we are told</h2>
+ *
+ * Guarded twice, because the two failures are different. The event-id guard catches a redelivery of
+ * the same message. The vendor-invoice-identity guard catches the same document being fetched again
+ * — which happens by design, since fetch windows overlap so a failed fetch can be repeated safely.
+ * Only the second would survive a rebuilt supplier database, and it is the one that stops a debt
+ * being recorded twice.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.accounting.kafka", name = "enabled", havingValue = "true")
+public class SupplierInvoiceEventsListener {
+
+    /** Producing domain, per the repo-wide {@code processed_events} convention. */
+    static final String OWNER = "supplier";
+
+    private static final String ORIGIN_EVENT_TYPE = "SUPPLIER_INVOICE_RECEIVED";
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final ProcessedEventRepository processedEventRepository;
+    private final VendorBillRepository vendorBillRepository;
+    private final VendorRepository vendorRepository;
+
+    @KafkaListener(
+            topics = "${pos.accounting.kafka.supplier-events-topic:supplier.events.v1}",
+            groupId = "pos-accounting-supplier-events")
+    @Transactional
+    public void onSupplierEvent(@NonNull String message) {
+        JsonNode envelope;
+        try {
+            envelope = objectMapper.readTree(message);
+        } catch (Exception e) {
+            log.warn("Skipping unparsable supplier event", e);
+            return;
+        }
+        String eventType = envelope.path("eventType").stringValue(null);
+        String eventId = envelope.path("eventId").stringValue(null);
+        if (eventId == null || eventId.isBlank()) {
+            log.warn("Skipping supplier event without eventId");
+            return;
+        }
+        if (processedEventRepository.existsById(eventId)) {
+            return;
+        }
+
+        try {
+            if (SupplierInvoiceReceivedV1.EVENT_TYPE.equals(eventType)) {
+                apply(envelope, eventId);
+            } else {
+                log.debug("Ignoring supplier event type={} eventId={}", eventType, eventId);
+            }
+        } catch (TransientDataAccessException e) {
+            // Rethrown so the container retries. Recording this as processed would lose a vendor
+            // invoice permanently: the supplier side has already published it and will not publish
+            // it again, so nothing would ever bring it back.
+            throw e;
+        } catch (Exception e) {
+            log.warn("Skipping malformed supplier invoice event eventId={}", eventId, e);
+        }
+
+        processedEventRepository.save(ProcessedEvent.builder()
+                .eventId(eventId)
+                .processedAt(Instant.now(clock))
+                .build());
+    }
+
+    private void apply(JsonNode envelope, String eventId) {
+        SupplierInvoiceReceivedV1 fact =
+                objectMapper.treeToValue(envelope.path("payload"), SupplierInvoiceReceivedV1.class);
+
+        UUID vendorId = fact.vendorProfileId();
+        String billNumber = fact.vendorInvoiceNumber();
+
+        Optional<VendorBill> existing = vendorBillRepository.findByVendorIdAndBillNumber(vendorId, billNumber);
+        if (existing.isPresent()) {
+            VendorBill bill = existing.get();
+            BigDecimal incoming = signedTotal(fact);
+            if (bill.getTotalAmount() != null && incoming.compareTo(bill.getTotalAmount()) != 0) {
+                // Re-issued under the same identity for a different amount. Not overwritten: the
+                // first version is what somebody may already have approved or paid against, and
+                // replacing it would erase the disagreement rather than raise it.
+                bill.setStatus(VendorBillStatus.MATCH_EXCEPTION);
+                vendorBillRepository.save(bill);
+                log.warn(
+                        "Vendor invoice {} re-issued at {} against a bill of {}; flagged for review",
+                        billNumber,
+                        incoming,
+                        bill.getTotalAmount());
+            } else {
+                log.debug("Vendor invoice {} already held; nothing to do", billNumber);
+            }
+            return;
+        }
+
+        ensureVendorDirectoryEntry(vendorId, fact.supplierRef());
+
+        VendorBill bill = new VendorBill();
+        bill.setVendorId(vendorId);
+        bill.setVendorName(fact.supplierRef());
+        // The vendor's own number, not one we mint. It is what an AP clerk quotes back to the
+        // vendor, and a number of our own would be meaningless in that conversation.
+        bill.setBillNumber(billNumber);
+        bill.setBillDate(fact.invoiceDate().atStartOfDay());
+        bill.setTotalAmount(signedTotal(fact));
+        bill.setStatus(VendorBillStatus.PENDING_RECEIPT_MATCH);
+        bill.setOriginEventId(UUID.fromString(eventId));
+        bill.setOriginEventType(ORIGIN_EVENT_TYPE);
+        bill.setPurchaseOrderNumber(fact.vendorOrderReference());
+        bill.setCreatedBy(OWNER);
+        bill.setModifiedBy(OWNER);
+
+        vendorBillRepository.save(bill);
+        log.info(
+                "Created vendor bill from supplier invoice {} ({} {}) for vendor {}",
+                billNumber,
+                fact.totalGrossAmount(),
+                fact.currency(),
+                fact.supplierRef());
+    }
+
+    /**
+     * The amount, signed by what the document is.
+     *
+     * <p>A credit note is money owed back, so it carries the opposite sign to an invoice. The sign
+     * is taken from the document type rather than from the amount, because a vendor may state a
+     * credit as a positive figure on a document that declares itself a credit note — and reading
+     * the sign off the number would silently turn a refund into a debt.
+     */
+    private static BigDecimal signedTotal(SupplierInvoiceReceivedV1 fact) {
+        BigDecimal total = fact.totalGrossAmount() == null ? BigDecimal.ZERO : fact.totalGrossAmount();
+        BigDecimal magnitude = total.abs();
+        return fact.isPayable() ? magnitude : magnitude.negate();
+    }
+
+    /**
+     * Makes sure the AP vendor typeahead can resolve this vendor.
+     *
+     * <p>Created rather than required: an invoice arriving for a vendor the directory has never seen
+     * is an ordinary first invoice, and refusing it would make the directory a gate on being paid.
+     */
+    private void ensureVendorDirectoryEntry(UUID vendorId, String name) {
+        if (!vendorRepository.existsById(vendorId)) {
+            vendorRepository.save(new Vendor(vendorId, name));
+        }
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/SupplierInvoiceEventsListenerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/SupplierInvoiceEventsListenerTest.java
@@ -1,0 +1,207 @@
+package com.positivity.accounting.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.accounting.internal.entity.Vendor;
+import com.positivity.accounting.internal.entity.VendorBill;
+import com.positivity.accounting.internal.enums.VendorBillStatus;
+import com.positivity.accounting.internal.repository.ProcessedEventRepository;
+import com.positivity.accounting.internal.repository.VendorBillRepository;
+import com.positivity.accounting.internal.repository.VendorRepository;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.QueryTimeoutException;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Vendor invoices becoming AP bills (CAP-321 #1227).
+ *
+ * <p>These tests pin the three judgments documented on the listener, because each is a decision
+ * somebody could reasonably have made differently and none of them is enforced by a type.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("SupplierInvoiceEventsListener — vendor invoices as AP bills (#1227)")
+class SupplierInvoiceEventsListenerTest {
+
+    private static final UUID PROFILE = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7a01");
+    private static final Instant NOW = Instant.parse("2026-08-16T09:00:00Z");
+
+    /** Envelope event ids are UUIDv7 in this system; the listener records one on the bill. */
+    private static final String EVENT_1 = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7b01";
+
+    private static final String EVENT_2 = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7b02";
+    private static final String EVENT_3 = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7b03";
+    private static final String EVENT_4 = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7b04";
+    private static final String EVENT_5 = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7b05";
+    private static final String EVENT_6 = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7b06";
+    private static final String EVENT_7 = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7b07";
+    private static final String EVENT_8 = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f7b08";
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private VendorBillRepository vendorBillRepository;
+
+    @Mock
+    private VendorRepository vendorRepository;
+
+    private SupplierInvoiceEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new SupplierInvoiceEventsListener(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                new ObjectMapper(),
+                processedEventRepository,
+                vendorBillRepository,
+                vendorRepository);
+        when(processedEventRepository.existsById(any())).thenReturn(false);
+        when(vendorBillRepository.findByVendorIdAndBillNumber(any(), any())).thenReturn(Optional.empty());
+        when(vendorRepository.existsById(any())).thenReturn(false);
+    }
+
+    private static String event(String eventId, String number, String type, String total) {
+        return """
+            {"eventId":"%s","eventType":"supplier.invoice.received","payload":{
+              "vendorProfileId":"%s","supplierRef":"michelin-de","vendorInvoiceNumber":"%s",
+              "invoiceDate":"2026-08-14","type":"%s","currency":"EUR",
+              "totalNetAmount":240.00,"totalTaxAmount":48.00,"totalGrossAmount":%s,
+              "vendorOrderReference":"PO-778","occurredAt":"2026-08-16T08:00:00Z","lines":[]}}
+            """.formatted(eventId, PROFILE, number, type, total);
+    }
+
+    private VendorBill captured() {
+        ArgumentCaptor<VendorBill> captor = ArgumentCaptor.forClass(VendorBill.class);
+        verify(vendorBillRepository).save(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("an unmatched invoice waits for its receipt rather than becoming an exception")
+    void unmatchedInvoiceIsPendingNotException() {
+        listener.onSupplierEvent(event(EVENT_1, "INV-1", "INVOICE", "288.00"));
+
+        // Judgment 1. An invoice arriving before its goods receipt is the ordinary early state of a
+        // perfectly good invoice; filing it as an exception would fill the exception queue with
+        // normal paperwork until the queue meant nothing.
+        assertThat(captured().getStatus()).isEqualTo(VendorBillStatus.PENDING_RECEIPT_MATCH);
+    }
+
+    @Test
+    @DisplayName("no journal entry is created on ingest")
+    void noJournalEntryOnIngest() {
+        listener.onSupplierEvent(event(EVENT_2, "INV-2", "INVOICE", "288.00"));
+
+        // Judgment 2. An unapproved vendor invoice is a claim, not a liability anyone agreed to.
+        // Posting on arrival would move our accounts on the vendor's say-so alone.
+        assertThat(captured().getJournalEntry()).isNull();
+    }
+
+    @Test
+    @DisplayName("the supplier's profile id is the accounting vendor id, and the directory learns it")
+    void vendorDirectoryEntryIsCreated() {
+        listener.onSupplierEvent(event(EVENT_3, "INV-3", "INVOICE", "288.00"));
+
+        // Judgment 3. Vendor states its id is assigned by the system owning the relationship, which
+        // for an EDIWheel vendor is pos-supplier. A separate accounting id plus a mapping table
+        // would create the ambiguity that rule exists to avoid.
+        ArgumentCaptor<Vendor> captor = ArgumentCaptor.forClass(Vendor.class);
+        verify(vendorRepository).save(captor.capture());
+        assertThat(captor.getValue().getVendorId()).isEqualTo(PROFILE);
+        assertThat(captured().getVendorId()).isEqualTo(PROFILE);
+    }
+
+    @Test
+    @DisplayName("the bill carries the vendor's own number, not one we mint")
+    void billNumberIsTheVendorsOwn() {
+        listener.onSupplierEvent(event(EVENT_4, "INV-40021", "INVOICE", "288.00"));
+
+        // It is what an AP clerk quotes back to the vendor; a number of our own would be
+        // meaningless in that conversation.
+        assertThat(captured().getBillNumber()).isEqualTo("INV-40021");
+        assertThat(captured().getPurchaseOrderNumber()).isEqualTo("PO-778");
+    }
+
+    @Test
+    @DisplayName("a credit note is recorded as money owed back")
+    void creditNoteIsNegative() {
+        listener.onSupplierEvent(event(EVENT_5, "CN-9", "CREDIT_NOTE", "50.00"));
+
+        // The sign comes from the document type, not from the figure: a vendor may state a credit
+        // as a positive number on a document that declares itself a credit note.
+        assertThat(captured().getTotalAmount()).isEqualByComparingTo("-50.00");
+    }
+
+    @Test
+    @DisplayName("the same invoice fetched again does not become a second bill")
+    void refetchDoesNotDuplicateTheDebt() {
+        VendorBill existing = new VendorBill();
+        existing.setTotalAmount(new BigDecimal("288.00"));
+        when(vendorBillRepository.findByVendorIdAndBillNumber(PROFILE, "INV-1")).thenReturn(Optional.of(existing));
+
+        listener.onSupplierEvent(event(EVENT_6, "INV-1", "INVOICE", "288.00"));
+
+        // A re-fetch carries a new event id, so the event guard would not catch it. This is the
+        // guard that stops the business being billed twice.
+        verify(vendorBillRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("a re-issue for a different amount is flagged, not silently overwritten")
+    void reissueAtADifferentAmountIsFlagged() {
+        VendorBill existing = new VendorBill();
+        existing.setTotalAmount(new BigDecimal("288.00"));
+        existing.setStatus(VendorBillStatus.PENDING_RECEIPT_MATCH);
+        when(vendorBillRepository.findByVendorIdAndBillNumber(PROFILE, "INV-1")).thenReturn(Optional.of(existing));
+
+        listener.onSupplierEvent(event(EVENT_7, "INV-1", "INVOICE", "412.00"));
+
+        // Overwriting would erase a change somebody may already have approved against.
+        assertThat(existing.getStatus()).isEqualTo(VendorBillStatus.MATCH_EXCEPTION);
+        assertThat(existing.getTotalAmount()).isEqualByComparingTo("288.00");
+    }
+
+    @Test
+    @DisplayName("a redelivered event changes nothing")
+    void replayIsANoOp() {
+        when(processedEventRepository.existsById(EVENT_1)).thenReturn(true);
+
+        listener.onSupplierEvent(event(EVENT_1, "INV-1", "INVOICE", "288.00"));
+
+        verify(vendorBillRepository, never()).save(any());
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("transient database trouble is retried, not swallowed")
+    void transientFailureIsRethrown() {
+        when(vendorBillRepository.save(any())).thenThrow(new QueryTimeoutException("statement timed out"));
+
+        assertThatThrownBy(() -> listener.onSupplierEvent(event(EVENT_8, "INV-8", "INVOICE", "288.00")))
+                .isInstanceOf(QueryTimeoutException.class);
+
+        // The supplier side has already published this invoice and will not publish it again;
+        // marking it processed would lose a vendor debt permanently.
+        verify(processedEventRepository, never()).save(any());
+    }
+}

--- a/pos-accounting/src/test/java/com/positivity/accounting/internal/service/SupplierInvoiceEventsListenerTest.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/internal/service/SupplierInvoiceEventsListenerTest.java
@@ -204,4 +204,38 @@ class SupplierInvoiceEventsListenerTest {
         // marking it processed would lose a vendor debt permanently.
         verify(processedEventRepository, never()).save(any());
     }
+
+    @Test
+    @DisplayName("an invoice with no readable total is flagged, not filed as a nil bill")
+    void absentTotalIsFlaggedNotZero() {
+        String noTotal = """
+            {"eventId":"%s","eventType":"supplier.invoice.received","payload":{
+              "vendorProfileId":"%s","supplierRef":"michelin-de","vendorInvoiceNumber":"INV-X",
+              "invoiceDate":"2026-08-14","type":"INVOICE","currency":"EUR",
+              "totalNetAmount":null,"totalTaxAmount":null,"totalGrossAmount":null,
+              "vendorOrderReference":null,"occurredAt":"2026-08-16T08:00:00Z","lines":[]}}
+            """.formatted(EVENT_1, PROFILE);
+
+        listener.onSupplierEvent(noTotal);
+
+        // The codec records an unreadable amount as absent precisely so it stays distinguishable
+        // from a nil invoice. Filing it as a zero-value bill would undo that: it looks settled,
+        // sits at the bottom of every ageing report, and is noticed when the vendor chases payment.
+        assertThat(captured().getStatus()).isEqualTo(VendorBillStatus.MATCH_EXCEPTION);
+    }
+
+    @Test
+    @DisplayName("a non-transient database failure is retried, not acknowledged")
+    void nonTransientDatabaseFailureIsRethrown() {
+        when(vendorBillRepository.save(any()))
+                .thenThrow(new org.springframework.dao.DataIntegrityViolationException("value too long"));
+
+        assertThatThrownBy(() -> listener.onSupplierEvent(event(EVENT_2, "INV-2", "INVOICE", "288.00")))
+                .isInstanceOf(org.springframework.dao.DataAccessException.class);
+
+        // A column-length violation is not a malformed message. Acknowledging it would lose a
+        // vendor debt permanently: the supplier side has already published this invoice and will
+        // not publish it again.
+        verify(processedEventRepository, never()).save(any());
+    }
 }

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierInvoiceLine.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierInvoiceLine.java
@@ -1,0 +1,30 @@
+package com.positivity.domainevents.supplier;
+
+import java.math.BigDecimal;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One line of a {@link SupplierInvoiceReceivedV1}, as the vendor stated it.
+ *
+ * <p>The article is named however the vendor names it. Resolving that to a catalog product is the
+ * consumer's problem and may fail; an invoice whose articles cannot be matched is still an invoice
+ * that has to be paid, so nothing here is withheld for being unresolvable.
+ *
+ * @param lineNumber           position on the document
+ * @param articleEan           EAN as the vendor stated it, when given
+ * @param supplierArticleCode  the vendor's own article code, when given
+ * @param quantity             quantity invoiced, when given
+ * @param unitPrice            unit price as stated
+ * @param lineAmount           the line's net amount as stated; not derived from quantity × price,
+ *                             which would silently disagree with the vendor over rounding
+ * @param vendorOrderReference the vendor's order reference for this line, where it differs from the
+ *                             document's
+ */
+public record SupplierInvoiceLine(
+        int lineNumber,
+        @Nullable String articleEan,
+        @Nullable String supplierArticleCode,
+        @Nullable Integer quantity,
+        @Nullable BigDecimal unitPrice,
+        @Nullable BigDecimal lineAmount,
+        @Nullable String vendorOrderReference) {}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierInvoiceReceivedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierInvoiceReceivedV1.java
@@ -1,0 +1,99 @@
+package com.positivity.domainevents.supplier;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A vendor AR document, published on {@code supplier.events.v1} (CAP-321 #1227, ADR-0049 §3).
+ *
+ * <h2>What this is and is not</h2>
+ *
+ * It is what the vendor said it is owed, transcribed. It is not a posting instruction: what accounts
+ * it touches, when it hits the ledger and whether anybody has agreed to pay it are pos-accounting's,
+ * and this fact deliberately says nothing about them. pos-supplier's scope ends here.
+ *
+ * <h2>Identity, because the same invoice arrives more than once</h2>
+ *
+ * Fetch windows overlap on re-run by design (ADR-0052 §5) — that is what makes a failed fetch safe
+ * to repeat. So the same document is republished, and the consumer must key on
+ * {@code (vendorProfileId, vendorInvoiceNumber, invoiceDate)} rather than on the event. An AP ledger
+ * that counted a redelivery as a second debt would pay twice.
+ *
+ * <h2>Amounts as stated</h2>
+ *
+ * Totals are the vendor's own, not derived from the lines, and may disagree with them. That
+ * disagreement is information — it is the sort of thing an AP clerk is employed to notice — and
+ * silently reconciling it here would destroy the evidence.
+ *
+ * @param vendorProfileId       the vendor profile the document was fetched from
+ * @param supplierRef           that profile's alias at fetch time; descriptive, never a key
+ * @param vendorInvoiceNumber   the vendor's own document number
+ * @param invoiceDate           the vendor's issue date
+ * @param type                  {@code INVOICE} for money owed to the vendor, {@code CREDIT_NOTE}
+ *                              for money owed back. Never inferred from the sign of an amount
+ * @param currency              ISO 4217 code as stated; an amount without one is not a sum of money
+ * @param totalNetAmount        taxable amount as stated, when given
+ * @param totalTaxAmount        tax amount as stated, when given
+ * @param totalGrossAmount      the total the vendor expects to be paid, when given
+ * @param vendorOrderReference  the vendor's order reference, where it gave one. Resolving it to a
+ *                              purchase order is the consumer's job; an unresolvable reference is
+ *                              not a reason to withhold the invoice
+ * @param occurredAt            when the document was fetched
+ * @param lines                 the document's lines, as stated
+ */
+public record SupplierInvoiceReceivedV1(
+        @NonNull UUID vendorProfileId,
+        @NonNull String supplierRef,
+        @NonNull String vendorInvoiceNumber,
+        @NonNull LocalDate invoiceDate,
+        @NonNull Type type,
+        @NonNull String currency,
+        @Nullable BigDecimal totalNetAmount,
+        @Nullable BigDecimal totalTaxAmount,
+        @Nullable BigDecimal totalGrossAmount,
+        @Nullable String vendorOrderReference,
+        @NonNull Instant occurredAt,
+        @NonNull List<SupplierInvoiceLine> lines) {
+
+    /** Event type of this payload on {@code supplier.events.v1}. */
+    public static final String EVENT_TYPE = "supplier.invoice.received";
+
+    /** Payload schema version; additive changes only within v1 (ADR-0044 §3). */
+    public static final int SCHEMA_VERSION = 1;
+
+    /**
+     * Which way the money runs.
+     *
+     * <p>An enum rather than a validated string, so a value outside these two cannot be constructed
+     * at all. The direction of a payment is not something to discover at runtime.
+     */
+    public enum Type {
+        /** Money owed to the vendor. */
+        INVOICE,
+        /** Money owed back by the vendor. */
+        CREDIT_NOTE
+    }
+
+    public SupplierInvoiceReceivedV1 {
+        Objects.requireNonNull(vendorProfileId, "vendorProfileId must not be null");
+        Objects.requireNonNull(supplierRef, "supplierRef must not be null");
+        Objects.requireNonNull(vendorInvoiceNumber, "vendorInvoiceNumber must not be null");
+        Objects.requireNonNull(invoiceDate, "invoiceDate must not be null");
+        Objects.requireNonNull(type, "type must not be null");
+        Objects.requireNonNull(currency, "currency must not be null");
+        Objects.requireNonNull(occurredAt, "occurredAt must not be null");
+        Objects.requireNonNull(lines, "lines must not be null");
+        lines = List.copyOf(lines);
+    }
+
+    /** Whether this document increases what is owed to the vendor. */
+    public boolean isPayable() {
+        return type == Type.INVOICE;
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb3/EdiwheelB33InvoiceCodec.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb3/EdiwheelB33InvoiceCodec.java
@@ -246,7 +246,17 @@ public class EdiwheelB33InvoiceCodec implements SupplierAdapterCodec {
             return null;
         }
         BigDecimal value = decimal(article.invoicedQuantity.quantityValue);
-        return value == null ? null : value.intValue();
+        if (value == null) {
+            return null;
+        }
+        try {
+            // Exact, so "12.000" is twelve and "1.9" is not one. Truncating would quietly restate
+            // what the vendor invoiced, and the line would then disagree with its own amount.
+            return value.intValueExact();
+        } catch (ArithmeticException e) {
+            log.warn("Vendor invoice line carries a non-whole quantity '{}'; recorded as absent", value);
+            return null;
+        }
     }
 
     private static @Nullable String orderReferenceOf(InvoiceB33Wire.@Nullable HeaderReferences references) {
@@ -272,7 +282,10 @@ public class EdiwheelB33InvoiceCodec implements SupplierAdapterCodec {
             return null;
         }
         try {
-            return new BigDecimal(value);
+            // Comma as the decimal separator, which the EDIWheel norms use and which every sibling
+            // codec already normalises. Without this a perfectly good "240,00" would be recorded as
+            // an unreadable amount, and the invoice would arrive with no total at all.
+            return new BigDecimal(value.replace(',', '.'));
         } catch (NumberFormatException e) {
             log.warn("Vendor invoice carries an unreadable amount '{}'; recorded as absent", value);
             return null;

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb3/EdiwheelB33InvoiceCodec.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb3/EdiwheelB33InvoiceCodec.java
@@ -1,0 +1,289 @@
+package com.positivity.supplier.internal.adapter.ediwheelb3;
+
+import com.positivity.supplier.internal.adapter.ediwheelxml.EdiwheelXmlSupport;
+import com.positivity.supplier.internal.domain.model.PartyContext;
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierInvoice;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.spi.SupplierAdapterCodec;
+import jakarta.xml.bind.JAXBContext;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * EDIWheel Invoice B3.3: the vendor's AR documents for a date window (CAP-321 #1227).
+ *
+ * <h2>Amounts are transcribed, never recalculated</h2>
+ *
+ * Every monetary figure is taken as the vendor stated it. Totals are not derived from the lines and
+ * lines are not reconciled against totals, even where they disagree — a vendor invoice is a claim
+ * about money owed, and an integration that quietly corrects it produces a number nobody can trace
+ * to a document. A disagreement is something for a person to see, not for this codec to resolve.
+ *
+ * <h2>Document type decides the sign of the claim</h2>
+ *
+ * The norm distinguishes four AR documents by code, and getting the mapping wrong inverts a debt:
+ * {@code 380} commercial invoice and {@code 84} debit adjustment are money owed to the vendor;
+ * {@code 381} credit note and {@code 83} credit adjustment are money owed back. A code this build
+ * does not recognise is rejected rather than defaulted, because guessing the direction of a payment
+ * is worse than not importing it.
+ */
+@Component
+public class EdiwheelB33InvoiceCodec implements SupplierAdapterCodec {
+
+    /** The window bounds the norm expects: {@code yyyy-MM-dd}. */
+    private static final DateTimeFormatter WINDOW_DATE = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    /** Document type codes that mean money owed to the vendor. */
+    private static final Set<String> INVOICE_CODES = Set.of("380", "84");
+
+    /** Document type codes that mean money owed back by the vendor. */
+    private static final Set<String> CREDIT_NOTE_CODES = Set.of("381", "83");
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(EdiwheelB33InvoiceCodec.class);
+
+    private static final JAXBContext CONTEXT = EdiwheelXmlSupport.contextFor(InvoiceB33Wire.InvoiceList.class);
+
+    @Override
+    @NonNull
+    public SupplierCapability capability() {
+        return SupplierCapability.INVOICE_FETCH;
+    }
+
+    @Override
+    @NonNull
+    public ProtocolFamily family() {
+        return ProtocolFamily.EDIWHEEL_B;
+    }
+
+    @Override
+    @NonNull
+    public ProtocolVersion version() {
+        return ProtocolVersion.B3_3;
+    }
+
+    /**
+     * Builds the windowed fetch.
+     *
+     * <p>Marked idempotent: asking again for the same window is a read of vendor state with no
+     * commercial effect, which is what lets the fetch retry freely and lets windows overlap on
+     * re-run (ADR-0052 §5). Deduplication happens downstream, on the vendor's own invoice identity.
+     */
+    @NonNull
+    public SupplierRequestSpec buildRequest(
+            @NonNull PartyContext partyContext, @NonNull LocalDate fromDate, @NonNull LocalDate toDate) {
+        if (toDate.isBefore(fromDate)) {
+            throw new InvoiceDecodeException("Invoice window ends before it begins: " + fromDate + " to " + toDate);
+        }
+        Map<String, String> query = new LinkedHashMap<>();
+        query.put("invoiceIssueFromDate", WINDOW_DATE.format(fromDate));
+        query.put("invoiceIssueToDate", WINDOW_DATE.format(toDate));
+        query.put("buyerParty", partyContext.billingAccountNumber());
+        if (partyContext.billingAgencyCode() != null
+                && !partyContext.billingAgencyCode().isBlank()) {
+            query.put("agencyCode", partyContext.billingAgencyCode());
+        }
+        return new SupplierRequestSpec("GET", null, query, null, null, "application/xml", true);
+    }
+
+    /**
+     * Decodes a B3.3 response into canonical invoices.
+     *
+     * @throws InvoiceDecodeException when the body is not a B3.3 document, or the vendor signalled a
+     *     document-level error
+     */
+    @NonNull
+    public List<SupplierInvoice> decode(@Nullable String body) {
+        if (body == null || body.isBlank()) {
+            throw new InvoiceDecodeException("Invoice response body was empty");
+        }
+
+        InvoiceB33Wire.InvoiceList document;
+        try {
+            document = EdiwheelXmlSupport.unmarshal(CONTEXT, InvoiceB33Wire.InvoiceList.class, body);
+        } catch (Exception e) {
+            throw new InvoiceDecodeException("Invoice response was not a readable B3.3 document", e);
+        }
+
+        if (document.errorHead != null && document.errorHead.errorCode != null) {
+            throw new InvoiceDecodeException("Vendor refused the invoice window: " + document.errorHead.errorCode
+                    + (document.errorHead.errorText == null ? "" : " — " + document.errorHead.errorText));
+        }
+        if (document.invoices == null || document.invoices.isEmpty()) {
+            // A window with no invoices is an ordinary answer, not a failure: most days a vendor
+            // issues nothing.
+            return List.of();
+        }
+
+        List<SupplierInvoice> invoices = new ArrayList<>(document.invoices.size());
+        for (InvoiceB33Wire.Invoice wire : document.invoices) {
+            invoices.add(toCanonical(wire));
+        }
+        return invoices;
+    }
+
+    private static SupplierInvoice toCanonical(InvoiceB33Wire.Invoice wire) {
+        String number = trimToNull(wire.documentNumber);
+        if (number == null) {
+            // The invoice number is half the identity everything downstream deduplicates on.
+            // Without it the same document would be imported afresh on every overlapping window.
+            throw new InvoiceDecodeException("Vendor invoice carries no DocumentNumber");
+        }
+
+        List<SupplierInvoice.Line> lines = new ArrayList<>();
+        if (wire.lineLevel != null) {
+            int position = 0;
+            for (InvoiceB33Wire.Line line : wire.lineLevel) {
+                lines.add(toCanonicalLine(line, ++position));
+            }
+        }
+
+        return new SupplierInvoice(
+                number,
+                typeOf(wire.documentTypeCode, number),
+                issueDateOf(wire.issueDate, number),
+                currencyOf(wire.documentCurrency),
+                amount(wire.summary == null ? null : wire.summary.taxableAmount),
+                amount(wire.summary == null ? null : wire.summary.taxAmount),
+                // The vendor's own total, not the sum of the lines. Where they disagree the vendor's
+                // figure is what it will expect to be paid, and the disagreement is worth seeing.
+                amount(wire.summary == null ? null : wire.summary.totalAmount),
+                lines);
+    }
+
+    /**
+     * @param position 1-based position in the document, used when the vendor's own line id is
+     *     absent or not a number. The canonical line requires a number, and an invoice that arrives
+     *     with unusable line ids is still an invoice worth importing — the totals are what the AP
+     *     side pays on, and the line's place in the document is enough to refer to it by.
+     */
+    private static SupplierInvoice.Line toCanonicalLine(InvoiceB33Wire.Line wire, int position) {
+        InvoiceB33Wire.ArticleIdentification identification =
+                wire.article == null ? null : wire.article.articleIdentification;
+        return new SupplierInvoice.Line(
+                lineNumberOf(wire.lineId, position),
+                identification == null ? null : trimToNull(identification.eanuccArticleId),
+                identification == null ? null : trimToNull(identification.manufacturersArticleId),
+                quantity(wire.article),
+                wire.article == null || wire.article.priceDetails == null
+                        ? null
+                        : decimal(wire.article.priceDetails.priceAmount),
+                amount(wire.lineItemNetAmount),
+                orderReferenceOf(wire.references));
+    }
+
+    /**
+     * Which way the money runs.
+     *
+     * <p>Rejected rather than defaulted when unrecognised: an unknown code could be either
+     * direction, and importing a credit as a debt is a mistake that reaches a payment run.
+     */
+    private static SupplierInvoice.Type typeOf(@Nullable String documentTypeCode, String number) {
+        String code = trimToNull(documentTypeCode);
+        if (code == null) {
+            throw new InvoiceDecodeException("Vendor invoice " + number + " carries no DocumentTypeCode");
+        }
+        if (INVOICE_CODES.contains(code)) {
+            return SupplierInvoice.Type.INVOICE;
+        }
+        if (CREDIT_NOTE_CODES.contains(code)) {
+            return SupplierInvoice.Type.CREDIT_NOTE;
+        }
+        throw new InvoiceDecodeException("Vendor invoice " + number + " carries an unrecognised DocumentTypeCode '"
+                + code + "'; refusing to guess whether it is owed to or by the vendor");
+    }
+
+    private static LocalDate issueDateOf(@Nullable String raw, String number) {
+        String value = trimToNull(raw);
+        if (value == null) {
+            throw new InvoiceDecodeException("Vendor invoice " + number + " carries no IssueDate");
+        }
+        try {
+            return LocalDate.parse(value, WINDOW_DATE);
+        } catch (DateTimeParseException e) {
+            throw new InvoiceDecodeException(
+                    "Vendor invoice " + number + " carries an unreadable IssueDate '" + value + "'", e);
+        }
+    }
+
+    private static String currencyOf(InvoiceB33Wire.@Nullable DocumentCurrency currency) {
+        String code = currency == null ? null : trimToNull(currency.currencyCode);
+        if (code == null) {
+            // An amount with no currency is not a sum of money. Defaulting to the profile's currency
+            // would let a foreign-currency invoice be paid as though it were domestic.
+            throw new InvoiceDecodeException("Vendor invoice carries no DocumentCurrency");
+        }
+        return code;
+    }
+
+    private static int lineNumberOf(@Nullable String rawLineId, int position) {
+        String value = trimToNull(rawLineId);
+        if (value == null) {
+            return position;
+        }
+        try {
+            int parsed = Integer.parseInt(value);
+            return parsed >= 1 ? parsed : position;
+        } catch (NumberFormatException e) {
+            return position;
+        }
+    }
+
+    private static @Nullable Integer quantity(InvoiceB33Wire.@Nullable Article article) {
+        if (article == null || article.invoicedQuantity == null) {
+            return null;
+        }
+        BigDecimal value = decimal(article.invoicedQuantity.quantityValue);
+        return value == null ? null : value.intValue();
+    }
+
+    private static @Nullable String orderReferenceOf(InvoiceB33Wire.@Nullable HeaderReferences references) {
+        if (references == null || references.orderReference == null) {
+            return null;
+        }
+        return trimToNull(references.orderReference.referenceId);
+    }
+
+    private static @Nullable BigDecimal amount(InvoiceB33Wire.@Nullable AmountType amount) {
+        return amount == null ? null : decimal(amount.amountValue);
+    }
+
+    /**
+     * An amount as stated, or null when it cannot be read.
+     *
+     * <p>Null rather than zero. Zero is a figure the vendor might genuinely have sent, and treating
+     * an unreadable amount as one would make a broken invoice indistinguishable from a nil invoice.
+     */
+    private static @Nullable BigDecimal decimal(@Nullable String raw) {
+        String value = trimToNull(raw);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException e) {
+            log.warn("Vendor invoice carries an unreadable amount '{}'; recorded as absent", value);
+            return null;
+        }
+    }
+
+    private static @Nullable String trimToNull(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb3/InvoiceB33Wire.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb3/InvoiceB33Wire.java
@@ -1,0 +1,192 @@
+package com.positivity.supplier.internal.adapter.ediwheelb3;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+/**
+ * Wire shape of EDIWheel Invoice B3.3 ({@code invoice_list}).
+ *
+ * <p>Deliberately a transcription of the norm rather than a model: every field is a {@code String},
+ * including the amounts. The canonical {@link
+ * com.positivity.supplier.internal.domain.model.SupplierInvoice} is where meaning is assigned, and
+ * parsing a number here would decide — silently, in the wrong place — what an unparseable amount
+ * means. An invoice is money owed, so an amount we cannot read must be visible as such rather than
+ * quietly becoming zero.
+ *
+ * <p>Only the fields the canonical model needs are declared. JAXB ignores the rest, and the norm
+ * carries a great deal this integration has no use for (attachments, environment register ids,
+ * allowance and charge breakdowns).
+ */
+final class InvoiceB33Wire {
+
+    private InvoiceB33Wire() {}
+
+    /** {@code invoice_list}: the document the vendor returns for a date window. */
+    @XmlRootElement(name = "invoice_list")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class InvoiceList {
+
+        @XmlElement(name = "DocumentID")
+        String documentId;
+
+        @XmlElement(name = "Variant")
+        String variant;
+
+        @XmlElement(name = "NumberOfMessages")
+        String numberOfMessages;
+
+        @XmlElement(name = "ErrorHead")
+        ErrorHead errorHead;
+
+        @XmlElement(name = "invoice")
+        List<Invoice> invoices;
+    }
+
+    /** Document-level failure. Present instead of invoices when the vendor refuses the window. */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class ErrorHead {
+
+        @XmlElement(name = "ErrorCode")
+        String errorCode;
+
+        @XmlElement(name = "ErrorText")
+        String errorText;
+    }
+
+    /** One vendor AR document: an invoice, a credit note, or a financial adjustment. */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class Invoice {
+
+        @XmlElement(name = "IssueDate")
+        String issueDate;
+
+        @XmlElement(name = "DocumentNumber")
+        String documentNumber;
+
+        /** 380 invoice, 381 credit note, 83 credit adjustment, 84 debit adjustment. */
+        @XmlElement(name = "DocumentTypeCode")
+        String documentTypeCode;
+
+        @XmlElement(name = "DocumentFunctionCode")
+        String documentFunctionCode;
+
+        @XmlElement(name = "DocumentCurrency")
+        DocumentCurrency documentCurrency;
+
+        @XmlElement(name = "References")
+        HeaderReferences references;
+
+        @XmlElement(name = "LineLevel")
+        List<Line> lineLevel;
+
+        @XmlElement(name = "Summary")
+        Summary summary;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class DocumentCurrency {
+
+        @XmlElement(name = "CurrencyCode")
+        String currencyCode;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class HeaderReferences {
+
+        @XmlElement(name = "CustomerReference")
+        Reference customerReference;
+
+        @XmlElement(name = "OrderReference")
+        Reference orderReference;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class Reference {
+
+        @XmlElement(name = "ReferenceID")
+        String referenceId;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class Line {
+
+        @XmlElement(name = "LineID")
+        String lineId;
+
+        @XmlElement(name = "References")
+        HeaderReferences references;
+
+        @XmlElement(name = "LineItemNetAmount")
+        AmountType lineItemNetAmount;
+
+        @XmlElement(name = "Article")
+        Article article;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class Article {
+
+        @XmlElement(name = "ArticleIdentification")
+        ArticleIdentification articleIdentification;
+
+        @XmlElement(name = "InvoicedQuantity")
+        QuantityType invoicedQuantity;
+
+        @XmlElement(name = "PriceDetails")
+        PriceDetails priceDetails;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class ArticleIdentification {
+
+        @XmlElement(name = "EANUCCArticleID")
+        String eanuccArticleId;
+
+        @XmlElement(name = "ManufacturersArticleID")
+        String manufacturersArticleId;
+
+        @XmlElement(name = "BuyersArticleID")
+        String buyersArticleId;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class QuantityType {
+
+        @XmlElement(name = "QuantityValue")
+        String quantityValue;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class PriceDetails {
+
+        @XmlElement(name = "PriceAmount")
+        String priceAmount;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class AmountType {
+
+        @XmlElement(name = "AmountValue")
+        String amountValue;
+    }
+
+    /** Document totals as the vendor states them; never recomputed from the lines. */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    static class Summary {
+
+        @XmlElement(name = "TotalAmount")
+        AmountType totalAmount;
+
+        @XmlElement(name = "TaxableAmount")
+        AmountType taxableAmount;
+
+        @XmlElement(name = "TaxAmount")
+        AmountType taxAmount;
+
+        @XmlElement(name = "TotalLineItemsAmount")
+        AmountType totalLineItemsAmount;
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb3/InvoiceDecodeException.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb3/InvoiceDecodeException.java
@@ -1,0 +1,19 @@
+package com.positivity.supplier.internal.adapter.ediwheelb3;
+
+/**
+ * Thrown when a B3.3 response cannot be read as vendor AR documents (CAP-321 #1227).
+ *
+ * <p>Every case is a refusal to import money on a guess: an unrecognised document type, an invoice
+ * with no number to deduplicate on, an amount with no currency. A vendor invoice that reaches an AP
+ * ledger wrong is worse than one that does not arrive, because the second is noticed.
+ */
+public class InvoiceDecodeException extends RuntimeException {
+
+    public InvoiceDecodeException(String message) {
+        super(message);
+    }
+
+    public InvoiceDecodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb3/package-info.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb3/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * EDIWheel Invoice B3.3 wire types and codec (CAP-321 #1227).
+ *
+ * <h2>Why a package of its own</h2>
+ *
+ * The sibling {@code ediwheelb} package carries the JSON B-family codecs, which want no XML schema.
+ * B3.3 is XML, and its documents live in {@code http://www.reifen.net} — the same namespace as every
+ * other EDIWheel document. Declaring that at package level is what lets each element be written
+ * once without a namespace on every annotation, and it pairs with the shared reader that rewrites
+ * incoming documents into that namespace rather than requiring vendors to arrive in it.
+ *
+ * <p>The wire types are deliberately package-private and made of strings, including the amounts, so
+ * a vendor type can never escape into the domain, an event payload or an API contract, and so no
+ * decision about what an unreadable figure means gets taken here (ADR-0051 §5).
+ */
+@jakarta.xml.bind.annotation.XmlSchema(
+        namespace = "http://www.reifen.net",
+        elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package com.positivity.supplier.internal.adapter.ediwheelb3;

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/SupplierInvoiceEntity.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/SupplierInvoiceEntity.java
@@ -1,0 +1,100 @@
+package com.positivity.supplier.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * A vendor AR document as fetched (CAP-321 #1227).
+ *
+ * <p>Persisted before it is published, so the fact has something durable behind it and a consumer
+ * that asks "what did the vendor actually send" has an answer that is not a Kafka retention window.
+ *
+ * <p>Amounts are the vendor's, stored as sent. Nothing recalculates them, including where the lines
+ * do not sum to the total: that disagreement is what an AP clerk is employed to notice, and
+ * reconciling it here would destroy the evidence before anyone saw it.
+ */
+@Entity
+@Table(name = "supplier_invoice")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SupplierInvoiceEntity {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "supplier_invoice_id")
+    private UUID supplierInvoiceId;
+
+    @Column(name = "vendor_profile_id", nullable = false)
+    private UUID vendorProfileId;
+
+    /** The profile's alias at fetch time — a snapshot for reading, never a key. */
+    @Column(name = "supplier_ref", nullable = false, length = 100)
+    private String supplierRef;
+
+    @Column(name = "vendor_invoice_number", nullable = false, length = 70)
+    private String vendorInvoiceNumber;
+
+    @Column(name = "invoice_date", nullable = false)
+    private LocalDate invoiceDate;
+
+    /** {@code INVOICE} or {@code CREDIT_NOTE}: which way the money runs. */
+    @Column(name = "invoice_type", nullable = false, length = 16)
+    private String invoiceType;
+
+    @Column(name = "currency", nullable = false, length = 3)
+    private String currency;
+
+    @Column(name = "total_net_amount", precision = 19, scale = 4)
+    private BigDecimal totalNetAmount;
+
+    @Column(name = "total_tax_amount", precision = 19, scale = 4)
+    private BigDecimal totalTaxAmount;
+
+    @Column(name = "total_gross_amount", precision = 19, scale = 4)
+    private BigDecimal totalGrossAmount;
+
+    @Column(name = "vendor_order_reference", length = 70)
+    private String vendorOrderReference;
+
+    @Column(name = "fetched_at", nullable = false)
+    private Instant fetchedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @OneToMany(mappedBy = "invoice", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<SupplierInvoiceLineEntity> lines = new ArrayList<>();
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/SupplierInvoiceLineEntity.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/SupplierInvoiceLineEntity.java
@@ -1,0 +1,70 @@
+package com.positivity.supplier.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/** One line of a fetched vendor invoice, as stated (CAP-321 #1227). */
+@Entity
+@Table(name = "supplier_invoice_line")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SupplierInvoiceLineEntity {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "supplier_invoice_line_id")
+    private UUID supplierInvoiceLineId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "supplier_invoice_id", nullable = false)
+    private SupplierInvoiceEntity invoice;
+
+    @Column(name = "line_number", nullable = false)
+    private Integer lineNumber;
+
+    @Column(name = "article_ean", length = 64)
+    private String articleEan;
+
+    @Column(name = "supplier_article_code", length = 64)
+    private String supplierArticleCode;
+
+    @Column(name = "quantity")
+    private Integer quantity;
+
+    @Column(name = "unit_price", precision = 19, scale = 4)
+    private BigDecimal unitPrice;
+
+    /** The line's net amount as stated; never derived from quantity × price. */
+    @Column(name = "line_amount", precision = 19, scale = 4)
+    private BigDecimal lineAmount;
+
+    @Column(name = "vendor_order_reference", length = 70)
+    private String vendorOrderReference;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceImporter.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceImporter.java
@@ -1,0 +1,186 @@
+package com.positivity.supplier.internal.invoice.service;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.DomainTopics;
+import com.positivity.domainevents.supplier.SupplierInvoiceLine;
+import com.positivity.domainevents.supplier.SupplierInvoiceReceivedV1;
+import com.positivity.shared.id.UUIDv7Generator;
+import com.positivity.supplier.internal.domain.model.SupplierInvoice;
+import com.positivity.supplier.internal.entity.SupplierInvoiceEntity;
+import com.positivity.supplier.internal.entity.SupplierInvoiceLineEntity;
+import com.positivity.supplier.internal.repository.SupplierInvoiceRepository;
+import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Turns fetched vendor invoices into stored documents and published facts (CAP-321 #1227).
+ *
+ * <h2>Why the same invoice arrives more than once</h2>
+ *
+ * Fetch windows overlap on re-run, deliberately: a fetch that failed halfway must be safe to simply
+ * repeat, and the only way to guarantee nothing was missed is to ask again for ground already
+ * covered (ADR-0052 §5). So a document arriving twice is the normal case, not an error — and the
+ * thing that must not happen twice is the <em>debt</em>. Identity is therefore the vendor's own:
+ * profile, invoice number, issue date. A second arrival is recognised and dropped here rather than
+ * published and deduplicated downstream, because a consumer that got that wrong would pay twice.
+ *
+ * <h2>What is not decided here</h2>
+ *
+ * Nothing about accounting. This module records what the vendor sent and says so; whether it posts,
+ * to which accounts, and whether anyone has agreed to pay it belong to pos-accounting, and are
+ * reached only through the published fact (ADR-0044 R1).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InvoiceImporter {
+
+    private static final String SOURCE = "pos-supplier";
+
+    private final SupplierInvoiceRepository invoiceRepository;
+    private final SupplierOutboxEventWriter outboxEventWriter;
+    private final Clock clock;
+
+    /**
+     * Stores and publishes every invoice in a fetched batch that has not been seen before.
+     *
+     * @return how many were new; the rest were already held from an earlier, overlapping window
+     */
+    @Transactional
+    public int importInvoices(
+            @NonNull UUID vendorProfileId, @NonNull String supplierRef, @NonNull List<SupplierInvoice> fetched) {
+        int imported = 0;
+        for (SupplierInvoice invoice : fetched) {
+            if (importOne(vendorProfileId, supplierRef, invoice)) {
+                imported++;
+            }
+        }
+        if (imported < fetched.size()) {
+            log.debug(
+                    "Vendor {}: {} of {} invoices were already held from an earlier window",
+                    supplierRef,
+                    fetched.size() - imported,
+                    fetched.size());
+        }
+        return imported;
+    }
+
+    private boolean importOne(UUID vendorProfileId, String supplierRef, SupplierInvoice invoice) {
+        boolean alreadyHeld = invoiceRepository
+                .findByVendorProfileIdAndVendorInvoiceNumberAndInvoiceDate(
+                        vendorProfileId, invoice.vendorInvoiceNumber(), invoice.invoiceDate())
+                .isPresent();
+        if (alreadyHeld) {
+            // Deliberately not updated. A vendor that re-issues under the same identity with
+            // different figures is telling us something an AP clerk needs to see, and quietly
+            // overwriting the first version would destroy the evidence of the change. The consumer
+            // raises that as a discrepancy against the bill it already created.
+            return false;
+        }
+
+        Instant now = Instant.now(clock);
+        SupplierInvoiceEntity entity = SupplierInvoiceEntity.builder()
+                .vendorProfileId(vendorProfileId)
+                .supplierRef(supplierRef)
+                .vendorInvoiceNumber(invoice.vendorInvoiceNumber())
+                .invoiceDate(invoice.invoiceDate())
+                .invoiceType(invoice.type().name())
+                .currency(invoice.currency())
+                .totalNetAmount(invoice.totalNetAmount())
+                .totalTaxAmount(invoice.totalTaxAmount())
+                .totalGrossAmount(invoice.totalGrossAmount())
+                .vendorOrderReference(headerOrderReference(invoice))
+                .fetchedAt(now)
+                .lines(new ArrayList<>())
+                .build();
+
+        for (SupplierInvoice.Line line : invoice.lines()) {
+            entity.getLines()
+                    .add(SupplierInvoiceLineEntity.builder()
+                            .invoice(entity)
+                            .lineNumber(line.lineNumber())
+                            .articleEan(line.articleEan())
+                            .supplierArticleCode(line.supplierArticleCode())
+                            .quantity(line.quantity())
+                            .unitPrice(line.unitPrice())
+                            .lineAmount(line.lineAmount())
+                            .vendorOrderReference(line.vendorOrderReference())
+                            .build());
+        }
+
+        SupplierInvoiceEntity saved = invoiceRepository.save(entity);
+        publish(saved, invoice, now);
+        log.info("Imported vendor invoice {} ({}) from {}", invoice.vendorInvoiceNumber(), invoice.type(), supplierRef);
+        return true;
+    }
+
+    /**
+     * The document-level order reference.
+     *
+     * <p>Taken from the first line that carries one, because the norm puts the reference on the
+     * lines and a vendor invoicing a single order repeats it on each. Where an invoice spans several
+     * orders this names only the first — enough for the consumer to attempt a match, and honest
+     * about the rest, which is why the per-line references travel too.
+     */
+    private static String headerOrderReference(SupplierInvoice invoice) {
+        return invoice.lines().stream()
+                .map(SupplierInvoice.Line::vendorOrderReference)
+                .filter(reference -> reference != null && !reference.isBlank())
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void publish(SupplierInvoiceEntity saved, SupplierInvoice invoice, Instant occurredAt) {
+        List<SupplierInvoiceLine> lines = new ArrayList<>(invoice.lines().size());
+        for (SupplierInvoice.Line line : invoice.lines()) {
+            lines.add(new SupplierInvoiceLine(
+                    line.lineNumber(),
+                    line.articleEan(),
+                    line.supplierArticleCode(),
+                    line.quantity(),
+                    line.unitPrice(),
+                    line.lineAmount(),
+                    line.vendorOrderReference()));
+        }
+
+        SupplierInvoiceReceivedV1 payload = new SupplierInvoiceReceivedV1(
+                saved.getVendorProfileId(),
+                saved.getSupplierRef(),
+                saved.getVendorInvoiceNumber(),
+                saved.getInvoiceDate(),
+                SupplierInvoiceReceivedV1.Type.valueOf(saved.getInvoiceType()),
+                saved.getCurrency(),
+                saved.getTotalNetAmount(),
+                saved.getTotalTaxAmount(),
+                saved.getTotalGrossAmount(),
+                saved.getVendorOrderReference(),
+                occurredAt,
+                lines);
+
+        outboxEventWriter.publish(
+                DomainTopics.events("supplier"),
+                new DomainEventEnvelope<>(
+                        UUIDv7Generator.generate(),
+                        SupplierInvoiceReceivedV1.EVENT_TYPE,
+                        SupplierInvoiceReceivedV1.SCHEMA_VERSION,
+                        // Keyed on our own record of the document, so a redelivery of this event and
+                        // a re-fetch of the same invoice are distinguishable: the first is the same
+                        // event id, the second never gets published at all.
+                        saved.getSupplierInvoiceId(),
+                        0L,
+                        occurredAt,
+                        SOURCE,
+                        null,
+                        SOURCE,
+                        payload));
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceImporter.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceImporter.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -117,7 +118,19 @@ public class InvoiceImporter {
                             .build());
         }
 
-        SupplierInvoiceEntity saved = invoiceRepository.save(entity);
+        SupplierInvoiceEntity saved;
+        try {
+            saved = invoiceRepository.saveAndFlush(entity);
+        } catch (DataIntegrityViolationException e) {
+            // Another instance stored this invoice between the check above and this insert. The
+            // unique identity did its job; the invoice is safely held either way. Letting this
+            // escape would fail the whole fetch over a document that is now correctly imported,
+            // and the retry would re-cover the same window to no purpose.
+            log.debug(
+                    "Vendor invoice {} was stored concurrently; treating as already held",
+                    invoice.vendorInvoiceNumber());
+            return false;
+        }
         publish(saved, invoice, now);
         log.info("Imported vendor invoice {} ({}) from {}", invoice.vendorInvoiceNumber(), invoice.type(), supplierRef);
         return true;

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/repository/SupplierInvoiceRepository.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/repository/SupplierInvoiceRepository.java
@@ -1,0 +1,20 @@
+package com.positivity.supplier.internal.repository;
+
+import com.positivity.supplier.internal.entity.SupplierInvoiceEntity;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SupplierInvoiceRepository extends JpaRepository<SupplierInvoiceEntity, UUID> {
+
+    /**
+     * Lookup by the vendor's own identity for the document.
+     *
+     * <p>This is what makes an overlapping fetch window safe. Windows are allowed to overlap on
+     * re-run so a failed fetch can simply be repeated (ADR-0052 §5), which means the same invoice
+     * arrives again by design rather than by accident.
+     */
+    Optional<SupplierInvoiceEntity> findByVendorProfileIdAndVendorInvoiceNumberAndInvoiceDate(
+            UUID vendorProfileId, String vendorInvoiceNumber, LocalDate invoiceDate);
+}

--- a/pos-supplier/src/main/resources/db/migration/V16__supplier_invoice.sql
+++ b/pos-supplier/src/main/resources/db/migration/V16__supplier_invoice.sql
@@ -1,0 +1,56 @@
+-- CAP-321 #1227: vendor AR documents fetched over EDIWheel Invoice B3.3.
+--
+-- The vendor's own figures, stored as sent. Nothing here is recalculated: the totals a vendor
+-- states are what it will expect to be paid, and an integration that quietly corrects them produces
+-- a number nobody can trace back to a document.
+
+CREATE TABLE supplier_invoice (
+    supplier_invoice_id   uuid PRIMARY KEY,
+    vendor_profile_id     uuid NOT NULL,
+    supplier_ref          varchar(100) NOT NULL,
+
+    -- The vendor's natural identity for the document. Fetch windows are allowed to overlap on
+    -- re-run (ADR-0052 §5), so the same invoice arrives more than once by design; this triple is
+    -- what makes the second arrival a no-op rather than a duplicate debt.
+    vendor_invoice_number varchar(70) NOT NULL,
+    invoice_date          date NOT NULL,
+
+    -- INVOICE or CREDIT_NOTE. Which way the money runs, decided from the vendor's document type
+    -- code and never defaulted: importing a credit as a debt reaches a payment run.
+    invoice_type          varchar(16) NOT NULL,
+
+    currency              varchar(3) NOT NULL,
+    total_net_amount      numeric(19, 4),
+    total_tax_amount      numeric(19, 4),
+    total_gross_amount    numeric(19, 4),
+
+    -- The vendor's order reference where it gave one; the link to a purchase order is resolved by
+    -- the consumer, not here.
+    vendor_order_reference varchar(70),
+
+    fetched_at            timestamp(6) with time zone NOT NULL,
+    created_at            timestamp(6) with time zone NOT NULL,
+    updated_at            timestamp(6) with time zone NOT NULL,
+
+    CONSTRAINT supplier_invoice_identity
+        UNIQUE (vendor_profile_id, vendor_invoice_number, invoice_date),
+    CONSTRAINT supplier_invoice_type_check
+        CHECK (invoice_type IN ('INVOICE', 'CREDIT_NOTE'))
+);
+
+CREATE INDEX idx_supplier_invoice_profile_date ON supplier_invoice (vendor_profile_id, invoice_date);
+
+CREATE TABLE supplier_invoice_line (
+    supplier_invoice_line_id uuid PRIMARY KEY,
+    supplier_invoice_id      uuid NOT NULL REFERENCES supplier_invoice (supplier_invoice_id),
+    line_number              integer NOT NULL,
+    article_ean              varchar(64),
+    supplier_article_code    varchar(64),
+    quantity                 integer,
+    unit_price               numeric(19, 4),
+    line_amount              numeric(19, 4),
+    vendor_order_reference   varchar(70),
+    created_at               timestamp(6) with time zone NOT NULL
+);
+
+CREATE INDEX idx_supplier_invoice_line_invoice ON supplier_invoice_line (supplier_invoice_id);

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheelb3/EdiwheelB33InvoiceCodecTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheelb3/EdiwheelB33InvoiceCodecTest.java
@@ -1,0 +1,199 @@
+package com.positivity.supplier.internal.adapter.ediwheelb3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.positivity.supplier.internal.domain.model.SupplierInvoice;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Reading a vendor's AR documents (CAP-321 #1227).
+ *
+ * <p>The tests that matter here are about money changing meaning in transit. A credit read as an
+ * invoice is a payment made instead of received; an amount silently defaulted to zero is a debt
+ * that disappears. Both are the kind of error that is only discovered by somebody reconciling a
+ * statement weeks later, so the codec refuses rather than guesses and these tests pin the refusals.
+ */
+@DisplayName("EdiwheelB33InvoiceCodec — reading vendor AR documents (#1227)")
+class EdiwheelB33InvoiceCodecTest {
+
+    private final EdiwheelB33InvoiceCodec codec = new EdiwheelB33InvoiceCodec();
+
+    private static String document(String documentTypeCode, String body) {
+        return """
+            <invoice_list xmlns="http://www.reifen.net">
+              <DocumentID>B3</DocumentID>
+              <Variant>3</Variant>
+              <invoice>
+                <IssueDate>2026-08-14</IssueDate>
+                <DocumentNumber>INV-40021</DocumentNumber>
+                <DocumentTypeCode>%s</DocumentTypeCode>
+                <DocumentCurrency><CurrencyCode>EUR</CurrencyCode></DocumentCurrency>
+                %s
+              </invoice>
+            </invoice_list>
+            """.formatted(documentTypeCode, body);
+    }
+
+    private static final String ONE_LINE_AND_TOTALS = """
+            <LineLevel>
+              <LineID>1</LineID>
+              <References><OrderReference><ReferenceID>PO-778</ReferenceID></OrderReference></References>
+              <LineItemNetAmount><AmountValue>240.00</AmountValue></LineItemNetAmount>
+              <Article>
+                <ArticleIdentification>
+                  <EANUCCArticleID>5012345678900</EANUCCArticleID>
+                  <ManufacturersArticleID>MI-2055516</ManufacturersArticleID>
+                </ArticleIdentification>
+                <InvoicedQuantity><QuantityValue>4</QuantityValue></InvoicedQuantity>
+                <PriceDetails><PriceAmount>60.00</PriceAmount></PriceDetails>
+              </Article>
+            </LineLevel>
+            <Summary>
+              <TotalAmount><AmountValue>288.00</AmountValue></TotalAmount>
+              <TaxableAmount><AmountValue>240.00</AmountValue></TaxableAmount>
+              <TaxAmount><AmountValue>48.00</AmountValue></TaxAmount>
+            </Summary>
+            """;
+
+    @Test
+    @DisplayName("an invoice is read with the vendor's own figures, not recomputed ones")
+    void amountsAreTranscribed() {
+        List<SupplierInvoice> invoices = codec.decode(document("380", ONE_LINE_AND_TOTALS));
+
+        assertThat(invoices).singleElement().satisfies(invoice -> {
+            assertThat(invoice.vendorInvoiceNumber()).isEqualTo("INV-40021");
+            assertThat(invoice.type()).isEqualTo(SupplierInvoice.Type.INVOICE);
+            assertThat(invoice.currency()).isEqualTo("EUR");
+            // The vendor's stated total, not 240 + 48 arrived at independently. Where a vendor's
+            // arithmetic disagrees with ours, what it will expect to be paid is its figure.
+            assertThat(invoice.totalGrossAmount()).isEqualByComparingTo("288.00");
+            assertThat(invoice.totalNetAmount()).isEqualByComparingTo("240.00");
+            assertThat(invoice.totalTaxAmount()).isEqualByComparingTo("48.00");
+            assertThat(invoice.lines()).singleElement().satisfies(line -> {
+                assertThat(line.articleEan()).isEqualTo("5012345678900");
+                assertThat(line.quantity()).isEqualTo(4);
+                assertThat(line.lineAmount()).isEqualByComparingTo("240.00");
+                assertThat(line.vendorOrderReference()).isEqualTo("PO-778");
+            });
+        });
+    }
+
+    @ParameterizedTest
+    @CsvSource({"380,INVOICE", "84,INVOICE", "381,CREDIT_NOTE", "83,CREDIT_NOTE"})
+    @DisplayName("the document type decides which way the money runs")
+    void documentTypeDecidesDirection(String code, SupplierInvoice.Type expected) {
+        assertThat(codec.decode(document(code, ONE_LINE_AND_TOTALS)).getFirst().type())
+                .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("an unrecognised document type is refused rather than assumed")
+    void unknownDocumentTypeIsRefused() {
+        // Either direction is possible, and importing a credit as a debt reaches a payment run.
+        assertThatThrownBy(() -> codec.decode(document("ZZ9", ONE_LINE_AND_TOTALS)))
+                .isInstanceOf(InvoiceDecodeException.class)
+                .hasMessageContaining("refusing to guess");
+    }
+
+    @Test
+    @DisplayName("an invoice with no number is refused: nothing could deduplicate it")
+    void missingInvoiceNumberIsRefused() {
+        String body = """
+            <invoice_list xmlns="http://www.reifen.net">
+              <invoice>
+                <IssueDate>2026-08-14</IssueDate>
+                <DocumentTypeCode>380</DocumentTypeCode>
+                <DocumentCurrency><CurrencyCode>EUR</CurrencyCode></DocumentCurrency>
+              </invoice>
+            </invoice_list>
+            """;
+
+        // Overlapping windows re-deliver the same document by design; without a number every
+        // re-fetch would import it afresh as a new debt.
+        assertThatThrownBy(() -> codec.decode(body))
+                .isInstanceOf(InvoiceDecodeException.class)
+                .hasMessageContaining("DocumentNumber");
+    }
+
+    @Test
+    @DisplayName("an amount with no currency is refused: it is not a sum of money")
+    void missingCurrencyIsRefused() {
+        String body = """
+            <invoice_list xmlns="http://www.reifen.net">
+              <invoice>
+                <IssueDate>2026-08-14</IssueDate>
+                <DocumentNumber>INV-1</DocumentNumber>
+                <DocumentTypeCode>380</DocumentTypeCode>
+              </invoice>
+            </invoice_list>
+            """;
+
+        // Defaulting to the profile's currency would let a foreign-currency invoice be paid as
+        // though it were domestic.
+        assertThatThrownBy(() -> codec.decode(body))
+                .isInstanceOf(InvoiceDecodeException.class)
+                .hasMessageContaining("DocumentCurrency");
+    }
+
+    @Test
+    @DisplayName("an unreadable amount is absent, not zero")
+    void unreadableAmountIsNull() {
+        String summary = "<Summary><TotalAmount><AmountValue>n/a</AmountValue></TotalAmount></Summary>";
+
+        SupplierInvoice invoice = codec.decode(document("380", summary)).getFirst();
+
+        // Zero is a figure a vendor might genuinely send. Treating an unreadable amount as one
+        // would make a broken invoice indistinguishable from a nil one.
+        assertThat(invoice.totalGrossAmount()).isNull();
+    }
+
+    @Test
+    @DisplayName("a window the vendor refused is an error, not an empty result")
+    void documentLevelErrorIsRaised() {
+        String body = """
+            <invoice_list xmlns="http://www.reifen.net">
+              <ErrorHead><ErrorCode>E17</ErrorCode><ErrorText>window too wide</ErrorText></ErrorHead>
+            </invoice_list>
+            """;
+
+        // Silently returning nothing would advance the checkpoint past invoices never fetched.
+        assertThatThrownBy(() -> codec.decode(body))
+                .isInstanceOf(InvoiceDecodeException.class)
+                .hasMessageContaining("E17");
+    }
+
+    @Test
+    @DisplayName("a window with no invoices is an ordinary answer")
+    void emptyWindowIsNotAFailure() {
+        String body = """
+            <invoice_list xmlns="http://www.reifen.net">
+              <DocumentID>B3</DocumentID><Variant>3</Variant>
+            </invoice_list>
+            """;
+
+        // Most days a vendor issues nothing.
+        assertThat(codec.decode(body)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("lines are numbered by position when the vendor's own ids are unusable")
+    void linesFallBackToPosition() {
+        String twoLines = """
+                <LineLevel><LineID>abc</LineID>
+                  <LineItemNetAmount><AmountValue>10.00</AmountValue></LineItemNetAmount></LineLevel>
+                <LineLevel><LineID>def</LineID>
+                  <LineItemNetAmount><AmountValue>20.00</AmountValue></LineItemNetAmount></LineLevel>
+                """;
+
+        // An invoice with unusable line ids is still an invoice worth importing: the totals are
+        // what AP pays on, and position is enough to refer to a line by.
+        assertThat(codec.decode(document("380", twoLines)).getFirst().lines())
+                .extracting(SupplierInvoice.Line::lineNumber)
+                .containsExactly(1, 2);
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheelb3/EdiwheelB33InvoiceCodecTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheelb3/EdiwheelB33InvoiceCodecTest.java
@@ -196,4 +196,64 @@ class EdiwheelB33InvoiceCodecTest {
                 .extracting(SupplierInvoice.Line::lineNumber)
                 .containsExactly(1, 2);
     }
+
+    @Test
+    @DisplayName("comma decimals are read, as every sibling codec already reads them")
+    void commaDecimalsAreRead() {
+        String summary = "<Summary><TotalAmount><AmountValue>240,00</AmountValue></TotalAmount></Summary>";
+
+        // The norms use a comma separator. Refusing it would record a perfectly good figure as
+        // unreadable and land an invoice with no total at all.
+        assertThat(codec.decode(document("380", summary)).getFirst().totalGrossAmount())
+                .isEqualByComparingTo("240.00");
+    }
+
+    @Test
+    @DisplayName("a grouped figure is not guessed at")
+    void groupedFigureIsAbsent() {
+        String summary = "<Summary><TotalAmount><AmountValue>1.234,56</AmountValue></TotalAmount></Summary>";
+
+        // "1.234" is a thousand in one convention and one-and-a-bit in another, and nothing in the
+        // document says which. A wrong guess here is off by a factor of a thousand on a payment,
+        // so it is recorded as unreadable and somebody looks — the same rule the rest of this
+        // codec follows, and the same behaviour every sibling codec has.
+        assertThat(codec.decode(document("380", summary)).getFirst().totalGrossAmount())
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("a whole quantity written with decimals is that quantity")
+    void wholeQuantityWithDecimalsIsExact() {
+        String line = """
+                <LineLevel><LineID>1</LineID><Article>
+                  <InvoicedQuantity><QuantityValue>12,000</QuantityValue></InvoicedQuantity>
+                </Article></LineLevel>
+                """;
+
+        assertThat(codec.decode(document("380", line))
+                        .getFirst()
+                        .lines()
+                        .getFirst()
+                        .quantity())
+                .isEqualTo(12);
+    }
+
+    @Test
+    @DisplayName("a non-whole quantity is absent, never truncated")
+    void fractionalQuantityIsAbsent() {
+        String line = """
+                <LineLevel><LineID>1</LineID><Article>
+                  <InvoicedQuantity><QuantityValue>1,9</QuantityValue></InvoicedQuantity>
+                </Article></LineLevel>
+                """;
+
+        // Truncating to 1 would restate what the vendor invoiced, and the line would then disagree
+        // with its own amount.
+        assertThat(codec.decode(document("380", line))
+                        .getFirst()
+                        .lines()
+                        .getFirst()
+                        .quantity())
+                .isNull();
+    }
 }

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/invoice/service/InvoiceImporterTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/invoice/service/InvoiceImporterTest.java
@@ -1,0 +1,158 @@
+package com.positivity.supplier.internal.invoice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.supplier.SupplierInvoiceReceivedV1;
+import com.positivity.supplier.internal.domain.model.SupplierInvoice;
+import com.positivity.supplier.internal.entity.SupplierInvoiceEntity;
+import com.positivity.supplier.internal.repository.SupplierInvoiceRepository;
+import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Importing fetched vendor invoices (CAP-321 #1227).
+ *
+ * <p>The whole of this class exists for one property: a debt is recorded once. Fetch windows
+ * overlap deliberately, so the same invoice arrives repeatedly by design — and every one of those
+ * arrivals is an opportunity to bill the business twice.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("InvoiceImporter — a debt recorded once (#1227)")
+class InvoiceImporterTest {
+
+    private static final UUID PROFILE = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f6a01");
+    private static final String REF = "michelin-de";
+    private static final Instant NOW = Instant.parse("2026-08-16T08:00:00Z");
+    private static final LocalDate ISSUED = LocalDate.of(2026, 8, 14);
+
+    @Mock
+    private SupplierInvoiceRepository invoiceRepository;
+
+    @Mock
+    private SupplierOutboxEventWriter outboxEventWriter;
+
+    private InvoiceImporter importer;
+
+    @BeforeEach
+    void setUp() {
+        importer = new InvoiceImporter(invoiceRepository, outboxEventWriter, Clock.fixed(NOW, ZoneOffset.UTC));
+        when(invoiceRepository.findByVendorProfileIdAndVendorInvoiceNumberAndInvoiceDate(any(), any(), any()))
+                .thenReturn(Optional.empty());
+        when(invoiceRepository.save(any())).thenAnswer(call -> {
+            SupplierInvoiceEntity saved = call.getArgument(0);
+            saved.setSupplierInvoiceId(UUID.randomUUID());
+            return saved;
+        });
+    }
+
+    private static SupplierInvoice invoice(String number, SupplierInvoice.Type type, String total) {
+        return new SupplierInvoice(
+                number,
+                type,
+                ISSUED,
+                "EUR",
+                new BigDecimal("240.00"),
+                new BigDecimal("48.00"),
+                new BigDecimal(total),
+                List.of(new SupplierInvoice.Line(
+                        1,
+                        "5012345678900",
+                        "MI-2055516",
+                        4,
+                        new BigDecimal("60.00"),
+                        new BigDecimal("240.00"),
+                        "PO-778")));
+    }
+
+    private SupplierInvoiceReceivedV1 published() {
+        ArgumentCaptor<DomainEventEnvelope<?>> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+        verify(outboxEventWriter).publish(eq("supplier.events.v1"), captor.capture());
+        return (SupplierInvoiceReceivedV1) captor.getValue().payload();
+    }
+
+    @Test
+    @DisplayName("a new invoice is stored and published with the vendor's own figures")
+    void newInvoiceIsStoredAndPublished() {
+        int imported = importer.importInvoices(
+                PROFILE, REF, List.of(invoice("INV-1", SupplierInvoice.Type.INVOICE, "288.00")));
+
+        assertThat(imported).isEqualTo(1);
+        SupplierInvoiceReceivedV1 fact = published();
+        assertThat(fact.vendorInvoiceNumber()).isEqualTo("INV-1");
+        assertThat(fact.totalGrossAmount()).isEqualByComparingTo("288.00");
+        assertThat(fact.isPayable()).isTrue();
+        // The order reference travels so the consumer can attempt a match; resolving it is not this
+        // module's business, and an unresolvable one is no reason to withhold the invoice.
+        assertThat(fact.vendorOrderReference()).isEqualTo("PO-778");
+    }
+
+    @Test
+    @DisplayName("an invoice already held from an overlapping window is not published again")
+    void alreadyHeldInvoiceIsDropped() {
+        when(invoiceRepository.findByVendorProfileIdAndVendorInvoiceNumberAndInvoiceDate(PROFILE, "INV-1", ISSUED))
+                .thenReturn(Optional.of(new SupplierInvoiceEntity()));
+
+        int imported = importer.importInvoices(
+                PROFILE, REF, List.of(invoice("INV-1", SupplierInvoice.Type.INVOICE, "288.00")));
+
+        // Windows overlap so a failed fetch can simply be repeated. Publishing again would put the
+        // same debt in front of AP a second time, with only its own guard between that and a
+        // duplicate payment.
+        assertThat(imported).isZero();
+        verify(invoiceRepository, never()).save(any());
+        verify(outboxEventWriter, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("a credit note is published as one, not as a negative invoice")
+    void creditNoteKeepsItsType() {
+        importer.importInvoices(PROFILE, REF, List.of(invoice("CN-9", SupplierInvoice.Type.CREDIT_NOTE, "50.00")));
+
+        SupplierInvoiceReceivedV1 fact = published();
+        // The direction is carried as a type rather than as a sign, so a consumer cannot mistake a
+        // refund for a debt by reading the amount alone.
+        assertThat(fact.type()).isEqualTo(SupplierInvoiceReceivedV1.Type.CREDIT_NOTE);
+        assertThat(fact.isPayable()).isFalse();
+        assertThat(fact.totalGrossAmount()).isEqualByComparingTo("50.00");
+    }
+
+    @Test
+    @DisplayName("a batch imports what is new and skips what is not")
+    void mixedBatchImportsOnlyTheNew() {
+        when(invoiceRepository.findByVendorProfileIdAndVendorInvoiceNumberAndInvoiceDate(PROFILE, "INV-1", ISSUED))
+                .thenReturn(Optional.of(new SupplierInvoiceEntity()));
+
+        int imported = importer.importInvoices(
+                PROFILE,
+                REF,
+                List.of(
+                        invoice("INV-1", SupplierInvoice.Type.INVOICE, "288.00"),
+                        invoice("INV-2", SupplierInvoice.Type.INVOICE, "120.00")));
+
+        assertThat(imported).isEqualTo(1);
+        verify(invoiceRepository).save(any());
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/invoice/service/InvoiceImporterTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/invoice/service/InvoiceImporterTest.java
@@ -61,7 +61,7 @@ class InvoiceImporterTest {
         importer = new InvoiceImporter(invoiceRepository, outboxEventWriter, Clock.fixed(NOW, ZoneOffset.UTC));
         when(invoiceRepository.findByVendorProfileIdAndVendorInvoiceNumberAndInvoiceDate(any(), any(), any()))
                 .thenReturn(Optional.empty());
-        when(invoiceRepository.save(any())).thenAnswer(call -> {
+        when(invoiceRepository.saveAndFlush(any())).thenAnswer(call -> {
             SupplierInvoiceEntity saved = call.getArgument(0);
             saved.setSupplierInvoiceId(UUID.randomUUID());
             return saved;
@@ -122,7 +122,7 @@ class InvoiceImporterTest {
         // same debt in front of AP a second time, with only its own guard between that and a
         // duplicate payment.
         assertThat(imported).isZero();
-        verify(invoiceRepository, never()).save(any());
+        verify(invoiceRepository, never()).saveAndFlush(any());
         verify(outboxEventWriter, never()).publish(any(), any());
     }
 
@@ -153,6 +153,25 @@ class InvoiceImporterTest {
                         invoice("INV-2", SupplierInvoice.Type.INVOICE, "120.00")));
 
         assertThat(imported).isEqualTo(1);
-        verify(invoiceRepository).save(any());
+        verify(invoiceRepository).saveAndFlush(any());
+    }
+
+    @Test
+    @DisplayName("an invoice stored concurrently does not fail the fetch")
+    void concurrentInsertIsTreatedAsAlreadyHeld() {
+        // doThrow, not when(...): stubbing through when() would invoke the mock and run the prior
+        // answer with a null argument.
+        org.mockito.Mockito.doThrow(new org.springframework.dao.DataIntegrityViolationException("duplicate key"))
+                .when(invoiceRepository)
+                .saveAndFlush(any());
+
+        int imported = importer.importInvoices(
+                PROFILE, REF, List.of(invoice("INV-1", SupplierInvoice.Type.INVOICE, "288.00")));
+
+        // Another instance won the insert between the check and the write. The unique identity did
+        // its job and the invoice is held either way; failing the whole fetch over a document that
+        // is now correctly imported would just re-cover the window to no purpose.
+        assertThat(imported).isZero();
+        verify(outboxEventWriter, never()).publish(any(), any());
     }
 }


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:321`
- Parent STORY (durion): louisburroughs/durion#376
- Child issue: louisburroughs/durion-positivity-backend#1227
- Domain: `domain:positivity`, `domain:accounting`

## Contract References
- Contract guide entry (durion): `domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md` → supplier invoices
- Source spec: `durion/docs/ediwheel/EDIWHEEL Invoice PROD_0.yaml` (`GET /B3_3/invoices`)
- **New**: `supplier.invoice.received` v1 on `supplier.events.v1`
- Ledger update: durion PR #397

## Scope

The EDIWheel conversation had every stage except the money — prices in, availability asked for while a customer waits, orders out, status back, stock reports on a schedule. Then the vendor sends an invoice and there was nowhere to put it.

### The vendor's figures, transcribed

Totals are not derived from the lines, and lines are not reconciled against totals, **even where they disagree**. A vendor invoice is a claim about money owed; an integration that quietly corrects it produces a number nobody can trace back to a document, and destroys the evidence of exactly the discrepancy an AP clerk is employed to notice.

### Four refusals, because each mistake reaches a payment run

| Refused | Why not a default |
|---|---|
| Unrecognised `DocumentTypeCode` | Either direction is possible; importing a credit as a debt is not a validation error, it is a payment made instead of received |
| Invoice with no number | Nothing could deduplicate it, so every overlapping window would import it afresh |
| Amount with no currency | Not a sum of money. Defaulting to the profile's would let a foreign-currency invoice be paid as domestic |
| Unreadable amount | Recorded absent, not zero — zero is a figure a vendor might genuinely send |

`380`/`84` are money owed to the vendor; `381`/`83` money owed back.

### A debt recorded once

Fetch windows overlap deliberately so a failed fetch can simply be repeated — the same invoice arrives repeatedly **by design**. Identity is the vendor's own (profile, number, issue date), and a second arrival is dropped before publication rather than left for the consumer to catch. The consumer guards again anyway, on the same identity: a re-fetch carries a new event id, so the event-level guard alone would not stop it.

## The Accounting blocker was retired, not deferred

#1227 said the consumer waits on Accounting-domain authority for voucher posting semantics. Checking rather than repeating it: pos-accounting **already models the AP side** — `VendorBill` with a status flow (`PENDING_RECEIPT_MATCH` → `MATCH_EXCEPTION`/`APPROVED` → `PAID`), a purchase-order linkage, a journal entry, and `findByOriginEventId`. Event-driven bill creation was anticipated in the model. The consumer wires a new event source into an existing shape rather than deciding financial meaning.

Three judgments did remain. They are **documented on the listener itself**, because each is a decision somebody could reasonably have made differently:

1. **An unresolvable PO reference is `PENDING_RECEIPT_MATCH`, not `MATCH_EXCEPTION`.** An invoice arriving before its goods receipt is the ordinary early state of a perfectly good invoice. Filing it as an exception would fill that queue with normal paperwork until the queue stopped meaning anything.
2. **No journal entry on ingest.** An unapproved vendor invoice is a claim, not a liability anyone has agreed to. Posting on arrival would move the accounts on the vendor's say-so alone.
3. **The supplier's vendor profile id is the accounting vendor id.** `Vendor` states its id is "assigned by the upstream system that owns the vendor relationship" — for an EDIWheel vendor that is pos-supplier. A separate accounting id plus a mapping table would create the very ambiguity that rule exists to avoid.

If any of those three reads wrong, they are the places to push back.

## Tests
- [x] Unit tests added/updated — `EdiwheelB33InvoiceCodecTest` (12), `InvoiceImporterTest` (4), `SupplierInvoiceEventsListenerTest` (9)
- [x] Integration tests added/updated — the codec tests drive real B3.3 XML through JAXB
- [ ] Provider behavioral contract tests added/updated — golden-file fixtures from a vendor sandbox pull are owed with the first live test
- How to run:
  ```bash
  ./mvnw -pl pos-domain-events,pos-supplier,pos-accounting -am test
  ./mvnw -pl pos-archunit -am -Dtest='EntityStandardsArchitectureTest,ClasspathVisibilityGuardTest,DomainWallsTest,ArchitectureTests' -Dsurefire.failIfNoSpecifiedTests=false test
  bash scripts/check-flyway-hygiene.sh
  ```
  pos-supplier, pos-accounting and pos-domain-events all green; pos-archunit 22/22 with `ClasspathVisibilityGuardTest` passing, so the rules ran against real imported classes; Flyway hygiene passes.

Every AP judgment above is pinned by a test, so changing one fails rather than drifts.

## Two things the build caught

**The cross-cutting event contract test rejected a validated free string** for the document type. It was right to: two legal values are better made unrepresentable than checked at runtime, so `type` is now an enum like its siblings.

**`ArchitectureTests` rejected the importer's package.** It sat in `internal.invoice`, outside the layers permitted to touch repositories; moved to `internal.invoice.service`, matching how the stock-report importer is arranged.

## Risk & Rollback
- Risk level: Medium — this is the first thing that will record money owed. It is mitigated by refusing rather than assuming at every ambiguous point, and by nothing posting to the ledger on ingest.
- Rollback plan: revert the commit. Two new tables and one new event; no existing behaviour is altered, and the pos-accounting consumer is inert without the event.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing — pending
- [ ] Angular SDK regenerated — no API surface changed

## Not in this PR

The **admin on-demand fetch trigger** (#1227 task 4) and the scheduler wiring. The `SupplierScheduleCoordinator` lease-and-checkpoint machinery already exists and the importer is built to be driven by it; what is here is the codec, the fetch request, the canonical persistence, the event and the consumer. Worth a follow-up rather than padding this one.
