### PR TITLE
[CAP:324] feat(supplier): MKCAT C1.2 marketing catalogue enrichment (#1230, #1257)

### DIFF
--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,9 +1,9 @@
-generatedAt: "2026-08-16T20:30:21.598598+00:00"
+generatedAt: "2026-08-17T00:38:56.814838+00:00"
 root: "."
 summary:
-  manifestCount: 22
-  permissionCount: 429
-  uniquePermissionCount: 429
+  manifestCount: 23
+  permissionCount: 431
+  uniquePermissionCount: 431
   duplicatePermissionNameCount: 0
   parseIssueCount: 0
 manifests:
@@ -300,6 +300,15 @@ manifests:
     permissions:
       - name: "documents:render"
         description: "Render document content into supported output formats"
+  - module: "pos-image"
+    path: "pos-image/src/main/resources/permissions.yaml"
+    domain: "image"
+    serviceName: "pos-image"
+    version: "1.0"
+    permissionCount: 1
+    permissions:
+      - name: "image:image:store"
+        description: "Store image bytes in the image service"
   - module: "pos-inventory"
     path: "pos-inventory/src/main/resources/permissions.yaml"
     domain: "inventory"
@@ -792,7 +801,7 @@ manifests:
     domain: "supplier"
     serviceName: "pos-supplier"
     version: "1.0"
-    permissionCount: 11
+    permissionCount: 12
     permissions:
       - name: "supplier:audit:read"
         description: "Read supplier exchange audit records"
@@ -816,6 +825,8 @@ manifests:
         description: "Ask a fleet program to authorize work, and look up fleet vehicles, contracts and policies"
       - name: "supplier:workorderauth:review"
         description: "View and clear fleet workorder authorizations parked for manual review"
+      - name: "supplier:mktcat:import"
+        description: "Run a marketing-catalogue (MKCAT) import on demand and read staged enrichment"
   - module: "pos-tax"
     path: "pos-tax/src/main/resources/permissions.yaml"
     domain: "tax"
@@ -1800,6 +1811,12 @@ permissions:
     serviceName: "pos-documents"
     module: "pos-documents"
     source: "pos-documents/src/main/resources/permissions.yaml"
+  - name: "image:image:store"
+    description: "Store image bytes in the image service"
+    domain: "image"
+    serviceName: "pos-image"
+    module: "pos-image"
+    source: "pos-image/src/main/resources/permissions.yaml"
   - name: "inventory:adjustment:approve"
     description: "Approve and post an adjustment to the ledger (creates ADJUSTMENT_IN/OUT events)"
     domain: "inventory"
@@ -3032,6 +3049,12 @@ permissions:
     source: "pos-supplier/src/main/resources/permissions.yaml"
   - name: "supplier:invoice:fetch"
     description: "Run a vendor invoice fetch on demand"
+    domain: "supplier"
+    serviceName: "pos-supplier"
+    module: "pos-supplier"
+    source: "pos-supplier/src/main/resources/permissions.yaml"
+  - name: "supplier:mktcat:import"
+    description: "Run a marketing-catalogue (MKCAT) import on demand and read staged enrichment"
     domain: "supplier"
     serviceName: "pos-supplier"
     module: "pos-supplier"

--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,4 +1,4 @@
-generatedAt: "2026-08-17T00:38:56.814838+00:00"
+generatedAt: "2026-08-17T01:13:23.631215+00:00"
 root: "."
 summary:
   manifestCount: 23

--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -495,6 +495,8 @@ paths:
     $ref: ../../pos-event-receiver/openapi.yaml#/paths/~1v1~1events~1summary~1lastHour
   /v1/events/summary/lastWeek:
     $ref: ../../pos-event-receiver/openapi.yaml#/paths/~1v1~1events~1summary~1lastWeek
+  /v1/images:
+    $ref: ../../pos-image/openapi.yaml#/paths/~1v1~1images
   /v1/images/filename/{filename}:
     $ref: ../../pos-image/openapi.yaml#/paths/~1v1~1images~1filename~1{filename}
   /v1/images/id/{id}:
@@ -1315,6 +1317,10 @@ paths:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1fleet~1{supplierRef}~1vehicles~1{vehicleIdent}
   /v1/supplier/invoices/{supplierRef}/fetches:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1invoices~1{supplierRef}~1fetches
+  /v1/supplier/mktcat/{supplierRef}/imports:
+    $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1mktcat~1{supplierRef}~1imports
+  /v1/supplier/mktcat/{supplierRef}/variants:
+    $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1mktcat~1{supplierRef}~1variants
   /v1/supplier/stock/inquiries:
     $ref: ../../pos-supplier/openapi.yaml#/paths/~1v1~1supplier~1stock~1inquiries
   /v1/supplier/transmissions/purchase-order/{purchaseOrderId}:

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 54;
+    public static final int CATALOG_VERSION = 55;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -557,7 +557,11 @@ public final class GatewayPermissionCatalog {
         "PERM_supplier:workorderauth:request", // 462
 
         // ── New batch (bits 463–463) ──────────────────────────────────────────
-        "PERM_supplier:workorderauth:review" // 463
+        "PERM_supplier:workorderauth:review", // 463
+
+        // ── New batch (bits 464–465) ──────────────────────────────────────────
+        "PERM_image:image:store", // 464
+        "PERM_supplier:mktcat:import" // 465
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,13 +1142,13 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 54")
+    @DisplayName("CATALOG_VERSION is 55")
     void catalogVersionMatchesCurrent() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(54);
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(55);
     }
 
     @Test
-    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 463")
+    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 465")
     void authorityByBitCoversNewEntries() {
         // batch-2: previously missing (bits 241-261)
         assertThat(GatewayPermissionCatalog.authorityForBit(241)).isEqualTo("PERM_accounting:events:reprocess");
@@ -1323,8 +1323,14 @@ class SecurityGatewayConfigTest {
         // rows where money is already owed for work already done, and whoever chases that is not
         // necessarily whoever books the job in.
         assertThat(GatewayPermissionCatalog.authorityForBit(463)).isEqualTo("PERM_supplier:workorderauth:review");
+        // Storing image bytes (CAP-324 #1257). pos-image gained a write endpoint, and an ungated one
+        // would accept and keep arbitrary bytes from anyone able to reach the service.
+        assertThat(GatewayPermissionCatalog.authorityForBit(464)).isEqualTo("PERM_image:image:store");
+        // Running a marketing-catalogue import (CAP-324 #1230): a full read of a centrally published
+        // catalogue, not a cheap local query.
+        assertThat(GatewayPermissionCatalog.authorityForBit(465)).isEqualTo("PERM_supplier:mktcat:import");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(464)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(466)).isNull();
     }
 
     @Test

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierCatalogEnrichmentImage.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierCatalogEnrichmentImage.java
@@ -1,0 +1,52 @@
+package com.positivity.domainevents.supplier;
+
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One piece of manufacturer artwork on a catalogue enrichment (CAP-324 #1230, #1257).
+ *
+ * <h2>A stored reference, never a vendor URL</h2>
+ *
+ * {@code imageId} points at bytes the platform holds. The vendor's own URL travels as
+ * {@code sourceUri} for provenance and is not somewhere to fetch from: rendering a product page
+ * from a manufacturer's server puts a third party's uptime and rate limits in front of every view,
+ * and gives the platform nothing to cache or optimise.
+ *
+ * <h2>Unresolved images are still published</h2>
+ *
+ * When the bytes could not be fetched or stored, {@code imageId} is absent and {@code unresolved} is
+ * true. The enrichment goes out regardless, because dropping a whole product's marketing copy over
+ * one failed download would be a silent loss of everything else on the record — and the missing
+ * picture is retried on its own.
+ *
+ * @param imageType   the vendor's own classification of the image, as stated
+ * @param imageId     pos-image identifier for the stored bytes; absent when unresolved
+ * @param contentHash SHA-256 of the stored bytes, so a consumer can tell one picture from another
+ *                    without fetching either
+ * @param sourceUri   where the vendor published it. Provenance only
+ * @param unresolved  whether the bytes are still missing and will be retried
+ */
+public record SupplierCatalogEnrichmentImage(
+        @Nullable String imageType,
+        @Nullable Long imageId,
+        @Nullable String contentHash,
+        @Nullable String sourceUri,
+        boolean unresolved) {
+
+    public SupplierCatalogEnrichmentImage {
+        if (!unresolved && imageId == null) {
+            // A resolved image with nothing to point at is the shape that quietly loses artwork:
+            // a consumer would treat it as present and render nothing.
+            throw new IllegalArgumentException("a resolved enrichment image must carry an imageId");
+        }
+    }
+
+    /** An image whose bytes could not be obtained; it will be retried. */
+    @NonNull
+    public static SupplierCatalogEnrichmentImage unresolved(@Nullable String imageType, @NonNull String sourceUri) {
+        Objects.requireNonNull(sourceUri, "sourceUri must not be null");
+        return new SupplierCatalogEnrichmentImage(imageType, null, null, sourceUri, true);
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierCatalogEnrichmentText.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierCatalogEnrichmentText.java
@@ -1,0 +1,29 @@
+package com.positivity.domainevents.supplier;
+
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Marketing copy in one language (CAP-324 #1230).
+ *
+ * <p>Kept per language rather than flattened to a single "description". A tyre's marketing text is
+ * written per market, and collapsing it would force whoever consumes this to pick a language at
+ * ingestion time — before anyone knows which shop will read it.
+ *
+ * @param languageCode the vendor's language code, as stated. Not normalised to a locale: a value
+ *                     this side did not recognise is more useful than one it invented
+ * @param name         product name in that language, where given
+ * @param description  marketing description in that language, where given
+ * @param footNotes    legal or qualifying text the vendor attached, where given
+ */
+public record SupplierCatalogEnrichmentText(
+        @NonNull String languageCode,
+        @Nullable String name,
+        @Nullable String description,
+        @Nullable String footNotes) {
+
+    public SupplierCatalogEnrichmentText {
+        Objects.requireNonNull(languageCode, "languageCode must not be null");
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierCatalogUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/supplier/SupplierCatalogUpdatedV1.java
@@ -1,0 +1,89 @@
+package com.positivity.domainevents.supplier;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Manufacturer marketing enrichment for one tread design variant, published on
+ * {@code supplier.events.v1} (CAP-324 #1230/#1257, ADR-0044 R1).
+ *
+ * <h2>Enrichment, not identity</h2>
+ *
+ * This describes how a manufacturer markets a tread design: names, marketing copy per language,
+ * artwork, seasonality, vehicle type. It says nothing about what a product <em>is</em> — no
+ * dimensions, no load index, no article code — because product identity and structure belong to
+ * pos-catalog and a supplier fact must not be able to redefine them. A consumer that let this change
+ * a product's identity would have handed a vendor edit rights over the catalogue.
+ *
+ * <h2>Matching is the consumer's problem, and may fail</h2>
+ *
+ * A tread design variant is a <em>design</em>, not an article: it has no EAN, because one design
+ * spans many sizes each with their own. The identifiers here — brand, design names, the vendor's own
+ * variant id — are what the vendor gives, published as stated. Whether they resolve to anything in
+ * the catalogue is pos-catalog's decision, and an enrichment that matches nothing is an ordinary
+ * outcome rather than an error.
+ *
+ * <h2>Identity, because the same variant is republished</h2>
+ *
+ * Both ingestion modes — change subscription and scheduled diffing — republish a variant whenever
+ * the vendor's content changes, and a redelivery can repeat one. A consumer must key on
+ * {@code (vendorProfileId, vendorVariantId)} rather than on the event.
+ *
+ * @param vendorProfileId  the vendor profile the enrichment was fetched from
+ * @param supplierRef      that profile's alias at fetch time; descriptive, never a key
+ * @param vendorVariantId  the vendor's own tread design variant identifier
+ * @param brand            brand as stated
+ * @param treadDesign      primary tread design name as stated
+ * @param treadDesign2     secondary tread design name, where the vendor uses one
+ * @param productName      the vendor's product name, where given
+ * @param vehicleType      vehicle class the design is for, as stated
+ * @param seasonality      summer, winter, all-season and so on, as the vendor states it. Not mapped
+ *                         to a Durion vocabulary: the mapping is a catalogue decision
+ * @param contentHash      hash of everything above plus the texts and images, so a consumer can skip
+ *                         a republication whose content did not actually change
+ * @param texts            marketing copy per language, as stated
+ * @param images           artwork, as stored references — never vendor URLs
+ * @param occurredAt       when the enrichment was fetched
+ */
+public record SupplierCatalogUpdatedV1(
+        @NonNull UUID vendorProfileId,
+        @NonNull String supplierRef,
+        @NonNull String vendorVariantId,
+        @Nullable String brand,
+        @Nullable String treadDesign,
+        @Nullable String treadDesign2,
+        @Nullable String productName,
+        @Nullable String vehicleType,
+        @Nullable String seasonality,
+        @NonNull String contentHash,
+        @NonNull List<SupplierCatalogEnrichmentText> texts,
+        @NonNull List<SupplierCatalogEnrichmentImage> images,
+        @NonNull Instant occurredAt) {
+
+    /** Event type of this payload on {@code supplier.events.v1}. */
+    public static final String EVENT_TYPE = "supplier.catalog.updated";
+
+    /** Payload schema version; additive changes only within v1 (ADR-0044 §3). */
+    public static final int SCHEMA_VERSION = 1;
+
+    public SupplierCatalogUpdatedV1 {
+        Objects.requireNonNull(vendorProfileId, "vendorProfileId must not be null");
+        Objects.requireNonNull(supplierRef, "supplierRef must not be null");
+        Objects.requireNonNull(vendorVariantId, "vendorVariantId must not be null");
+        Objects.requireNonNull(contentHash, "contentHash must not be null");
+        Objects.requireNonNull(texts, "texts must not be null");
+        Objects.requireNonNull(images, "images must not be null");
+        Objects.requireNonNull(occurredAt, "occurredAt must not be null");
+        texts = List.copyOf(texts);
+        images = List.copyOf(images);
+    }
+
+    /** Whether any artwork on this enrichment is still missing and awaiting retry. */
+    public boolean hasUnresolvedImages() {
+        return images.stream().anyMatch(SupplierCatalogEnrichmentImage::unresolved);
+    }
+}

--- a/pos-image/openapi.yaml
+++ b/pos-image/openapi.yaml
@@ -55,11 +55,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/StoredImage'
         '400':
-          description: The content was empty.
+          description: The content was empty, or was not valid base64.
           content:
-            '*/*':
+            application/json:
               schema:
-                $ref: '#/components/schemas/StoredImage'
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - image:image:store
@@ -199,6 +199,69 @@ components:
       - content
       - contentType
       - filename
+    ApiError:
+      type: object
+      description: Standard error response envelope returned by all Durion backend APIs
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+          example: ORDER_NOT_FOUND
+        message:
+          type: string
+          description: Human-readable error message
+          example: Order '550e8400-e29b-41d4-a716-446655440000' was not found
+        status:
+          type: integer
+          format: int32
+          description: HTTP status code
+          example: 404
+        timestamp:
+          type: string
+          description: ISO 8601 UTC timestamp of the error
+          example: 2026-03-17 14:30:00+00:00
+        correlationId:
+          type: string
+          description: Unique correlation ID for distributed request tracing
+          example: 550e8400-e29b-41d4-a716-446655440000
+        fieldErrors:
+          type: array
+          description: Field-level validation errors; present (non-null) for validation-related errors such as VALIDATION_ERROR or VALIDATION_FAILED; omitted for all other error types
+          items:
+            $ref: '#/components/schemas/FieldError'
+        referenceId:
+          type: string
+          description: Workflow or review-case reference identifier, when applicable
+          example: REVIEW-2026-000123
+        nextAction:
+          type: string
+          description: Recommended next step for the caller, when applicable
+          example: Retry the request with a valid quantity
+        supportAction:
+          type: string
+          description: Support or admin investigation guidance, when applicable
+          example: Contact support with the correlation ID for assistance
+      required:
+      - code
+      - correlationId
+      - message
+      - status
+      - timestamp
+    FieldError:
+      type: object
+      description: Validation error for a specific request field
+      properties:
+        field:
+          type: string
+          description: Field name
+          example: quantity
+        message:
+          type: string
+          description: Validation failure message
+          example: must be greater than 0
+      required:
+      - field
+      - message
     StoredImage:
       type: object
       properties:

--- a/pos-image/openapi.yaml
+++ b/pos-image/openapi.yaml
@@ -10,6 +10,61 @@ tags:
 - name: Image API
   description: Operations related to image retrieval and serving
 paths:
+  /v1/images:
+    post:
+      tags:
+      - Image API
+      summary: Store An Image
+      description: 'Stores image bytes and returns a reference to them, or returns the reference already held when the same bytes from the same origin have been stored before.
+
+        Use this tool when ingesting artwork that must not depend on a third party to render, such as manufacturer marketing images; do not use it to register an image that already lives somewhere this service can read, because that needs no copy.
+
+        Preconditions: the content must not be empty, because an empty body is a failed download and storing one would stop it ever being retried.
+
+        Required inputs: filename, contentType and content as base64; sourceUri and context are optional, and sourceUri is kept as provenance rather than as a render source.
+
+        No events are emitted.
+
+        Returns 200 with the reference, whose newlyStored flag says whether this call did the storing or found the bytes already held, and 400 when the content is empty.
+
+        '
+      operationId: storeImage
+      requestBody:
+        description: The image to store, with the origin it was fetched from where there was one.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StoreImageRequest'
+            examples:
+              Manufacturer tread pattern artwork:
+                description: Manufacturer tread pattern artwork
+                value:
+                  filename: primacy-4-tread.jpg
+                  contentType: image/jpeg
+                  content: /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAY=
+                  sourceUri: https://mkcat.example.com/images/9981.jpg
+                  context:
+                  - mkcat
+                  - tread-design
+        required: true
+      responses:
+        '200':
+          description: The stored image reference.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/StoredImage'
+        '400':
+          description: The content was empty.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/StoredImage'
+      security:
+      - bearerAuth:
+        - image:image:store
+      x-required-permissions:
+      - image:image:store
   /v1/images/id/{id}:
     get:
       tags:
@@ -57,6 +112,8 @@ paths:
               schema:
                 type: string
                 format: binary
+      x-required-permissions:
+      - AUTHENTICATED
   /v1/images/filename/{filename}:
     get:
       tags:
@@ -109,4 +166,55 @@ paths:
               schema:
                 type: string
                 format: binary
-components: {}
+      x-required-permissions:
+      - AUTHENTICATED
+components:
+  schemas:
+    StoreImageRequest:
+      type: object
+      description: Image bytes to store, base64-encoded, with optional provenance
+      properties:
+        filename:
+          type: string
+          description: Name to store the image under
+          example: primacy-4-tread.jpg
+          minLength: 1
+        contentType:
+          type: string
+          description: MIME type of the bytes
+          example: image/jpeg
+          minLength: 1
+        content:
+          type: string
+          description: The image bytes, base64-encoded
+        sourceUri:
+          type: string
+          description: Where the bytes were fetched from. Kept as provenance for audit and reconciliation, never used as a render source
+        context:
+          type: array
+          description: Tags this image should carry
+          items:
+            type: string
+      required:
+      - content
+      - contentType
+      - filename
+    StoredImage:
+      type: object
+      properties:
+        imageId:
+          type: integer
+          format: int64
+        filename:
+          type: string
+        contentType:
+          type: string
+        byteSize:
+          type: integer
+          format: int64
+        contentHash:
+          type: string
+        sourceUri:
+          type: string
+        newlyStored:
+          type: boolean

--- a/pos-image/pom.xml
+++ b/pos-image/pom.xml
@@ -25,6 +25,14 @@
     <packaging>jar</packaging>
     <dependencies>
         <!-- Lombok for annotation processing -->
+        <!-- Standard ApiError envelope (docs/ERROR_ENVELOPE.md). Added with the store endpoint
+             (CAP-324 #1257): this module had no error handling because it had no writes, and a new
+             write must not answer in a shape no client parses. -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-shared-dtos</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- Gateway-based stateless security. Added with the store endpoint (CAP-324 #1257):
              the read endpoints never needed a gate, but an ungated write accepts and keeps
              arbitrary bytes from anyone who can reach the service. -->

--- a/pos-image/pom.xml
+++ b/pos-image/pom.xml
@@ -25,6 +25,20 @@
     <packaging>jar</packaging>
     <dependencies>
         <!-- Lombok for annotation processing -->
+        <!-- Gateway-based stateless security. Added with the store endpoint (CAP-324 #1257):
+             the read endpoints never needed a gate, but an ungated write accepts and keeps
+             arbitrary bytes from anyone who can reach the service. -->
+        <dependency>
+            <groupId>com.positivity</groupId>
+            <artifactId>pos-security-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- JSpecify for null safety annotations -->
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>1.0.0</version>
+        </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/pos-image/src/main/java/com/positivity/image/internal/config/ImagePermissionRegistration.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/config/ImagePermissionRegistration.java
@@ -1,0 +1,18 @@
+package com.positivity.image.internal.config;
+
+import com.positivity.security.common.PermissionRegistrationSupport;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/** Registers this module's permissions with pos-security-service at startup (CAP-324 #1257). */
+@Component
+public class ImagePermissionRegistration extends PermissionRegistrationSupport {
+
+    public ImagePermissionRegistration(
+            RestClient.Builder restClientBuilder,
+            @Value("${pos.security.base-url:http://pos-security-service:8080}") String securityServiceUrl,
+            @Value("${pos.security.permission-registration.enabled:true}") boolean enabled) {
+        super(restClientBuilder, securityServiceUrl, enabled, "permissions.yaml");
+    }
+}

--- a/pos-image/src/main/java/com/positivity/image/internal/config/RestClientConfig.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/config/RestClientConfig.java
@@ -1,0 +1,21 @@
+package com.positivity.image.internal.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+/**
+ * RestClient builder for this module's platform registrations (CAP-324 #1257).
+ *
+ * <p>Needed because permission registration talks to pos-security-service at startup, and this
+ * module had never made an outbound call before — it only served images it already held. Added with
+ * the store endpoint, which is the reason there are permissions to register at all.
+ */
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient.Builder restClientBuilder() {
+        return RestClient.builder();
+    }
+}

--- a/pos-image/src/main/java/com/positivity/image/internal/config/SecurityConfig.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/config/SecurityConfig.java
@@ -1,0 +1,20 @@
+package com.positivity.image.internal.config;
+
+import com.positivity.security.common.GatewaySecurityConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Image service security configuration (CAP-324 #1257).
+ *
+ * <p>Reuses the standard gateway-based stateless chain: the API gateway validates JWTs and injects
+ * {@code X-Authorities} / {@code X-User}, which this filter chain trusts. Method security is
+ * deny-by-default via {@code @PreAuthorize} with {@code ImagePermissions} (ADR-0040).
+ *
+ * <p>Added when this module gained a way to store images. The read endpoints predate it and stay
+ * open — they serve images into page renders — but a write that accepts and keeps arbitrary bytes
+ * from any caller that can reach the service needed a gate.
+ */
+@Configuration
+@Import(GatewaySecurityConfig.class)
+public class SecurityConfig {}

--- a/pos-image/src/main/java/com/positivity/image/internal/controller/ImageController.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/controller/ImageController.java
@@ -1,21 +1,33 @@
 package com.positivity.image.internal.controller;
 
+import com.positivity.image.internal.dto.ImageContentView;
 import com.positivity.image.internal.dto.ImageFileView;
+import com.positivity.image.internal.dto.StoreImageRequest;
+import com.positivity.image.internal.security.ImagePermissions;
 import com.positivity.image.service.ImageService;
+import com.positivity.image.service.ImageStorageService;
+import com.positivity.image.service.model.StoredImage;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,6 +38,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/images")
 public class ImageController {
     private final ImageService imageService;
+    private final ImageStorageService imageStorageService;
 
     @Operation(
             operationId = "getImageById",
@@ -46,6 +59,10 @@ public class ImageController {
     @GetMapping("/id/{id}")
     public ResponseEntity<Resource> getImageById(
             @Parameter(description = "ID of the image to retrieve", example = "1") @PathVariable Long id) {
+        Optional<ImageContentView> stored = imageService.findContentById(id);
+        if (stored.isPresent()) {
+            return serveStoredContent(stored.get());
+        }
         Optional<ImageFileView> imageOpt = imageService.findById(id);
         if (imageOpt.isEmpty()) {
             return ResponseEntity.notFound().build();
@@ -77,12 +94,83 @@ public class ImageController {
     public ResponseEntity<Resource> getImageByFilename(
             @Parameter(description = "Filename of the image to retrieve", example = "logo.png") @PathVariable
                     String filename) {
+        Optional<ImageContentView> stored = imageService.findContentByFilename(filename);
+        if (stored.isPresent()) {
+            return serveStoredContent(stored.get());
+        }
         Optional<ImageFileView> imageOpt = imageService.findByFilename(filename);
         if (imageOpt.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
         ImageFileView image = imageOpt.get();
         return serveImageFile(image);
+    }
+
+    /**
+     * Serves bytes this service holds.
+     *
+     * <p>Inline rather than as an attachment, and with the real content type: these are product
+     * images rendered in a page, not files a user is being asked to download. The legacy path below
+     * keeps its attachment disposition, because changing how existing callers receive existing
+     * images is not this story's business.
+     */
+    private ResponseEntity<Resource> serveStoredContent(ImageContentView image) {
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + image.filename() + "\"")
+                .contentType(MediaType.parseMediaType(image.contentType()))
+                .body(new ByteArrayResource(image.content()));
+    }
+
+    @PostMapping
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"image:image:store"})
+    @PreAuthorize("hasAuthority('" + ImagePermissions.IMAGE_STORE + "')")
+    @Operation(
+            operationId = "storeImage",
+            summary = "Store An Image",
+            description = """
+                    Stores image bytes and returns a reference to them, or returns the reference already held when \
+                    the same bytes from the same origin have been stored before.
+                    Use this tool when ingesting artwork that must not depend on a third party to render, such as \
+                    manufacturer marketing images; do not use it to register an image that already lives \
+                    somewhere this service can read, because that needs no copy.
+                    Preconditions: the content must not be empty, because an empty body is a failed download and \
+                    storing one would stop it ever being retried.
+                    Required inputs: filename, contentType and content as base64; sourceUri and context are \
+                    optional, and sourceUri is kept as provenance rather than as a render source.
+                    No events are emitted.
+                    Returns 200 with the reference, whose newlyStored flag says whether this call did the storing \
+                    or found the bytes already held, and 400 when the content is empty.
+                    """,
+            tags = {"Image API"})
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "The image to store, with the origin it was fetched from where there was one.",
+            required = true,
+            content =
+                    @Content(
+                            schema = @Schema(implementation = StoreImageRequest.class),
+                            examples =
+                                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                            name = "Manufacturer tread pattern artwork",
+                                            value = """
+                                                    {
+                                                      "filename": "primacy-4-tread.jpg",
+                                                      "contentType": "image/jpeg",
+                                                      "content": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAY=",
+                                                      "sourceUri": "https://mkcat.example.com/images/9981.jpg",
+                                                      "context": ["mkcat", "tread-design"]
+                                                    }
+                                                    """)))
+    @ApiResponse(responseCode = "200", description = "The stored image reference.")
+    @ApiResponse(responseCode = "400", description = "The content was empty.")
+    public ResponseEntity<StoredImage> storeImage(@Valid @RequestBody StoreImageRequest request) {
+        return ResponseEntity.ok(imageStorageService.store(
+                request.filename(),
+                request.contentType(),
+                request.decodedContent(),
+                request.sourceUri(),
+                request.context()));
     }
 
     private ResponseEntity<Resource> serveImageFile(ImageFileView image) {

--- a/pos-image/src/main/java/com/positivity/image/internal/controller/ImageController.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/controller/ImageController.java
@@ -7,6 +7,7 @@ import com.positivity.image.internal.security.ImagePermissions;
 import com.positivity.image.service.ImageService;
 import com.positivity.image.service.ImageStorageService;
 import com.positivity.image.service.model.StoredImage;
+import com.positivity.shared.error.ApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -163,7 +164,10 @@ public class ImageController {
                                                     }
                                                     """)))
     @ApiResponse(responseCode = "200", description = "The stored image reference.")
-    @ApiResponse(responseCode = "400", description = "The content was empty.")
+    @ApiResponse(
+            responseCode = "400",
+            description = "The content was empty, or was not valid base64.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
     public ResponseEntity<StoredImage> storeImage(@Valid @RequestBody StoreImageRequest request) {
         return ResponseEntity.ok(imageStorageService.store(
                 request.filename(),

--- a/pos-image/src/main/java/com/positivity/image/internal/dto/ImageContentView.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/dto/ImageContentView.java
@@ -1,0 +1,14 @@
+package com.positivity.image.internal.dto;
+
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Image bytes held by this service, ready to serve (CAP-324 #1257).
+ *
+ * <p>Distinct from {@link ImageFileView}, which names a file for the caller to resolve on disk. This
+ * one carries the content itself, because for a stored image there is no file to resolve — and the
+ * two cases must not be conflated, or a stored image would be looked for on a volume that has never
+ * held it.
+ */
+public record ImageContentView(
+        @NonNull String filename, @NonNull String contentType, byte[] content) {}

--- a/pos-image/src/main/java/com/positivity/image/internal/dto/StoreImageRequest.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/dto/StoreImageRequest.java
@@ -1,0 +1,44 @@
+package com.positivity.image.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.Base64;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/** An image to store, with the origin it was fetched from where there was one (CAP-324 #1257). */
+@Schema(description = "Image bytes to store, base64-encoded, with optional provenance")
+public record StoreImageRequest(
+        @Schema(description = "Name to store the image under", example = "primacy-4-tread.jpg") @NotBlank
+        String filename,
+
+        @Schema(description = "MIME type of the bytes", example = "image/jpeg") @NotBlank
+        String contentType,
+
+        @Schema(description = "The image bytes, base64-encoded") @NotNull
+        String content,
+
+        @Schema(
+                description =
+                        "Where the bytes were fetched from. Kept as provenance for audit and reconciliation, never used as a render source")
+        @Nullable
+        String sourceUri,
+
+        @Schema(description = "Tags this image should carry") @Nullable
+        List<String> context) {
+
+    /**
+     * The decoded bytes.
+     *
+     * <p>Decoded here rather than accepted as a byte array so an unreadable body is a request
+     * problem with a clear message, rather than a deserialisation failure somewhere in the stack.
+     */
+    public byte[] decodedContent() {
+        try {
+            return Base64.getDecoder().decode(content);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("content is not valid base64: " + e.getMessage(), e);
+        }
+    }
+}

--- a/pos-image/src/main/java/com/positivity/image/internal/entity/ImageContentEntity.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/entity/ImageContentEntity.java
@@ -1,0 +1,82 @@
+package com.positivity.image.internal.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/**
+ * The bytes of an image, addressed by their own SHA-256 (CAP-324 #1257).
+ *
+ * <h2>Content-addressed on purpose</h2>
+ *
+ * A manufacturer republishes the same artwork unchanged on every catalogue refresh. A store keyed on
+ * anything but the content would take a fresh copy each cycle and grow without bound, while nothing
+ * downstream could tell that two ids referred to the same picture.
+ *
+ * <p>The consequence worth knowing: rows here are shared. Several {@code image} records — different
+ * filenames, different contexts, different vendors — may point at one of these. Deleting content
+ * because one of them went away would blank the others.
+ */
+@Entity
+@Table(name = "image_content")
+public class ImageContentEntity {
+
+    /** Lower-case hex SHA-256 of {@link #content}. The identity of an image is its bytes. */
+    @Id
+    @Column(name = "content_hash", length = 64)
+    private String contentHash;
+
+    @Column(name = "content_type", nullable = false)
+    private String contentType;
+
+    @Column(name = "byte_size", nullable = false)
+    private long byteSize;
+
+    @Column(name = "content", nullable = false)
+    private byte[] content;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    public String getContentHash() {
+        return contentHash;
+    }
+
+    public void setContentHash(String contentHash) {
+        this.contentHash = contentHash;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public long getByteSize() {
+        return byteSize;
+    }
+
+    public void setByteSize(long byteSize) {
+        this.byteSize = byteSize;
+    }
+
+    public byte[] getContent() {
+        return content;
+    }
+
+    public void setContent(byte[] content) {
+        this.content = content;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/pos-image/src/main/java/com/positivity/image/internal/entity/ImageEntity.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/entity/ImageEntity.java
@@ -29,6 +29,88 @@ public class ImageEntity {
     @Schema(description = "Classification of the image", implementation = Classification.class)
     private Classification classification;
 
+    /**
+     * SHA-256 of the stored bytes, when this record has bytes at all (CAP-324 #1257).
+     *
+     * <p>Null for every record created before image content could be stored: those are served by
+     * resolving {@link #url} as a filesystem path, and they keep working that way. The two are read
+     * in that order — content first, path second — so a record that gains bytes stops depending on a
+     * file this service may no longer have.
+     */
+    @Schema(description = "SHA-256 of the stored image bytes; null when the image is served from its url path")
+    private String contentHash;
+
+    @Schema(description = "MIME type of the stored bytes", example = "image/jpeg")
+    private String contentType;
+
+    @Schema(description = "Size of the stored bytes")
+    private Long byteSize;
+
+    /**
+     * Where the bytes were fetched from, kept as evidence rather than as a render source.
+     *
+     * <p>A vendor URL stops being how an image is served the moment the bytes are held here; it does
+     * not stop being how the image is explained when somebody asks where a picture came from.
+     */
+    @Schema(description = "Origin the bytes were fetched from; provenance only, never a render source")
+    private String sourceUri;
+
+    @org.springframework.data.annotation.CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private java.time.Instant createdAt;
+
+    @org.springframework.data.annotation.LastModifiedDate
+    @Column(name = "updated_at")
+    private java.time.Instant updatedAt;
+
+    public String getContentHash() {
+        return contentHash;
+    }
+
+    public void setContentHash(String contentHash) {
+        this.contentHash = contentHash;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public Long getByteSize() {
+        return byteSize;
+    }
+
+    public void setByteSize(Long byteSize) {
+        this.byteSize = byteSize;
+    }
+
+    public String getSourceUri() {
+        return sourceUri;
+    }
+
+    public void setSourceUri(String sourceUri) {
+        this.sourceUri = sourceUri;
+    }
+
+    public java.time.Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(java.time.Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public java.time.Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(java.time.Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
     // Getters and setters
     public Long getId() {
         return id;

--- a/pos-image/src/main/java/com/positivity/image/internal/exception/ImageExceptionHandler.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/exception/ImageExceptionHandler.java
@@ -1,0 +1,84 @@
+package com.positivity.image.internal.exception;
+
+import com.positivity.shared.error.ApiError;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Error responses for this module (CAP-324 #1257, docs/ERROR_ENVELOPE.md).
+ *
+ * <h2>Why this module suddenly needs one</h2>
+ *
+ * pos-image had no error handling because it had no writes: a read either found an image or answered
+ * 404, and neither needed an envelope. The store endpoint can be sent a body that is not valid
+ * base64, or one that decodes to nothing — both the caller's problem, and both of which would
+ * otherwise have surfaced as a 500 while the contract advertised 400.
+ *
+ * <p>A 500 for a malformed request is worse than untidy. It tells the caller to retry an identical
+ * request that will fail identically, and it puts a client error into whatever alerts on server
+ * errors.
+ */
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class ImageExceptionHandler {
+
+    private static final String X_CORRELATION_ID = "X-Correlation-Id";
+
+    private final Clock clock;
+
+    /**
+     * A request this service cannot make sense of.
+     *
+     * <p>Logged at debug, not warn: a client sending a bad body is an ordinary event on an endpoint
+     * that accepts uploads, and logging it at warn would turn routine misuse into noise that hides
+     * real problems.
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiError> handleBadRequest(IllegalArgumentException ex, HttpServletRequest request) {
+        log.debug("Rejecting image request: {}", ex.getMessage());
+        return build(HttpStatus.BAD_REQUEST, "IMAGE_REQUEST_INVALID", ex.getMessage(), request);
+    }
+
+    /**
+     * A record that points at content this service does not hold.
+     *
+     * <p>A broken row rather than a bad request, so it is a 500 and says so. Handled explicitly to
+     * stop it being reported as a client error, which would send whoever hit it looking at their own
+     * request instead of at the data.
+     */
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiError> handleBrokenState(IllegalStateException ex, HttpServletRequest request) {
+        log.error("Image service is in an inconsistent state", ex);
+        return build(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_STATE_INVALID", ex.getMessage(), request);
+    }
+
+    private ResponseEntity<ApiError> build(HttpStatus status, String code, String message, HttpServletRequest request) {
+        String correlationId = resolveCorrelationId(request);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(X_CORRELATION_ID, correlationId);
+        return new ResponseEntity<>(
+                ApiError.of(
+                        code,
+                        message == null ? status.getReasonPhrase() : message,
+                        status.value(),
+                        Instant.now(clock).toString(),
+                        correlationId),
+                headers,
+                status);
+    }
+
+    private static String resolveCorrelationId(HttpServletRequest request) {
+        String supplied = request.getHeader(X_CORRELATION_ID);
+        return supplied == null || supplied.isBlank() ? UUID.randomUUID().toString() : supplied;
+    }
+}

--- a/pos-image/src/main/java/com/positivity/image/internal/repository/ImageContentRepository.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/repository/ImageContentRepository.java
@@ -1,0 +1,9 @@
+package com.positivity.image.internal.repository;
+
+import com.positivity.image.internal.entity.ImageContentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Image bytes, keyed by their own SHA-256 (CAP-324 #1257). */
+@Repository
+public interface ImageContentRepository extends JpaRepository<ImageContentEntity, String> {}

--- a/pos-image/src/main/java/com/positivity/image/internal/repository/ImageRepository.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/repository/ImageRepository.java
@@ -5,5 +5,16 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ImageRepository extends JpaRepository<ImageEntity, Long> {
+
+    /**
+     * The image already held for this origin and content, if there is one (CAP-324 #1257).
+     *
+     * <p>Both halves matter. Matching on the source alone would return a stale record after a
+     * manufacturer replaced the artwork behind a URL it kept; matching on content alone would
+     * return an unrelated record that happens to be the same picture, and hand back its filename
+     * and context. Together they mean "we have already ingested exactly this, from exactly here".
+     */
+    java.util.Optional<ImageEntity> findFirstBySourceUriAndContentHash(String sourceUri, String contentHash);
+
     Optional<ImageEntity> findByFilename(String filename);
 }

--- a/pos-image/src/main/java/com/positivity/image/internal/repository/ImageRepository.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/repository/ImageRepository.java
@@ -2,19 +2,25 @@ package com.positivity.image.internal.repository;
 
 import com.positivity.image.internal.entity.ImageEntity;
 import java.util.Optional;
+import org.jspecify.annotations.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+/** Stored image records (CAP-324 #1257). */
+@Repository
 public interface ImageRepository extends JpaRepository<ImageEntity, Long> {
 
     /**
      * The image already held for this origin and content, if there is one (CAP-324 #1257).
      *
      * <p>Both halves matter. Matching on the source alone would return a stale record after a
-     * manufacturer replaced the artwork behind a URL it kept; matching on content alone would
-     * return an unrelated record that happens to be the same picture, and hand back its filename
-     * and context. Together they mean "we have already ingested exactly this, from exactly here".
+     * manufacturer replaced the artwork behind a URL it kept; matching on content alone would return
+     * an unrelated record that happens to be the same picture, and hand back its filename and
+     * context. Together they mean "we have already ingested exactly this, from exactly here".
      */
-    java.util.Optional<ImageEntity> findFirstBySourceUriAndContentHash(String sourceUri, String contentHash);
+    @NonNull
+    Optional<ImageEntity> findFirstBySourceUriAndContentHash(@NonNull String sourceUri, @NonNull String contentHash);
 
-    Optional<ImageEntity> findByFilename(String filename);
+    @NonNull
+    Optional<ImageEntity> findByFilename(@NonNull String filename);
 }

--- a/pos-image/src/main/java/com/positivity/image/internal/security/ImagePermissions.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/security/ImagePermissions.java
@@ -1,0 +1,19 @@
+package com.positivity.image.internal.security;
+
+/**
+ * Permissions this module enforces (CAP-324 #1257).
+ *
+ * <h2>Why only the write is gated</h2>
+ *
+ * Reading an image has never required a permission here, and this story does not change that: the
+ * read endpoints predate it and are used by page renders. Writing is different in kind. An ungated
+ * store endpoint accepts arbitrary bytes from anyone who can reach the service and keeps them, which
+ * is a storage-exhaustion and content-hosting problem regardless of who is asking.
+ */
+public final class ImagePermissions {
+
+    /** Storing image bytes. */
+    public static final String IMAGE_STORE = "image:image:store";
+
+    private ImagePermissions() {}
+}

--- a/pos-image/src/main/java/com/positivity/image/internal/service/ImageServiceImpl.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/service/ImageServiceImpl.java
@@ -1,6 +1,9 @@
 package com.positivity.image.internal.service;
 
+import com.positivity.image.internal.dto.ImageContentView;
 import com.positivity.image.internal.dto.ImageFileView;
+import com.positivity.image.internal.entity.ImageEntity;
+import com.positivity.image.internal.repository.ImageContentRepository;
 import com.positivity.image.internal.repository.ImageRepository;
 import com.positivity.image.service.ImageService;
 import java.util.Optional;
@@ -9,9 +12,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class ImageServiceImpl implements ImageService {
     private final ImageRepository imageRepository;
+    private final ImageContentRepository contentRepository;
 
-    public ImageServiceImpl(ImageRepository imageRepository) {
+    public ImageServiceImpl(ImageRepository imageRepository, ImageContentRepository contentRepository) {
         this.imageRepository = imageRepository;
+        this.contentRepository = contentRepository;
     }
 
     @Override
@@ -24,5 +29,39 @@ public class ImageServiceImpl implements ImageService {
         return imageRepository
                 .findByFilename(filename)
                 .map(image -> new ImageFileView(image.getFilename(), image.getUrl()));
+    }
+
+    @Override
+    public Optional<ImageContentView> findContentById(Long id) {
+        return imageRepository
+                .findById(id)
+                .flatMap(ImageServiceImpl::withContent)
+                .map(this::toContentView);
+    }
+
+    @Override
+    public Optional<ImageContentView> findContentByFilename(String filename) {
+        return imageRepository
+                .findByFilename(filename)
+                .flatMap(ImageServiceImpl::withContent)
+                .map(this::toContentView);
+    }
+
+    /** Records that predate content storage carry no hash and are served from their url path. */
+    private static Optional<ImageEntity> withContent(ImageEntity image) {
+        return image.getContentHash() == null || image.getContentHash().isBlank()
+                ? Optional.empty()
+                : Optional.of(image);
+    }
+
+    private ImageContentView toContentView(ImageEntity image) {
+        return contentRepository
+                .findById(image.getContentHash())
+                .map(blob -> new ImageContentView(image.getFilename(), blob.getContentType(), blob.getContent()))
+                // A record pointing at content that is not there is a broken row, not an empty
+                // image: reporting it as absent sends the reader to the url fallback, which for a
+                // stored image is a path that never existed.
+                .orElseThrow(() -> new IllegalStateException("Image " + image.getId() + " references content "
+                        + image.getContentHash() + " which is not stored"));
     }
 }

--- a/pos-image/src/main/java/com/positivity/image/internal/service/ImageStorageServiceImpl.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/service/ImageStorageServiceImpl.java
@@ -1,0 +1,138 @@
+package com.positivity.image.internal.service;
+
+import com.positivity.image.internal.entity.ImageContentEntity;
+import com.positivity.image.internal.entity.ImageEntity;
+import com.positivity.image.internal.repository.ImageContentRepository;
+import com.positivity.image.internal.repository.ImageRepository;
+import com.positivity.image.service.ImageStorageService;
+import com.positivity.image.service.model.StoredImage;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Storing image bytes, content-addressed (CAP-324 #1257).
+ *
+ * <h2>Two levels of "already have it"</h2>
+ *
+ * The bytes are keyed by their own SHA-256, so identical artwork from two manufacturers occupies one
+ * row. The <em>record</em> is keyed by origin and content together, so re-ingesting the same picture
+ * from the same URL returns the same id rather than a new one.
+ *
+ * <p>Both are needed. Deduplicating only the bytes would still hand a consumer a fresh id on every
+ * catalogue refresh, which defeats the point — a consumer that cannot tell "unchanged" from "new"
+ * re-renders and re-caches everything each cycle.
+ *
+ * <h2>Empty content is refused</h2>
+ *
+ * An empty body is what a failed download looks like. Storing it would satisfy every later
+ * "do we already have this?" check, and the missing artwork would never be retried.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ImageStorageServiceImpl implements ImageStorageService {
+
+    private final ImageRepository imageRepository;
+    private final ImageContentRepository contentRepository;
+    private final Clock clock;
+
+    @Override
+    @NonNull
+    @Transactional
+    public StoredImage store(
+            @NonNull String filename,
+            @NonNull String contentType,
+            byte[] content,
+            @Nullable String sourceUri,
+            @Nullable List<String> context) {
+        if (content == null || content.length == 0) {
+            throw new IllegalArgumentException("refusing to store an empty image for '" + filename
+                    + "': an empty body is a failed download, and storing it would stop it ever being retried");
+        }
+
+        String contentHash = sha256(content);
+
+        Optional<ImageEntity> existing = sourceUri == null
+                ? Optional.empty()
+                : imageRepository.findFirstBySourceUriAndContentHash(sourceUri, contentHash);
+        if (existing.isPresent()) {
+            return toReference(existing.get(), false);
+        }
+
+        storeContentOnce(contentHash, contentType, content);
+
+        ImageEntity record = new ImageEntity();
+        record.setFilename(filename);
+        record.setContentHash(contentHash);
+        record.setContentType(contentType);
+        record.setByteSize((long) content.length);
+        record.setSourceUri(sourceUri);
+        record.setContext(context == null ? List.of() : List.copyOf(context));
+        // The url column is what the legacy read path resolves as a filesystem path. Left null:
+        // this record's bytes are held here, and inventing a path would send the reader looking for
+        // a file that does not exist.
+        record.setUrl(null);
+
+        ImageEntity saved = imageRepository.save(record);
+        log.debug("Stored image {} ({} bytes) from {}", saved.getId(), content.length, sourceUri);
+        return toReference(saved, true);
+    }
+
+    /**
+     * Writes the bytes unless they are already held.
+     *
+     * <p>The insert can lose a race with a concurrent ingest of the same artwork — two catalogue
+     * runs, or two instances. That collision means the content is present, which is the outcome
+     * wanted, so it is treated as success rather than failing an ingest over a duplicate.
+     */
+    private void storeContentOnce(String contentHash, String contentType, byte[] content) {
+        if (contentRepository.existsById(contentHash)) {
+            return;
+        }
+        ImageContentEntity blob = new ImageContentEntity();
+        blob.setContentHash(contentHash);
+        blob.setContentType(contentType);
+        blob.setByteSize(content.length);
+        blob.setContent(content);
+        blob.setCreatedAt(Instant.now(clock));
+        try {
+            contentRepository.save(blob);
+        } catch (DataIntegrityViolationException e) {
+            log.debug("Image content {} was stored concurrently; keeping the existing copy", contentHash);
+        }
+    }
+
+    private static StoredImage toReference(ImageEntity record, boolean newlyStored) {
+        return new StoredImage(
+                record.getId(),
+                record.getFilename(),
+                record.getContentType() == null ? "application/octet-stream" : record.getContentType(),
+                record.getByteSize() == null ? 0L : record.getByteSize(),
+                record.getContentHash(),
+                record.getSourceUri(),
+                newlyStored);
+    }
+
+    @NonNull
+    private static String sha256(byte[] content) {
+        try {
+            return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(content));
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is required of every Java platform; if it is absent the deployment is broken
+            // in a way no fallback would improve.
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+}

--- a/pos-image/src/main/java/com/positivity/image/service/ImageService.java
+++ b/pos-image/src/main/java/com/positivity/image/service/ImageService.java
@@ -1,5 +1,6 @@
 package com.positivity.image.service;
 
+import com.positivity.image.internal.dto.ImageContentView;
 import com.positivity.image.internal.dto.ImageFileView;
 import java.util.Optional;
 
@@ -7,4 +8,16 @@ public interface ImageService {
     Optional<ImageFileView> findById(Long id);
 
     Optional<ImageFileView> findByFilename(String filename);
+
+    /**
+     * The stored bytes for an image, when this service holds them (CAP-324 #1257).
+     *
+     * <p>Empty for records that predate content storage — those name a file for the caller to
+     * resolve, and are still served that way. A caller should try this first and fall back, rather
+     * than choosing by inspecting the record: which of the two applies is this service's business.
+     */
+    Optional<ImageContentView> findContentById(Long id);
+
+    /** The stored bytes for an image looked up by filename. */
+    Optional<ImageContentView> findContentByFilename(String filename);
 }

--- a/pos-image/src/main/java/com/positivity/image/service/ImageStorageService.java
+++ b/pos-image/src/main/java/com/positivity/image/service/ImageStorageService.java
@@ -1,0 +1,46 @@
+package com.positivity.image.service;
+
+import com.positivity.image.service.model.StoredImage;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Putting image bytes into this service (CAP-324 #1257, ADR-0009).
+ *
+ * <h2>Why this exists</h2>
+ *
+ * pos-image could previously only serve images that had arrived by some other route — a file placed
+ * on a volume, a URL recorded by hand. Nothing could put one in. MKCAT ingestion fetches
+ * manufacturer artwork from a vendor and has to keep it, because the alternative is publishing the
+ * vendor's own URL as the render source, which makes every product page depend on a third party's
+ * uptime and rate limits and gives this service nothing to cache or optimise.
+ *
+ * <h2>Storing is idempotent</h2>
+ *
+ * Storing the same bytes from the same origin twice returns the first reference rather than a second
+ * copy. That is not an optimisation: a catalogue refresh republishes unchanged artwork every cycle,
+ * so a store that took it at face value would grow forever and give a consumer a new id each time
+ * for a picture that never changed.
+ */
+public interface ImageStorageService {
+
+    /**
+     * Stores image bytes, or returns the reference already held for them.
+     *
+     * @param filename    name to store it under
+     * @param contentType MIME type; the caller's claim about the bytes, not a sniff of them
+     * @param content     the bytes. Must not be empty — an empty image is a failed download, and
+     *                    storing one would satisfy every later "do we have it?" check
+     * @param sourceUri   where the bytes came from, for provenance. May be null for direct uploads
+     * @param context     tags this image should carry
+     * @return the reference, with {@code newlyStored} saying whether this call did the storing
+     */
+    @NonNull
+    StoredImage store(
+            @NonNull String filename,
+            @NonNull String contentType,
+            byte[] content,
+            @Nullable String sourceUri,
+            @Nullable List<String> context);
+}

--- a/pos-image/src/main/java/com/positivity/image/service/model/StoredImage.java
+++ b/pos-image/src/main/java/com/positivity/image/service/model/StoredImage.java
@@ -1,0 +1,39 @@
+package com.positivity.image.service.model;
+
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A reference to an image this service holds (CAP-324 #1257).
+ *
+ * <p>What a consumer needs to render or re-request the image, and nothing about where the bytes
+ * physically live. That the store is a database table today and might be object storage tomorrow is
+ * not a caller's concern, and a reference that leaked it would have to change when the store did.
+ *
+ * @param imageId     this service's identifier, stable across re-ingests of the same content
+ * @param filename    the name it was stored under
+ * @param contentType MIME type of the stored bytes
+ * @param byteSize    size of the stored bytes
+ * @param contentHash SHA-256 of the bytes, lower-case hex. Two references with the same hash are
+ *                    the same picture, which is how a consumer avoids re-fetching one it has
+ * @param sourceUri   where the bytes were fetched from, when they were fetched from somewhere.
+ *                    Provenance only — never a render source, because rendering from it puts a
+ *                    third party in the path of every page view
+ * @param newlyStored whether this call stored the bytes, or found them already held
+ */
+public record StoredImage(
+        long imageId,
+        @NonNull String filename,
+        @NonNull String contentType,
+        long byteSize,
+        @NonNull String contentHash,
+        @Nullable String sourceUri,
+        boolean newlyStored) {
+
+    public StoredImage {
+        Objects.requireNonNull(filename, "filename must not be null");
+        Objects.requireNonNull(contentType, "contentType must not be null");
+        Objects.requireNonNull(contentHash, "contentHash must not be null");
+    }
+}

--- a/pos-image/src/main/resources/db/migration/V2__image_content_storage.sql
+++ b/pos-image/src/main/resources/db/migration/V2__image_content_storage.sql
@@ -1,0 +1,42 @@
+-- CAP-324 (#1257): pos-image gains somewhere to put image bytes.
+--
+-- Until now this module was a registry of filenames and URLs: the read path resolved `url` as a
+-- filesystem path and served whatever was there. Nothing could put an image in, which is why MKCAT
+-- ingestion had nowhere to store the manufacturer artwork it fetches.
+--
+-- Content-addressed, not id-addressed. The same manufacturer image is republished unchanged on
+-- every catalogue refresh, and a store keyed on anything but the bytes would accumulate a new copy
+-- per fetch cycle forever.
+
+CREATE TABLE IF NOT EXISTS image_content (
+    -- SHA-256 of the bytes, lower-case hex. The identity of an image IS its content.
+    content_hash  VARCHAR(64)  PRIMARY KEY,
+    content_type  VARCHAR(255) NOT NULL,
+    byte_size     BIGINT       NOT NULL,
+    content       bytea        NOT NULL,
+    created_at    timestamp(6) with time zone NOT NULL,
+
+    CONSTRAINT ck_image_content_size CHECK (byte_size > 0)
+);
+
+-- Existing rows keep working exactly as before: a null content_hash means "served from the url
+-- path", which is what every row created before this migration is. Backfilling them would mean
+-- reading files this service may no longer have.
+ALTER TABLE image ADD COLUMN IF NOT EXISTS content_hash VARCHAR(64);
+ALTER TABLE image ADD COLUMN IF NOT EXISTS content_type VARCHAR(255);
+ALTER TABLE image ADD COLUMN IF NOT EXISTS byte_size    BIGINT;
+
+-- Where the bytes came from, kept as evidence rather than as a render source. A vendor URL stops
+-- being how the image is served; it does not stop being how the image is explained.
+ALTER TABLE image ADD COLUMN IF NOT EXISTS source_uri VARCHAR(2000);
+
+ALTER TABLE image ADD COLUMN IF NOT EXISTS created_at timestamp(6) with time zone;
+ALTER TABLE image ADD COLUMN IF NOT EXISTS updated_at timestamp(6) with time zone;
+
+-- Finding the record for a set of bytes without scanning: this is how a re-ingest of unchanged
+-- vendor content resolves to the image already held instead of storing a second one.
+CREATE INDEX IF NOT EXISTS ix_image_content_hash ON image (content_hash);
+
+-- Answering "have we already fetched this vendor URL", which is the cheap check before the
+-- expensive one.
+CREATE INDEX IF NOT EXISTS ix_image_source_uri ON image (source_uri);

--- a/pos-image/src/main/resources/permissions.yaml
+++ b/pos-image/src/main/resources/permissions.yaml
@@ -1,3 +1,5 @@
+domain: image
+serviceName: pos-image
 version: "1.0"
 permissions:
   - name: "image:image:store"

--- a/pos-image/src/main/resources/permissions.yaml
+++ b/pos-image/src/main/resources/permissions.yaml
@@ -1,0 +1,4 @@
+version: "1.0"
+permissions:
+  - name: "image:image:store"
+    description: "Store image bytes in the image service"

--- a/pos-image/src/test/java/com/positivity/image/internal/controller/ImageControllerTest.java
+++ b/pos-image/src/test/java/com/positivity/image/internal/controller/ImageControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 
 import com.positivity.image.internal.dto.ImageFileView;
 import com.positivity.image.service.ImageService;
+import com.positivity.image.service.ImageStorageService;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -39,6 +40,9 @@ class ImageControllerTest {
     @Mock
     private ImageService imageService;
 
+    @Mock
+    private ImageStorageService storageService;
+
     @Test
     @DisplayName("serves a stored file as an attachment under its own filename")
     void servesExistingFile(@TempDir Path tempDir) throws Exception {
@@ -47,7 +51,7 @@ class ImageControllerTest {
         when(imageService.findById(1L))
                 .thenReturn(Optional.of(new ImageFileView("vehicle-front.jpg", file.toString())));
 
-        ResponseEntity<Resource> response = new ImageController(imageService).getImageById(1L);
+        ResponseEntity<Resource> response = new ImageController(imageService, storageService).getImageById(1L);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
@@ -63,7 +67,9 @@ class ImageControllerTest {
     void missingRowIsNotFound() {
         when(imageService.findById(99L)).thenReturn(Optional.empty());
 
-        assertThat(new ImageController(imageService).getImageById(99L).getStatusCode())
+        assertThat(new ImageController(imageService, storageService)
+                        .getImageById(99L)
+                        .getStatusCode())
                 .isEqualTo(HttpStatus.NOT_FOUND);
     }
 
@@ -76,7 +82,9 @@ class ImageControllerTest {
                 .thenReturn(Optional.of(new ImageFileView(
                         "gone.jpg", tempDir.resolve("gone.jpg").toString())));
 
-        assertThat(new ImageController(imageService).getImageById(1L).getStatusCode())
+        assertThat(new ImageController(imageService, storageService)
+                        .getImageById(1L)
+                        .getStatusCode())
                 .isEqualTo(HttpStatus.NOT_FOUND);
     }
 
@@ -89,7 +97,7 @@ class ImageControllerTest {
                 .thenReturn(Optional.of(new ImageFileView("logo.png", file.toString())));
         when(imageService.findByFilename("absent.png")).thenReturn(Optional.empty());
 
-        ImageController controller = new ImageController(imageService);
+        ImageController controller = new ImageController(imageService, storageService);
 
         assertThat(controller.getImageByFilename("logo.png").getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(controller.getImageByFilename("absent.png").getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);

--- a/pos-image/src/test/java/com/positivity/image/internal/exception/ImageExceptionHandlerTest.java
+++ b/pos-image/src/test/java/com/positivity/image/internal/exception/ImageExceptionHandlerTest.java
@@ -1,0 +1,97 @@
+package com.positivity.image.internal.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.image.internal.dto.StoreImageRequest;
+import com.positivity.shared.error.ApiError;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * A malformed store request is the caller's problem, and says so (CAP-324 #1257).
+ *
+ * <p>A 500 for a bad body is worse than untidy: it tells the caller to retry a request that will
+ * fail identically, and it files a client error wherever server errors are alerted on.
+ */
+@DisplayName("ImageExceptionHandler — a bad request is a 400, not a 500 (#1257)")
+class ImageExceptionHandlerTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-16T10:00:00Z");
+
+    private final ImageExceptionHandler handler = new ImageExceptionHandler(Clock.fixed(NOW, ZoneOffset.UTC));
+
+    @Test
+    @DisplayName("content that is not base64 answers 400 in the standard envelope")
+    void invalidBase64IsABadRequest() {
+        StoreImageRequest request =
+                new StoreImageRequest("tread.jpg", "image/jpeg", "not base64 at all!!", null, List.of());
+
+        ResponseEntity<ApiError> response =
+                handler.handleBadRequest(catchIllegalArgument(request::decodedContent), servletRequest());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code()).isEqualTo("IMAGE_REQUEST_INVALID");
+        assertThat(response.getBody().message()).contains("base64");
+        assertThat(response.getBody().status()).isEqualTo(400);
+        assertThat(response.getBody().timestamp()).isEqualTo(NOW.toString());
+    }
+
+    @Test
+    @DisplayName("an empty body answers 400, since refusing it is the point")
+    void emptyContentIsABadRequest() {
+        ResponseEntity<ApiError> response = handler.handleBadRequest(
+                new IllegalArgumentException("refusing to store an empty image; it would never be retried"),
+                servletRequest());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("a supplied correlation id is echoed rather than replaced")
+    void correlationIdIsPreserved() {
+        MockHttpServletRequest request = servletRequest();
+        request.addHeader("X-Correlation-Id", "corr-from-caller");
+
+        ResponseEntity<ApiError> response = handler.handleBadRequest(new IllegalArgumentException("bad"), request);
+
+        // Replacing it would break the one thread a caller has for following its own request
+        // through the platform.
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().correlationId()).isEqualTo("corr-from-caller");
+        assertThat(response.getHeaders().getFirst("X-Correlation-Id")).isEqualTo("corr-from-caller");
+    }
+
+    @Test
+    @DisplayName("a record pointing at content nobody holds is a 500, not a client error")
+    void brokenStateIsAServerError() {
+        // A broken row must not send whoever hit it looking at their own request.
+        ResponseEntity<ApiError> response = handler.handleBrokenState(
+                new IllegalStateException("Image 7 references content abc which is not stored"), servletRequest());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code()).isEqualTo("IMAGE_STATE_INVALID");
+    }
+
+    private static MockHttpServletRequest servletRequest() {
+        return new MockHttpServletRequest("POST", "/v1/images");
+    }
+
+    private static IllegalArgumentException catchIllegalArgument(Runnable action) {
+        try {
+            action.run();
+            throw new AssertionError("expected an IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            return e;
+        }
+    }
+}

--- a/pos-image/src/test/java/com/positivity/image/internal/service/ImageStorageServiceImplTest.java
+++ b/pos-image/src/test/java/com/positivity/image/internal/service/ImageStorageServiceImplTest.java
@@ -1,0 +1,175 @@
+package com.positivity.image.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.image.internal.entity.ImageContentEntity;
+import com.positivity.image.internal.entity.ImageEntity;
+import com.positivity.image.internal.repository.ImageContentRepository;
+import com.positivity.image.internal.repository.ImageRepository;
+import com.positivity.image.service.model.StoredImage;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/**
+ * Storing image bytes without accumulating copies (CAP-324 #1257).
+ *
+ * <p>A catalogue refresh republishes unchanged manufacturer artwork on every cycle. The behaviour
+ * that matters is therefore not "can it store an image" but what happens the second, tenth and
+ * hundredth time it is handed the same one.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ImageStorageServiceImpl — storing without accumulating (#1257)")
+class ImageStorageServiceImplTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-16T10:00:00Z");
+    private static final byte[] ARTWORK = "tread-pattern-bytes".getBytes(StandardCharsets.UTF_8);
+    private static final String VENDOR_URI = "https://mkcat.example.com/images/9981.jpg";
+
+    @Mock
+    private ImageRepository imageRepository;
+
+    @Mock
+    private ImageContentRepository contentRepository;
+
+    private ImageStorageServiceImpl storage;
+
+    @BeforeEach
+    void setUp() {
+        storage = new ImageStorageServiceImpl(imageRepository, contentRepository, Clock.fixed(NOW, ZoneOffset.UTC));
+        when(imageRepository.save(any())).thenAnswer(invocation -> {
+            ImageEntity saved = invocation.getArgument(0);
+            saved.setId(42L);
+            return saved;
+        });
+        when(imageRepository.findFirstBySourceUriAndContentHash(any(), any())).thenReturn(Optional.empty());
+        when(contentRepository.existsById(any())).thenReturn(false);
+    }
+
+    @Test
+    @DisplayName("stores the bytes and reports having done so")
+    void storesNewContent() {
+        StoredImage stored = storage.store("tread.jpg", "image/jpeg", ARTWORK, VENDOR_URI, List.of("mkcat"));
+
+        assertThat(stored.newlyStored()).isTrue();
+        assertThat(stored.imageId()).isEqualTo(42L);
+        assertThat(stored.byteSize()).isEqualTo(ARTWORK.length);
+        assertThat(stored.contentHash()).hasSize(64);
+        // Kept as evidence of where it came from, not as somewhere to fetch it from later.
+        assertThat(stored.sourceUri()).isEqualTo(VENDOR_URI);
+        verify(contentRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("re-ingesting the same artwork from the same origin returns the first reference")
+    void reIngestDoesNotDuplicate() {
+        ImageEntity alreadyHeld = new ImageEntity();
+        alreadyHeld.setId(7L);
+        alreadyHeld.setFilename("tread.jpg");
+        alreadyHeld.setContentType("image/jpeg");
+        alreadyHeld.setByteSize((long) ARTWORK.length);
+        alreadyHeld.setContentHash(hashOf(ARTWORK));
+        alreadyHeld.setSourceUri(VENDOR_URI);
+        when(imageRepository.findFirstBySourceUriAndContentHash(VENDOR_URI, hashOf(ARTWORK)))
+                .thenReturn(Optional.of(alreadyHeld));
+
+        StoredImage stored = storage.store("tread.jpg", "image/jpeg", ARTWORK, VENDOR_URI, List.of("mkcat"));
+
+        // The same id, so a consumer can tell "unchanged" from "new" and skip re-rendering.
+        assertThat(stored.imageId()).isEqualTo(7L);
+        assertThat(stored.newlyStored()).isFalse();
+        verify(imageRepository, never()).save(any());
+        verify(contentRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("identical bytes already held are not written a second time")
+    void identicalBytesAreStoredOnce() {
+        // A different manufacturer publishing the same picture: a new record, but one copy of the
+        // content. Content is addressed by its own hash precisely so this is free.
+        when(contentRepository.existsById(hashOf(ARTWORK))).thenReturn(true);
+
+        StoredImage stored = storage.store("other.jpg", "image/jpeg", ARTWORK, "https://elsewhere/x.jpg", List.of());
+
+        assertThat(stored.newlyStored()).isTrue();
+        verify(imageRepository).save(any());
+        verify(contentRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("losing the race to write content is success, not a failed ingest")
+    void concurrentContentInsertIsNotAFailure() {
+        // Two catalogue runs, or two instances, fetching the same artwork. The collision means the
+        // content is present, which is the outcome wanted.
+        when(contentRepository.save(any())).thenThrow(new DataIntegrityViolationException("duplicate key"));
+
+        StoredImage stored = storage.store("tread.jpg", "image/jpeg", ARTWORK, VENDOR_URI, List.of());
+
+        assertThat(stored.imageId()).isEqualTo(42L);
+    }
+
+    @Test
+    @DisplayName("an empty body is refused, because storing one would stop it being retried")
+    void emptyContentIsRefused() {
+        // An empty body is what a failed download looks like. Stored, it would satisfy every later
+        // "do we already have this?" check and the artwork would silently never arrive.
+        assertThatThrownBy(() -> storage.store("tread.jpg", "image/jpeg", new byte[0], VENDOR_URI, List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("retried");
+
+        verify(imageRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("a direct upload with no origin is stored, and the origin lookup is skipped")
+    void uploadWithoutAnOriginIsAccepted() {
+        StoredImage stored = storage.store("hand-uploaded.png", "image/png", ARTWORK, null, null);
+
+        assertThat(stored.sourceUri()).isNull();
+        assertThat(stored.newlyStored()).isTrue();
+        // No origin to match on, so the lookup is skipped rather than run with a null key.
+        verify(imageRepository, never()).findFirstBySourceUriAndContentHash(any(), any());
+    }
+
+    @Test
+    @DisplayName("the content hash is the SHA-256 of the bytes, so two callers agree on identity")
+    void contentHashIsSha256() {
+        ArgumentCaptor<ImageContentEntity> captor = ArgumentCaptor.forClass(ImageContentEntity.class);
+        storage.store("tread.jpg", "image/jpeg", ARTWORK, VENDOR_URI, List.of());
+        verify(contentRepository).save(captor.capture());
+
+        assertThat(captor.getValue().getContentHash()).isEqualTo(hashOf(ARTWORK));
+        assertThat(captor.getValue().getContent()).isEqualTo(ARTWORK);
+        assertThat(captor.getValue().getCreatedAt()).isEqualTo(NOW);
+    }
+
+    private static String hashOf(byte[] content) {
+        try {
+            return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(content));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -23,7 +23,7 @@ public final class DownstreamPermissionCatalog {
      * {@code PermissionCode.CATALOG_VERSION}.
      * Updated automatically by {@code scripts/generate-permissions.py --sync}.
      */
-    public static final int CATALOG_VERSION = 54;
+    public static final int CATALOG_VERSION = 55;
 
     /**
      * Index-to-authority mapping. Entry at position N is the {@code PERM_*}-prefixed
@@ -583,7 +583,11 @@ public final class DownstreamPermissionCatalog {
         "PERM_supplier:workorderauth:request", // 462
 
         // ── New batch (bits 463–463) ──────────────────────────────────────────
-        "PERM_supplier:workorderauth:review" // 463
+        "PERM_supplier:workorderauth:review", // 463
+
+        // ── New batch (bits 464–465) ──────────────────────────────────────────
+        "PERM_image:image:store", // 464
+        "PERM_supplier:mktcat:import" // 465
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -609,13 +609,18 @@ public enum PermissionCode {
     // ── Supplier (new) ─────────────────────────────────────────────────────────
     SUPPLIER__WORKORDERAUTH__REQUEST(462, "supplier:workorderauth:request"),
     // ── Supplier (new) ─────────────────────────────────────────────────────────
-    SUPPLIER__WORKORDERAUTH__REVIEW(463, "supplier:workorderauth:review");
+    SUPPLIER__WORKORDERAUTH__REVIEW(463, "supplier:workorderauth:review"),
+    // ── Image (new) ────────────────────────────────────────────────────────────
+    IMAGE__IMAGE__STORE(464, "image:image:store"),
+
+    // ── Supplier (new) ─────────────────────────────────────────────────────────
+    SUPPLIER__MKTCAT__IMPORT(465, "supplier:mktcat:import");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 54;
+    public static final int CATALOG_VERSION = 55;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 464;
-    private static final int EXPECTED_CATALOG_VERSION = 54;
+    private static final int EXPECTED_PERMISSION_COUNT = 466;
+    private static final int EXPECTED_CATALOG_VERSION = 55;
 
     // -------------------------------------------------------------------------
     // AC-1: Catalog size — EXPECTED_PERMISSION_COUNT entries

--- a/pos-supplier/openapi.yaml
+++ b/pos-supplier/openapi.yaml
@@ -30,6 +30,8 @@ tags:
   description: Read the supplier exchange-audit trail. Metadata is free to browse; reading stored payload content requires the same permission and is itself recorded.
 - name: Supplier Stock Inquiry
   description: 'Ask a vendor, live, what stock it holds for a receiving location. Vendor-side failure is reported as a status on a 200 response, never as an error status: callers are expected to degrade and render without live stock rather than fail their own flow.'
+- name: Supplier Marketing Catalog
+  description: Manufacturer marketing enrichment (MKCAT C1.2)
 paths:
   /v1/supplier/admin/profiles/{vendorProfileId}:
     get:
@@ -963,6 +965,62 @@ paths:
       - bearerAuth: []
       x-required-permissions:
       - supplier:stock:inquire
+  /v1/supplier/mktcat/{supplierRef}/imports:
+    post:
+      tags:
+      - Supplier Marketing Catalog
+      summary: Import The Marketing Catalog
+      description: 'Reads the manufacturer marketing catalogue and publishes enrichment for every tread design variant whose content has changed since the last run.
+
+        Use this tool to bring a newly configured catalogue in without waiting for its first scheduled sweep, or after fixing a configuration problem; do not use it to force republication of unchanged content, because publication is decided by content and an unchanged variant emits nothing however often it is imported.
+
+        Preconditions: the vendor profile must be enabled and have a marketing-catalogue binding configured.
+
+        Required inputs: supplierRef path parameter.
+
+        Emits a SUPPLIER_MKTCAT_IMPORT event, and for each changed variant publishes supplier.catalog.updated for the catalog domain to attach.
+
+        Returns 200 with how many variants were seen, published and skipped; 404 when the vendor profile is unknown; 409 when the profile is disabled or has no marketing-catalogue binding; and 422 when the catalogue could not be read at all.
+
+        '
+      operationId: importMarketingCatalog
+      parameters:
+      - name: supplierRef
+        in: path
+        description: Vendor profile alias
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: What the import saw and published
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Vendor profile unknown
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: Vendor profile disabled, or no marketing-catalogue binding configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '422':
+          description: The catalogue could not be read
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - supplier:mktcat:import
+      x-required-permissions:
+      - supplier:mktcat:import
   /v1/supplier/invoices/{supplierRef}/fetches:
     post:
       tags:
@@ -2073,6 +2131,60 @@ paths:
       - bearerAuth: []
       x-required-permissions:
       - supplier:transmission:read
+  /v1/supplier/mktcat/{supplierRef}/variants:
+    get:
+      tags:
+      - Supplier Marketing Catalog
+      summary: List Staged Marketing Enrichment
+      description: 'Lists the tread design variants a marketing catalogue last sent, most recently seen first, including which of them are still missing artwork.
+
+        Use this tool when a product''s marketing copy is not what was expected, to see what the catalogue actually published; do not read this as catalog content, because nothing here has been attached to a product and a variant may match no product at all.
+
+        Preconditions: none.
+
+        Required inputs: supplierRef path parameter; limit defaults to 100.
+
+        Emits a SUPPLIER_MKTCAT_VARIANT_LIST event.
+
+        Returns 200 with the staged variants, which is an empty list when the catalogue has never been imported, and 404 when the vendor profile is unknown.
+
+        '
+      operationId: listMarketingCatalogVariants
+      parameters:
+      - name: supplierRef
+        in: path
+        description: Vendor profile alias
+        required: true
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: Maximum rows to return
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 100
+      responses:
+        '200':
+          description: Staged enrichment for this catalogue
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MarketingEnrichmentView'
+        '404':
+          description: Vendor profile unknown
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - supplier:mktcat:import
+      x-required-permissions:
+      - supplier:mktcat:import
   /v1/supplier/fleet/{supplierRef}/vehicles/{vehicleIdent}:
     get:
       tags:
@@ -3564,6 +3676,32 @@ components:
         failureDetail:
           type: string
           description: Operator-facing failure summary for a failed import.
+    MarketingEnrichmentView:
+      type: object
+      properties:
+        vendorVariantId:
+          type: string
+        supplierRef:
+          type: string
+        brand:
+          type: string
+        treadDesign:
+          type: string
+        productName:
+          type: string
+        seasonality:
+          type: string
+        unresolvedImages:
+          type: boolean
+        firstSeenAt:
+          type: string
+          format: date-time
+        lastSeenAt:
+          type: string
+          format: date-time
+        lastPublishedAt:
+          type: string
+          format: date-time
     FleetVehicle:
       type: object
       properties:

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelc12/EdiwheelC12MktCatCodec.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelc12/EdiwheelC12MktCatCodec.java
@@ -1,0 +1,336 @@
+package com.positivity.supplier.internal.adapter.ediwheelc12;
+
+import com.positivity.supplier.internal.domain.model.MarketingVariant;
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.spi.SupplierAdapterCodec;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * EDIWheel C1.2 MKCAT marketing catalogue codec (CAP-324 #1230).
+ *
+ * <h2>Four reads make one variant</h2>
+ *
+ * The catalogue splits a tread design variant across separate resources: a list, a detail, its
+ * images and its language-dependent data. This codec builds and decodes each; assembling them into
+ * one enrichment is the importer's job, because the assembly involves fetching artwork and that is
+ * I/O a codec must not do (ADR-0051 §5).
+ *
+ * <h2>An unreadable catalogue is not an empty one</h2>
+ *
+ * Every decode raises rather than returning an empty list. The importer diffs what it fetched
+ * against what it holds, so "the vendor published nothing" and "we could not read the response"
+ * would otherwise reach the same conclusion — that every variant previously held has been withdrawn.
+ */
+@Component
+@RequiredArgsConstructor
+public class EdiwheelC12MktCatCodec implements SupplierAdapterCodec {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @NonNull
+    public SupplierCapability capability() {
+        return SupplierCapability.MARKETING_CATALOG;
+    }
+
+    @Override
+    @NonNull
+    public ProtocolFamily family() {
+        return ProtocolFamily.EDIWHEEL_JSON;
+    }
+
+    @Override
+    @NonNull
+    public ProtocolVersion version() {
+        return ProtocolVersion.C1_2;
+    }
+
+    /** Lists every tread design variant the catalogue publishes. */
+    @NonNull
+    public SupplierRequestSpec buildVariantListRequest() {
+        return new SupplierRequestSpec("GET", "/treadDesignVariants/", Map.of(), null, null, "application/json", true);
+    }
+
+    /** Reads one variant's detail. */
+    @NonNull
+    public SupplierRequestSpec buildVariantDetailRequest(@NonNull String variantId) {
+        return new SupplierRequestSpec(
+                "GET",
+                "/treadDesignVariants/" + encode(variantId) + "/",
+                Map.of(),
+                null,
+                null,
+                "application/json",
+                true);
+    }
+
+    /** Reads one variant's artwork listing. */
+    @NonNull
+    public SupplierRequestSpec buildVariantImagesRequest(@NonNull String variantId) {
+        return new SupplierRequestSpec(
+                "GET",
+                "/treadDesignVariants/" + encode(variantId) + "/images",
+                Map.of(),
+                null,
+                null,
+                "application/json",
+                true);
+    }
+
+    /** Reads one variant's language-dependent marketing copy. */
+    @NonNull
+    public SupplierRequestSpec buildVariantLanguageDataRequest(@NonNull String variantId) {
+        return new SupplierRequestSpec(
+                "GET",
+                "/treadDesignVariants/" + encode(variantId) + "/languageDependentData",
+                Map.of(),
+                null,
+                null,
+                "application/json",
+                true);
+    }
+
+    /**
+     * Subscribes to catalogue change notifications.
+     *
+     * <p>Not idempotent: the catalogue records a subscription per call, so a blind re-send after an
+     * ambiguous failure risks a second one and therefore duplicate callbacks. The subscription state
+     * is tracked on this side and reconciled rather than re-sent.
+     */
+    @NonNull
+    public SupplierRequestSpec buildSubscribeRequest(@NonNull String callbackUrl, @NonNull String event) {
+        Map<String, String> query = new LinkedHashMap<>();
+        query.put("callbackUrl", callbackUrl);
+        query.put("event", event);
+        return new SupplierRequestSpec(
+                "POST", "/treadDesignVariants/subscribe/", query, "{}", "application/json", "application/json", false);
+    }
+
+    /** Cancels a change subscription. */
+    @NonNull
+    public SupplierRequestSpec buildUnsubscribeRequest(@NonNull String callbackUrl, @NonNull String event) {
+        Map<String, String> query = new LinkedHashMap<>();
+        query.put("callbackUrl", callbackUrl);
+        query.put("event", event);
+        return new SupplierRequestSpec(
+                "DELETE", "/treadDesignVariants/subscribe/", query, null, null, "application/json", true);
+    }
+
+    /** Lists supplier master data. */
+    @NonNull
+    public SupplierRequestSpec buildSupplierListRequest() {
+        return new SupplierRequestSpec("GET", "/suppliers/", Map.of(), null, null, "application/json", true);
+    }
+
+    /**
+     * Decodes the variant list into the catalogue's own identifiers.
+     *
+     * @return every variant id the catalogue published, in the order it published them
+     * @throws MktCatDecodeException when the body is not a readable variant list
+     */
+    @NonNull
+    public List<String> decodeVariantIds(@Nullable String body) {
+        List<MktCatWire.VariantListEntry> entries =
+                readList(body, new TypeReference<List<MktCatWire.VariantListEntry>>() {}, "tread design variant list");
+        List<String> ids = new ArrayList<>(entries.size());
+        for (MktCatWire.VariantListEntry entry : entries) {
+            if (entry.TreadDesignVariant() != null
+                    && !entry.TreadDesignVariant().isBlank()) {
+                ids.add(entry.TreadDesignVariant().trim());
+            }
+        }
+        return List.copyOf(ids);
+    }
+
+    /**
+     * Assembles one variant from its detail, images and language data.
+     *
+     * @param variantId       the catalogue id being assembled, carried through rather than taken
+     *                        from the response: a detail body that echoes a different id is a vendor
+     *                        defect, and adopting it would attach this variant's copy to another
+     * @param detailBody      body of the detail read
+     * @param imagesBody      body of the images read; may be absent when the variant has none
+     * @param languageBody    body of the language-data read; may be absent
+     * @throws MktCatDecodeException when the detail cannot be read
+     */
+    @NonNull
+    public MarketingVariant decodeVariant(
+            @NonNull String variantId,
+            @Nullable String detailBody,
+            @Nullable String imagesBody,
+            @Nullable String languageBody) {
+        MktCatWire.VariantDetail detail = read(detailBody, MktCatWire.VariantDetail.class, "tread design variant");
+
+        return new MarketingVariant(
+                variantId,
+                trimToNull(detail.Brand()),
+                trimToNull(detail.TreadDesign1()),
+                trimToNull(detail.TreadDesign2()),
+                trimToNull(detail.ProductName()),
+                trimToNull(detail.VehicleType()),
+                trimToNull(detail.Seasonality()),
+                decodeTexts(languageBody),
+                decodeImageRefs(imagesBody, languageBody));
+    }
+
+    /**
+     * Reads marketing copy per language.
+     *
+     * <p>An absent or unreadable language body yields no texts rather than raising. Marketing copy
+     * is the enrichment's most replaceable part: a variant with artwork and no description is still
+     * worth publishing, and failing the whole import over it would lose the rest.
+     */
+    @NonNull
+    private List<MarketingVariant.MarketingText> decodeTexts(@Nullable String languageBody) {
+        if (languageBody == null || languageBody.isBlank()) {
+            return List.of();
+        }
+        List<MktCatWire.LanguageEntry> entries;
+        try {
+            entries = objectMapper.readValue(languageBody, new TypeReference<List<MktCatWire.LanguageEntry>>() {});
+        } catch (RuntimeException e) {
+            return List.of();
+        }
+        List<MarketingVariant.MarketingText> texts = new ArrayList<>();
+        for (MktCatWire.LanguageEntry entry : entries) {
+            String language = trimToNull(entry.LanguageID() != null ? entry.LanguageID() : entry.Language());
+            if (language == null) {
+                // Copy nobody can say the language of cannot be shown to anybody: a shop would have
+                // no way to know whether it is reading German marketing text to a French customer.
+                continue;
+            }
+            texts.add(new MarketingVariant.MarketingText(
+                    language,
+                    trimToNull(entry.ProductName()),
+                    trimToNull(entry.Description()),
+                    trimToNull(entry.FootNotes())));
+        }
+        return List.copyOf(texts);
+    }
+
+    /**
+     * Collects every artwork URI the catalogue offers for a variant.
+     *
+     * <p>From both places it publishes them: the variant's own images resource, and the additional
+     * graphics attached to language-dependent data. Reading only the first would silently drop the
+     * per-market artwork, which is exactly the material a marketing catalogue exists to supply.
+     */
+    @NonNull
+    private List<MarketingVariant.MarketingImageRef> decodeImageRefs(
+            @Nullable String imagesBody, @Nullable String languageBody) {
+        Map<String, MarketingVariant.MarketingImageRef> byUri = new LinkedHashMap<>();
+
+        if (imagesBody != null && !imagesBody.isBlank()) {
+            try {
+                for (MktCatWire.ImageEntry entry : objectMapper.<List<MktCatWire.ImageEntry>>readValue(
+                        imagesBody, new TypeReference<List<MktCatWire.ImageEntry>>() {})) {
+                    String uri = trimToNull(entry.URI());
+                    if (uri != null) {
+                        byUri.putIfAbsent(
+                                uri, new MarketingVariant.MarketingImageRef(trimToNull(entry.ImageType()), uri));
+                    }
+                }
+            } catch (RuntimeException e) {
+                throw new MktCatDecodeException("variant image list was not readable JSON: " + e.getMessage(), e);
+            }
+        }
+
+        if (languageBody != null && !languageBody.isBlank()) {
+            try {
+                for (MktCatWire.LanguageEntry entry : objectMapper.<List<MktCatWire.LanguageEntry>>readValue(
+                        languageBody, new TypeReference<List<MktCatWire.LanguageEntry>>() {})) {
+                    if (entry.AdditionalGraphic() == null) {
+                        continue;
+                    }
+                    for (MktCatWire.AdditionalGraphic graphic : entry.AdditionalGraphic()) {
+                        String uri = trimToNull(graphic.URI());
+                        if (uri != null) {
+                            byUri.putIfAbsent(
+                                    uri, new MarketingVariant.MarketingImageRef(trimToNull(graphic.Graphic()), uri));
+                        }
+                    }
+                }
+            } catch (RuntimeException e) {
+                // The language body is optional and already tolerated above; a graphic list that
+                // will not parse costs those graphics, not the variant.
+                return List.copyOf(byUri.values());
+            }
+        }
+
+        // Deduplicated by URI: the same picture is routinely listed against several languages, and
+        // fetching it once per language would multiply every ingest by the number of markets.
+        return List.copyOf(byUri.values());
+    }
+
+    /** Decodes supplier master data into the catalogue's party identifiers and names. */
+    @NonNull
+    public Map<String, String> decodeSuppliers(@Nullable String body) {
+        List<MktCatWire.SupplierEntry> entries =
+                readList(body, new TypeReference<List<MktCatWire.SupplierEntry>>() {}, "supplier list");
+        Map<String, String> byPartyId = new LinkedHashMap<>();
+        for (MktCatWire.SupplierEntry entry : entries) {
+            String partyId = trimToNull(entry.PartyID());
+            if (partyId == null) {
+                continue;
+            }
+            String name = null;
+            if (entry.Name() != null && !entry.Name().isEmpty()) {
+                name = trimToNull(entry.Name().getFirst().Name());
+            }
+            byPartyId.put(partyId, name == null ? partyId : name);
+        }
+        return Map.copyOf(byPartyId);
+    }
+
+    @NonNull
+    private <T> T read(@Nullable String body, @NonNull Class<T> type, @NonNull String what) {
+        if (body == null || body.isBlank()) {
+            throw new MktCatDecodeException(what + " response body was empty");
+        }
+        try {
+            return objectMapper.readValue(body, type);
+        } catch (RuntimeException e) {
+            throw new MktCatDecodeException(what + " response was not readable JSON: " + e.getMessage(), e);
+        }
+    }
+
+    @NonNull
+    private <T> List<T> readList(@Nullable String body, @NonNull TypeReference<List<T>> type, @NonNull String what) {
+        if (body == null || body.isBlank()) {
+            throw new MktCatDecodeException(what + " response body was empty");
+        }
+        try {
+            return objectMapper.readValue(body, type);
+        } catch (RuntimeException e) {
+            throw new MktCatDecodeException(what + " response was not readable JSON: " + e.getMessage(), e);
+        }
+    }
+
+    @Nullable
+    private static String trimToNull(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    /** Percent-encodes a path segment so a catalogue id cannot alter the path it sits in. */
+    @NonNull
+    private static String encode(@NonNull String segment) {
+        return java.net.URLEncoder.encode(segment, java.nio.charset.StandardCharsets.UTF_8)
+                .replace("+", "%20");
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelc12/MktCatDecodeException.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelc12/MktCatDecodeException.java
@@ -1,0 +1,25 @@
+package com.positivity.supplier.internal.adapter.ediwheelc12;
+
+import java.io.Serial;
+
+/**
+ * A C1.2 MKCAT response could not be read (CAP-324 #1230).
+ *
+ * <p>Raised rather than returned as an empty catalogue. An empty result and an unreadable one lead
+ * to opposite conclusions: the first means the vendor published nothing, the second means we cannot
+ * tell — and a diffing importer that treated the second as the first would conclude every variant it
+ * previously held had been withdrawn.
+ */
+public class MktCatDecodeException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public MktCatDecodeException(String message) {
+        super(message);
+    }
+
+    public MktCatDecodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelc12/MktCatWire.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelc12/MktCatWire.java
@@ -1,0 +1,88 @@
+package com.positivity.supplier.internal.adapter.ediwheelc12;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * C1.2 MKCAT wire records, modelled literally (ADR-0051 §2).
+ *
+ * <p>The spec's element names are upper-camel and its values are frequently wrapped one level deeper
+ * than a reader expects — {@code Name} is a list of language-tagged objects, not a string. These
+ * records reproduce that rather than tidying it, so the tidying happens in one place with a name on
+ * it.
+ *
+ * <p>Unknown properties are ignored throughout. The catalogue is published centrally to many
+ * consumers and gains fields on the standards body's schedule, not ours; a strict reader would fail
+ * a whole catalogue import over an addition that concerned somebody else.
+ */
+final class MktCatWire {
+
+    private MktCatWire() {}
+
+    /** An entry in {@code GET /treadDesignVariants/}. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record VariantListEntry(
+            @Nullable String TreadDesignVariant,
+            @Nullable String TreadDesign1,
+            @Nullable String TreadDesign2,
+            @Nullable String ProductName) {}
+
+    /** {@code GET /treadDesignVariants/{ID}/}. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record VariantDetail(
+            @Nullable String TreadDesignVariant,
+            @Nullable String DateCreated,
+            @Nullable String DateLastModified,
+            @Nullable String TreadDesign1,
+            @Nullable String TreadDesign2,
+            @Nullable String ProductName,
+            @Nullable String Brand,
+            @Nullable String VehicleType,
+            @Nullable String Seasonality,
+            @Nullable String MainFunction,
+            @Nullable String TreadPattern) {}
+
+    /**
+     * An image entry from {@code GET /treadDesignVariants/{ID}/images}.
+     *
+     * <p>{@code URI} is where the bytes are, and is the only field this integration acts on: the
+     * artwork is fetched and stored, and the URI is kept as provenance rather than republished as a
+     * render source.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record ImageEntry(
+            @Nullable String ImageType,
+            @Nullable String DefinitionHeight,
+            @Nullable String DefinitionWidth,
+            @Nullable String Resolution,
+            @Nullable String FileType,
+            @Nullable String FileName,
+            @Nullable String URI) {}
+
+    /** An entry from {@code GET /treadDesignVariants/{ID}/languageDependentData}. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record LanguageEntry(
+            @Nullable String LanguageID,
+            @Nullable String Language,
+            @Nullable String ProductName,
+            @Nullable String Description,
+            @Nullable String FootNotes,
+            @Nullable List<AdditionalGraphic> AdditionalGraphic) {}
+
+    /** Extra artwork attached to language-dependent data rather than to the variant. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record AdditionalGraphic(
+            @Nullable String Graphic, @Nullable String URI) {}
+
+    /** An entry from {@code GET /suppliers/}. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record SupplierEntry(
+            @Nullable String PartyID,
+            @Nullable String AgencyCode,
+            @Nullable List<NameEntry> Name) {}
+
+    /** A language-tagged name. The catalogue wraps names one level deeper than a reader expects. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record NameEntry(@Nullable String LanguageID, @Nullable String Name) {}
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelc12/package-info.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelc12/package-info.java
@@ -1,0 +1,26 @@
+/**
+ * EDIWheel C1.2 JSON adapter package (ADR-0051 §2) — the {@code ediwheel.net} MKCAT API.
+ *
+ * <h2>A third wire generation</h2>
+ *
+ * The A2.x norms are XML, the B-series are report-style JSON and XML, C1.x is the current XML
+ * guideline. C1.2 is the resource-and-message JSON API that {@code ediwheel.net} publishes centrally
+ * and that EDIWheel manufacturers are expected to converge on. It is not a vendor's own API: the
+ * marketing catalogue is served by the standards body, so one integration covers every participating
+ * manufacturer rather than one per vendor.
+ *
+ * <p>That is also why this package holds no per-vendor quirks. If a manufacturer's marketing data
+ * needed special handling here, the value of a central catalogue would already have been lost.
+ *
+ * <h2>What C1.2 describes, and what it does not</h2>
+ *
+ * Tread <em>designs</em>, not articles. A design spans many sizes, each with its own EAN, and MKCAT
+ * carries none of them — so nothing decoded here can be matched to a product by article code. The
+ * identifiers available are brand, design names and the catalogue's own variant id. Whether they
+ * resolve to anything is the consuming domain's problem, and one that no amount of care in this
+ * package can solve.
+ *
+ * <p>Wire records are package-private so a catalogue type cannot escape into the domain, an event
+ * payload or an API contract. Codecs convert to canonical models and perform no I/O (ADR-0051 §5).
+ */
+package com.positivity.supplier.internal.adapter.ediwheelc12;

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/client/ImageStoreClient.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/client/ImageStoreClient.java
@@ -1,0 +1,104 @@
+package com.positivity.supplier.internal.client;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Puts fetched artwork into pos-image (CAP-324 #1257).
+ *
+ * <h2>Why the bytes are copied rather than linked</h2>
+ *
+ * Publishing a manufacturer's own URL as the render source would put a third party's uptime and rate
+ * limits in front of every product page view, and leave the platform nothing to cache or optimise.
+ * So MKCAT ingestion fetches the bytes and hands them here; the vendor URL travels on as provenance
+ * only.
+ *
+ * <h2>Failure returns empty rather than throwing</h2>
+ *
+ * A missing picture must not cost a product its marketing copy. The caller records the image as
+ * unresolved, publishes everything else, and retries the image on its own — which is the behaviour
+ * #1257 asks for, and it only works if a failure here is an answer rather than an exception.
+ *
+ * <p>pos-image is a Utility module under ADR-0044 and may be called directly.
+ */
+@Slf4j
+@Component
+public class ImageStoreClient {
+
+    /** The authority pos-image requires of a store. */
+    private static final String IMAGE_STORE_AUTHORITY = "image:image:store";
+
+    private static final String SERVICE_USER = "pos-supplier-service";
+
+    private final RestClient restClient;
+    private final String basePath;
+
+    public ImageStoreClient(
+            @Qualifier("loadBalancedRestClientBuilder") RestClient.Builder restClientBuilder,
+            @Value("${pos.image.service-id:image}") String serviceId,
+            @Value("${pos.image.base-path:/v1/images}") String basePath) {
+        this.basePath = basePath;
+        this.restClient = restClientBuilder.baseUrl("http://" + serviceId).build();
+    }
+
+    /**
+     * Stores image bytes and returns the reference, or empty when it could not be done.
+     *
+     * @param filename    name to store it under
+     * @param contentType MIME type as the vendor served it
+     * @param content     the fetched bytes
+     * @param sourceUri   where they came from; kept as provenance by pos-image
+     * @return the stored reference, or empty when pos-image refused or could not be reached
+     */
+    @NonNull
+    public Optional<StoredImageRef> store(
+            @NonNull String filename, @NonNull String contentType, byte[] content, @NonNull String sourceUri) {
+        try {
+            StoredImageRef stored = restClient
+                    .post()
+                    .uri(basePath)
+                    // Authorised like any other caller. Without these the store is rejected and
+                    // every image silently becomes unresolved, which looks exactly like a vendor
+                    // serving broken artwork.
+                    .header("X-User", SERVICE_USER)
+                    .header("X-Authorities", IMAGE_STORE_AUTHORITY)
+                    .body(Map.of(
+                            "filename",
+                            filename,
+                            "contentType",
+                            contentType,
+                            "content",
+                            Base64.getEncoder().encodeToString(content),
+                            "sourceUri",
+                            sourceUri,
+                            "context",
+                            List.of("mkcat")))
+                    .retrieve()
+                    .body(StoredImageRef.class);
+            return Optional.ofNullable(stored);
+        } catch (Exception e) {
+            // Deliberately broad and deliberately not rethrown: see the class note. One picture
+            // must not cost a product its entire marketing record.
+            log.warn("Storing image from {} failed: {}", sourceUri, e.toString());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * What pos-image says it stored.
+     *
+     * @param imageId     pos-image's identifier
+     * @param contentHash SHA-256 of the stored bytes
+     * @param newlyStored whether that call stored them or found them already held
+     */
+    public record StoredImageRef(long imageId, @Nullable String contentHash, boolean newlyStored) {}
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/config/RestClientConfig.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/config/RestClientConfig.java
@@ -2,6 +2,7 @@ package com.positivity.supplier.internal.config;
 
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -46,5 +47,22 @@ public class RestClientConfig {
         factory.setConnectTimeout(Duration.ofMillis(connectTimeoutMs));
         factory.setReadTimeout(Duration.ofMillis(readTimeoutMs));
         return RestClient.builder().requestFactory(factory);
+    }
+
+    /**
+     * Load-balanced builder resolving Eureka service ids for sibling-service clients.
+     *
+     * <p>Separate from the primary builder because that one carries this module's own connect and
+     * read timeouts, tuned for platform registrations. A call to a sibling service is a different
+     * kind of call — it goes through Eureka, and its timeouts belong to the client that makes it —
+     * so sharing one builder would silently apply the wrong deadline to whichever came second.
+     *
+     * <p>Added for the pos-image client (CAP-324 #1257): MKCAT artwork is stored in pos-image rather
+     * than rendered from a manufacturer's own server.
+     */
+    @Bean
+    @LoadBalanced
+    public RestClient.Builder loadBalancedRestClientBuilder() {
+        return RestClient.builder();
     }
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/config/SupplierEventTypes.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/config/SupplierEventTypes.java
@@ -134,6 +134,13 @@ public final class SupplierEventTypes {
                 EventTypeRegistration.fastRead(
                                 "SUPPLIER_WORKORDER_AUTHORIZATION_REVIEW_LIST",
                                 "List fleet authorizations and completions waiting on a person")
+                        .build(),
+                // Marketing catalogue (CAP-324). A full catalogue read, not a local query: the
+                // threshold that matters is the standards body's, and it serves every consumer.
+                EventTypeRegistration.write("SUPPLIER_MKTCAT_IMPORT", "Run a marketing-catalogue import on demand")
+                        .build(),
+                EventTypeRegistration.fastRead(
+                                "SUPPLIER_MKTCAT_VARIANT_LIST", "List staged marketing-catalogue enrichment")
                         .build());
     }
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierMarketingCatalogController.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/controller/SupplierMarketingCatalogController.java
@@ -1,0 +1,132 @@
+package com.positivity.supplier.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.shared.error.ApiError;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.mktcat.service.MktCatImporter;
+import com.positivity.supplier.internal.mktcat.service.MktCatStagedReader;
+import com.positivity.supplier.internal.security.SupplierPermissions;
+import com.positivity.supplier.service.model.MarketingEnrichmentView;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Marketing catalogue (MKCAT) enrichment (CAP-324 #1230, #1257).
+ *
+ * <p>The scheduled sweep covers the ordinary case. These exist for the two moments it does not:
+ * bringing a newly configured catalogue in without waiting for its first cron firing, and looking at
+ * what the catalogue actually sent when a product's marketing copy is not what somebody expected.
+ */
+@RestController
+@RequestMapping("/v1/supplier/mktcat")
+@RequiredArgsConstructor
+@Tag(name = "Supplier Marketing Catalog", description = "Manufacturer marketing enrichment (MKCAT C1.2)")
+public class SupplierMarketingCatalogController {
+
+    private final MktCatImporter importer;
+    private final MktCatStagedReader stagedReader;
+
+    @PostMapping("/{supplierRef}/imports")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"supplier:mktcat:import"})
+    @PreAuthorize("hasAuthority('" + SupplierPermissions.MARKETING_CATALOG_IMPORT + "')")
+    @EmitEvent(id = "SUPPLIER_MKTCAT_IMPORT", apiVersion = "1")
+    @Operation(
+            operationId = "importMarketingCatalog",
+            summary = "Import The Marketing Catalog",
+            description = """
+                    Reads the manufacturer marketing catalogue and publishes enrichment for every tread design \
+                    variant whose content has changed since the last run.
+                    Use this tool to bring a newly configured catalogue in without waiting for its first \
+                    scheduled sweep, or after fixing a configuration problem; do not use it to force \
+                    republication of unchanged content, because publication is decided by content and an \
+                    unchanged variant emits nothing however often it is imported.
+                    Preconditions: the vendor profile must be enabled and have a marketing-catalogue binding \
+                    configured.
+                    Required inputs: supplierRef path parameter.
+                    Emits a SUPPLIER_MKTCAT_IMPORT event, and for each changed variant publishes \
+                    supplier.catalog.updated for the catalog domain to attach.
+                    Returns 200 with how many variants were seen, published and skipped; 404 when the vendor \
+                    profile is unknown; 409 when the profile is disabled or has no marketing-catalogue binding; \
+                    and 422 when the catalogue could not be read at all.
+                    """,
+            tags = {"Supplier Marketing Catalog"})
+    @ApiResponse(responseCode = "200", description = "What the import saw and published")
+    @ApiResponse(
+            responseCode = "404",
+            description = "Vendor profile unknown",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "Vendor profile disabled, or no marketing-catalogue binding configured",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "422",
+            description = "The catalogue could not be read",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<Map<String, Object>> importMarketingCatalog(
+            @Parameter(description = "Vendor profile alias", required = true) @PathVariable String supplierRef) {
+        MktCatImporter.ImportOutcome outcome = importer.importAll(new SupplierRef(supplierRef));
+        // Three numbers because they answer different questions: seen says whether the catalogue had
+        // anything, published how much of it changed, and skipped whether anything was unreadable.
+        // An import reporting 4000 seen and 0 published is working exactly as intended.
+        return ResponseEntity.ok(Map.of(
+                "supplierRef",
+                supplierRef,
+                "seen",
+                outcome.seen(),
+                "published",
+                outcome.published(),
+                "skipped",
+                outcome.skipped()));
+    }
+
+    @GetMapping("/{supplierRef}/variants")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"supplier:mktcat:import"})
+    @PreAuthorize("hasAuthority('" + SupplierPermissions.MARKETING_CATALOG_IMPORT + "')")
+    @EmitEvent(id = "SUPPLIER_MKTCAT_VARIANT_LIST", apiVersion = "1")
+    @Operation(
+            operationId = "listMarketingCatalogVariants",
+            summary = "List Staged Marketing Enrichment",
+            description = """
+                    Lists the tread design variants a marketing catalogue last sent, most recently seen first, \
+                    including which of them are still missing artwork.
+                    Use this tool when a product's marketing copy is not what was expected, to see what the \
+                    catalogue actually published; do not read this as catalog content, because nothing here has \
+                    been attached to a product and a variant may match no product at all.
+                    Preconditions: none.
+                    Required inputs: supplierRef path parameter; limit defaults to 100.
+                    Emits a SUPPLIER_MKTCAT_VARIANT_LIST event.
+                    Returns 200 with the staged variants, which is an empty list when the catalogue has never \
+                    been imported, and 404 when the vendor profile is unknown.
+                    """,
+            tags = {"Supplier Marketing Catalog"})
+    @ApiResponse(responseCode = "200", description = "Staged enrichment for this catalogue")
+    @ApiResponse(
+            responseCode = "404",
+            description = "Vendor profile unknown",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<List<MarketingEnrichmentView>> listMarketingCatalogVariants(
+            @Parameter(description = "Vendor profile alias", required = true) @PathVariable String supplierRef,
+            @Parameter(description = "Maximum rows to return") @RequestParam(defaultValue = "100") int limit) {
+        return ResponseEntity.ok(stagedReader.findStaged(new SupplierRef(supplierRef), limit));
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/MarketingVariant.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/MarketingVariant.java
@@ -1,0 +1,64 @@
+package com.positivity.supplier.internal.domain.model;
+
+import java.util.List;
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A manufacturer's marketing view of one tread design variant (CAP-324 #1230).
+ *
+ * <p>Everything here is as the catalogue states it. Seasonality is not mapped to a Durion
+ * vocabulary, language codes are not normalised to locales, and vehicle type is not translated —
+ * each of those is a catalogue decision, and making it here would bake one reading of a vendor's
+ * words into the integration layer where nobody would find it again.
+ *
+ * @param vendorVariantId the catalogue's own variant identifier
+ * @param brand           as stated
+ * @param treadDesign     primary design name as stated
+ * @param treadDesign2    secondary design name, where used
+ * @param productName     the vendor's product name, where given
+ * @param vehicleType     as stated
+ * @param seasonality     as stated
+ * @param texts           marketing copy per language
+ * @param imageUris       where the catalogue publishes artwork, paired with the vendor's own type
+ *                        label. These are fetch targets, not render sources
+ */
+public record MarketingVariant(
+        @NonNull String vendorVariantId,
+        @Nullable String brand,
+        @Nullable String treadDesign,
+        @Nullable String treadDesign2,
+        @Nullable String productName,
+        @Nullable String vehicleType,
+        @Nullable String seasonality,
+        @NonNull List<MarketingText> texts,
+        @NonNull List<MarketingImageRef> imageUris) {
+
+    public MarketingVariant {
+        Objects.requireNonNull(vendorVariantId, "vendorVariantId must not be null");
+        Objects.requireNonNull(texts, "texts must not be null");
+        Objects.requireNonNull(imageUris, "imageUris must not be null");
+        texts = List.copyOf(texts);
+        imageUris = List.copyOf(imageUris);
+    }
+
+    /** Marketing copy in one language, as published. */
+    public record MarketingText(
+            @NonNull String languageCode,
+            @Nullable String name,
+            @Nullable String description,
+            @Nullable String footNotes) {
+        public MarketingText {
+            Objects.requireNonNull(languageCode, "languageCode must not be null");
+        }
+    }
+
+    /** Where a piece of artwork is published, and what the vendor calls it. */
+    public record MarketingImageRef(
+            @Nullable String imageType, @NonNull String uri) {
+        public MarketingImageRef {
+            Objects.requireNonNull(uri, "uri must not be null");
+        }
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/SupplierMktCatVariantEntity.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/entity/SupplierMktCatVariantEntity.java
@@ -1,0 +1,119 @@
+package com.positivity.supplier.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * A tread design variant as the MKCAT catalogue last published it (CAP-324 #1230).
+ *
+ * <h2>Staging, not catalogue</h2>
+ *
+ * Nothing here is product data. pos-catalog owns what a product is; this records what a manufacturer
+ * says about how it markets a design. Keeping the two apart is what stops a supplier fact from being
+ * able to redefine a product (ADR-0044 R1).
+ *
+ * <h2>The content hash is what makes diffing possible</h2>
+ *
+ * Without it, deciding whether a variant changed since the last run would mean comparing every
+ * field, every text and every image reference of every variant on every run — and a catalogue that
+ * republishes itself nightly would be indistinguishable from one that changes nightly. The hash
+ * covers everything that gets published, so an unchanged republication is recognised and no event
+ * goes out.
+ */
+@Entity
+@Table(name = "supplier_mktcat_variant")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SupplierMktCatVariantEntity {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "supplier_mktcat_variant_id")
+    private UUID supplierMktCatVariantId;
+
+    @Column(name = "vendor_profile_id", nullable = false)
+    private UUID vendorProfileId;
+
+    @Column(name = "supplier_ref", nullable = false, length = 100)
+    private String supplierRef;
+
+    /** The catalogue's own variant id. A design, not an article — there is no EAN to match on. */
+    @Column(name = "vendor_variant_id", nullable = false, length = 100)
+    private String vendorVariantId;
+
+    @Column(name = "brand", length = 200)
+    private String brand;
+
+    @Column(name = "tread_design", length = 200)
+    private String treadDesign;
+
+    @Column(name = "tread_design_2", length = 200)
+    private String treadDesign2;
+
+    @Column(name = "product_name", length = 300)
+    private String productName;
+
+    @Column(name = "vehicle_type", length = 100)
+    private String vehicleType;
+
+    @Column(name = "seasonality", length = 100)
+    private String seasonality;
+
+    @Column(name = "content_hash", nullable = false, length = 64)
+    private String contentHash;
+
+    /** The published texts, as JSON, so a republication can be rebuilt without re-fetching. */
+    @Column(name = "texts_json", nullable = false, columnDefinition = "TEXT")
+    private String textsJson;
+
+    /** The published image references, as JSON. */
+    @Column(name = "images_json", nullable = false, columnDefinition = "TEXT")
+    private String imagesJson;
+
+    /**
+     * Whether any artwork is still missing.
+     *
+     * <p>A column rather than something derived from {@link #imagesJson} at query time: the retry
+     * runner selects on it, and a scan that parsed JSON per row to find its work would be the one
+     * query guaranteed to get slower as the catalogue grows.
+     */
+    @Column(name = "has_unresolved_images", nullable = false)
+    private boolean hasUnresolvedImages;
+
+    @Column(name = "first_seen_at", nullable = false)
+    private Instant firstSeenAt;
+
+    @Column(name = "last_seen_at", nullable = false)
+    private Instant lastSeenAt;
+
+    @Column(name = "last_published_at")
+    private Instant lastPublishedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/MktCatImportException.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/MktCatImportException.java
@@ -1,0 +1,24 @@
+package com.positivity.supplier.internal.exception;
+
+import java.io.Serial;
+
+/**
+ * A MKCAT import could not proceed (CAP-324 #1230).
+ *
+ * <p>Raised rather than reported as an empty catalogue, because the importer diffs what it fetched
+ * against what it holds: "the catalogue published nothing" and "we could not read it" would
+ * otherwise reach the same conclusion, and that conclusion is that every variant has been withdrawn.
+ */
+public class MktCatImportException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public MktCatImportException(String message) {
+        super(message);
+    }
+
+    public MktCatImportException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/SupplierExceptionHandler.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/exception/SupplierExceptionHandler.java
@@ -110,6 +110,18 @@ public class SupplierExceptionHandler {
      * simply could not be reached or said something unreadable. An operator seeing this should try
      * again or check the vendor's status, not go and edit a profile.
      */
+    /**
+     * A marketing-catalogue import that could not be read.
+     *
+     * <p>422 rather than 502: the request was well-formed and the configuration is fine — the
+     * catalogue could not be reached or answered unreadably. Distinguished from an empty catalogue
+     * on purpose, because an importer that diffs would read "unreadable" as "everything withdrawn".
+     */
+    @ExceptionHandler(MktCatImportException.class)
+    public ResponseEntity<ApiError> handleMktCatImportFailure(MktCatImportException ex, HttpServletRequest request) {
+        return build(HttpStatus.UNPROCESSABLE_ENTITY, "SUPPLIER_MKTCAT_IMPORT_FAILED", ex.getMessage(), request);
+    }
+
     @ExceptionHandler(FleetLookupException.class)
     public ResponseEntity<ApiError> handleFleetLookupFailure(FleetLookupException ex, HttpServletRequest request) {
         return build(HttpStatus.UNPROCESSABLE_ENTITY, "SUPPLIER_FLEET_LOOKUP_FAILED", ex.getMessage(), request);

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatImageFetcher.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatImageFetcher.java
@@ -3,6 +3,8 @@ package com.positivity.supplier.internal.mktcat.service;
 import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentImage;
 import com.positivity.supplier.internal.client.ImageStoreClient;
 import com.positivity.supplier.internal.domain.model.MarketingVariant;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -53,12 +55,22 @@ public class MktCatImageFetcher {
      */
     private final long maxBytes;
 
+    /**
+     * Deadline for the whole exchange, not just the connect.
+     *
+     * <p>A connect timeout alone leaves a server free to accept the connection and then dribble
+     * bytes indefinitely, parking an ingest thread on a host nobody controls -- and the catalogue
+     * names those hosts, so they are not even a vendor we have a relationship with.
+     */
+    private final Duration requestTimeout;
+
     public MktCatImageFetcher(
             ImageStoreClient imageStoreClient,
             @Value("${pos.supplier.mktcat.image-fetch-timeout-ms:15000}") long fetchTimeoutMs,
             @Value("${pos.supplier.mktcat.image-max-bytes:10485760}") long maxBytes) {
         this.imageStoreClient = imageStoreClient;
         this.maxBytes = maxBytes;
+        this.requestTimeout = Duration.ofMillis(fetchTimeoutMs);
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofMillis(fetchTimeoutMs))
                 // Not followed: a redirect from a catalogue asset URL can move the fetch to a host
@@ -88,28 +100,42 @@ public class MktCatImageFetcher {
         byte[] content;
         String contentType;
         try {
-            HttpResponse<byte[]> response = httpClient.send(
-                    HttpRequest.newBuilder(URI.create(ref.uri())).GET().build(),
-                    HttpResponse.BodyHandlers.ofByteArray());
+            HttpResponse<InputStream> response = httpClient.send(
+                    HttpRequest.newBuilder(URI.create(ref.uri()))
+                            .timeout(requestTimeout)
+                            .GET()
+                            .build(),
+                    HttpResponse.BodyHandlers.ofInputStream());
             if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                response.body().close();
                 return unresolved(ref, "HTTP " + response.statusCode());
             }
-            content = response.body();
             contentType = response.headers().firstValue("content-type").orElse("application/octet-stream");
+
+            // The declared length is checked first where a server gives one: refusing before
+            // reading is cheaper than refusing after, and that is the common case for a genuinely
+            // large file.
+            long declared =
+                    response.headers().firstValueAsLong("content-length").orElse(-1L);
+            if (declared > maxBytes) {
+                response.body().close();
+                return unresolved(ref, "declares " + declared + " bytes, over the " + maxBytes + " cap");
+            }
+
+            content = readCapped(response.body());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             return unresolved(ref, "interrupted");
+        } catch (ImageTooLargeException e) {
+            return unresolved(ref, "exceeds " + maxBytes + " bytes");
         } catch (Exception e) {
             return unresolved(ref, e.toString());
         }
 
-        if (content == null || content.length == 0) {
+        if (content.length == 0) {
             // An empty body is a failed download wearing a 200. Storing it would satisfy every
             // later "do we have this?" check and the artwork would never arrive.
             return unresolved(ref, "empty body");
-        }
-        if (content.length > maxBytes) {
-            return unresolved(ref, "exceeds " + maxBytes + " bytes");
         }
 
         Optional<ImageStoreClient.StoredImageRef> stored =
@@ -119,6 +145,46 @@ public class MktCatImageFetcher {
         }
         return new SupplierCatalogEnrichmentImage(
                 ref.imageType(), stored.get().imageId(), stored.get().contentHash(), ref.uri(), false);
+    }
+
+    /**
+     * Reads at most {@link #maxBytes}, stopping rather than finishing.
+     *
+     * <p>A declared content length is a claim, not a guarantee: a server may omit it, understate it,
+     * or stream without one. Buffering the whole body and checking its size afterwards would mean a
+     * response that lies about its length is already in memory by the time the cap is consulted --
+     * which is precisely the case the cap exists for.
+     *
+     * @throws ImageTooLargeException as soon as one byte past the cap is seen, so nothing larger is
+     *     ever held
+     */
+    @NonNull
+    private byte[] readCapped(@NonNull InputStream body) throws IOException {
+        try (body) {
+            java.io.ByteArrayOutputStream buffer = new java.io.ByteArrayOutputStream();
+            byte[] chunk = new byte[8192];
+            long total = 0;
+            int read;
+            while ((read = body.read(chunk)) != -1) {
+                total += read;
+                if (total > maxBytes) {
+                    throw new ImageTooLargeException();
+                }
+                buffer.write(chunk, 0, read);
+            }
+            return buffer.toByteArray();
+        }
+    }
+
+    /** Signals the cap was reached mid-read. Internal control flow; never leaves this class. */
+    private static final class ImageTooLargeException extends RuntimeException {
+
+        @java.io.Serial
+        private static final long serialVersionUID = 1L;
+
+        ImageTooLargeException() {
+            super(null, null, false, false);
+        }
     }
 
     @NonNull

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatImageFetcher.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatImageFetcher.java
@@ -1,0 +1,148 @@
+package com.positivity.supplier.internal.mktcat.service;
+
+import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentImage;
+import com.positivity.supplier.internal.client.ImageStoreClient;
+import com.positivity.supplier.internal.domain.model.MarketingVariant;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Fetches manufacturer artwork and hands it to pos-image (CAP-324 #1257).
+ *
+ * <h2>Why the bytes are copied at all</h2>
+ *
+ * Publishing the catalogue's own image URL as the render source would put a third party in front of
+ * every product page view — its uptime, its rate limits, its decision to move a file — and leave the
+ * platform nothing to cache. So the bytes are fetched once at ingestion and stored.
+ *
+ * <h2>Every failure is an unresolved image, never a lost record</h2>
+ *
+ * A refused connection, a 404, a body that is empty, an image larger than the cap: all of them
+ * produce an unresolved entry rather than an exception. The enrichment publishes with its text and
+ * its other pictures intact, and the missing one is retried. The alternative — failing the variant —
+ * would discard the marketing copy that did arrive because a picture did not.
+ *
+ * <h2>Fetched directly, not through the supplier base client</h2>
+ *
+ * The base client speaks to a configured vendor endpoint with vendor credentials and records an
+ * exchange audit row per call. An image URI is an arbitrary asset URL published inside a document;
+ * sending vendor credentials to it would leak them to whatever host the catalogue happens to name.
+ */
+@Slf4j
+@Component
+public class MktCatImageFetcher {
+
+    private final ImageStoreClient imageStoreClient;
+    private final HttpClient httpClient;
+
+    /**
+     * Largest artwork this will accept.
+     *
+     * <p>Bounded because the URI comes from a document rather than from configuration: without a cap
+     * a mistyped link to a very large file would be pulled into memory and stored.
+     */
+    private final long maxBytes;
+
+    public MktCatImageFetcher(
+            ImageStoreClient imageStoreClient,
+            @Value("${pos.supplier.mktcat.image-fetch-timeout-ms:15000}") long fetchTimeoutMs,
+            @Value("${pos.supplier.mktcat.image-max-bytes:10485760}") long maxBytes) {
+        this.imageStoreClient = imageStoreClient;
+        this.maxBytes = maxBytes;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(fetchTimeoutMs))
+                // Not followed: a redirect from a catalogue asset URL can move the fetch to a host
+                // nobody configured, and this request is made without vendor credentials precisely
+                // so that nothing sensitive travels. Following would undermine both.
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build();
+    }
+
+    /**
+     * Fetches and stores each image, in order.
+     *
+     * @return one entry per input, resolved where the bytes were obtained and unresolved where they
+     *     were not. Never shorter than the input: a dropped entry is a silently lost picture
+     */
+    @NonNull
+    public List<SupplierCatalogEnrichmentImage> fetchAndStore(List<MarketingVariant.@NonNull MarketingImageRef> refs) {
+        List<SupplierCatalogEnrichmentImage> results = new ArrayList<>(refs.size());
+        for (MarketingVariant.MarketingImageRef ref : refs) {
+            results.add(fetchOne(ref));
+        }
+        return List.copyOf(results);
+    }
+
+    @NonNull
+    private SupplierCatalogEnrichmentImage fetchOne(MarketingVariant.@NonNull MarketingImageRef ref) {
+        byte[] content;
+        String contentType;
+        try {
+            HttpResponse<byte[]> response = httpClient.send(
+                    HttpRequest.newBuilder(URI.create(ref.uri())).GET().build(),
+                    HttpResponse.BodyHandlers.ofByteArray());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                return unresolved(ref, "HTTP " + response.statusCode());
+            }
+            content = response.body();
+            contentType = response.headers().firstValue("content-type").orElse("application/octet-stream");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return unresolved(ref, "interrupted");
+        } catch (Exception e) {
+            return unresolved(ref, e.toString());
+        }
+
+        if (content == null || content.length == 0) {
+            // An empty body is a failed download wearing a 200. Storing it would satisfy every
+            // later "do we have this?" check and the artwork would never arrive.
+            return unresolved(ref, "empty body");
+        }
+        if (content.length > maxBytes) {
+            return unresolved(ref, "exceeds " + maxBytes + " bytes");
+        }
+
+        Optional<ImageStoreClient.StoredImageRef> stored =
+                imageStoreClient.store(filenameFor(ref.uri()), contentType, content, ref.uri());
+        if (stored.isEmpty()) {
+            return unresolved(ref, "image service did not store it");
+        }
+        return new SupplierCatalogEnrichmentImage(
+                ref.imageType(), stored.get().imageId(), stored.get().contentHash(), ref.uri(), false);
+    }
+
+    @NonNull
+    private SupplierCatalogEnrichmentImage unresolved(
+            MarketingVariant.@NonNull MarketingImageRef ref, @NonNull String why) {
+        log.debug("Artwork at {} is unresolved and will be retried: {}", ref.uri(), why);
+        return SupplierCatalogEnrichmentImage.unresolved(ref.imageType(), ref.uri());
+    }
+
+    /**
+     * A filename for the stored image, taken from the URI's last path segment.
+     *
+     * <p>Falls back to the whole URI's hash-free tail rather than inventing a name, so an operator
+     * looking at stored artwork can still recognise where it came from.
+     */
+    @NonNull
+    private static String filenameFor(@NonNull String uri) {
+        String path = uri;
+        int query = path.indexOf('?');
+        if (query >= 0) {
+            path = path.substring(0, query);
+        }
+        int slash = path.lastIndexOf('/');
+        String candidate = slash >= 0 && slash < path.length() - 1 ? path.substring(slash + 1) : path;
+        return candidate.isBlank() ? "mktcat-image" : candidate;
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatImageRetryRunner.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatImageRetryRunner.java
@@ -1,0 +1,81 @@
+package com.positivity.supplier.internal.mktcat.service;
+
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.entity.SupplierMktCatVariantEntity;
+import com.positivity.supplier.internal.repository.SupplierMktCatVariantRepository;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Limit;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * Re-attempts artwork that could not be fetched (CAP-324 #1257).
+ *
+ * <h2>Why a separate runner</h2>
+ *
+ * An image fails for reasons that have nothing to do with the catalogue entry it belongs to -- a
+ * transient 503 from an asset host, a link that was briefly wrong. Waiting for the next full sweep
+ * to retry it would tie a picture's recovery to a cadence chosen for a completely different reason,
+ * and on a nightly sweep that means a missing image stays missing for a day.
+ *
+ * <h2>Retrying is a re-import of the variant, not a re-fetch of the image</h2>
+ *
+ * The variant is imported again through the ordinary path. That costs a few more calls than fetching
+ * the image alone and buys the thing that matters: the retry cannot produce an enrichment that
+ * differs from what a sweep would have produced. A bespoke image-only path would be a second way to
+ * build the same event, and the second way is the one that drifts.
+ */
+@Slf4j
+@Service
+public class MktCatImageRetryRunner {
+
+    private final SupplierMktCatVariantRepository variantRepository;
+    private final MktCatImporter importer;
+    private final int batchSize;
+
+    public MktCatImageRetryRunner(
+            SupplierMktCatVariantRepository variantRepository,
+            MktCatImporter importer,
+            @Value("${pos.supplier.mktcat.image-retry-batch-size:25}") int batchSize) {
+        this.variantRepository = variantRepository;
+        this.importer = importer;
+        this.batchSize = batchSize;
+    }
+
+    /** Re-imports variants whose artwork is still missing, least recently touched first. */
+    @Scheduled(fixedDelayString = "${pos.supplier.mktcat.image-retry-interval-ms:1800000}")
+    public void retryUnresolvedImages() {
+        List<SupplierMktCatVariantEntity> pending =
+                variantRepository.findByHasUnresolvedImagesTrueOrderByUpdatedAtAsc(Limit.of(batchSize));
+        if (pending.isEmpty()) {
+            return;
+        }
+
+        for (SupplierMktCatVariantEntity row : pending) {
+            try {
+                importer.importVariants(new SupplierRef(row.getSupplierRef()), List.of(row.getVendorVariantId()));
+            } catch (Exception e) {
+                // One catalogue being unreachable must not stop the others being retried. The row
+                // keeps its unresolved flag, so the next run tries it again.
+                log.warn(
+                        "Retrying artwork for variant {} at {} failed: {}",
+                        row.getVendorVariantId(),
+                        row.getSupplierRef(),
+                        e.toString());
+            }
+        }
+    }
+
+    /** How many variants one run will re-attempt. */
+    int batchSize() {
+        return batchSize;
+    }
+
+    @NonNull
+    List<SupplierMktCatVariantEntity> pendingBatch() {
+        return variantRepository.findByHasUnresolvedImagesTrueOrderByUpdatedAtAsc(Limit.of(batchSize));
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatImporter.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatImporter.java
@@ -1,0 +1,352 @@
+package com.positivity.supplier.internal.mktcat.service;
+
+import com.positivity.domainevents.DomainEventEnvelope;
+import com.positivity.domainevents.DomainTopics;
+import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentImage;
+import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentText;
+import com.positivity.domainevents.supplier.SupplierCatalogUpdatedV1;
+import com.positivity.shared.id.UUIDv7Generator;
+import com.positivity.supplier.internal.adapter.ediwheelc12.EdiwheelC12MktCatCodec;
+import com.positivity.supplier.internal.adapter.ediwheelc12.MktCatDecodeException;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.client.SupplierHttpRequest;
+import com.positivity.supplier.internal.client.SupplierHttpResponse;
+import com.positivity.supplier.internal.domain.model.MarketingVariant;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.entity.SupplierMktCatVariantEntity;
+import com.positivity.supplier.internal.exception.MktCatImportException;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.registry.AdapterResolution;
+import com.positivity.supplier.internal.repository.SupplierMktCatVariantRepository;
+import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Ingests MKCAT marketing enrichment and publishes what changed (CAP-324 #1230, #1257).
+ *
+ * <h2>One importer, two triggers</h2>
+ *
+ * A change callback and a scheduled sweep both arrive here. That is what makes the two modes produce
+ * identical events -- not a rule anyone remembers to follow, but the fact that there is only one path
+ * that can produce one. Two implementations would drift, and the one that drifts is the callback
+ * path, which fires rarely and is watched by nobody.
+ *
+ * <h2>Publication is by content, not by arrival</h2>
+ *
+ * A variant is published when its content hash differs from the staged one. A catalogue that
+ * republishes itself nightly is entirely normal, and treating arrival as change would emit the whole
+ * catalogue every night -- which downstream is indistinguishable from every product's marketing copy
+ * having actually changed.
+ *
+ * <h2>A failed image never costs a record</h2>
+ *
+ * Artwork is fetched and stored before publication, but a fetch or store failure marks that one image
+ * unresolved and publishes everything else. Dropping a product's entire marketing copy over one
+ * broken download would be a silent loss of the material that did arrive, and the missing image is
+ * retried on its own cadence.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MktCatImporter {
+
+    private static final String SOURCE = "pos-supplier";
+
+    /** Field separator for hashing. A control character, so it cannot occur in vendor text. */
+    private static final char FIELD_SEPARATOR = '\u001f';
+
+    private final SupplierProfileResolver profileResolver;
+    private final AdapterRegistry adapterRegistry;
+    private final SupplierBaseClient baseClient;
+    private final SupplierMktCatVariantRepository variantRepository;
+    private final MktCatImageFetcher imageFetcher;
+    private final SupplierOutboxEventWriter outboxEventWriter;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    /**
+     * Ingests the catalogue's full variant list.
+     *
+     * @param supplierRef the catalogue profile to read
+     * @return what was seen and how much of it was new or changed
+     */
+    @NonNull
+    public ImportOutcome importAll(@NonNull SupplierRef supplierRef) {
+        ResolvedBinding binding = profileResolver.resolveBinding(supplierRef, SupplierCapability.MARKETING_CATALOG);
+        EdiwheelC12MktCatCodec codec = resolveCodec(binding);
+
+        SupplierHttpResponse listResponse = exchange(binding, codec.buildVariantListRequest());
+        if (!listResponse.isSuccess()) {
+            // Thrown rather than reported as an empty catalogue. An importer that diffs would read
+            // an empty list as "the vendor withdrew everything".
+            throw new MktCatImportException("catalogue variant list could not be read: " + listResponse.outcome()
+                    + (listResponse.failureDetail() == null ? "" : " -- " + listResponse.failureDetail()));
+        }
+
+        return importVariants(supplierRef, codec.decodeVariantIds(listResponse.body()));
+    }
+
+    /**
+     * Ingests a specific set of variants, as named by a change callback.
+     *
+     * <p>The same code as the full sweep, deliberately: see the class note.
+     */
+    @NonNull
+    public ImportOutcome importVariants(@NonNull SupplierRef supplierRef, @NonNull List<String> variantIds) {
+        ResolvedBinding binding = profileResolver.resolveBinding(supplierRef, SupplierCapability.MARKETING_CATALOG);
+        EdiwheelC12MktCatCodec codec = resolveCodec(binding);
+        UUID vendorProfileId = binding.profile().getVendorProfileId();
+
+        int seen = 0;
+        int published = 0;
+        int skipped = 0;
+
+        for (String variantId : variantIds) {
+            seen++;
+            try {
+                if (importOne(binding, codec, supplierRef, vendorProfileId, variantId)) {
+                    published++;
+                }
+            } catch (MktCatDecodeException | MktCatImportException e) {
+                // One unreadable variant must not end the import. The rest of the catalogue is
+                // still worth having, and this one is re-attempted on the next sweep.
+                skipped++;
+                log.warn("Skipping MKCAT variant {} for {}: {}", variantId, supplierRef.value(), e.getMessage());
+            }
+        }
+
+        log.info(
+                "MKCAT import for {}: {} seen, {} published, {} skipped",
+                supplierRef.value(),
+                seen,
+                published,
+                skipped);
+        return new ImportOutcome(seen, published, skipped);
+    }
+
+    /** @return whether this variant's content had changed and was therefore published */
+    private boolean importOne(
+            @NonNull ResolvedBinding binding,
+            @NonNull EdiwheelC12MktCatCodec codec,
+            @NonNull SupplierRef supplierRef,
+            @NonNull UUID vendorProfileId,
+            @NonNull String variantId) {
+        String detail = bodyOrThrow(exchange(binding, codec.buildVariantDetailRequest(variantId)), "variant detail");
+        // Images and language data are optional: a variant with neither is still a variant, and
+        // refusing it would lose the design entirely over its lack of a picture.
+        String images = bodyOrNull(exchange(binding, codec.buildVariantImagesRequest(variantId)));
+        String languages = bodyOrNull(exchange(binding, codec.buildVariantLanguageDataRequest(variantId)));
+
+        MarketingVariant variant = codec.decodeVariant(variantId, detail, images, languages);
+        List<SupplierCatalogEnrichmentImage> storedImages = imageFetcher.fetchAndStore(variant.imageUris());
+        List<SupplierCatalogEnrichmentText> texts = variant.texts().stream()
+                .map(text -> new SupplierCatalogEnrichmentText(
+                        text.languageCode(), text.name(), text.description(), text.footNotes()))
+                .toList();
+
+        return stageAndPublish(
+                vendorProfileId, supplierRef, variant, texts, storedImages, hashOf(variant, storedImages));
+    }
+
+    /**
+     * Stages the variant and publishes it when its content changed.
+     *
+     * <p>Both in one transaction, through the outbox: a variant recorded as published that was never
+     * emitted would be skipped on every later run, because its hash now matches (ADR-0044 section 4).
+     */
+    @Transactional
+    public boolean stageAndPublish(
+            @NonNull UUID vendorProfileId,
+            @NonNull SupplierRef supplierRef,
+            @NonNull MarketingVariant variant,
+            @NonNull List<SupplierCatalogEnrichmentText> texts,
+            @NonNull List<SupplierCatalogEnrichmentImage> images,
+            @NonNull String contentHash) {
+        Instant now = Instant.now(clock);
+        Optional<SupplierMktCatVariantEntity> existing =
+                variantRepository.findByVendorProfileIdAndVendorVariantId(vendorProfileId, variant.vendorVariantId());
+
+        if (existing.isPresent() && contentHash.equals(existing.get().getContentHash())) {
+            // Seen, not changed. Recorded so an operator can tell "the catalogue stopped sending
+            // this" from "the catalogue keeps sending it unchanged" -- which look identical if only
+            // changes are timestamped.
+            SupplierMktCatVariantEntity row = existing.get();
+            row.setLastSeenAt(now);
+            variantRepository.save(row);
+            return false;
+        }
+
+        SupplierMktCatVariantEntity row = existing.orElseGet(() -> SupplierMktCatVariantEntity.builder()
+                .vendorProfileId(vendorProfileId)
+                .vendorVariantId(variant.vendorVariantId())
+                .firstSeenAt(now)
+                .build());
+
+        row.setSupplierRef(supplierRef.value());
+        row.setBrand(variant.brand());
+        row.setTreadDesign(variant.treadDesign());
+        row.setTreadDesign2(variant.treadDesign2());
+        row.setProductName(variant.productName());
+        row.setVehicleType(variant.vehicleType());
+        row.setSeasonality(variant.seasonality());
+        row.setContentHash(contentHash);
+        row.setTextsJson(objectMapper.writeValueAsString(texts));
+        row.setImagesJson(objectMapper.writeValueAsString(images));
+        row.setHasUnresolvedImages(images.stream().anyMatch(SupplierCatalogEnrichmentImage::unresolved));
+        row.setLastSeenAt(now);
+        row.setLastPublishedAt(now);
+        SupplierMktCatVariantEntity saved = variantRepository.save(row);
+
+        outboxEventWriter.publish(
+                DomainTopics.events("supplier"),
+                new DomainEventEnvelope<>(
+                        UUIDv7Generator.generate(),
+                        SupplierCatalogUpdatedV1.EVENT_TYPE,
+                        SupplierCatalogUpdatedV1.SCHEMA_VERSION,
+                        // Keyed on the staged row, so every enrichment for one variant lands on one
+                        // partition in order: a stale republication overtaking a newer one would put
+                        // withdrawn marketing copy back on a product.
+                        saved.getSupplierMktCatVariantId(),
+                        0L,
+                        now,
+                        SOURCE,
+                        null,
+                        SOURCE,
+                        new SupplierCatalogUpdatedV1(
+                                vendorProfileId,
+                                supplierRef.value(),
+                                variant.vendorVariantId(),
+                                variant.brand(),
+                                variant.treadDesign(),
+                                variant.treadDesign2(),
+                                variant.productName(),
+                                variant.vehicleType(),
+                                variant.seasonality(),
+                                contentHash,
+                                texts,
+                                images,
+                                now)));
+        return true;
+    }
+
+    /**
+     * The hash that decides whether anything changed.
+     *
+     * <p>Covers exactly what gets published, image content hashes included -- so replaced artwork at
+     * an unchanged URL counts as a change, and unchanged artwork republished at a new URL does not.
+     * Unresolved images are included as unresolved, which means a variant whose artwork is still
+     * missing keeps a different hash from the same variant once the artwork arrives, and is
+     * republished when it does.
+     */
+    @NonNull
+    private String hashOf(@NonNull MarketingVariant variant, @NonNull List<SupplierCatalogEnrichmentImage> images) {
+        StringBuilder material = new StringBuilder();
+        append(material, variant.vendorVariantId());
+        append(material, variant.brand());
+        append(material, variant.treadDesign());
+        append(material, variant.treadDesign2());
+        append(material, variant.productName());
+        append(material, variant.vehicleType());
+        append(material, variant.seasonality());
+        for (MarketingVariant.MarketingText text : variant.texts()) {
+            append(material, text.languageCode());
+            append(material, text.name());
+            append(material, text.description());
+            append(material, text.footNotes());
+        }
+        for (SupplierCatalogEnrichmentImage image : images) {
+            append(material, image.imageType());
+            append(material, image.contentHash());
+            append(material, String.valueOf(image.unresolved()));
+        }
+        try {
+            return HexFormat.of()
+                    .formatHex(MessageDigest.getInstance("SHA-256")
+                            .digest(material.toString().getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    /**
+     * Appends one field and its separator.
+     *
+     * <p>Separated rather than concatenated so two different variants cannot hash alike: a brand of
+     * "Michelin" with design "X" and a brand of "MichelinX" with no design would otherwise produce
+     * identical material, and one would silently never be republished.
+     */
+    private static void append(@NonNull StringBuilder material, @Nullable String value) {
+        material.append(value == null ? "" : value).append(FIELD_SEPARATOR);
+    }
+
+    @NonNull
+    private SupplierHttpResponse exchange(@NonNull ResolvedBinding binding, @NonNull SupplierRequestSpec spec) {
+        return baseClient.exchange(new SupplierHttpRequest(
+                binding,
+                HttpMethod.valueOf(spec.method()),
+                spec.pathSuffix(),
+                spec.queryParams(),
+                spec.body(),
+                spec.contentType(),
+                spec.accept(),
+                spec.idempotent(),
+                spec.headers()));
+    }
+
+    @NonNull
+    private static String bodyOrThrow(@NonNull SupplierHttpResponse response, @NonNull String what) {
+        if (!response.isSuccess() || response.body() == null) {
+            throw new MktCatImportException(what + " could not be read: " + response.outcome());
+        }
+        return response.body();
+    }
+
+    @Nullable
+    private static String bodyOrNull(@NonNull SupplierHttpResponse response) {
+        return response.isSuccess() ? response.body() : null;
+    }
+
+    @NonNull
+    private EdiwheelC12MktCatCodec resolveCodec(@NonNull ResolvedBinding binding) {
+        AdapterResolution resolution =
+                adapterRegistry.resolve(SupplierCapability.MARKETING_CATALOG, binding.family(), binding.version());
+        if (resolution instanceof AdapterResolution.Resolved resolved
+                && resolved.codec() instanceof EdiwheelC12MktCatCodec codec) {
+            return codec;
+        }
+        throw new SupplierConfigurationException(
+                SupplierConfigurationException.CAPABILITY_NOT_CONFIGURED,
+                "No marketing catalogue codec registered for " + binding.family() + " "
+                        + binding.version().value());
+    }
+
+    /**
+     * What one import run did.
+     *
+     * @param seen      variants the catalogue offered
+     * @param published variants whose content had changed and were emitted
+     * @param skipped   variants that could not be read this run and will be re-attempted
+     */
+    public record ImportOutcome(int seen, int published, int skipped) {}
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatScheduler.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatScheduler.java
@@ -1,0 +1,141 @@
+package com.positivity.supplier.internal.mktcat.service;
+
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.entity.SupplierScheduleLeaseEntity;
+import com.positivity.supplier.internal.repository.SupplierEndpointBindingRepository;
+import com.positivity.supplier.internal.repository.SupplierProfileRepository;
+import com.positivity.supplier.internal.repository.SupplierScheduleLeaseRepository;
+import com.positivity.supplier.internal.service.SupplierScheduleCoordinator;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.support.CronExpression;
+import org.springframework.stereotype.Service;
+
+/**
+ * Sweeps the marketing catalogue on a schedule (CAP-324 #1230).
+ *
+ * <h2>The mode that always works</h2>
+ *
+ * Change subscription is better when a catalogue offers it: fewer calls, and changes arrive in
+ * minutes rather than at the next sweep. Not every deployment can accept callbacks, and a
+ * subscription the vendor has silently forgotten produces no error — just a catalogue that stops
+ * changing. The sweep is what makes either of those survivable, so it runs whether or not a
+ * subscription exists.
+ *
+ * <h2>Nothing is published twice by running both</h2>
+ *
+ * A sweep and a callback both go through {@code MktCatImporter}, which publishes on content change
+ * rather than on arrival. Running both modes together therefore costs extra reads and emits nothing
+ * extra — which is what makes belt and braces a sensible default rather than a duplicate feed.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MktCatScheduler {
+
+    private final SupplierEndpointBindingRepository bindingRepository;
+    private final SupplierProfileRepository profileRepository;
+    private final SupplierScheduleLeaseRepository leaseRepository;
+    private final SupplierScheduleCoordinator scheduleCoordinator;
+    private final MktCatImporter importer;
+    private final Clock clock;
+
+    /** Polls catalogue bindings that are due. Each runs at most once per tick, on one instance. */
+    @Scheduled(fixedDelayString = "${pos.supplier.mktcat.poll-interval-ms:900000}")
+    public void runDueSweeps() {
+        Instant now = Instant.now(clock);
+        for (SupplierEndpointBindingEntity binding :
+                bindingRepository.findByCapabilityAndEnabledTrueAndScheduleCronIsNotNull(
+                        SupplierCapability.MARKETING_CATALOG)) {
+            try {
+                runIfDue(binding, now);
+            } catch (Exception e) {
+                // One catalogue's problem must not stop the others. The checkpoint stayed put, so
+                // this binding is swept again next tick.
+                log.warn("Scheduled MKCAT sweep for binding {} failed: {}", binding.getId(), e.toString(), e);
+            }
+        }
+    }
+
+    private void runIfDue(@NonNull SupplierEndpointBindingEntity binding, @NonNull Instant now) {
+        Optional<SupplierProfileEntity> profile = profileRepository.findById(binding.getVendorProfileId());
+        if (profile.isEmpty() || !profile.get().isEnabled()) {
+            return;
+        }
+        if (!isDue(binding, now)) {
+            return;
+        }
+
+        String ownerToken = SupplierScheduleCoordinator.newOwnerToken();
+        if (!scheduleCoordinator.tryClaim(binding.getId(), ownerToken)) {
+            // Another instance holds this binding. Exactly one sweeper per catalogue is the point
+            // of the lease.
+            return;
+        }
+
+        String outcome = "FAILED";
+        try {
+            SupplierRef supplierRef = new SupplierRef(profile.get().getSupplierRef());
+            scheduleCoordinator.runPage(binding.getId(), ownerToken, () -> {
+                importer.importAll(supplierRef);
+                return now;
+            });
+            outcome = "SUCCEEDED";
+        } finally {
+            scheduleCoordinator.release(binding.getId(), ownerToken, outcome);
+        }
+    }
+
+    /**
+     * Whether this binding's own cadence says to sweep now.
+     *
+     * <p>Measured from the last completed sweep, because that is the only record of when this
+     * catalogue was actually read. Without evaluating the cron at all, every binding would be swept
+     * on every poll tick, which for a full catalogue read means thousands of calls a day to a
+     * standards body that is serving every consumer at once.
+     */
+    private boolean isDue(@NonNull SupplierEndpointBindingEntity binding, @NonNull Instant now) {
+        CronExpression cron;
+        try {
+            cron = CronExpression.parse(binding.getScheduleCron());
+        } catch (IllegalArgumentException e) {
+            // Logged every tick deliberately: a binding that silently never fires is exactly the
+            // failure an operator cannot see.
+            log.warn(
+                    "Binding {} has an unparseable schedule cron '{}': {}",
+                    binding.getId(),
+                    binding.getScheduleCron(),
+                    e.getMessage());
+            return false;
+        }
+
+        Instant checkpoint = checkpointFor(binding.getId());
+        if (checkpoint == null) {
+            // Never swept. Due immediately, so a newly configured catalogue does not wait a full
+            // cron period for its first read.
+            return true;
+        }
+        LocalDateTime next = cron.next(LocalDateTime.ofInstant(checkpoint, ZoneOffset.UTC));
+        return next != null && !next.isAfter(LocalDateTime.ofInstant(now, ZoneOffset.UTC));
+    }
+
+    private Instant checkpointFor(@NonNull UUID bindingId) {
+        return leaseRepository.findByBindingIdIn(List.of(bindingId)).stream()
+                .map(SupplierScheduleLeaseEntity::getCheckpointAt)
+                .filter(java.util.Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatStagedReader.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatStagedReader.java
@@ -1,0 +1,64 @@
+package com.positivity.supplier.internal.mktcat.service;
+
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.entity.SupplierMktCatVariantEntity;
+import com.positivity.supplier.internal.repository.SupplierMktCatVariantRepository;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.service.model.MarketingEnrichmentView;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Limit;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Reading what a marketing catalogue last sent (CAP-324 #1230).
+ *
+ * <h2>Staged, never presented as catalogue content</h2>
+ *
+ * Every row here is what a manufacturer published, not what any product says. A variant may match no
+ * product at all — that is an ordinary outcome for a design-level record in a catalogue of articles —
+ * and the view is deliberately shaped so nobody can mistake it for product data.
+ */
+@Service
+@RequiredArgsConstructor
+public class MktCatStagedReader {
+
+    private final SupplierProfileResolver profileResolver;
+    private final SupplierMktCatVariantRepository variantRepository;
+
+    /**
+     * The variants this catalogue last sent, most recently seen first.
+     *
+     * <p>Resolves the alias first, so an unknown {@code supplierRef} surfaces as the configuration
+     * problem it is rather than as an empty catalogue — those two answers send an operator in
+     * opposite directions.
+     */
+    @NonNull
+    @Transactional(readOnly = true)
+    public List<MarketingEnrichmentView> findStaged(@NonNull SupplierRef supplierRef, int limit) {
+        var binding = profileResolver.resolveBinding(supplierRef, SupplierCapability.MARKETING_CATALOG);
+        return variantRepository
+                .findByVendorProfileIdOrderByLastSeenAtDesc(binding.profile().getVendorProfileId(), Limit.of(limit))
+                .stream()
+                .map(MktCatStagedReader::toView)
+                .toList();
+    }
+
+    @NonNull
+    private static MarketingEnrichmentView toView(@NonNull SupplierMktCatVariantEntity row) {
+        return new MarketingEnrichmentView(
+                row.getVendorVariantId(),
+                row.getSupplierRef(),
+                row.getBrand(),
+                row.getTreadDesign(),
+                row.getProductName(),
+                row.getSeasonality(),
+                row.isHasUnresolvedImages(),
+                row.getFirstSeenAt(),
+                row.getLastSeenAt(),
+                row.getLastPublishedAt());
+    }
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/repository/SupplierMktCatVariantRepository.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/repository/SupplierMktCatVariantRepository.java
@@ -1,0 +1,33 @@
+package com.positivity.supplier.internal.repository;
+
+import com.positivity.supplier.internal.entity.SupplierMktCatVariantEntity;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Limit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Staged MKCAT tread design variants (CAP-324 #1230). */
+@Repository
+public interface SupplierMktCatVariantRepository extends JpaRepository<SupplierMktCatVariantEntity, UUID> {
+
+    @NonNull
+    Optional<SupplierMktCatVariantEntity> findByVendorProfileIdAndVendorVariantId(
+            @NonNull UUID vendorProfileId, @NonNull String vendorVariantId);
+
+    /**
+     * Variants with artwork still missing, least recently touched first.
+     *
+     * <p>The retry runner's working set. Ordering by last update spreads attention: ordering by age
+     * would let one permanently broken image absorb every run.
+     */
+    @NonNull
+    List<SupplierMktCatVariantEntity> findByHasUnresolvedImagesTrueOrderByUpdatedAtAsc(@NonNull Limit limit);
+
+    /** Everything staged for a vendor, for admin review of what the catalogue last sent. */
+    @NonNull
+    List<SupplierMktCatVariantEntity> findByVendorProfileIdOrderByLastSeenAtDesc(
+            @NonNull UUID vendorProfileId, @NonNull Limit limit);
+}

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/security/SupplierPermissions.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/security/SupplierPermissions.java
@@ -110,5 +110,14 @@ public final class SupplierPermissions {
      */
     public static final String WORKORDER_AUTHORIZATION_REVIEW = "supplier:workorderauth:review";
 
+    /**
+     * Running a marketing-catalogue import on demand, and reading what the catalogue last sent.
+     *
+     * <p>Its own permission because an import is a full read of a centrally published catalogue —
+     * thousands of calls to a standards body serving every consumer at once — rather than a cheap
+     * local query. Whoever may trigger that is not necessarily whoever may view a vendor profile.
+     */
+    public static final String MARKETING_CATALOG_IMPORT = "supplier:mktcat:import";
+
     private SupplierPermissions() {}
 }

--- a/pos-supplier/src/main/java/com/positivity/supplier/service/model/MarketingEnrichmentView.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/service/model/MarketingEnrichmentView.java
@@ -1,0 +1,44 @@
+package com.positivity.supplier.service.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * What the marketing catalogue last published for one tread design variant (CAP-324 #1230).
+ *
+ * <p>An operator-facing view of staged enrichment. It carries {@code unresolvedImages} because that
+ * is the state somebody has to act on: a variant whose artwork never arrived looks identical to one
+ * that has none, and only one of those is a problem.
+ *
+ * @param vendorVariantId  the catalogue's own variant identifier
+ * @param supplierRef      the catalogue profile it came from
+ * @param brand            as stated
+ * @param treadDesign      primary design name as stated
+ * @param productName      the vendor's product name, where given
+ * @param seasonality      as stated; not mapped to a Durion vocabulary
+ * @param unresolvedImages whether artwork is still missing and being retried
+ * @param firstSeenAt      when this variant was first seen
+ * @param lastSeenAt       when the catalogue last offered it, changed or not
+ * @param lastPublishedAt  when its content last changed and was published
+ */
+public record MarketingEnrichmentView(
+        @NonNull String vendorVariantId,
+        @NonNull String supplierRef,
+        @Nullable String brand,
+        @Nullable String treadDesign,
+        @Nullable String productName,
+        @Nullable String seasonality,
+        boolean unresolvedImages,
+        @NonNull Instant firstSeenAt,
+        @NonNull Instant lastSeenAt,
+        @Nullable Instant lastPublishedAt) {
+
+    public MarketingEnrichmentView {
+        Objects.requireNonNull(vendorVariantId, "vendorVariantId must not be null");
+        Objects.requireNonNull(supplierRef, "supplierRef must not be null");
+        Objects.requireNonNull(firstSeenAt, "firstSeenAt must not be null");
+        Objects.requireNonNull(lastSeenAt, "lastSeenAt must not be null");
+    }
+}

--- a/pos-supplier/src/main/resources/application.yml
+++ b/pos-supplier/src/main/resources/application.yml
@@ -61,6 +61,11 @@ springdoc:
   default-produces-media-type: application/json
 
 pos:
+  image:
+    # pos-image is a Utility module under ADR-0044 and may be called directly. MKCAT artwork is
+    # stored there so a product page never renders from a manufacturer's own server.
+    service-id: ${POS_IMAGE_SERVICE_ID:image}
+    base-path: ${POS_IMAGE_BASE_PATH:/v1/images}
   # ── Exchange-audit payload encryption (ADR-0050 §7) ─────────────────────────────────
   #
   # NOT optional plumbing. AuditPayloadCipher fails startup without a key unless the dev or test
@@ -193,6 +198,26 @@ pos:
     outbox:
       poll-interval-ms: ${SUPPLIER_OUTBOX_POLL_INTERVAL_MS:1000}
       send-timeout-ms: ${SUPPLIER_OUTBOX_SEND_TIMEOUT_MS:10000}
+    mktcat:
+      # Full catalogue sweep. The mode that always works: change subscription is better where a
+      # catalogue offers it, but a subscription the vendor has silently forgotten produces no error,
+      # just a catalogue that stops changing. Both modes go through one importer that publishes on
+      # content change, so running both costs reads and emits nothing extra.
+      poll-interval-ms: ${SUPPLIER_MKTCAT_POLL_INTERVAL_MS:900000}
+      # Artwork is fetched directly rather than through the supplier base client: an image URI is an
+      # arbitrary asset URL published inside a document, and sending vendor credentials to it would
+      # leak them to whatever host the catalogue names.
+      image-fetch-timeout-ms: ${SUPPLIER_MKTCAT_IMAGE_FETCH_TIMEOUT_MS:15000}
+      # Bounded because the URI comes from a document rather than from configuration: without a cap,
+      # a mistyped link to a very large file would be pulled into memory and stored.
+      image-max-bytes: ${SUPPLIER_MKTCAT_IMAGE_MAX_BYTES:10485760}
+      # Missing artwork is retried on its own cadence rather than waiting for the next sweep, which
+      # on a nightly schedule would leave a picture missing for a day for a reason unrelated to it.
+      image-retry-interval-ms: ${SUPPLIER_MKTCAT_IMAGE_RETRY_INTERVAL_MS:1800000}
+      image-retry-batch-size: ${SUPPLIER_MKTCAT_IMAGE_RETRY_BATCH_SIZE:25}
+      # Where the catalogue should send change notifications. Unset by default: a deployment that
+      # cannot accept callbacks must not advertise one, and the scheduled sweep covers it.
+      callback-base-url: ${SUPPLIER_MKTCAT_CALLBACK_BASE_URL:}
     workorderauth:
       # How often accepted-but-undecided authorizations are re-read. The S2S API may answer a
       # request with 202 and a Location instead of a decision; without this the 202 is

--- a/pos-supplier/src/main/resources/db/migration/V18__mkcat_enrichment.sql
+++ b/pos-supplier/src/main/resources/db/migration/V18__mkcat_enrichment.sql
@@ -1,0 +1,87 @@
+-- CAP-324 (#1230, #1257): MKCAT (C1.2 JSON) marketing catalogue enrichment.
+--
+-- Staging, not a catalogue. Nothing here is product data: pos-catalog owns what a product IS, and
+-- these rows only record what a manufacturer says about how it markets a tread design. The wall
+-- matters because a supplier fact that could alter product identity would hand a vendor edit rights
+-- over the catalogue (ADR-0044 R1).
+
+CREATE TABLE supplier_mktcat_variant (
+    supplier_mktcat_variant_id UUID         PRIMARY KEY,
+    vendor_profile_id          UUID         NOT NULL,
+    supplier_ref               VARCHAR(100) NOT NULL,
+
+    -- The vendor's own tread design variant id. A design, not an article: one design spans many
+    -- sizes, each with its own EAN, so there is no EAN here to match on.
+    vendor_variant_id          VARCHAR(100) NOT NULL,
+
+    brand                      VARCHAR(200),
+    tread_design               VARCHAR(200),
+    tread_design_2             VARCHAR(200),
+    product_name               VARCHAR(300),
+    vehicle_type               VARCHAR(100),
+    seasonality                VARCHAR(100),
+
+    -- Hash of everything published for this variant, texts and image references included.
+    -- This is what makes scheduled-diff mode possible at all: without it, "has this changed since
+    -- last time" would mean comparing every field of every variant on every run, and a vendor that
+    -- republishes its whole catalogue nightly would look like a catalogue that changes nightly.
+    content_hash               VARCHAR(64)  NOT NULL,
+
+    -- Raw decoded texts and image references, as published. Kept so a republication can be rebuilt
+    -- byte-identically without re-fetching the vendor, which is what makes the two ingestion modes
+    -- produce the same event.
+    texts_json                 TEXT         NOT NULL,
+    images_json                TEXT         NOT NULL,
+
+    -- Whether any artwork is still missing. Not derived from images_json at query time: the retry
+    -- runner reads this column, and a scan that parsed JSON per row to find its work would be the
+    -- one query guaranteed to get slower as the catalogue grows.
+    has_unresolved_images      BOOLEAN      NOT NULL DEFAULT FALSE,
+
+    first_seen_at              timestamp(6) with time zone NOT NULL,
+    last_seen_at               timestamp(6) with time zone NOT NULL,
+    last_published_at          timestamp(6) with time zone,
+
+    created_at                 timestamp(6) with time zone NOT NULL,
+    updated_at                 timestamp(6) with time zone NOT NULL
+);
+
+-- One row per variant per vendor. Two vendors may legitimately describe the same tread design, and
+-- their marketing copy is not interchangeable.
+CREATE UNIQUE INDEX ux_mktcat_variant_profile_variant
+    ON supplier_mktcat_variant (vendor_profile_id, vendor_variant_id);
+
+-- The image retry runner's working set.
+CREATE INDEX ix_mktcat_variant_unresolved
+    ON supplier_mktcat_variant (has_unresolved_images, updated_at);
+
+-- Answering "what did this vendor last send us" without a scan.
+CREATE INDEX ix_mktcat_variant_profile_seen
+    ON supplier_mktcat_variant (vendor_profile_id, last_seen_at);
+
+
+-- Change subscriptions the vendor holds on our behalf. Recorded because a subscription we believe
+-- exists and the vendor has forgotten is silent: no callbacks arrive, nothing errors, and the
+-- catalogue simply stops changing.
+CREATE TABLE supplier_mktcat_subscription (
+    supplier_mktcat_subscription_id UUID         PRIMARY KEY,
+    vendor_profile_id               UUID         NOT NULL,
+    supplier_ref                    VARCHAR(100) NOT NULL,
+    event_name                      VARCHAR(100) NOT NULL,
+    callback_url                    VARCHAR(1000) NOT NULL,
+
+    -- ACTIVE, or FAILED when the vendor refused or could not be reached.
+    status                          VARCHAR(20)  NOT NULL,
+    failure_detail                  VARCHAR(1000),
+
+    subscribed_at                   timestamp(6) with time zone,
+    last_callback_at                timestamp(6) with time zone,
+
+    created_at                      timestamp(6) with time zone NOT NULL,
+    updated_at                      timestamp(6) with time zone NOT NULL,
+
+    CONSTRAINT ck_mktcat_sub_status CHECK (status IN ('ACTIVE', 'FAILED', 'CANCELLED'))
+);
+
+CREATE UNIQUE INDEX ux_mktcat_sub_profile_event
+    ON supplier_mktcat_subscription (vendor_profile_id, event_name);

--- a/pos-supplier/src/main/resources/permissions.yaml
+++ b/pos-supplier/src/main/resources/permissions.yaml
@@ -24,3 +24,5 @@ permissions:
     description: "Ask a fleet program to authorize work, and look up fleet vehicles, contracts and policies"
   - name: "supplier:workorderauth:review"
     description: "View and clear fleet workorder authorizations parked for manual review"
+  - name: "supplier:mktcat:import"
+    description: "Run a marketing-catalogue (MKCAT) import on demand and read staged enrichment"

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheelc12/EdiwheelC12MktCatCodecTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheelc12/EdiwheelC12MktCatCodecTest.java
@@ -1,0 +1,218 @@
+package com.positivity.supplier.internal.adapter.ediwheelc12;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.positivity.supplier.internal.domain.model.MarketingVariant;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Reading the C1.2 marketing catalogue (CAP-324 #1230).
+ *
+ * <p>The behaviours worth pinning are the ones where being wrong loses material silently: artwork
+ * published in two places of which only one is read, copy whose language cannot be established, and
+ * an unreadable response mistaken for an empty catalogue.
+ */
+@DisplayName("EdiwheelC12MktCatCodec — reading the marketing catalogue (#1230)")
+class EdiwheelC12MktCatCodecTest {
+
+    private final EdiwheelC12MktCatCodec codec =
+            new EdiwheelC12MktCatCodec(JsonMapper.builder().build());
+
+    @Nested
+    @DisplayName("an unreadable catalogue is not an empty one")
+    class Readability {
+
+        @Test
+        @DisplayName("an empty variant list body is refused rather than read as no variants")
+        void emptyBodyIsRefused() {
+            // The importer diffs. "The catalogue published nothing" and "we could not read it" would
+            // otherwise reach the same conclusion: that every variant held has been withdrawn.
+            assertThatThrownBy(() -> codec.decodeVariantIds(null)).isInstanceOf(MktCatDecodeException.class);
+            assertThatThrownBy(() -> codec.decodeVariantIds("   ")).isInstanceOf(MktCatDecodeException.class);
+        }
+
+        @Test
+        @DisplayName("a variant list that is not JSON is refused")
+        void unreadableListIsRefused() {
+            assertThatThrownBy(() -> codec.decodeVariantIds("<html>maintenance</html>"))
+                    .isInstanceOf(MktCatDecodeException.class);
+        }
+
+        @Test
+        @DisplayName("an empty JSON array is an empty catalogue, which is a real answer")
+        void emptyArrayIsAnAnswer() {
+            assertThat(codec.decodeVariantIds("[]")).isEmpty();
+        }
+
+        @Test
+        @DisplayName("a variant with no detail body is refused rather than published blank")
+        void missingDetailIsRefused() {
+            assertThatThrownBy(() -> codec.decodeVariant("V1", null, null, null))
+                    .isInstanceOf(MktCatDecodeException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("assembling a variant")
+    class Assembly {
+
+        @Test
+        @DisplayName("the id is carried through, never taken from the catalogue's echo")
+        void idIsOurs() {
+            MarketingVariant variant = codec.decodeVariant(
+                    "V1", "{\"TreadDesignVariant\":\"SOMETHING-ELSE\",\"Brand\":\"Michelin\"}", null, null);
+
+            // A detail body echoing a different id is a catalogue defect; adopting it would attach
+            // this variant's marketing copy to another design.
+            assertThat(variant.vendorVariantId()).isEqualTo("V1");
+            assertThat(variant.brand()).isEqualTo("Michelin");
+        }
+
+        @Test
+        @DisplayName("a variant with neither artwork nor copy is still a variant")
+        void bareVariantSurvives() {
+            MarketingVariant variant = codec.decodeVariant("V1", "{\"TreadDesign1\":\"Primacy 4\"}", null, null);
+
+            assertThat(variant.treadDesign()).isEqualTo("Primacy 4");
+            assertThat(variant.texts()).isEmpty();
+            assertThat(variant.imageUris()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("blank vendor fields become absent rather than empty strings")
+        void blanksBecomeAbsent() {
+            MarketingVariant variant =
+                    codec.decodeVariant("V1", "{\"Brand\":\"   \",\"TreadDesign2\":\"\"}", null, null);
+
+            assertThat(variant.brand()).isNull();
+            assertThat(variant.treadDesign2()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("artwork, which the catalogue publishes in two places")
+    class Artwork {
+
+        private static final String IMAGES = """
+                [{"ImageType":"TREAD","URI":"https://cdn.example.com/tread.jpg"}]
+                """;
+
+        private static final String LANGUAGES = """
+                [{"LanguageID":"de","Description":"Sommerreifen",
+                  "AdditionalGraphic":[{"Graphic":"LABEL","URI":"https://cdn.example.com/label-de.png"}]},
+                 {"LanguageID":"fr","Description":"Pneu ete",
+                  "AdditionalGraphic":[{"Graphic":"LABEL","URI":"https://cdn.example.com/label-fr.png"}]}]
+                """;
+
+        @Test
+        @DisplayName("both the images resource and the per-language graphics are collected")
+        void bothSourcesAreRead() {
+            // Reading only the variant's own images resource would silently drop the per-market
+            // artwork, which is the material a marketing catalogue exists to supply.
+            MarketingVariant variant = codec.decodeVariant("V1", "{}", IMAGES, LANGUAGES);
+
+            assertThat(variant.imageUris())
+                    .extracting(MarketingVariant.MarketingImageRef::uri)
+                    .containsExactly(
+                            "https://cdn.example.com/tread.jpg",
+                            "https://cdn.example.com/label-de.png",
+                            "https://cdn.example.com/label-fr.png");
+        }
+
+        @Test
+        @DisplayName("the same picture listed against several languages is fetched once")
+        void duplicateUrisAreCollapsed() {
+            String sharedAcrossLanguages = """
+                    [{"LanguageID":"de","AdditionalGraphic":[{"URI":"https://cdn.example.com/shared.png"}]},
+                     {"LanguageID":"fr","AdditionalGraphic":[{"URI":"https://cdn.example.com/shared.png"}]}]
+                    """;
+
+            MarketingVariant variant = codec.decodeVariant("V1", "{}", null, sharedAcrossLanguages);
+
+            // Otherwise every ingest is multiplied by the number of markets, for one picture.
+            assertThat(variant.imageUris()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("an unreadable image list fails the variant, because artwork is not optional to lose quietly")
+        void unreadableImageListIsRefused() {
+            assertThatThrownBy(() -> codec.decodeVariant("V1", "{}", "not json", null))
+                    .isInstanceOf(MktCatDecodeException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("marketing copy")
+    class Copy {
+
+        @Test
+        @DisplayName("copy is kept per language rather than flattened")
+        void copyIsPerLanguage() {
+            MarketingVariant variant = codec.decodeVariant("V1", "{}", null, """
+                    [{"LanguageID":"de","ProductName":"Primacy","Description":"Sommerreifen","FootNotes":"*"},
+                     {"LanguageID":"en","ProductName":"Primacy","Description":"Summer tyre"}]
+                    """);
+
+            assertThat(variant.texts()).hasSize(2);
+            assertThat(variant.texts().getFirst().languageCode()).isEqualTo("de");
+            assertThat(variant.texts().getFirst().footNotes()).isEqualTo("*");
+        }
+
+        @Test
+        @DisplayName("copy with no language is dropped, because it cannot be shown to anyone safely")
+        void copyWithoutALanguageIsDropped() {
+            // A shop would have no way to know it was reading German text to a French customer.
+            MarketingVariant variant = codec.decodeVariant("V1", "{}", null, "[{\"Description\":\"orphaned text\"}]");
+
+            assertThat(variant.texts()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("an unreadable language body costs the copy, not the variant")
+        void unreadableCopyDoesNotFailTheVariant() {
+            MarketingVariant variant = codec.decodeVariant("V1", "{\"Brand\":\"Michelin\"}", null, "not json");
+
+            assertThat(variant.brand()).isEqualTo("Michelin");
+            assertThat(variant.texts()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("the requests it builds")
+    class Requests {
+
+        @Test
+        @DisplayName("reads are idempotent and subscribe is not")
+        void idempotencyMatchesTheEffect() {
+            assertThat(codec.buildVariantListRequest().idempotent()).isTrue();
+            assertThat(codec.buildVariantDetailRequest("V1").idempotent()).isTrue();
+            // The catalogue records a subscription per call, so a blind re-send risks a second one
+            // and therefore duplicate callbacks.
+            assertThat(codec.buildSubscribeRequest("https://us/callback", "TDV_CHANGED")
+                            .idempotent())
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("a catalogue id is encoded, so it cannot alter the path it sits in")
+        void idsCannotEscapeTheirSegment() {
+            SupplierRequestSpec spec = codec.buildVariantDetailRequest("V/../../admin");
+            assertThat(spec.pathSuffix()).contains("%2F").doesNotContain("/../");
+        }
+
+        @Test
+        @DisplayName("subscribe carries the callback and the event the catalogue needs")
+        void subscribeCarriesItsParameters() {
+            SupplierRequestSpec spec = codec.buildSubscribeRequest("https://us/callback", "TDV_CHANGED");
+
+            assertThat(spec.queryParams())
+                    .containsEntry("callbackUrl", "https://us/callback")
+                    .containsEntry("event", "TDV_CHANGED");
+        }
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatImageFetcherTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatImageFetcherTest.java
@@ -1,0 +1,123 @@
+package com.positivity.supplier.internal.mktcat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentImage;
+import com.positivity.supplier.internal.client.ImageStoreClient;
+import com.positivity.supplier.internal.domain.model.MarketingVariant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Artwork that could not be fetched must not cost a product its marketing copy (CAP-324 #1257).
+ *
+ * <p>The fetches themselves need a network and are not exercised here. What is exercised is the rule
+ * that governs every failure path: an entry comes back for every input, unresolved rather than
+ * missing, so a broken picture is visible and retryable instead of silently absent.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("MktCatImageFetcher — a failed image never costs a record (#1257)")
+class MktCatImageFetcherTest {
+
+    @Mock
+    private ImageStoreClient imageStoreClient;
+
+    private MktCatImageFetcher fetcher() {
+        return new MktCatImageFetcher(imageStoreClient, 50, 10_485_760L);
+    }
+
+    @Test
+    @DisplayName("an unreachable host yields an unresolved entry, not a dropped one")
+    void unreachableHostIsUnresolved() {
+        // A dropped entry is a silently lost picture: nothing downstream could tell the difference
+        // between "this design has no artwork" and "we failed to fetch its artwork".
+        List<SupplierCatalogEnrichmentImage> images = fetcher()
+                .fetchAndStore(List.of(
+                        new MarketingVariant.MarketingImageRef("TREAD", "http://127.0.0.1:1/never-listening.jpg")));
+
+        assertThat(images).hasSize(1);
+        assertThat(images.getFirst().unresolved()).isTrue();
+        assertThat(images.getFirst().imageId()).isNull();
+        // The origin survives, so the retry knows where to go back to.
+        assertThat(images.getFirst().sourceUri()).isEqualTo("http://127.0.0.1:1/never-listening.jpg");
+        assertThat(images.getFirst().imageType()).isEqualTo("TREAD");
+        verify(imageStoreClient, never()).store(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("every input produces exactly one entry, in order")
+    void everyInputProducesAnEntry() {
+        List<SupplierCatalogEnrichmentImage> images = fetcher()
+                .fetchAndStore(List.of(
+                        new MarketingVariant.MarketingImageRef("A", "http://127.0.0.1:1/one.jpg"),
+                        new MarketingVariant.MarketingImageRef("B", "http://127.0.0.1:1/two.jpg")));
+
+        assertThat(images).hasSize(2);
+        assertThat(images).extracting(SupplierCatalogEnrichmentImage::imageType).containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("no artwork means no entries, and no calls")
+    void emptyInputIsCheap() {
+        assertThat(fetcher().fetchAndStore(List.of())).isEmpty();
+        verify(imageStoreClient, never()).store(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("a malformed URI is unresolved rather than an exception escaping the import")
+    void malformedUriIsUnresolved() {
+        List<SupplierCatalogEnrichmentImage> images =
+                fetcher().fetchAndStore(List.of(new MarketingVariant.MarketingImageRef("TREAD", "not a uri at all")));
+
+        assertThat(images).hasSize(1);
+        assertThat(images.getFirst().unresolved()).isTrue();
+    }
+
+    @Test
+    @DisplayName("a resolved image carries the stored reference, never the vendor URL as its source")
+    void resolvedImageCarriesTheStoredReference() {
+        // Constructed directly: the render source must be the platform's id, and the vendor URL is
+        // provenance only. That distinction is the whole point of #1257.
+        SupplierCatalogEnrichmentImage resolved =
+                new SupplierCatalogEnrichmentImage("TREAD", 9L, "abc123", "https://cdn.example.com/x.jpg", false);
+
+        assertThat(resolved.imageId()).isEqualTo(9L);
+        assertThat(resolved.unresolved()).isFalse();
+        assertThat(resolved.sourceUri()).isEqualTo("https://cdn.example.com/x.jpg");
+    }
+
+    @Test
+    @DisplayName("a resolved image with nothing to point at cannot be constructed")
+    void resolvedImageMustHaveAnId() {
+        // The shape that quietly loses artwork: a consumer would treat it as present and render
+        // nothing.
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> new SupplierCatalogEnrichmentImage("TREAD", null, null, "https://x", false))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("the store client is asked with the origin, so pos-image can deduplicate re-ingests")
+    void storeIsCalledWithTheOrigin() {
+        when(imageStoreClient.store(any(), any(), any(), eq("https://cdn.example.com/x.jpg")))
+                .thenReturn(Optional.of(new ImageStoreClient.StoredImageRef(1L, "hash", true)));
+
+        // The fetch itself needs a network, so this asserts the contract the fetcher relies on:
+        // pos-image deduplicates on origin plus content, and cannot do so without the origin.
+        assertThat(imageStoreClient.store("x.jpg", "image/jpeg", new byte[] {1}, "https://cdn.example.com/x.jpg"))
+                .isPresent();
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatImageFetcherTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatImageFetcherTest.java
@@ -120,4 +120,121 @@ class MktCatImageFetcherTest {
         assertThat(imageStoreClient.store("x.jpg", "image/jpeg", new byte[] {1}, "https://cdn.example.com/x.jpg"))
                 .isPresent();
     }
+
+    @Test
+    @DisplayName("a server that declares an oversized body is refused before it is read")
+    void oversizedDeclarationIsRefusedUpFront() throws Exception {
+        // Refusing on the declared length is cheaper than refusing after reading, and it is the
+        // common case for a genuinely large file.
+        try (TinyServer server = TinyServer.serving(200, "image/jpeg", new byte[64], true)) {
+            MktCatImageFetcher fetcher = new MktCatImageFetcher(imageStoreClient, 2000, 8L);
+
+            List<SupplierCatalogEnrichmentImage> images =
+                    fetcher.fetchAndStore(List.of(new MarketingVariant.MarketingImageRef("TREAD", server.url())));
+
+            assertThat(images.getFirst().unresolved()).isTrue();
+            verify(imageStoreClient, never()).store(any(), any(), any(), any());
+        }
+    }
+
+    @Test
+    @DisplayName("a body that lies about its length is cut off at the cap rather than buffered whole")
+    void undeclaredOversizedBodyIsCutOff() throws Exception {
+        // The case the cap exists for. A server that omits or understates content-length would
+        // otherwise be fully in memory by the time anything checked its size.
+        try (TinyServer server = TinyServer.serving(200, "image/jpeg", new byte[4096], false)) {
+            MktCatImageFetcher fetcher = new MktCatImageFetcher(imageStoreClient, 2000, 64L);
+
+            List<SupplierCatalogEnrichmentImage> images =
+                    fetcher.fetchAndStore(List.of(new MarketingVariant.MarketingImageRef("TREAD", server.url())));
+
+            assertThat(images.getFirst().unresolved()).isTrue();
+            verify(imageStoreClient, never()).store(any(), any(), any(), any());
+        }
+    }
+
+    @Test
+    @DisplayName("a body within the cap is fetched and handed to the image service")
+    void bodyWithinTheCapIsStored() throws Exception {
+        when(imageStoreClient.store(any(), any(), any(), any()))
+                .thenReturn(Optional.of(new ImageStoreClient.StoredImageRef(11L, "hash", true)));
+
+        try (TinyServer server = TinyServer.serving(200, "image/png", new byte[32], true)) {
+            MktCatImageFetcher fetcher = new MktCatImageFetcher(imageStoreClient, 2000, 1024L);
+
+            List<SupplierCatalogEnrichmentImage> images =
+                    fetcher.fetchAndStore(List.of(new MarketingVariant.MarketingImageRef("TREAD", server.url())));
+
+            assertThat(images.getFirst().unresolved()).isFalse();
+            assertThat(images.getFirst().imageId()).isEqualTo(11L);
+        }
+    }
+
+    @Test
+    @DisplayName("a server that accepts the connection and then stalls does not park the thread forever")
+    void stalledResponseTimesOut() throws Exception {
+        // A connect timeout alone would not cover this: the connection succeeds and the body never
+        // arrives, which is what pins an ingest thread to a host nobody controls.
+        try (TinyServer server = TinyServer.stalling()) {
+            MktCatImageFetcher fetcher = new MktCatImageFetcher(imageStoreClient, 300, 1024L);
+
+            List<SupplierCatalogEnrichmentImage> images =
+                    fetcher.fetchAndStore(List.of(new MarketingVariant.MarketingImageRef("TREAD", server.url())));
+
+            assertThat(images.getFirst().unresolved()).isTrue();
+        }
+    }
+
+    /** A minimal HTTP server, so the fetch paths above are exercised rather than described. */
+    private static final class TinyServer implements AutoCloseable {
+
+        private final com.sun.net.httpserver.HttpServer server;
+
+        private TinyServer(com.sun.net.httpserver.HttpServer server) {
+            this.server = server;
+        }
+
+        static TinyServer serving(int status, String contentType, byte[] body, boolean declareLength)
+                throws java.io.IOException {
+            com.sun.net.httpserver.HttpServer server =
+                    com.sun.net.httpserver.HttpServer.create(new java.net.InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/artwork.jpg", exchange -> {
+                exchange.getResponseHeaders().add("Content-Type", contentType);
+                // -1 means chunked: no content-length, which is how a body hides its size.
+                exchange.sendResponseHeaders(status, declareLength ? body.length : 0);
+                try (java.io.OutputStream out = exchange.getResponseBody()) {
+                    out.write(body);
+                }
+            });
+            server.start();
+            return new TinyServer(server);
+        }
+
+        static TinyServer stalling() throws java.io.IOException {
+            com.sun.net.httpserver.HttpServer server =
+                    com.sun.net.httpserver.HttpServer.create(new java.net.InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/artwork.jpg", exchange -> {
+                try {
+                    // Comfortably longer than the fetcher's 300ms deadline, short enough that the
+                    // handler thread is not still sleeping when the suite moves on.
+                    Thread.sleep(2_000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                exchange.sendResponseHeaders(200, 0);
+                exchange.close();
+            });
+            server.start();
+            return new TinyServer(server);
+        }
+
+        String url() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/artwork.jpg";
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
 }

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatImporterTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatImporterTest.java
@@ -1,0 +1,205 @@
+package com.positivity.supplier.internal.mktcat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentImage;
+import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentText;
+import com.positivity.domainevents.supplier.SupplierCatalogUpdatedV1;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.domain.model.MarketingVariant;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.entity.SupplierMktCatVariantEntity;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.repository.SupplierMktCatVariantRepository;
+import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Publishing on change rather than on arrival (CAP-324 #1230).
+ *
+ * <p>A marketing catalogue republishing itself unchanged is the normal case, not the exception. If
+ * arrival counted as change, a nightly sweep would emit the entire catalogue every night — which
+ * downstream is indistinguishable from every product's marketing copy having actually changed.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("MktCatImporter — published when it changes, not when it arrives (#1230)")
+class MktCatImporterTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-16T10:00:00Z");
+    private static final UUID PROFILE_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000b1");
+    private static final SupplierRef SUPPLIER = new SupplierRef("ediwheel-net");
+
+    @Mock
+    private SupplierProfileResolver profileResolver;
+
+    @Mock
+    private AdapterRegistry adapterRegistry;
+
+    @Mock
+    private SupplierBaseClient baseClient;
+
+    @Mock
+    private SupplierMktCatVariantRepository variantRepository;
+
+    @Mock
+    private MktCatImageFetcher imageFetcher;
+
+    @Mock
+    private SupplierOutboxEventWriter outboxEventWriter;
+
+    private MktCatImporter importer;
+
+    @BeforeEach
+    void setUp() {
+        importer = new MktCatImporter(
+                profileResolver,
+                adapterRegistry,
+                baseClient,
+                variantRepository,
+                imageFetcher,
+                outboxEventWriter,
+                JsonMapper.builder().build(),
+                Clock.fixed(NOW, ZoneOffset.UTC));
+        when(variantRepository.save(any())).thenAnswer(invocation -> {
+            SupplierMktCatVariantEntity row = invocation.getArgument(0);
+            if (row.getSupplierMktCatVariantId() == null) {
+                row.setSupplierMktCatVariantId(UUID.fromString("019200aa-0000-7000-8000-0000000000a1"));
+            }
+            return row;
+        });
+    }
+
+    @Test
+    @DisplayName("a variant never seen before is staged and published")
+    void newVariantIsPublished() {
+        when(variantRepository.findByVendorProfileIdAndVendorVariantId(any(), any()))
+                .thenReturn(Optional.empty());
+
+        boolean published = importer.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), List.of(), "hash-1");
+
+        assertThat(published).isTrue();
+        verify(outboxEventWriter).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("an unchanged republication is recorded as seen and publishes nothing")
+    void unchangedRepublicationIsSilent() {
+        // The load-bearing case. A catalogue that republishes nightly must not look like a catalogue
+        // that changes nightly.
+        SupplierMktCatVariantEntity existing = staged("hash-1");
+        when(variantRepository.findByVendorProfileIdAndVendorVariantId(any(), any()))
+                .thenReturn(Optional.of(existing));
+
+        boolean published = importer.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), List.of(), "hash-1");
+
+        assertThat(published).isFalse();
+        verify(outboxEventWriter, never()).publish(any(), any());
+        // Still recorded as seen: "the catalogue stopped sending this" and "the catalogue keeps
+        // sending it unchanged" look identical if only changes are timestamped.
+        assertThat(existing.getLastSeenAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("changed content republishes and moves the published timestamp")
+    void changedContentIsPublished() {
+        SupplierMktCatVariantEntity existing = staged("hash-1");
+        when(variantRepository.findByVendorProfileIdAndVendorVariantId(any(), any()))
+                .thenReturn(Optional.of(existing));
+
+        boolean published = importer.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), List.of(), "hash-2");
+
+        assertThat(published).isTrue();
+        assertThat(existing.getContentHash()).isEqualTo("hash-2");
+        assertThat(existing.getLastPublishedAt()).isEqualTo(NOW);
+        verify(outboxEventWriter).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("a variant with unresolved artwork is flagged, so the retry runner can find it")
+    void unresolvedArtworkIsFlagged() {
+        when(variantRepository.findByVendorProfileIdAndVendorVariantId(any(), any()))
+                .thenReturn(Optional.empty());
+        List<SupplierCatalogEnrichmentImage> images =
+                List.of(SupplierCatalogEnrichmentImage.unresolved("TREAD", "https://cdn.example.com/x.jpg"));
+
+        importer.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), images, "hash-1");
+
+        // A column rather than something derived from JSON at query time: the retry runner selects
+        // on it, and a scan that parsed JSON per row would be the query that degrades as the
+        // catalogue grows.
+        verify(variantRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("the enrichment publishes its text even when a picture is missing")
+    void textSurvivesAMissingPicture() {
+        when(variantRepository.findByVendorProfileIdAndVendorVariantId(any(), any()))
+                .thenReturn(Optional.empty());
+        List<SupplierCatalogEnrichmentImage> images =
+                List.of(SupplierCatalogEnrichmentImage.unresolved("TREAD", "https://cdn.example.com/x.jpg"));
+
+        // Dropping the record would discard the marketing copy that did arrive because a picture
+        // did not.
+        boolean published = importer.stageAndPublish(PROFILE_ID, SUPPLIER, variant(), texts(), images, "hash-1");
+
+        assertThat(published).isTrue();
+        SupplierCatalogUpdatedV1 payload = new SupplierCatalogUpdatedV1(
+                PROFILE_ID,
+                SUPPLIER.value(),
+                "V1",
+                "Michelin",
+                "Primacy 4",
+                null,
+                null,
+                null,
+                null,
+                "hash-1",
+                texts(),
+                images,
+                NOW);
+        assertThat(payload.hasUnresolvedImages()).isTrue();
+        assertThat(payload.texts()).isNotEmpty();
+    }
+
+    private static MarketingVariant variant() {
+        return new MarketingVariant("V1", "Michelin", "Primacy 4", null, null, null, null, List.of(), List.of());
+    }
+
+    private static List<SupplierCatalogEnrichmentText> texts() {
+        return List.of(new SupplierCatalogEnrichmentText("de", "Primacy 4", "Sommerreifen", null));
+    }
+
+    private static SupplierMktCatVariantEntity staged(String contentHash) {
+        return SupplierMktCatVariantEntity.builder()
+                .supplierMktCatVariantId(UUID.fromString("019200aa-0000-7000-8000-0000000000a1"))
+                .vendorProfileId(PROFILE_ID)
+                .supplierRef(SUPPLIER.value())
+                .vendorVariantId("V1")
+                .contentHash(contentHash)
+                .textsJson("[]")
+                .imagesJson("[]")
+                .firstSeenAt(NOW.minusSeconds(86400))
+                .lastSeenAt(NOW.minusSeconds(86400))
+                .build();
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/registry/TireIdentificationDormancyTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/registry/TireIdentificationDormancyTest.java
@@ -1,0 +1,78 @@
+package com.positivity.supplier.internal.registry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.spi.SupplierAdapterCodec;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * DOT and sidewall scanning stay dormant, and are verified to be (CAP-324 #1230, §12 decision 10).
+ *
+ * <h2>Why an absence needs a test</h2>
+ *
+ * {@code TireIdentificationPort} is a deliberate placeholder: DOT scanning is likely to be required
+ * by most service providers, but it has not been confirmed, and the decision was to define the port
+ * and build no adapter until it is. An unwritten adapter needs no test — but a decision to leave one
+ * unwritten does, because nothing else would notice the day somebody adds one "while they were in
+ * there". By then the capability is half-built, unowned and untested against a vendor nobody chose.
+ *
+ * <p>So this asserts the two things that make dormancy real: the registry answers
+ * {@code CAPABILITY_NOT_CONFIGURED} for the capability, and no codec claims it.
+ */
+@DisplayName("Tire identification — verified dormant (#1230)")
+class TireIdentificationDormancyTest {
+
+    @Test
+    @DisplayName("no codec claims the tire-identification capability")
+    void noCodecClaimsIt() throws IOException {
+        List<String> claimants;
+        try (Stream<Path> sources = Files.walk(Path.of("src/main/java/com/positivity/supplier"))) {
+            claimants = sources.filter(path -> path.toString().endsWith(".java"))
+                    .filter(TireIdentificationDormancyTest::claimsTireIdentification)
+                    .map(Path::toString)
+                    .toList();
+        }
+
+        // The enum value may be referenced — by the port, and by the enum itself. What must not
+        // exist is a codec returning it from capability(), because that is what would make the
+        // registry resolve one.
+        assertThat(claimants)
+                .as("files declaring a codec for TIRE_IDENTIFICATION")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("the registry answers not-configured rather than resolving something")
+    void registryReportsNotConfigured() {
+        // An empty registry is the right shape for this assertion: it proves the not-configured
+        // answer is what an unbound capability produces, rather than an exception a caller would
+        // have to catch.
+        AdapterRegistry registry = new AdapterRegistry(List.<SupplierAdapterCodec>of());
+
+        AdapterResolution resolution = registry.resolve(
+                SupplierCapability.TIRE_IDENTIFICATION, ProtocolFamily.TEST, new ProtocolVersion("V1"));
+
+        assertThat(resolution).isInstanceOf(AdapterResolution.NotConfigured.class);
+    }
+
+    /** Whether a file declares a codec whose {@code capability()} returns tire identification. */
+    private static boolean claimsTireIdentification(Path path) {
+        try {
+            String source = Files.readString(path, StandardCharsets.UTF_8);
+            return source.contains("implements SupplierAdapterCodec")
+                    && source.contains("SupplierCapability.TIRE_IDENTIFICATION");
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not read " + path, e);
+        }
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:324`
- Parent STORY (durion): louisburroughs/durion#379
- Child issues: louisburroughs/durion-positivity-backend#1230, louisburroughs/durion-positivity-backend#1257
- Domain: `domain:positivity`, `domain:product`

## Contract References
- Contract guide entry (durion): `domains/positivity/.business-rules/BACKEND_CONTRACT_GUIDE.md` → supplier marketing catalogue enrichment
- Architecture: `durion/docs/architecture/integration/SUPPLIER_INTEGRATION_EDIWHEEL_ARCHITECTURE.md` §6, §11
- Source spec: `durion/docs/ediwheel/MKCAT_API_1.2.0.yaml`

## Contract Chain
- [x] OpenAPI annotations updated on the controllers
- [x] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated for pos-supplier and pos-image
- [ ] Angular SDK regenerated — handled separately

## Scope

**What changed:** the third wire generation. C1.2 is the resource-and-message JSON API
`ediwheel.net` publishes centrally, so one integration covers every participating manufacturer
rather than one per vendor. Tread design variants, per-language marketing copy and manufacturer
artwork are ingested and published as `supplier.catalog.updated.v1`.

**Why:** CAP-324 is the last unstarted capability, and the C1.2 family is the one EDIWheel
manufacturers are expected to converge on.

### Read this first: #1257 rested on a false premise

The story says MKCAT should store images in pos-image, which it describes as S3-backed with
`Image`/`ImageMetadata`/`ImageVariant` entities. **pos-image was a four-column URL registry** —
`id, filename, url, classification` — with a read-only service that resolved `url` as a filesystem
path. No upload endpoint, no S3 SDK anywhere in the backend, no blob column, no variants. There was
nowhere to put image bytes.

So this PR builds that half first (commit 1), then the MKCAT half on top of it.

**Storage backend, stated because nothing governs it:** bytes live in Postgres. No ADR covers image
storage and there is no AWS SDK in this repo, so choosing S3 here would mean picking infrastructure,
credentials and a bucket policy with nothing to follow. It sits behind `ImageStorageService`, so an
object-store implementation replaces it without touching a caller.

### Design decisions worth reviewing

**Publication is by content, not arrival.** A catalogue republishing itself unchanged is normal. If
arrival counted as change, a nightly sweep would emit the whole catalogue every night — downstream
that is indistinguishable from every product's copy having actually changed. The content hash covers
exactly what is published, image content hashes included, so replaced artwork behind an unchanged
URL *is* a change and unchanged artwork at a new URL is not.

**One importer, two triggers.** Subscription callbacks and scheduled sweeps both go through
`MktCatImporter`. That is what makes the two modes produce identical events — not a rule to
remember, but the absence of a second path. Running both costs extra reads and emits nothing extra.

**A failed image never costs a record.** Refused connection, 404, empty body, oversized file,
pos-image unreachable — every one produces an *unresolved* entry, and the enrichment publishes with
its text and other pictures intact. Dropping the variant would discard the copy that did arrive
because a picture did not. Unresolved state is a column, not derived from JSON at query time,
because the retry runner selects on it.

**Retry re-imports the variant, not the image.** A few more calls, in exchange for the guarantee
that a retry cannot produce an enrichment a sweep would not have. A bespoke image-only path would be
a second way to build the same event, and the second way drifts.

**Images are fetched outside the supplier base client.** An image URI is an arbitrary asset URL
published inside a document. Sending vendor credentials to it would leak them to whatever host the
catalogue names, so the fetch is unauthenticated and does not follow redirects.

**Storing is gated; reading is not.** pos-image had no security at all. Reads predate this and serve
page renders, but a write that accepts and keeps arbitrary bytes from any reachable caller needed a
gate, so the module gains the standard gateway chain and `image:image:store`.

### Deliberately not included

**The pos-catalog consumer.** #1230 names Product & Catalog as the authority for the enrichment
attachment model. Unlike the pos-accounting case I retired in #1227 by inspection, this blocker is
real: **pos-catalog has no enrichment concept and no image link of any kind** — there is nothing to
attach to, and the shape has to be designed by that domain. The events are published so it only has
to subscribe. Also note a matching wrinkle for whoever picks that up: a tread design variant is a
*design*, not an article, so it has no EAN — matching will be on brand and design names, not the
`EAN/GTIN` the story assumes.

**Tire identification** stays dormant per §12 decision 10 — and is now *verified* dormant.
`TireIdentificationDormancyTest` asserts no codec claims the capability and the registry answers
`CAPABILITY_NOT_CONFIGURED`. An unwritten adapter needs no test; a decision to leave one unwritten
does, because nothing else would notice the day somebody adds one in passing.

## Tests
- [x] Unit tests added — 37 new (codec 16, image fetcher 7, importer 5, dormancy 2, pos-image storage 7)
- [ ] Integration tests — none; the vendor and pos-image seams are covered at their client boundaries
- [x] Provider behavioral contract tests — `EdiwheelC12MktCatCodecTest` pins the decode rules
- How to run:
```bash
./mvnw -pl pos-supplier,pos-image,pos-domain-events -am test
./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test
```

Verified: pos-supplier 1047, pos-image 19, pos-domain-events 379, gateway 79, security-service 483,
security-common 103, architecture gates 22.

## Risk & Rollback
- Risk level: Medium — new capability and no existing path changed, but pos-image gains security it
  never had. Its read endpoints stay open by design; a deployment that reaches them through the
  gateway is unaffected.
- Rollback plan: revert both commits. `V2__image_content_storage.sql` only adds a table and nullable
  columns, and `V18__mkcat_enrichment.sql` adds two tables nothing else references, so both can be
  left in place or dropped independently.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [x] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mv7zVYjwbVu5GRqrfkfHc7
