### PR TITLE
fix(ci): run the coverage ratchet on pull requests, and clear the backlog it let through

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,22 +258,42 @@ jobs:
         # lowResourceTests bounds each Surefire fork to 1 GiB: with -T 1C up to four
         # module builds fork test JVMs concurrently, and default heap sizing would
         # overcommit the 16 GB runner.
+        #
+        # The `check` goal is invoked directly rather than by running `verify`: the
+        # ratchet's check-ratchet execution is bound to verify, so a build that stops at
+        # `test` never evaluates it and every PR merged ungated (the nightly then caught
+        # the regression a day late). Invoking the goal gates here without paying for
+        # package + spring-boot:repackage on every changed module. Its rules live at
+        # plugin level in the root pom precisely so this CLI invocation sees them.
+        #
+        # -DskipITs is what makes this the RIGHT gate: it is the measurement the nightly
+        # ratchet performs and the one the floors are derived from. Do not drop it.
         run: |
           ./mvnw ${{ steps.selection.outputs.args-pr }} \
             -DskipTests=false test \
             org.jacoco:jacoco-maven-plugin:0.8.14:report \
+            org.jacoco:jacoco-maven-plugin:0.8.14:check \
             -Darchunit.skipTests=true \
             -DlowResourceTests=true \
             -DskipITs -T 1C -B -ntp
 
       - name: Test changed modules and dependents incl. ITs (main)
         if: github.event_name != 'pull_request' && steps.selection.outputs.run-tests == 'true'
+        # This step runs the ITs, so its jacoco.exec is IT-inclusive and its coverage is
+        # higher than the floors describe. Reaching `verify` fires the check-ratchet
+        # execution against that inflated data, which cannot fail honestly — it can only
+        # pass a module the unit-only gate would reject, and that false green is exactly
+        # how pos-image and pos-supplier reached main below their floors. haltOnFailure is
+        # off here so the numbers are still logged for information while the binding
+        # verdicts come from the two unit-only measurements: the PR step above and the
+        # nightly ratchet job. See docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md §6.2.
         run: |
           ./mvnw ${{ steps.selection.outputs.args }} \
             -DskipTests=false verify \
             org.jacoco:jacoco-maven-plugin:0.8.14:report \
             -Darchunit.skipTests=true \
             -DlowResourceTests=true \
+            -Djacoco.check.haltOnFailure=false \
             -T 1C -B -ntp
 
       - name: Summarize test failures

--- a/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
+++ b/docs/TEST_COVERAGE_IMPROVEMENT_PLAN.md
@@ -754,6 +754,28 @@ The one narrow edge is a *partial* `jacoco.exec` left by an interrupted test run
 where a later `install -DskipTests` would judge incomplete data — `clean` fixes
 that, and CI always runs tests.
 
+**Where the gate actually runs.** Three CI steps touch coverage, and only two of
+them are binding:
+
+| step | measurement | binding? |
+|---|---|---|
+| PR — "Test changed modules and dependents" | `test` + `jacoco:check`, `-DskipITs` | **yes** — pre-merge gate |
+| main — "…incl. ITs" | `verify`, ITs included | no — `haltOnFailure=false` |
+| nightly — "Build aggregate coverage report" | `verify -DskipITs`, full reactor | **yes** — job fails on any violation |
+
+The PR step invokes `jacoco:check` directly instead of running `verify`. The
+`check-ratchet` execution is bound to `verify`, so a build that stops at `test`
+never evaluates it — which is why every PR merged ungated until 2026-08-16, and the
+nightly caught regressions a day late. The rules therefore live in a **plugin-level**
+`<configuration>` in the root pom, not inside the execution: execution configuration
+is invisible to CLI-invoked goals.
+
+The main step is deliberately **not** binding. It runs the ITs, so its coverage is
+higher than the floors describe; letting it decide would produce false greens, never
+honest failures. That is precisely how `pos-image` and `pos-supplier` reached main
+below their floors. Both binding gates measure `-DskipITs`, the same way the floors
+are derived (§6.1).
+
 **Working rules.**
 
 - Raise a module's floor when its coverage rises — that is what makes it a

--- a/pom.xml
+++ b/pom.xml
@@ -524,6 +524,31 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
+				<!-- Plugin-level, so the ratchet rules apply BOTH to the check-ratchet execution
+				     bound to verify AND to a direct `jacoco:check` on the command line. Execution
+				     configuration is invisible to CLI-invoked goals, and the PR build gates by
+				     invoking the goal directly rather than paying for a full `verify`
+				     (.github/workflows/ci.yml). Keeping one definition keeps the two in step. -->
+				<configuration>
+					<haltOnFailure>${jacoco.check.haltOnFailure}</haltOnFailure>
+					<rules>
+						<rule>
+							<element>BUNDLE</element>
+							<limits>
+								<limit>
+									<counter>LINE</counter>
+									<value>COVEREDRATIO</value>
+									<minimum>${jacoco.line.min}</minimum>
+								</limit>
+								<limit>
+									<counter>BRANCH</counter>
+									<value>COVEREDRATIO</value>
+									<minimum>${jacoco.branch.min}</minimum>
+								</limit>
+							</limits>
+						</rule>
+					</rules>
+				</configuration>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>
@@ -550,26 +575,6 @@
 						<goals>
 							<goal>check</goal>
 						</goals>
-						<configuration>
-							<haltOnFailure>${jacoco.check.haltOnFailure}</haltOnFailure>
-							<rules>
-								<rule>
-									<element>BUNDLE</element>
-									<limits>
-										<limit>
-											<counter>LINE</counter>
-											<value>COVEREDRATIO</value>
-											<minimum>${jacoco.line.min}</minimum>
-										</limit>
-										<limit>
-											<counter>BRANCH</counter>
-											<value>COVEREDRATIO</value>
-											<minimum>${jacoco.branch.min}</minimum>
-										</limit>
-									</limits>
-								</rule>
-							</rules>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/pos-image/src/test/java/com/positivity/image/internal/service/ImageServiceImplTest.java
+++ b/pos-image/src/test/java/com/positivity/image/internal/service/ImageServiceImplTest.java
@@ -1,0 +1,170 @@
+package com.positivity.image.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.positivity.image.internal.dto.ImageContentView;
+import com.positivity.image.internal.dto.ImageFileView;
+import com.positivity.image.internal.entity.ImageContentEntity;
+import com.positivity.image.internal.entity.ImageEntity;
+import com.positivity.image.internal.repository.ImageContentRepository;
+import com.positivity.image.internal.repository.ImageRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Reading images back (CAP-324 #1257). A record that carries a content hash is served from stored
+ * bytes; one that predates content storage carries no hash and falls back to its url path. A record
+ * whose hash points at content that is not there is a broken row, not an empty image.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ImageServiceImpl")
+class ImageServiceImplTest {
+
+    private static final long IMAGE_ID = 42L;
+    private static final String FILENAME = "logo.png";
+    private static final String HASH = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    private static final byte[] BYTES = "png-bytes".getBytes(StandardCharsets.UTF_8);
+
+    @Mock
+    private ImageRepository imageRepository;
+
+    @Mock
+    private ImageContentRepository contentRepository;
+
+    private ImageServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ImageServiceImpl(imageRepository, contentRepository);
+    }
+
+    private static ImageEntity record(String contentHash) {
+        ImageEntity image = new ImageEntity();
+        image.setId(IMAGE_ID);
+        image.setFilename(FILENAME);
+        image.setUrl("/legacy/path/logo.png");
+        image.setContentHash(contentHash);
+        return image;
+    }
+
+    private static ImageContentEntity blob() {
+        ImageContentEntity content = new ImageContentEntity();
+        content.setContentHash(HASH);
+        content.setContentType("image/png");
+        content.setByteSize(BYTES.length);
+        content.setContent(BYTES);
+        return content;
+    }
+
+    @Nested
+    @DisplayName("file lookups")
+    class FileLookups {
+
+        @Test
+        @DisplayName("maps a record to its filename and url by id")
+        void findsById() {
+            when(imageRepository.findById(IMAGE_ID)).thenReturn(Optional.of(record(HASH)));
+
+            assertThat(service.findById(IMAGE_ID)).contains(new ImageFileView(FILENAME, "/legacy/path/logo.png"));
+        }
+
+        @Test
+        @DisplayName("maps a record to its filename and url by filename")
+        void findsByFilename() {
+            when(imageRepository.findByFilename(FILENAME)).thenReturn(Optional.of(record(HASH)));
+
+            assertThat(service.findByFilename(FILENAME)).contains(new ImageFileView(FILENAME, "/legacy/path/logo.png"));
+        }
+
+        @Test
+        @DisplayName("returns empty for an unknown id or filename")
+        void missingRecord() {
+            when(imageRepository.findById(IMAGE_ID)).thenReturn(Optional.empty());
+            when(imageRepository.findByFilename(FILENAME)).thenReturn(Optional.empty());
+
+            assertThat(service.findById(IMAGE_ID)).isEmpty();
+            assertThat(service.findByFilename(FILENAME)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("content lookups")
+    class ContentLookups {
+
+        @Test
+        @DisplayName("serves the stored bytes for a record that carries a hash")
+        void servesStoredContent() {
+            when(imageRepository.findById(IMAGE_ID)).thenReturn(Optional.of(record(HASH)));
+            when(contentRepository.findById(HASH)).thenReturn(Optional.of(blob()));
+
+            assertThat(service.findContentById(IMAGE_ID)).contains(new ImageContentView(FILENAME, "image/png", BYTES));
+        }
+
+        @Test
+        @DisplayName("serves the stored bytes when looked up by filename")
+        void servesStoredContentByFilename() {
+            when(imageRepository.findByFilename(FILENAME)).thenReturn(Optional.of(record(HASH)));
+            when(contentRepository.findById(HASH)).thenReturn(Optional.of(blob()));
+
+            assertThat(service.findContentByFilename(FILENAME))
+                    .contains(new ImageContentView(FILENAME, "image/png", BYTES));
+        }
+
+        @Test
+        @DisplayName("reports no content for a record that predates content storage")
+        void nullHashFallsBackToUrl() {
+            when(imageRepository.findById(IMAGE_ID)).thenReturn(Optional.of(record(null)));
+            when(imageRepository.findByFilename(FILENAME)).thenReturn(Optional.of(record(null)));
+
+            assertThat(service.findContentById(IMAGE_ID)).isEmpty();
+            assertThat(service.findContentByFilename(FILENAME)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("treats a blank hash the same as none")
+        void blankHashFallsBackToUrl() {
+            when(imageRepository.findById(IMAGE_ID)).thenReturn(Optional.of(record("   ")));
+
+            assertThat(service.findContentById(IMAGE_ID)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("returns empty for an unknown record rather than reaching for content")
+        void missingRecord() {
+            when(imageRepository.findById(IMAGE_ID)).thenReturn(Optional.empty());
+            when(imageRepository.findByFilename(FILENAME)).thenReturn(Optional.empty());
+
+            assertThat(service.findContentById(IMAGE_ID)).isEmpty();
+            assertThat(service.findContentByFilename(FILENAME)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("fails loudly when a record points at content that is not stored")
+        void danglingContentHashIsABrokenRow() {
+            when(imageRepository.findById(IMAGE_ID)).thenReturn(Optional.of(record(HASH)));
+            when(imageRepository.findByFilename(FILENAME)).thenReturn(Optional.of(record(HASH)));
+            when(contentRepository.findById(HASH)).thenReturn(Optional.empty());
+
+            // Reporting this as absent would send the reader to the url fallback, which for a
+            // stored image is a path that never existed.
+            assertThatThrownBy(() -> service.findContentById(IMAGE_ID))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("which is not stored");
+            assertThatThrownBy(() -> service.findContentByFilename(FILENAME))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("which is not stored");
+        }
+    }
+}

--- a/pos-image/src/test/java/com/positivity/image/internal/service/ImageStorageServiceImplTest.java
+++ b/pos-image/src/test/java/com/positivity/image/internal/service/ImageStorageServiceImplTest.java
@@ -143,6 +143,37 @@ class ImageStorageServiceImplTest {
     }
 
     @Test
+    @DisplayName("a null body is refused the same way an empty one is")
+    void nullContentIsRefused() {
+        assertThatThrownBy(() -> storage.store("tread.jpg", "image/jpeg", null, VENDOR_URI, List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("retried");
+
+        verify(imageRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("a re-ingested record missing its type and size still yields a usable reference")
+    void referenceFillsInMissingTypeAndSize() {
+        // Rows written before the content columns existed carry neither. The reference has to name
+        // a content type and a size regardless, or a consumer cannot render what it is handed.
+        ImageEntity legacy = new ImageEntity();
+        legacy.setId(7L);
+        legacy.setFilename("legacy.jpg");
+        legacy.setContentHash("whatever-hash");
+        legacy.setSourceUri(VENDOR_URI);
+        legacy.setContentType(null);
+        legacy.setByteSize(null);
+        when(imageRepository.findFirstBySourceUriAndContentHash(any(), any())).thenReturn(Optional.of(legacy));
+
+        StoredImage reference = storage.store("tread.jpg", "image/jpeg", ARTWORK, VENDOR_URI, List.of());
+
+        assertThat(reference.contentType()).isEqualTo("application/octet-stream");
+        assertThat(reference.byteSize()).isZero();
+        assertThat(reference.newlyStored()).isFalse();
+    }
+
+    @Test
     @DisplayName("a direct upload with no origin is stored, and the origin lookup is skipped")
     void uploadWithoutAnOriginIsAccepted() {
         StoredImage stored = storage.store("hand-uploaded.png", "image/png", ARTWORK, null, null);

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatImporterSweepTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/mktcat/service/MktCatImporterSweepTest.java
@@ -1,0 +1,345 @@
+package com.positivity.supplier.internal.mktcat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentImage;
+import com.positivity.supplier.internal.adapter.ediwheelc12.EdiwheelC12MktCatCodec;
+import com.positivity.supplier.internal.adapter.ediwheelc12.MktCatDecodeException;
+import com.positivity.supplier.internal.client.SupplierBaseClient;
+import com.positivity.supplier.internal.client.SupplierHttpResponse;
+import com.positivity.supplier.internal.domain.model.MarketingVariant;
+import com.positivity.supplier.internal.domain.model.ProtocolFamily;
+import com.positivity.supplier.internal.domain.model.ProtocolVersion;
+import com.positivity.supplier.internal.domain.model.SupplierCapability;
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
+import com.positivity.supplier.internal.entity.SupplierAuthConfigEntity;
+import com.positivity.supplier.internal.entity.SupplierEndpointBindingEntity;
+import com.positivity.supplier.internal.entity.SupplierMktCatVariantEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.exception.MktCatImportException;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
+import com.positivity.supplier.internal.registry.AdapterRegistry;
+import com.positivity.supplier.internal.registry.AdapterResolution;
+import com.positivity.supplier.internal.repository.SupplierMktCatVariantRepository;
+import com.positivity.supplier.internal.service.SupplierOutboxEventWriter;
+import com.positivity.supplier.internal.service.SupplierProfileResolver;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import com.positivity.supplier.internal.spi.ExchangeOutcome;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * The sweep around {@code stageAndPublish} (CAP-324 #1230): reading the variant list, fetching each
+ * variant's detail, images and language data, and surviving the ones that cannot be read.
+ *
+ * <p>The load-bearing behaviour here is partial failure. One unreadable variant must cost that
+ * variant and nothing else — a sweep that aborted would lose the whole catalogue over a single bad
+ * row, and one that reported an empty list would look to a differ like the vendor withdrawing
+ * everything.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("MktCatImporter — the sweep")
+class MktCatImporterSweepTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-16T10:00:00Z");
+    private static final UUID PROFILE_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000b1");
+    private static final SupplierRef SUPPLIER = new SupplierRef("ediwheel-net");
+
+    @Mock
+    private SupplierProfileResolver profileResolver;
+
+    @Mock
+    private AdapterRegistry adapterRegistry;
+
+    @Mock
+    private SupplierBaseClient baseClient;
+
+    @Mock
+    private SupplierMktCatVariantRepository variantRepository;
+
+    @Mock
+    private MktCatImageFetcher imageFetcher;
+
+    @Mock
+    private SupplierOutboxEventWriter outboxEventWriter;
+
+    @Mock
+    private EdiwheelC12MktCatCodec codec;
+
+    private MktCatImporter importer;
+
+    @BeforeEach
+    void setUp() {
+        importer = new MktCatImporter(
+                profileResolver,
+                adapterRegistry,
+                baseClient,
+                variantRepository,
+                imageFetcher,
+                outboxEventWriter,
+                JsonMapper.builder().build(),
+                Clock.fixed(NOW, ZoneOffset.UTC));
+
+        when(profileResolver.resolveBinding(any(), any())).thenReturn(binding());
+        when(adapterRegistry.resolve(any(), any(), any())).thenReturn(new AdapterResolution.Resolved(codec));
+        SupplierRequestSpec spec =
+                new SupplierRequestSpec("GET", "/variants", Map.of(), null, null, null, true, Map.of());
+        when(codec.buildVariantListRequest()).thenReturn(spec);
+        when(codec.buildVariantDetailRequest(any())).thenReturn(spec);
+        when(codec.buildVariantImagesRequest(any())).thenReturn(spec);
+        when(codec.buildVariantLanguageDataRequest(any())).thenReturn(spec);
+        when(baseClient.exchange(any())).thenReturn(ok("{}"));
+        when(imageFetcher.fetchAndStore(any())).thenReturn(List.of());
+        when(variantRepository.findByVendorProfileIdAndVendorVariantId(any(), any()))
+                .thenReturn(Optional.empty());
+        when(variantRepository.save(any())).thenAnswer(invocation -> {
+            SupplierMktCatVariantEntity row = invocation.getArgument(0);
+            if (row.getSupplierMktCatVariantId() == null) {
+                row.setSupplierMktCatVariantId(UUID.fromString("019200aa-0000-7000-8000-0000000000a1"));
+            }
+            return row;
+        });
+    }
+
+    private static ResolvedBinding binding() {
+        SupplierProfileEntity profile = new SupplierProfileEntity();
+        profile.setVendorProfileId(PROFILE_ID);
+        profile.setSupplierRef(SUPPLIER.value());
+        return new ResolvedBinding(
+                profile,
+                new SupplierEndpointBindingEntity(),
+                new SupplierAuthConfigEntity(),
+                SupplierCapability.MARKETING_CATALOG,
+                ProtocolFamily.EDIWHEEL_JSON,
+                new ProtocolVersion("C1.2"));
+    }
+
+    private static SupplierHttpResponse ok(String body) {
+        return new SupplierHttpResponse(
+                ExchangeOutcome.OK, 200, body, "corr-1", 1, Duration.ofMillis(5), null, Map.of());
+    }
+
+    private static SupplierHttpResponse failed(String detail) {
+        return new SupplierHttpResponse(
+                ExchangeOutcome.PRE_SEND_FAILURE, null, null, "corr-1", 1, Duration.ofMillis(5), detail, Map.of());
+    }
+
+    private static MarketingVariant variant(String id) {
+        return new MarketingVariant(
+                id, "Michelin", "Primacy 4", null, "Primacy 4", "PC", "SUMMER", List.of(), List.of());
+    }
+
+    @Nested
+    @DisplayName("importAll")
+    class ImportAll {
+
+        @Test
+        @DisplayName("imports every variant the list names")
+        void importsTheWholeList() {
+            when(codec.decodeVariantIds(any())).thenReturn(List.of("V1", "V2"));
+            when(codec.decodeVariant(any(), any(), any(), any())).thenAnswer(i -> variant(i.getArgument(0)));
+
+            MktCatImporter.ImportOutcome outcome = importer.importAll(SUPPLIER);
+
+            assertThat(outcome.seen()).isEqualTo(2);
+            assertThat(outcome.published()).isEqualTo(2);
+            assertThat(outcome.skipped()).isZero();
+        }
+
+        @Test
+        @DisplayName("throws rather than reporting an empty catalogue when the list cannot be read")
+        void unreadableListThrows() {
+            // Reported as empty, a differ would read this as the vendor withdrawing everything.
+            when(baseClient.exchange(any())).thenReturn(failed("connection refused"));
+
+            assertThatThrownBy(() -> importer.importAll(SUPPLIER))
+                    .isInstanceOf(MktCatImportException.class)
+                    .hasMessageContaining("variant list could not be read")
+                    .hasMessageContaining("connection refused");
+            verify(outboxEventWriter, never()).publish(any(), any());
+        }
+
+        @Test
+        @DisplayName("omits the detail suffix when the failure carried none")
+        void unreadableListWithoutDetail() {
+            when(baseClient.exchange(any()))
+                    .thenReturn(new SupplierHttpResponse(
+                            ExchangeOutcome.PRE_SEND_FAILURE,
+                            null,
+                            null,
+                            "corr-1",
+                            1,
+                            Duration.ofMillis(5),
+                            null,
+                            Map.of()));
+
+            assertThatThrownBy(() -> importer.importAll(SUPPLIER))
+                    .isInstanceOf(MktCatImportException.class)
+                    .hasMessageNotContaining("--");
+        }
+
+        @Test
+        @DisplayName("an empty catalogue is a valid answer and publishes nothing")
+        void emptyCatalogue() {
+            when(codec.decodeVariantIds(any())).thenReturn(List.of());
+
+            MktCatImporter.ImportOutcome outcome = importer.importAll(SUPPLIER);
+
+            assertThat(outcome.seen()).isZero();
+            verify(outboxEventWriter, never()).publish(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("importVariants")
+    class ImportVariants {
+
+        @Test
+        @DisplayName("one unreadable variant is skipped and the rest of the sweep continues")
+        void oneBadVariantDoesNotEndTheImport() {
+            when(codec.decodeVariant(eq("V1"), any(), any(), any())).thenThrow(new MktCatDecodeException("bad xml"));
+            when(codec.decodeVariant(eq("V2"), any(), any(), any())).thenReturn(variant("V2"));
+
+            MktCatImporter.ImportOutcome outcome = importer.importVariants(SUPPLIER, List.of("V1", "V2"));
+
+            assertThat(outcome.seen()).isEqualTo(2);
+            assertThat(outcome.published()).isEqualTo(1);
+            assertThat(outcome.skipped()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("a variant whose detail cannot be read is skipped, not fatal")
+        void unreadableDetailIsSkipped() {
+            when(baseClient.exchange(any())).thenReturn(failed("timeout"));
+
+            MktCatImporter.ImportOutcome outcome = importer.importVariants(SUPPLIER, List.of("V1"));
+
+            assertThat(outcome.skipped()).isEqualTo(1);
+            assertThat(outcome.published()).isZero();
+        }
+
+        @Test
+        @DisplayName("an unchanged variant is seen but not published")
+        void unchangedVariantIsNotRepublished() {
+            when(codec.decodeVariant(any(), any(), any(), any())).thenReturn(variant("V1"));
+            MktCatImporter.ImportOutcome first = importer.importVariants(SUPPLIER, List.of("V1"));
+            String hash = firstSavedHash();
+
+            when(variantRepository.findByVendorProfileIdAndVendorVariantId(any(), any()))
+                    .thenReturn(Optional.of(SupplierMktCatVariantEntity.builder()
+                            .supplierMktCatVariantId(UUID.fromString("019200aa-0000-7000-8000-0000000000a1"))
+                            .vendorProfileId(PROFILE_ID)
+                            .vendorVariantId("V1")
+                            .contentHash(hash)
+                            .build()));
+
+            MktCatImporter.ImportOutcome second = importer.importVariants(SUPPLIER, List.of("V1"));
+
+            assertThat(first.published()).isEqualTo(1);
+            assertThat(second.published()).isZero();
+            assertThat(second.seen()).isEqualTo(1);
+        }
+
+        private String firstSavedHash() {
+            org.mockito.ArgumentCaptor<SupplierMktCatVariantEntity> captor =
+                    org.mockito.ArgumentCaptor.forClass(SupplierMktCatVariantEntity.class);
+            verify(variantRepository).save(captor.capture());
+            return captor.getValue().getContentHash();
+        }
+    }
+
+    @Nested
+    @DisplayName("optional data and hashing")
+    class OptionalDataAndHashing {
+
+        @Test
+        @DisplayName("missing images and language data do not stop the variant being imported")
+        void optionalDataMayBeAbsent() {
+            // A variant with neither is still a variant; refusing it would lose the design entirely
+            // over its lack of a picture.
+            when(baseClient.exchange(any()))
+                    .thenReturn(ok("<detail/>"))
+                    .thenReturn(failed("no images"))
+                    .thenReturn(failed("no languages"));
+            when(codec.decodeVariant(any(), any(), any(), any())).thenReturn(variant("V1"));
+
+            assertThat(importer.importVariants(SUPPLIER, List.of("V1")).published())
+                    .isEqualTo(1);
+            verify(codec).decodeVariant(eq("V1"), eq("<detail/>"), eq(null), eq(null));
+        }
+
+        @Test
+        @DisplayName("unresolved artwork changes the hash, so the variant republishes once it arrives")
+        void unresolvedArtworkIsPartOfTheHash() {
+            when(codec.decodeVariant(any(), any(), any(), any())).thenReturn(variant("V1"));
+            when(imageFetcher.fetchAndStore(any()))
+                    .thenReturn(List.of(new SupplierCatalogEnrichmentImage("MAIN", null, null, null, true)));
+            importer.importVariants(SUPPLIER, List.of("V1"));
+            String unresolvedHash = savedHash();
+
+            org.mockito.Mockito.reset(variantRepository);
+            when(variantRepository.findByVendorProfileIdAndVendorVariantId(any(), any()))
+                    .thenReturn(Optional.empty());
+            when(variantRepository.save(any())).thenAnswer(i -> {
+                SupplierMktCatVariantEntity row = i.getArgument(0);
+                row.setSupplierMktCatVariantId(UUID.fromString("019200aa-0000-7000-8000-0000000000a1"));
+                return row;
+            });
+            when(imageFetcher.fetchAndStore(any()))
+                    .thenReturn(List.of(new SupplierCatalogEnrichmentImage(
+                            "MAIN", 1L, "hash-a", "https://cdn.example.com/1.jpg", false)));
+            importer.importVariants(SUPPLIER, List.of("V1"));
+
+            assertThat(savedHash()).isNotEqualTo(unresolvedHash);
+        }
+
+        private String savedHash() {
+            org.mockito.ArgumentCaptor<SupplierMktCatVariantEntity> captor =
+                    org.mockito.ArgumentCaptor.forClass(SupplierMktCatVariantEntity.class);
+            verify(variantRepository).save(captor.capture());
+            return captor.getValue().getContentHash();
+        }
+    }
+
+    @Nested
+    @DisplayName("codec resolution")
+    class CodecResolution {
+
+        @Test
+        @DisplayName("refuses a binding with no marketing catalogue codec registered")
+        void noCodecRegistered() {
+            when(adapterRegistry.resolve(any(), any(), any()))
+                    .thenReturn(new AdapterResolution.NotConfigured("nothing bound"));
+
+            // Asserting on the capability and protocol rather than the sentence: the message is
+            // SupplierCodecs' to word, and pinning its prose makes this test fail on a rewording.
+            assertThatThrownBy(() -> importer.importAll(SUPPLIER))
+                    .isInstanceOf(SupplierConfigurationException.class)
+                    .hasMessageContainingAll("MARKETING_CATALOG", "EDIWHEEL_JSON", "C1.2");
+        }
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/SupplierPriceCatalogServiceImplTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/SupplierPriceCatalogServiceImplTest.java
@@ -1,0 +1,285 @@
+package com.positivity.supplier.internal.pricecatalog.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.entity.PriceCatalogImportEntity;
+import com.positivity.supplier.internal.entity.PriceCatalogUnmatchedLineEntity;
+import com.positivity.supplier.internal.entity.SupplierProfileEntity;
+import com.positivity.supplier.internal.enums.PriceCatalogImportStatus;
+import com.positivity.supplier.internal.enums.UnmatchedLineReason;
+import com.positivity.supplier.internal.exception.SupplierConfigurationException;
+import com.positivity.supplier.internal.repository.PriceCatalogImportRepository;
+import com.positivity.supplier.internal.repository.PriceCatalogUnmatchedLineRepository;
+import com.positivity.supplier.internal.repository.SupplierProfileRepository;
+import com.positivity.supplier.service.model.PagedResponse;
+import com.positivity.supplier.service.model.PriceCatalogImportSummary;
+import com.positivity.supplier.service.model.UnmatchedPriceCatalogLineView;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Import bookkeeping and the on-demand trigger for vendor price catalogs (ADR-0053 §7).
+ *
+ * <p>The reads are thin projections, but they are the projections an operator uses to tell a run
+ * that completed from one that failed, and a line that went unmatched from one that was resolved —
+ * so every field the view promises has to survive the mapping.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("SupplierPriceCatalogServiceImpl")
+class SupplierPriceCatalogServiceImplTest {
+
+    private static final UUID PROFILE_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000b1");
+    private static final UUID MANIFEST_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000c1");
+    private static final UUID LINE_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000d1");
+    private static final Instant FETCHED = Instant.parse("2026-08-16T09:00:00Z");
+    private static final Instant COMPLETED = Instant.parse("2026-08-16T09:04:00Z");
+
+    @Mock
+    private PriceCatalogImportRepository importRepository;
+
+    @Mock
+    private PriceCatalogUnmatchedLineRepository unmatchedLineRepository;
+
+    @Mock
+    private SupplierProfileRepository profileRepository;
+
+    @Mock
+    private PriceCatalogImporter importService;
+
+    @Mock
+    private QuarantineReapplier reapplicationService;
+
+    private SupplierPriceCatalogServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SupplierPriceCatalogServiceImpl(
+                importRepository, unmatchedLineRepository, profileRepository, importService, reapplicationService);
+    }
+
+    private static PriceCatalogImportEntity importRow(PriceCatalogImportStatus status) {
+        return PriceCatalogImportEntity.builder()
+                .importManifestId(MANIFEST_ID)
+                .vendorProfileId(PROFILE_ID)
+                .supplierRef("michelin-eu")
+                .status(status)
+                .fetchedAt(FETCHED)
+                .completedAt(status == PriceCatalogImportStatus.COMPLETED ? COMPLETED : null)
+                .linesFetched(1200)
+                .linesMatched(1180)
+                .linesUnmatched(15)
+                .linesDuplicate(5)
+                .chunkCount(3)
+                .sourceDocumentId("PRICAT-88")
+                .sourceDocumentDate(LocalDate.of(2026, 8, 16))
+                .countryCode("DE")
+                .currency("EUR")
+                .failureDetail(status == PriceCatalogImportStatus.FAILED ? "vendor returned 503" : null)
+                .build();
+    }
+
+    private static PriceCatalogUnmatchedLineEntity unmatchedRow() {
+        return PriceCatalogUnmatchedLineEntity.builder()
+                .unmatchedLineId(LINE_ID)
+                .importManifestId(MANIFEST_ID)
+                .vendorProfileId(PROFILE_ID)
+                .positionNumber(17)
+                .articleEan("4001861234567")
+                .supplierArticleCode("MI-225-45-17")
+                .xReferenceCode("XREF-9")
+                .reason(UnmatchedLineReason.NO_CATALOG_MATCH)
+                .reasonDetail("no product carries this EAN")
+                .netPrice(new BigDecimal("81.40"))
+                .grossPrice(new BigDecimal("96.87"))
+                .effectiveFrom(LocalDate.of(2026, 9, 1))
+                .currency("EUR")
+                .fetchedAt(FETCHED)
+                .resolvedAt(null)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("findLatestImport")
+    class FindLatestImport {
+
+        @Test
+        @DisplayName("maps every field of the newest completed run")
+        void mapsTheLatestCompletedRun() {
+            when(importRepository.findFirstByVendorProfileIdAndStatusOrderByFetchedAtDesc(
+                            PROFILE_ID, PriceCatalogImportStatus.COMPLETED))
+                    .thenReturn(Optional.of(importRow(PriceCatalogImportStatus.COMPLETED)));
+
+            Optional<PriceCatalogImportSummary> summary = service.findLatestImport(PROFILE_ID);
+
+            assertThat(summary).isPresent();
+            PriceCatalogImportSummary s = summary.get();
+            assertThat(s.importManifestId()).isEqualTo(MANIFEST_ID);
+            assertThat(s.vendorProfileId()).isEqualTo(PROFILE_ID);
+            assertThat(s.supplierRef()).isEqualTo("michelin-eu");
+            assertThat(s.status()).isEqualTo("COMPLETED");
+            assertThat(s.fetchedAt()).isEqualTo(FETCHED);
+            assertThat(s.completedAt()).isEqualTo(COMPLETED);
+            assertThat(s.linesFetched()).isEqualTo(1200);
+            assertThat(s.linesMatched()).isEqualTo(1180);
+            assertThat(s.linesUnmatched()).isEqualTo(15);
+            assertThat(s.linesDuplicate()).isEqualTo(5);
+            assertThat(s.chunkCount()).isEqualTo(3);
+            assertThat(s.sourceDocumentId()).isEqualTo("PRICAT-88");
+            assertThat(s.sourceDocumentDate()).isEqualTo(LocalDate.of(2026, 8, 16));
+            assertThat(s.countryCode()).isEqualTo("DE");
+            assertThat(s.currency()).isEqualTo("EUR");
+            assertThat(s.failureDetail()).isNull();
+        }
+
+        @Test
+        @DisplayName("returns empty when the profile has never completed a run")
+        void noCompletedRun() {
+            when(importRepository.findFirstByVendorProfileIdAndStatusOrderByFetchedAtDesc(any(), any()))
+                    .thenReturn(Optional.empty());
+
+            assertThat(service.findLatestImport(PROFILE_ID)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("listing")
+    class Listing {
+
+        @Test
+        @DisplayName("pages the import history and carries a failed run's detail through")
+        void pagesImportHistory() {
+            PriceCatalogImportEntity failed = importRow(PriceCatalogImportStatus.FAILED);
+            when(importRepository.findByVendorProfileIdOrderByFetchedAtDesc(eq(PROFILE_ID), any(Pageable.class)))
+                    .thenReturn(new PageImpl<>(List.of(failed), PageRequest.of(1, 20), 21));
+
+            PagedResponse<PriceCatalogImportSummary> page = service.listImports(PROFILE_ID, 1, 20);
+
+            assertThat(page.page()).isEqualTo(1);
+            assertThat(page.size()).isEqualTo(20);
+            assertThat(page.totalElements()).isEqualTo(21);
+            assertThat(page.items()).singleElement().satisfies(item -> {
+                assertThat(item.status()).isEqualTo("FAILED");
+                assertThat(item.completedAt()).isNull();
+                assertThat(item.failureDetail()).isEqualTo("vendor returned 503");
+            });
+        }
+
+        @Test
+        @DisplayName("lists only unresolved quarantine lines, mapping the identifiers an operator matches on")
+        void pagesUnmatchedLines() {
+            when(unmatchedLineRepository.findByVendorProfileIdAndResolvedAtIsNullOrderByCreatedAtDesc(
+                            eq(PROFILE_ID), any(Pageable.class)))
+                    .thenReturn(new PageImpl<>(List.of(unmatchedRow()), PageRequest.of(0, 50), 1));
+
+            PagedResponse<UnmatchedPriceCatalogLineView> page = service.listUnmatchedLines(PROFILE_ID, 0, 50);
+
+            assertThat(page.items()).singleElement().satisfies(line -> {
+                assertThat(line.unmatchedLineId()).isEqualTo(LINE_ID);
+                assertThat(line.importManifestId()).isEqualTo(MANIFEST_ID);
+                assertThat(line.positionNumber()).isEqualTo(17);
+                assertThat(line.articleEan()).isEqualTo("4001861234567");
+                assertThat(line.supplierArticleCode()).isEqualTo("MI-225-45-17");
+                assertThat(line.xReferenceCode()).isEqualTo("XREF-9");
+                assertThat(line.reason()).isEqualTo("NO_CATALOG_MATCH");
+                assertThat(line.reasonDetail()).isEqualTo("no product carries this EAN");
+                assertThat(line.netPrice()).isEqualByComparingTo("81.40");
+                assertThat(line.grossPrice()).isEqualByComparingTo("96.87");
+                assertThat(line.effectiveFrom()).isEqualTo(LocalDate.of(2026, 9, 1));
+                assertThat(line.currency()).isEqualTo("EUR");
+                assertThat(line.resolvedAt()).isNull();
+            });
+        }
+
+        @Test
+        @DisplayName("an empty page reports its paging rather than pretending there is one row")
+        void emptyPage() {
+            when(importRepository.findByVendorProfileIdOrderByFetchedAtDesc(any(), any(Pageable.class)))
+                    .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 20), 0));
+
+            PagedResponse<PriceCatalogImportSummary> page = service.listImports(PROFILE_ID, 0, 20);
+
+            assertThat(page.items()).isEmpty();
+            assertThat(page.totalElements()).isZero();
+            assertThat(page.totalPages()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("runImport")
+    class RunImport {
+
+        @Test
+        @DisplayName("runs the same import path the scheduler takes, keyed by the profile's supplier ref")
+        void runsTheImport() {
+            SupplierProfileEntity profile = new SupplierProfileEntity();
+            profile.setVendorProfileId(PROFILE_ID);
+            profile.setSupplierRef("michelin-eu");
+            when(profileRepository.findById(PROFILE_ID)).thenReturn(Optional.of(profile));
+            when(importService.runImport(new SupplierRef("michelin-eu")))
+                    .thenReturn(importRow(PriceCatalogImportStatus.COMPLETED));
+
+            assertThat(service.runImport(PROFILE_ID).status()).isEqualTo("COMPLETED");
+            verify(importService).runImport(new SupplierRef("michelin-eu"));
+        }
+
+        @Test
+        @DisplayName("refuses an unknown profile rather than importing nothing quietly")
+        void unknownProfileIsRefused() {
+            when(profileRepository.findById(PROFILE_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.runImport(PROFILE_ID))
+                    .isInstanceOf(SupplierConfigurationException.class)
+                    .hasMessageContaining("No vendor profile exists with id");
+            verify(importService, never()).runImport(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("reapplyQuarantine")
+    class ReapplyQuarantine {
+
+        @Test
+        @DisplayName("maps every run the reapplication produced")
+        void mapsReapplicationRuns() {
+            when(reapplicationService.reapply(PROFILE_ID))
+                    .thenReturn(List.of(
+                            importRow(PriceCatalogImportStatus.COMPLETED), importRow(PriceCatalogImportStatus.FAILED)));
+
+            assertThat(service.reapplyQuarantine(PROFILE_ID))
+                    .extracting(PriceCatalogImportSummary::status)
+                    .containsExactly("COMPLETED", "FAILED");
+        }
+
+        @Test
+        @DisplayName("nothing quarantined is an empty answer, not a failure")
+        void nothingToReapply() {
+            when(reapplicationService.reapply(PROFILE_ID)).thenReturn(List.of());
+
+            assertThat(service.reapplyQuarantine(PROFILE_ID)).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — CI health; closes the last hole behind the recurring nightly ratchet failures
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: build/CI, `domain:image`, `domain:supplier`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Not applicable — no production code changes. The diff is one workflow file, the root pom's JaCoCo plugin configuration, one doc section, and four test files. No controllers, DTOs, `*Request`/`*Response` types, events, `openapi.yaml`, or validation/error models are touched, so no `BACKEND_CONTRACT_GUIDE.md` entry applies.

## Contract Chain (when a Controller changed)
No controller changed; the items below are not applicable.
- [ ] OpenAPI annotations updated on the controller
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`)

## Scope

Two commits, in order: fix the gate, then clear the backlog it let through.

### 1. The gate (`9528132`)

The nightly caught `pos-image` and `pos-supplier` below their floors *after* the code that pushed them there had merged. It should have failed the PR. Three things were in the way.

**The ratchet never ran on a pull request.** The PR step stops at the `test` phase and `check-ratchet` is bound to `verify`, so `jacoco:check` was never invoked. The step generated a coverage report and nothing read it. Every PR merged ungated; the nightly was the first thing to look.

**The main-branch step could only ever pass dishonestly.** It runs `verify` *including* the ITs, so `check-ratchet` evaluated IT-inclusive coverage — higher than the floors describe, which are derived from a `-DskipITs` run (§6.1). A module below its unit-only floor sails through because the ITs cover the gap. That is exactly how these two reached main.

This is the same measurement mismatch fixed in #1341, in a second place that change did not touch: there the floors disagreed with the nightly, here the merge gate disagreed with both.

**What changed:**

- The PR step now invokes `jacoco:check` directly, alongside the report it already generated. Invoking the goal rather than switching the phase to `verify` gates without paying for `package` + `spring-boot:repackage` on every changed module and its dependents. It keeps `-DskipITs`, so the pre-merge verdict is measured the same way the floors are.
- That required **hoisting the ratchet rules** from the `check-ratchet` execution up to a plugin-level `<configuration>` in the root pom. Execution configuration is invisible to CLI-invoked goals, so a direct `jacoco:check` would otherwise have found no rules and silently no-opped — worse than the old behaviour, because it would *look* like a gate. Verified both directions on pos-price: an inflated floor fails the CLI check, the real floor passes.
- The main step keeps running the ITs — that signal is worth having — but with `haltOnFailure=false`, so its inflated numbers are logged for information instead of issuing a verdict it cannot make honestly.
- §6.2 gains a table of which steps are binding and why the main one is not.

### 2. The backlog (`e34b5f3`)

**pos-image** went from 6 branches at 100% to 25 of 36 when the image-bytes store landed (#1257) — branch coverage 0.69 against a 0.83 floor. Adds `ImageServiceImplTest` for the read path, which had no unit test at all: serving stored bytes by id and filename, the no-hash and blank-hash fallbacks for records predating content storage, and the dangling-hash case, which throws rather than reporting the image absent — reporting absence would send the reader to a url fallback that for a stored image never existed. Two cases join the storage test for the branches it left: a null body refused the same way an empty one is, and a re-ingested legacy row with neither content type nor size still yielding a usable reference.

**pos-supplier** took MKCAT, fleet authorization, vendor invoices and the transmission scheduler in quick succession, landing at 0.82 line / 0.69 branch against 0.84 / 0.70. Adds:

- `MktCatImporterSweepTest` — the sweep around `stageAndPublish` that the existing test does not reach: the variant list read, per-variant detail, images and language data, and the partial-failure behaviour that matters most here. One unreadable variant costs that variant and nothing else, while an unreadable *list* throws rather than reporting an empty catalogue, which a differ would read as the vendor withdrawing everything.
- `SupplierPriceCatalogServiceImplTest` — the import bookkeeping, which had no test: the projections an operator uses to tell a completed run from a failed one and an unmatched line from a resolved one, plus the unknown-profile refusal.

## Tests

- [x] Unit tests added/updated — four test files across two modules
- [ ] Integration tests added/updated — unchanged
- [ ] Provider behavioral contract tests added/updated — unchanged

**How to run** — the gate's own command:

```bash
./mvnw -pl pos-image,pos-supplier -am verify -DskipITs -Darchunit.skipTests=true
```

Result: `BUILD SUCCESS`, zero test failures, zero `Rule violated for bundle` lines, Spotless / Checkstyle / SpotBugs clean.

| module | line | branch |
|---|---|---|
| pos-image | 0.7488 (floor 0.28) | **0.8889** (floor 0.83) |
| pos-supplier | **0.8483** (floor 0.84) | **0.7097** (floor 0.70) |

pos-supplier is deliberately not left on the line. It was at 0.8394 after the first pass — six lines above its floor — and this work has repeatedly shown what a margin that thin does on a nightly, so a second test class went in rather than declaring victory there.

## Rebased onto the SPI ports refactor

Rebased onto `c769071` after #1349 merged, and **one of the new tests broke**, which is worth flagging rather than burying. The refactor moved codec resolution out of `MktCatImporter` into `SupplierCodecs.require`, which words its failure differently:

```
was:  No marketing catalogue codec registered for ...
now:  No MARKETING_CATALOG codec registered for EDIWHEEL_JSON C1.2
```

The assertion had pinned the old prose. It now asserts on what the message must *convey* — capability, protocol family, version — since the wording belongs to `SupplierCodecs` and pinning it would break again on any rewording. The other nine sweep tests survived the refactor untouched.

The refactor also shrank the module (6705 → 6605 lines, 2262 → 2222 branches) while coverage rose on both counters; the figures above are measured post-rebase.

## Risk & Rollback

- Risk level: **Low** for the test additions; **Medium** for the gate change, because of what it does to everyone else's PRs rather than what it does at runtime. No production code is touched.
- **PRs that would previously have merged clean can now fail on coverage.** That is the intent, and it is the change people will feel. Expect a short adjustment period while modules that had drifted under their floors get caught at the PR rather than in a nightly.
- The PR step gets slightly longer (one extra goal, no extra phase). The main step gets no slower.
- Rollback plan: revert either commit independently. Reverting the gate commit restores the previous behaviour exactly; reverting the test commit only removes tests.

## Note on what is now guarded

After this, all three coverage touchpoints agree on what they measure:

| step | measurement | binding? |
|---|---|---|
| PR | `test` + `jacoco:check`, `-DskipITs` | **yes** |
| main | `verify`, ITs included | no — informational |
| nightly | `verify -DskipITs`, full reactor | **yes** |

Both binding gates measure the same way the floors are derived. That is the property that was missing, and its absence is what produced every ratchet failure in this sequence.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch was pre-assigned as `claude/unit-test-coverage-gaps-qhdok2`
- [ ] PR title starts with `[CAP:<cap-id>]` — no capability id; CI health work
- [ ] Links to parent + child issues are present — no tracking issue for the ratchet failures
- [x] Contract guide updated (when contract semantics changed) — n/a, no contract semantics changed
- [ ] Required CI checks passing — pending this run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9EcuvmxZu9k32ekEiHXZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9EcuvmxZu9k32ekEiHXZX)_