### PR TITLE
[CAP:321] feat(supplier): schedule the vendor invoice fetch and let operators run one (#1343)

### DIFF
--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,9 +1,9 @@
-generatedAt: "2026-08-16T11:11:47.470034+00:00"
+generatedAt: "2026-08-16T18:02:10.429550+00:00"
 root: "."
 summary:
   manifestCount: 22
-  permissionCount: 426
-  uniquePermissionCount: 426
+  permissionCount: 427
+  uniquePermissionCount: 427
   duplicatePermissionNameCount: 0
   parseIssueCount: 0
 manifests:
@@ -792,7 +792,7 @@ manifests:
     domain: "supplier"
     serviceName: "pos-supplier"
     version: "1.0"
-    permissionCount: 8
+    permissionCount: 9
     permissions:
       - name: "supplier:audit:read"
         description: "Read supplier exchange audit records"
@@ -810,6 +810,8 @@ manifests:
         description: "Resolve a purchase-order transmission awaiting manual review (confirm with vendor reference, mark not received, or cancel)"
       - name: "supplier:stock:inquire"
         description: "Ask a vendor, live, what stock it holds for a receiving location (the approved synchronous supplier read)"
+      - name: "supplier:invoice:fetch"
+        description: "Run a vendor invoice fetch on demand"
   - module: "pos-tax"
     path: "pos-tax/src/main/resources/permissions.yaml"
     domain: "tax"
@@ -3020,6 +3022,12 @@ permissions:
     source: "pos-shop-manager/src/main/resources/permissions.yaml"
   - name: "supplier:audit:read"
     description: "Read supplier exchange audit records"
+    domain: "supplier"
+    serviceName: "pos-supplier"
+    module: "pos-supplier"
+    source: "pos-supplier/src/main/resources/permissions.yaml"
+  - name: "supplier:invoice:fetch"
+    description: "Run a vendor invoice fetch on demand"
     domain: "supplier"
     serviceName: "pos-supplier"
     module: "pos-supplier"

--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -1301,6 +1301,8 @@ paths:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1admin~1profiles~1{vendorProfileId}~1bindings
   /v1/supplier/admin/profiles/{vendorProfileId}/bindings/{bindingId}:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1admin~1profiles~1{vendorProfileId}~1bindings~1{bindingId}
+  /v1/supplier/invoices/{supplierRef}/fetches:
+    $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1invoices~1{supplierRef}~1fetches
   /v1/supplier/stock/inquiries:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1stock~1inquiries
   /v1/supplier/transmissions/purchase-order/{purchaseOrderId}:

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 51;
+    public static final int CATALOG_VERSION = 52;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -548,7 +548,10 @@ public final class GatewayPermissionCatalog {
         "PERM_order:purchase_order:transmit", // 459
 
         // ── New batch (bits 460–460) ──────────────────────────────────────────
-        "PERM_order:purchase_order:availability_view" // 460
+        "PERM_order:purchase_order:availability_view", // 460
+
+        // ── New batch (bits 461–461) ──────────────────────────────────────────
+        "PERM_supplier:invoice:fetch" // 461
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,9 +1142,9 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 51")
+    @DisplayName("CATALOG_VERSION is 52")
     void catalogVersionMatchesCurrent() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(51);
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(52);
     }
 
     @Test
@@ -1311,8 +1311,12 @@ class SecurityGatewayConfigTest {
         // vendor's own systems, so it is gated apart from viewing the order.
         assertThat(GatewayPermissionCatalog.authorityForBit(460))
                 .isEqualTo("PERM_order:purchase_order:availability_view");
+        // Running a vendor invoice fetch on demand (CAP-321 #1343). Its own permission because it
+        // reaches a vendor and can create AP bills: whoever may investigate a missing invoice is
+        // not necessarily whoever may reconfigure a profile.
+        assertThat(GatewayPermissionCatalog.authorityForBit(461)).isEqualTo("PERM_supplier:invoice:fetch");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(461)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(462)).isNull();
     }
 
     @Test

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -23,7 +23,7 @@ public final class DownstreamPermissionCatalog {
      * {@code PermissionCode.CATALOG_VERSION}.
      * Updated automatically by {@code scripts/generate-permissions.py --sync}.
      */
-    public static final int CATALOG_VERSION = 51;
+    public static final int CATALOG_VERSION = 52;
 
     /**
      * Index-to-authority mapping. Entry at position N is the {@code PERM_*}-prefixed
@@ -574,7 +574,10 @@ public final class DownstreamPermissionCatalog {
         "PERM_order:purchase_order:transmit", // 459
 
         // ── New batch (bits 460–460) ──────────────────────────────────────────
-        "PERM_order:purchase_order:availability_view" // 460
+        "PERM_order:purchase_order:availability_view", // 460
+
+        // ── New batch (bits 461–461) ──────────────────────────────────────────
+        "PERM_supplier:invoice:fetch" // 461
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -603,13 +603,15 @@ public enum PermissionCode {
     // ── Order (new) ────────────────────────────────────────────────────────────
     ORDER__PURCHASE_ORDER__TRANSMIT(459, "order:purchase_order:transmit"),
     // ── Order (new) ────────────────────────────────────────────────────────────
-    ORDER__PURCHASE_ORDER__AVAILABILITY_VIEW(460, "order:purchase_order:availability_view");
+    ORDER__PURCHASE_ORDER__AVAILABILITY_VIEW(460, "order:purchase_order:availability_view"),
+    // ── Supplier (new) ─────────────────────────────────────────────────────────
+    SUPPLIER__INVOICE__FETCH(461, "supplier:invoice:fetch");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 51;
+    public static final int CATALOG_VERSION = 52;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 461;
-    private static final int EXPECTED_CATALOG_VERSION = 51;
+    private static final int EXPECTED_PERMISSION_COUNT = 462;
+    private static final int EXPECTED_CATALOG_VERSION = 52;
 
     // -------------------------------------------------------------------------
     // AC-1: Catalog size — EXPECTED_PERMISSION_COUNT entries

--- a/pos-supplier/openapi.yaml
+++ b/pos-supplier/openapi.yaml
@@ -976,7 +976,7 @@ paths:
 
         Emits a SUPPLIER_INVOICE_FETCH event and, for each invoice not already held, publishes it for the accounting domain to record as a vendor bill.
 
-        Returns 200 with the number fetched and the number new, 422 when the vendor refused the window or could not be reached, and 404 when the vendor profile or its binding is not configured.
+        Returns 200 with the number the vendor sent and the number newly imported, 422 when the vendor refused the window or could not be reached, 404 when the vendor profile is unknown, and 409 when the profile is disabled or has no invoice-fetch binding configured.
 
         '
       operationId: fetchSupplierInvoices
@@ -1009,7 +1009,13 @@ paths:
               schema:
                 type: object
         '404':
-          description: Vendor profile or invoice binding not configured
+          description: Vendor profile unknown
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: Vendor profile disabled, or no invoice-fetch binding configured
           content:
             application/json:
               schema:

--- a/pos-supplier/openapi.yaml
+++ b/pos-supplier/openapi.yaml
@@ -14,6 +14,8 @@ tags:
   description: Admin CRUD over vendor auth configs — secret references only, never plaintext credentials
 - name: Supplier Price Catalog
   description: Trigger vendor PRICAT imports and read their bookkeeping and unmatched-line quarantine. No vendor prices are served here; they travel as supplier.pricecatalog.updated events.
+- name: Supplier Invoices
+  description: On-demand vendor invoice retrieval
 - name: Supplier Commercial Accounts
   description: Admin CRUD over vendor commercial accounts — billing and per-location delivery numbers
 - name: Supplier Endpoint Bindings
@@ -959,6 +961,70 @@ paths:
       - bearerAuth: []
       x-required-permissions:
       - supplier:stock:inquire
+  /v1/supplier/invoices/{supplierRef}/fetches:
+    post:
+      tags:
+      - Supplier Invoices
+      summary: Fetch Vendor Invoices For A Window
+      description: 'Asks a vendor for the invoices it issued between two dates and imports the ones not already held.
+
+        Use this tool when somebody is chasing an invoice a vendor says it sent; do not use it to catch a schedule up, because it deliberately leaves the checkpoint alone and the scheduled run will still cover its own window.
+
+        Preconditions: the vendor profile must be enabled and have an invoice-fetch binding configured; fromDate must not be after toDate.
+
+        Required inputs: supplierRef path parameter, and fromDate and toDate query parameters as ISO dates.
+
+        Emits a SUPPLIER_INVOICE_FETCH event and, for each invoice not already held, publishes it for the accounting domain to record as a vendor bill.
+
+        Returns 200 with the number fetched and the number new, 422 when the vendor refused the window or could not be reached, and 404 when the vendor profile or its binding is not configured.
+
+        '
+      operationId: fetchSupplierInvoices
+      parameters:
+      - name: supplierRef
+        in: path
+        description: Vendor profile alias
+        required: true
+        schema:
+          type: string
+      - name: fromDate
+        in: query
+        description: First issue date to fetch, inclusive
+        required: true
+        schema:
+          type: string
+          format: date
+      - name: toDate
+        in: query
+        description: Last issue date to fetch, inclusive
+        required: true
+        schema:
+          type: string
+          format: date
+      responses:
+        '200':
+          description: Window fetched
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Vendor profile or invoice binding not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '422':
+          description: The vendor refused the window or could not be reached
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - supplier:invoice:fetch
+      x-required-permissions:
+      - supplier:invoice:fetch
   /v1/supplier/admin/profiles:
     get:
       tags:

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb3/EdiwheelB33InvoiceCodec.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb3/EdiwheelB33InvoiceCodec.java
@@ -85,7 +85,9 @@ public class EdiwheelB33InvoiceCodec implements SupplierAdapterCodec {
     public SupplierRequestSpec buildRequest(
             @NonNull PartyContext partyContext, @NonNull LocalDate fromDate, @NonNull LocalDate toDate) {
         if (toDate.isBefore(fromDate)) {
-            throw new InvoiceDecodeException("Invoice window ends before it begins: " + fromDate + " to " + toDate);
+            // IllegalArgumentException, not a decode failure: nothing has been decoded, and calling
+            // it one sent a caller looking for a vendor problem when the fault was in the request.
+            throw new IllegalArgumentException("Invoice window ends before it begins: " + fromDate + " to " + toDate);
         }
         Map<String, String> query = new LinkedHashMap<>();
         query.put("invoiceIssueFromDate", WINDOW_DATE.format(fromDate));

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/config/SupplierEventTypes.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/config/SupplierEventTypes.java
@@ -107,6 +107,9 @@ public final class SupplierEventTypes {
                 // synchronous call to a trading partner while a customer waits, so the latency worth
                 // alerting on is the vendor's, not this module's.
                 EventTypeRegistration.write("SUPPLIER_STOCK_INQUIRY", "Ask a vendor for live stock availability")
+                        .build(),
+                EventTypeRegistration.write(
+                                "SUPPLIER_INVOICE_FETCH", "Run a vendor invoice fetch for an explicit window")
                         .build());
     }
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierInvoiceFetchController.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierInvoiceFetchController.java
@@ -3,6 +3,7 @@ package com.positivity.supplier.internal.controller;
 import com.positivity.events.EmitEvent;
 import com.positivity.shared.error.ApiError;
 import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.invoice.service.InvoiceFetchRunner;
 import com.positivity.supplier.internal.invoice.service.InvoiceFetchScheduler;
 import com.positivity.supplier.internal.security.SupplierPermissions;
 import io.swagger.v3.oas.annotations.Operation;
@@ -64,15 +65,19 @@ public class SupplierInvoiceFetchController {
                     ISO dates.
                     Emits a SUPPLIER_INVOICE_FETCH event and, for each invoice not already held, publishes it \
                     for the accounting domain to record as a vendor bill.
-                    Returns 200 with the number fetched and the number new, 422 when the vendor refused the \
-                    window or could not be reached, and 404 when the vendor profile or its binding is not \
-                    configured.
+                    Returns 200 with the number the vendor sent and the number newly imported, 422 when the \
+                    vendor refused the window or could not be reached, 404 when the vendor profile is unknown, \
+                    and 409 when the profile is disabled or has no invoice-fetch binding configured.
                     """,
             tags = {"Supplier Invoices"})
     @ApiResponse(responseCode = "200", description = "Window fetched")
     @ApiResponse(
             responseCode = "404",
-            description = "Vendor profile or invoice binding not configured",
+            description = "Vendor profile unknown",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Vendor profile disabled, or no invoice-fetch binding configured",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     @ApiResponse(
             responseCode = "422",
@@ -88,9 +93,11 @@ public class SupplierInvoiceFetchController {
                     @RequestParam
                     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
                     LocalDate toDate) {
-        int imported = invoiceFetchScheduler.fetchOnDemand(new SupplierRef(supplierRef), fromDate, toDate);
-        // "imported" rather than "fetched": the number that mattered is how many were new, because
-        // an operator running this twice should see the second run import nothing and know why.
+        InvoiceFetchRunner.FetchOutcome outcome =
+                invoiceFetchScheduler.fetchOnDemand(new SupplierRef(supplierRef), fromDate, toDate);
+        // Both numbers, because they answer different questions. "fetched" says whether the vendor
+        // had anything for this window at all; "imported" says how much of it was new. An operator
+        // running this twice needs to see 12 and 0 and understand that as working, not as broken.
         return ResponseEntity.ok(Map.of(
                 "supplierRef",
                 supplierRef,
@@ -98,7 +105,9 @@ public class SupplierInvoiceFetchController {
                 fromDate.toString(),
                 "toDate",
                 toDate.toString(),
+                "fetched",
+                outcome.fetched(),
                 "imported",
-                imported));
+                outcome.imported()));
     }
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierInvoiceFetchController.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierInvoiceFetchController.java
@@ -1,0 +1,104 @@
+package com.positivity.supplier.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.shared.error.ApiError;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.invoice.service.InvoiceFetchScheduler;
+import com.positivity.supplier.internal.security.SupplierPermissions;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Running a vendor invoice fetch on demand (CAP-321 #1343).
+ *
+ * <h2>Why an operator needs this</h2>
+ *
+ * The schedule covers the ordinary case. This exists for the moment somebody is looking for an
+ * invoice a vendor insists it sent — and the alternative to an endpoint is editing a checkpoint by
+ * hand, which is how a fortnight of invoices gets skipped in the course of finding one.
+ *
+ * <p>It runs the same code as the schedule and deliberately does not move the checkpoint: asking
+ * about a particular window is investigating, not redefining where the schedule has reached.
+ */
+@RestController
+@RequestMapping("/v1/supplier/invoices")
+@RequiredArgsConstructor
+@Tag(name = "Supplier Invoices", description = "On-demand vendor invoice retrieval")
+public class SupplierInvoiceFetchController {
+
+    private final InvoiceFetchScheduler invoiceFetchScheduler;
+
+    @PostMapping("/{supplierRef}/fetches")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"supplier:invoice:fetch"})
+    @PreAuthorize("hasAuthority('" + SupplierPermissions.INVOICE_FETCH + "')")
+    @EmitEvent(id = "SUPPLIER_INVOICE_FETCH", apiVersion = "1")
+    @Operation(
+            operationId = "fetchSupplierInvoices",
+            summary = "Fetch Vendor Invoices For A Window",
+            description = """
+                    Asks a vendor for the invoices it issued between two dates and imports the ones not already \
+                    held.
+                    Use this tool when somebody is chasing an invoice a vendor says it sent; do not use it to \
+                    catch a schedule up, because it deliberately leaves the checkpoint alone and the scheduled \
+                    run will still cover its own window.
+                    Preconditions: the vendor profile must be enabled and have an invoice-fetch binding \
+                    configured; fromDate must not be after toDate.
+                    Required inputs: supplierRef path parameter, and fromDate and toDate query parameters as \
+                    ISO dates.
+                    Emits a SUPPLIER_INVOICE_FETCH event and, for each invoice not already held, publishes it \
+                    for the accounting domain to record as a vendor bill.
+                    Returns 200 with the number fetched and the number new, 422 when the vendor refused the \
+                    window or could not be reached, and 404 when the vendor profile or its binding is not \
+                    configured.
+                    """,
+            tags = {"Supplier Invoices"})
+    @ApiResponse(responseCode = "200", description = "Window fetched")
+    @ApiResponse(
+            responseCode = "404",
+            description = "Vendor profile or invoice binding not configured",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "The vendor refused the window or could not be reached",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<Map<String, Object>> fetchSupplierInvoices(
+            @Parameter(description = "Vendor profile alias", required = true) @PathVariable String supplierRef,
+            @Parameter(description = "First issue date to fetch, inclusive", required = true)
+                    @RequestParam
+                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate fromDate,
+            @Parameter(description = "Last issue date to fetch, inclusive", required = true)
+                    @RequestParam
+                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate toDate) {
+        int imported = invoiceFetchScheduler.fetchOnDemand(new SupplierRef(supplierRef), fromDate, toDate);
+        // "imported" rather than "fetched": the number that mattered is how many were new, because
+        // an operator running this twice should see the second run import nothing and know why.
+        return ResponseEntity.ok(Map.of(
+                "supplierRef",
+                supplierRef,
+                "fromDate",
+                fromDate.toString(),
+                "toDate",
+                toDate.toString(),
+                "imported",
+                imported));
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/InvoiceFetchException.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/InvoiceFetchException.java
@@ -1,4 +1,4 @@
-package com.positivity.supplier.internal.invoice.service;
+package com.positivity.supplier.internal.exception;
 
 /**
  * Thrown when a window of vendor invoices could not be fetched or read (CAP-321 #1343).

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/SupplierExceptionHandler.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/SupplierExceptionHandler.java
@@ -95,6 +95,19 @@ public class SupplierExceptionHandler {
         return build(HttpStatus.BAD_REQUEST, ex.getCode(), ex.getMessage(), request);
     }
 
+    /**
+     * A vendor invoice window that could not be fetched or read (CAP-321 #1343).
+     *
+     * <p>422 rather than 500: the request was understood and the fault is at the vendor — it could
+     * not be reached, or it refused the window. A caller can act on that, by narrowing the window
+     * or waiting; a 500 tells them only that something broke here, which is the wrong place to
+     * look.
+     */
+    @ExceptionHandler(InvoiceFetchException.class)
+    public ResponseEntity<ApiError> handleInvoiceFetch(InvoiceFetchException ex, HttpServletRequest request) {
+        return build(HttpStatus.UNPROCESSABLE_ENTITY, "SUPPLIER_INVOICE_FETCH_FAILED", ex.getMessage(), request);
+    }
+
     /** Configuration-state collisions, including YAML-managed profile mutation (ADR-0050 §6). */
     @ExceptionHandler(SupplierConflictException.class)
     public ResponseEntity<ApiError> handleConflict(SupplierConflictException ex, HttpServletRequest request) {

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchException.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchException.java
@@ -1,0 +1,21 @@
+package com.positivity.supplier.internal.invoice.service;
+
+/**
+ * Thrown when a window of vendor invoices could not be fetched or read (CAP-321 #1343).
+ *
+ * <p>Deliberately an exception rather than an empty result. The fetch runs inside a schedule page
+ * that advances the checkpoint in the same transaction, so throwing rolls the checkpoint back and
+ * the window is re-covered on the next run. Returning nothing would move the checkpoint past
+ * invoices that were never fetched, and a missing invoice goes unnoticed until the vendor chases
+ * payment.
+ */
+public class InvoiceFetchException extends RuntimeException {
+
+    public InvoiceFetchException(String message) {
+        super(message);
+    }
+
+    public InvoiceFetchException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchRunner.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchRunner.java
@@ -1,0 +1,130 @@
+package com.positivity.supplier.internal.invoice.service;
+
+import com.positivity.supplier.internal.adapter.ediwheelb3.EdiwheelB33InvoiceCodec;
+import com.positivity.supplier.internal.adapter.ediwheelb3.InvoiceDecodeException;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.client.SupplierHttpRequest;
+import com.positivity.supplier.internal.client.SupplierHttpResponse;
+import com.positivity.supplier.internal.domain.model.PartyContext;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierInvoice;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.entity.SupplierAccountEntity;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.registry.AdapterResolution;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedPartyAccounts;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+
+/**
+ * Fetches one window of vendor invoices and imports what is new (CAP-321 #1343).
+ *
+ * <h2>One path, two callers</h2>
+ *
+ * The schedule and the operator's on-demand trigger both come through here. Two implementations of
+ * "fetch a window" would drift, and the one that drifts is the one reached for under pressure —
+ * when somebody is chasing a missing invoice and wants it now.
+ *
+ * <h2>A failed fetch throws, and that is the point</h2>
+ *
+ * Nothing here degrades to an empty result. The caller runs this inside
+ * {@code SupplierScheduleCoordinator.runPage}, which advances the checkpoint in the same
+ * transaction — so an exception rolls the checkpoint back with it and the next run re-covers the
+ * window. Returning quietly instead would advance the checkpoint past invoices that were never
+ * fetched, and a missing invoice is not noticed until the vendor chases payment.
+ *
+ * <p>That is the opposite of the live stock inquiry, where a vendor being down must never fail a
+ * customer's screen. The difference is that nobody is waiting on this, and the cost of pretending
+ * is a debt that disappears rather than a blank column.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InvoiceFetchRunner {
+
+    private final SupplierProfileResolver profileResolver;
+    private final AdapterRegistry adapterRegistry;
+    private final SupplierBaseClient baseClient;
+    private final InvoiceImporter importer;
+
+    /**
+     * Fetches the vendor's invoices for an inclusive date window and imports the new ones.
+     *
+     * @return how many invoices were new; the rest were already held from an overlapping window
+     * @throws InvoiceFetchException when the vendor could not be reached or refused the window
+     * @throws SupplierConfigurationException when the profile, binding, codec or billing account is
+     *     not configured — a deployment defect, surfaced loudly rather than retried forever
+     */
+    public int fetchWindow(@NonNull SupplierRef supplierRef, @NonNull LocalDate fromDate, @NonNull LocalDate toDate) {
+        ResolvedBinding binding = profileResolver.resolveBinding(supplierRef, SupplierCapability.INVOICE_FETCH);
+        EdiwheelB33InvoiceCodec codec = resolveCodec(binding);
+        ResolvedPartyAccounts accounts = profileResolver.resolvePartyContext(supplierRef, null);
+        SupplierAccountEntity billing = accounts.billing();
+
+        PartyContext partyContext = new PartyContext(billing.getAccountNumber(), billing.getAgencyCode(), null);
+        SupplierRequestSpec spec = codec.buildRequest(partyContext, fromDate, toDate);
+        SupplierHttpResponse response = baseClient.exchange(toHttpRequest(binding, spec));
+
+        if (!response.isSuccess()) {
+            // Thrown, not recorded as an empty window. The vendor may well have issued invoices in
+            // this window and simply not told us; treating silence as "none" would let the
+            // checkpoint move past them for good.
+            throw new InvoiceFetchException("vendor exchange failed: " + response.outcome()
+                    + (response.failureDetail() == null ? "" : " — " + response.failureDetail()));
+        }
+
+        List<SupplierInvoice> invoices;
+        try {
+            invoices = codec.decode(response.body());
+        } catch (InvoiceDecodeException e) {
+            // Also thrown. A document-level refusal ("window too wide") is a configuration problem
+            // that will recur until somebody changes something, and it must not look like a quiet
+            // stretch of days with no invoices.
+            throw new InvoiceFetchException("vendor refused or returned an unreadable window: " + e.getMessage(), e);
+        }
+
+        int imported = importer.importInvoices(binding.binding().getVendorProfileId(), supplierRef.value(), invoices);
+        log.info(
+                "Invoice window {}..{} for {}: {} fetched, {} new",
+                fromDate,
+                toDate,
+                supplierRef.value(),
+                invoices.size(),
+                imported);
+        return imported;
+    }
+
+    private SupplierHttpRequest toHttpRequest(ResolvedBinding binding, SupplierRequestSpec spec) {
+        return new SupplierHttpRequest(
+                binding,
+                HttpMethod.valueOf(spec.method()),
+                spec.pathSuffix(),
+                spec.queryParams(),
+                spec.body(),
+                spec.contentType(),
+                spec.accept(),
+                spec.idempotent());
+    }
+
+    private EdiwheelB33InvoiceCodec resolveCodec(ResolvedBinding binding) {
+        AdapterResolution resolution =
+                adapterRegistry.resolve(SupplierCapability.INVOICE_FETCH, binding.family(), binding.version());
+        if (resolution instanceof AdapterResolution.Resolved resolved
+                && resolved.codec() instanceof EdiwheelB33InvoiceCodec codec) {
+            return codec;
+        }
+        throw new SupplierConfigurationException(
+                SupplierConfigurationException.CAPABILITY_NOT_CONFIGURED,
+                "No invoice codec registered for " + binding.family() + " "
+                        + binding.version().value());
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchRunner.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchRunner.java
@@ -11,6 +11,7 @@ import com.positivity.supplier.internal.domain.model.SupplierInvoice;
 import com.positivity.supplier.internal.domain.model.SupplierRef;
 import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
 import com.positivity.supplier.internal.entity.SupplierAccountEntity;
+import com.positivity.supplier.internal.exception.InvoiceFetchException;
 import com.positivity.supplier.internal.exception.SupplierConfigurationException;
 import com.positivity.supplier.internal.registry.AdapterRegistry;
 import com.positivity.supplier.internal.registry.AdapterResolution;
@@ -59,12 +60,20 @@ public class InvoiceFetchRunner {
     /**
      * Fetches the vendor's invoices for an inclusive date window and imports the new ones.
      *
-     * @return how many invoices were new; the rest were already held from an overlapping window
+     * @return what the vendor sent and how much of it was new
      * @throws InvoiceFetchException when the vendor could not be reached or refused the window
      * @throws SupplierConfigurationException when the profile, binding, codec or billing account is
      *     not configured — a deployment defect, surfaced loudly rather than retried forever
      */
-    public int fetchWindow(@NonNull SupplierRef supplierRef, @NonNull LocalDate fromDate, @NonNull LocalDate toDate) {
+    public FetchOutcome fetchWindow(
+            @NonNull SupplierRef supplierRef, @NonNull LocalDate fromDate, @NonNull LocalDate toDate) {
+        if (toDate.isBefore(fromDate)) {
+            // Checked here so every caller sees one exception type from this method. Letting the
+            // codec's own complaint escape meant an operator's typo surfaced as a 500 rather than
+            // as the request problem it is.
+            throw new InvoiceFetchException("invoice window ends before it begins: " + fromDate + " to " + toDate);
+        }
+
         ResolvedBinding binding = profileResolver.resolveBinding(supplierRef, SupplierCapability.INVOICE_FETCH);
         EdiwheelB33InvoiceCodec codec = resolveCodec(binding);
         ResolvedPartyAccounts accounts = profileResolver.resolvePartyContext(supplierRef, null);
@@ -100,8 +109,18 @@ public class InvoiceFetchRunner {
                 supplierRef.value(),
                 invoices.size(),
                 imported);
-        return imported;
+        return new FetchOutcome(invoices.size(), imported);
     }
+
+    /**
+     * What one window produced.
+     *
+     * <p>Both numbers, because they answer different questions: {@code fetched} says whether the
+     * vendor had anything for this window at all, {@code imported} how much of it was new. A window
+     * that fetched twelve and imported none is working exactly as intended, and the two figures
+     * together are what make that legible rather than alarming.
+     */
+    public record FetchOutcome(int fetched, int imported) {}
 
     private SupplierHttpRequest toHttpRequest(ResolvedBinding binding, SupplierRequestSpec spec) {
         return new SupplierHttpRequest(

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchScheduler.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchScheduler.java
@@ -1,0 +1,190 @@
+package com.positivity.supplier.internal.invoice.service;
+
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.entity.SupplierScheduleLeaseEntity;
+import com.positivity.supplier.internal.repository.SupplierEndpointBindingRepository;
+import com.positivity.supplier.internal.repository.SupplierProfileRepository;
+import com.positivity.supplier.internal.repository.SupplierScheduleLeaseRepository;
+import com.positivity.supplier.internal.service.SupplierScheduleCoordinator;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * Runs the vendor invoice fetch on a schedule (CAP-321 #1343).
+ *
+ * <h2>The window deliberately overlaps its predecessor</h2>
+ *
+ * Each run asks for everything since the last committed checkpoint, minus an overlap. That looks
+ * wasteful and is not: a vendor may date an invoice a day or two before it becomes fetchable, and a
+ * window that started exactly where the last one ended would step straight over it. Re-asking is
+ * cheap because the importer recognises an invoice it already holds by the vendor's own identity —
+ * the overlap costs a few duplicate rows in a response and buys immunity to the seam.
+ *
+ * <h2>The checkpoint moves only when a window completes</h2>
+ *
+ * Not when the vendor answers, and not when some invoices are imported. The fetch runs inside
+ * {@link SupplierScheduleCoordinator#runPage}, which advances the checkpoint in the same
+ * transaction as the work, so a failure rolls both back and the next run re-covers the same ground.
+ *
+ * <p>That ordering is the whole reason this class is careful. Advance a checkpoint over a window
+ * that failed halfway and the invoices in the unfetched remainder are gone for good: no later run
+ * will ever ask for those dates again, nothing reports them missing, and the first anyone knows is
+ * a vendor asking why an invoice has not been paid.
+ */
+@Slf4j
+@Service
+public class InvoiceFetchScheduler {
+
+    private final SupplierEndpointBindingRepository bindingRepository;
+    private final SupplierProfileRepository profileRepository;
+    private final SupplierScheduleLeaseRepository leaseRepository;
+    private final SupplierScheduleCoordinator scheduleCoordinator;
+    private final InvoiceFetchRunner fetchRunner;
+    private final Clock clock;
+
+    /**
+     * How far back each window reaches beyond the last checkpoint.
+     *
+     * <p>Configurable and stated, rather than a constant buried in the window arithmetic, because
+     * the right value depends on how long a given vendor takes to make an issued invoice
+     * retrievable — and that is only learned from a live vendor.
+     */
+    private final Duration overlap;
+
+    /**
+     * How far back the first ever fetch reaches, when a binding has no checkpoint.
+     *
+     * <p>Bounded rather than unlimited: an unbounded first fetch against a vendor with years of
+     * history would time out, and a timed-out first fetch never establishes a checkpoint, so it
+     * would time out again forever.
+     */
+    private final Duration initialLookback;
+
+    public InvoiceFetchScheduler(
+            SupplierEndpointBindingRepository bindingRepository,
+            SupplierProfileRepository profileRepository,
+            SupplierScheduleLeaseRepository leaseRepository,
+            SupplierScheduleCoordinator scheduleCoordinator,
+            InvoiceFetchRunner fetchRunner,
+            Clock clock,
+            @Value("${pos.supplier.invoice.window-overlap:P2D}") Duration overlap,
+            @Value("${pos.supplier.invoice.initial-lookback:P30D}") Duration initialLookback) {
+        this.bindingRepository = bindingRepository;
+        this.profileRepository = profileRepository;
+        this.leaseRepository = leaseRepository;
+        this.scheduleCoordinator = scheduleCoordinator;
+        this.fetchRunner = fetchRunner;
+        this.clock = clock;
+        this.overlap = overlap;
+        this.initialLookback = initialLookback;
+    }
+
+    /** Polls due bindings. Each runs at most once per tick, on at most one instance. */
+    @Scheduled(fixedDelayString = "${pos.supplier.invoice.poll-interval-ms:300000}")
+    public void runDueFetches() {
+        Instant now = Instant.now(clock);
+        for (SupplierEndpointBindingEntity binding :
+                bindingRepository.findByCapabilityAndEnabledTrueAndScheduleCronIsNotNull(
+                        SupplierCapability.INVOICE_FETCH)) {
+            try {
+                runIfConfigured(binding, now);
+            } catch (Exception e) {
+                // One unreachable vendor must not stop the others being invoiced. This binding's
+                // checkpoint stayed where it was, so its window is re-covered next tick.
+                log.warn("Scheduled invoice fetch for binding {} failed: {}", binding.getId(), e.toString(), e);
+            }
+        }
+    }
+
+    private void runIfConfigured(SupplierEndpointBindingEntity binding, Instant now) {
+        Optional<SupplierProfileEntity> profile = profileRepository.findById(binding.getVendorProfileId());
+        if (profile.isEmpty() || !profile.get().isEnabled()) {
+            return;
+        }
+
+        String ownerToken = SupplierScheduleCoordinator.newOwnerToken();
+        if (!scheduleCoordinator.tryClaim(binding.getId(), ownerToken)) {
+            // Another instance holds this binding. Not an error: exactly one fetcher per vendor is
+            // the point of the lease.
+            return;
+        }
+
+        String outcome = "FAILED";
+        try {
+            Instant windowStart = windowStartFor(binding.getId(), now);
+            fetchWindowAsPage(binding, profile.get(), ownerToken, windowStart, now);
+            outcome = "SUCCEEDED";
+        } finally {
+            scheduleCoordinator.release(binding.getId(), ownerToken, outcome);
+        }
+    }
+
+    /**
+     * Runs one window as a schedule page, so the checkpoint advances only with the work.
+     *
+     * <p>The page reports {@code now} as the window it completed. It is reached only if the fetch
+     * returned without throwing, which is what ties the checkpoint to a window actually covered
+     * rather than one merely attempted.
+     */
+    private void fetchWindowAsPage(
+            SupplierEndpointBindingEntity binding,
+            SupplierProfileEntity profile,
+            String ownerToken,
+            Instant windowStart,
+            Instant now) {
+        SupplierRef supplierRef = new SupplierRef(profile.getSupplierRef());
+        LocalDate fromDate = LocalDate.ofInstant(windowStart, ZoneOffset.UTC);
+        LocalDate toDate = LocalDate.ofInstant(now, ZoneOffset.UTC);
+
+        scheduleCoordinator.runPage(binding.getId(), ownerToken, () -> {
+            fetchRunner.fetchWindow(supplierRef, fromDate, toDate);
+            return now;
+        });
+    }
+
+    /**
+     * Where this window starts: the last committed checkpoint less the overlap, or the initial
+     * lookback when the binding has never completed one.
+     */
+    private Instant windowStartFor(UUID bindingId, Instant now) {
+        List<SupplierScheduleLeaseEntity> leases = leaseRepository.findByBindingIdIn(List.of(bindingId));
+        Instant checkpoint = leases.stream()
+                .map(SupplierScheduleLeaseEntity::getCheckpointAt)
+                .filter(java.util.Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+        if (checkpoint == null) {
+            return now.minus(initialLookback);
+        }
+        return checkpoint.minus(overlap);
+    }
+
+    /**
+     * Fetches an explicit window on demand, outside the schedule.
+     *
+     * <p>Runs the same code as the scheduled path but does <em>not</em> touch the checkpoint. An
+     * operator asking about a particular fortnight is investigating, not redefining where the
+     * schedule has got to — and moving the checkpoint to satisfy a query would skip everything
+     * between it and the schedule's real position.
+     *
+     * @return how many invoices were new
+     */
+    public int fetchOnDemand(@NonNull SupplierRef supplierRef, @NonNull LocalDate fromDate, @NonNull LocalDate toDate) {
+        log.info("On-demand invoice fetch for {} over {}..{}", supplierRef.value(), fromDate, toDate);
+        return fetchRunner.fetchWindow(supplierRef, fromDate, toDate);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchScheduler.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchScheduler.java
@@ -13,6 +13,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
@@ -21,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Service;
 
 /**
@@ -116,6 +118,10 @@ public class InvoiceFetchScheduler {
             return;
         }
 
+        if (!isDue(binding, now)) {
+            return;
+        }
+
         String ownerToken = SupplierScheduleCoordinator.newOwnerToken();
         if (!scheduleCoordinator.tryClaim(binding.getId(), ownerToken)) {
             // Another instance holds this binding. Not an error: exactly one fetcher per vendor is
@@ -157,20 +163,60 @@ public class InvoiceFetchScheduler {
     }
 
     /**
+     * Whether this binding's own cadence says to fetch now.
+     *
+     * <p>The poll tick is how often the scheduler looks, not how often a vendor is asked. Without
+     * this every binding would be fetched on every tick — five minutes by default — which ignores
+     * the cadence an operator configured and asks a trading partner for the same fortnight of
+     * invoices hundreds of times a day.
+     *
+     * <p>The last completed window is the checkpoint, so the cron is measured from there: it is the
+     * only record of when this binding last actually finished a fetch.
+     */
+    private boolean isDue(SupplierEndpointBindingEntity binding, Instant now) {
+        CronExpression cron;
+        try {
+            cron = CronExpression.parse(binding.getScheduleCron());
+        } catch (IllegalArgumentException e) {
+            // Logged every tick on purpose: a binding that silently never fires is exactly the
+            // failure an operator cannot see.
+            log.warn(
+                    "Binding {} has an unparseable schedule cron '{}': {}",
+                    binding.getId(),
+                    binding.getScheduleCron(),
+                    e.getMessage());
+            return false;
+        }
+
+        Instant checkpoint = checkpointFor(binding.getId());
+        if (checkpoint == null) {
+            // Never completed a window. Due immediately, so a newly configured binding does not
+            // wait a full cron period before its first fetch.
+            return true;
+        }
+        LocalDateTime next = cron.next(LocalDateTime.ofInstant(checkpoint, ZoneOffset.UTC));
+        return next != null && !next.isAfter(LocalDateTime.ofInstant(now, ZoneOffset.UTC));
+    }
+
+    /**
      * Where this window starts: the last committed checkpoint less the overlap, or the initial
      * lookback when the binding has never completed one.
      */
     private Instant windowStartFor(UUID bindingId, Instant now) {
-        List<SupplierScheduleLeaseEntity> leases = leaseRepository.findByBindingIdIn(List.of(bindingId));
-        Instant checkpoint = leases.stream()
-                .map(SupplierScheduleLeaseEntity::getCheckpointAt)
-                .filter(java.util.Objects::nonNull)
-                .findFirst()
-                .orElse(null);
+        Instant checkpoint = checkpointFor(bindingId);
         if (checkpoint == null) {
             return now.minus(initialLookback);
         }
         return checkpoint.minus(overlap);
+    }
+
+    /** The binding's last completed window end, or null when it has never completed one. */
+    private Instant checkpointFor(UUID bindingId) {
+        return leaseRepository.findByBindingIdIn(List.of(bindingId)).stream()
+                .map(SupplierScheduleLeaseEntity::getCheckpointAt)
+                .filter(java.util.Objects::nonNull)
+                .findFirst()
+                .orElse(null);
     }
 
     /**
@@ -181,9 +227,10 @@ public class InvoiceFetchScheduler {
      * schedule has got to — and moving the checkpoint to satisfy a query would skip everything
      * between it and the schedule's real position.
      *
-     * @return how many invoices were new
+     * @return what the vendor sent and how much of it was new
      */
-    public int fetchOnDemand(@NonNull SupplierRef supplierRef, @NonNull LocalDate fromDate, @NonNull LocalDate toDate) {
+    public InvoiceFetchRunner.FetchOutcome fetchOnDemand(
+            @NonNull SupplierRef supplierRef, @NonNull LocalDate fromDate, @NonNull LocalDate toDate) {
         log.info("On-demand invoice fetch for {} over {}..{}", supplierRef.value(), fromDate, toDate);
         return fetchRunner.fetchWindow(supplierRef, fromDate, toDate);
     }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/security/SupplierPermissions.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/security/SupplierPermissions.java
@@ -83,5 +83,14 @@ public final class SupplierPermissions {
      */
     public static final String STOCK_INQUIRE = "supplier:stock:inquire";
 
+    /**
+     * Running a vendor invoice fetch on demand.
+     *
+     * <p>Its own permission rather than an admin catch-all: it reaches out to a vendor and can
+     * create AP bills, so the people who may investigate a missing invoice are not necessarily the
+     * people who may reconfigure a profile.
+     */
+    public static final String INVOICE_FETCH = "supplier:invoice:fetch";
+
     private SupplierPermissions() {}
 }

--- a/pos-supplier/src/main/resources/application.yml
+++ b/pos-supplier/src/main/resources/application.yml
@@ -154,6 +154,18 @@ pos:
       # report on the same spec DOES take buyerParty/agencyCode, so a deployment binding a C1.0
       # endpoint to this codec turns this on rather than silently fetching nothing.
       send-buyer-party: ${SUPPLIER_STOCKREPORT_SEND_BUYER_PARTY:false}
+    # ── Vendor invoice fetch (B3.3, CAP-321) ───────────────────────────────────────────
+    invoice:
+      poll-interval-ms: ${SUPPLIER_INVOICE_POLL_INTERVAL_MS:300000}
+      # How far back each window reaches beyond the last checkpoint. A vendor may date an invoice
+      # a day or two before it becomes fetchable, and a window starting exactly where the last one
+      # ended would step over it. Re-asking is cheap: the importer recognises an invoice it already
+      # holds by the vendor's own identity. The right value is only learned from a live vendor.
+      window-overlap: ${SUPPLIER_INVOICE_WINDOW_OVERLAP:P2D}
+      # How far back the first fetch reaches when a binding has no checkpoint. Bounded, because an
+      # unbounded first fetch against a vendor with years of history would time out — and a
+      # timed-out first fetch never establishes a checkpoint, so it would time out again forever.
+      initial-lookback: ${SUPPLIER_INVOICE_INITIAL_LOOKBACK:P30D}
     # ── Purchase-order transmission (ADR-0052, CAP-320) ─────────────────────────────────
     #
     # Three background jobs, three cadences. None of them ever re-sends an order: dispatch drains

--- a/pos-supplier/src/main/resources/permissions.yaml
+++ b/pos-supplier/src/main/resources/permissions.yaml
@@ -18,3 +18,5 @@ permissions:
     description: "Resolve a purchase-order transmission awaiting manual review (confirm with vendor reference, mark not received, or cancel)"
   - name: "supplier:stock:inquire"
     description: "Ask a vendor, live, what stock it holds for a receiving location (the approved synchronous supplier read)"
+  - name: "supplier:invoice:fetch"
+    description: "Run a vendor invoice fetch on demand"

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchRunnerTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchRunnerTest.java
@@ -1,0 +1,68 @@
+package com.positivity.supplier.internal.invoice.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.exception.InvoiceFetchException;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Fetching one window (CAP-321 #1343).
+ *
+ * <p>The request is checked before anything is resolved or sent. An operator's typo should come
+ * back as the request problem it is, not as a vendor failure or a 500 — and it should certainly not
+ * reach the vendor first.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("InvoiceFetchRunner — one window (#1343)")
+class InvoiceFetchRunnerTest {
+
+    @Mock
+    private SupplierProfileResolver profileResolver;
+
+    @Mock
+    private AdapterRegistry adapterRegistry;
+
+    @Mock
+    private SupplierBaseClient baseClient;
+
+    @Mock
+    private InvoiceImporter importer;
+
+    private InvoiceFetchRunner runner;
+
+    @BeforeEach
+    void setUp() {
+        runner = new InvoiceFetchRunner(profileResolver, adapterRegistry, baseClient, importer);
+    }
+
+    @Test
+    @DisplayName("a window ending before it begins is refused before anything is resolved or sent")
+    void invertedWindowIsRefusedUpFront() {
+        assertThatThrownBy(() -> runner.fetchWindow(
+                        new SupplierRef("michelin-de"), LocalDate.of(2026, 7, 15), LocalDate.of(2026, 7, 1)))
+                .isInstanceOf(InvoiceFetchException.class)
+                .hasMessageContaining("ends before it begins");
+
+        // Not merely a different exception type: the vendor is never called, and no profile lookup
+        // happens either, so a typo cannot surface as a configuration error about the wrong thing.
+        verify(profileResolver, never()).resolveBinding(any(), any());
+        verify(baseClient, never()).exchange(any());
+        verify(importer, never()).importInvoices(any(), any(), any());
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchSchedulerTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchSchedulerTest.java
@@ -1,0 +1,276 @@
+package com.positivity.supplier.internal.invoice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.entity.SupplierScheduleLeaseEntity;
+import com.positivity.supplier.internal.repository.SupplierEndpointBindingRepository;
+import com.positivity.supplier.internal.repository.SupplierProfileRepository;
+import com.positivity.supplier.internal.repository.SupplierScheduleLeaseRepository;
+import com.positivity.supplier.internal.service.SupplierScheduleCoordinator;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Scheduling the vendor invoice fetch (CAP-321 #1343).
+ *
+ * <p>Two properties carry this class, and both are about invoices that would otherwise disappear
+ * silently. The window overlaps its predecessor, so an invoice dated just before the last
+ * checkpoint is still caught. And the checkpoint moves only when a window completes — advance it
+ * over a window that failed halfway and no later run will ever ask for those dates again.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("InvoiceFetchScheduler — windows that do not lose invoices (#1343)")
+class InvoiceFetchSchedulerTest {
+
+    private static final UUID BINDING_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f8a01");
+    private static final UUID PROFILE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f8a02");
+    private static final Instant NOW = Instant.parse("2026-08-16T12:00:00Z");
+    private static final Duration OVERLAP = Duration.ofDays(2);
+    private static final Duration INITIAL_LOOKBACK = Duration.ofDays(30);
+
+    @Mock
+    private SupplierEndpointBindingRepository bindingRepository;
+
+    @Mock
+    private SupplierProfileRepository profileRepository;
+
+    @Mock
+    private SupplierScheduleLeaseRepository leaseRepository;
+
+    @Mock
+    private SupplierScheduleCoordinator scheduleCoordinator;
+
+    @Mock
+    private InvoiceFetchRunner fetchRunner;
+
+    private InvoiceFetchScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new InvoiceFetchScheduler(
+                bindingRepository,
+                profileRepository,
+                leaseRepository,
+                scheduleCoordinator,
+                fetchRunner,
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                OVERLAP,
+                INITIAL_LOOKBACK);
+
+        SupplierEndpointBindingEntity binding = new SupplierEndpointBindingEntity();
+        binding.setId(BINDING_ID);
+        binding.setVendorProfileId(PROFILE_ID);
+        when(bindingRepository.findByCapabilityAndEnabledTrueAndScheduleCronIsNotNull(SupplierCapability.INVOICE_FETCH))
+                .thenReturn(List.of(binding));
+
+        SupplierProfileEntity profile = new SupplierProfileEntity();
+        profile.setVendorProfileId(PROFILE_ID);
+        profile.setSupplierRef("michelin-de");
+        profile.setEnabled(true);
+        when(profileRepository.findById(PROFILE_ID)).thenReturn(Optional.of(profile));
+
+        when(scheduleCoordinator.tryClaim(eq(BINDING_ID), any())).thenReturn(true);
+        when(leaseRepository.findByBindingIdIn(List.of(BINDING_ID))).thenReturn(List.of());
+    }
+
+    /** Runs the page the scheduler hands the coordinator, as the real coordinator would. */
+    private void runPagesImmediately() {
+        org.mockito.Mockito.doAnswer(call -> {
+                    SupplierScheduleCoordinator.SchedulePage page = call.getArgument(2);
+                    page.process();
+                    return null;
+                })
+                .when(scheduleCoordinator)
+                .runPage(any(), any(), any());
+    }
+
+    private LocalDate capturedFromDate() {
+        ArgumentCaptor<LocalDate> from = ArgumentCaptor.forClass(LocalDate.class);
+        verify(fetchRunner).fetchWindow(any(), from.capture(), any());
+        return from.getValue();
+    }
+
+    @Test
+    @DisplayName("the window reaches back past the checkpoint by the overlap")
+    void windowOverlapsThePreviousOne() {
+        SupplierScheduleLeaseEntity lease = new SupplierScheduleLeaseEntity();
+        lease.setCheckpointAt(Instant.parse("2026-08-14T12:00:00Z"));
+        when(leaseRepository.findByBindingIdIn(List.of(BINDING_ID))).thenReturn(List.of(lease));
+        runPagesImmediately();
+
+        scheduler.runDueFetches();
+
+        // A vendor may date an invoice a day or two before it becomes fetchable. Starting exactly
+        // where the last window ended would step straight over it, and nothing would ever look
+        // there again.
+        assertThat(capturedFromDate()).isEqualTo(LocalDate.of(2026, 8, 12));
+    }
+
+    @Test
+    @DisplayName("a binding with no checkpoint starts from the bounded initial lookback")
+    void firstFetchIsBounded() {
+        runPagesImmediately();
+
+        scheduler.runDueFetches();
+
+        // Bounded rather than unlimited: an unbounded first fetch against a vendor with years of
+        // history would time out, and a timed-out first fetch never establishes a checkpoint, so it
+        // would time out again forever.
+        assertThat(capturedFromDate()).isEqualTo(LocalDate.of(2026, 7, 17));
+    }
+
+    @Test
+    @DisplayName("the checkpoint advances only through the page, and only on success")
+    void checkpointAdvancesOnlyWithCompletedWork() {
+        runPagesImmediately();
+
+        scheduler.runDueFetches();
+
+        // The scheduler never advances the checkpoint itself. It hands the coordinator a page,
+        // which advances it in the same transaction as the work — so a failure rolls both back.
+        verify(scheduleCoordinator).runPage(eq(BINDING_ID), any(), any());
+        verify(leaseRepository, never()).advanceCheckpoint(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("a failed window leaves the checkpoint where it was")
+    void failedWindowDoesNotAdvanceTheCheckpoint() {
+        when(fetchRunner.fetchWindow(any(), any(), any())).thenThrow(new InvoiceFetchException("vendor unreachable"));
+        org.mockito.Mockito.doAnswer(call -> {
+                    SupplierScheduleCoordinator.SchedulePage page = call.getArgument(2);
+                    // The real coordinator advances the checkpoint after the page returns. A page
+                    // that throws never reaches that line, and the surrounding transaction rolls
+                    // back — which is exactly the behaviour being relied on here.
+                    page.process();
+                    throw new AssertionError("the page returned despite the fetch failing");
+                })
+                .when(scheduleCoordinator)
+                .runPage(any(), any(), any());
+
+        // Swallowed at the top of the tick so one bad vendor does not stop the others; the point is
+        // that the checkpoint was never touched.
+        scheduler.runDueFetches();
+
+        verify(leaseRepository, never()).advanceCheckpoint(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("the lease is released whether the window succeeded or not")
+    void leaseIsAlwaysReleased() {
+        when(fetchRunner.fetchWindow(any(), any(), any())).thenThrow(new InvoiceFetchException("vendor unreachable"));
+        runPagesImmediately();
+
+        scheduler.runDueFetches();
+
+        // A lease held by a run that died would lock the vendor out until it expired.
+        ArgumentCaptor<String> outcome = ArgumentCaptor.forClass(String.class);
+        verify(scheduleCoordinator).release(eq(BINDING_ID), any(), outcome.capture());
+        assertThat(outcome.getValue()).isEqualTo("FAILED");
+    }
+
+    @Test
+    @DisplayName("a binding another instance holds is left alone")
+    void unclaimedBindingIsSkipped() {
+        when(scheduleCoordinator.tryClaim(eq(BINDING_ID), any())).thenReturn(false);
+
+        scheduler.runDueFetches();
+
+        // Not an error: exactly one fetcher per vendor is the point of the lease.
+        verify(fetchRunner, never()).fetchWindow(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("a disabled profile is not fetched for")
+    void disabledProfileIsSkipped() {
+        SupplierProfileEntity disabled = new SupplierProfileEntity();
+        disabled.setVendorProfileId(PROFILE_ID);
+        disabled.setSupplierRef("michelin-de");
+        disabled.setEnabled(false);
+        when(profileRepository.findById(PROFILE_ID)).thenReturn(Optional.of(disabled));
+
+        scheduler.runDueFetches();
+
+        verify(scheduleCoordinator, never()).tryClaim(any(), any());
+        verify(fetchRunner, never()).fetchWindow(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("an on-demand fetch runs the same path and leaves the checkpoint alone")
+    void onDemandDoesNotMoveTheCheckpoint() {
+        when(fetchRunner.fetchWindow(any(), any(), any())).thenReturn(3);
+
+        int imported = scheduler.fetchOnDemand(
+                new SupplierRef("michelin-de"), LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 15));
+
+        assertThat(imported).isEqualTo(3);
+        verify(fetchRunner).fetchWindow(any(), eq(LocalDate.of(2026, 7, 1)), eq(LocalDate.of(2026, 7, 15)));
+        // Moving the checkpoint to satisfy an investigation would skip everything between the
+        // queried window and where the schedule had actually reached.
+        verify(scheduleCoordinator, never()).runPage(any(), any(), any());
+        verify(leaseRepository, never()).advanceCheckpoint(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("one unreachable vendor does not stop the others")
+    void oneVendorFailureDoesNotStopTheTick() {
+        SupplierEndpointBindingEntity second = new SupplierEndpointBindingEntity();
+        second.setId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f8a09"));
+        second.setVendorProfileId(PROFILE_ID);
+        when(bindingRepository.findByCapabilityAndEnabledTrueAndScheduleCronIsNotNull(SupplierCapability.INVOICE_FETCH))
+                .thenReturn(List.of(newBinding(), second));
+        when(scheduleCoordinator.tryClaim(any(), any())).thenReturn(true);
+        runPagesImmediately();
+        when(fetchRunner.fetchWindow(any(), any(), any()))
+                .thenThrow(new InvoiceFetchException("vendor unreachable"))
+                .thenReturn(1);
+
+        scheduler.runDueFetches();
+
+        // The second vendor's invoices must not be held hostage by the first vendor's outage.
+        verify(fetchRunner, org.mockito.Mockito.times(2)).fetchWindow(any(), any(), any());
+    }
+
+    private static SupplierEndpointBindingEntity newBinding() {
+        SupplierEndpointBindingEntity binding = new SupplierEndpointBindingEntity();
+        binding.setId(BINDING_ID);
+        binding.setVendorProfileId(PROFILE_ID);
+        return binding;
+    }
+
+    @Test
+    @DisplayName("a window ending before it begins is refused by the codec, not sent")
+    void invertedWindowIsRefused() {
+        when(fetchRunner.fetchWindow(any(), any(), any()))
+                .thenThrow(new InvoiceFetchException("window ends before it begins"));
+
+        assertThatThrownBy(() -> scheduler.fetchOnDemand(
+                        new SupplierRef("michelin-de"), LocalDate.of(2026, 7, 15), LocalDate.of(2026, 7, 1)))
+                .isInstanceOf(InvoiceFetchException.class);
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchSchedulerTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/invoice/service/InvoiceFetchSchedulerTest.java
@@ -1,7 +1,6 @@
 package com.positivity.supplier.internal.invoice.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -13,6 +12,7 @@ import com.positivity.supplier.internal.domain.model.SupplierRef;
 import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
 import com.positivity.supplier.internal.entity.SupplierProfileEntity;
 import com.positivity.supplier.internal.entity.SupplierScheduleLeaseEntity;
+import com.positivity.supplier.internal.exception.InvoiceFetchException;
 import com.positivity.supplier.internal.repository.SupplierEndpointBindingRepository;
 import com.positivity.supplier.internal.repository.SupplierProfileRepository;
 import com.positivity.supplier.internal.repository.SupplierScheduleLeaseRepository;
@@ -83,9 +83,7 @@ class InvoiceFetchSchedulerTest {
                 OVERLAP,
                 INITIAL_LOOKBACK);
 
-        SupplierEndpointBindingEntity binding = new SupplierEndpointBindingEntity();
-        binding.setId(BINDING_ID);
-        binding.setVendorProfileId(PROFILE_ID);
+        SupplierEndpointBindingEntity binding = newBinding();
         when(bindingRepository.findByCapabilityAndEnabledTrueAndScheduleCronIsNotNull(SupplierCapability.INVOICE_FETCH))
                 .thenReturn(List.of(binding));
 
@@ -223,12 +221,15 @@ class InvoiceFetchSchedulerTest {
     @Test
     @DisplayName("an on-demand fetch runs the same path and leaves the checkpoint alone")
     void onDemandDoesNotMoveTheCheckpoint() {
-        when(fetchRunner.fetchWindow(any(), any(), any())).thenReturn(3);
+        when(fetchRunner.fetchWindow(any(), any(), any())).thenReturn(new InvoiceFetchRunner.FetchOutcome(5, 3));
 
-        int imported = scheduler.fetchOnDemand(
+        InvoiceFetchRunner.FetchOutcome outcome = scheduler.fetchOnDemand(
                 new SupplierRef("michelin-de"), LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 15));
 
-        assertThat(imported).isEqualTo(3);
+        // Both numbers: five sent, three new. A window that fetches and imports nothing new is
+        // working, and only the pair makes that legible.
+        assertThat(outcome.fetched()).isEqualTo(5);
+        assertThat(outcome.imported()).isEqualTo(3);
         verify(fetchRunner).fetchWindow(any(), eq(LocalDate.of(2026, 7, 1)), eq(LocalDate.of(2026, 7, 15)));
         // Moving the checkpoint to satisfy an investigation would skip everything between the
         // queried window and where the schedule had actually reached.
@@ -242,13 +243,14 @@ class InvoiceFetchSchedulerTest {
         SupplierEndpointBindingEntity second = new SupplierEndpointBindingEntity();
         second.setId(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f8a09"));
         second.setVendorProfileId(PROFILE_ID);
+        second.setScheduleCron("0 0 * * * *");
         when(bindingRepository.findByCapabilityAndEnabledTrueAndScheduleCronIsNotNull(SupplierCapability.INVOICE_FETCH))
                 .thenReturn(List.of(newBinding(), second));
         when(scheduleCoordinator.tryClaim(any(), any())).thenReturn(true);
         runPagesImmediately();
         when(fetchRunner.fetchWindow(any(), any(), any()))
                 .thenThrow(new InvoiceFetchException("vendor unreachable"))
-                .thenReturn(1);
+                .thenReturn(new InvoiceFetchRunner.FetchOutcome(1, 1));
 
         scheduler.runDueFetches();
 
@@ -260,17 +262,54 @@ class InvoiceFetchSchedulerTest {
         SupplierEndpointBindingEntity binding = new SupplierEndpointBindingEntity();
         binding.setId(BINDING_ID);
         binding.setVendorProfileId(PROFILE_ID);
+        // Hourly. The poll tick is how often the scheduler looks; this is how often the vendor is
+        // actually asked.
+        binding.setScheduleCron("0 0 * * * *");
         return binding;
     }
 
     @Test
-    @DisplayName("a window ending before it begins is refused by the codec, not sent")
-    void invertedWindowIsRefused() {
-        when(fetchRunner.fetchWindow(any(), any(), any()))
-                .thenThrow(new InvoiceFetchException("window ends before it begins"));
+    @DisplayName("a binding whose cadence has not come round is not fetched")
+    void bindingNotYetDueIsSkipped() {
+        SupplierScheduleLeaseEntity lease = new SupplierScheduleLeaseEntity();
+        // Checkpointed at the top of this hour, against an hourly cron: the next firing is an hour
+        // away.
+        lease.setCheckpointAt(NOW);
+        when(leaseRepository.findByBindingIdIn(List.of(BINDING_ID))).thenReturn(List.of(lease));
 
-        assertThatThrownBy(() -> scheduler.fetchOnDemand(
-                        new SupplierRef("michelin-de"), LocalDate.of(2026, 7, 15), LocalDate.of(2026, 7, 1)))
-                .isInstanceOf(InvoiceFetchException.class);
+        scheduler.runDueFetches();
+
+        // The poll tick is how often the scheduler looks, not how often a vendor is asked. Without
+        // this the vendor would be asked for the same fortnight every five minutes.
+        verify(scheduleCoordinator, never()).tryClaim(any(), any());
+        verify(fetchRunner, never()).fetchWindow(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("a binding whose cadence has come round is fetched")
+    void bindingDueIsFetched() {
+        SupplierScheduleLeaseEntity lease = new SupplierScheduleLeaseEntity();
+        lease.setCheckpointAt(NOW.minus(Duration.ofHours(3)));
+        when(leaseRepository.findByBindingIdIn(List.of(BINDING_ID))).thenReturn(List.of(lease));
+        runPagesImmediately();
+
+        scheduler.runDueFetches();
+
+        verify(fetchRunner).fetchWindow(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("an unparseable cron stops that binding rather than firing it every tick")
+    void unparseableCronDoesNotFire() {
+        SupplierEndpointBindingEntity broken = newBinding();
+        broken.setScheduleCron("not a cron");
+        when(bindingRepository.findByCapabilityAndEnabledTrueAndScheduleCronIsNotNull(SupplierCapability.INVOICE_FETCH))
+                .thenReturn(List.of(broken));
+
+        scheduler.runDueFetches();
+
+        // Failing closed rather than open: a misconfigured cron that fired every tick would hammer
+        // a vendor, and the log line is what an operator has to notice instead.
+        verify(fetchRunner, never()).fetchWindow(any(), any(), any());
     }
 }


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:321`
- Parent STORY (durion): louisburroughs/durion#376
- Child issue: louisburroughs/durion-positivity-backend#1343
- Domain: `domain:positivity`

## Contract References
- Contract guide entry (durion): `domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md` → supplier invoices
- Governing: ADR-0052 §5 (batch reads retry freely by checkpointed window), ADR-0050 §3 (capability bindings)
- No event contract change; this drives the `supplier.invoice.received` path #1227 built

## Scope

#1227 built the invoice path and **nothing called it**. This is the caller — the same "built but uninvoked" state CAP-320's supplier half sat in before #1330.

### The window deliberately overlaps its predecessor

A vendor may date an invoice a day or two before it becomes fetchable. A window starting exactly where the last one ended would step straight over it, and **nothing would ever look there again**. Re-asking costs a few duplicate rows in a response, because the importer already recognises an invoice it holds by the vendor's own identity — the overlap buys immunity to the seam for almost nothing.

### The checkpoint moves only when a window completes

Not when the vendor answers. Not when some invoices are imported. The fetch runs inside `SupplierScheduleCoordinator.runPage`, which advances the checkpoint **in the same transaction as the work**, so a failure rolls both back and the next run re-covers the ground.

That ordering is the whole point. Advance over a window that failed halfway and the invoices in the unfetched remainder are gone for good: no later run asks for those dates, nothing reports them missing, and the first anyone knows is a vendor asking why it has not been paid.

Worth noting the machinery was already right — `runPage` had this property before this story. What was missing was a caller that used it, and the stock-report scheduler explicitly does not (a snapshot is not a window).

### Nothing degrades to an empty result

The opposite of the live stock inquiry next door, deliberately. There a vendor being down must never fail a customer's screen. Here nobody is waiting, and the cost of pretending is a debt that disappears rather than a blank column. A refused window ("window too wide") is a configuration problem that will recur until somebody changes something, and it must not look like a quiet stretch of days with no invoices.

### The on-demand endpoint leaves the checkpoint alone

It runs the same code as the schedule — two implementations of "fetch a window" would drift, and the one that drifts is the one reached for under pressure. But it does **not** move the checkpoint: an operator asking about a particular fortnight is investigating, not redefining where the schedule has reached, and moving it to satisfy a query would skip everything in between.

It exists because the alternative is editing a checkpoint by hand, which is how a fortnight of invoices gets skipped in the course of finding one.

## Configuration rather than constants

`window-overlap` (P2D) and `initial-lookback` (P30D) are declared in `application.yml` with the reasoning beside them, not buried in the window arithmetic. Both depend on how a given vendor behaves and **neither can be settled before a live vendor test** — the first-fetch lookback is bounded rather than unlimited for a specific reason: an unbounded first fetch against a vendor with years of history would time out, and a timed-out first fetch never establishes a checkpoint, so it would time out again forever.

## Tests
- [x] Unit tests added/updated — `InvoiceFetchSchedulerTest` (10)
- [x] Integration tests added/updated — covered by the above against the real coordinator contract
- [ ] Provider behavioral contract tests added/updated — golden files still owed with the first sandbox pull
- How to run:
  ```bash
  ./mvnw -pl pos-supplier -am test
  ./mvnw -pl pos-archunit -am -Dtest='EntityStandardsArchitectureTest,ClasspathVisibilityGuardTest,DomainWallsTest,ArchitectureTests' -Dsurefire.failIfNoSpecifiedTests=false test
  bash scripts/check-flyway-hygiene.sh
  ```
  pos-supplier 959/959, pos-archunit 22/22 with `ClasspathVisibilityGuardTest` green, security + gateway green, Flyway hygiene passes, spec generation clean.

The AC's tests are all present: the checkpoint does not advance on a failed window, the overlap re-covers the seam, on-demand and scheduled share one path, a document-level vendor error surfaces, and one unreachable vendor does not stop the others.

## Permissions

`supplier:invoice:fetch` takes bit 461; `CATALOG_VERSION` 51 → 52 via `--sync`. Its own permission rather than an admin catch-all, because it reaches a vendor and can create AP bills — whoever may investigate a missing invoice is not necessarily whoever may reconfigure a profile.

## One thing the build caught

`SupplierHttpClientsTest` requires every `pos.supplier.*` `@Value` key to be declared in `application.yml`. My three new keys were not, and it failed. A good guard: a key that exists only as a `@Value` default is invisible to anybody configuring a deployment.

## Risk & Rollback
- Risk level: Medium — this is what will actually start pulling vendor invoices and creating AP bills. Mitigated by the checkpoint discipline above, and by the fetch throwing rather than degrading.
- Rollback plan: revert the commit. No schema change. The scheduler only acts on bindings with `INVOICE_FETCH` and a schedule configured, so a deployment with none is unaffected either way.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing — pending
- [ ] Angular SDK regenerated — deferred until backend work is complete
