### PR TITLE
[CAP:323] feat(supplier): fleet workorder authorization via Michelin S2S (#1229)

### DIFF
--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,9 +1,9 @@
-generatedAt: "2026-08-16T18:02:10.429550+00:00"
+generatedAt: "2026-08-16T20:30:21.598598+00:00"
 root: "."
 summary:
   manifestCount: 22
-  permissionCount: 427
-  uniquePermissionCount: 427
+  permissionCount: 429
+  uniquePermissionCount: 429
   duplicatePermissionNameCount: 0
   parseIssueCount: 0
 manifests:
@@ -792,7 +792,7 @@ manifests:
     domain: "supplier"
     serviceName: "pos-supplier"
     version: "1.0"
-    permissionCount: 9
+    permissionCount: 11
     permissions:
       - name: "supplier:audit:read"
         description: "Read supplier exchange audit records"
@@ -812,6 +812,10 @@ manifests:
         description: "Ask a vendor, live, what stock it holds for a receiving location (the approved synchronous supplier read)"
       - name: "supplier:invoice:fetch"
         description: "Run a vendor invoice fetch on demand"
+      - name: "supplier:workorderauth:request"
+        description: "Ask a fleet program to authorize work, and look up fleet vehicles, contracts and policies"
+      - name: "supplier:workorderauth:review"
+        description: "View and clear fleet workorder authorizations parked for manual review"
   - module: "pos-tax"
     path: "pos-tax/src/main/resources/permissions.yaml"
     domain: "tax"
@@ -3070,6 +3074,18 @@ permissions:
     source: "pos-supplier/src/main/resources/permissions.yaml"
   - name: "supplier:transmission:resolve"
     description: "Resolve a purchase-order transmission awaiting manual review (confirm with vendor reference, mark not received, or cancel)"
+    domain: "supplier"
+    serviceName: "pos-supplier"
+    module: "pos-supplier"
+    source: "pos-supplier/src/main/resources/permissions.yaml"
+  - name: "supplier:workorderauth:request"
+    description: "Ask a fleet program to authorize work, and look up fleet vehicles, contracts and policies"
+    domain: "supplier"
+    serviceName: "pos-supplier"
+    module: "pos-supplier"
+    source: "pos-supplier/src/main/resources/permissions.yaml"
+  - name: "supplier:workorderauth:review"
+    description: "View and clear fleet workorder authorizations parked for manual review"
     domain: "supplier"
     serviceName: "pos-supplier"
     module: "pos-supplier"

--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -1301,6 +1301,18 @@ paths:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1admin~1profiles~1{vendorProfileId}~1bindings
   /v1/supplier/admin/profiles/{vendorProfileId}/bindings/{bindingId}:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1admin~1profiles~1{vendorProfileId}~1bindings~1{bindingId}
+  /v1/supplier/fleet/authorizations/reviews:
+    $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1fleet~1authorizations~1reviews
+  /v1/supplier/fleet/{supplierRef}/authorizations:
+    $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1fleet~1{supplierRef}~1authorizations
+  /v1/supplier/fleet/{supplierRef}/authorizations/{workorderId}:
+    $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1fleet~1{supplierRef}~1authorizations~1{workorderId}
+  /v1/supplier/fleet/{supplierRef}/contracts:
+    $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1fleet~1{supplierRef}~1contracts
+  /v1/supplier/fleet/{supplierRef}/policies:
+    $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1fleet~1{supplierRef}~1policies
+  /v1/supplier/fleet/{supplierRef}/vehicles/{vehicleIdent}:
+    $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1fleet~1{supplierRef}~1vehicles~1{vehicleIdent}
   /v1/supplier/invoices/{supplierRef}/fetches:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1invoices~1{supplierRef}~1fetches
   /v1/supplier/stock/inquiries:

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 52;
+    public static final int CATALOG_VERSION = 54;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -551,7 +551,13 @@ public final class GatewayPermissionCatalog {
         "PERM_order:purchase_order:availability_view", // 460
 
         // ── New batch (bits 461–461) ──────────────────────────────────────────
-        "PERM_supplier:invoice:fetch" // 461
+        "PERM_supplier:invoice:fetch", // 461
+
+        // ── New batch (bits 462–462) ──────────────────────────────────────────
+        "PERM_supplier:workorderauth:request", // 462
+
+        // ── New batch (bits 463–463) ──────────────────────────────────────────
+        "PERM_supplier:workorderauth:review" // 463
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,13 +1142,13 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 52")
+    @DisplayName("CATALOG_VERSION is 54")
     void catalogVersionMatchesCurrent() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(52);
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(54);
     }
 
     @Test
-    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 455")
+    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 463")
     void authorityByBitCoversNewEntries() {
         // batch-2: previously missing (bits 241-261)
         assertThat(GatewayPermissionCatalog.authorityForBit(241)).isEqualTo("PERM_accounting:events:reprocess");
@@ -1315,8 +1315,16 @@ class SecurityGatewayConfigTest {
         // reaches a vendor and can create AP bills: whoever may investigate a missing invoice is
         // not necessarily whoever may reconfigure a profile.
         assertThat(GatewayPermissionCatalog.authorityForBit(461)).isEqualTo("PERM_supplier:invoice:fetch");
+        // Fleet workorder authorization (CAP-323 #1229). One permission covers the lookups and the
+        // request, because in a shop they are one act: a vehicle is looked up in order to ask for
+        // authorization on it.
+        assertThat(GatewayPermissionCatalog.authorityForBit(462)).isEqualTo("PERM_supplier:workorderauth:request");
+        // Working the queue of authorizations no vendor would answer. Separate, because these are
+        // rows where money is already owed for work already done, and whoever chases that is not
+        // necessarily whoever books the job in.
+        assertThat(GatewayPermissionCatalog.authorityForBit(463)).isEqualTo("PERM_supplier:workorderauth:review");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(462)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(464)).isNull();
     }
 
     @Test

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierWorkorderAuthDeniedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierWorkorderAuthDeniedV1.java
@@ -1,0 +1,55 @@
+package com.positivity.domainevents.supplier;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A fleet program refused to authorize work on a workorder, published on
+ * {@code supplier.events.v1} (CAP-323 #1229, ADR-0049 §3).
+ *
+ * <h2>Refusal is an answer, not a failure</h2>
+ *
+ * A denial is the vendor doing its job. It is deliberately a separate event from
+ * {@link SupplierWorkorderAuthGrantedV1} rather than a status field on one, so a consumer cannot
+ * subscribe to "authorization decided" and then forget to branch. The two outcomes lead to
+ * completely different work in a shop, and the shape of the event should make that unavoidable.
+ *
+ * <p>Distinguish this from an authorization that could not be obtained — a vendor being unreachable,
+ * a token that would not mint, a poll that never reached a terminal state. Those are not denials and
+ * are never published as one: they stay in the supplier domain as {@code MANUAL_REVIEW}, because
+ * telling a shop the fleet said no when in fact nobody asked is worse than telling it nothing.
+ *
+ * @param vendorProfileId       the vendor profile that made the decision
+ * @param supplierRef           that profile's alias at decision time; descriptive, never a key
+ * @param workorderId           the pos-workorder identity the decision concerns
+ * @param vendorAuthorizationId the vendor's own identifier for the request, where it gave one
+ * @param reasonCode            the vendor's own refusal code, as stated. Not translated to a Durion
+ *                              vocabulary: the code is what a shop quotes back to the fleet
+ * @param reasonText            the vendor's refusal text, as stated
+ * @param occurredAt            when the decision was observed
+ */
+public record SupplierWorkorderAuthDeniedV1(
+        @NonNull UUID vendorProfileId,
+        @NonNull String supplierRef,
+        @NonNull UUID workorderId,
+        @Nullable String vendorAuthorizationId,
+        @Nullable String reasonCode,
+        @Nullable String reasonText,
+        @NonNull Instant occurredAt) {
+
+    /** Event type of this payload on {@code supplier.events.v1}. */
+    public static final String EVENT_TYPE = "supplier.workorderauth.denied";
+
+    /** Payload schema version; additive changes only within v1 (ADR-0044 §3). */
+    public static final int SCHEMA_VERSION = 1;
+
+    public SupplierWorkorderAuthDeniedV1 {
+        Objects.requireNonNull(vendorProfileId, "vendorProfileId must not be null");
+        Objects.requireNonNull(supplierRef, "supplierRef must not be null");
+        Objects.requireNonNull(workorderId, "workorderId must not be null");
+        Objects.requireNonNull(occurredAt, "occurredAt must not be null");
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierWorkorderAuthGrantedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierWorkorderAuthGrantedV1.java
@@ -1,0 +1,67 @@
+package com.positivity.domainevents.supplier;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A fleet program authorized work on a workorder, published on {@code supplier.events.v1}
+ * (CAP-323 #1229, ADR-0049 §3).
+ *
+ * <h2>An input to a workflow, not a state change</h2>
+ *
+ * This says what the vendor decided. It does not say what the workorder should now do about it —
+ * that mapping belongs to pos-workorder, which stays authoritative for workorder state (ADR-0049
+ * §2). Publishing a decision and publishing a transition are different things, and conflating them
+ * would put a second state machine for workorders inside the supplier domain.
+ *
+ * <h2>Identity, because a decision can arrive twice</h2>
+ *
+ * An asynchronous authorization is resolved by polling, and a poll that times out is retried, so the
+ * same terminal decision can be observed more than once. A consumer must key on
+ * {@code (vendorProfileId, workorderId)} rather than on the event: this is a decision about a
+ * workorder, and a workorder has one live authorization at a time.
+ *
+ * @param vendorProfileId       the vendor profile that made the decision
+ * @param supplierRef           that profile's alias at decision time; descriptive, never a key
+ * @param workorderId           the pos-workorder identity the decision concerns
+ * @param vendorAuthorizationId the vendor's own identifier for the authorization, where it gave one.
+ *                              Needed to approve completion later, so its absence is worth noticing
+ * @param contractReference     the fleet contract the authorization was granted under, as stated
+ * @param authorizedAmount      the amount authorized, as stated by the vendor. Absent when the
+ *                              vendor authorized the work without stating a ceiling — which is not
+ *                              the same as authorizing zero
+ * @param currency              ISO 4217 code for {@code authorizedAmount}; absent together with it
+ * @param occurredAt            when the decision was observed
+ */
+public record SupplierWorkorderAuthGrantedV1(
+        @NonNull UUID vendorProfileId,
+        @NonNull String supplierRef,
+        @NonNull UUID workorderId,
+        @Nullable String vendorAuthorizationId,
+        @Nullable String contractReference,
+        @Nullable BigDecimal authorizedAmount,
+        @Nullable String currency,
+        @NonNull Instant occurredAt) {
+
+    /** Event type of this payload on {@code supplier.events.v1}. */
+    public static final String EVENT_TYPE = "supplier.workorderauth.granted";
+
+    /** Payload schema version; additive changes only within v1 (ADR-0044 §3). */
+    public static final int SCHEMA_VERSION = 1;
+
+    public SupplierWorkorderAuthGrantedV1 {
+        Objects.requireNonNull(vendorProfileId, "vendorProfileId must not be null");
+        Objects.requireNonNull(supplierRef, "supplierRef must not be null");
+        Objects.requireNonNull(workorderId, "workorderId must not be null");
+        Objects.requireNonNull(occurredAt, "occurredAt must not be null");
+        if (authorizedAmount != null && currency == null) {
+            // An amount without a currency is not a sum of money, and a fleet ceiling that a
+            // consumer has to guess the currency of is worse than no ceiling at all.
+            throw new IllegalArgumentException("currency is required when authorizedAmount is present");
+        }
+    }
+}

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -23,7 +23,7 @@ public final class DownstreamPermissionCatalog {
      * {@code PermissionCode.CATALOG_VERSION}.
      * Updated automatically by {@code scripts/generate-permissions.py --sync}.
      */
-    public static final int CATALOG_VERSION = 52;
+    public static final int CATALOG_VERSION = 54;
 
     /**
      * Index-to-authority mapping. Entry at position N is the {@code PERM_*}-prefixed
@@ -577,7 +577,13 @@ public final class DownstreamPermissionCatalog {
         "PERM_order:purchase_order:availability_view", // 460
 
         // ── New batch (bits 461–461) ──────────────────────────────────────────
-        "PERM_supplier:invoice:fetch" // 461
+        "PERM_supplier:invoice:fetch", // 461
+
+        // ── New batch (bits 462–462) ──────────────────────────────────────────
+        "PERM_supplier:workorderauth:request", // 462
+
+        // ── New batch (bits 463–463) ──────────────────────────────────────────
+        "PERM_supplier:workorderauth:review" // 463
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -605,13 +605,17 @@ public enum PermissionCode {
     // ── Order (new) ────────────────────────────────────────────────────────────
     ORDER__PURCHASE_ORDER__AVAILABILITY_VIEW(460, "order:purchase_order:availability_view"),
     // ── Supplier (new) ─────────────────────────────────────────────────────────
-    SUPPLIER__INVOICE__FETCH(461, "supplier:invoice:fetch");
+    SUPPLIER__INVOICE__FETCH(461, "supplier:invoice:fetch"),
+    // ── Supplier (new) ─────────────────────────────────────────────────────────
+    SUPPLIER__WORKORDERAUTH__REQUEST(462, "supplier:workorderauth:request"),
+    // ── Supplier (new) ─────────────────────────────────────────────────────────
+    SUPPLIER__WORKORDERAUTH__REVIEW(463, "supplier:workorderauth:review");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 52;
+    public static final int CATALOG_VERSION = 54;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 462;
-    private static final int EXPECTED_CATALOG_VERSION = 52;
+    private static final int EXPECTED_PERMISSION_COUNT = 464;
+    private static final int EXPECTED_CATALOG_VERSION = 54;
 
     // -------------------------------------------------------------------------
     // AC-1: Catalog size — EXPECTED_PERMISSION_COUNT entries

--- a/pos-supplier/openapi.yaml
+++ b/pos-supplier/openapi.yaml
@@ -18,6 +18,8 @@ tags:
   description: On-demand vendor invoice retrieval
 - name: Supplier Commercial Accounts
   description: Admin CRUD over vendor commercial accounts — billing and per-location delivery numbers
+- name: Supplier Fleet Authorization
+  description: Fleet workorder authorization and lookups
 - name: Supplier Endpoint Bindings
   description: Admin CRUD over capability endpoint bindings — capability → (family, version, URL, auth)
 - name: Supplier Order Transmission
@@ -1031,6 +1033,82 @@ paths:
         - supplier:invoice:fetch
       x-required-permissions:
       - supplier:invoice:fetch
+  /v1/supplier/fleet/{supplierRef}/authorizations:
+    post:
+      tags:
+      - Supplier Fleet Authorization
+      summary: Request Fleet Authorization For A Workorder
+      description: 'Asks a vendor''s fleet program to authorize the work on a workorder, and records what it said.
+
+        Use this tool once the vehicle and the work are known; do not call it repeatedly to check for an answer, because asking again can open a second authorization against the same contract — use getFleetWorkorderAuthorization to read the outcome instead.
+
+        Preconditions: the vendor profile must be enabled with a workorder-authorization binding and a billing account number, and the request must identify the vehicle by vendor vehicle id, license plate, VIN or fleet number.
+
+        Required inputs: supplierRef path parameter, workorderId, and at least one vehicle identifier; contractId, odometerValue and lines are optional.
+
+        Emits a SUPPLIER_WORKORDER_AUTHORIZATION_REQUEST event, and on a decision publishes supplier.workorderauth.granted or supplier.workorderauth.denied for the workorder domain.
+
+        Returns 200 with the authorization, whose status is GRANTED, DENIED, NOT_FOUND, PENDING when the vendor accepted the request and will decide later, or MANUAL_REVIEW when no decision could be obtained at all; 400 when no vehicle identifier is given; 404 when the vendor profile is unknown; and 409 when the profile is disabled or has no workorder-authorization binding configured.
+
+        '
+      operationId: requestFleetWorkorderAuthorization
+      parameters:
+      - name: supplierRef
+        in: path
+        description: Vendor profile alias
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: 'The work being requested, and how the fleet vehicle is identified. At least one of vendorVehicleId, licensePlate, vin or fleetNumber must be given: a request that identifies no vehicle cannot be authorized by anyone.'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FleetAuthorizationRequestBody'
+            examples:
+              Two front tyres on a plated fleet vehicle:
+                description: Two front tyres on a plated fleet vehicle
+                value:
+                  workorderId: 019200aa-0000-7000-8000-0000000000c1
+                  licensePlate: ABC-123
+                  contractId: C-1
+                  odometerValue: '104500'
+                  lines:
+                  - reference: '4001111'
+                    description: Front axle tyres
+                    quantity: 2
+                    tirePosition: 1L
+        required: true
+      responses:
+        '200':
+          description: Authorization requested; see status for the outcome
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FleetAuthorizationResponse'
+        '400':
+          description: The request identifies no vehicle
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '404':
+          description: Vendor profile unknown
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: Vendor profile disabled, or no workorder-authorization binding configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - supplier:workorderauth:request
+      x-required-permissions:
+      - supplier:workorderauth:request
   /v1/supplier/admin/profiles:
     get:
       tags:
@@ -1995,6 +2073,277 @@ paths:
       - bearerAuth: []
       x-required-permissions:
       - supplier:transmission:read
+  /v1/supplier/fleet/{supplierRef}/vehicles/{vehicleIdent}:
+    get:
+      tags:
+      - Supplier Fleet Authorization
+      summary: Look Up A Fleet Vehicle
+      description: 'Asks a vendor''s fleet program what it knows about a vehicle, by license plate, VIN, fleet number or the vendor''s own vehicle id.
+
+        Use this tool before requesting authorization, to confirm the vehicle is on a fleet contract and to obtain the vendor vehicle id; do not treat the answer as authorization, because only requestFleetWorkorderAuthorization obtains that.
+
+        Preconditions: the vendor profile must be enabled with a workorder-authorization binding.
+
+        Required inputs: supplierRef and vehicleIdent path parameters.
+
+        Emits a SUPPLIER_FLEET_VEHICLE_LOOKUP event.
+
+        Returns 200 with the vehicle as the fleet holds it, 404 when the fleet does not know the vehicle or the vendor profile is unknown, 409 when the profile is disabled or unconfigured, and 422 when the vendor could not be reached or answered unreadably.
+
+        '
+      operationId: lookupFleetVehicle
+      parameters:
+      - name: supplierRef
+        in: path
+        description: Vendor profile alias
+        required: true
+        schema:
+          type: string
+      - name: vehicleIdent
+        in: path
+        description: Plate, VIN, fleet number or vendor vehicle id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: The vehicle as the fleet holds it
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FleetVehicle'
+        '404':
+          description: The fleet does not know this vehicle, or the vendor profile is unknown
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: Vendor profile disabled, or no workorder-authorization binding configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '422':
+          description: The vendor could not be reached or answered unreadably
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - supplier:workorderauth:request
+      x-required-permissions:
+      - supplier:workorderauth:request
+  /v1/supplier/fleet/{supplierRef}/policies:
+    get:
+      tags:
+      - Supplier Fleet Authorization
+      summary: List Fleet Policies
+      description: 'Lists what a fleet program says it will and will not pay for.
+
+        Use this tool to narrow what is offered to a fleet customer; do not use it as permission, because it is advisory and only requestFleetWorkorderAuthorization obtains a decision.
+
+        Preconditions: the vendor profile must be enabled with a workorder-authorization binding.
+
+        Required inputs: supplierRef path parameter.
+
+        Emits a SUPPLIER_FLEET_POLICY_LIST event.
+
+        Returns 200 with the policies as stated — an empty list when the vendor states none or answers in a shape this adapter does not recognise — 404 when the vendor profile is unknown, 409 when the profile is disabled or unconfigured, and 422 when the vendor could not be reached.
+
+        '
+      operationId: listFleetPolicies
+      parameters:
+      - name: supplierRef
+        in: path
+        description: Vendor profile alias
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: The fleet policies as stated
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FleetPolicy'
+        '404':
+          description: Vendor profile unknown
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: Vendor profile disabled, or no workorder-authorization binding configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '422':
+          description: The vendor could not be reached
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - supplier:workorderauth:request
+      x-required-permissions:
+      - supplier:workorderauth:request
+  /v1/supplier/fleet/{supplierRef}/contracts:
+    get:
+      tags:
+      - Supplier Fleet Authorization
+      summary: List Fleet Contracts
+      description: 'Lists the fleet contracts this service provider may claim work under at a vendor.
+
+        Use this tool to populate a contract choice before requesting authorization; do not use the contract dates to decide whether work is covered, because only the vendor decides that when authorization is requested.
+
+        Preconditions: the vendor profile must be enabled with a workorder-authorization binding.
+
+        Required inputs: supplierRef path parameter.
+
+        Emits a SUPPLIER_FLEET_CONTRACT_LIST event.
+
+        Returns 200 with the contracts as stated, 404 when the vendor profile is unknown, 409 when the profile is disabled or unconfigured, and 422 when the vendor could not be reached.
+
+        '
+      operationId: listFleetContracts
+      parameters:
+      - name: supplierRef
+        in: path
+        description: Vendor profile alias
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: The fleet contracts as stated
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FleetContract'
+        '404':
+          description: Vendor profile unknown
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: Vendor profile disabled, or no workorder-authorization binding configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '422':
+          description: The vendor could not be reached or answered unreadably
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - supplier:workorderauth:request
+      x-required-permissions:
+      - supplier:workorderauth:request
+  /v1/supplier/fleet/{supplierRef}/authorizations/{workorderId}:
+    get:
+      tags:
+      - Supplier Fleet Authorization
+      summary: Read A Fleet Authorization
+      description: 'Returns the fleet authorization recorded for a workorder at a vendor, including the vendor''s reason where it gave one.
+
+        Use this tool to check the outcome of an authorization that came back PENDING; do not call requestFleetWorkorderAuthorization again for that, because it can open a second authorization.
+
+        Preconditions: none.
+
+        Required inputs: supplierRef and workorderId path parameters.
+
+        Emits a SUPPLIER_WORKORDER_AUTHORIZATION_READ event.
+
+        Returns 200 with the authorization, and 404 when the vendor profile is unknown or no authorization was ever requested for this workorder.
+
+        '
+      operationId: getFleetWorkorderAuthorization
+      parameters:
+      - name: supplierRef
+        in: path
+        description: Vendor profile alias
+        required: true
+        schema:
+          type: string
+      - name: workorderId
+        in: path
+        description: Workorder the authorization concerns
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: The recorded authorization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FleetAuthorizationResponse'
+        '404':
+          description: Vendor profile unknown, or no authorization recorded for this workorder
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - supplier:workorderauth:request
+      x-required-permissions:
+      - supplier:workorderauth:request
+  /v1/supplier/fleet/authorizations/reviews:
+    get:
+      tags:
+      - Supplier Fleet Authorization
+      summary: List Fleet Authorizations Needing Review
+      description: 'Lists fleet authorizations and completions that could not be resolved with a vendor and are waiting on a person, newest first.
+
+        Use this tool to work the queue of stuck fleet jobs; the reviewReason says what went wrong and approvalStatus distinguishes an authorization nobody could obtain from a completion nobody could get signed off. Do not read a row here as a vendor decision — nothing in this list has been refused by a fleet, only left unresolved — and do not use it to check one workorder, because getFleetWorkorderAuthorization answers that directly instead.
+
+        Preconditions: none.
+
+        Required inputs: none; limit defaults to 100.
+
+        Emits a SUPPLIER_WORKORDER_AUTHORIZATION_REVIEW_LIST event.
+
+        Returns 200 with the rows waiting on a person, which is an empty list when nothing is stuck.
+
+        '
+      operationId: listFleetAuthorizationsNeedingReview
+      parameters:
+      - name: limit
+        in: query
+        description: Maximum rows to return
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 100
+      responses:
+        '200':
+          description: Authorizations and completions waiting on a person
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FleetAuthorizationResponse'
+      security:
+      - bearerAuth:
+        - supplier:workorderauth:review
+      x-required-permissions:
+      - supplier:workorderauth:review
   /v1/supplier/admin/price-catalog/{vendorProfileId}/unmatched-lines:
     get:
       tags:
@@ -3038,6 +3387,103 @@ components:
           type: string
           format: date-time
           description: When this answer was obtained. Present when the status is OK; a cached answer carries the instant of the original inquiry, not of the cache hit.
+    FleetAuthorizationRequestBody:
+      type: object
+      description: A request to have a fleet program authorize the work on a workorder
+      properties:
+        workorderId:
+          type: string
+          format: uuid
+          description: Workorder the authorization is for
+        vendorVehicleId:
+          type: string
+          description: The vendor's own vehicle id, when a lookup has already resolved one
+        licensePlate:
+          type: string
+          description: License plate as presented
+        vin:
+          type: string
+          description: VIN as presented
+        fleetNumber:
+          type: string
+          description: The fleet's own unit number
+        contractId:
+          type: string
+          description: Fleet contract claimed, when known
+        odometerValue:
+          type: string
+          description: Odometer reading at check-in, as recorded
+        lines:
+          type: array
+          description: The work being requested
+          items:
+            $ref: '#/components/schemas/Line'
+      required:
+      - workorderId
+    Line:
+      type: object
+      description: One requested operation or part
+      properties:
+        reference:
+          type: string
+          description: Part or operation reference as the shop knows it
+        description:
+          type: string
+          description: Free text for a human reading the request at the fleet
+        quantity:
+          type: integer
+          format: int32
+          description: How many
+          minimum: 0
+        tirePosition:
+          type: string
+          description: Wheel position, where the work is position-specific
+    FleetAuthorizationResponse:
+      type: object
+      description: A fleet workorder authorization and its vendor-side sign-off state
+      properties:
+        workorderId:
+          type: string
+          format: uuid
+          description: Workorder the authorization concerns
+        supplierRef:
+          type: string
+          description: Vendor profile alias
+        status:
+          type: string
+          description: GRANTED, DENIED, NOT_FOUND, PENDING while the vendor decides, or MANUAL_REVIEW when no decision could be obtained
+        vendorAuthorizationId:
+          type: string
+          description: The vendor's own authorization id, needed to approve completion
+        contractReference:
+          type: string
+          description: Contract the work was authorized under, as stated
+        authorizedAmount:
+          type: number
+          description: Ceiling the vendor stated, when it stated one
+        currency:
+          type: string
+          description: ISO 4217 code for authorizedAmount
+        reasonCode:
+          type: string
+          description: The vendor's refusal code, as stated
+        reasonText:
+          type: string
+          description: The vendor's refusal text, as stated
+        reviewReason:
+          type: string
+          description: Why this authorization needs a human; never a vendor decision
+        approvalStatus:
+          type: string
+          description: NOT_REQUESTED, PENDING, APPROVED or MANUAL_REVIEW
+        requestedAt:
+          type: string
+          format: date-time
+          description: When the authorization was requested
+        decidedAt:
+          type: string
+          format: date-time
+          description: When the vendor decided, if it has
     PriceCatalogImportSummary:
       type: object
       description: Bookkeeping summary of one vendor PRICAT import run.
@@ -3118,6 +3564,64 @@ components:
         failureDetail:
           type: string
           description: Operator-facing failure summary for a failed import.
+    FleetVehicle:
+      type: object
+      properties:
+        vendorVehicleId:
+          type: string
+        licensePlate:
+          type: string
+        fleetNumber:
+          type: string
+        vin:
+          type: string
+        brand:
+          type: string
+        model:
+          type: string
+        modelYear:
+          type: integer
+          format: int32
+        odometerValue:
+          type: string
+        identifiable:
+          type: boolean
+    FleetPolicy:
+      type: object
+      properties:
+        policyId:
+          type: string
+        name:
+          type: string
+        useBlacklist:
+          type: boolean
+        useWhitelist:
+          type: boolean
+        blacklisted:
+          type: array
+          items:
+            type: string
+        whitelisted:
+          type: array
+          items:
+            type: string
+    FleetContract:
+      type: object
+      properties:
+        vendorContractId:
+          type: string
+        name:
+          type: string
+        contractorId:
+          type: string
+        contractorName:
+          type: string
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
     PagedResponse:
       type: object
       description: A page of results.

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/michelins2s/MichelinS2SWorkorderAuthCodec.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/michelins2s/MichelinS2SWorkorderAuthCodec.java
@@ -1,0 +1,517 @@
+package com.positivity.supplier.internal.adapter.michelins2s;
+
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.domain.model.SupplierWorkorderAuthorization;
+import com.positivity.supplier.internal.domain.model.WorkorderAuthorizationRequest;
+import com.positivity.supplier.internal.spi.SupplierAdapterCodec;
+import com.positivity.supplier.service.model.FleetContract;
+import com.positivity.supplier.service.model.FleetPolicy;
+import com.positivity.supplier.service.model.FleetVehicle;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Michelin S2S workorder authorization codec (CAP-323 #1229) — the second protocol family.
+ *
+ * <h2>Transport-free, like every other codec</h2>
+ *
+ * This class builds request specs and reads bodies. It performs no I/O, holds no vendor connection
+ * and knows nothing about polling: the fact that a 202 must be followed up is expressed by returning
+ * a {@code PENDING} authorization carrying the {@code Location}, and acting on that is the runner's
+ * job (ADR-0051 §5).
+ *
+ * <h2>Reading a decision from an underspecified response</h2>
+ *
+ * The source spec gives no response schema for the workorder operations, so the decoder accepts
+ * several plausible field names for the same thing rather than committing to one. That is not
+ * defensive padding: picking a single name and being wrong produces a <em>granted authorization with
+ * no vendor id</em>, which looks fine for months and then cannot be approved when the work
+ * completes. Reading whichever of the candidates is present costs nothing and removes that failure.
+ *
+ * <p>By the same reasoning an unrecognised status word is never treated as a grant. Work proceeding
+ * on a misread word is the one outcome that cannot be undone by fixing the codec afterwards.
+ */
+@Component
+@RequiredArgsConstructor
+public class MichelinS2SWorkorderAuthCodec implements SupplierAdapterCodec {
+
+    /**
+     * Vendor words that mean the fleet said yes.
+     *
+     * <p>An allowlist, matched case-insensitively. Anything not in it is not a grant — see the class
+     * note: the asymmetry is deliberate, because a false grant authorises real work and a false
+     * non-grant merely asks again.
+     */
+    private static final Set<String> GRANTED_WORDS =
+            Set.of("granted", "approved", "authorized", "authorised", "accepted");
+
+    /** Vendor words that mean the fleet said no. A real answer, and a normal one. */
+    private static final Set<String> DENIED_WORDS = Set.of("denied", "refused", "rejected", "declined");
+
+    /** Vendor words that mean it does not know what we are talking about. */
+    private static final Set<String> NOT_FOUND_WORDS = Set.of("notfound", "not_found", "unknown");
+
+    /** Vendor words that mean "still deciding". */
+    private static final Set<String> PENDING_WORDS =
+            Set.of("pending", "inprogress", "in_progress", "processing", "accepted_pending");
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @NonNull
+    public SupplierCapability capability() {
+        return SupplierCapability.WORKORDER_AUTHORIZATION;
+    }
+
+    @Override
+    @NonNull
+    public ProtocolFamily family() {
+        return ProtocolFamily.MICHELIN_S2S;
+    }
+
+    @Override
+    @NonNull
+    public ProtocolVersion version() {
+        return ProtocolVersion.S2S_V1;
+    }
+
+    /**
+     * Builds the authorization request.
+     *
+     * @param request  what is being asked for
+     * @param partnerId the service-provider identity the vendor uses to contextualise the request,
+     *                  from profile configuration. Required by the spec
+     * @param apiMajorVersion major version for the {@code API-Version} header, per the spec's rule
+     *                        that it carry the MAJOR version only and match the URI version
+     * @return a transport-free request spec
+     */
+    @NonNull
+    public SupplierRequestSpec buildAuthorizationRequest(
+            @NonNull WorkorderAuthorizationRequest request,
+            @NonNull String partnerId,
+            @NonNull String apiMajorVersion) {
+        List<WorkorderS2SWire.WorkorderRequestLine> lines = new ArrayList<>();
+        for (WorkorderAuthorizationRequest.Line line : request.lines()) {
+            lines.add(new WorkorderS2SWire.WorkorderRequestLine(
+                    line.reference(), line.description(), line.quantity(), line.tirePosition()));
+        }
+
+        WorkorderS2SWire.WorkorderRequest body = new WorkorderS2SWire.WorkorderRequest(
+                request.workorderId().toString(),
+                request.vendorVehicleId(),
+                request.licensePlate(),
+                request.vin(),
+                request.fleetNumber(),
+                request.contractId(),
+                request.odometerValue(),
+                lines.isEmpty() ? null : lines);
+
+        // Not idempotent: creating an authorization is a commercial act at the fleet, and a blind
+        // re-send after an ambiguous failure could open a second authorization against the same
+        // contract. Recovery goes through the stored row, not through re-dispatch (ADR-0052 §5).
+        return new SupplierRequestSpec(
+                "POST",
+                "/api/v1/workOrders",
+                partnerQuery(partnerId),
+                objectMapper.writeValueAsString(body),
+                "application/json",
+                "application/json",
+                false,
+                apiVersionHeader(apiMajorVersion));
+    }
+
+    /**
+     * Builds the completion sign-off.
+     *
+     * @param vendorAuthorizationId the vendor's own id for the authorization being approved
+     */
+    @NonNull
+    public SupplierRequestSpec buildApprovalRequest(
+            @NonNull String vendorAuthorizationId, @NonNull String partnerId, @NonNull String apiMajorVersion) {
+        // Idempotent: approving an already-approved workorder is the vendor restating a fact, so a
+        // retry after an ambiguous failure is safe — and it must be, because the alternative to
+        // retrying is work performed that the fleet never agreed to pay for.
+        return new SupplierRequestSpec(
+                "PATCH",
+                "/api/v1/workOrders/" + encodePathSegment(vendorAuthorizationId) + "/approve",
+                partnerQuery(partnerId),
+                "{}",
+                "application/json",
+                "application/json",
+                true,
+                apiVersionHeader(apiMajorVersion));
+    }
+
+    /** Builds a re-read of an accepted-but-undecided authorization, from the 202's {@code Location}. */
+    @NonNull
+    public SupplierRequestSpec buildPollRequest(@NonNull String pollPath, @NonNull String partnerId) {
+        return new SupplierRequestSpec("GET", pollPath, partnerQuery(partnerId), null, null, "application/json", true);
+    }
+
+    /** Builds the vehicle lookup. */
+    @NonNull
+    public SupplierRequestSpec buildVehicleLookup(@NonNull String vehicleIdent, @NonNull String partnerId) {
+        return new SupplierRequestSpec(
+                "GET",
+                "/api/v1/vehicles/" + encodePathSegment(vehicleIdent),
+                partnerQuery(partnerId),
+                null,
+                null,
+                "application/json",
+                true);
+    }
+
+    /** Builds the contract lookup. */
+    @NonNull
+    public SupplierRequestSpec buildContractLookup(@NonNull String partnerId) {
+        return new SupplierRequestSpec(
+                "GET", "/api/v1/contracts", partnerQuery(partnerId), null, null, "application/json", true);
+    }
+
+    /** Builds the policy lookup. */
+    @NonNull
+    public SupplierRequestSpec buildPolicyLookup(@NonNull String partnerId) {
+        return new SupplierRequestSpec(
+                "GET", "/api/v1/policies", partnerQuery(partnerId), null, null, "application/json", true);
+    }
+
+    /**
+     * Reads an authorization decision.
+     *
+     * @param body         response body as received; may be absent on a 202, which carries its answer
+     *                     in the {@code Location} header instead
+     * @param httpStatus   the status the vendor answered with
+     * @param location     the {@code Location} header, where the vendor sent one
+     * @param workorderId  this side's key for the job, carried through because the vendor's echo of
+     *                     it cannot be relied on
+     * @return the decision, or a {@code PENDING} authorization when the vendor accepted and will
+     *     answer later
+     * @throws WorkorderAuthDecodeException when the body is present but unreadable, or the vendor
+     *     answered a status this codec cannot interpret
+     */
+    @NonNull
+    public SupplierWorkorderAuthorization decodeDecision(
+            @Nullable String body, int httpStatus, @Nullable String location, @NonNull UUID workorderId) {
+        if (httpStatus == 202) {
+            // Accepted, undecided. The Location is the whole content of the answer: without it there
+            // is nothing to come back to, which is a vendor defect and must not read as "pending
+            // forever".
+            if (location == null || location.isBlank()) {
+                throw new WorkorderAuthDecodeException(
+                        "vendor accepted the authorization (HTTP 202) without a Location header, so its decision can never be read");
+            }
+            return SupplierWorkorderAuthorization.pending(workorderId, location);
+        }
+
+        if (body == null || body.isBlank()) {
+            // A 201 with no body is not a grant. The vendor created something and told us nothing
+            // about it; if a Location was given we can still go and read it.
+            if (location != null && !location.isBlank()) {
+                return SupplierWorkorderAuthorization.pending(workorderId, location);
+            }
+            throw new WorkorderAuthDecodeException("vendor answered HTTP " + httpStatus
+                    + " with neither a body nor a Location, so no decision can be read");
+        }
+
+        WorkorderS2SWire.WorkorderDecision decision;
+        try {
+            decision = objectMapper.readValue(body, WorkorderS2SWire.WorkorderDecision.class);
+        } catch (RuntimeException e) {
+            throw new WorkorderAuthDecodeException(
+                    "authorization response was not readable JSON: " + e.getMessage(), e);
+        }
+
+        String vendorId = firstPresent(decision.id(), decision.workOrderId());
+        String statusWord = firstPresent(decision.status(), decision.state());
+        SupplierWorkorderAuthorization.Status status = classify(statusWord, decision, location);
+
+        if (status == SupplierWorkorderAuthorization.Status.PENDING) {
+            return new SupplierWorkorderAuthorization(
+                    vendorId,
+                    workorderId,
+                    SupplierWorkorderAuthorization.Status.PENDING,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    location);
+        }
+
+        BigDecimal amount = decimalOrNull(decision.authorizedAmount());
+        String currency = decision.currency();
+        if (amount != null && (currency == null || currency.isBlank())) {
+            // An amount the vendor gave no currency for is not a ceiling anybody can act on, and
+            // guessing the profile's currency here would invent a commercial term.
+            amount = null;
+            currency = null;
+        }
+
+        return new SupplierWorkorderAuthorization(
+                vendorId,
+                workorderId,
+                status,
+                firstPresent(decision.reason(), decision.message(), firstErrorDetail(decision)),
+                firstPresent(decision.reasonCode(), firstErrorCode(decision)),
+                firstPresent(decision.contractReference(), decision.contractId()),
+                amount,
+                amount == null ? null : currency,
+                null);
+    }
+
+    /** Reads a vehicle lookup response. */
+    @NonNull
+    public FleetVehicle decodeVehicle(@Nullable String body) {
+        WorkorderS2SWire.Vehicle vehicle = read(body, WorkorderS2SWire.Vehicle.class, "vehicle");
+        return new FleetVehicle(
+                vehicle.id(),
+                vehicle.licensePlate(),
+                vehicle.fleetNumber(),
+                vehicle.vin(),
+                vehicle.brand(),
+                vehicle.model(),
+                vehicle.year(),
+                vehicle.odometerValue());
+    }
+
+    /** Reads a contract lookup response. Both the v1 and v2.0.0 endpoints answer with this shape. */
+    @NonNull
+    public List<FleetContract> decodeContracts(@Nullable String body) {
+        List<WorkorderS2SWire.ContractDetails> wire =
+                readList(body, new TypeReference<List<WorkorderS2SWire.ContractDetails>>() {}, "contracts");
+        List<FleetContract> contracts = new ArrayList<>(wire.size());
+        for (WorkorderS2SWire.ContractDetails details : wire) {
+            contracts.add(new FleetContract(
+                    details.id(),
+                    details.name(),
+                    details.contractor() == null ? null : details.contractor().id(),
+                    details.contractor() == null ? null : details.contractor().name(),
+                    dateOrNull(details.startDate()),
+                    dateOrNull(details.endDate())));
+        }
+        return List.copyOf(contracts);
+    }
+
+    /**
+     * Reads a policy lookup response.
+     *
+     * <p>The spec gives {@code /policies} a bare {@code 200} with no schema, so this reads the
+     * black/white list vocabulary the spec defines elsewhere and returns an empty policy rather than
+     * throwing when it finds something else. A policy is advisory — failing a quote because an
+     * advisory read came back in an unexpected shape would be the wrong trade.
+     */
+    @NonNull
+    public List<FleetPolicy> decodePolicies(@Nullable String body) {
+        if (body == null || body.isBlank()) {
+            return List.of();
+        }
+        try {
+            List<Map<String, Object>> raw =
+                    objectMapper.readValue(body, new TypeReference<List<Map<String, Object>>>() {});
+            List<FleetPolicy> policies = new ArrayList<>(raw.size());
+            for (Map<String, Object> entry : raw) {
+                policies.add(new FleetPolicy(
+                        stringOrNull(entry.get("id")),
+                        stringOrNull(entry.get("name")),
+                        Boolean.TRUE.equals(entry.get("useBlacklist")),
+                        Boolean.TRUE.equals(entry.get("useWhiteList")),
+                        references(entry.get("blackList")),
+                        references(entry.get("whiteList"))));
+            }
+            return List.copyOf(policies);
+        } catch (RuntimeException e) {
+            return List.of();
+        }
+    }
+
+    /**
+     * Maps a vendor status word onto a decision.
+     *
+     * <p>Unrecognised words raise rather than defaulting. There is no safe default: defaulting to
+     * granted authorises work nobody agreed to pay for, and defaulting to denied turns away a paying
+     * fleet customer. Raising puts the row in front of a human, which is the only correct answer to
+     * "the vendor said something we do not understand".
+     */
+    private SupplierWorkorderAuthorization.@NonNull Status classify(
+            @Nullable String statusWord,
+            WorkorderS2SWire.@NonNull WorkorderDecision decision,
+            @Nullable String location) {
+        if (statusWord == null || statusWord.isBlank()) {
+            // No status word at all. An error list means refusal; anything else is undecided, and
+            // undecided is only actionable if we were told where to look.
+            if (decision.errors() != null && !decision.errors().isEmpty()) {
+                return SupplierWorkorderAuthorization.Status.DENIED;
+            }
+            if (location != null && !location.isBlank()) {
+                return SupplierWorkorderAuthorization.Status.PENDING;
+            }
+            throw new WorkorderAuthDecodeException(
+                    "authorization response carried no status and no error, so the vendor's position is unknown");
+        }
+
+        String normalised = statusWord.trim().toLowerCase(Locale.ROOT).replace('-', '_');
+        if (GRANTED_WORDS.contains(normalised)) {
+            return SupplierWorkorderAuthorization.Status.GRANTED;
+        }
+        if (DENIED_WORDS.contains(normalised)) {
+            return SupplierWorkorderAuthorization.Status.DENIED;
+        }
+        if (NOT_FOUND_WORDS.contains(normalised.replace(" ", ""))) {
+            return SupplierWorkorderAuthorization.Status.NOT_FOUND;
+        }
+        if (PENDING_WORDS.contains(normalised)) {
+            return SupplierWorkorderAuthorization.Status.PENDING;
+        }
+        throw new WorkorderAuthDecodeException("vendor answered with an unrecognised authorization status '"
+                + statusWord + "'; refusing to guess whether work is authorized");
+    }
+
+    /**
+     * The {@code API-Version} header, which the spec says carries the MAJOR version only and must
+     * match the URI version.
+     *
+     * <p>Sent so a vendor that has moved to a major version this codec was not written against
+     * says so, rather than answering a v2 body to a v1 caller that will misread it. Omitted when
+     * unconfigured rather than defaulted, because guessing a version is how that mismatch happens.
+     */
+    @NonNull
+    private static Map<String, String> apiVersionHeader(@NonNull String apiMajorVersion) {
+        return apiMajorVersion.isBlank() ? Map.of() : Map.of("API-Version", apiMajorVersion);
+    }
+
+    @NonNull
+    private Map<String, String> partnerQuery(@NonNull String partnerId) {
+        Map<String, String> query = new LinkedHashMap<>();
+        query.put("partnerId", partnerId);
+        return query;
+    }
+
+    @NonNull
+    private <T> T read(@Nullable String body, @NonNull Class<T> type, @NonNull String what) {
+        if (body == null || body.isBlank()) {
+            throw new WorkorderAuthDecodeException(what + " response body was empty");
+        }
+        try {
+            return objectMapper.readValue(body, type);
+        } catch (RuntimeException e) {
+            throw new WorkorderAuthDecodeException(what + " response was not readable JSON: " + e.getMessage(), e);
+        }
+    }
+
+    @NonNull
+    private <T> List<T> readList(@Nullable String body, @NonNull TypeReference<List<T>> type, @NonNull String what) {
+        if (body == null || body.isBlank()) {
+            throw new WorkorderAuthDecodeException(what + " response body was empty");
+        }
+        try {
+            return objectMapper.readValue(body, type);
+        } catch (RuntimeException e) {
+            throw new WorkorderAuthDecodeException(what + " response was not readable JSON: " + e.getMessage(), e);
+        }
+    }
+
+    @Nullable
+    private static String firstPresent(String... candidates) {
+        for (String candidate : candidates) {
+            if (candidate != null && !candidate.isBlank()) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private static String firstErrorDetail(WorkorderS2SWire.@NonNull WorkorderDecision decision) {
+        if (decision.errors() == null || decision.errors().isEmpty()) {
+            return null;
+        }
+        return decision.errors().getFirst().detail();
+    }
+
+    @Nullable
+    private static String firstErrorCode(WorkorderS2SWire.@NonNull WorkorderDecision decision) {
+        if (decision.errors() == null || decision.errors().isEmpty()) {
+            return null;
+        }
+        return decision.errors().getFirst().code();
+    }
+
+    /**
+     * Reads a vendor decimal.
+     *
+     * <p>Comma decimal separators are normalised, as in every sibling codec: a vendor writing
+     * {@code 1.234,56} in a locale that does so must not be read as one thousand two hundred.
+     */
+    @Nullable
+    private static BigDecimal decimalOrNull(@Nullable String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(value.trim().replace(",", "."));
+        } catch (NumberFormatException e) {
+            // An unreadable ceiling is not a zero ceiling. Dropping it leaves the authorization
+            // without a stated limit, which is what "we could not read it" actually means.
+            return null;
+        }
+    }
+
+    @Nullable
+    private static LocalDate dateOrNull(@Nullable String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(value.trim().length() > 10 ? value.trim().substring(0, 10) : value.trim());
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    private static String stringOrNull(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    /** Pulls {@code references.value} strings out of an EDIWheel black/white list entry array. */
+    @NonNull
+    @SuppressWarnings("unchecked")
+    private static List<String> references(Object listNode) {
+        if (!(listNode instanceof List<?> entries)) {
+            return List.of();
+        }
+        List<String> values = new ArrayList<>();
+        for (Object entry : entries) {
+            if (entry instanceof Map<?, ?> entryMap
+                    && entryMap.get("references") instanceof Map<?, ?> reference
+                    && reference.get("value") != null) {
+                values.add(String.valueOf(reference.get("value")));
+            }
+        }
+        return List.copyOf(values);
+    }
+
+    /** Percent-encodes a path segment so a vendor identifier cannot alter the path it sits in. */
+    @NonNull
+    private static String encodePathSegment(@NonNull String segment) {
+        return java.net.URLEncoder.encode(segment, java.nio.charset.StandardCharsets.UTF_8)
+                .replace("+", "%20");
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/michelins2s/WorkorderAuthDecodeException.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/michelins2s/WorkorderAuthDecodeException.java
@@ -1,0 +1,24 @@
+package com.positivity.supplier.internal.adapter.michelins2s;
+
+import java.io.Serial;
+
+/**
+ * A Michelin S2S workorder response could not be read (CAP-323 #1229).
+ *
+ * <p>Raised rather than returned as an "unknown" status, because every caller of the decoder is
+ * about to decide whether a shop may do work. An unreadable answer must not be able to flow onward
+ * looking like an answer.
+ */
+public class WorkorderAuthDecodeException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public WorkorderAuthDecodeException(String message) {
+        super(message);
+    }
+
+    public WorkorderAuthDecodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/michelins2s/WorkorderS2SWire.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/michelins2s/WorkorderS2SWire.java
@@ -1,0 +1,115 @@
+package com.positivity.supplier.internal.adapter.michelins2s;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Michelin S2S wire records, modelled literally (ADR-0051 §2).
+ *
+ * <h2>Fields marked GUESS are guesses</h2>
+ *
+ * The source spec types the workorder request body as {@code JsonNode} and gives no response schema
+ * for the workorder operations, so the request shape below is derived from the EDIWheel
+ * party/vehicle/reference vocabulary the same spec <em>does</em> define for its lookups. Each such
+ * field carries a {@code GUESS} note.
+ *
+ * <p>They are marked rather than merely written because the alternative is a first sandbox run that
+ * fails with "400 Bad Request" and no way to tell an invented field from a mistyped one. The lookup
+ * records below are not guesses — those shapes are specified.
+ *
+ * <p>Package-private by design: no vendor type reaches the domain, an event, or an API contract.
+ */
+final class WorkorderS2SWire {
+
+    private WorkorderS2SWire() {}
+
+    /**
+     * The authorization request body.
+     *
+     * <p>GUESS — the spec declares this as {@code JsonNode}. Modelled on the EDIWheel vocabulary the
+     * lookups use, so that when a sandbox corrects it the correction is likely to be renaming or
+     * nesting rather than starting over.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    record WorkorderRequest(
+            /* GUESS: our own reference for the job, echoed back on the decision. */
+            @Nullable String externalReference,
+            /* GUESS: how the fleet vehicle is identified — the lookups accept an ident of this shape. */
+            @Nullable String vehicleId,
+            @Nullable String licensePlate,
+            @Nullable String vin,
+            @Nullable String fleetNumber,
+            /* GUESS: the contract the work is claimed under. */
+            @Nullable String contractId,
+            @Nullable String odometerValue,
+            /* GUESS: line items the authorization is requested for. */
+            @Nullable List<WorkorderRequestLine> lines) {}
+
+    /** GUESS — one requested operation or part on the authorization request. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    record WorkorderRequestLine(
+            @Nullable String reference,
+            @Nullable String description,
+            @Nullable Integer quantity,
+            @Nullable String tirePosition) {}
+
+    /**
+     * The authorization decision, however it arrives — in a 201 body, or from polling a 202's
+     * {@code Location}.
+     *
+     * <p>GUESS on field names. Several alternatives are accepted at decode time rather than one
+     * being picked, because guessing wrong here silently yields "granted with no id", which cannot
+     * be approved on completion and is not noticed until months later.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record WorkorderDecision(
+            @Nullable String id,
+            @Nullable String workOrderId,
+            @Nullable String status,
+            @Nullable String state,
+            @Nullable String contractId,
+            @Nullable String contractReference,
+            @Nullable String authorizedAmount,
+            @Nullable String currency,
+            @Nullable String reasonCode,
+            @Nullable String reason,
+            @Nullable String message,
+            @Nullable List<ApiErrorDetail> errors) {}
+
+    /** {@code ApiErrorDetail} — specified by the source spec. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record ApiErrorDetail(
+            @Nullable String id,
+            @Nullable String code,
+            @Nullable String detail) {}
+
+    /** {@code EDIWheelVehicle} — specified by the source spec. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Vehicle(
+            @Nullable String id,
+            @Nullable String licensePlate,
+            @Nullable String fleetNumber,
+            @Nullable String vin,
+            @Nullable String registrationCountry,
+            @Nullable String brand,
+            @Nullable String model,
+            @Nullable Integer year,
+            @Nullable String type,
+            @Nullable String odometerValue) {}
+
+    /** {@code EDIWheelVehicleDetails} — a contract with the vehicles it covers. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record ContractDetails(
+            @Nullable String id,
+            @Nullable String name,
+            @Nullable Contractor contractor,
+            @Nullable String startDate,
+            @Nullable String endDate,
+            @Nullable List<Vehicle> vehicles) {}
+
+    /** {@code EDIWheelContractor} — specified by the source spec. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Contractor(@Nullable String id, @Nullable String name) {}
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/michelins2s/package-info.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/michelins2s/package-info.java
@@ -1,0 +1,34 @@
+/**
+ * Michelin S2S workorder authorization adapter (CAP-323 #1229) — the second protocol family.
+ *
+ * <h2>Why this package is the reusability proof</h2>
+ *
+ * Every other adapter in this module speaks EDIWheel. This one does not: it is JSON REST over
+ * OAuth2 client credentials, with an asynchronous acceptance pattern no EDIWheel norm uses. If
+ * adding it required changes to the orchestration, the registry or the consuming domains, then the
+ * claim that a new vendor costs "an adapter plus configuration" was false. So the interesting output
+ * of this package is not the code but the list of things outside it that had to change — which is
+ * asserted, not asserted-to-be-empty, by {@code MichelinS2SReusabilityTest}.
+ *
+ * <h2>What the source spec does and does not define</h2>
+ *
+ * {@code durion/docs/ediwheel/ediwheel-workorder-michelin-implementation_1.json} is an
+ * implementation note, not a contract. It defines the operations, the {@code partnerId} query
+ * convention, the {@code API-Version} header and the 201/202 + {@code Location} acceptance pattern.
+ * It defines the vehicle, contract and policy <em>response</em> shapes.
+ *
+ * <p>It does <strong>not</strong> define the workorder request body: the spec types it as
+ * {@code JsonNode}, which is to say "some JSON". Nor does it give response schemas for the workorder
+ * operations. The request shape built here is therefore derived from the EDIWheel party/vehicle/
+ * reference vocabulary the same spec does define, and it is a best guess until a sandbox corrects
+ * it. Every field that is a guess is marked as one at its declaration in {@code WorkorderS2SWire},
+ * so a first sandbox run is a matter of fixing named fields rather than re-reading a vendor's mind.
+ *
+ * <h2>Decoding is defensive on purpose</h2>
+ *
+ * Because the response shapes are unspecified, the decoder reads what it recognises and reports what
+ * it cannot rather than failing on an unexpected field. A vendor adding a field must not break an
+ * authorization; a vendor omitting the authorization id must not be silently read as a grant with no
+ * id, because that grant cannot be approved on completion later.
+ */
+package com.positivity.supplier.internal.adapter.michelins2s;

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/client/SupplierBaseClient.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/client/SupplierBaseClient.java
@@ -26,6 +26,8 @@ import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -225,6 +227,9 @@ public class SupplierBaseClient {
             // and therefore never retried, reporting a permanent rejection of a valid document.
             headers.set(HttpHeaders.CONTENT_TYPE, request.contentType());
         }
+        // Applied before auth, so a codec cannot overwrite a credential header with one of its own:
+        // a protocol header is a vendor's routing concern and never an authorisation one.
+        request.headers().forEach(headers::set);
         try {
             // Credentials resolved at call time; the resolved values live only in these headers.
             authStrategies.apply(headers, binding.authConfig());
@@ -304,7 +309,8 @@ public class SupplierBaseClient {
                     decode(entity.getBody(), entity.getHeaders().getContentType()),
                     null,
                     started,
-                    Instant.now(clock));
+                    Instant.now(clock),
+                    carriedHeaders(entity.getHeaders()));
             metrics.recordBreakerState(binding.profile().getVendorProfileId(), binding.capability(), breaker);
             return ok;
 
@@ -570,10 +576,44 @@ public class SupplierBaseClient {
             @Nullable String failureDetail,
             @NonNull Instant started,
             @NonNull Instant finished) {
+        return recordAndBuild(
+                request,
+                uri,
+                correlationId,
+                attemptNumber,
+                outcome,
+                httpStatus,
+                responseBody,
+                failureDetail,
+                started,
+                finished,
+                Map.of());
+    }
+
+    @NonNull
+    private SupplierHttpResponse recordAndBuild(
+            @NonNull SupplierHttpRequest request,
+            @NonNull String uri,
+            @NonNull String correlationId,
+            int attemptNumber,
+            @NonNull ExchangeOutcome outcome,
+            @Nullable Integer httpStatus,
+            @Nullable String responseBody,
+            @Nullable String failureDetail,
+            @NonNull Instant started,
+            @NonNull Instant finished,
+            @NonNull Map<String, String> responseHeaders) {
         ResolvedBinding binding = request.binding();
         Duration duration = Duration.between(started, finished);
         SupplierHttpResponse response = new SupplierHttpResponse(
-                outcome, httpStatus, responseBody, correlationId, attemptNumber, duration, failureDetail);
+                outcome,
+                httpStatus,
+                responseBody,
+                correlationId,
+                attemptNumber,
+                duration,
+                failureDetail,
+                responseHeaders);
 
         try {
             exchangeObserver.onExchange(new ExchangeContext(
@@ -615,7 +655,27 @@ public class SupplierBaseClient {
                 response.correlationId(),
                 attempts,
                 Duration.between(callStarted, Instant.now(clock)),
-                response.failureDetail());
+                response.failureDetail(),
+                response.responseHeaders());
+    }
+
+    /**
+     * The subset of response headers the transport carries out, per
+     * {@link SupplierHttpResponse#CARRIED_RESPONSE_HEADERS}.
+     *
+     * <p>Filtered here rather than by the caller so no code path can hand the whole vendor header
+     * map onward by accident.
+     */
+    @NonNull
+    private static Map<String, String> carriedHeaders(@NonNull HttpHeaders headers) {
+        Map<String, String> carried = new LinkedHashMap<>();
+        headers.forEach((name, values) -> {
+            if (SupplierHttpResponse.CARRIED_RESPONSE_HEADERS.contains(name.toLowerCase(Locale.ROOT))
+                    && !values.isEmpty()) {
+                carried.put(name, values.getFirst());
+            }
+        });
+        return carried;
     }
 
     @NonNull

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/client/SupplierHttpRequest.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/client/SupplierHttpRequest.java
@@ -1,6 +1,7 @@
 package com.positivity.supplier.internal.client;
 
 import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -50,8 +51,13 @@ public record SupplierHttpRequest(
             throw new IllegalArgumentException("contentType is required when a body is present");
         }
         Objects.requireNonNull(headers, "headers must not be null");
-        queryParams = Map.copyOf(new LinkedHashMap<>(queryParams));
-        headers = Map.copyOf(new LinkedHashMap<>(headers));
+        // Collections.unmodifiableMap over a LinkedHashMap, not Map.copyOf: the latter gives no
+        // ordering guarantee, and the query string is built by iterating this map. SupplierRequestSpec
+        // takes the same care one layer up, so copying with Map.copyOf here discarded the order it had
+        // just preserved -- leaving a vendor's query parameters in an arbitrary sequence that could
+        // differ between runs of the same request.
+        queryParams = Collections.unmodifiableMap(new LinkedHashMap<>(queryParams));
+        headers = Collections.unmodifiableMap(new LinkedHashMap<>(headers));
     }
 
     /** Builds a request that adds no headers of its own. */

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/client/SupplierHttpRequest.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/client/SupplierHttpRequest.java
@@ -36,7 +36,8 @@ public record SupplierHttpRequest(
         @Nullable String body,
         @Nullable String contentType,
         @Nullable String accept,
-        boolean idempotent) {
+        boolean idempotent,
+        @NonNull Map<String, String> headers) {
 
     public SupplierHttpRequest {
         Objects.requireNonNull(binding, "binding must not be null");
@@ -48,7 +49,22 @@ public record SupplierHttpRequest(
         if (body != null && (contentType == null || contentType.isBlank())) {
             throw new IllegalArgumentException("contentType is required when a body is present");
         }
+        Objects.requireNonNull(headers, "headers must not be null");
         queryParams = Map.copyOf(new LinkedHashMap<>(queryParams));
+        headers = Map.copyOf(new LinkedHashMap<>(headers));
+    }
+
+    /** Builds a request that adds no headers of its own. */
+    public SupplierHttpRequest(
+            @NonNull ResolvedBinding binding,
+            @NonNull HttpMethod method,
+            @Nullable String pathSuffix,
+            @NonNull Map<String, String> queryParams,
+            @Nullable String body,
+            @Nullable String contentType,
+            @Nullable String accept,
+            boolean idempotent) {
+        this(binding, method, pathSuffix, queryParams, body, contentType, accept, idempotent, Map.of());
     }
 
     /**
@@ -76,6 +92,7 @@ public record SupplierHttpRequest(
      */
     @NonNull
     public SupplierHttpRequest asIdempotentRead() {
-        return new SupplierHttpRequest(binding, method, pathSuffix, queryParams, body, contentType, accept, true);
+        return new SupplierHttpRequest(
+                binding, method, pathSuffix, queryParams, body, contentType, accept, true, headers);
     }
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/client/SupplierHttpResponse.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/client/SupplierHttpResponse.java
@@ -2,7 +2,12 @@ package com.positivity.supplier.internal.client;
 
 import com.positivity.supplier.internal.spi.ExchangeOutcome;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -23,6 +28,8 @@ import org.jspecify.annotations.Nullable;
  * @param attempts how many attempts were made, {@code >= 1}
  * @param totalDuration wall-clock duration across all attempts
  * @param failureDetail operator-facing failure summary; {@code null} on success. Never a credential
+ * @param responseHeaders control-flow response headers, restricted to
+ *     {@link #CARRIED_RESPONSE_HEADERS}; empty when none were present
  */
 public record SupplierHttpResponse(
         @NonNull ExchangeOutcome outcome,
@@ -31,15 +38,69 @@ public record SupplierHttpResponse(
         @NonNull String correlationId,
         int attempts,
         @NonNull Duration totalDuration,
-        @Nullable String failureDetail) {
+        @Nullable String failureDetail,
+        @NonNull Map<String, String> responseHeaders) {
+
+    /**
+     * The only response headers carried out of the transport, matched case-insensitively.
+     *
+     * <p>An allowlist rather than the whole header map, because these three carry protocol control
+     * flow and nothing else does. {@code Location} is where an asynchronously accepted request says
+     * its result will appear — without it a 202 is indistinguishable from a request that vanished.
+     * {@code API-Version} lets a caller notice it is talking to a major version it was not built
+     * for. {@code Retry-After} is a vendor stating its own backoff.
+     *
+     * <p>Carrying every header instead would put arbitrary vendor-controlled strings — set-cookie,
+     * bearer challenges, tracing identifiers — into an object that is logged and flows toward the
+     * exchange audit. That is a credential-leak shape for no gain: no caller has ever wanted them.
+     */
+    public static final Set<String> CARRIED_RESPONSE_HEADERS = Set.of("location", "api-version", "retry-after");
 
     public SupplierHttpResponse {
         Objects.requireNonNull(outcome, "outcome must not be null");
         Objects.requireNonNull(correlationId, "correlationId must not be null");
         Objects.requireNonNull(totalDuration, "totalDuration must not be null");
+        Objects.requireNonNull(responseHeaders, "responseHeaders must not be null");
         if (attempts < 1) {
             throw new IllegalArgumentException("attempts must be >= 1");
         }
+        // Lower-cased keys so a caller need not guess a vendor's capitalisation: HTTP header names
+        // are case-insensitive and vendors do vary.
+        Map<String, String> normalised = new LinkedHashMap<>();
+        responseHeaders.forEach((name, value) -> {
+            if (name != null && value != null) {
+                normalised.put(name.toLowerCase(Locale.ROOT), value);
+            }
+        });
+        responseHeaders = Collections.unmodifiableMap(normalised);
+    }
+
+    /**
+     * Builds a response that carried no headers.
+     *
+     * <p>Kept so the many call sites that never had headers to report — every EDIWheel capability,
+     * and every failure path that received no response at all — say that by omission rather than by
+     * threading an empty map through.
+     */
+    public SupplierHttpResponse(
+            @NonNull ExchangeOutcome outcome,
+            @Nullable Integer httpStatus,
+            @Nullable String body,
+            @NonNull String correlationId,
+            int attempts,
+            @NonNull Duration totalDuration,
+            @Nullable String failureDetail) {
+        this(outcome, httpStatus, body, correlationId, attempts, totalDuration, failureDetail, Map.of());
+    }
+
+    /**
+     * The named response header, or {@code null} when the vendor did not send it.
+     *
+     * @param name header name; matched case-insensitively
+     */
+    @Nullable
+    public String header(@NonNull String name) {
+        return responseHeaders.get(name.toLowerCase(Locale.ROOT));
     }
 
     /** Whether the vendor accepted and answered. */

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/config/SupplierEventTypes.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/config/SupplierEventTypes.java
@@ -110,6 +110,30 @@ public final class SupplierEventTypes {
                         .build(),
                 EventTypeRegistration.write(
                                 "SUPPLIER_INVOICE_FETCH", "Run a vendor invoice fetch for an explicit window")
+                        .build(),
+                // Fleet workorder authorization (CAP-323). Approval-grade rather than write: this
+                // asks a trading partner for a commercial decision, and asking twice can open two
+                // authorizations against one contract — so a duplicate here costs a phone call to a
+                // fleet manager, not a retry.
+                EventTypeRegistration.approval(
+                                "SUPPLIER_WORKORDER_AUTHORIZATION_REQUEST",
+                                "Ask a fleet program to authorize work on a workorder")
+                        .build(),
+                EventTypeRegistration.fastRead(
+                                "SUPPLIER_WORKORDER_AUTHORIZATION_READ",
+                                "Read the fleet authorization recorded for a workorder")
+                        .build(),
+                // The lookups reach a vendor synchronously while a service advisor waits, so their
+                // threshold is the vendor's latency, as with the stock inquiry above.
+                EventTypeRegistration.write("SUPPLIER_FLEET_VEHICLE_LOOKUP", "Look up a vehicle in a fleet program")
+                        .build(),
+                EventTypeRegistration.write("SUPPLIER_FLEET_CONTRACT_LIST", "List a vendor's fleet contracts")
+                        .build(),
+                EventTypeRegistration.write("SUPPLIER_FLEET_POLICY_LIST", "List a fleet program's policies")
+                        .build(),
+                EventTypeRegistration.fastRead(
+                                "SUPPLIER_WORKORDER_AUTHORIZATION_REVIEW_LIST",
+                                "List fleet authorizations and completions waiting on a person")
                         .build());
     }
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierWorkorderAuthorizationController.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierWorkorderAuthorizationController.java
@@ -1,0 +1,345 @@
+package com.positivity.supplier.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.shared.error.ApiError;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.WorkorderAuthorizationRequest;
+import com.positivity.supplier.internal.security.SupplierPermissions;
+import com.positivity.supplier.internal.workorderauth.service.FleetLookupRunner;
+import com.positivity.supplier.internal.workorderauth.service.WorkorderAuthorizationRunner;
+import com.positivity.supplier.service.model.FleetAuthorizationRequestBody;
+import com.positivity.supplier.service.model.FleetAuthorizationResponse;
+import com.positivity.supplier.service.model.FleetContract;
+import com.positivity.supplier.service.model.FleetPolicy;
+import com.positivity.supplier.service.model.FleetVehicle;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Fleet workorder authorization (CAP-323 #1229).
+ *
+ * <h2>Why a shop needs each of these</h2>
+ *
+ * The lookups come first in time: a vehicle arrives, somebody checks whether the fleet knows it and
+ * what contract covers it, and only then is authorization requested for specific work. Exposing the
+ * lookups separately is what makes the authorization request something a service advisor can fill in
+ * correctly rather than guess at.
+ *
+ * <p>The authorization request is the commercial act, and the reason it is not retried anywhere in
+ * this module: asking twice can open two authorizations against one contract.
+ */
+@RestController
+@RequestMapping("/v1/supplier/fleet")
+@RequiredArgsConstructor
+@Tag(name = "Supplier Fleet Authorization", description = "Fleet workorder authorization and lookups")
+public class SupplierWorkorderAuthorizationController {
+
+    private final WorkorderAuthorizationRunner authorizationRunner;
+    private final FleetLookupRunner fleetLookupService;
+
+    @PostMapping("/{supplierRef}/authorizations")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"supplier:workorderauth:request"})
+    @PreAuthorize("hasAuthority('" + SupplierPermissions.WORKORDER_AUTHORIZE + "')")
+    @EmitEvent(id = "SUPPLIER_WORKORDER_AUTHORIZATION_REQUEST", apiVersion = "1")
+    @Operation(
+            operationId = "requestFleetWorkorderAuthorization",
+            summary = "Request Fleet Authorization For A Workorder",
+            description = """
+                    Asks a vendor's fleet program to authorize the work on a workorder, and records what it \
+                    said.
+                    Use this tool once the vehicle and the work are known; do not call it repeatedly to check \
+                    for an answer, because asking again can open a second authorization against the same \
+                    contract — use getFleetWorkorderAuthorization to read the outcome instead.
+                    Preconditions: the vendor profile must be enabled with a workorder-authorization binding and \
+                    a billing account number, and the request must identify the vehicle by vendor vehicle id, \
+                    license plate, VIN or fleet number.
+                    Required inputs: supplierRef path parameter, workorderId, and at least one vehicle \
+                    identifier; contractId, odometerValue and lines are optional.
+                    Emits a SUPPLIER_WORKORDER_AUTHORIZATION_REQUEST event, and on a decision publishes \
+                    supplier.workorderauth.granted or supplier.workorderauth.denied for the workorder domain.
+                    Returns 200 with the authorization, whose status is GRANTED, DENIED, NOT_FOUND, PENDING \
+                    when the vendor accepted the request and will decide later, or MANUAL_REVIEW when no \
+                    decision could be obtained at all; 400 when no vehicle identifier is given; 404 when the \
+                    vendor profile is unknown; and 409 when the profile is disabled or has no \
+                    workorder-authorization binding configured.
+                    """,
+            tags = {"Supplier Fleet Authorization"})
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "The work being requested, and how the fleet vehicle is identified. At least one of "
+                    + "vendorVehicleId, licensePlate, vin or fleetNumber must be given: a request that "
+                    + "identifies no vehicle cannot be authorized by anyone.",
+            required = true,
+            content =
+                    @Content(
+                            schema = @Schema(implementation = FleetAuthorizationRequestBody.class),
+                            examples =
+                                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                            name = "Two front tyres on a plated fleet vehicle",
+                                            value = """
+                                                    {
+                                                      "workorderId": "019200aa-0000-7000-8000-0000000000c1",
+                                                      "licensePlate": "ABC-123",
+                                                      "contractId": "C-1",
+                                                      "odometerValue": "104500",
+                                                      "lines": [
+                                                        {
+                                                          "reference": "4001111",
+                                                          "description": "Front axle tyres",
+                                                          "quantity": 2,
+                                                          "tirePosition": "1L"
+                                                        }
+                                                      ]
+                                                    }
+                                                    """)))
+    @ApiResponse(responseCode = "200", description = "Authorization requested; see status for the outcome")
+    @ApiResponse(
+            responseCode = "400",
+            description = "The request identifies no vehicle",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Vendor profile unknown",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Vendor profile disabled, or no workorder-authorization binding configured",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<FleetAuthorizationResponse> requestFleetWorkorderAuthorization(
+            @Parameter(description = "Vendor profile alias", required = true) @PathVariable String supplierRef,
+            @Valid @RequestBody FleetAuthorizationRequestBody body) {
+        return ResponseEntity.ok(authorizationRunner.requestAndProject(new SupplierRef(supplierRef), toDomain(body)));
+    }
+
+    @GetMapping("/{supplierRef}/authorizations/{workorderId}")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"supplier:workorderauth:request"})
+    @PreAuthorize("hasAuthority('" + SupplierPermissions.WORKORDER_AUTHORIZE + "')")
+    @EmitEvent(id = "SUPPLIER_WORKORDER_AUTHORIZATION_READ", apiVersion = "1")
+    @Operation(
+            operationId = "getFleetWorkorderAuthorization",
+            summary = "Read A Fleet Authorization",
+            description = """
+                    Returns the fleet authorization recorded for a workorder at a vendor, including the vendor's \
+                    reason where it gave one.
+                    Use this tool to check the outcome of an authorization that came back PENDING; do not call \
+                    requestFleetWorkorderAuthorization again for that, because it can open a second \
+                    authorization.
+                    Preconditions: none.
+                    Required inputs: supplierRef and workorderId path parameters.
+                    Emits a SUPPLIER_WORKORDER_AUTHORIZATION_READ event.
+                    Returns 200 with the authorization, and 404 when the vendor profile is unknown or no \
+                    authorization was ever requested for this workorder.
+                    """,
+            tags = {"Supplier Fleet Authorization"})
+    @ApiResponse(responseCode = "200", description = "The recorded authorization")
+    @ApiResponse(
+            responseCode = "404",
+            description = "Vendor profile unknown, or no authorization recorded for this workorder",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<FleetAuthorizationResponse> getFleetWorkorderAuthorization(
+            @Parameter(description = "Vendor profile alias", required = true) @PathVariable String supplierRef,
+            @Parameter(description = "Workorder the authorization concerns", required = true) @PathVariable
+                    java.util.UUID workorderId) {
+        return authorizationRunner
+                .findProjection(new SupplierRef(supplierRef), workorderId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{supplierRef}/vehicles/{vehicleIdent}")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"supplier:workorderauth:request"})
+    @PreAuthorize("hasAuthority('" + SupplierPermissions.WORKORDER_AUTHORIZE + "')")
+    @EmitEvent(id = "SUPPLIER_FLEET_VEHICLE_LOOKUP", apiVersion = "1")
+    @Operation(
+            operationId = "lookupFleetVehicle",
+            summary = "Look Up A Fleet Vehicle",
+            description = """
+                    Asks a vendor's fleet program what it knows about a vehicle, by license plate, VIN, fleet \
+                    number or the vendor's own vehicle id.
+                    Use this tool before requesting authorization, to confirm the vehicle is on a fleet contract \
+                    and to obtain the vendor vehicle id; do not treat the answer as authorization, because only \
+                    requestFleetWorkorderAuthorization obtains that.
+                    Preconditions: the vendor profile must be enabled with a workorder-authorization binding.
+                    Required inputs: supplierRef and vehicleIdent path parameters.
+                    Emits a SUPPLIER_FLEET_VEHICLE_LOOKUP event.
+                    Returns 200 with the vehicle as the fleet holds it, 404 when the fleet does not know the \
+                    vehicle or the vendor profile is unknown, 409 when the profile is disabled or unconfigured, \
+                    and 422 when the vendor could not be reached or answered unreadably.
+                    """,
+            tags = {"Supplier Fleet Authorization"})
+    @ApiResponse(responseCode = "200", description = "The vehicle as the fleet holds it")
+    @ApiResponse(
+            responseCode = "404",
+            description = "The fleet does not know this vehicle, or the vendor profile is unknown",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Vendor profile disabled, or no workorder-authorization binding configured",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "The vendor could not be reached or answered unreadably",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<FleetVehicle> lookupFleetVehicle(
+            @Parameter(description = "Vendor profile alias", required = true) @PathVariable String supplierRef,
+            @Parameter(description = "Plate, VIN, fleet number or vendor vehicle id", required = true) @PathVariable
+                    String vehicleIdent) {
+        return fleetLookupService
+                .findVehicle(new SupplierRef(supplierRef), vehicleIdent)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{supplierRef}/contracts")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"supplier:workorderauth:request"})
+    @PreAuthorize("hasAuthority('" + SupplierPermissions.WORKORDER_AUTHORIZE + "')")
+    @EmitEvent(id = "SUPPLIER_FLEET_CONTRACT_LIST", apiVersion = "1")
+    @Operation(
+            operationId = "listFleetContracts",
+            summary = "List Fleet Contracts",
+            description = """
+                    Lists the fleet contracts this service provider may claim work under at a vendor.
+                    Use this tool to populate a contract choice before requesting authorization; do not use the \
+                    contract dates to decide whether work is covered, because only the vendor decides that when \
+                    authorization is requested.
+                    Preconditions: the vendor profile must be enabled with a workorder-authorization binding.
+                    Required inputs: supplierRef path parameter.
+                    Emits a SUPPLIER_FLEET_CONTRACT_LIST event.
+                    Returns 200 with the contracts as stated, 404 when the vendor profile is unknown, 409 when \
+                    the profile is disabled or unconfigured, and 422 when the vendor could not be reached.
+                    """,
+            tags = {"Supplier Fleet Authorization"})
+    @ApiResponse(responseCode = "200", description = "The fleet contracts as stated")
+    @ApiResponse(
+            responseCode = "404",
+            description = "Vendor profile unknown",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Vendor profile disabled, or no workorder-authorization binding configured",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "The vendor could not be reached or answered unreadably",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<List<FleetContract>> listFleetContracts(
+            @Parameter(description = "Vendor profile alias", required = true) @PathVariable String supplierRef) {
+        return ResponseEntity.ok(fleetLookupService.listContracts(new SupplierRef(supplierRef)));
+    }
+
+    @GetMapping("/{supplierRef}/policies")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"supplier:workorderauth:request"})
+    @PreAuthorize("hasAuthority('" + SupplierPermissions.WORKORDER_AUTHORIZE + "')")
+    @EmitEvent(id = "SUPPLIER_FLEET_POLICY_LIST", apiVersion = "1")
+    @Operation(
+            operationId = "listFleetPolicies",
+            summary = "List Fleet Policies",
+            description = """
+                    Lists what a fleet program says it will and will not pay for.
+                    Use this tool to narrow what is offered to a fleet customer; do not use it as permission, \
+                    because it is advisory and only requestFleetWorkorderAuthorization obtains a decision.
+                    Preconditions: the vendor profile must be enabled with a workorder-authorization binding.
+                    Required inputs: supplierRef path parameter.
+                    Emits a SUPPLIER_FLEET_POLICY_LIST event.
+                    Returns 200 with the policies as stated — an empty list when the vendor states none or \
+                    answers in a shape this adapter does not recognise — 404 when the vendor profile is \
+                    unknown, 409 when the profile is disabled or unconfigured, and 422 when the vendor could \
+                    not be reached.
+                    """,
+            tags = {"Supplier Fleet Authorization"})
+    @ApiResponse(responseCode = "200", description = "The fleet policies as stated")
+    @ApiResponse(
+            responseCode = "404",
+            description = "Vendor profile unknown",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Vendor profile disabled, or no workorder-authorization binding configured",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "The vendor could not be reached",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<List<FleetPolicy>> listFleetPolicies(
+            @Parameter(description = "Vendor profile alias", required = true) @PathVariable String supplierRef) {
+        return ResponseEntity.ok(fleetLookupService.listPolicies(new SupplierRef(supplierRef)));
+    }
+
+    @GetMapping("/authorizations/reviews")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"supplier:workorderauth:review"})
+    @PreAuthorize("hasAuthority('" + SupplierPermissions.WORKORDER_AUTHORIZATION_REVIEW + "')")
+    @EmitEvent(id = "SUPPLIER_WORKORDER_AUTHORIZATION_REVIEW_LIST", apiVersion = "1")
+    @Operation(
+            operationId = "listFleetAuthorizationsNeedingReview",
+            summary = "List Fleet Authorizations Needing Review",
+            description = """
+                    Lists fleet authorizations and completions that could not be resolved with a vendor and are \
+                    waiting on a person, newest first.
+                    Use this tool to work the queue of stuck fleet jobs; the reviewReason says what went wrong and \
+                    approvalStatus distinguishes an authorization nobody could obtain from a completion nobody \
+                    could get signed off. Do not read a row here as a vendor decision — nothing in this list has \
+                    been refused by a fleet, only left unresolved — and do not use it to check one workorder, \
+                    because getFleetWorkorderAuthorization answers that directly instead.
+                    Preconditions: none.
+                    Required inputs: none; limit defaults to 100.
+                    Emits a SUPPLIER_WORKORDER_AUTHORIZATION_REVIEW_LIST event.
+                    Returns 200 with the rows waiting on a person, which is an empty list when nothing is stuck.
+                    """,
+            tags = {"Supplier Fleet Authorization"})
+    @ApiResponse(responseCode = "200", description = "Authorizations and completions waiting on a person")
+    public ResponseEntity<List<FleetAuthorizationResponse>> listFleetAuthorizationsNeedingReview(
+            @Parameter(description = "Maximum rows to return") @RequestParam(defaultValue = "100") int limit) {
+        return ResponseEntity.ok(authorizationRunner.findNeedingReview(limit));
+    }
+
+    /**
+     * Builds the canonical request, where the "identifies a vehicle" rule is enforced.
+     *
+     * <p>Mapped here rather than on the request body so the contract package holds no dependency on
+     * the internal domain: the DTO is a shape on the wire, and the rule about what makes a valid
+     * request belongs with the model that has to honour it.
+     */
+    private static WorkorderAuthorizationRequest toDomain(FleetAuthorizationRequestBody body) {
+        List<WorkorderAuthorizationRequest.Line> lines = new java.util.ArrayList<>();
+        for (FleetAuthorizationRequestBody.Line line : body.linesOrEmpty()) {
+            lines.add(new WorkorderAuthorizationRequest.Line(
+                    line.reference(), line.description(), line.quantity(), line.tirePosition()));
+        }
+        return new WorkorderAuthorizationRequest(
+                body.workorderId(),
+                body.vendorVehicleId(),
+                body.licensePlate(),
+                body.vin(),
+                body.fleetNumber(),
+                body.contractId(),
+                body.odometerValue(),
+                lines);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/SupplierRequestSpec.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/SupplierRequestSpec.java
@@ -36,7 +36,8 @@ public record SupplierRequestSpec(
         @Nullable String body,
         @Nullable String contentType,
         @Nullable String accept,
-        boolean idempotent) {
+        boolean idempotent,
+        @NonNull Map<String, String> headers) {
 
     public SupplierRequestSpec {
         Objects.requireNonNull(method, "method must not be null");
@@ -53,6 +54,27 @@ public record SupplierRequestSpec(
         // Collections.unmodifiableMap over a LinkedHashMap, not Map.copyOf: the latter is unordered,
         // which would quietly make the documented insertion order untrue and produce a different
         // query string on every run.
+        Objects.requireNonNull(headers, "headers must not be null");
         queryParams = Collections.unmodifiableMap(new LinkedHashMap<>(queryParams));
+        headers = Collections.unmodifiableMap(new LinkedHashMap<>(headers));
+    }
+
+    /**
+     * Builds a spec that adds no headers of its own.
+     *
+     * <p>Kept because no EDIWheel capability needs one: the norms identify the buyer through
+     * credentials and query parameters, so every codec written before the Michelin S2S family said
+     * everything it had to say without touching headers. Those call sites keep saying it by
+     * omission.
+     */
+    public SupplierRequestSpec(
+            @NonNull String method,
+            @Nullable String pathSuffix,
+            @NonNull Map<String, String> queryParams,
+            @Nullable String body,
+            @Nullable String contentType,
+            @Nullable String accept,
+            boolean idempotent) {
+        this(method, pathSuffix, queryParams, body, contentType, accept, idempotent, Map.of());
     }
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/SupplierWorkorderAuthorization.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/SupplierWorkorderAuthorization.java
@@ -1,43 +1,78 @@
 package com.positivity.supplier.internal.domain.model;
 
+import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
- * State of a fleet workorder authorization at the vendor (Michelin S2S). Feeds the
- * {@code supplier.workorderauth.granted} / {@code supplier.workorderauth.denied} results
- * consumed by pos-workorder (ADR-0049 §3); workorder state itself stays in pos-workorder.
+ * A fleet program's answer about a workorder (CAP-323 #1229).
  *
- * <p>Pragmatic/minimal for the CAP-317 foundation slice; grows with CAP-323 (vehicles,
- * contracts, policies, completion approval).
+ * <h2>PENDING is an answer too</h2>
  *
- * @param vendorAuthorizationId vendor-native authorization identity, carried as an attribute;
- *     {@code null} until the vendor has assigned one
- * @param workorderId pos-workorder identity the authorization concerns
- * @param status vendor decision state
- * @param vendorReason vendor-supplied reason (e.g. denial detail), verbatim
+ * The vendor may accept the request and decide later (HTTP 202). That is not a failure and not a
+ * grant; it is a promise to answer at {@link #pollLocation}. Collapsing it into either would be
+ * wrong in a way nobody notices until a shop either starts unauthorized work or turns away a fleet
+ * customer it was going to be paid for.
+ *
+ * @param vendorAuthorizationId the vendor's identifier, where it gave one. Required to approve
+ *                              completion later, so its absence on a grant is a defect worth seeing
+ * @param workorderId           the pos-workorder identity the decision concerns
+ * @param status                the decision, or {@code PENDING} while the vendor is still deciding
+ * @param vendorReason          the vendor's stated reason, for a denial. Never invented
+ * @param vendorReasonCode      the vendor's own code, untranslated: it is what a shop quotes back
+ * @param contractReference     the contract the work was authorized under, as stated
+ * @param authorizedAmount      the ceiling the vendor stated, when it stated one. Absent is not zero
+ * @param currency              ISO 4217 for {@code authorizedAmount}; absent together with it
+ * @param pollLocation          where an asynchronously accepted request said its answer will appear
  */
 public record SupplierWorkorderAuthorization(
         @Nullable String vendorAuthorizationId,
         @NonNull UUID workorderId,
         @NonNull Status status,
-        @Nullable String vendorReason) {
+        @Nullable String vendorReason,
+        @Nullable String vendorReasonCode,
+        @Nullable String contractReference,
+        @Nullable BigDecimal authorizedAmount,
+        @Nullable String currency,
+        @Nullable String pollLocation) {
 
+    /**
+     * The vendor's position.
+     *
+     * <p>Note there is no value here for "we could not ask". That is deliberately not a vendor
+     * answer and lives on the stored row as {@code MANUAL_REVIEW}, so no code path can turn an
+     * unreachable vendor into a refusal.
+     */
     public enum Status {
-        /** Authorization requested; the vendor has not decided yet. */
         PENDING,
-        /** The vendor granted the authorization. */
         GRANTED,
-        /** The vendor denied the authorization. */
         DENIED,
-        /** The vendor has no such authorization. */
         NOT_FOUND
     }
 
     public SupplierWorkorderAuthorization {
         Objects.requireNonNull(workorderId, "workorderId must not be null");
         Objects.requireNonNull(status, "status must not be null");
+        if (authorizedAmount != null && currency == null) {
+            throw new IllegalArgumentException("currency is required when authorizedAmount is present");
+        }
+    }
+
+    /**
+     * A vendor that accepted the request and will answer later.
+     *
+     * @param location where the answer will appear, from the 202's {@code Location} header
+     */
+    @NonNull
+    public static SupplierWorkorderAuthorization pending(@NonNull UUID workorderId, @Nullable String location) {
+        return new SupplierWorkorderAuthorization(
+                null, workorderId, Status.PENDING, null, null, null, null, null, location);
+    }
+
+    /** Whether the vendor has finished deciding, so polling should stop. */
+    public boolean isTerminal() {
+        return status != Status.PENDING;
     }
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/WorkorderAuthorizationRequest.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/WorkorderAuthorizationRequest.java
@@ -1,0 +1,83 @@
+package com.positivity.supplier.internal.domain.model;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * What a caller must supply to ask a fleet program to authorize work (CAP-323 #1229).
+ *
+ * <h2>Vehicle identity is a choice of several, not one</h2>
+ *
+ * A shop has whatever the customer arrived with. Sometimes that is a fleet unit number on a
+ * windscreen sticker, sometimes only a plate, occasionally a VIN. Requiring one specific identifier
+ * would make the capability unusable in exactly the cases it exists for, so any one will do and the
+ * codec sends what it was given.
+ *
+ * @param workorderId    the pos-workorder identity being authorized. This side's key throughout
+ * @param vendorVehicleId the vendor's own vehicle id, when a lookup has already resolved one
+ * @param licensePlate   as the customer presented it
+ * @param vin            as the customer presented it
+ * @param fleetNumber    the fleet's unit number, where known
+ * @param contractId     the fleet contract claimed, when a lookup has already resolved one
+ * @param odometerValue  reading at check-in, as recorded. A string because the vendor states it as
+ *                       one and shops record it with and without units
+ * @param lines          the work being requested
+ */
+public record WorkorderAuthorizationRequest(
+        @NonNull UUID workorderId,
+        @Nullable String vendorVehicleId,
+        @Nullable String licensePlate,
+        @Nullable String vin,
+        @Nullable String fleetNumber,
+        @Nullable String contractId,
+        @Nullable String odometerValue,
+        @NonNull List<Line> lines) {
+
+    /**
+     * One requested operation or part.
+     *
+     * @param reference   the part or operation reference, as the shop knows it
+     * @param description free text for a human reading the request at the fleet
+     * @param quantity    how many; never negative
+     * @param tirePosition wheel position where the work is position-specific, as stated
+     */
+    public record Line(
+            @Nullable String reference,
+            @Nullable String description,
+            int quantity,
+            @Nullable String tirePosition) {
+
+        public Line {
+            if (quantity < 0) {
+                throw new IllegalArgumentException("quantity must not be negative");
+            }
+        }
+    }
+
+    public WorkorderAuthorizationRequest {
+        Objects.requireNonNull(workorderId, "workorderId must not be null");
+        Objects.requireNonNull(lines, "lines must not be null");
+        lines = List.copyOf(lines);
+        if (!identifiesAVehicle(vendorVehicleId, licensePlate, vin, fleetNumber)) {
+            // Refused here rather than sent, because a request with no vehicle cannot be authorized
+            // by anyone and the vendor's rejection would arrive hours later as an opaque 400.
+            throw new IllegalArgumentException(
+                    "an authorization request must identify a vehicle by vendor id, plate, VIN or fleet number");
+        }
+    }
+
+    private static boolean identifiesAVehicle(
+            @Nullable String vendorVehicleId,
+            @Nullable String licensePlate,
+            @Nullable String vin,
+            @Nullable String fleetNumber) {
+        return notBlank(vendorVehicleId) || notBlank(licensePlate) || notBlank(vin) || notBlank(fleetNumber);
+    }
+
+    private static boolean notBlank(@Nullable String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/SupplierWorkorderAuthorizationEntity.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/SupplierWorkorderAuthorizationEntity.java
@@ -1,0 +1,132 @@
+package com.positivity.supplier.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.supplier.internal.enums.WorkorderApprovalStatus;
+import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * A fleet workorder authorization at a vendor (CAP-323 #1229).
+ *
+ * <h2>Not a shadow of the workorder</h2>
+ *
+ * This row holds what the vendor said and how far this side got in asking. It holds nothing about
+ * what the workorder is doing, because pos-workorder owns that (ADR-0049 §2). The temptation with a
+ * table like this is to cache a workorder status "for convenience" and then have two answers to the
+ * same question, one of them stale.
+ *
+ * <h2>The row is written before the vendor is called</h2>
+ *
+ * A request that was sent and never answered is the interesting case — it is the one where a shop
+ * waits on a fleet that will never reply — and it only exists in the record if the row predates the
+ * answer.
+ *
+ * <h2>Two independent lifecycles</h2>
+ *
+ * {@code status} tracks the authorization decision; {@code approvalStatus} tracks the completion
+ * sign-off that happens much later. They are separate columns rather than one because they fail
+ * independently: work that was authorized can still fail to be approved on completion, and
+ * collapsing the two would make an unsigned-off job look unauthorized.
+ */
+@Entity
+@Table(name = "supplier_workorder_authorization")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SupplierWorkorderAuthorizationEntity {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "supplier_workorder_authorization_id")
+    private UUID supplierWorkorderAuthorizationId;
+
+    @Column(name = "vendor_profile_id", nullable = false)
+    private UUID vendorProfileId;
+
+    /** The profile's alias when the authorization was requested; descriptive, never a key. */
+    @Column(name = "supplier_ref", nullable = false, length = 100)
+    private String supplierRef;
+
+    @Column(name = "workorder_id", nullable = false)
+    private UUID workorderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private WorkorderAuthorizationStatus status;
+
+    /** The vendor's own identifier; required to approve completion later. */
+    @Column(name = "vendor_authorization_id", length = 100)
+    private String vendorAuthorizationId;
+
+    /** Where an asynchronously accepted request said its result would appear (202 {@code Location}). */
+    @Column(name = "poll_location", length = 1000)
+    private String pollLocation;
+
+    @Column(name = "contract_reference", length = 100)
+    private String contractReference;
+
+    @Column(name = "authorized_amount", precision = 19, scale = 4)
+    private BigDecimal authorizedAmount;
+
+    @Column(name = "currency", length = 3)
+    private String currency;
+
+    @Column(name = "reason_code", length = 50)
+    private String reasonCode;
+
+    @Column(name = "reason_text", length = 1000)
+    private String reasonText;
+
+    /** Why this row needs a human. Set together with a {@code MANUAL_REVIEW} status, never alone. */
+    @Column(name = "review_reason", length = 1000)
+    private String reviewReason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "approval_status", nullable = false, length = 20)
+    private WorkorderApprovalStatus approvalStatus;
+
+    @Column(name = "approval_attempts", nullable = false)
+    private int approvalAttempts;
+
+    @Column(name = "approved_at")
+    private Instant approvedAt;
+
+    @Column(name = "requested_at", nullable = false)
+    private Instant requestedAt;
+
+    @Column(name = "decided_at")
+    private Instant decidedAt;
+
+    @Column(name = "last_polled_at")
+    private Instant lastPolledAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/enums/WorkorderApprovalStatus.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/enums/WorkorderApprovalStatus.java
@@ -1,0 +1,35 @@
+package com.positivity.supplier.internal.enums;
+
+/**
+ * Where the vendor-side completion sign-off has got to (CAP-323 #1229).
+ *
+ * <p>Tracked apart from {@link WorkorderAuthorizationStatus} because the two fail independently.
+ * Work that was authorized months ago can still fail to be approved on completion, and a single
+ * status column would make that job look unauthorized — which is both wrong and the kind of wrong
+ * that gets a shop paid late.
+ */
+public enum WorkorderApprovalStatus {
+
+    /** The workorder has not completed yet, so nothing has been sent. */
+    NOT_REQUESTED,
+
+    /** Completion approval has been attempted and has not yet succeeded. */
+    PENDING,
+
+    /** The vendor accepted the completion. */
+    APPROVED,
+
+    /**
+     * Approval failed in a way retrying will not fix, and money is likely owed.
+     *
+     * <p>This is the state that must be visible to somebody. An unapproved completion is work
+     * already performed that the fleet has not agreed to pay for, and unlike a failed fetch it
+     * cannot be recovered by asking again later.
+     */
+    MANUAL_REVIEW;
+
+    /** Whether the approver should keep trying. */
+    public boolean isOutstanding() {
+        return this == PENDING;
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/enums/WorkorderAuthorizationStatus.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/enums/WorkorderAuthorizationStatus.java
@@ -1,0 +1,48 @@
+package com.positivity.supplier.internal.enums;
+
+/**
+ * Where a fleet workorder authorization has got to (CAP-323 #1229).
+ *
+ * <p>Four of these are the vendor's answer. {@link #MANUAL_REVIEW} is not: it is this side stating
+ * that it could not get one. The distinction is the whole point of having a fifth value — a shop
+ * told "the fleet declined" when in truth the vendor was unreachable will argue with a fleet manager
+ * about a decision nobody made.
+ */
+public enum WorkorderAuthorizationStatus {
+
+    /** Requested, and the vendor has not yet answered. Asynchronous acceptances live here. */
+    PENDING,
+
+    /** The fleet program authorized the work. */
+    GRANTED,
+
+    /** The fleet program refused. A real answer, and a normal one. */
+    DENIED,
+
+    /**
+     * The vendor does not know this vehicle, contract or workorder.
+     *
+     * <p>Distinct from {@link #DENIED} because it is answerable: a fleet number typed wrong is
+     * fixed by fixing it, whereas a denial is fixed by talking to the fleet.
+     */
+    NOT_FOUND,
+
+    /**
+     * No decision could be obtained and retrying is not expected to help.
+     *
+     * <p>Never published as a denial. The row stays here until a human looks at it, because the
+     * alternative — retrying forever, or quietly treating silence as refusal — either hides the
+     * problem or invents an answer.
+     */
+    MANUAL_REVIEW;
+
+    /** Whether the vendor has given its final answer, so polling should stop. */
+    public boolean isTerminal() {
+        return this != PENDING;
+    }
+
+    /** Whether work may proceed under a fleet contract. */
+    public boolean permitsWork() {
+        return this == GRANTED;
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/FleetLookupException.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/FleetLookupException.java
@@ -1,0 +1,24 @@
+package com.positivity.supplier.internal.exception;
+
+import java.io.Serial;
+
+/**
+ * A fleet lookup could not be answered (CAP-323 #1229).
+ *
+ * <p>Distinct from an empty result. "The fleet does not know this plate" is an answer and comes back
+ * as an empty {@code Optional}; this means nobody managed to ask. A service advisor deciding whether
+ * to start work needs those two to look different on screen.
+ */
+public class FleetLookupException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public FleetLookupException(String message) {
+        super(message);
+    }
+
+    public FleetLookupException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/SupplierExceptionHandler.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/SupplierExceptionHandler.java
@@ -103,6 +103,18 @@ public class SupplierExceptionHandler {
      * or waiting; a 500 tells them only that something broke here, which is the wrong place to
      * look.
      */
+    /**
+     * A fleet lookup that could not be answered.
+     *
+     * <p>422 rather than 502: the request was well-formed and the configuration is fine — the vendor
+     * simply could not be reached or said something unreadable. An operator seeing this should try
+     * again or check the vendor's status, not go and edit a profile.
+     */
+    @ExceptionHandler(FleetLookupException.class)
+    public ResponseEntity<ApiError> handleFleetLookupFailure(FleetLookupException ex, HttpServletRequest request) {
+        return build(HttpStatus.UNPROCESSABLE_ENTITY, "SUPPLIER_FLEET_LOOKUP_FAILED", ex.getMessage(), request);
+    }
+
     @ExceptionHandler(InvoiceFetchException.class)
     public ResponseEntity<ApiError> handleInvoiceFetch(InvoiceFetchException ex, HttpServletRequest request) {
         return build(HttpStatus.UNPROCESSABLE_ENTITY, "SUPPLIER_INVOICE_FETCH_FAILED", ex.getMessage(), request);

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/repository/SupplierWorkorderAuthorizationRepository.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/repository/SupplierWorkorderAuthorizationRepository.java
@@ -1,0 +1,82 @@
+package com.positivity.supplier.internal.repository;
+
+import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
+import com.positivity.supplier.internal.enums.WorkorderApprovalStatus;
+import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Limit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/** Fleet workorder authorizations (CAP-323 #1229). */
+@Repository
+public interface SupplierWorkorderAuthorizationRepository
+        extends JpaRepository<SupplierWorkorderAuthorizationEntity, UUID> {
+
+    /**
+     * The live authorization for a workorder at a vendor.
+     *
+     * <p>Scoped by profile as well as workorder because the uniqueness constraint is on the pair: a
+     * workorder could in principle be authorized by two fleet programs, and looking one up without
+     * saying which vendor would silently pick whichever row came back first.
+     */
+    @NonNull
+    Optional<SupplierWorkorderAuthorizationEntity> findByVendorProfileIdAndWorkorderId(
+            @NonNull UUID vendorProfileId, @NonNull UUID workorderId);
+
+    /**
+     * Any authorization recorded for a workorder, newest first.
+     *
+     * <p>The read surface is asked by workorder alone, because a shop asking "is this job
+     * authorized" does not know or care which vendor profile answered.
+     */
+    @NonNull
+    List<SupplierWorkorderAuthorizationEntity> findByWorkorderIdOrderByRequestedAtDesc(@NonNull UUID workorderId);
+
+    /**
+     * Authorizations still waiting on a vendor, least recently attended to first.
+     *
+     * <p>Ordering by last poll rather than by age spreads attention evenly: ordering by age would
+     * let one old stuck row absorb every tick while newer ones went unpolled.
+     *
+     * <p>A never-polled row orders by when it was requested, via {@code COALESCE}, rather than by
+     * relying on null ordering. That is not tidiness: Postgres sorts nulls last on an ascending
+     * sort and H2 sorts them first, so a derived query would have put brand-new authorizations at
+     * the back of the queue in production and at the front in every test that checked it.
+     */
+    @Query("""
+            select a from SupplierWorkorderAuthorizationEntity a
+            where a.status = :status
+            order by coalesce(a.lastPolledAt, a.requestedAt) asc
+            """)
+    @NonNull
+    List<SupplierWorkorderAuthorizationEntity> findAwaitingPoll(
+            @Param("status") @NonNull WorkorderAuthorizationStatus status, @NonNull Limit limit);
+
+    /** Completions whose vendor sign-off has not yet succeeded. */
+    @NonNull
+    List<SupplierWorkorderAuthorizationEntity> findByApprovalStatusOrderByUpdatedAtAsc(
+            @NonNull WorkorderApprovalStatus approvalStatus, @NonNull Limit limit);
+
+    /**
+     * Everything a human needs to look at, newest first.
+     *
+     * <p>Both kinds of stuck row in one query, because to an operator they are one queue: an
+     * authorization nobody could obtain and a completion nobody could get signed off are both work
+     * that will not be paid for unless somebody acts. Splitting them into two screens is how the
+     * quieter of the two stops being looked at.
+     */
+    @Query("""
+            select a from SupplierWorkorderAuthorizationEntity a
+            where a.status = com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus.MANUAL_REVIEW
+               or a.approvalStatus = com.positivity.supplier.internal.enums.WorkorderApprovalStatus.MANUAL_REVIEW
+            order by a.updatedAt desc
+            """)
+    @NonNull
+    List<SupplierWorkorderAuthorizationEntity> findNeedingReview(@NonNull Limit limit);
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/security/SupplierPermissions.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/security/SupplierPermissions.java
@@ -92,5 +92,23 @@ public final class SupplierPermissions {
      */
     public static final String INVOICE_FETCH = "supplier:invoice:fetch";
 
+    /**
+     * Asking a fleet program to authorize work, and reading fleet vehicles, contracts and policies.
+     *
+     * <p>One permission covering the read lookups and the authorization request, because in a shop
+     * they are one act: a service advisor looks a fleet vehicle up in order to ask for authorization
+     * on it, and separating them would mean a role that can see a fleet contract but cannot use it.
+     */
+    public static final String WORKORDER_AUTHORIZE = "supplier:workorderauth:request";
+
+    /**
+     * Seeing and clearing authorizations parked for manual review.
+     *
+     * <p>Separate from requesting, because these are the rows where a vendor could not be reached or
+     * a completion could not be signed off — money already owed for work already done. Whoever
+     * chases that is not necessarily whoever books the job in.
+     */
+    public static final String WORKORDER_AUTHORIZATION_REVIEW = "supplier:workorderauth:review";
+
     private SupplierPermissions() {}
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/spi/SupplierWorkorderAuthorizationPort.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/spi/SupplierWorkorderAuthorizationPort.java
@@ -1,10 +1,8 @@
 package com.positivity.supplier.internal.spi;
 
-import com.positivity.supplier.internal.domain.model.PartyContext;
-import com.positivity.supplier.internal.domain.model.SupplierExchange;
 import com.positivity.supplier.internal.domain.model.SupplierRef;
 import com.positivity.supplier.internal.domain.model.SupplierWorkorderAuthorization;
-import java.util.UUID;
+import com.positivity.supplier.internal.domain.model.WorkorderAuthorizationRequest;
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -12,14 +10,42 @@ import org.jspecify.annotations.NonNull;
  * ({@code WORKORDER_AUTHORIZATION}; Michelin S2S — not an EDIWheel norm).
  *
  * <p>Governing ADRs: ADR-0049 §2/§3 — workorder state stays in pos-workorder; the vendor
- * decision surfaces as {@code supplier.workorderauth.granted}/{@code denied} results.
- * CAP-323 extends this port with completion approval and vehicle/contract/policy lookups
- * (architecture doc §6.1).
+ * decision surfaces as {@code supplier.workorderauth.granted}/{@code denied} facts.
+ *
+ * <h2>Two deliberate deviations from the sibling ports</h2>
+ *
+ * <p><strong>It takes a canonical request rather than a {@code PartyContext} and an id.</strong>
+ * The original signature could not express what a fleet program actually needs — how the vehicle is
+ * identified, which contract is claimed, what work is being asked for. Implementing it would have
+ * meant inventing a vehicle identifier out of an account number, which compiles, passes a test, and
+ * cannot work against a real vendor. The signature was widened to the information the operation
+ * genuinely requires (CAP-323 #1229).
+ *
+ * <p><strong>It returns the decision, not a {@code SupplierExchange}.</strong> The wrapper carries
+ * an exchange audit id and correlation id that the caller of this port has no use for: an
+ * authorization is decided over minutes or hours and possibly across several exchanges, so there is
+ * no single exchange to point at. The audit trail is written by the base client regardless and is
+ * queried by exchange, not by return value.
+ *
+ * <h2>A note on the SPI layer as a whole</h2>
+ *
+ * As of CAP-323 this is the only capability port with an implementation. The delivered capabilities
+ * — stock inquiry, orders, price catalogue, stock report, invoices — all route through their own
+ * {@code *Runner} and never reference their port. The ports were declared by the CAP-317 foundation
+ * and the capabilities that followed did not adopt them. That is worth knowing before treating this
+ * package as the module's contract surface: today it mostly is not.
  */
 public interface SupplierWorkorderAuthorizationPort {
 
-    /** Requests authorization for the given workorder from the vendor's fleet program. */
+    /**
+     * Asks the vendor's fleet program to authorize the requested work.
+     *
+     * @param supplierRef the fleet program to ask
+     * @param request     what is being asked for, including how the vehicle is identified
+     * @return the vendor's decision, which may be {@code PENDING} when the vendor accepted the
+     *     request and will decide later
+     */
     @NonNull
-    SupplierExchange<SupplierWorkorderAuthorization> requestAuthorization(
-            @NonNull SupplierRef supplierRef, @NonNull PartyContext partyContext, @NonNull UUID workorderId);
+    SupplierWorkorderAuthorization requestAuthorization(
+            @NonNull SupplierRef supplierRef, @NonNull WorkorderAuthorizationRequest request);
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/FleetLookupRunner.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/FleetLookupRunner.java
@@ -1,0 +1,150 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import com.positivity.supplier.internal.adapter.michelins2s.MichelinS2SWorkorderAuthCodec;
+import com.positivity.supplier.internal.adapter.michelins2s.WorkorderAuthDecodeException;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.client.SupplierHttpRequest;
+import com.positivity.supplier.internal.client.SupplierHttpResponse;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.exception.FleetLookupException;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.registry.AdapterResolution;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import com.positivity.supplier.service.model.FleetContract;
+import com.positivity.supplier.service.model.FleetPolicy;
+import com.positivity.supplier.service.model.FleetVehicle;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+
+/**
+ * Reads vehicles, contracts and policies from a fleet program (CAP-323 #1229).
+ *
+ * <h2>These are quoting aids, not gates</h2>
+ *
+ * A service advisor uses them to know what to offer before asking for authorization. None of them
+ * decides anything: the vendor decides, when authorization is requested. Treating a policy read here
+ * as permission would either quote work the fleet refuses or refuse work the fleet would have paid
+ * for, and both failures are invisible because no request was ever made.
+ *
+ * <h2>A missing vehicle is empty, not an error</h2>
+ *
+ * "The fleet does not know this plate" is an ordinary answer to an ordinary question, and it happens
+ * every time somebody mistypes. It comes back as an empty {@link Optional} so a caller handles it as
+ * a result. Vendor unreachability is different and does throw, because a blank screen that means
+ * "not a fleet vehicle" and a blank screen that means "we could not ask" would otherwise look
+ * identical to the person deciding whether to start work.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FleetLookupRunner {
+
+    private final SupplierProfileResolver profileResolver;
+    private final AdapterRegistry adapterRegistry;
+    private final SupplierBaseClient baseClient;
+
+    /**
+     * Looks up one vehicle in the fleet program.
+     *
+     * @param vehicleIdent plate, VIN, fleet number or vendor vehicle id, as the vendor accepts
+     * @return the vehicle, or empty when the fleet does not know it
+     * @throws SupplierConfigurationException when the capability is not configured for this vendor
+     * @throws FleetLookupException when the vendor could not be reached or answered unreadably
+     */
+    @NonNull
+    public Optional<FleetVehicle> findVehicle(@NonNull SupplierRef supplierRef, @NonNull String vehicleIdent) {
+        Call call = prepare(supplierRef);
+        SupplierRequestSpec spec = call.codec().buildVehicleLookup(vehicleIdent, call.partnerId());
+        SupplierHttpResponse response = baseClient.exchange(toHttpRequest(call.binding(), spec));
+
+        if (response.httpStatus() != null && response.httpStatus() == 404) {
+            return Optional.empty();
+        }
+        require(response, "vehicle lookup");
+        try {
+            return Optional.of(call.codec().decodeVehicle(response.body()));
+        } catch (WorkorderAuthDecodeException e) {
+            throw new FleetLookupException("vehicle lookup answer could not be read: " + e.getMessage(), e);
+        }
+    }
+
+    /** Lists the fleet contracts this service provider may claim work under. */
+    @NonNull
+    public List<FleetContract> listContracts(@NonNull SupplierRef supplierRef) {
+        Call call = prepare(supplierRef);
+        SupplierRequestSpec spec = call.codec().buildContractLookup(call.partnerId());
+        SupplierHttpResponse response = baseClient.exchange(toHttpRequest(call.binding(), spec));
+        require(response, "contract lookup");
+        try {
+            return call.codec().decodeContracts(response.body());
+        } catch (WorkorderAuthDecodeException e) {
+            throw new FleetLookupException("contract lookup answer could not be read: " + e.getMessage(), e);
+        }
+    }
+
+    /** Lists the fleet's own inclusion and exclusion policies. Advisory; see the class note. */
+    @NonNull
+    public List<FleetPolicy> listPolicies(@NonNull SupplierRef supplierRef) {
+        Call call = prepare(supplierRef);
+        SupplierRequestSpec spec = call.codec().buildPolicyLookup(call.partnerId());
+        SupplierHttpResponse response = baseClient.exchange(toHttpRequest(call.binding(), spec));
+        require(response, "policy lookup");
+        return call.codec().decodePolicies(response.body());
+    }
+
+    private void require(@NonNull SupplierHttpResponse response, @NonNull String what) {
+        if (!response.isSuccess()) {
+            throw new FleetLookupException(what + " failed: " + response.outcome()
+                    + (response.failureDetail() == null ? "" : " — " + response.failureDetail()));
+        }
+    }
+
+    @NonNull
+    private Call prepare(@NonNull SupplierRef supplierRef) {
+        ResolvedBinding binding =
+                profileResolver.resolveBinding(supplierRef, SupplierCapability.WORKORDER_AUTHORIZATION);
+        AdapterResolution resolution = adapterRegistry.resolve(
+                SupplierCapability.WORKORDER_AUTHORIZATION, binding.family(), binding.version());
+        if (!(resolution instanceof AdapterResolution.Resolved resolved)
+                || !(resolved.codec() instanceof MichelinS2SWorkorderAuthCodec codec)) {
+            throw new SupplierConfigurationException(
+                    SupplierConfigurationException.CAPABILITY_NOT_CONFIGURED,
+                    "No workorder authorization codec registered for " + binding.family() + " "
+                            + binding.version().value());
+        }
+        String partnerId =
+                profileResolver.resolvePartyContext(supplierRef, null).billing().getAccountNumber();
+        if (partnerId == null || partnerId.isBlank()) {
+            throw new SupplierConfigurationException(
+                    SupplierConfigurationException.CAPABILITY_NOT_CONFIGURED,
+                    "No billing account number configured for " + supplierRef.value()
+                            + "; the S2S partnerId has nowhere to come from");
+        }
+        return new Call(binding, codec, partnerId);
+    }
+
+    @NonNull
+    private SupplierHttpRequest toHttpRequest(@NonNull ResolvedBinding binding, @NonNull SupplierRequestSpec spec) {
+        return new SupplierHttpRequest(
+                binding,
+                HttpMethod.valueOf(spec.method()),
+                spec.pathSuffix(),
+                spec.queryParams(),
+                spec.body(),
+                spec.contentType(),
+                spec.accept(),
+                spec.idempotent(),
+                spec.headers());
+    }
+
+    private record Call(ResolvedBinding binding, MichelinS2SWorkorderAuthCodec codec, String partnerId) {}
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/FleetLookupRunner.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/FleetLookupRunner.java
@@ -121,15 +121,7 @@ public class FleetLookupRunner {
                     "No workorder authorization codec registered for " + binding.family() + " "
                             + binding.version().value());
         }
-        String partnerId =
-                profileResolver.resolvePartyContext(supplierRef, null).billing().getAccountNumber();
-        if (partnerId == null || partnerId.isBlank()) {
-            throw new SupplierConfigurationException(
-                    SupplierConfigurationException.CAPABILITY_NOT_CONFIGURED,
-                    "No billing account number configured for " + supplierRef.value()
-                            + "; the S2S partnerId has nowhere to come from");
-        }
-        return new Call(binding, codec, partnerId);
+        return new Call(binding, codec, S2SPartnerId.resolve(profileResolver, supplierRef));
     }
 
     @NonNull

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/S2SPartnerId.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/S2SPartnerId.java
@@ -1,0 +1,48 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.entity.SupplierAccountEntity;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Resolving the {@code partnerId} the Michelin S2S spec requires on every operation (CAP-323 #1229).
+ *
+ * <h2>One rule, because three callers had drifted into two</h2>
+ *
+ * The spec requires {@code partnerId} on every call: it is how the vendor knows which service centre
+ * is asking, and a fleet authorization from an unidentified caller is not something any vendor
+ * grants. The request path treated a missing billing account number as the deployment defect it is;
+ * the poller and the approver quietly substituted an empty string and carried on.
+ *
+ * <p>That difference was not visible at any call site. The poller would have polled a request the
+ * vendor had rejected as unidentified until it timed out a day later, and the approver would have
+ * spent its whole retry budget on a call that could never succeed — escalating a money-critical
+ * approval for a reason that had nothing to do with the vendor. Both would have reported the
+ * misconfiguration as a vendor problem.
+ */
+final class S2SPartnerId {
+
+    private S2SPartnerId() {}
+
+    /**
+     * The service-provider identity for this vendor, from the profile's billing account.
+     *
+     * @throws SupplierConfigurationException when no billing account number is configured — a
+     *     deployment defect, surfaced loudly rather than sent as an empty string
+     */
+    @NonNull
+    static String resolve(@NonNull SupplierProfileResolver profileResolver, @NonNull SupplierRef supplierRef) {
+        SupplierAccountEntity billing =
+                profileResolver.resolvePartyContext(supplierRef, null).billing();
+        String partnerId = billing.getAccountNumber();
+        if (partnerId == null || partnerId.isBlank()) {
+            throw new SupplierConfigurationException(
+                    SupplierConfigurationException.CAPABILITY_NOT_CONFIGURED,
+                    "No billing account number configured for " + supplierRef.value()
+                            + "; the S2S partnerId has nowhere to come from");
+        }
+        return partnerId;
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/SupplierWorkorderAuthorizationServiceImpl.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/SupplierWorkorderAuthorizationServiceImpl.java
@@ -1,0 +1,63 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
+import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
+import com.positivity.supplier.internal.repository.SupplierWorkorderAuthorizationRepository;
+import com.positivity.supplier.service.SupplierWorkorderAuthorizationService;
+import com.positivity.supplier.service.model.WorkorderAuthorizationView;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The contract read surface over fleet authorization state (CAP-323 #1229, ADR-0026).
+ *
+ * <h2>MANUAL_REVIEW is reported as PENDING</h2>
+ *
+ * The published view has four values and deliberately keeps them: {@code MANUAL_REVIEW} is this
+ * module's own operational state, meaning "we could not get an answer and a human is looking". To a
+ * caller asking whether a job is authorized, the honest answer is still "not yet" — the vendor has
+ * not granted and has not refused.
+ *
+ * <p>Leaking the fifth value would invite callers to branch on our queue depth, and any caller that
+ * treated it as a refusal would be reporting a decision the fleet never made. Operators see the real
+ * state through the admin surface, which is where an operational state belongs.
+ */
+@Service
+@RequiredArgsConstructor
+public class SupplierWorkorderAuthorizationServiceImpl implements SupplierWorkorderAuthorizationService {
+
+    private final SupplierWorkorderAuthorizationRepository authorizationRepository;
+
+    @Override
+    @NonNull
+    @Transactional(readOnly = true)
+    public Optional<WorkorderAuthorizationView> findByWorkorderId(@NonNull UUID workorderId) {
+        return authorizationRepository.findByWorkorderIdOrderByRequestedAtDesc(workorderId).stream()
+                .findFirst()
+                .map(SupplierWorkorderAuthorizationServiceImpl::toView);
+    }
+
+    @NonNull
+    private static WorkorderAuthorizationView toView(@NonNull SupplierWorkorderAuthorizationEntity row) {
+        return new WorkorderAuthorizationView(
+                row.getWorkorderId(),
+                viewStatus(row.getStatus()),
+                row.getVendorAuthorizationId(),
+                // The reason a human is looking is not the vendor's reason and must not be presented
+                // as one: a caller quoting our queue state back to a fleet manager helps nobody.
+                row.getStatus() == WorkorderAuthorizationStatus.MANUAL_REVIEW ? null : row.getReasonText());
+    }
+
+    private static WorkorderAuthorizationView.@NonNull Status viewStatus(@NonNull WorkorderAuthorizationStatus status) {
+        return switch (status) {
+            case GRANTED -> WorkorderAuthorizationView.Status.GRANTED;
+            case DENIED -> WorkorderAuthorizationView.Status.DENIED;
+            case NOT_FOUND -> WorkorderAuthorizationView.Status.NOT_FOUND;
+            case PENDING, MANUAL_REVIEW -> WorkorderAuthorizationView.Status.PENDING;
+        };
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPoller.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPoller.java
@@ -11,6 +11,7 @@ import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
 import com.positivity.supplier.internal.domain.model.SupplierWorkorderAuthorization;
 import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
 import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
 import com.positivity.supplier.internal.registry.AdapterRegistry;
 import com.positivity.supplier.internal.registry.AdapterResolution;
 import com.positivity.supplier.internal.repository.SupplierWorkorderAuthorizationRepository;
@@ -134,10 +135,19 @@ public class WorkorderAuthorizationPoller {
         ResolvedBinding binding =
                 profileResolver.resolveBinding(supplierRef, SupplierCapability.WORKORDER_AUTHORIZATION);
         MichelinS2SWorkorderAuthCodec codec = resolveCodec(binding);
-        String partnerId =
-                profileResolver.resolvePartyContext(supplierRef, null).billing().getAccountNumber();
 
-        SupplierRequestSpec spec = codec.buildPollRequest(pollPath, partnerId == null ? "" : partnerId);
+        String partnerId;
+        try {
+            partnerId = S2SPartnerId.resolve(profileResolver, supplierRef);
+        } catch (SupplierConfigurationException e) {
+            // Polling on with an empty partnerId would ask a vendor that has already rejected the
+            // request as unidentified, once every tick, until the pending timeout expired a day
+            // later -- and would then report the misconfiguration as a vendor that never decided.
+            runner.parkForReview(row, "authorization cannot be polled: " + e.getMessage());
+            return;
+        }
+
+        SupplierRequestSpec spec = codec.buildPollRequest(pollPath, partnerId);
         SupplierHttpResponse response = baseClient.exchange(toHttpRequest(binding, spec));
 
         if (!response.isSuccess()) {

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPoller.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPoller.java
@@ -1,0 +1,219 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import com.positivity.supplier.internal.adapter.michelins2s.MichelinS2SWorkorderAuthCodec;
+import com.positivity.supplier.internal.adapter.michelins2s.WorkorderAuthDecodeException;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.client.SupplierHttpRequest;
+import com.positivity.supplier.internal.client.SupplierHttpResponse;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.domain.model.SupplierWorkorderAuthorization;
+import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
+import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.registry.AdapterResolution;
+import com.positivity.supplier.internal.repository.SupplierWorkorderAuthorizationRepository;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import java.net.URI;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Limit;
+import org.springframework.http.HttpMethod;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves authorizations the vendor accepted but did not decide (CAP-323 #1229).
+ *
+ * <h2>Why this exists at all</h2>
+ *
+ * The S2S API may answer a request with 202 and a {@code Location} instead of a decision. Without
+ * something that goes back and reads that location, a 202 is indistinguishable from a request that
+ * vanished: the shop waits, the fleet has decided, and nobody connects the two. This is the piece
+ * that makes an asynchronous acceptance an actual answer rather than a promise nobody collects.
+ *
+ * <h2>Giving up is part of the design</h2>
+ *
+ * A row that has been pending past {@code pending-timeout} stops being polled and goes to
+ * {@code MANUAL_REVIEW}. Polling forever would be cheaper to write and worse: an authorization that
+ * a vendor will never resolve would be indistinguishable from one it is about to, and the shop
+ * waiting on it would never be told to stop waiting.
+ */
+@Slf4j
+@Service
+public class WorkorderAuthorizationPoller {
+
+    private final SupplierWorkorderAuthorizationRepository authorizationRepository;
+    private final SupplierProfileResolver profileResolver;
+    private final AdapterRegistry adapterRegistry;
+    private final SupplierBaseClient baseClient;
+    private final WorkorderAuthorizationRunner runner;
+    private final Clock clock;
+
+    /** How many rows one tick will read. Bounded so a backlog cannot monopolise a tick. */
+    private final int batchSize;
+
+    /**
+     * How long an authorization may stay undecided before a human is asked to look.
+     *
+     * <p>Configurable because it is a claim about a vendor's turnaround, and that is only learned
+     * from a live vendor. Bounded because "never" is not an answer a shop can act on.
+     */
+    private final Duration pendingTimeout;
+
+    public WorkorderAuthorizationPoller(
+            SupplierWorkorderAuthorizationRepository authorizationRepository,
+            SupplierProfileResolver profileResolver,
+            AdapterRegistry adapterRegistry,
+            SupplierBaseClient baseClient,
+            WorkorderAuthorizationRunner runner,
+            Clock clock,
+            @Value("${pos.supplier.workorderauth.poll-batch-size:50}") int batchSize,
+            @Value("${pos.supplier.workorderauth.pending-timeout:PT24H}") Duration pendingTimeout) {
+        this.authorizationRepository = authorizationRepository;
+        this.profileResolver = profileResolver;
+        this.adapterRegistry = adapterRegistry;
+        this.baseClient = baseClient;
+        this.runner = runner;
+        this.clock = clock;
+        this.batchSize = batchSize;
+        this.pendingTimeout = pendingTimeout;
+    }
+
+    /** Polls undecided authorizations, least recently polled first. */
+    @Scheduled(fixedDelayString = "${pos.supplier.workorderauth.poll-interval-ms:120000}")
+    public void pollPendingAuthorizations() {
+        List<SupplierWorkorderAuthorizationEntity> pending =
+                authorizationRepository.findAwaitingPoll(WorkorderAuthorizationStatus.PENDING, Limit.of(batchSize));
+
+        for (SupplierWorkorderAuthorizationEntity row : pending) {
+            try {
+                pollOne(row);
+            } catch (Exception e) {
+                // One vendor's problem must not stop the others being resolved. The row keeps its
+                // PENDING status, so the next tick tries it again.
+                log.warn(
+                        "Polling authorization {} for workorder {} failed: {}",
+                        row.getSupplierWorkorderAuthorizationId(),
+                        row.getWorkorderId(),
+                        e.toString(),
+                        e);
+            }
+        }
+    }
+
+    private void pollOne(@NonNull SupplierWorkorderAuthorizationEntity row) {
+        Instant now = Instant.now(clock);
+        if (row.getRequestedAt() != null
+                && row.getRequestedAt().plus(pendingTimeout).isBefore(now)) {
+            runner.parkForReview(
+                    row,
+                    "vendor accepted the authorization but did not decide within " + pendingTimeout
+                            + "; it has not been asked again");
+            return;
+        }
+
+        String pollPath = pollPathFor(row.getPollLocation());
+        if (pollPath == null) {
+            // Accepted with nowhere to look. Nothing further is possible for this row, and the
+            // codec should have refused it at 202 -- so reaching here means a row predates that
+            // check or was written by hand.
+            runner.parkForReview(row, "authorization is pending with no poll location, so its decision cannot be read");
+            return;
+        }
+
+        SupplierRef supplierRef = new SupplierRef(row.getSupplierRef());
+        ResolvedBinding binding =
+                profileResolver.resolveBinding(supplierRef, SupplierCapability.WORKORDER_AUTHORIZATION);
+        MichelinS2SWorkorderAuthCodec codec = resolveCodec(binding);
+        String partnerId =
+                profileResolver.resolvePartyContext(supplierRef, null).billing().getAccountNumber();
+
+        SupplierRequestSpec spec = codec.buildPollRequest(pollPath, partnerId == null ? "" : partnerId);
+        SupplierHttpResponse response = baseClient.exchange(toHttpRequest(binding, spec));
+
+        if (!response.isSuccess()) {
+            // Left PENDING deliberately: a failed poll says nothing about the vendor's decision, and
+            // the timeout above is what eventually stops this becoming an infinite wait.
+            log.debug(
+                    "Poll of authorization {} did not succeed ({}); will retry",
+                    row.getSupplierWorkorderAuthorizationId(),
+                    response.outcome());
+            row.setLastPolledAt(now);
+            authorizationRepository.save(row);
+            return;
+        }
+
+        SupplierWorkorderAuthorization decision;
+        try {
+            decision = codec.decodeDecision(
+                    response.body(),
+                    response.httpStatus() == null ? 0 : response.httpStatus(),
+                    response.header("Location"),
+                    row.getWorkorderId());
+        } catch (WorkorderAuthDecodeException e) {
+            runner.parkForReview(row, "vendor answer could not be read while polling: " + e.getMessage());
+            return;
+        }
+
+        runner.applyDecision(row, decision);
+    }
+
+    /**
+     * Turns a vendor {@code Location} into a path this client can request.
+     *
+     * <p>An absolute URL is reduced to its path because the binding owns the base URL: honouring a
+     * vendor-supplied host would let a redirect move an authenticated, credential-bearing request to
+     * a host nobody configured.
+     */
+    @Nullable
+    private static String pollPathFor(@Nullable String location) {
+        if (location == null || location.isBlank()) {
+            return null;
+        }
+        String trimmed = location.trim();
+        try {
+            URI uri = URI.create(trimmed);
+            String path = uri.getPath();
+            if (path == null || path.isBlank()) {
+                return null;
+            }
+            return path.startsWith("/") ? path : "/" + path;
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    @NonNull
+    private SupplierHttpRequest toHttpRequest(@NonNull ResolvedBinding binding, @NonNull SupplierRequestSpec spec) {
+        return new SupplierHttpRequest(
+                binding,
+                HttpMethod.valueOf(spec.method()),
+                spec.pathSuffix(),
+                spec.queryParams(),
+                spec.body(),
+                spec.contentType(),
+                spec.accept(),
+                spec.idempotent(),
+                spec.headers());
+    }
+
+    @NonNull
+    private MichelinS2SWorkorderAuthCodec resolveCodec(@NonNull ResolvedBinding binding) {
+        AdapterResolution resolution = adapterRegistry.resolve(
+                SupplierCapability.WORKORDER_AUTHORIZATION, binding.family(), binding.version());
+        if (resolution instanceof AdapterResolution.Resolved resolved
+                && resolved.codec() instanceof MichelinS2SWorkorderAuthCodec codec) {
+            return codec;
+        }
+        throw new IllegalStateException("No workorder authorization codec registered for " + binding.family());
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPublisher.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPublisher.java
@@ -1,0 +1,111 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.DomainTopics;
+import com.positivity.domainevents.supplier.SupplierWorkorderAuthDeniedV1;
+import com.positivity.domainevents.supplier.SupplierWorkorderAuthGrantedV1;
+import com.positivity.shared.id.UUIDv7Generator;
+import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
+import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+
+/**
+ * Publishes fleet authorization decisions (CAP-323 #1229, ADR-0044 R1).
+ *
+ * <h2>Only the vendor's answers are published</h2>
+ *
+ * {@code GRANTED} and {@code DENIED} go out. {@code PENDING} does not — there is nothing to say
+ * yet. {@code MANUAL_REVIEW} does not, and that is the load-bearing decision here: it means "we
+ * could not get an answer", and publishing it would put a non-answer onto a topic whose consumers
+ * are deciding whether work may proceed. A shop that hears "denied" acts very differently from one
+ * that hears nothing, and only one of those is honest about an unreachable vendor.
+ *
+ * <h2>{@code NOT_FOUND} is published as a denial</h2>
+ *
+ * With the vendor's own reason attached, unchanged. The vendor did answer — it said it does not know
+ * this vehicle or contract — and the practical consequence for a shop is the same as a refusal: do
+ * not proceed under the fleet contract. The reason text is what tells a service advisor that this
+ * one is fixable by correcting a fleet number rather than by phoning the fleet.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WorkorderAuthorizationPublisher {
+
+    private static final String SOURCE = "pos-supplier";
+
+    private final SupplierOutboxEventWriter outboxEventWriter;
+
+    /**
+     * Publishes the decision on a row, when there is one to publish.
+     *
+     * @param row the authorization as stored
+     * @param occurredAt when the decision was observed
+     */
+    public void publishIfTerminal(@NonNull SupplierWorkorderAuthorizationEntity row, @NonNull Instant occurredAt) {
+        switch (row.getStatus()) {
+            case GRANTED ->
+                publish(
+                        SupplierWorkorderAuthGrantedV1.EVENT_TYPE,
+                        SupplierWorkorderAuthGrantedV1.SCHEMA_VERSION,
+                        row,
+                        occurredAt,
+                        new SupplierWorkorderAuthGrantedV1(
+                                row.getVendorProfileId(),
+                                row.getSupplierRef(),
+                                row.getWorkorderId(),
+                                row.getVendorAuthorizationId(),
+                                row.getContractReference(),
+                                row.getAuthorizedAmount(),
+                                row.getCurrency(),
+                                occurredAt));
+            case DENIED, NOT_FOUND ->
+                publish(
+                        SupplierWorkorderAuthDeniedV1.EVENT_TYPE,
+                        SupplierWorkorderAuthDeniedV1.SCHEMA_VERSION,
+                        row,
+                        occurredAt,
+                        new SupplierWorkorderAuthDeniedV1(
+                                row.getVendorProfileId(),
+                                row.getSupplierRef(),
+                                row.getWorkorderId(),
+                                row.getVendorAuthorizationId(),
+                                row.getReasonCode(),
+                                row.getReasonText(),
+                                occurredAt));
+            case PENDING, MANUAL_REVIEW -> {
+                // Nothing to say. See the class note: a non-answer must not reach consumers that
+                // are deciding whether work may proceed.
+            }
+        }
+    }
+
+    private void publish(
+            @NonNull String eventType,
+            int schemaVersion,
+            @NonNull SupplierWorkorderAuthorizationEntity row,
+            @NonNull Instant occurredAt,
+            @NonNull Object payload) {
+        outboxEventWriter.publish(
+                DomainTopics.events("supplier"),
+                new DomainEventEnvelope<>(
+                        UUIDv7Generator.generate(),
+                        eventType,
+                        schemaVersion,
+                        // Keyed on the authorization row, so every decision about one workorder
+                        // lands on one partition in order. A grant overtaking the denial it
+                        // replaced would authorise work the fleet had already refused.
+                        row.getSupplierWorkorderAuthorizationId(),
+                        0L,
+                        occurredAt,
+                        SOURCE,
+                        null,
+                        SOURCE,
+                        payload));
+        log.info("Published {} for workorder {} at {}", eventType, row.getWorkorderId(), row.getSupplierRef());
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationRunner.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationRunner.java
@@ -10,7 +10,6 @@ import com.positivity.supplier.internal.domain.model.SupplierRef;
 import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
 import com.positivity.supplier.internal.domain.model.SupplierWorkorderAuthorization;
 import com.positivity.supplier.internal.domain.model.WorkorderAuthorizationRequest;
-import com.positivity.supplier.internal.entity.SupplierAccountEntity;
 import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
 import com.positivity.supplier.internal.enums.WorkorderApprovalStatus;
 import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
@@ -108,7 +107,7 @@ public class WorkorderAuthorizationRunner implements SupplierWorkorderAuthorizat
         ResolvedBinding binding =
                 profileResolver.resolveBinding(supplierRef, SupplierCapability.WORKORDER_AUTHORIZATION);
         MichelinS2SWorkorderAuthCodec codec = resolveCodec(binding);
-        String partnerId = partnerIdFor(supplierRef);
+        String partnerId = S2SPartnerId.resolve(profileResolver, supplierRef);
 
         SupplierWorkorderAuthorizationEntity row = openRow(binding, supplierRef, request);
 
@@ -260,23 +259,6 @@ public class WorkorderAuthorizationRunner implements SupplierWorkorderAuthorizat
         row.setDecidedAt(null);
         row.setPollLocation(null);
         return authorizationRepository.save(row);
-    }
-
-    @NonNull
-    private String partnerIdFor(@NonNull SupplierRef supplierRef) {
-        SupplierAccountEntity billing =
-                profileResolver.resolvePartyContext(supplierRef, null).billing();
-        String partnerId = billing.getAccountNumber();
-        if (partnerId == null || partnerId.isBlank()) {
-            // The spec requires partnerId on every operation. Without it the vendor cannot tell
-            // which service centre is asking, and a fleet authorization from an unidentified caller
-            // is not something any vendor grants.
-            throw new SupplierConfigurationException(
-                    SupplierConfigurationException.CAPABILITY_NOT_CONFIGURED,
-                    "No billing account number configured for " + supplierRef.value()
-                            + "; the S2S partnerId has nowhere to come from");
-        }
-        return partnerId;
     }
 
     @NonNull

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationRunner.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationRunner.java
@@ -1,0 +1,416 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import com.positivity.supplier.internal.adapter.michelins2s.MichelinS2SWorkorderAuthCodec;
+import com.positivity.supplier.internal.adapter.michelins2s.WorkorderAuthDecodeException;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.client.SupplierHttpRequest;
+import com.positivity.supplier.internal.client.SupplierHttpResponse;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.domain.model.SupplierWorkorderAuthorization;
+import com.positivity.supplier.internal.domain.model.WorkorderAuthorizationRequest;
+import com.positivity.supplier.internal.entity.SupplierAccountEntity;
+import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
+import com.positivity.supplier.internal.enums.WorkorderApprovalStatus;
+import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.registry.AdapterResolution;
+import com.positivity.supplier.internal.repository.SupplierWorkorderAuthorizationRepository;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import com.positivity.supplier.internal.spi.SupplierWorkorderAuthorizationPort;
+import com.positivity.supplier.service.model.FleetAuthorizationResponse;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Limit;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Asks a fleet program to authorize work, and records what it said (CAP-323 #1229).
+ *
+ * <h2>The row is written before the vendor is called</h2>
+ *
+ * In its own transaction, and committed. If the call then fails, the record of having asked
+ * survives — which is the difference between an operator seeing "requested, no answer" and seeing
+ * nothing at all. A shop waiting on a fleet authorization that was never recorded has no way to
+ * discover it is waiting.
+ *
+ * <h2>Nothing here is retried automatically</h2>
+ *
+ * Creating an authorization is a commercial act at the fleet: a blind re-send after an ambiguous
+ * failure can open a second authorization against the same contract, which somebody then has to
+ * unpick with a fleet manager. So an ambiguous outcome parks the row in {@code MANUAL_REVIEW} with
+ * the reason attached, and a human decides whether to ask again. That is more work than a retry loop
+ * and it is the right amount of work for the risk.
+ *
+ * <h2>Unreachable is never denied</h2>
+ *
+ * A vendor that cannot be reached, a token that would not mint, a response nobody can parse — none
+ * of these are refusals, and none are published as one. They stay here as {@code MANUAL_REVIEW}.
+ * Telling a shop the fleet said no when in fact nobody asked sends it to argue with a fleet manager
+ * about a decision that was never made.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WorkorderAuthorizationRunner implements SupplierWorkorderAuthorizationPort {
+
+    /**
+     * The {@code API-Version} major the S2S v1 URIs carry.
+     *
+     * <p>A constant rather than configuration because the spec requires the header to match the URI
+     * version, and the URIs this codec builds are {@code /api/v1/...}. Making it configurable would
+     * only create the possibility of the two disagreeing.
+     */
+    private static final String API_MAJOR_VERSION = "1";
+
+    private final SupplierProfileResolver profileResolver;
+    private final AdapterRegistry adapterRegistry;
+    private final SupplierBaseClient baseClient;
+    private final SupplierWorkorderAuthorizationRepository authorizationRepository;
+    private final WorkorderAuthorizationPublisher publisher;
+    private final Clock clock;
+
+    @Override
+    @NonNull
+    public SupplierWorkorderAuthorization requestAuthorization(
+            @NonNull SupplierRef supplierRef, @NonNull WorkorderAuthorizationRequest request) {
+        return toDomain(requestAuthorizationRow(supplierRef, request));
+    }
+
+    /**
+     * Requests authorization and returns the stored row.
+     *
+     * <p>The row rather than the decision, because callers inside this module go on to work with
+     * the operational state — {@code MANUAL_REVIEW}, the review reason, the approval lifecycle —
+     * none of which is part of the vendor's answer and none of which belongs in the port's return
+     * type.
+     *
+     * @param supplierRef the fleet program to ask
+     * @param request     what is being asked for
+     * @return the authorization as it now stands, which may still be {@code PENDING}
+     * @throws SupplierConfigurationException when the profile, binding or codec is not configured
+     */
+    @NonNull
+    public SupplierWorkorderAuthorizationEntity requestAuthorizationRow(
+            @NonNull SupplierRef supplierRef, @NonNull WorkorderAuthorizationRequest request) {
+        ResolvedBinding binding =
+                profileResolver.resolveBinding(supplierRef, SupplierCapability.WORKORDER_AUTHORIZATION);
+        MichelinS2SWorkorderAuthCodec codec = resolveCodec(binding);
+        String partnerId = partnerIdFor(supplierRef);
+
+        SupplierWorkorderAuthorizationEntity row = openRow(binding, supplierRef, request);
+
+        SupplierRequestSpec spec = codec.buildAuthorizationRequest(request, partnerId, API_MAJOR_VERSION);
+        SupplierHttpResponse response = baseClient.exchange(toHttpRequest(binding, spec));
+
+        if (!response.isSuccess()) {
+            // Not a denial. The vendor may never have seen the request, or may have created an
+            // authorization and failed to tell us -- and those two are indistinguishable from here,
+            // which is exactly why a human has to look rather than a loop retrying.
+            return parkForReview(
+                    row,
+                    "vendor exchange failed: " + response.outcome()
+                            + (response.failureDetail() == null ? "" : " — " + response.failureDetail()));
+        }
+
+        SupplierWorkorderAuthorization decision;
+        try {
+            decision = codec.decodeDecision(
+                    response.body(),
+                    response.httpStatus() == null ? 0 : response.httpStatus(),
+                    response.header("Location"),
+                    request.workorderId());
+        } catch (WorkorderAuthDecodeException e) {
+            // The vendor answered something. We could not read it. Guessing either way decides
+            // whether a shop does work, so neither guess is available.
+            return parkForReview(row, "vendor answer could not be read: " + e.getMessage());
+        }
+
+        return applyDecision(row, decision);
+    }
+
+    /**
+     * Records a decision against an existing row and publishes it if terminal.
+     *
+     * <p>Shared with the poller, so an answer that arrives synchronously and one that arrives an
+     * hour later are recorded and published by the same code. Two paths would drift, and the one
+     * that drifts is the asynchronous one, which is also the one nobody watches.
+     */
+    @Transactional
+    @NonNull
+    public SupplierWorkorderAuthorizationEntity applyDecision(
+            @NonNull SupplierWorkorderAuthorizationEntity row, @NonNull SupplierWorkorderAuthorization decision) {
+        Instant now = Instant.now(clock);
+        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
+                .findById(row.getSupplierWorkorderAuthorizationId())
+                .orElse(row);
+
+        managed.setLastPolledAt(now);
+        if (decision.vendorAuthorizationId() != null) {
+            managed.setVendorAuthorizationId(decision.vendorAuthorizationId());
+        }
+
+        switch (decision.status()) {
+            case PENDING -> {
+                managed.setStatus(WorkorderAuthorizationStatus.PENDING);
+                if (decision.pollLocation() != null) {
+                    managed.setPollLocation(decision.pollLocation());
+                }
+            }
+            case GRANTED -> {
+                managed.setStatus(WorkorderAuthorizationStatus.GRANTED);
+                managed.setContractReference(decision.contractReference());
+                managed.setAuthorizedAmount(decision.authorizedAmount());
+                managed.setCurrency(decision.currency());
+                managed.setDecidedAt(now);
+            }
+            case DENIED -> {
+                managed.setStatus(WorkorderAuthorizationStatus.DENIED);
+                managed.setReasonCode(decision.vendorReasonCode());
+                managed.setReasonText(decision.vendorReason());
+                managed.setDecidedAt(now);
+            }
+            case NOT_FOUND -> {
+                managed.setStatus(WorkorderAuthorizationStatus.NOT_FOUND);
+                managed.setReasonCode(decision.vendorReasonCode());
+                managed.setReasonText(decision.vendorReason());
+                managed.setDecidedAt(now);
+            }
+        }
+
+        SupplierWorkorderAuthorizationEntity saved = authorizationRepository.save(managed);
+
+        // Published inside the same transaction as the state change, through the outbox: a decision
+        // recorded but not published would leave the rest of the platform believing the fleet never
+        // answered (ADR-0044 §4).
+        publisher.publishIfTerminal(saved, now);
+        return saved;
+    }
+
+    /**
+     * Parks a row for a human and says why.
+     *
+     * <p>{@code REQUIRES_NEW} so the reason survives whatever the caller does next. A review reason
+     * rolled back with the transaction that discovered it is the one piece of information nobody can
+     * reconstruct afterwards.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @NonNull
+    public SupplierWorkorderAuthorizationEntity parkForReview(
+            @NonNull SupplierWorkorderAuthorizationEntity row, @NonNull String reason) {
+        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
+                .findById(row.getSupplierWorkorderAuthorizationId())
+                .orElse(row);
+        managed.setStatus(WorkorderAuthorizationStatus.MANUAL_REVIEW);
+        managed.setReviewReason(truncate(reason));
+        managed.setLastPolledAt(Instant.now(clock));
+        log.warn(
+                "Workorder authorization for workorder {} at {} needs review: {}",
+                managed.getWorkorderId(),
+                managed.getSupplierRef(),
+                reason);
+        return authorizationRepository.save(managed);
+    }
+
+    /**
+     * Opens (or re-opens) the row for this workorder, committed before the vendor is called.
+     *
+     * <p>Re-requesting updates the existing row rather than adding a second. Two rows would let a
+     * denial and a grant coexist for one workorder with nothing to say which one a shop should act
+     * on, and the uniqueness index exists to make that impossible rather than merely unlikely.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @NonNull
+    public SupplierWorkorderAuthorizationEntity openRow(
+            @NonNull ResolvedBinding binding,
+            @NonNull SupplierRef supplierRef,
+            @NonNull WorkorderAuthorizationRequest request) {
+        Instant now = Instant.now(clock);
+        UUID vendorProfileId = binding.profile().getVendorProfileId();
+
+        SupplierWorkorderAuthorizationEntity row = authorizationRepository
+                .findByVendorProfileIdAndWorkorderId(vendorProfileId, request.workorderId())
+                .orElseGet(() -> SupplierWorkorderAuthorizationEntity.builder()
+                        .vendorProfileId(vendorProfileId)
+                        .workorderId(request.workorderId())
+                        .approvalStatus(WorkorderApprovalStatus.NOT_REQUESTED)
+                        .approvalAttempts(0)
+                        .build());
+
+        row.setSupplierRef(supplierRef.value());
+        row.setStatus(WorkorderAuthorizationStatus.PENDING);
+        row.setRequestedAt(now);
+        // Cleared on re-request: a stale reason from the previous attempt read as if it described
+        // this one.
+        row.setReviewReason(null);
+        row.setReasonCode(null);
+        row.setReasonText(null);
+        row.setDecidedAt(null);
+        row.setPollLocation(null);
+        return authorizationRepository.save(row);
+    }
+
+    @NonNull
+    private String partnerIdFor(@NonNull SupplierRef supplierRef) {
+        SupplierAccountEntity billing =
+                profileResolver.resolvePartyContext(supplierRef, null).billing();
+        String partnerId = billing.getAccountNumber();
+        if (partnerId == null || partnerId.isBlank()) {
+            // The spec requires partnerId on every operation. Without it the vendor cannot tell
+            // which service centre is asking, and a fleet authorization from an unidentified caller
+            // is not something any vendor grants.
+            throw new SupplierConfigurationException(
+                    SupplierConfigurationException.CAPABILITY_NOT_CONFIGURED,
+                    "No billing account number configured for " + supplierRef.value()
+                            + "; the S2S partnerId has nowhere to come from");
+        }
+        return partnerId;
+    }
+
+    @NonNull
+    private SupplierHttpRequest toHttpRequest(@NonNull ResolvedBinding binding, @NonNull SupplierRequestSpec spec) {
+        return new SupplierHttpRequest(
+                binding,
+                HttpMethod.valueOf(spec.method()),
+                spec.pathSuffix(),
+                spec.queryParams(),
+                spec.body(),
+                spec.contentType(),
+                spec.accept(),
+                spec.idempotent(),
+                spec.headers());
+    }
+
+    @NonNull
+    private MichelinS2SWorkorderAuthCodec resolveCodec(@NonNull ResolvedBinding binding) {
+        AdapterResolution resolution = adapterRegistry.resolve(
+                SupplierCapability.WORKORDER_AUTHORIZATION, binding.family(), binding.version());
+        if (resolution instanceof AdapterResolution.Resolved resolved
+                && resolved.codec() instanceof MichelinS2SWorkorderAuthCodec codec) {
+            return codec;
+        }
+        throw new SupplierConfigurationException(
+                SupplierConfigurationException.CAPABILITY_NOT_CONFIGURED,
+                "No workorder authorization codec registered for " + binding.family() + " "
+                        + binding.version().value());
+    }
+
+    /** Keeps a vendor's error text inside the column it is stored in. */
+    @NonNull
+    private static String truncate(@NonNull String reason) {
+        return reason.length() <= 1000 ? reason : reason.substring(0, 1000);
+    }
+
+    /**
+     * The live authorization for a workorder at a named vendor, if one was ever requested.
+     *
+     * <p>Resolves the alias to a profile first, so an unknown {@code supplierRef} surfaces as the
+     * configuration problem it is rather than as "no authorization found" — those two answers lead a
+     * service advisor to do very different things.
+     */
+    @NonNull
+    public Optional<SupplierWorkorderAuthorizationEntity> findBySupplierRef(
+            @NonNull SupplierRef supplierRef, @NonNull UUID workorderId) {
+        ResolvedBinding binding =
+                profileResolver.resolveBinding(supplierRef, SupplierCapability.WORKORDER_AUTHORIZATION);
+        return authorizationRepository.findByVendorProfileIdAndWorkorderId(
+                binding.profile().getVendorProfileId(), workorderId);
+    }
+
+    /**
+     * The vendor's answer, without this module's operational state.
+     *
+     * <p>{@code MANUAL_REVIEW} maps to {@code PENDING}: it means nobody got an answer, and the
+     * honest thing to tell a caller asking whether work is authorized is "not yet". Mapping it to
+     * denied would report a refusal the fleet never made.
+     */
+    @NonNull
+    private static SupplierWorkorderAuthorization toDomain(@NonNull SupplierWorkorderAuthorizationEntity row) {
+        return new SupplierWorkorderAuthorization(
+                row.getVendorAuthorizationId(),
+                row.getWorkorderId(),
+                switch (row.getStatus()) {
+                    case GRANTED -> SupplierWorkorderAuthorization.Status.GRANTED;
+                    case DENIED -> SupplierWorkorderAuthorization.Status.DENIED;
+                    case NOT_FOUND -> SupplierWorkorderAuthorization.Status.NOT_FOUND;
+                    case PENDING, MANUAL_REVIEW -> SupplierWorkorderAuthorization.Status.PENDING;
+                },
+                row.getReasonText(),
+                row.getReasonCode(),
+                row.getContractReference(),
+                row.getAuthorizedAmount(),
+                row.getCurrency(),
+                row.getPollLocation());
+    }
+
+    /**
+     * Requests authorization and returns the operator-facing projection.
+     *
+     * <p>The projection is built here rather than in the controller so no controller holds a JPA
+     * entity: an entity on a request thread is a lazy-loading accident waiting for a field nobody
+     * fetched, and the architecture rules forbid it for that reason.
+     */
+    @NonNull
+    public FleetAuthorizationResponse requestAndProject(
+            @NonNull SupplierRef supplierRef, @NonNull WorkorderAuthorizationRequest request) {
+        return project(requestAuthorizationRow(supplierRef, request));
+    }
+
+    /** The recorded authorization for a workorder at a named vendor, projected. */
+    @NonNull
+    public Optional<FleetAuthorizationResponse> findProjection(
+            @NonNull SupplierRef supplierRef, @NonNull UUID workorderId) {
+        return findBySupplierRef(supplierRef, workorderId).map(WorkorderAuthorizationRunner::project);
+    }
+
+    /**
+     * The operator-facing view, review state included.
+     *
+     * <p>Unlike the cross-module contract view this does show {@code MANUAL_REVIEW} and its reason.
+     * The whole point of that state is that somebody can see it: hiding it here would leave the
+     * queue of unapproved, unpaid work with no way to look at it.
+     */
+    @NonNull
+    private static FleetAuthorizationResponse project(@NonNull SupplierWorkorderAuthorizationEntity row) {
+        return new FleetAuthorizationResponse(
+                row.getWorkorderId(),
+                row.getSupplierRef(),
+                row.getStatus().name(),
+                row.getVendorAuthorizationId(),
+                row.getContractReference(),
+                row.getAuthorizedAmount(),
+                row.getCurrency(),
+                row.getReasonCode(),
+                row.getReasonText(),
+                row.getReviewReason(),
+                row.getApprovalStatus().name(),
+                row.getRequestedAt(),
+                row.getDecidedAt());
+    }
+
+    /**
+     * The authorizations and completions waiting on a human, newest first.
+     *
+     * <p>This is the reason {@code MANUAL_REVIEW} exists at all. A state that nothing can list is a
+     * state nobody acts on, and the rows in it represent work already performed that a fleet has not
+     * agreed to pay for.
+     */
+    @NonNull
+    public List<FleetAuthorizationResponse> findNeedingReview(int limit) {
+        return authorizationRepository.findNeedingReview(Limit.of(limit)).stream()
+                .map(WorkorderAuthorizationRunner::project)
+                .toList();
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionApprover.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionApprover.java
@@ -10,6 +10,7 @@ import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
 import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
 import com.positivity.supplier.internal.enums.WorkorderApprovalStatus;
 import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
 import com.positivity.supplier.internal.registry.AdapterRegistry;
 import com.positivity.supplier.internal.registry.AdapterResolution;
 import com.positivity.supplier.internal.repository.SupplierWorkorderAuthorizationRepository;
@@ -148,11 +149,19 @@ public class WorkorderCompletionApprover {
         ResolvedBinding binding =
                 profileResolver.resolveBinding(supplierRef, SupplierCapability.WORKORDER_AUTHORIZATION);
         MichelinS2SWorkorderAuthCodec codec = resolveCodec(binding);
-        String partnerId =
-                profileResolver.resolvePartyContext(supplierRef, null).billing().getAccountNumber();
 
-        SupplierRequestSpec spec =
-                codec.buildApprovalRequest(vendorAuthorizationId, partnerId == null ? "" : partnerId, "1");
+        String partnerId;
+        try {
+            partnerId = S2SPartnerId.resolve(profileResolver, supplierRef);
+        } catch (SupplierConfigurationException e) {
+            // Parked, not retried. No number of attempts fixes a missing account number, and
+            // spending the budget on it would escalate a money-critical approval with a review
+            // reason blaming the vendor for a defect on this side.
+            park(row, "completion cannot be approved: " + e.getMessage());
+            return;
+        }
+
+        SupplierRequestSpec spec = codec.buildApprovalRequest(vendorAuthorizationId, partnerId, "1");
         SupplierHttpResponse response = baseClient.exchange(toHttpRequest(binding, spec));
 
         if (response.isSuccess()) {

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionApprover.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionApprover.java
@@ -1,0 +1,246 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import com.positivity.supplier.internal.adapter.michelins2s.MichelinS2SWorkorderAuthCodec;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.client.SupplierHttpRequest;
+import com.positivity.supplier.internal.client.SupplierHttpResponse;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
+import com.positivity.supplier.internal.enums.WorkorderApprovalStatus;
+import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.registry.AdapterResolution;
+import com.positivity.supplier.internal.repository.SupplierWorkorderAuthorizationRepository;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Limit;
+import org.springframework.http.HttpMethod;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Tells the fleet the authorized work is done (CAP-323 #1229).
+ *
+ * <h2>This is the step that gets a shop paid</h2>
+ *
+ * An authorization that is never approved on completion is work already performed that the fleet has
+ * not agreed to pay for. Unlike a failed fetch, it cannot be recovered by asking again later once
+ * anyone notices, because by then the job has been invoiced and closed. So this retries on its own
+ * schedule and, when it stops retrying, it says so loudly rather than quietly.
+ *
+ * <h2>Retried, unlike the authorization request</h2>
+ *
+ * Approving an already-approved workorder is the vendor restating a fact, so a repeat is harmless —
+ * the opposite of the create call, where a repeat can open a second authorization. That asymmetry is
+ * why the two live in different classes with different rules rather than sharing a "send with
+ * retry" helper that would have to be right about both.
+ */
+@Slf4j
+@Service
+public class WorkorderCompletionApprover {
+
+    private final SupplierWorkorderAuthorizationRepository authorizationRepository;
+    private final SupplierProfileResolver profileResolver;
+    private final AdapterRegistry adapterRegistry;
+    private final SupplierBaseClient baseClient;
+    private final Clock clock;
+
+    /** How many outstanding approvals one tick will attempt. */
+    private final int batchSize;
+
+    /**
+     * How many times an approval is attempted before a human is asked to look.
+     *
+     * <p>Finite on purpose. An approval that retries forever looks like an approval that is working,
+     * and the money involved means somebody has to be told when it is not.
+     */
+    private final int maxAttempts;
+
+    public WorkorderCompletionApprover(
+            SupplierWorkorderAuthorizationRepository authorizationRepository,
+            SupplierProfileResolver profileResolver,
+            AdapterRegistry adapterRegistry,
+            SupplierBaseClient baseClient,
+            Clock clock,
+            @Value("${pos.supplier.workorderauth.approval-batch-size:50}") int batchSize,
+            @Value("${pos.supplier.workorderauth.approval-max-attempts:6}") int maxAttempts) {
+        this.authorizationRepository = authorizationRepository;
+        this.profileResolver = profileResolver;
+        this.adapterRegistry = adapterRegistry;
+        this.baseClient = baseClient;
+        this.clock = clock;
+        this.batchSize = batchSize;
+        this.maxAttempts = maxAttempts;
+    }
+
+    /**
+     * Marks a completed workorder as needing vendor sign-off.
+     *
+     * <p>Recorded rather than sent immediately. The completion event that triggers this is consumed
+     * in a transaction that must not depend on a vendor being reachable — a fleet API being down is
+     * not a reason to fail the handling of a workorder completion.
+     *
+     * @return the row queued for approval, or empty when this workorder has no live authorization
+     *     (most workorders are not fleet work at all)
+     */
+    @Transactional
+    @NonNull
+    public Optional<SupplierWorkorderAuthorizationEntity> queueApproval(@NonNull UUID workorderId) {
+        List<SupplierWorkorderAuthorizationEntity> rows =
+                authorizationRepository.findByWorkorderIdOrderByRequestedAtDesc(workorderId);
+        for (SupplierWorkorderAuthorizationEntity row : rows) {
+            if (row.getStatus() != WorkorderAuthorizationStatus.GRANTED) {
+                continue;
+            }
+            if (row.getApprovalStatus() == WorkorderApprovalStatus.APPROVED) {
+                // Already signed off. A redelivered completion event must not reopen it.
+                return Optional.of(row);
+            }
+            row.setApprovalStatus(WorkorderApprovalStatus.PENDING);
+            return Optional.of(authorizationRepository.save(row));
+        }
+        return Optional.empty();
+    }
+
+    /** Attempts outstanding approvals, oldest first. */
+    @Scheduled(fixedDelayString = "${pos.supplier.workorderauth.approval-interval-ms:300000}")
+    public void approveOutstanding() {
+        List<SupplierWorkorderAuthorizationEntity> outstanding =
+                authorizationRepository.findByApprovalStatusOrderByUpdatedAtAsc(
+                        WorkorderApprovalStatus.PENDING, Limit.of(batchSize));
+
+        for (SupplierWorkorderAuthorizationEntity row : outstanding) {
+            try {
+                approveOne(row);
+            } catch (Exception e) {
+                log.warn(
+                        "Approval of workorder {} at {} failed: {}",
+                        row.getWorkorderId(),
+                        row.getSupplierRef(),
+                        e.toString(),
+                        e);
+                recordAttempt(row, "approval attempt threw: " + e);
+            }
+        }
+    }
+
+    private void approveOne(@NonNull SupplierWorkorderAuthorizationEntity row) {
+        String vendorAuthorizationId = row.getVendorAuthorizationId();
+        if (vendorAuthorizationId == null || vendorAuthorizationId.isBlank()) {
+            // Granted, but the vendor never told us what to call it. No amount of retrying invents
+            // an identifier, so this goes to a human immediately rather than burning attempts.
+            park(row, "the vendor granted this authorization without an id, so its completion cannot be approved");
+            return;
+        }
+
+        SupplierRef supplierRef = new SupplierRef(row.getSupplierRef());
+        ResolvedBinding binding =
+                profileResolver.resolveBinding(supplierRef, SupplierCapability.WORKORDER_AUTHORIZATION);
+        MichelinS2SWorkorderAuthCodec codec = resolveCodec(binding);
+        String partnerId =
+                profileResolver.resolvePartyContext(supplierRef, null).billing().getAccountNumber();
+
+        SupplierRequestSpec spec =
+                codec.buildApprovalRequest(vendorAuthorizationId, partnerId == null ? "" : partnerId, "1");
+        SupplierHttpResponse response = baseClient.exchange(toHttpRequest(binding, spec));
+
+        if (response.isSuccess()) {
+            markApproved(row);
+            return;
+        }
+        recordAttempt(
+                row,
+                "vendor refused or could not be reached: " + response.outcome()
+                        + (response.failureDetail() == null ? "" : " — " + response.failureDetail()));
+    }
+
+    @Transactional
+    void markApproved(@NonNull SupplierWorkorderAuthorizationEntity row) {
+        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
+                .findById(row.getSupplierWorkorderAuthorizationId())
+                .orElse(row);
+        managed.setApprovalStatus(WorkorderApprovalStatus.APPROVED);
+        managed.setApprovedAt(Instant.now(clock));
+        managed.setApprovalAttempts(managed.getApprovalAttempts() + 1);
+        authorizationRepository.save(managed);
+        log.info(
+                "Vendor approved completion of workorder {} at {}", managed.getWorkorderId(), managed.getSupplierRef());
+    }
+
+    /** Counts a failed attempt, and escalates once the budget is spent. */
+    @Transactional
+    void recordAttempt(@NonNull SupplierWorkorderAuthorizationEntity row, @NonNull String reason) {
+        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
+                .findById(row.getSupplierWorkorderAuthorizationId())
+                .orElse(row);
+        int attempts = managed.getApprovalAttempts() + 1;
+        managed.setApprovalAttempts(attempts);
+        if (attempts >= maxAttempts) {
+            managed.setApprovalStatus(WorkorderApprovalStatus.MANUAL_REVIEW);
+            managed.setReviewReason(truncate("completion approval gave up after " + attempts + " attempts: " + reason));
+            log.error(
+                    "Completion approval for workorder {} at {} needs review after {} attempts: {}",
+                    managed.getWorkorderId(),
+                    managed.getSupplierRef(),
+                    attempts,
+                    reason);
+        }
+        authorizationRepository.save(managed);
+    }
+
+    @Transactional
+    void park(@NonNull SupplierWorkorderAuthorizationEntity row, @NonNull String reason) {
+        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
+                .findById(row.getSupplierWorkorderAuthorizationId())
+                .orElse(row);
+        managed.setApprovalStatus(WorkorderApprovalStatus.MANUAL_REVIEW);
+        managed.setReviewReason(truncate(reason));
+        authorizationRepository.save(managed);
+        log.error(
+                "Completion approval for workorder {} at {} cannot proceed: {}",
+                managed.getWorkorderId(),
+                managed.getSupplierRef(),
+                reason);
+    }
+
+    @NonNull
+    private SupplierHttpRequest toHttpRequest(@NonNull ResolvedBinding binding, @NonNull SupplierRequestSpec spec) {
+        return new SupplierHttpRequest(
+                binding,
+                HttpMethod.valueOf(spec.method()),
+                spec.pathSuffix(),
+                spec.queryParams(),
+                spec.body(),
+                spec.contentType(),
+                spec.accept(),
+                spec.idempotent(),
+                spec.headers());
+    }
+
+    @NonNull
+    private MichelinS2SWorkorderAuthCodec resolveCodec(@NonNull ResolvedBinding binding) {
+        AdapterResolution resolution = adapterRegistry.resolve(
+                SupplierCapability.WORKORDER_AUTHORIZATION, binding.family(), binding.version());
+        if (resolution instanceof AdapterResolution.Resolved resolved
+                && resolved.codec() instanceof MichelinS2SWorkorderAuthCodec codec) {
+            return codec;
+        }
+        throw new IllegalStateException("No workorder authorization codec registered for " + binding.family());
+    }
+
+    @NonNull
+    private static String truncate(@NonNull String reason) {
+        return reason.length() <= 1000 ? reason : reason.substring(0, 1000);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionEventsListener.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionEventsListener.java
@@ -1,0 +1,108 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import com.positivity.domainevents.workorder.WorkorderServiceCompletedV1;
+import com.positivity.supplier.internal.entity.ProcessedEvent;
+import com.positivity.supplier.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Queues vendor sign-off when a fleet workorder completes (CAP-323 #1229, ADR-0044 R1).
+ *
+ * <h2>Consuming, not asking</h2>
+ *
+ * pos-supplier learns that work finished from a workexec fact, never by reading pos-workorder. This
+ * is the direction the domain wall permits, and it is also the only direction that works: a
+ * completion is a moment in time, and a poller asking "has it finished yet" would either miss it or
+ * hammer a domain that has no reason to answer.
+ *
+ * <h2>Most completions are not fleet work</h2>
+ *
+ * The great majority of workorders have no authorization at all, so the common path here is to
+ * record the event as processed and do nothing. That is why the lookup is by workorder id against
+ * this module's own table rather than anything more elaborate — an ordinary retail job must cost
+ * one indexed read.
+ *
+ * <h2>The vendor is not called here</h2>
+ *
+ * Completion only marks the row as needing approval; the approver sends it later on its own
+ * schedule. A fleet API being unreachable must never fail the handling of a workorder completion,
+ * because the completion is a fact that already happened and refusing to record it does not make it
+ * un-happen.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.supplier.kafka", name = "enabled", havingValue = "true")
+public class WorkorderCompletionEventsListener {
+
+    private static final String OWNER = "supplier-workorderauth";
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final ProcessedEventRepository processedEventRepository;
+    private final WorkorderCompletionApprover approver;
+
+    @KafkaListener(
+            topics = "${pos.supplier.kafka.workorder-events-topic:workorder.events.v1}",
+            groupId = "${pos.supplier.kafka.workorder-events-consumer-group:pos-supplier-workorder-events}")
+    @Transactional
+    public void onWorkorderEvent(@NonNull String message) {
+        JsonNode envelope;
+        try {
+            envelope = objectMapper.readTree(message);
+        } catch (Exception e) {
+            log.warn("Skipping unparsable workorder event", e);
+            return;
+        }
+        String eventType = envelope.path("eventType").stringValue(null);
+        String eventId = envelope.path("eventId").stringValue(null);
+        if (eventId == null || eventId.isBlank()) {
+            log.warn("Skipping workorder event without eventId");
+            return;
+        }
+        if (processedEventRepository.existsById(eventId)) {
+            return;
+        }
+
+        try {
+            if (WorkorderServiceCompletedV1.EVENT_TYPE.equals(eventType)) {
+                applyCompletion(envelope);
+            } else {
+                log.debug("Ignoring workorder event type={} eventId={}", eventType, eventId);
+            }
+        } catch (TransientDataAccessException e) {
+            // Rethrown so the container retries. Marking this processed would leave an authorized
+            // job never queued for sign-off, which is work performed that the fleet is never asked
+            // to pay for -- and nothing later would report it missing.
+            throw e;
+        } catch (Exception e) {
+            log.warn("Skipping malformed workorder completion event eventId={}", eventId, e);
+        }
+        processedEventRepository.save(ProcessedEvent.builder()
+                .eventId(eventId)
+                .owner(OWNER)
+                .processedAt(Instant.now(clock))
+                .build());
+    }
+
+    private void applyCompletion(@NonNull JsonNode envelope) {
+        WorkorderServiceCompletedV1 payload =
+                objectMapper.treeToValue(envelope.path("payload"), WorkorderServiceCompletedV1.class);
+        approver.queueApproval(payload.workorderId())
+                .ifPresent(row -> log.info(
+                        "Queued vendor approval for completed workorder {} at {}",
+                        row.getWorkorderId(),
+                        row.getSupplierRef()));
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/service/model/FleetAuthorizationRequestBody.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/service/model/FleetAuthorizationRequestBody.java
@@ -1,0 +1,63 @@
+package com.positivity.supplier.service.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A request to have a fleet program authorize work (CAP-323 #1229).
+ *
+ * <p>No single vehicle identifier is marked required, because a shop has whatever the customer
+ * arrived with — sometimes a fleet unit number on a sticker, sometimes only a plate. That at least
+ * one must be present is enforced in the domain, which is where the rule can be stated once for
+ * every caller rather than repeated per field.
+ */
+@Schema(description = "A request to have a fleet program authorize the work on a workorder")
+public record FleetAuthorizationRequestBody(
+        @Schema(description = "Workorder the authorization is for", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
+        UUID workorderId,
+
+        @Schema(description = "The vendor's own vehicle id, when a lookup has already resolved one") @Nullable
+        String vendorVehicleId,
+
+        @Schema(description = "License plate as presented") @Nullable
+        String licensePlate,
+
+        @Schema(description = "VIN as presented") @Nullable String vin,
+
+        @Schema(description = "The fleet's own unit number") @Nullable
+        String fleetNumber,
+
+        @Schema(description = "Fleet contract claimed, when known") @Nullable
+        String contractId,
+
+        @Schema(description = "Odometer reading at check-in, as recorded") @Nullable
+        String odometerValue,
+
+        @Schema(description = "The work being requested") @Nullable
+        List<Line> lines) {
+
+    /** One requested operation or part. */
+    @Schema(description = "One requested operation or part")
+    public record Line(
+            @Schema(description = "Part or operation reference as the shop knows it") @Nullable
+            String reference,
+
+            @Schema(description = "Free text for a human reading the request at the fleet") @Nullable
+            String description,
+
+            @Schema(description = "How many") @PositiveOrZero
+            int quantity,
+
+            @Schema(description = "Wheel position, where the work is position-specific") @Nullable
+            String tirePosition) {}
+
+    /** The requested lines, never null. */
+    public List<Line> linesOrEmpty() {
+        return lines == null ? List.of() : List.copyOf(lines);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/service/model/FleetAuthorizationResponse.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/service/model/FleetAuthorizationResponse.java
@@ -1,0 +1,60 @@
+package com.positivity.supplier.service.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A fleet authorization as this module holds it (CAP-323 #1229).
+ *
+ * <p>Unlike the cross-module {@code WorkorderAuthorizationView}, this one does show
+ * {@code MANUAL_REVIEW} and the reason for it. This is the operator-facing surface: the whole point
+ * of the state is that somebody can see it and act, and hiding it here would leave the queue of
+ * unpaid, unapproved work with no way to look at it.
+ */
+@Schema(description = "A fleet workorder authorization and its vendor-side sign-off state")
+public record FleetAuthorizationResponse(
+        @Schema(description = "Workorder the authorization concerns") @NonNull
+        UUID workorderId,
+
+        @Schema(description = "Vendor profile alias") @NonNull
+        String supplierRef,
+
+        @Schema(
+                description =
+                        "GRANTED, DENIED, NOT_FOUND, PENDING while the vendor decides, or MANUAL_REVIEW when no decision could be obtained")
+        @NonNull
+        String status,
+
+        @Schema(description = "The vendor's own authorization id, needed to approve completion") @Nullable
+        String vendorAuthorizationId,
+
+        @Schema(description = "Contract the work was authorized under, as stated") @Nullable
+        String contractReference,
+
+        @Schema(description = "Ceiling the vendor stated, when it stated one") @Nullable
+        BigDecimal authorizedAmount,
+
+        @Schema(description = "ISO 4217 code for authorizedAmount") @Nullable
+        String currency,
+
+        @Schema(description = "The vendor's refusal code, as stated") @Nullable
+        String reasonCode,
+
+        @Schema(description = "The vendor's refusal text, as stated") @Nullable
+        String reasonText,
+
+        @Schema(description = "Why this authorization needs a human; never a vendor decision") @Nullable
+        String reviewReason,
+
+        @Schema(description = "NOT_REQUESTED, PENDING, APPROVED or MANUAL_REVIEW") @NonNull
+        String approvalStatus,
+
+        @Schema(description = "When the authorization was requested") @NonNull
+        Instant requestedAt,
+
+        @Schema(description = "When the vendor decided, if it has") @Nullable
+        Instant decidedAt) {}

--- a/pos-supplier/src/main/java/com/positivity/supplier/service/model/FleetContract.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/service/model/FleetContract.java
@@ -1,0 +1,26 @@
+package com.positivity.supplier.service.model;
+
+import java.time.LocalDate;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A fleet contract as the vendor states it (CAP-323 #1229).
+ *
+ * <p>Dates are the vendor's own and are not used to decide whether the contract is live. That
+ * decision is the vendor's, made when authorization is requested: a contract that looks expired
+ * here may have been renewed, and refusing locally would deny work the fleet would have paid for.
+ *
+ * @param vendorContractId  the vendor's identifier, quoted on an authorization request
+ * @param name              the contract's name, as stated
+ * @param contractorId      the fleet operator's identifier at the vendor
+ * @param contractorName    the fleet operator's name, as stated
+ * @param startDate         as stated; may be absent or unparseable, in which case null
+ * @param endDate           as stated; absence does not mean open-ended
+ */
+public record FleetContract(
+        @Nullable String vendorContractId,
+        @Nullable String name,
+        @Nullable String contractorId,
+        @Nullable String contractorName,
+        @Nullable LocalDate startDate,
+        @Nullable LocalDate endDate) {}

--- a/pos-supplier/src/main/java/com/positivity/supplier/service/model/FleetPolicy.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/service/model/FleetPolicy.java
@@ -1,0 +1,37 @@
+package com.positivity.supplier.service.model;
+
+import java.util.List;
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * What a fleet program will and will not pay for (CAP-323 #1229).
+ *
+ * <p>Advisory only. A policy read here narrows what a service advisor offers; it never substitutes
+ * for asking the vendor to authorize. The vendor decides, and a local pre-filter that guessed wrong
+ * would either quote work the fleet refuses or refuse work the fleet would have paid for — both
+ * invisible, because no request was ever made.
+ *
+ * @param policyId       the vendor's identifier for the policy
+ * @param name           as stated
+ * @param useBlacklist   whether the vendor says the exclusion list applies
+ * @param useWhitelist   whether the vendor says the inclusion list applies
+ * @param blacklisted    product or operation references the fleet excludes, as stated
+ * @param whitelisted    product or operation references the fleet permits, as stated
+ */
+public record FleetPolicy(
+        @Nullable String policyId,
+        @Nullable String name,
+        boolean useBlacklist,
+        boolean useWhitelist,
+        @NonNull List<String> blacklisted,
+        @NonNull List<String> whitelisted) {
+
+    public FleetPolicy {
+        Objects.requireNonNull(blacklisted, "blacklisted must not be null");
+        Objects.requireNonNull(whitelisted, "whitelisted must not be null");
+        blacklisted = List.copyOf(blacklisted);
+        whitelisted = List.copyOf(whitelisted);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/service/model/FleetVehicle.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/service/model/FleetVehicle.java
@@ -1,0 +1,41 @@
+package com.positivity.supplier.service.model;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A vehicle as the vendor's fleet program knows it (CAP-323 #1229).
+ *
+ * <p>Deliberately not reconciled against pos-vehicle-inventory. This is what the fleet says, and a
+ * quoting flow needs to show exactly that: if the fleet's record disagrees with ours about a
+ * license plate, the disagreement is the useful information and silently preferring one side would
+ * destroy it.
+ *
+ * @param vendorVehicleId the vendor's identifier, used to request authorization
+ * @param licensePlate    as registered with the fleet
+ * @param fleetNumber     the fleet's own unit number, where it uses one
+ * @param vin             as registered with the fleet
+ * @param brand           vehicle make, as stated
+ * @param model           vehicle model, as stated
+ * @param modelYear       as stated
+ * @param odometerValue   last odometer reading the fleet holds, as stated — a string because the
+ *                        vendor states it as one and the unit is not always given
+ */
+public record FleetVehicle(
+        @Nullable String vendorVehicleId,
+        @Nullable String licensePlate,
+        @Nullable String fleetNumber,
+        @Nullable String vin,
+        @Nullable String brand,
+        @Nullable String model,
+        @Nullable Integer modelYear,
+        @Nullable String odometerValue) {
+
+    /** Whether this record identifies a vehicle well enough to request authorization for it. */
+    public boolean isIdentifiable() {
+        return notBlank(vendorVehicleId) || notBlank(licensePlate) || notBlank(vin) || notBlank(fleetNumber);
+    }
+
+    private static boolean notBlank(@Nullable String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/pos-supplier/src/main/resources/application.yml
+++ b/pos-supplier/src/main/resources/application.yml
@@ -193,6 +193,24 @@ pos:
     outbox:
       poll-interval-ms: ${SUPPLIER_OUTBOX_POLL_INTERVAL_MS:1000}
       send-timeout-ms: ${SUPPLIER_OUTBOX_SEND_TIMEOUT_MS:10000}
+    workorderauth:
+      # How often accepted-but-undecided authorizations are re-read. The S2S API may answer a
+      # request with 202 and a Location instead of a decision; without this the 202 is
+      # indistinguishable from a request that vanished.
+      poll-interval-ms: ${SUPPLIER_WORKORDERAUTH_POLL_INTERVAL_MS:120000}
+      poll-batch-size: ${SUPPLIER_WORKORDERAUTH_POLL_BATCH_SIZE:50}
+      # How long an authorization may stay undecided before a human is asked to look. Bounded
+      # because "never" is not an answer a shop can act on: a vendor that will never resolve a
+      # request must not look the same as one that is about to.
+      pending-timeout: ${SUPPLIER_WORKORDERAUTH_PENDING_TIMEOUT:PT24H}
+      # Completion sign-off. Retried, unlike the authorization request: approving an
+      # already-approved workorder is the vendor restating a fact, whereas re-requesting an
+      # authorization can open a second one against the same contract.
+      approval-interval-ms: ${SUPPLIER_WORKORDERAUTH_APPROVAL_INTERVAL_MS:300000}
+      approval-batch-size: ${SUPPLIER_WORKORDERAUTH_APPROVAL_BATCH_SIZE:50}
+      # Finite on purpose. An approval that retries forever looks like one that is working, and an
+      # unapproved completion is work already performed that the fleet has not agreed to pay for.
+      approval-max-attempts: ${SUPPLIER_WORKORDERAUTH_APPROVAL_MAX_ATTEMPTS:6}
     kafka:
       # Off by default so a deployment without a broker starts cleanly; the outbox still records
       # events, and they drain once this is enabled. It also gates the catalog product-code
@@ -201,6 +219,10 @@ pos:
       enabled: ${SUPPLIER_KAFKA_ENABLED:false}
       catalog-events-topic: ${SUPPLIER_CATALOG_EVENTS_TOPIC:catalog.events.v1}
       catalog-events-consumer-group: ${SUPPLIER_CATALOG_EVENTS_CONSUMER_GROUP:pos-supplier-catalog-events}
+      # Workorder completions, which queue the fleet sign-off (CAP-323). Its own consumer group:
+      # one group per topic per module, so a lag or a reset here cannot disturb the catalog replica.
+      workorder-events-topic: ${SUPPLIER_WORKORDER_EVENTS_TOPIC:workorder.events.v1}
+      workorder-events-consumer-group: ${SUPPLIER_WORKORDER_EVENTS_CONSUMER_GROUP:pos-supplier-workorder-events}
       # Inbound commands (ADR-0049 §3): purchase-order transmission requests from pos-order and
       # PRICAT re-publication requests from pos-catalog. Also gated by `enabled` above: with Kafka
       # off nothing is consumed and no order is transmitted, which is the safe direction — the

--- a/pos-supplier/src/main/resources/db/migration/V17__supplier_workorder_authorization.sql
+++ b/pos-supplier/src/main/resources/db/migration/V17__supplier_workorder_authorization.sql
@@ -1,0 +1,77 @@
+-- CAP-323 (#1229): fleet workorder authorization at the vendor (Michelin S2S).
+--
+-- One row per workorder authorization. The vendor's decision is an input to pos-workorder's
+-- workflow, never a copy of workorder state: nothing here records what the workorder is doing,
+-- only what the fleet program said about it (ADR-0049 §2).
+--
+-- The row exists from the moment the request is made, not from the moment a decision arrives.
+-- An authorization requested and never answered is exactly the case an operator needs to see,
+-- and a table that only holds decisions cannot show it.
+
+CREATE TABLE supplier_workorder_authorization (
+    supplier_workorder_authorization_id UUID         PRIMARY KEY,
+    vendor_profile_id                   UUID         NOT NULL,
+    supplier_ref                        VARCHAR(100) NOT NULL,
+    workorder_id                        UUID         NOT NULL,
+
+    -- PENDING, GRANTED, DENIED, NOT_FOUND, MANUAL_REVIEW.
+    -- MANUAL_REVIEW is deliberately not a vendor answer: it is this side giving up on getting one.
+    status                              VARCHAR(20)  NOT NULL,
+
+    -- The vendor's own id for the authorization. Needed to approve completion later, so a GRANTED
+    -- row without one is a defect worth being able to query for.
+    vendor_authorization_id             VARCHAR(100),
+
+    -- Where an asynchronously accepted request said its result would appear (HTTP 202 Location).
+    -- Null on the synchronous path. Without this a 202 is indistinguishable from a lost request.
+    poll_location                       VARCHAR(1000),
+
+    contract_reference                  VARCHAR(100),
+    authorized_amount                   NUMERIC(19, 4),
+    currency                            VARCHAR(3),
+
+    -- The vendor's refusal, as stated. Not translated: the code is what a shop quotes back.
+    reason_code                         VARCHAR(50),
+    reason_text                         VARCHAR(1000),
+
+    -- Why this row needs a human. Set with MANUAL_REVIEW and never on its own.
+    review_reason                       VARCHAR(1000),
+
+    -- Completion approval (PATCH .../approve), tracked separately from the authorization decision
+    -- because they fail independently: work can be authorized and still fail to be signed off.
+    approval_status                     VARCHAR(20)  NOT NULL DEFAULT 'NOT_REQUESTED',
+    approval_attempts                   INTEGER      NOT NULL DEFAULT 0,
+    approved_at                         timestamp(6) with time zone,
+
+    requested_at                        timestamp(6) with time zone  NOT NULL,
+    decided_at                          timestamp(6) with time zone,
+    last_polled_at                      timestamp(6) with time zone,
+
+    created_at                          timestamp(6) with time zone  NOT NULL,
+    updated_at                          timestamp(6) with time zone  NOT NULL,
+
+    CONSTRAINT ck_swa_status CHECK (status IN ('PENDING', 'GRANTED', 'DENIED', 'NOT_FOUND', 'MANUAL_REVIEW')),
+    CONSTRAINT ck_swa_approval_status CHECK (
+        approval_status IN ('NOT_REQUESTED', 'PENDING', 'APPROVED', 'MANUAL_REVIEW')
+    ),
+    -- An amount without a currency is not a sum of money.
+    CONSTRAINT ck_swa_amount_currency CHECK (authorized_amount IS NULL OR currency IS NOT NULL)
+);
+
+-- One live authorization per workorder per vendor. This is what makes a re-requested authorization
+-- an update rather than a second opinion: two rows would let a denial and a grant coexist with
+-- nothing to say which one the shop should act on.
+CREATE UNIQUE INDEX ux_swa_profile_workorder
+    ON supplier_workorder_authorization (vendor_profile_id, workorder_id);
+
+-- The poller's working set: rows still waiting on a vendor, least recently polled first.
+-- Not a partial index, though only PENDING rows are ever read through it: H2 backs the dev profile
+-- and does not support them, and an index that exists on Postgres and not in test is an index whose
+-- query plan nothing exercises before production.
+CREATE INDEX ix_swa_status_polled ON supplier_workorder_authorization (status, last_polled_at);
+
+-- The approver's working set, and an operator's queue of stuck approvals.
+CREATE INDEX ix_swa_approval_status ON supplier_workorder_authorization (approval_status, updated_at);
+
+-- Answering "what needs a human at this vendor" without scanning the table.
+CREATE INDEX ix_swa_profile_status ON supplier_workorder_authorization (vendor_profile_id, status);

--- a/pos-supplier/src/main/resources/permissions.yaml
+++ b/pos-supplier/src/main/resources/permissions.yaml
@@ -20,3 +20,7 @@ permissions:
     description: "Ask a vendor, live, what stock it holds for a receiving location (the approved synchronous supplier read)"
   - name: "supplier:invoice:fetch"
     description: "Run a vendor invoice fetch on demand"
+  - name: "supplier:workorderauth:request"
+    description: "Ask a fleet program to authorize work, and look up fleet vehicles, contracts and policies"
+  - name: "supplier:workorderauth:review"
+    description: "View and clear fleet workorder authorizations parked for manual review"

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/michelins2s/MichelinS2SReusabilityTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/michelins2s/MichelinS2SReusabilityTest.java
@@ -1,0 +1,127 @@
+package com.positivity.supplier.internal.adapter.michelins2s;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The reusability claim, asserted rather than assumed (CAP-323 #1229).
+ *
+ * <h2>What the claim is</h2>
+ *
+ * The architecture says a new vendor costs an adapter plus configuration, and nothing else. Michelin
+ * S2S is the first test of it that means anything: every other adapter in this module speaks
+ * EDIWheel, so a design that quietly assumed EDIWheel would have looked reusable right up until it
+ * was not.
+ *
+ * <h2>What actually had to change outside this package</h2>
+ *
+ * Two things, both in the shared transport, and both because no EDIWheel norm had ever needed them:
+ *
+ * <ul>
+ *   <li>{@code SupplierHttpResponse} gained an allowlisted response-header map. The S2S 202
+ *       acceptance carries its whole meaning in {@code Location}, and the transport used to discard
+ *       every response header.
+ *   <li>{@code SupplierRequestSpec} and {@code SupplierHttpRequest} gained a per-request header map,
+ *       for {@code API-Version}. The EDIWheel norms identify the buyer through credentials and query
+ *       parameters, so no codec had ever needed to set a header.
+ * </ul>
+ *
+ * <p>Both are capability-neutral additions to the transport, not Michelin-shaped ones — any protocol
+ * with an asynchronous acceptance or a version header now has them. The orchestration, the registry,
+ * the profile model and every consuming domain were untouched, which is the part of the claim that
+ * mattered. Recording the exceptions is the point: a reusability claim with no stated cost has not
+ * been tested, it has been asserted.
+ *
+ * <h2>What this test pins</h2>
+ *
+ * That vendor knowledge stays here. If a Michelin path or wire type ever appears outside this
+ * package, the next protocol family will not be a matter of adding a package.
+ */
+@DisplayName("Michelin S2S — vendor knowledge stays in its adapter (#1229)")
+class MichelinS2SReusabilityTest {
+
+    private static final String ADAPTER_PACKAGE = "com.positivity.supplier.internal.adapter.michelins2s";
+
+    private static JavaClasses supplierClasses;
+
+    @BeforeAll
+    static void importClasses() {
+        supplierClasses = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("com.positivity.supplier");
+
+        // Guards against the rule below passing vacuously on an empty import, which is how an
+        // architecture test comes to protect nothing at all.
+        assertThat(supplierClasses).isNotEmpty();
+        assertThat(supplierClasses.stream()
+                        .filter(clazz -> clazz.getPackageName().equals(ADAPTER_PACKAGE))
+                        .count())
+                .as("the adapter package was imported")
+                .isGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("the vendor's wire records never leave the adapter package")
+    void wireTypesStayInTheAdapter() {
+        ArchRule rule = ArchRuleDefinition.noClasses()
+                .that()
+                .resideOutsideOfPackage(ADAPTER_PACKAGE)
+                .should()
+                .dependOnClassesThat()
+                .haveFullyQualifiedName(ADAPTER_PACKAGE + ".WorkorderS2SWire")
+                .because("a vendor type outside its adapter is a vendor shape in the domain, and the next "
+                        + "vendor then has to match this one's JSON");
+
+        rule.check(supplierClasses);
+    }
+
+    @Test
+    @DisplayName("the vendor's URL paths appear only in the adapter")
+    void vendorPathsStayInTheAdapter() throws IOException {
+        Path mainSources = Path.of("src/main/java/com/positivity/supplier");
+        assertThat(Files.isDirectory(mainSources))
+                .as("source tree found at %s", mainSources.toAbsolutePath())
+                .isTrue();
+
+        List<String> offenders;
+        try (Stream<Path> sources = Files.walk(mainSources)) {
+            offenders = sources.filter(path -> path.toString().endsWith(".java"))
+                    .filter(path -> !path.toString().contains("michelins2s"))
+                    .filter(MichelinS2SReusabilityTest::mentionsAVendorPath)
+                    .map(Path::toString)
+                    .toList();
+        }
+
+        // The whole reusability argument in one assertion: if the orchestration knows the vendor's
+        // URLs, then a second vendor is a change to the orchestration, not a new package.
+        assertThat(offenders)
+                .as("files outside the adapter that hard-code a Michelin S2S path")
+                .isEmpty();
+    }
+
+    private static boolean mentionsAVendorPath(Path path) {
+        try {
+            String source = Files.readString(path, StandardCharsets.UTF_8);
+            return source.contains("/api/v1/workOrders")
+                    || source.contains("/api/v1/vehicles")
+                    || source.contains("/api/v1/contracts")
+                    || source.contains("/api/v1/policies");
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not read " + path, e);
+        }
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/michelins2s/MichelinS2SWorkorderAuthCodecTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/michelins2s/MichelinS2SWorkorderAuthCodecTest.java
@@ -1,0 +1,285 @@
+package com.positivity.supplier.internal.adapter.michelins2s;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.domain.model.SupplierWorkorderAuthorization;
+import com.positivity.supplier.internal.domain.model.WorkorderAuthorizationRequest;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Michelin S2S workorder authorization codec (CAP-323 #1229).
+ *
+ * <p>The behaviours worth pinning are the ones where being wrong authorises work: a status word
+ * misread as a grant, a 202 whose {@code Location} was dropped, or a granted authorization whose id
+ * was not read and so can never be approved when the job completes.
+ */
+@DisplayName("MichelinS2SWorkorderAuthCodec — reading a fleet decision (#1229)")
+class MichelinS2SWorkorderAuthCodecTest {
+
+    private static final UUID WORKORDER_ID = UUID.fromString("019200aa-0000-7000-8000-00000000ab01");
+
+    private final MichelinS2SWorkorderAuthCodec codec =
+            new MichelinS2SWorkorderAuthCodec(JsonMapper.builder().build());
+
+    @Nested
+    @DisplayName("acceptance that is not yet a decision")
+    class Acceptance {
+
+        @Test
+        @DisplayName("a 202 becomes PENDING carrying the Location to come back to")
+        void acceptedRequestCarriesItsPollLocation() {
+            SupplierWorkorderAuthorization decision =
+                    codec.decodeDecision(null, 202, "/api/v1/workOrders/WO-778", WORKORDER_ID);
+
+            assertThat(decision.status()).isEqualTo(SupplierWorkorderAuthorization.Status.PENDING);
+            assertThat(decision.pollLocation()).isEqualTo("/api/v1/workOrders/WO-778");
+        }
+
+        @Test
+        @DisplayName("a 202 without a Location is refused, because its decision could never be read")
+        void acceptedWithoutLocationIsRefused() {
+            // Recording this as "pending" would leave a shop waiting on an answer that has nowhere
+            // to arrive from -- the row would be polled forever against a null address.
+            assertThatThrownBy(() -> codec.decodeDecision(null, 202, null, WORKORDER_ID))
+                    .isInstanceOf(WorkorderAuthDecodeException.class)
+                    .hasMessageContaining("never be read");
+        }
+
+        @Test
+        @DisplayName("a 201 with neither body nor Location is refused rather than read as a grant")
+        void createdWithNothingInItIsRefused() {
+            assertThatThrownBy(() -> codec.decodeDecision("  ", 201, null, WORKORDER_ID))
+                    .isInstanceOf(WorkorderAuthDecodeException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("reading the vendor's word for it")
+    class StatusWords {
+
+        @ParameterizedTest(name = "\"{0}\" is a grant")
+        @ValueSource(strings = {"GRANTED", "approved", "Authorised", "AUTHORIZED", "accepted"})
+        void grantSynonymsAreRead(String word) {
+            SupplierWorkorderAuthorization decision =
+                    codec.decodeDecision("{\"id\":\"WO-1\",\"status\":\"" + word + "\"}", 201, null, WORKORDER_ID);
+            assertThat(decision.status()).isEqualTo(SupplierWorkorderAuthorization.Status.GRANTED);
+        }
+
+        @ParameterizedTest(name = "\"{0}\" is a refusal")
+        @ValueSource(strings = {"DENIED", "refused", "Rejected", "declined"})
+        void refusalSynonymsAreRead(String word) {
+            SupplierWorkorderAuthorization decision =
+                    codec.decodeDecision("{\"id\":\"WO-1\",\"status\":\"" + word + "\"}", 201, null, WORKORDER_ID);
+            assertThat(decision.status()).isEqualTo(SupplierWorkorderAuthorization.Status.DENIED);
+        }
+
+        @Test
+        @DisplayName("an unrecognised status raises rather than defaulting either way")
+        void unknownStatusRefusesToGuess() {
+            // There is no safe default. Defaulting to granted authorises work nobody agreed to pay
+            // for; defaulting to denied turns away a paying fleet customer. Both are silent.
+            assertThatThrownBy(() ->
+                            codec.decodeDecision("{\"id\":\"WO-1\",\"status\":\"ESCALATED\"}", 201, null, WORKORDER_ID))
+                    .isInstanceOf(WorkorderAuthDecodeException.class)
+                    .hasMessageContaining("ESCALATED");
+        }
+
+        @Test
+        @DisplayName("no status and no error is refused, not assumed")
+        void silenceIsNotADecision() {
+            assertThatThrownBy(() -> codec.decodeDecision("{\"id\":\"WO-1\"}", 201, null, WORKORDER_ID))
+                    .isInstanceOf(WorkorderAuthDecodeException.class);
+        }
+
+        @Test
+        @DisplayName("errors with no status word are read as a refusal, with the vendor's own code")
+        void errorsWithoutAStatusAreARefusal() {
+            SupplierWorkorderAuthorization decision = codec.decodeDecision("""
+                    {"id":"WO-1","errors":[{"code":"CONTRACT_EXPIRED","detail":"Contract 44 ended 2026-01-31"}]}
+                    """, 201, null, WORKORDER_ID);
+
+            assertThat(decision.status()).isEqualTo(SupplierWorkorderAuthorization.Status.DENIED);
+            assertThat(decision.vendorReasonCode()).isEqualTo("CONTRACT_EXPIRED");
+            assertThat(decision.vendorReason()).contains("ended 2026-01-31");
+        }
+    }
+
+    @Nested
+    @DisplayName("the authorization id, which completion approval depends on")
+    class AuthorizationId {
+
+        @Test
+        @DisplayName("read from either field the vendor may have used")
+        void idIsReadFromEitherCandidate() {
+            assertThat(codec.decodeDecision(
+                                    "{\"workOrderId\":\"WO-9\",\"status\":\"granted\"}", 201, null, WORKORDER_ID)
+                            .vendorAuthorizationId())
+                    .isEqualTo("WO-9");
+            assertThat(codec.decodeDecision("{\"id\":\"WO-8\",\"status\":\"granted\"}", 201, null, WORKORDER_ID)
+                            .vendorAuthorizationId())
+                    .isEqualTo("WO-8");
+        }
+
+        @Test
+        @DisplayName("this side's workorder id is carried through, never taken from the vendor's echo")
+        void workorderIdIsOurs() {
+            SupplierWorkorderAuthorization decision = codec.decodeDecision(
+                    "{\"id\":\"WO-1\",\"workOrderId\":\"not-a-uuid\",\"status\":\"granted\"}", 201, null, WORKORDER_ID);
+            assertThat(decision.workorderId()).isEqualTo(WORKORDER_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("the authorized ceiling")
+    class Ceiling {
+
+        @Test
+        @DisplayName("comma decimal separators are normalised, as in every sibling codec")
+        void commaDecimalsAreRead() {
+            SupplierWorkorderAuthorization decision = codec.decodeDecision(
+                    "{\"id\":\"WO-1\",\"status\":\"granted\",\"authorizedAmount\":\"1234,56\",\"currency\":\"EUR\"}",
+                    201,
+                    null,
+                    WORKORDER_ID);
+            assertThat(decision.authorizedAmount()).isEqualByComparingTo(new BigDecimal("1234.56"));
+        }
+
+        @Test
+        @DisplayName("an amount with no currency is dropped rather than guessed at")
+        void amountWithoutCurrencyIsDropped() {
+            // A number nobody can name a currency for is not a commercial ceiling, and inferring
+            // the profile's currency here would invent a term the vendor never stated.
+            SupplierWorkorderAuthorization decision = codec.decodeDecision(
+                    "{\"id\":\"WO-1\",\"status\":\"granted\",\"authorizedAmount\":\"400.00\"}",
+                    201,
+                    null,
+                    WORKORDER_ID);
+
+            assertThat(decision.authorizedAmount()).isNull();
+            assertThat(decision.currency()).isNull();
+        }
+
+        @Test
+        @DisplayName("an unreadable amount leaves no ceiling, rather than a zero one")
+        void unreadableAmountIsNotZero() {
+            SupplierWorkorderAuthorization decision = codec.decodeDecision(
+                    "{\"id\":\"WO-1\",\"status\":\"granted\",\"authorizedAmount\":\"see contract\",\"currency\":\"EUR\"}",
+                    201,
+                    null,
+                    WORKORDER_ID);
+            assertThat(decision.authorizedAmount()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("the requests it builds")
+    class Requests {
+
+        @Test
+        @DisplayName("an authorization request is not idempotent, and carries partnerId and API-Version")
+        void authorizationRequestIsNotRedispatchable() {
+            SupplierRequestSpec spec = codec.buildAuthorizationRequest(request(), "SP01234", "1");
+
+            // Not idempotent: a blind re-send can open a second authorization against one contract.
+            assertThat(spec.idempotent()).isFalse();
+            assertThat(spec.method()).isEqualTo("POST");
+            assertThat(spec.pathSuffix()).isEqualTo("/api/v1/workOrders");
+            assertThat(spec.queryParams()).containsEntry("partnerId", "SP01234");
+            assertThat(spec.headers()).containsEntry("API-Version", "1");
+            assertThat(spec.body()).contains("ABC-123");
+        }
+
+        @Test
+        @DisplayName("an approval is idempotent, because restating a completed fact is safe")
+        void approvalIsRedispatchable() {
+            SupplierRequestSpec spec = codec.buildApprovalRequest("WO-42", "SP01234", "1");
+
+            assertThat(spec.idempotent()).isTrue();
+            assertThat(spec.method()).isEqualTo("PATCH");
+            assertThat(spec.pathSuffix()).isEqualTo("/api/v1/workOrders/WO-42/approve");
+        }
+
+        @Test
+        @DisplayName("a vendor id is encoded, so it cannot alter the path it sits in")
+        void identifiersCannotEscapeTheirPathSegment() {
+            SupplierRequestSpec spec = codec.buildApprovalRequest("WO/../../admin", "SP01234", "1");
+
+            // The separators are what make traversal possible, so those are what must be encoded.
+            // The literal dots survive and are inert inside one segment.
+            assertThat(spec.pathSuffix()).isEqualTo("/api/v1/workOrders/WO%2F..%2F..%2Fadmin/approve");
+            assertThat(spec.pathSuffix().split("/")).hasSize(6);
+        }
+
+        @Test
+        @DisplayName("an unconfigured API version is omitted rather than defaulted")
+        void blankApiVersionSendsNoHeader() {
+            assertThat(codec.buildAuthorizationRequest(request(), "SP01234", "").headers())
+                    .isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("the lookups")
+    class Lookups {
+
+        @Test
+        @DisplayName("a contract's dates are read, and an unparseable one is left absent")
+        void contractsAreRead() {
+            var contracts = codec.decodeContracts("""
+                    [{"id":"C-1","name":"Fleet A","contractor":{"id":"K-9","name":"Haulage Ltd"},
+                      "startDate":"2026-01-01","endDate":"not a date"}]
+                    """);
+
+            assertThat(contracts).hasSize(1);
+            assertThat(contracts.getFirst().vendorContractId()).isEqualTo("C-1");
+            assertThat(contracts.getFirst().contractorName()).isEqualTo("Haulage Ltd");
+            assertThat(contracts.getFirst().startDate()).isNotNull();
+            assertThat(contracts.getFirst().endDate()).isNull();
+        }
+
+        @Test
+        @DisplayName("a policy body in an unexpected shape yields no policies rather than failing a quote")
+        void unreadablePoliciesAreEmpty() {
+            // Policies are advisory. Failing a service advisor's screen because an advisory read
+            // came back oddly would be the wrong trade.
+            assertThat(codec.decodePolicies("{\"unexpected\":true}")).isEmpty();
+            assertThat(codec.decodePolicies(null)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("black and white lists are read out of the EDIWheel reference vocabulary")
+        void policyListsAreRead() {
+            var policies = codec.decodePolicies("""
+                    [{"id":"P-1","name":"Tyres only","useBlacklist":true,"useWhiteList":false,
+                      "blackList":[{"references":{"typeCode":"EAN","value":"4001111"}}],
+                      "whiteList":[]}]
+                    """);
+
+            assertThat(policies).hasSize(1);
+            assertThat(policies.getFirst().useBlacklist()).isTrue();
+            assertThat(policies.getFirst().blacklisted()).containsExactly("4001111");
+        }
+    }
+
+    private static WorkorderAuthorizationRequest request() {
+        return new WorkorderAuthorizationRequest(
+                WORKORDER_ID,
+                null,
+                "ABC-123",
+                null,
+                null,
+                "C-1",
+                "104500",
+                List.of(new WorkorderAuthorizationRequest.Line("EAN-1", "Front tyres", 2, "1L")));
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/client/SupplierHttpRequestOrderingTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/client/SupplierHttpRequestOrderingTest.java
@@ -1,0 +1,95 @@
+package com.positivity.supplier.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.entity.SupplierAuthConfigEntity;
+import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Query parameters and headers keep the order a codec put them in (CAP-323 #1229).
+ *
+ * <p>{@link SupplierRequestSpec} takes care to preserve insertion order, and the query string is
+ * built by iterating the map — so a {@code Map.copyOf} anywhere between the two silently throws that
+ * away. It gives no ordering guarantee at all, which means the same request could go out with its
+ * parameters in a different sequence on different runs. That is invisible in a passing test and
+ * awkward everywhere else: vendor-side logs, signed requests, and anyone comparing two exchanges in
+ * the audit to work out why one failed.
+ */
+@DisplayName("SupplierHttpRequest — a codec's ordering survives the transport boundary")
+class SupplierHttpRequestOrderingTest {
+
+    /** Enough entries that an unordered copy is overwhelmingly unlikely to come back in order. */
+    private static final int ENOUGH_TO_SHUFFLE = 12;
+
+    @Test
+    @DisplayName("query parameters reach the request in the order the codec wrote them")
+    void queryParameterOrderSurvives() {
+        Map<String, String> ordered = new LinkedHashMap<>();
+        for (int i = 0; i < ENOUGH_TO_SHUFFLE; i++) {
+            ordered.put("param" + i, "value" + i);
+        }
+
+        SupplierRequestSpec spec =
+                new SupplierRequestSpec("GET", "/api/v1/contracts", ordered, null, null, "application/json", true);
+        SupplierHttpRequest request = new SupplierHttpRequest(
+                binding(),
+                org.springframework.http.HttpMethod.GET,
+                spec.pathSuffix(),
+                spec.queryParams(),
+                spec.body(),
+                spec.contentType(),
+                spec.accept(),
+                spec.idempotent(),
+                spec.headers());
+
+        assertThat(request.queryParams().keySet()).containsExactlyElementsOf(ordered.keySet());
+    }
+
+    @Test
+    @DisplayName("headers reach the request in the order the codec wrote them")
+    void headerOrderSurvives() {
+        Map<String, String> ordered = new LinkedHashMap<>();
+        for (int i = 0; i < ENOUGH_TO_SHUFFLE; i++) {
+            ordered.put("X-Header-" + i, "value" + i);
+        }
+
+        SupplierRequestSpec spec = new SupplierRequestSpec(
+                "POST", "/api/v1/workOrders", Map.of(), "{}", "application/json", "application/json", false, ordered);
+        SupplierHttpRequest request = new SupplierHttpRequest(
+                binding(),
+                org.springframework.http.HttpMethod.POST,
+                spec.pathSuffix(),
+                spec.queryParams(),
+                spec.body(),
+                spec.contentType(),
+                spec.accept(),
+                spec.idempotent(),
+                spec.headers());
+
+        assertThat(request.headers().keySet()).containsExactlyElementsOf(ordered.keySet());
+    }
+
+    private static ResolvedBinding binding() {
+        SupplierProfileEntity profile = new SupplierProfileEntity();
+        profile.setSupplierRef("michelin-de");
+        SupplierEndpointBindingEntity endpointBinding = new SupplierEndpointBindingEntity();
+        endpointBinding.setCapability(SupplierCapability.WORKORDER_AUTHORIZATION);
+        return new ResolvedBinding(
+                profile,
+                endpointBinding,
+                new SupplierAuthConfigEntity(),
+                SupplierCapability.WORKORDER_AUTHORIZATION,
+                ProtocolFamily.MICHELIN_S2S,
+                ProtocolVersion.S2S_V1);
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPollerTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPollerTest.java
@@ -191,6 +191,23 @@ class WorkorderAuthorizationPollerTest {
         verify(runner, never()).parkForReview(any(), any());
     }
 
+    @Test
+    @DisplayName("a vendor with no billing account parks the row instead of polling with an empty partnerId")
+    void missingPartnerIdParksRatherThanPolls() {
+        // An empty partnerId is rejected by the vendor as an unidentified caller. Polling on with
+        // one would ask once a tick until the pending timeout expired a day later, and would then
+        // report a misconfiguration on this side as a vendor that never decided.
+        givenPending(pending("/api/v1/workOrders/WO-77"));
+        SupplierAccountEntity unconfigured = new SupplierAccountEntity();
+        when(profileResolver.resolvePartyContext(any(), any()))
+                .thenReturn(new ResolvedPartyAccounts(unconfigured, unconfigured));
+
+        poller.pollPendingAuthorizations();
+
+        verify(runner).parkForReview(any(), contains("partnerId"));
+        verify(baseClient, never()).exchange(any());
+    }
+
     private void givenPending(SupplierWorkorderAuthorizationEntity row) {
         when(authorizationRepository.findAwaitingPoll(WorkorderAuthorizationStatus.PENDING, Limit.of(50)))
                 .thenReturn(List.of(row));

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPollerTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPollerTest.java
@@ -1,0 +1,240 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.supplier.internal.adapter.michelins2s.MichelinS2SWorkorderAuthCodec;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.client.SupplierHttpRequest;
+import com.positivity.supplier.internal.client.SupplierHttpResponse;
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.entity.SupplierAccountEntity;
+import com.positivity.supplier.internal.entity.SupplierAuthConfigEntity;
+import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
+import com.positivity.supplier.internal.enums.WorkorderApprovalStatus;
+import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.registry.AdapterResolution;
+import com.positivity.supplier.internal.repository.SupplierWorkorderAuthorizationRepository;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedPartyAccounts;
+import com.positivity.supplier.internal.spi.ExchangeOutcome;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Limit;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Collecting an answer the vendor promised to give later (CAP-323 #1229).
+ *
+ * <p>Without this a 202 is indistinguishable from a request that vanished. The cases below are the
+ * two ways that goes wrong anyway: waiting forever on a vendor that will never resolve, and
+ * following a vendor-supplied address to somewhere nobody configured.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("WorkorderAuthorizationPoller — collecting a promised answer (#1229)")
+class WorkorderAuthorizationPollerTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-16T10:00:00Z");
+    private static final UUID PROFILE_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000b1");
+    private static final UUID WORKORDER_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000c1");
+    private static final Duration PENDING_TIMEOUT = Duration.ofHours(24);
+
+    @Mock
+    private SupplierWorkorderAuthorizationRepository authorizationRepository;
+
+    @Mock
+    private SupplierProfileResolver profileResolver;
+
+    @Mock
+    private AdapterRegistry adapterRegistry;
+
+    @Mock
+    private SupplierBaseClient baseClient;
+
+    @Mock
+    private WorkorderAuthorizationRunner runner;
+
+    @Captor
+    private ArgumentCaptor<SupplierHttpRequest> requestCaptor;
+
+    private WorkorderAuthorizationPoller poller;
+
+    @BeforeEach
+    void setUp() {
+        poller = new WorkorderAuthorizationPoller(
+                authorizationRepository,
+                profileResolver,
+                adapterRegistry,
+                baseClient,
+                runner,
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                50,
+                PENDING_TIMEOUT);
+
+        when(profileResolver.resolveBinding(any(), any())).thenReturn(binding());
+        when(adapterRegistry.resolve(any(), any(), any()))
+                .thenReturn(new AdapterResolution.Resolved(
+                        new MichelinS2SWorkorderAuthCodec(JsonMapper.builder().build())));
+        when(profileResolver.resolvePartyContext(any(), any())).thenReturn(accounts());
+        when(authorizationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    @DisplayName("a vendor that never decides stops being polled and reaches a human")
+    void pendingPastTheTimeoutIsEscalated() {
+        // Polling forever is cheaper to write and worse: the shop waiting on this would never be
+        // told to stop waiting.
+        SupplierWorkorderAuthorizationEntity row = pending("/api/v1/workOrders/WO-77");
+        row.setRequestedAt(NOW.minus(PENDING_TIMEOUT).minus(Duration.ofMinutes(1)));
+        givenPending(row);
+
+        poller.pollPendingAuthorizations();
+
+        verify(runner).parkForReview(any(), contains("did not decide within"));
+        verify(baseClient, never()).exchange(any());
+    }
+
+    @Test
+    @DisplayName("a pending authorization with nowhere to look reaches a human rather than spinning")
+    void pendingWithoutALocationIsEscalated() {
+        givenPending(pending(null));
+
+        poller.pollPendingAuthorizations();
+
+        verify(runner).parkForReview(any(), contains("no poll location"));
+        verify(baseClient, never()).exchange(any());
+    }
+
+    @Test
+    @DisplayName("an absolute Location is reduced to its path, so a vendor cannot redirect a credentialled call")
+    void vendorSuppliedHostIsIgnored() {
+        // The binding owns the base URL. Honouring a vendor-supplied host would send an
+        // authenticated request bearing a fleet token to a host nobody configured.
+        givenPending(pending("https://not-the-vendor.example.com/api/v1/workOrders/WO-77"));
+        when(baseClient.exchange(any()))
+                .thenReturn(new SupplierHttpResponse(
+                        ExchangeOutcome.OK,
+                        200,
+                        "{\"id\":\"WO-77\",\"status\":\"granted\"}",
+                        "corr",
+                        1,
+                        Duration.ofMillis(5),
+                        null,
+                        Map.of()));
+
+        poller.pollPendingAuthorizations();
+
+        verify(baseClient).exchange(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().pathSuffix()).isEqualTo("/api/v1/workOrders/WO-77");
+    }
+
+    @Test
+    @DisplayName("a decision that arrives late is applied by the same code as one that arrived at once")
+    void lateDecisionIsApplied() {
+        SupplierWorkorderAuthorizationEntity row = pending("/api/v1/workOrders/WO-77");
+        givenPending(row);
+        when(baseClient.exchange(any()))
+                .thenReturn(new SupplierHttpResponse(
+                        ExchangeOutcome.OK,
+                        200,
+                        "{\"id\":\"WO-77\",\"status\":\"denied\",\"reasonCode\":\"NO_COVER\"}",
+                        "corr",
+                        1,
+                        Duration.ofMillis(5),
+                        null,
+                        Map.of()));
+
+        poller.pollPendingAuthorizations();
+
+        verify(runner).applyDecision(any(), any());
+    }
+
+    @Test
+    @DisplayName("a failed poll leaves the authorization pending, because it says nothing about the decision")
+    void failedPollChangesNothing() {
+        SupplierWorkorderAuthorizationEntity row = pending("/api/v1/workOrders/WO-77");
+        givenPending(row);
+        when(baseClient.exchange(any()))
+                .thenReturn(new SupplierHttpResponse(
+                        ExchangeOutcome.PRE_SEND_FAILURE, null, null, "corr", 1, Duration.ofMillis(5), "down"));
+
+        poller.pollPendingAuthorizations();
+
+        assertThat(row.getStatus()).isEqualTo(WorkorderAuthorizationStatus.PENDING);
+        verify(runner, never()).applyDecision(any(), any());
+        verify(runner, never()).parkForReview(any(), any());
+    }
+
+    private void givenPending(SupplierWorkorderAuthorizationEntity row) {
+        when(authorizationRepository.findAwaitingPoll(WorkorderAuthorizationStatus.PENDING, Limit.of(50)))
+                .thenReturn(List.of(row));
+    }
+
+    private static SupplierWorkorderAuthorizationEntity pending(String pollLocation) {
+        return SupplierWorkorderAuthorizationEntity.builder()
+                .supplierWorkorderAuthorizationId(UUID.fromString("019200aa-0000-7000-8000-0000000000a1"))
+                .vendorProfileId(PROFILE_ID)
+                .supplierRef("michelin-de")
+                .workorderId(WORKORDER_ID)
+                .status(WorkorderAuthorizationStatus.PENDING)
+                .pollLocation(pollLocation)
+                .approvalStatus(WorkorderApprovalStatus.NOT_REQUESTED)
+                .requestedAt(NOW.minus(Duration.ofMinutes(10)))
+                .build();
+    }
+
+    private static ResolvedBinding binding() {
+        SupplierProfileEntity profile = new SupplierProfileEntity();
+        profile.setVendorProfileId(PROFILE_ID);
+        profile.setSupplierRef("michelin-de");
+        profile.setEnabled(true);
+
+        SupplierEndpointBindingEntity endpointBinding = new SupplierEndpointBindingEntity();
+        endpointBinding.setId(UUID.fromString("019200aa-0000-7000-8000-0000000000d1"));
+        endpointBinding.setVendorProfileId(PROFILE_ID);
+        endpointBinding.setCapability(SupplierCapability.WORKORDER_AUTHORIZATION);
+        endpointBinding.setProtocolFamily(ProtocolFamily.MICHELIN_S2S);
+        endpointBinding.setProtocolVersion("S2S_V1");
+        endpointBinding.setEnabled(true);
+
+        return new ResolvedBinding(
+                profile,
+                endpointBinding,
+                new SupplierAuthConfigEntity(),
+                SupplierCapability.WORKORDER_AUTHORIZATION,
+                ProtocolFamily.MICHELIN_S2S,
+                ProtocolVersion.S2S_V1);
+    }
+
+    private static ResolvedPartyAccounts accounts() {
+        SupplierAccountEntity billing = new SupplierAccountEntity();
+        billing.setAccountNumber("SP01234");
+        return new ResolvedPartyAccounts(billing, billing);
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPublisherTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPublisherTest.java
@@ -1,0 +1,131 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.supplier.SupplierWorkorderAuthDeniedV1;
+import com.positivity.domainevents.supplier.SupplierWorkorderAuthGrantedV1;
+import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
+import com.positivity.supplier.internal.enums.WorkorderApprovalStatus;
+import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
+import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
+import java.time.Instant;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * What reaches the rest of the platform, and what deliberately does not (CAP-323 #1229).
+ *
+ * <p>The consumers of these events decide whether a shop may do work under a fleet contract. The
+ * cases below are the ones where publishing the wrong thing — or publishing at all — would have a
+ * shop either working unpaid or turning away a customer the fleet would have covered.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WorkorderAuthorizationPublisher — only vendor answers go out (#1229)")
+class WorkorderAuthorizationPublisherTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-16T10:00:00Z");
+
+    @Mock
+    private SupplierOutboxEventWriter outboxEventWriter;
+
+    @InjectMocks
+    private WorkorderAuthorizationPublisher publisher;
+
+    @Captor
+    private ArgumentCaptor<DomainEventEnvelope<?>> envelopeCaptor;
+
+    @Test
+    @DisplayName("a grant is published with the vendor's id and ceiling")
+    void grantIsPublished() {
+        SupplierWorkorderAuthorizationEntity row = row(WorkorderAuthorizationStatus.GRANTED);
+        row.setVendorAuthorizationId("WO-42");
+        row.setContractReference("C-1");
+
+        publisher.publishIfTerminal(row, NOW);
+
+        verify(outboxEventWriter).publish(eq("supplier.events.v1"), envelopeCaptor.capture());
+        Assertions.assertThat(envelopeCaptor.getValue().eventType())
+                .isEqualTo(SupplierWorkorderAuthGrantedV1.EVENT_TYPE);
+        Assertions.assertThat(envelopeCaptor.getValue().payload())
+                .isInstanceOfSatisfying(SupplierWorkorderAuthGrantedV1.class, payload -> {
+                    Assertions.assertThat(payload.vendorAuthorizationId()).isEqualTo("WO-42");
+                    Assertions.assertThat(payload.contractReference()).isEqualTo("C-1");
+                });
+    }
+
+    @Test
+    @DisplayName("a vendor that does not know the vehicle is published as a denial, with its reason")
+    void notFoundIsPublishedAsDenial() {
+        // The vendor did answer. For a shop the consequence is a refusal — but the reason text is
+        // what says this one is fixable by correcting a fleet number rather than by phoning anyone.
+        SupplierWorkorderAuthorizationEntity row = row(WorkorderAuthorizationStatus.NOT_FOUND);
+        row.setReasonCode("VEHICLE_UNKNOWN");
+        row.setReasonText("No vehicle matches fleet number 9981");
+
+        publisher.publishIfTerminal(row, NOW);
+
+        verify(outboxEventWriter).publish(eq("supplier.events.v1"), envelopeCaptor.capture());
+        Assertions.assertThat(envelopeCaptor.getValue().eventType())
+                .isEqualTo(SupplierWorkorderAuthDeniedV1.EVENT_TYPE);
+        Assertions.assertThat(envelopeCaptor.getValue().payload())
+                .isInstanceOfSatisfying(
+                        SupplierWorkorderAuthDeniedV1.class,
+                        payload -> Assertions.assertThat(payload.reasonCode()).isEqualTo("VEHICLE_UNKNOWN"));
+    }
+
+    @Test
+    @DisplayName("an authorization nobody could get an answer for publishes nothing at all")
+    void manualReviewIsNeverPublished() {
+        // The load-bearing case. MANUAL_REVIEW means the vendor was unreachable or unreadable.
+        // Publishing it as a denial would send a shop to argue with a fleet manager about a
+        // decision that was never made.
+        publisher.publishIfTerminal(row(WorkorderAuthorizationStatus.MANUAL_REVIEW), NOW);
+
+        verify(outboxEventWriter, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("an authorization the vendor has not decided yet publishes nothing")
+    void pendingIsNeverPublished() {
+        publisher.publishIfTerminal(row(WorkorderAuthorizationStatus.PENDING), NOW);
+
+        verify(outboxEventWriter, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("decisions are keyed on the authorization, so one workorder's answers stay ordered")
+    void decisionsAreKeyedOnTheAuthorization() {
+        SupplierWorkorderAuthorizationEntity row = row(WorkorderAuthorizationStatus.DENIED);
+
+        publisher.publishIfTerminal(row, NOW);
+
+        verify(outboxEventWriter).publish(any(), envelopeCaptor.capture());
+        // A grant overtaking the denial it replaced would authorise work the fleet had refused.
+        Assertions.assertThat(envelopeCaptor.getValue().aggregateId())
+                .isEqualTo(row.getSupplierWorkorderAuthorizationId());
+    }
+
+    private static SupplierWorkorderAuthorizationEntity row(WorkorderAuthorizationStatus status) {
+        return SupplierWorkorderAuthorizationEntity.builder()
+                .supplierWorkorderAuthorizationId(UUID.fromString("019200aa-0000-7000-8000-0000000000a1"))
+                .vendorProfileId(UUID.fromString("019200aa-0000-7000-8000-0000000000b1"))
+                .supplierRef("michelin-de")
+                .workorderId(UUID.fromString("019200aa-0000-7000-8000-0000000000c1"))
+                .status(status)
+                .approvalStatus(WorkorderApprovalStatus.NOT_REQUESTED)
+                .requestedAt(NOW)
+                .build();
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationRunnerTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationRunnerTest.java
@@ -1,0 +1,280 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.supplier.internal.adapter.michelins2s.MichelinS2SWorkorderAuthCodec;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.client.SupplierHttpResponse;
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.WorkorderAuthorizationRequest;
+import com.positivity.supplier.internal.entity.SupplierAccountEntity;
+import com.positivity.supplier.internal.entity.SupplierAuthConfigEntity;
+import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
+import com.positivity.supplier.internal.enums.WorkorderApprovalStatus;
+import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.registry.AdapterResolution;
+import com.positivity.supplier.internal.repository.SupplierWorkorderAuthorizationRepository;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedPartyAccounts;
+import com.positivity.supplier.internal.spi.ExchangeOutcome;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Limit;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Asking a fleet program, and what happens when it does not answer (CAP-323 #1229).
+ *
+ * <p>The cases below are all versions of the same question: what is recorded when the vendor's
+ * position is unknown. Getting that wrong either tells a shop the fleet refused when nobody asked,
+ * or lets an unanswered request disappear.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("WorkorderAuthorizationRunner — unreachable is never denied (#1229)")
+class WorkorderAuthorizationRunnerTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-16T10:00:00Z");
+    private static final UUID PROFILE_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000b1");
+    private static final UUID WORKORDER_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000c1");
+
+    @Mock
+    private SupplierProfileResolver profileResolver;
+
+    @Mock
+    private AdapterRegistry adapterRegistry;
+
+    @Mock
+    private SupplierBaseClient baseClient;
+
+    @Mock
+    private SupplierWorkorderAuthorizationRepository authorizationRepository;
+
+    @Mock
+    private WorkorderAuthorizationPublisher publisher;
+
+    private WorkorderAuthorizationRunner runner;
+
+    @BeforeEach
+    void setUp() {
+        runner = new WorkorderAuthorizationRunner(
+                profileResolver,
+                adapterRegistry,
+                baseClient,
+                authorizationRepository,
+                publisher,
+                Clock.fixed(NOW, ZoneOffset.UTC));
+
+        when(profileResolver.resolveBinding(any(), any())).thenReturn(binding());
+        when(adapterRegistry.resolve(any(), any(), any()))
+                .thenReturn(new AdapterResolution.Resolved(
+                        new MichelinS2SWorkorderAuthCodec(JsonMapper.builder().build())));
+        when(profileResolver.resolvePartyContext(any(), any())).thenReturn(accounts());
+        when(authorizationRepository.findByVendorProfileIdAndWorkorderId(any(), any()))
+                .thenReturn(Optional.empty());
+        when(authorizationRepository.save(any())).thenAnswer(invocation -> {
+            SupplierWorkorderAuthorizationEntity row = invocation.getArgument(0);
+            if (row.getSupplierWorkorderAuthorizationId() == null) {
+                row.setSupplierWorkorderAuthorizationId(UUID.fromString("019200aa-0000-7000-8000-0000000000a1"));
+            }
+            return row;
+        });
+        when(authorizationRepository.findById(any())).thenAnswer(invocation -> Optional.empty());
+    }
+
+    @Test
+    @DisplayName("an unreachable vendor is recorded for review, never as a refusal")
+    void unreachableVendorIsNotADenial() {
+        when(baseClient.exchange(any())).thenReturn(failed(ExchangeOutcome.PRE_SEND_FAILURE, "connect timed out"));
+
+        SupplierWorkorderAuthorizationEntity row =
+                runner.requestAuthorizationRow(new SupplierRef("michelin-de"), request());
+
+        assertThat(row.getStatus()).isEqualTo(WorkorderAuthorizationStatus.MANUAL_REVIEW);
+        assertThat(row.getReviewReason()).contains("connect timed out");
+        // Nothing published: a shop told "the fleet said no" would go and argue about a decision
+        // that was never made.
+        verify(publisher, never()).publishIfTerminal(any(), any());
+    }
+
+    @Test
+    @DisplayName("an answer nobody can read is recorded for review, not guessed at")
+    void unreadableAnswerIsNotADecision() {
+        when(baseClient.exchange(any())).thenReturn(ok(200, "{\"id\":\"WO-1\",\"status\":\"ESCALATED\"}", Map.of()));
+
+        SupplierWorkorderAuthorizationEntity row =
+                runner.requestAuthorizationRow(new SupplierRef("michelin-de"), request());
+
+        assertThat(row.getStatus()).isEqualTo(WorkorderAuthorizationStatus.MANUAL_REVIEW);
+        assertThat(row.getReviewReason()).contains("ESCALATED");
+        verify(publisher, never()).publishIfTerminal(any(), any());
+    }
+
+    @Test
+    @DisplayName("a grant is recorded with its ceiling and published")
+    void grantIsRecordedAndPublished() {
+        when(baseClient.exchange(any()))
+                .thenReturn(ok(
+                        201,
+                        "{\"id\":\"WO-42\",\"status\":\"granted\",\"contractId\":\"C-1\",\"authorizedAmount\":\"400,00\",\"currency\":\"EUR\"}",
+                        Map.of()));
+
+        SupplierWorkorderAuthorizationEntity row =
+                runner.requestAuthorizationRow(new SupplierRef("michelin-de"), request());
+
+        assertThat(row.getStatus()).isEqualTo(WorkorderAuthorizationStatus.GRANTED);
+        assertThat(row.getVendorAuthorizationId()).isEqualTo("WO-42");
+        assertThat(row.getAuthorizedAmount()).isEqualByComparingTo("400.00");
+        assertThat(row.getDecidedAt()).isEqualTo(NOW);
+        verify(publisher).publishIfTerminal(any(), any());
+    }
+
+    @Test
+    @DisplayName("a 202 is recorded as pending with the location to come back to, and publishes nothing")
+    void acceptedRequestWaits() {
+        when(baseClient.exchange(any())).thenReturn(ok(202, null, Map.of("location", "/api/v1/workOrders/WO-77")));
+
+        SupplierWorkorderAuthorizationEntity row =
+                runner.requestAuthorizationRow(new SupplierRef("michelin-de"), request());
+
+        assertThat(row.getStatus()).isEqualTo(WorkorderAuthorizationStatus.PENDING);
+        assertThat(row.getPollLocation()).isEqualTo("/api/v1/workOrders/WO-77");
+        verify(publisher).publishIfTerminal(any(), any());
+    }
+
+    @Test
+    @DisplayName("re-requesting updates the one row, and clears the previous attempt's reasons")
+    void reRequestUpdatesTheSameRow() {
+        SupplierWorkorderAuthorizationEntity existing = SupplierWorkorderAuthorizationEntity.builder()
+                .supplierWorkorderAuthorizationId(UUID.fromString("019200aa-0000-7000-8000-0000000000a1"))
+                .vendorProfileId(PROFILE_ID)
+                .supplierRef("michelin-de")
+                .workorderId(WORKORDER_ID)
+                .status(WorkorderAuthorizationStatus.MANUAL_REVIEW)
+                .reviewReason("vendor exchange failed last time")
+                .reasonCode("OLD")
+                .reasonText("old refusal")
+                .approvalStatus(WorkorderApprovalStatus.NOT_REQUESTED)
+                .requestedAt(NOW.minus(Duration.ofDays(1)))
+                .build();
+        when(authorizationRepository.findByVendorProfileIdAndWorkorderId(any(), any()))
+                .thenReturn(Optional.of(existing));
+        when(baseClient.exchange(any())).thenReturn(ok(201, "{\"id\":\"WO-9\",\"status\":\"granted\"}", Map.of()));
+        when(authorizationRepository.findById(any())).thenReturn(Optional.of(existing));
+
+        SupplierWorkorderAuthorizationEntity row =
+                runner.requestAuthorizationRow(new SupplierRef("michelin-de"), request());
+
+        // One row, not two: a denial and a grant coexisting for one workorder leaves nothing to say
+        // which the shop should act on.
+        assertThat(row.getSupplierWorkorderAuthorizationId()).isEqualTo(existing.getSupplierWorkorderAuthorizationId());
+        assertThat(row.getStatus()).isEqualTo(WorkorderAuthorizationStatus.GRANTED);
+        // A stale reason left in place would read as if it described this attempt.
+        assertThat(row.getReviewReason()).isNull();
+        assertThat(row.getReasonCode()).isNull();
+    }
+
+    @Test
+    @DisplayName("the review queue projects both stuck kinds, with the reason a person needs")
+    void reviewQueueIsVisible() {
+        // MANUAL_REVIEW only earns its place if something can list it. A state nothing surfaces is
+        // a state nobody acts on, and these rows are work already done that will not be paid for.
+        SupplierWorkorderAuthorizationEntity stuckAuthorization = SupplierWorkorderAuthorizationEntity.builder()
+                .supplierWorkorderAuthorizationId(UUID.fromString("019200aa-0000-7000-8000-0000000000a2"))
+                .vendorProfileId(PROFILE_ID)
+                .supplierRef("michelin-de")
+                .workorderId(WORKORDER_ID)
+                .status(WorkorderAuthorizationStatus.MANUAL_REVIEW)
+                .reviewReason("vendor exchange failed: PRE_SEND_FAILURE")
+                .approvalStatus(WorkorderApprovalStatus.NOT_REQUESTED)
+                .requestedAt(NOW)
+                .build();
+        SupplierWorkorderAuthorizationEntity stuckApproval = SupplierWorkorderAuthorizationEntity.builder()
+                .supplierWorkorderAuthorizationId(UUID.fromString("019200aa-0000-7000-8000-0000000000a3"))
+                .vendorProfileId(PROFILE_ID)
+                .supplierRef("michelin-de")
+                .workorderId(UUID.fromString("019200aa-0000-7000-8000-0000000000c2"))
+                .status(WorkorderAuthorizationStatus.GRANTED)
+                .approvalStatus(WorkorderApprovalStatus.MANUAL_REVIEW)
+                .reviewReason("completion approval gave up after 6 attempts")
+                .requestedAt(NOW)
+                .build();
+        when(authorizationRepository.findNeedingReview(Limit.of(100)))
+                .thenReturn(List.of(stuckAuthorization, stuckApproval));
+
+        var queue = runner.findNeedingReview(100);
+
+        assertThat(queue).hasSize(2);
+        assertThat(queue.getFirst().reviewReason()).contains("PRE_SEND_FAILURE");
+        // The two kinds are told apart by approvalStatus, so an operator can see which is which.
+        assertThat(queue.get(1).status()).isEqualTo("GRANTED");
+        assertThat(queue.get(1).approvalStatus()).isEqualTo("MANUAL_REVIEW");
+    }
+
+    private static WorkorderAuthorizationRequest request() {
+        return new WorkorderAuthorizationRequest(WORKORDER_ID, null, "ABC-123", null, null, null, null, List.of());
+    }
+
+    private static SupplierHttpResponse ok(int status, String body, Map<String, String> headers) {
+        return new SupplierHttpResponse(
+                ExchangeOutcome.OK, status, body, "corr-1", 1, Duration.ofMillis(10), null, headers);
+    }
+
+    private static SupplierHttpResponse failed(ExchangeOutcome outcome, String detail) {
+        return new SupplierHttpResponse(outcome, null, null, "corr-1", 1, Duration.ofMillis(10), detail);
+    }
+
+    private static ResolvedBinding binding() {
+        SupplierProfileEntity profile = new SupplierProfileEntity();
+        profile.setVendorProfileId(PROFILE_ID);
+        profile.setSupplierRef("michelin-de");
+        profile.setEnabled(true);
+
+        SupplierEndpointBindingEntity endpointBinding = new SupplierEndpointBindingEntity();
+        endpointBinding.setId(UUID.fromString("019200aa-0000-7000-8000-0000000000d1"));
+        endpointBinding.setVendorProfileId(PROFILE_ID);
+        endpointBinding.setCapability(SupplierCapability.WORKORDER_AUTHORIZATION);
+        endpointBinding.setProtocolFamily(ProtocolFamily.MICHELIN_S2S);
+        endpointBinding.setProtocolVersion("S2S_V1");
+        endpointBinding.setEnabled(true);
+
+        return new ResolvedBinding(
+                profile,
+                endpointBinding,
+                new SupplierAuthConfigEntity(),
+                SupplierCapability.WORKORDER_AUTHORIZATION,
+                ProtocolFamily.MICHELIN_S2S,
+                ProtocolVersion.S2S_V1);
+    }
+
+    private static ResolvedPartyAccounts accounts() {
+        SupplierAccountEntity billing = new SupplierAccountEntity();
+        billing.setAccountNumber("SP01234");
+        return new ResolvedPartyAccounts(billing, billing);
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionApproverTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionApproverTest.java
@@ -198,6 +198,29 @@ class WorkorderCompletionApproverTest {
         assertThat(row.getApprovedAt()).isEqualTo(NOW);
     }
 
+    @Test
+    @DisplayName("a vendor with no billing account parks at once, without spending the retry budget")
+    void missingPartnerIdParksWithoutBurningAttempts() {
+        // No number of attempts supplies a missing account number. Retrying would escalate a
+        // money-critical approval with a review reason blaming the vendor for a defect on this side.
+        SupplierWorkorderAuthorizationEntity row = granted();
+        row.setApprovalStatus(WorkorderApprovalStatus.PENDING);
+        when(authorizationRepository.findByApprovalStatusOrderByUpdatedAtAsc(
+                        WorkorderApprovalStatus.PENDING, Limit.of(50)))
+                .thenReturn(List.of(row));
+        when(authorizationRepository.findById(any())).thenReturn(Optional.of(row));
+        SupplierAccountEntity unconfigured = new SupplierAccountEntity();
+        when(profileResolver.resolvePartyContext(any(), any()))
+                .thenReturn(new ResolvedPartyAccounts(unconfigured, unconfigured));
+
+        approver.approveOutstanding();
+
+        assertThat(row.getApprovalStatus()).isEqualTo(WorkorderApprovalStatus.MANUAL_REVIEW);
+        assertThat(row.getApprovalAttempts()).isZero();
+        assertThat(row.getReviewReason()).contains("partnerId");
+        verify(baseClient, never()).exchange(any());
+    }
+
     private static SupplierWorkorderAuthorizationEntity granted() {
         return SupplierWorkorderAuthorizationEntity.builder()
                 .supplierWorkorderAuthorizationId(UUID.fromString("019200aa-0000-7000-8000-0000000000a1"))

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionApproverTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderCompletionApproverTest.java
@@ -1,0 +1,243 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.supplier.internal.adapter.michelins2s.MichelinS2SWorkorderAuthCodec;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.client.SupplierHttpResponse;
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.entity.SupplierAccountEntity;
+import com.positivity.supplier.internal.entity.SupplierAuthConfigEntity;
+import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
+import com.positivity.supplier.internal.enums.WorkorderApprovalStatus;
+import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.registry.AdapterResolution;
+import com.positivity.supplier.internal.repository.SupplierWorkorderAuthorizationRepository;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedPartyAccounts;
+import com.positivity.supplier.internal.spi.ExchangeOutcome;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Limit;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Telling the fleet the work is done (CAP-323 #1229).
+ *
+ * <p>This is the step that gets a shop paid, so the cases that matter are the ones where it stops:
+ * an approval that can never succeed must reach a human quickly, and one that merely failed must be
+ * retried a bounded number of times and then also reach a human. Retrying silently forever is the
+ * failure mode that looks like success.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("WorkorderCompletionApprover — the step that gets a shop paid (#1229)")
+class WorkorderCompletionApproverTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-16T10:00:00Z");
+    private static final UUID PROFILE_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000b1");
+    private static final UUID WORKORDER_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000c1");
+    private static final int MAX_ATTEMPTS = 3;
+
+    @Mock
+    private SupplierWorkorderAuthorizationRepository authorizationRepository;
+
+    @Mock
+    private SupplierProfileResolver profileResolver;
+
+    @Mock
+    private AdapterRegistry adapterRegistry;
+
+    @Mock
+    private SupplierBaseClient baseClient;
+
+    private WorkorderCompletionApprover approver;
+
+    @BeforeEach
+    void setUp() {
+        approver = new WorkorderCompletionApprover(
+                authorizationRepository,
+                profileResolver,
+                adapterRegistry,
+                baseClient,
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                50,
+                MAX_ATTEMPTS);
+
+        when(profileResolver.resolveBinding(any(), any())).thenReturn(binding());
+        when(adapterRegistry.resolve(any(), any(), any()))
+                .thenReturn(new AdapterResolution.Resolved(
+                        new MichelinS2SWorkorderAuthCodec(JsonMapper.builder().build())));
+        when(profileResolver.resolvePartyContext(any(), any())).thenReturn(accounts());
+        when(authorizationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    @DisplayName("a completed fleet job is queued for sign-off")
+    void completionQueuesApproval() {
+        SupplierWorkorderAuthorizationEntity row = granted();
+        when(authorizationRepository.findByWorkorderIdOrderByRequestedAtDesc(WORKORDER_ID))
+                .thenReturn(List.of(row));
+
+        Optional<SupplierWorkorderAuthorizationEntity> queued = approver.queueApproval(WORKORDER_ID);
+
+        assertThat(queued).isPresent();
+        assertThat(queued.get().getApprovalStatus()).isEqualTo(WorkorderApprovalStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("an ordinary retail job queues nothing")
+    void nonFleetCompletionQueuesNothing() {
+        // The common case by a wide margin. It must cost one indexed read and no vendor call.
+        when(authorizationRepository.findByWorkorderIdOrderByRequestedAtDesc(WORKORDER_ID))
+                .thenReturn(List.of());
+
+        assertThat(approver.queueApproval(WORKORDER_ID)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a redelivered completion does not reopen an approval already accepted")
+    void redeliveredCompletionDoesNotReopenAnApproval() {
+        SupplierWorkorderAuthorizationEntity row = granted();
+        row.setApprovalStatus(WorkorderApprovalStatus.APPROVED);
+        when(authorizationRepository.findByWorkorderIdOrderByRequestedAtDesc(WORKORDER_ID))
+                .thenReturn(List.of(row));
+
+        assertThat(approver.queueApproval(WORKORDER_ID))
+                .get()
+                .extracting(SupplierWorkorderAuthorizationEntity::getApprovalStatus)
+                .isEqualTo(WorkorderApprovalStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("an authorization that never got an id goes to a human at once, without burning attempts")
+    void grantWithoutAnIdCannotBeApproved() {
+        // No amount of retrying invents an identifier. Spending the retry budget on it would only
+        // delay the moment somebody finds out.
+        SupplierWorkorderAuthorizationEntity row = granted();
+        row.setVendorAuthorizationId(null);
+        row.setApprovalStatus(WorkorderApprovalStatus.PENDING);
+        when(authorizationRepository.findByApprovalStatusOrderByUpdatedAtAsc(
+                        WorkorderApprovalStatus.PENDING, Limit.of(50)))
+                .thenReturn(List.of(row));
+        when(authorizationRepository.findById(any())).thenReturn(Optional.of(row));
+
+        approver.approveOutstanding();
+
+        assertThat(row.getApprovalStatus()).isEqualTo(WorkorderApprovalStatus.MANUAL_REVIEW);
+        assertThat(row.getApprovalAttempts()).isZero();
+        verify(baseClient, never()).exchange(any());
+    }
+
+    @Test
+    @DisplayName("a failed approval is retried, and escalates once the budget is spent")
+    void failedApprovalEscalatesAfterTheBudget() {
+        SupplierWorkorderAuthorizationEntity row = granted();
+        row.setApprovalStatus(WorkorderApprovalStatus.PENDING);
+        when(authorizationRepository.findByApprovalStatusOrderByUpdatedAtAsc(
+                        WorkorderApprovalStatus.PENDING, Limit.of(50)))
+                .thenReturn(List.of(row));
+        when(authorizationRepository.findById(any())).thenReturn(Optional.of(row));
+        when(baseClient.exchange(any()))
+                .thenReturn(new SupplierHttpResponse(
+                        ExchangeOutcome.PRE_SEND_FAILURE, null, null, "corr", 1, Duration.ofMillis(5), "vendor down"));
+
+        for (int attempt = 1; attempt < MAX_ATTEMPTS; attempt++) {
+            approver.approveOutstanding();
+            assertThat(row.getApprovalStatus())
+                    .as("still retrying after attempt %s", attempt)
+                    .isEqualTo(WorkorderApprovalStatus.PENDING);
+        }
+
+        approver.approveOutstanding();
+
+        // An approval that retried forever would look exactly like one that was working.
+        assertThat(row.getApprovalStatus()).isEqualTo(WorkorderApprovalStatus.MANUAL_REVIEW);
+        assertThat(row.getReviewReason()).contains("vendor down");
+    }
+
+    @Test
+    @DisplayName("a vendor that accepts the sign-off closes the row")
+    void acceptedApprovalIsRecorded() {
+        SupplierWorkorderAuthorizationEntity row = granted();
+        row.setApprovalStatus(WorkorderApprovalStatus.PENDING);
+        when(authorizationRepository.findByApprovalStatusOrderByUpdatedAtAsc(
+                        WorkorderApprovalStatus.PENDING, Limit.of(50)))
+                .thenReturn(List.of(row));
+        when(authorizationRepository.findById(any())).thenReturn(Optional.of(row));
+        when(baseClient.exchange(any()))
+                .thenReturn(
+                        new SupplierHttpResponse(ExchangeOutcome.OK, 200, "{}", "corr", 1, Duration.ofMillis(5), null));
+
+        approver.approveOutstanding();
+
+        assertThat(row.getApprovalStatus()).isEqualTo(WorkorderApprovalStatus.APPROVED);
+        assertThat(row.getApprovedAt()).isEqualTo(NOW);
+    }
+
+    private static SupplierWorkorderAuthorizationEntity granted() {
+        return SupplierWorkorderAuthorizationEntity.builder()
+                .supplierWorkorderAuthorizationId(UUID.fromString("019200aa-0000-7000-8000-0000000000a1"))
+                .vendorProfileId(PROFILE_ID)
+                .supplierRef("michelin-de")
+                .workorderId(WORKORDER_ID)
+                .status(WorkorderAuthorizationStatus.GRANTED)
+                .vendorAuthorizationId("WO-42")
+                .approvalStatus(WorkorderApprovalStatus.NOT_REQUESTED)
+                .approvalAttempts(0)
+                .requestedAt(NOW.minus(Duration.ofHours(3)))
+                .build();
+    }
+
+    private static ResolvedBinding binding() {
+        SupplierProfileEntity profile = new SupplierProfileEntity();
+        profile.setVendorProfileId(PROFILE_ID);
+        profile.setSupplierRef("michelin-de");
+        profile.setEnabled(true);
+
+        SupplierEndpointBindingEntity endpointBinding = new SupplierEndpointBindingEntity();
+        endpointBinding.setId(UUID.fromString("019200aa-0000-7000-8000-0000000000d1"));
+        endpointBinding.setVendorProfileId(PROFILE_ID);
+        endpointBinding.setCapability(SupplierCapability.WORKORDER_AUTHORIZATION);
+        endpointBinding.setProtocolFamily(ProtocolFamily.MICHELIN_S2S);
+        endpointBinding.setProtocolVersion("S2S_V1");
+        endpointBinding.setEnabled(true);
+
+        return new ResolvedBinding(
+                profile,
+                endpointBinding,
+                new SupplierAuthConfigEntity(),
+                SupplierCapability.WORKORDER_AUTHORIZATION,
+                ProtocolFamily.MICHELIN_S2S,
+                ProtocolVersion.S2S_V1);
+    }
+
+    private static ResolvedPartyAccounts accounts() {
+        SupplierAccountEntity billing = new SupplierAccountEntity();
+        billing.setAccountNumber("SP01234");
+        return new ResolvedPartyAccounts(billing, billing);
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:323`
- Parent STORY (durion): louisburroughs/durion#378
- Child issue: louisburroughs/durion-positivity-backend#1229
- Domain: `domain:positivity`, `domain:workexec`

## Contract References
- Contract guide entry (durion): `domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md` → supplier fleet workorder authorization
- Architecture: `durion/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md` §6, §8, §10
- Source spec: `durion/docs/ediwheel/ediwheel-workorder-michelin-implementation_1.json`

## Contract Chain
- [x] OpenAPI annotations updated on the controller
- [x] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — handled separately

## Scope

**What changed:** the second protocol family, end to end. A service advisor looks a vehicle up in a
fleet program, sees which contracts cover it, requests authorization for specific work, and when the
job completes the vendor is told and asked to sign it off. Decisions publish
`supplier.workorderauth.granted` / `.denied`; workorder state stays in pos-workorder (ADR-0049 §2).

**Why:** CAP-323 is the reusability proof. Every other adapter here speaks EDIWheel, so a design that
quietly assumed EDIWheel would have looked reusable right up until it was not. Michelin S2S is JSON
REST over OAuth2 client credentials with an asynchronous acceptance pattern no EDIWheel norm uses.

### Three judgments worth reading

**Unreachable is never denied.** A vendor that cannot be reached, a token that would not mint, an
answer nobody can parse — none are refusals. They park the row in `MANUAL_REVIEW` and publish
*nothing*. Telling a shop the fleet said no when nobody asked sends it to argue with a fleet manager
about a decision that was never made. The codec raises on an unrecognised status word for the same
reason: defaulting to granted authorises unpaid work, defaulting to denied turns away a paying
customer, and both are silent.

**Authorization requests are never retried; completion approvals always are.** Creating an
authorization is a commercial act — a blind re-send can open a second authorization against one
contract. Approving an already-approved workorder is the vendor restating a fact. They live in
separate classes with separate rules rather than sharing a retry helper that would have to be right
about both. Approval retries are finite and then escalate: one that retried forever would look
exactly like one that was working.

**A 202 is not an answer.** Something has to collect one. The poller reads the `Location`, gives up
after a configurable timeout rather than waiting forever, and reduces an absolute `Location` to its
path so a vendor cannot redirect a credential-bearing call to a host nobody configured.

### What the reusability claim actually cost

Two changes outside `adapter/michelins2s/`, both in the shared transport, both because no EDIWheel
norm ever needed them:

| Change | Why |
|---|---|
| `SupplierHttpResponse` gained an allowlisted response-header map | A 202's whole meaning is in `Location`; the transport discarded every response header |
| `SupplierRequestSpec` / `SupplierHttpRequest` gained per-request headers | For `API-Version`; the EDIWheel norms identify the buyer via credentials and query params |

Both are capability-neutral. The orchestration, registry, profile model and every consuming domain
were untouched. `MichelinS2SReusabilityTest` asserts no vendor path or wire type appears outside the
adapter, and records these two exceptions in its javadoc — a reusability claim with no stated cost
has not been tested.

### Two findings for reviewers

1. **`SupplierWorkorderAuthorizationPort` could not express the operation.** It took a `PartyContext`
   and a workorder id, with nowhere to say how the vehicle is identified. Implementing it as written
   meant inventing a vehicle identifier from an account number — compiles, passes a test, cannot work
   against a real vendor. It now takes the canonical request.
2. **It is the only capability port in this module with an implementation.** Stock inquiry, orders,
   price catalogue, stock report and invoices each route through their own runner and never reference
   their port. Noted in the port's javadoc rather than fixed here.

### Known limitation

The source spec types the workorder request body as `JsonNode` and gives no response schema for the
workorder operations. The request shape is derived from the EDIWheel party/vehicle/reference
vocabulary the same spec *does* define for its lookups, and every guessed field is marked `GUESS` at
its declaration in `WorkorderS2SWire`. A first sandbox run should be a matter of correcting named
fields. The lookup response shapes are specified and are not guesses.

The workexec-side mapping of outcomes onto workorder state is deliberately not in this PR — the
story names it as needing Workorder Execution domain authority, and no `WorkorderStatus` value was
added unilaterally. The events are published so workexec only has to subscribe.

## Tests
- [x] Unit tests added — 51 new (codec 27, runner 6, approver 6, poller 5, publisher 5, reusability 2)
- [ ] Integration tests — none added; the vendor seam is covered at the client boundary
- [x] Provider behavioral contract tests — `MichelinS2SWorkorderAuthCodecTest` pins the decision reading
- How to run:
```bash
./mvnw -pl pos-supplier -am test
./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test
```

The reusability guard was verified non-vacuous by temporarily adding a vendor path outside the
adapter and confirming the build failed.

## Risk & Rollback
- Risk level: Low — new capability, no existing path changed. The two transport additions are
  backwards-compatible overloads; every existing call site compiles and behaves unchanged.
- Rollback plan: revert the commit. `V17__supplier_workorder_authorization.sql` creates one new table
  referenced by nothing else, so it can be left in place or dropped independently.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mv7zVYjwbVu5GRqrfkfHc7
