### PR TITLE
[CAP:323] feat(workorder): fleet payment authorization gate (#1346)

### DIFF
--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,9 +1,9 @@
-generatedAt: "2026-08-17T01:13:23.631215+00:00"
+generatedAt: "2026-08-17T14:44:05.196073+00:00"
 root: "."
 summary:
   manifestCount: 23
-  permissionCount: 431
-  uniquePermissionCount: 431
+  permissionCount: 433
+  uniquePermissionCount: 433
   duplicatePermissionNameCount: 0
   parseIssueCount: 0
 manifests:
@@ -926,7 +926,7 @@ manifests:
     domain: "workorder"
     serviceName: "pos-workorder"
     version: "1.0"
-    permissionCount: 51
+    permissionCount: 53
     permissions:
       - name: "workorder:approval_config:create"
         description: "Create approval configurations"
@@ -1030,6 +1030,10 @@ manifests:
         description: "Start work on workorders"
       - name: "workorder:workorder:view"
         description: "View workorders"
+      - name: "workorder:fleet_auth:request"
+        description: "Request or re-request a fleet payment authorization for a workorder"
+      - name: "workorder:fleet_auth:resolve"
+        description: "Resolve a fleet payment authorization that was refused, by revising scope or cancelling"
 permissions:
   - name: "accounting:ap:pay"
     description: "Process payments"
@@ -3469,6 +3473,18 @@ permissions:
     source: "pos-workorder/src/main/resources/permissions.yaml"
   - name: "workorder:events:replay"
     description: "Re-emit published domain events from the outbox (replica seeding and drift repair)"
+    domain: "workorder"
+    serviceName: "pos-workorder"
+    module: "pos-workorder"
+    source: "pos-workorder/src/main/resources/permissions.yaml"
+  - name: "workorder:fleet_auth:request"
+    description: "Request or re-request a fleet payment authorization for a workorder"
+    domain: "workorder"
+    serviceName: "pos-workorder"
+    module: "pos-workorder"
+    source: "pos-workorder/src/main/resources/permissions.yaml"
+  - name: "workorder:fleet_auth:resolve"
+    description: "Resolve a fleet payment authorization that was refused, by revising scope or cancelling"
     domain: "workorder"
     serviceName: "pos-workorder"
     module: "pos-workorder"

--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -1545,6 +1545,12 @@ paths:
     $ref: ../../pos-workorder/openapi.yaml#/paths/~1v1~1workorders~1{workorderId}~1completion-preconditions
   /v1/workorders/{workorderId}/detail:
     $ref: ../../pos-workorder/openapi.yaml#/paths/~1v1~1workorders~1{workorderId}~1detail
+  /v1/workorders/{workorderId}/fleet-authorization:
+    $ref: ../../pos-workorder/openapi.yaml#/paths/~1v1~1workorders~1{workorderId}~1fleet-authorization
+  /v1/workorders/{workorderId}/fleet-authorization/requests:
+    $ref: ../../pos-workorder/openapi.yaml#/paths/~1v1~1workorders~1{workorderId}~1fleet-authorization~1requests
+  /v1/workorders/{workorderId}/fleet-authorization/resolution:
+    $ref: ../../pos-workorder/openapi.yaml#/paths/~1v1~1workorders~1{workorderId}~1fleet-authorization~1resolution
   /v1/workorders/{workorderId}/generate-invoice:
     $ref: ../../pos-workorder/openapi.yaml#/paths/~1v1~1workorders~1{workorderId}~1generate-invoice
   /v1/workorders/{workorderId}/labor:

--- a/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
+++ b/pos-api-gateway/src/main/java/com/positivity/gateway/config/GatewayPermissionCatalog.java
@@ -3,7 +3,7 @@ package com.positivity.gateway.config;
 public final class GatewayPermissionCatalog {
     private GatewayPermissionCatalog() {}
 
-    public static final int CATALOG_VERSION = 55;
+    public static final int CATALOG_VERSION = 56;
 
     protected static final String[] AUTHORITY_BY_BIT = {
         "PERM_accounting:je:view",
@@ -561,7 +561,11 @@ public final class GatewayPermissionCatalog {
 
         // ── New batch (bits 464–465) ──────────────────────────────────────────
         "PERM_image:image:store", // 464
-        "PERM_supplier:mktcat:import" // 465
+        "PERM_supplier:mktcat:import", // 465
+
+        // ── New batch (bits 466–467) ──────────────────────────────────────────
+        "PERM_workorder:fleet_auth:request", // 466
+        "PERM_workorder:fleet_auth:resolve" // 467
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
+++ b/pos-api-gateway/src/test/java/com/positivity/gateway/config/SecurityGatewayConfigTest.java
@@ -1142,13 +1142,13 @@ class SecurityGatewayConfigTest {
     // ── Task-2: new catalog version + extended array tests ───────────────────
 
     @Test
-    @DisplayName("CATALOG_VERSION is 55")
+    @DisplayName("CATALOG_VERSION is 56")
     void catalogVersionMatchesCurrent() {
-        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(55);
+        assertThat(GatewayPermissionCatalog.CATALOG_VERSION).isEqualTo(56);
     }
 
     @Test
-    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 465")
+    @DisplayName("AUTHORITY_BY_BIT covers all bits 241 through 467")
     void authorityByBitCoversNewEntries() {
         // batch-2: previously missing (bits 241-261)
         assertThat(GatewayPermissionCatalog.authorityForBit(241)).isEqualTo("PERM_accounting:events:reprocess");
@@ -1329,8 +1329,11 @@ class SecurityGatewayConfigTest {
         // Running a marketing-catalogue import (CAP-324 #1230): a full read of a centrally published
         // catalogue, not a cheap local query.
         assertThat(GatewayPermissionCatalog.authorityForBit(465)).isEqualTo("PERM_supplier:mktcat:import");
+        // Fleet payment authorization (#1346): requesting one, and resolving a refusal.
+        assertThat(GatewayPermissionCatalog.authorityForBit(466)).isEqualTo("PERM_workorder:fleet_auth:request");
+        assertThat(GatewayPermissionCatalog.authorityForBit(467)).isEqualTo("PERM_workorder:fleet_auth:resolve");
         // beyond array must return null
-        assertThat(GatewayPermissionCatalog.authorityForBit(466)).isNull();
+        assertThat(GatewayPermissionCatalog.authorityForBit(468)).isNull();
     }
 
     @Test

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/invoice/BillingRulesUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/invoice/BillingRulesUpdatedV1.java
@@ -19,13 +19,22 @@ import org.jspecify.annotations.Nullable;
  * @param paymentTermsCode payment terms code (e.g. NET_30)
  * @param invoiceDeliveryMethod delivery method name (EMAIL, PRINT, ...)
  * @param invoiceGroupingStrategy grouping strategy name (PER_WORKORDER, ...)
+ * @param fleetAuthorizationRequired whether work for this party needs a fleet payment authorization
+ *     before it may start (CAP-323 #1346). A policy of the payer, not of the job: it is the same
+ *     answer for every workorder this party pays for, which is why it lives here beside
+ *     {@code purchaseOrderRequired} rather than being decided per workorder and forgotten
+ * @param fleetSupplierRef which fleet program authorises for this party, as a supplier profile
+ *     alias. Carried with the flag because the two are useless apart — knowing authorization is
+ *     required without knowing who to ask leaves a workorder blocked with nowhere to go
  */
 public record BillingRulesUpdatedV1(
         @NonNull String partyId,
         boolean purchaseOrderRequired,
         @Nullable String paymentTermsCode,
         @Nullable String invoiceDeliveryMethod,
-        @Nullable String invoiceGroupingStrategy) {
+        @Nullable String invoiceGroupingStrategy,
+        boolean fleetAuthorizationRequired,
+        @Nullable String fleetSupplierRef) {
 
     public static final String EVENT_TYPE = "invoice.billing-rules.updated";
     public static final int SCHEMA_VERSION = 1;
@@ -33,6 +42,12 @@ public record BillingRulesUpdatedV1(
     public BillingRulesUpdatedV1 {
         if (partyId == null || partyId.isBlank()) {
             throw new IllegalArgumentException("partyId must not be blank");
+        }
+        if (fleetAuthorizationRequired && (fleetSupplierRef == null || fleetSupplierRef.isBlank())) {
+            // A party that needs authorization but names no authoriser would block every one of its
+            // workorders with no way to unblock them: the gate would refuse the start and nothing
+            // could ever ask anybody for permission.
+            throw new IllegalArgumentException("fleetSupplierRef is required when fleetAuthorizationRequired is true");
         }
     }
 }

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/workorder/WorkorderFleetAuthRequestedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/workorder/WorkorderFleetAuthRequestedV1.java
@@ -1,0 +1,106 @@
+package com.positivity.domainevents.workorder;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Workexec asks a fleet program to authorize payment for a workorder, published on
+ * {@code workorder.events.v1} (#1346, ADR-0044 R1).
+ *
+ * <h2>A command, not a fact</h2>
+ *
+ * Unusually for this topic, this asks for something rather than reporting something that happened.
+ * It is here because the alternative is workexec calling pos-supplier synchronously, and the domains
+ * are walled: pos-supplier evaluates authorization, workexec owns the decision record and the
+ * execution gate. The asking has to cross that wall somehow, and an event is the sanctioned way.
+ *
+ * <h2>Vehicle identity travels with the request</h2>
+ *
+ * A fleet program identifies a vehicle by plate, VIN or its own unit number, and at least one is
+ * required — CAP-323's canonical request refuses to be built without one. They are carried here
+ * rather than looked up by the consumer because pos-supplier has no vehicle replica and no business
+ * acquiring one: the domain that owns the workorder is the one that knows which vehicle it is about.
+ *
+ * <h2>Re-requesting is expected</h2>
+ *
+ * An advisor may ask again after revising scope, and {@code attempt} says which try this is. The
+ * consumer keys on {@code (supplierRef, workorderId)} so a re-request updates one authorization
+ * rather than opening a second at the vendor — two live authorizations against one contract is a
+ * thing somebody has to unpick with a fleet manager.
+ *
+ * @param workorderId    the workorder needing payment authorization
+ * @param supplierRef    the fleet program to ask, from the payer's billing rules
+ * @param vendorVehicleId the vendor's own vehicle id, when a previous answer supplied one
+ * @param licensePlate   as registered, where known
+ * @param vin            as registered, where known
+ * @param fleetNumber    the fleet's own unit number, where its operator uses one
+ * @param odometerValue  reading at check-in, as recorded
+ * @param attempt        which request this is for this workorder, starting at 1
+ * @param lines          the work being requested
+ */
+public record WorkorderFleetAuthRequestedV1(
+        @NonNull UUID workorderId,
+        @NonNull String supplierRef,
+        @Nullable String vendorVehicleId,
+        @Nullable String licensePlate,
+        @Nullable String vin,
+        @Nullable String fleetNumber,
+        @Nullable String odometerValue,
+        int attempt,
+        @NonNull List<RequestedLine> lines) {
+
+    /** Event type of this payload on {@code workorder.events.v1}. */
+    public static final String EVENT_TYPE = "workorder.fleetauth.requested";
+
+    /** Payload schema version; additive changes only within v1 (ADR-0044 §3). */
+    public static final int SCHEMA_VERSION = 1;
+
+    /**
+     * One operation or part the fleet is being asked to cover.
+     *
+     * @param reference   the part or operation reference as the shop knows it
+     * @param description free text for a person reading the request at the fleet
+     * @param quantity    how many; never negative
+     */
+    public record RequestedLine(
+            @Nullable String reference, @Nullable String description, int quantity) {
+
+        public RequestedLine {
+            if (quantity < 0) {
+                throw new IllegalArgumentException("quantity must not be negative");
+            }
+        }
+    }
+
+    public WorkorderFleetAuthRequestedV1 {
+        Objects.requireNonNull(workorderId, "workorderId must not be null");
+        Objects.requireNonNull(supplierRef, "supplierRef must not be null");
+        Objects.requireNonNull(lines, "lines must not be null");
+        lines = List.copyOf(lines);
+        if (attempt < 1) {
+            throw new IllegalArgumentException("attempt must be at least 1");
+        }
+        if (!identifiesAVehicle(vendorVehicleId, licensePlate, vin, fleetNumber)) {
+            // Refused here rather than sent, because no fleet program can authorize work on a
+            // vehicle nobody named — and the vendor's rejection would arrive later as an opaque
+            // refusal that looks like the fleet declining to pay.
+            throw new IllegalArgumentException(
+                    "a fleet authorization request must identify a vehicle by vendor id, plate, VIN or fleet number");
+        }
+    }
+
+    private static boolean identifiesAVehicle(
+            @Nullable String vendorVehicleId,
+            @Nullable String licensePlate,
+            @Nullable String vin,
+            @Nullable String fleetNumber) {
+        return notBlank(vendorVehicleId) || notBlank(licensePlate) || notBlank(vin) || notBlank(fleetNumber);
+    }
+
+    private static boolean notBlank(@Nullable String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/workorder/WorkorderFleetAuthRequestedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/workorder/WorkorderFleetAuthRequestedV1Test.java
@@ -1,0 +1,66 @@
+package com.positivity.domainevents.workorder;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A fleet authorization request must name a vehicle (#1346).
+ *
+ * <p>The rule mirrors CAP-323's canonical request on the pos-supplier side: refusing at
+ * construction is what turns a missing vehicle identity into a request problem visible before
+ * anything is sent, rather than an opaque refusal from the vendor arriving later that looks like the
+ * fleet declining to pay.
+ */
+@DisplayName("WorkorderFleetAuthRequestedV1 — a vehicle must be identifiable (#1346)")
+class WorkorderFleetAuthRequestedV1Test {
+
+    private static final UUID WORKORDER_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000c1");
+
+    @Test
+    @DisplayName("no identifier at all is refused")
+    void noIdentifierIsRefused() {
+        assertThatThrownBy(() -> new WorkorderFleetAuthRequestedV1(
+                        WORKORDER_ID, "michelin-de", null, null, null, null, null, 1, List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("identify a vehicle");
+    }
+
+    @Test
+    @DisplayName("blank identifiers count as absent")
+    void blankIdentifiersAreRefused() {
+        assertThatThrownBy(() -> new WorkorderFleetAuthRequestedV1(
+                        WORKORDER_ID, "michelin-de", "  ", "", null, "   ", null, 1, List.of()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("any single identifier is enough")
+    void oneIdentifierIsEnough() {
+        new WorkorderFleetAuthRequestedV1(WORKORDER_ID, "michelin-de", null, "ABC-123", null, null, null, 1, List.of());
+        new WorkorderFleetAuthRequestedV1(
+                WORKORDER_ID, "michelin-de", null, null, "1HGCM82633A004352", null, null, 1, List.of());
+        new WorkorderFleetAuthRequestedV1(WORKORDER_ID, "michelin-de", null, null, null, "FLEET-9", null, 1, List.of());
+        new WorkorderFleetAuthRequestedV1(
+                WORKORDER_ID, "michelin-de", "VENDOR-1", null, null, null, null, 1, List.of());
+    }
+
+    @Test
+    @DisplayName("attempt must be at least 1")
+    void attemptMustBePositive() {
+        assertThatThrownBy(() -> new WorkorderFleetAuthRequestedV1(
+                        WORKORDER_ID, "michelin-de", "VENDOR-1", null, null, null, null, 0, List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("attempt");
+    }
+
+    @Test
+    @DisplayName("a negative line quantity is refused")
+    void negativeQuantityIsRefused() {
+        assertThatThrownBy(() -> new WorkorderFleetAuthRequestedV1.RequestedLine("EAN-1", "Tyres", -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/config/InvoiceEventPublisher.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/config/InvoiceEventPublisher.java
@@ -155,7 +155,9 @@ public class InvoiceEventPublisher {
                         : rules.getInvoiceDeliveryMethod().name(),
                 rules.getInvoiceGroupingStrategy() == null
                         ? null
-                        : rules.getInvoiceGroupingStrategy().name());
+                        : rules.getInvoiceGroupingStrategy().name(),
+                rules.isFleetAuthorizationRequired(),
+                rules.getFleetSupplierRef());
         DomainEventEnvelope<BillingRulesUpdatedV1> envelope = DomainEventEnvelope.of(
                 BillingRulesUpdatedV1.EVENT_TYPE,
                 BillingRulesUpdatedV1.SCHEMA_VERSION,

--- a/pos-invoice/src/main/java/com/positivity/invoice/internal/entity/BillingRules.java
+++ b/pos-invoice/src/main/java/com/positivity/invoice/internal/entity/BillingRules.java
@@ -36,6 +36,27 @@ public class BillingRules {
     @Column(name = "purchase_order_required", nullable = false)
     private boolean purchaseOrderRequired = false;
 
+    /**
+     * Whether this party's work needs a fleet payment authorization before it may start (#1346).
+     *
+     * <p>A policy of the payer rather than of the job: the same commercial account answers the same
+     * way for every workorder it pays for. Deciding it per workorder would make it something an
+     * advisor can forget, and an unset gate is an open gate.
+     */
+    @Column(name = "fleet_authorization_required", nullable = false)
+    private boolean fleetAuthorizationRequired = false;
+
+    /**
+     * Which fleet program authorises for this party, as a supplier profile alias.
+     *
+     * <p>Held with the flag because the two are useless apart. A party marked as needing
+     * authorization but naming no authoriser would have every workorder blocked at the start gate
+     * with nothing able to ask anyone for permission — which is why the database rejects that
+     * combination outright.
+     */
+    @Column(name = "fleet_supplier_ref", length = 100)
+    private String fleetSupplierRef;
+
     @Column(name = "payment_terms_code", nullable = false, length = 50)
     private String paymentTermsCode = "NET_30";
 

--- a/pos-invoice/src/main/resources/db/migration/V17__billing_rules_fleet_authorization.sql
+++ b/pos-invoice/src/main/resources/db/migration/V17__billing_rules_fleet_authorization.sql
@@ -1,0 +1,25 @@
+-- CAP-323 (#1346): whether a party's work needs fleet payment authorization before it may start.
+--
+-- A policy of the payer, not of the job. The same commercial account gives the same answer for every
+-- workorder it pays for, which is why it sits beside purchase_order_required rather than being
+-- decided per workorder — a per-job flag is one somebody forgets to set, and an unset gate is an
+-- open gate.
+--
+-- Defaults false: every party that exists today is unaffected, and no workorder starts blocking
+-- because this column appeared.
+
+ALTER TABLE billing_rules
+    ADD COLUMN IF NOT EXISTS fleet_authorization_required BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Which fleet program authorises for this party, as a supplier profile alias.
+--
+-- Stored with the flag because the two are useless apart: knowing that authorization is required
+-- without knowing who to ask leaves every one of this party's workorders blocked with nowhere to go.
+ALTER TABLE billing_rules
+    ADD COLUMN IF NOT EXISTS fleet_supplier_ref VARCHAR(100);
+
+-- Enforced in the database as well as in the event payload, because a row edited by hand or by a
+-- future admin endpoint must not be able to create the unblockable state described above.
+ALTER TABLE billing_rules
+    ADD CONSTRAINT ck_billing_rules_fleet_ref
+    CHECK (fleet_authorization_required = FALSE OR fleet_supplier_ref IS NOT NULL);

--- a/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
+++ b/pos-security-common/src/main/java/com/positivity/security/common/DownstreamPermissionCatalog.java
@@ -23,7 +23,7 @@ public final class DownstreamPermissionCatalog {
      * {@code PermissionCode.CATALOG_VERSION}.
      * Updated automatically by {@code scripts/generate-permissions.py --sync}.
      */
-    public static final int CATALOG_VERSION = 55;
+    public static final int CATALOG_VERSION = 56;
 
     /**
      * Index-to-authority mapping. Entry at position N is the {@code PERM_*}-prefixed
@@ -587,7 +587,11 @@ public final class DownstreamPermissionCatalog {
 
         // ── New batch (bits 464–465) ──────────────────────────────────────────
         "PERM_image:image:store", // 464
-        "PERM_supplier:mktcat:import" // 465
+        "PERM_supplier:mktcat:import", // 465
+
+        // ── New batch (bits 466–467) ──────────────────────────────────────────
+        "PERM_workorder:fleet_auth:request", // 466
+        "PERM_workorder:fleet_auth:resolve" // 467
     };
 
     public static String authorityForBit(int bitIndex) {

--- a/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/internal/enums/PermissionCode.java
@@ -614,13 +614,16 @@ public enum PermissionCode {
     IMAGE__IMAGE__STORE(464, "image:image:store"),
 
     // ── Supplier (new) ─────────────────────────────────────────────────────────
-    SUPPLIER__MKTCAT__IMPORT(465, "supplier:mktcat:import");
+    SUPPLIER__MKTCAT__IMPORT(465, "supplier:mktcat:import"),
+    // ── Workorder (new) ────────────────────────────────────────────────────────
+    WORKORDER__FLEET_AUTH__REQUEST(466, "workorder:fleet_auth:request"),
+    WORKORDER__FLEET_AUTH__RESOLVE(467, "workorder:fleet_auth:resolve");
 
     /**
      * Current catalog version. Increment when new permissions are added to a new
      * batch.
      */
-    public static final int CATALOG_VERSION = 55;
+    public static final int CATALOG_VERSION = 56;
 
     private static final Map<String, PermissionCode> BY_CODE =
             Stream.of(values()).collect(Collectors.toUnmodifiableMap(PermissionCode::code, pc -> pc));

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/enums/PermissionCodeTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Test;
 @DisplayName("PermissionCode catalog contract (PERM-001)")
 class PermissionCodeTest {
 
-    private static final int EXPECTED_PERMISSION_COUNT = 466;
-    private static final int EXPECTED_CATALOG_VERSION = 55;
+    private static final int EXPECTED_PERMISSION_COUNT = 468;
+    private static final int EXPECTED_CATALOG_VERSION = 56;
 
     // -------------------------------------------------------------------------
     // AC-1: Catalog size — EXPECTED_PERMISSION_COUNT entries

--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -48,6 +48,8 @@ tags:
   description: Endpoints for assigning technicians to workorders
 - name: Change Request API
   description: Endpoints for managing additional work requests and approvals
+- name: Workorder Fleet Authorization
+  description: Fleet payment authorization for a workorder
 - name: Estimate API
   description: Endpoints for estimate management and approval workflow
 - name: WIP Dashboard
@@ -1912,6 +1914,115 @@ paths:
         - workorder:workorder:generate_invoice
       x-required-permissions:
       - workorder:workorder:generate_invoice
+  /v1/workorders/{workorderId}/fleet-authorization/resolution:
+    post:
+      tags:
+      - Workorder Fleet Authorization
+      summary: Resolve A Refused Fleet Payment Authorization
+      description: 'Records what an advisor decided to do about a fleet payment authorization that did not come back granted: revise the scope and try again, or cancel and find another payer.
+
+        Use this tool after a fleet program refuses payment or no answer could be obtained; do not use it to select a different payer directly, because that needs a payer model this endpoint does not have -- cancel here and record the new payer through whatever assigns one.
+
+        Preconditions: an authorization must be recorded for this workorder and must not already be GRANTED.
+
+        Required inputs: workorderId path parameter; resolution (SCOPE_REVISED or CANCELLED) and reason in the request body.
+
+        Emits a WORKORDER_FLEET_AUTHORIZATION_RESOLVE event.
+
+        Returns 200 with the authorization, 404 when none is recorded for this workorder, and 409 when the recorded authorization is already GRANTED and needs no resolution.
+
+        '
+      operationId: resolveWorkorderFleetAuthorization
+      parameters:
+      - name: workorderId
+        in: path
+        description: Workorder whose authorization is being resolved
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        description: What the advisor decided to do about the refusal, and why. Do not use this to select a different payer directly, because that needs a payer model this endpoint does not have -- use CANCELLED here and record the new payer through whatever assigns one instead.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FleetAuthorizationResolutionRequest'
+            examples:
+              Scope revised to fit fleet coverage:
+                description: Scope revised to fit fleet coverage
+                value:
+                  resolution: SCOPE_REVISED
+                  reason: Customer approved a reduced scope the fleet will cover
+        required: true
+      responses:
+        '200':
+          description: The resolved authorization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FleetAuthorizationView'
+        '404':
+          description: No fleet payment authorization is recorded for this workorder
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: The recorded authorization is already GRANTED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - workorder:fleet_auth:resolve
+      x-required-permissions:
+      - workorder:fleet_auth:resolve
+  /v1/workorders/{workorderId}/fleet-authorization/requests:
+    post:
+      tags:
+      - Workorder Fleet Authorization
+      summary: Request Or Re-Request Fleet Payment Authorization
+      description: 'Asks this workorder''s payer''s fleet program to authorize paying for it. The same endpoint that fires automatically on approval; calling it again is how an advisor retries after fixing whatever blocked the first attempt, such as a missing vehicle identity.
+
+        Use this tool to retry a stuck authorization; do not call it while one is already PENDING or GRANTED, because it will not re-ask in either case and asking a fleet twice for the same workorder risks opening a second authorization at the vendor.
+
+        Preconditions: this workorder''s payer must require fleet authorization; there is nothing to request otherwise.
+
+        Required inputs: workorderId path parameter.
+
+        Emits a WORKORDER_FLEET_AUTHORIZATION_REQUEST event, and where a vehicle can be identified, a workorder.fleetauth.requested command for pos-supplier to act on.
+
+        Returns 200 with the authorization, whose status is PENDING when the vendor was asked, or MANUAL_REVIEW when no vehicle could be identified so nobody was asked; and 404 when this workorder''s payer does not require fleet authorization.
+
+        '
+      operationId: requestWorkorderFleetAuthorization
+      parameters:
+      - name: workorderId
+        in: path
+        description: Workorder to request authorization for
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: The authorization as it now stands
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FleetAuthorizationView'
+        '404':
+          description: This workorder's payer does not require fleet authorization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - workorder:fleet_auth:request
+      x-required-permissions:
+      - workorder:fleet_auth:request
   /v1/workorders/{workorderId}/complete:
     post:
       tags:
@@ -4703,6 +4814,51 @@ paths:
         - workorder:labor:view
       x-required-permissions:
       - workorder:labor:view
+  /v1/workorders/{workorderId}/fleet-authorization:
+    get:
+      tags:
+      - Workorder Fleet Authorization
+      summary: Read A Workorder's Fleet Payment Authorization
+      description: 'Returns the fleet payment authorization recorded for a workorder, including the vendor''s own reason where it gave one.
+
+        Use this tool to check why a fleet-covered workorder cannot start, or whether a re-request has been answered; do not use it to decide whether work may start, because startWorkorder enforces that itself and will refuse a start this endpoint would not have blocked.
+
+        Preconditions: none.
+
+        Required inputs: workorderId path parameter.
+
+        Emits a WORKORDER_FLEET_AUTHORIZATION_READ event.
+
+        Returns 200 with the authorization, and 404 when this workorder''s payer requires none or none has ever been requested.
+
+        '
+      operationId: getWorkorderFleetAuthorization
+      parameters:
+      - name: workorderId
+        in: path
+        description: Workorder the authorization concerns
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: The recorded authorization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FleetAuthorizationView'
+        '404':
+          description: No fleet payment authorization is recorded for this workorder
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - workorder:fleet_auth:request
+      x-required-permissions:
+      - workorder:fleet_auth:request
   /v1/workorders/{workorderId}/detail:
     get:
       tags:
@@ -6918,6 +7074,57 @@ components:
       - taxAmount
       - totalAmount
       - workorderId
+    FleetAuthorizationResolutionRequest:
+      type: object
+      description: An advisor's resolution of a refused or unresolvable fleet payment authorization
+      properties:
+        resolution:
+          type: string
+          description: What the advisor decided
+          enum:
+          - SCOPE_REVISED
+          - CANCELLED
+        reason:
+          type: string
+          description: Why, for the audit record
+          example: Customer approved a reduced scope the fleet will cover
+          minLength: 1
+      required:
+      - reason
+      - resolution
+    FleetAuthorizationView:
+      type: object
+      description: A workorder's fleet payment authorization
+      properties:
+        workorderId:
+          type: string
+          format: uuid
+        supplierRef:
+          type: string
+        status:
+          type: string
+        vendorReasonCode:
+          type: string
+        vendorReasonText:
+          type: string
+        reviewReason:
+          type: string
+        contractReference:
+          type: string
+        authorizedAmount:
+          type: number
+        currency:
+          type: string
+        resolution:
+          type: string
+        resolutionReason:
+          type: string
+        requestedAt:
+          type: string
+          format: date-time
+        decidedAt:
+          type: string
+          format: date-time
     CompleteWorkorderRequest:
       type: object
       description: Request payload to complete a workorder

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/EventTypes.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/EventTypes.java
@@ -513,6 +513,24 @@ public final class EventTypes {
             .apiVersion("1")
             .build();
 
+    // Fleet payment authorization events (#1346)
+    public static final EventTypeRegistration WORKORDER_FLEET_AUTHORIZATION_READ = EventTypeRegistration.fastRead(
+                    "WORKORDER_FLEET_AUTHORIZATION_READ", "Read a workorder's fleet payment authorization")
+            .apiVersion("1")
+            .build();
+
+    // Approval-grade rather than write: this asks a trading partner for a commercial decision, and
+    // asking twice can open two authorizations against one contract.
+    public static final EventTypeRegistration WORKORDER_FLEET_AUTHORIZATION_REQUEST = EventTypeRegistration.approval(
+                    "WORKORDER_FLEET_AUTHORIZATION_REQUEST", "Request or re-request fleet payment authorization")
+            .apiVersion("1")
+            .build();
+
+    public static final EventTypeRegistration WORKORDER_FLEET_AUTHORIZATION_RESOLVE = EventTypeRegistration.write(
+                    "WORKORDER_FLEET_AUTHORIZATION_RESOLVE", "Resolve a refused fleet payment authorization")
+            .apiVersion("1")
+            .build();
+
     // ==================== ALL EVENT TYPES ====================
 
     /** All event types for registration at startup */
@@ -611,5 +629,9 @@ public final class EventTypes {
             WORKORDER_PICK_FACADE_RESOLVE_SCAN,
             WORKORDER_PICK_FACADE_CONFIRM_LINE,
             WORKORDER_PICK_FACADE_COMPLETE_TASK,
-            WORKORDER_PICKED_ITEMS_CONSUME);
+            WORKORDER_PICKED_ITEMS_CONSUME,
+            // Fleet payment authorization events (#1346)
+            WORKORDER_FLEET_AUTHORIZATION_READ,
+            WORKORDER_FLEET_AUTHORIZATION_REQUEST,
+            WORKORDER_FLEET_AUTHORIZATION_RESOLVE);
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderFleetAuthorizationController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderFleetAuthorizationController.java
@@ -1,0 +1,185 @@
+package com.positivity.workorder.internal.controller;
+
+import com.positivity.events.EmitEvent;
+import com.positivity.shared.error.ApiError;
+import com.positivity.workorder.internal.dto.FleetAuthorizationResolutionRequest;
+import com.positivity.workorder.internal.dto.FleetAuthorizationView;
+import com.positivity.workorder.internal.entity.WorkorderFleetAuthorization;
+import com.positivity.workorder.internal.security.WorkorderPermissions;
+import com.positivity.workorder.internal.service.FleetAuthorizationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Fleet payment authorization for a workorder (#1346).
+ *
+ * <h2>What an advisor uses this for</h2>
+ *
+ * A request is sent automatically when a fleet-covered workorder is approved. This controller exists
+ * for what does not happen automatically: reading the current state, re-requesting after fixing
+ * whatever blocked the first attempt, and resolving a refusal — which the domain ruled must always
+ * be an explicit human decision, never automatic.
+ */
+@RestController
+@RequestMapping("/v1/workorders/{workorderId}/fleet-authorization")
+@RequiredArgsConstructor
+@Tag(name = "Workorder Fleet Authorization", description = "Fleet payment authorization for a workorder")
+public class WorkorderFleetAuthorizationController {
+
+    private final FleetAuthorizationService fleetAuthorizationService;
+
+    @GetMapping
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"workorder:fleet_auth:request"})
+    @PreAuthorize("hasAuthority('" + WorkorderPermissions.FLEET_AUTHORIZATION_REQUEST + "')")
+    @EmitEvent(id = "WORKORDER_FLEET_AUTHORIZATION_READ", apiVersion = "1")
+    @Operation(
+            operationId = "getWorkorderFleetAuthorization",
+            summary = "Read A Workorder's Fleet Payment Authorization",
+            description = """
+                    Returns the fleet payment authorization recorded for a workorder, including the vendor's own \
+                    reason where it gave one.
+                    Use this tool to check why a fleet-covered workorder cannot start, or whether a re-request has \
+                    been answered; do not use it to decide whether work may start, because startWorkorder enforces \
+                    that itself and will refuse a start this endpoint would not have blocked.
+                    Preconditions: none.
+                    Required inputs: workorderId path parameter.
+                    Emits a WORKORDER_FLEET_AUTHORIZATION_READ event.
+                    Returns 200 with the authorization, and 404 when this workorder's payer requires none or none \
+                    has ever been requested.
+                    """,
+            tags = {"Workorder Fleet Authorization"})
+    @ApiResponse(responseCode = "200", description = "The recorded authorization")
+    @ApiResponse(
+            responseCode = "404",
+            description = "No fleet payment authorization is recorded for this workorder",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<FleetAuthorizationView> getWorkorderFleetAuthorization(
+            @Parameter(description = "Workorder the authorization concerns", required = true) @PathVariable
+                    UUID workorderId) {
+        return fleetAuthorizationService
+                .find(workorderId)
+                .map(FleetAuthorizationView::from)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/requests")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"workorder:fleet_auth:request"})
+    @PreAuthorize("hasAuthority('" + WorkorderPermissions.FLEET_AUTHORIZATION_REQUEST + "')")
+    @EmitEvent(id = "WORKORDER_FLEET_AUTHORIZATION_REQUEST", apiVersion = "1")
+    @Operation(
+            operationId = "requestWorkorderFleetAuthorization",
+            summary = "Request Or Re-Request Fleet Payment Authorization",
+            description = """
+                    Asks this workorder's payer's fleet program to authorize paying for it. The same endpoint \
+                    that fires automatically on approval; calling it again is how an advisor retries after fixing \
+                    whatever blocked the first attempt, such as a missing vehicle identity.
+                    Use this tool to retry a stuck authorization; do not call it while one is already PENDING or \
+                    GRANTED, because it will not re-ask in either case and asking a fleet twice for the same \
+                    workorder risks opening a second authorization at the vendor.
+                    Preconditions: this workorder's payer must require fleet authorization; there is nothing to \
+                    request otherwise.
+                    Required inputs: workorderId path parameter.
+                    Emits a WORKORDER_FLEET_AUTHORIZATION_REQUEST event, and where a vehicle can be identified, a \
+                    workorder.fleetauth.requested command for pos-supplier to act on.
+                    Returns 200 with the authorization, whose status is PENDING when the vendor was asked, or \
+                    MANUAL_REVIEW when no vehicle could be identified so nobody was asked; and 404 when this \
+                    workorder's payer does not require fleet authorization.
+                    """,
+            tags = {"Workorder Fleet Authorization"})
+    @ApiResponse(responseCode = "200", description = "The authorization as it now stands")
+    @ApiResponse(
+            responseCode = "404",
+            description = "This workorder's payer does not require fleet authorization",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<FleetAuthorizationView> requestWorkorderFleetAuthorization(
+            @Parameter(description = "Workorder to request authorization for", required = true) @PathVariable
+                    UUID workorderId) {
+        return fleetAuthorizationService
+                .requestAuthorization(workorderId)
+                .map(FleetAuthorizationView::from)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/resolution")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"workorder:fleet_auth:resolve"})
+    @PreAuthorize("hasAuthority('" + WorkorderPermissions.FLEET_AUTHORIZATION_RESOLVE + "')")
+    @EmitEvent(id = "WORKORDER_FLEET_AUTHORIZATION_RESOLVE", apiVersion = "1")
+    @Operation(
+            operationId = "resolveWorkorderFleetAuthorization",
+            summary = "Resolve A Refused Fleet Payment Authorization",
+            description = """
+                    Records what an advisor decided to do about a fleet payment authorization that did not come \
+                    back granted: revise the scope and try again, or cancel and find another payer.
+                    Use this tool after a fleet program refuses payment or no answer could be obtained; do not use \
+                    it to select a different payer directly, because that needs a payer model this endpoint does \
+                    not have -- cancel here and record the new payer through whatever assigns one.
+                    Preconditions: an authorization must be recorded for this workorder and must not already be \
+                    GRANTED.
+                    Required inputs: workorderId path parameter; resolution (SCOPE_REVISED or CANCELLED) and \
+                    reason in the request body.
+                    Emits a WORKORDER_FLEET_AUTHORIZATION_RESOLVE event.
+                    Returns 200 with the authorization, 404 when none is recorded for this workorder, and 409 \
+                    when the recorded authorization is already GRANTED and needs no resolution.
+                    """,
+            tags = {"Workorder Fleet Authorization"})
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "What the advisor decided to do about the refusal, and why. Do not use this to select a "
+                    + "different payer directly, because that needs a payer model this endpoint does not "
+                    + "have -- use CANCELLED here and record the new payer through whatever assigns one "
+                    + "instead.",
+            required = true,
+            content =
+                    @Content(
+                            schema = @Schema(implementation = FleetAuthorizationResolutionRequest.class),
+                            examples =
+                                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                            name = "Scope revised to fit fleet coverage",
+                                            value = """
+                                                    {
+                                                      "resolution": "SCOPE_REVISED",
+                                                      "reason": "Customer approved a reduced scope the fleet will cover"
+                                                    }
+                                                    """)))
+    @ApiResponse(responseCode = "200", description = "The resolved authorization")
+    @ApiResponse(
+            responseCode = "404",
+            description = "No fleet payment authorization is recorded for this workorder",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "409",
+            description = "The recorded authorization is already GRANTED",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<FleetAuthorizationView> resolveWorkorderFleetAuthorization(
+            @Parameter(description = "Workorder whose authorization is being resolved", required = true) @PathVariable
+                    UUID workorderId,
+            @Valid @RequestBody FleetAuthorizationResolutionRequest request,
+            Authentication authentication) {
+        WorkorderFleetAuthorization resolved = fleetAuthorizationService.resolve(
+                workorderId, request.resolution(), request.reason(), authentication.getName());
+        return ResponseEntity.ok(FleetAuthorizationView.from(resolved));
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/FleetAuthorizationResolutionRequest.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/FleetAuthorizationResolutionRequest.java
@@ -1,0 +1,19 @@
+package com.positivity.workorder.internal.dto;
+
+import com.positivity.workorder.internal.enums.FleetAuthorizationResolution;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/** An advisor's decision about a fleet payment authorization that did not come back granted (#1346). */
+@Schema(description = "An advisor's resolution of a refused or unresolvable fleet payment authorization")
+public record FleetAuthorizationResolutionRequest(
+        @Schema(description = "What the advisor decided", requiredMode = Schema.RequiredMode.REQUIRED) @NotNull
+        FleetAuthorizationResolution resolution,
+
+        @Schema(
+                description = "Why, for the audit record",
+                example = "Customer approved a reduced scope the fleet will cover",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
+        String reason) {}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/FleetAuthorizationView.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/FleetAuthorizationView.java
@@ -1,0 +1,53 @@
+package com.positivity.workorder.internal.dto;
+
+import com.positivity.workorder.internal.entity.WorkorderFleetAuthorization;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A fleet payment authorization as this domain holds it (#1346).
+ *
+ * <p>{@code MANUAL_REVIEW} is shown as itself, not folded into {@code PENDING}, because this is the
+ * operator-facing surface: an advisor needs to see that nobody could get an answer, which is a
+ * different problem from the fleet still deciding and points at a different fix.
+ */
+@Schema(description = "A workorder's fleet payment authorization")
+public record FleetAuthorizationView(
+        @NonNull UUID workorderId,
+        @NonNull String supplierRef,
+        @NonNull String status,
+        @Nullable String vendorReasonCode,
+        @Nullable String vendorReasonText,
+        @Nullable String reviewReason,
+        @Nullable String contractReference,
+        @Nullable BigDecimal authorizedAmount,
+        @Nullable String currency,
+        @Nullable String resolution,
+        @Nullable String resolutionReason,
+        @Nullable Instant requestedAt,
+        @Nullable Instant decidedAt) {
+
+    @NonNull
+    public static FleetAuthorizationView from(@NonNull WorkorderFleetAuthorization authorization) {
+        return new FleetAuthorizationView(
+                authorization.getWorkorderId(),
+                authorization.getSupplierRef(),
+                authorization.getStatus().name(),
+                authorization.getVendorReasonCode(),
+                authorization.getVendorReasonText(),
+                authorization.getReviewReason(),
+                authorization.getContractReference(),
+                authorization.getAuthorizedAmount(),
+                authorization.getCurrency(),
+                authorization.getResolution() == null
+                        ? null
+                        : authorization.getResolution().name(),
+                authorization.getResolutionReason(),
+                authorization.getRequestedAt(),
+                authorization.getDecidedAt());
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/ExtBillingRulesReplica.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/ExtBillingRulesReplica.java
@@ -36,6 +36,21 @@ public class ExtBillingRulesReplica {
     @Column(name = "purchase_order_required", nullable = false)
     private boolean purchaseOrderRequired;
 
+    /**
+     * Whether this party's work needs a fleet payment authorization before it may start (#1346).
+     *
+     * <p>Replicated rather than asked for, because the start gate runs inside
+     * {@code WorkorderStateMachine.startWork} — in a transaction, on the path of every job that
+     * begins. A synchronous read to another domain there would be both a wall breach (ADR-0044 R1)
+     * and a way for pos-invoice being slow to stop work starting.
+     */
+    @Column(name = "fleet_authorization_required", nullable = false)
+    private boolean fleetAuthorizationRequired;
+
+    /** Which fleet program authorises for this party, as a supplier profile alias. */
+    @Column(name = "fleet_supplier_ref", length = 100)
+    private String fleetSupplierRef;
+
     @Column(name = "payment_terms_code", length = 50)
     private String paymentTermsCode;
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/ExtVehicleReplica.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/ExtVehicleReplica.java
@@ -1,0 +1,76 @@
+package com.positivity.workorder.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Vehicle identity as pos-vehicle-inventory last published it (#1346, ADR-0044 R3).
+ *
+ * <h2>Why this domain needs it</h2>
+ *
+ * A fleet program identifies a vehicle by plate, VIN or its own unit number. This domain holds only
+ * a {@code vehicleId} UUID, so without these fields an authorization request cannot name the vehicle
+ * it is about — and CAP-323's canonical request refuses to be built without at least one of them.
+ *
+ * <h2>Read from facts, not asked for</h2>
+ *
+ * pos-vehicle-inventory is a Domain module under ADR-0044, so it is read through
+ * {@code vehicle.events.v1} rather than called. pos-warranty already does the same thing with the
+ * same fact, which is the precedent this follows.
+ *
+ * <h2>Not a second vehicle registry</h2>
+ *
+ * Only the identifying fields are here. Nothing is authoritative, nothing is written back, and
+ * anything not needed to name a vehicle to a fleet program is deliberately absent — a replica that
+ * grows toward completeness becomes a competing source of truth, and then the two disagree.
+ */
+@Entity
+@Table(name = "ext_vehicle")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExtVehicleReplica {
+
+    @Id
+    @Column(name = "vehicle_id", nullable = false)
+    private UUID vehicleId;
+
+    @Column(name = "vin", length = 64)
+    private String vin;
+
+    @Column(name = "license_plate", length = 32)
+    private String licensePlate;
+
+    /** The fleet's own unit number for the vehicle, where its operator uses one. */
+    @Column(name = "unit_number", length = 64)
+    private String unitNumber;
+
+    @Column(name = "odometer_value")
+    private Integer odometerValue;
+
+    @Column(name = "odometer_unit", length = 16)
+    private String odometerUnit;
+
+    @Column(name = "aggregate_version", nullable = false)
+    private long aggregateVersion;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    /** ArchUnit UUIDv7 rule hook (ADR-0013): the key is the owner's UUIDv7, stored verbatim. */
+    @Transient
+    public Class<?> uuidv7Dependency() {
+        return UUIDv7Id.class;
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/WorkorderFleetAuthorization.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/WorkorderFleetAuthorization.java
@@ -1,0 +1,145 @@
+package com.positivity.workorder.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import com.positivity.workorder.internal.enums.FleetAuthorizationResolution;
+import com.positivity.workorder.internal.enums.FleetAuthorizationStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * A workorder's fleet payment authorization — the payer's permission to do the work (#1346).
+ *
+ * <h2>Owned here, evaluated elsewhere</h2>
+ *
+ * pos-supplier talks to the fleet program and reports what it said. This row is workexec's record of
+ * that decision, and workexec owns the execution gate and every workorder state transition. The
+ * division matters: a supplier result must distinguish granted, refused and pending, and this side
+ * must preserve that distinction without reinterpretation.
+ *
+ * <h2>Why it is not a workorder status</h2>
+ *
+ * The domain ruled fleet authorization is a separate payer-authorization lifecycle.
+ * {@code AWAITING_APPROVAL} keeps its existing meaning — customer consent for added scope during
+ * execution — and is untouched. Renaming or overloading an existing state would need a state-machine
+ * migration, and would conflate "who is paying" with "how far along is the work".
+ *
+ * <h2>The row records attempts, not just outcomes</h2>
+ *
+ * {@link #firstBlockedAt} is set the first time the start gate refuses a start, and the delayed
+ * release of held resources is measured from there rather than from the request. A job nobody has
+ * tried to start is not holding a bay up, so releasing its assignment would cost capacity to solve a
+ * problem that does not exist yet.
+ */
+@Entity
+@Table(name = "workorder_fleet_authorization")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkorderFleetAuthorization {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "workorder_fleet_authorization_id")
+    private UUID workorderFleetAuthorizationId;
+
+    @Column(name = "workorder_id", nullable = false)
+    private UUID workorderId;
+
+    /** The fleet program asked, from the payer's billing rules. */
+    @Column(name = "supplier_ref", nullable = false, length = 100)
+    private String supplierRef;
+
+    /** The vendor profile that answered, once a decision names one. */
+    @Column(name = "vendor_profile_id")
+    private UUID vendorProfileId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private FleetAuthorizationStatus status;
+
+    /** The vendor's own refusal code, unchanged: it is what an advisor quotes back to a fleet. */
+    @Column(name = "vendor_reason_code", length = 50)
+    private String vendorReasonCode;
+
+    @Column(name = "vendor_reason_text", length = 1000)
+    private String vendorReasonText;
+
+    /** Why no answer could be obtained. Never presented as a vendor decision. */
+    @Column(name = "review_reason", length = 1000)
+    private String reviewReason;
+
+    @Column(name = "contract_reference", length = 100)
+    private String contractReference;
+
+    @Column(name = "authorized_amount", precision = 19, scale = 4)
+    private BigDecimal authorizedAmount;
+
+    @Column(name = "currency", length = 3)
+    private String currency;
+
+    /** What an advisor decided to do about a refusal. Null while nothing has been decided. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "resolution", length = 30)
+    private FleetAuthorizationResolution resolution;
+
+    @Column(name = "resolution_reason", length = 1000)
+    private String resolutionReason;
+
+    @Column(name = "resolved_by", length = 100)
+    private String resolvedBy;
+
+    @Column(name = "resolved_at")
+    private Instant resolvedAt;
+
+    @Column(name = "requested_at")
+    private Instant requestedAt;
+
+    @Column(name = "decided_at")
+    private Instant decidedAt;
+
+    /** When the start gate first refused a start. The release delay is measured from here. */
+    @Column(name = "first_blocked_at")
+    private Instant firstBlockedAt;
+
+    @Column(name = "resources_released_at")
+    private Instant resourcesReleasedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @CreatedBy
+    @Column(name = "created_by", length = 100)
+    private String createdBy;
+
+    @LastModifiedBy
+    @Column(name = "updated_by", length = 100)
+    private String updatedBy;
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/enums/FleetAuthorizationResolution.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/enums/FleetAuthorizationResolution.java
@@ -1,0 +1,27 @@
+package com.positivity.workorder.internal.enums;
+
+/**
+ * What an advisor decided to do about a fleet authorization that did not come back granted (#1346).
+ *
+ * <h2>Recorded because none of it is automatic</h2>
+ *
+ * The domain ruled that a refusal leaves the workorder open: it is not cancelled, and it is not
+ * converted to customer-pay. Somebody chooses, and the choice is theirs to answer for — so it is
+ * stored with who made it, when, and why, rather than inferred from the workorder's later shape.
+ *
+ * <p>Selecting a different payer is deliberately absent. That needs a payer model this domain does
+ * not have yet, and inventing one here would decide a commercial question inside a start gate.
+ */
+public enum FleetAuthorizationResolution {
+
+    /**
+     * The work was changed so the fleet will cover it, and authorization will be sought again.
+     *
+     * <p>Recorded on the authorization rather than only on the workorder, so a second refusal after
+     * a revision is legible as a second refusal rather than as the first one repeating.
+     */
+    SCOPE_REVISED,
+
+    /** The advisor stopped pursuing fleet payment for this workorder. */
+    CANCELLED
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/enums/FleetAuthorizationStatus.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/enums/FleetAuthorizationStatus.java
@@ -1,0 +1,75 @@
+package com.positivity.workorder.internal.enums;
+
+/**
+ * Where a workorder's fleet payment authorization stands (#1346).
+ *
+ * <h2>Not a workorder status</h2>
+ *
+ * This is a payer-authorization lifecycle, deliberately separate from {@code WorkorderStatus}. The
+ * domain ruled that fleet authorization records whether the Commercial Customer agrees to pay, while
+ * {@code AWAITING_APPROVAL} means customer consent for added scope during execution. Folding them
+ * together would make "who is paying" and "how far along is the work" the same question, and would
+ * silently change the meaning of an existing state.
+ *
+ * <h2>Three of these are the vendor's answer; two are not</h2>
+ *
+ * {@link #GRANTED}, {@link #REFUSED} and {@link #PENDING} come from the fleet program and are
+ * preserved without reinterpretation. {@link #MANUAL_REVIEW} is <em>this platform</em> reporting that
+ * nobody could get an answer, and {@link #CANCELLED} is an advisor deciding to stop asking. Neither
+ * is a refusal, and the difference is the whole point: telling a shop the fleet said no when nobody
+ * could reach the fleet sends it to argue about a decision that was never made.
+ */
+public enum FleetAuthorizationStatus {
+
+    /** Required, and not yet asked for. */
+    NOT_REQUESTED,
+
+    /**
+     * Asked, and no answer yet — including an asynchronous acceptance the vendor will resolve later.
+     *
+     * <p>Keeps the start gate closed. "We have not heard back" is not permission.
+     */
+    PENDING,
+
+    /** The fleet program agreed to pay. The only status that opens the start gate. */
+    GRANTED,
+
+    /**
+     * The fleet program declined to pay. A real answer, and a normal one.
+     *
+     * <p>Leaves the workorder open. Nothing is cancelled or converted automatically — an advisor
+     * decides explicitly what happens next, per the domain ruling.
+     */
+    REFUSED,
+
+    /**
+     * No answer could be obtained, and retrying is not expected to help.
+     *
+     * <p>A <em>pending disposition</em>, never a denial: it keeps the gate closed exactly as
+     * {@link #PENDING} does. A timeout or a communication failure must not manufacture a refusal.
+     */
+    MANUAL_REVIEW,
+
+    /** An advisor stopped pursuing this authorization. The workorder needs another payer or none. */
+    CANCELLED;
+
+    /**
+     * Whether work may start under this authorization.
+     *
+     * <p>Only a grant opens the gate. Every other value — including the two that are not the
+     * vendor's fault — keeps it shut, because none of them is permission to spend a fleet's money.
+     */
+    public boolean permitsStart() {
+        return this == GRANTED;
+    }
+
+    /** Whether the fleet has given its final answer, so polling and re-asking should stop. */
+    public boolean isVendorDecided() {
+        return this == GRANTED || this == REFUSED;
+    }
+
+    /** Whether an advisor still has something to resolve. */
+    public boolean needsAttention() {
+        return this == REFUSED || this == MANUAL_REVIEW;
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/exception/FleetAuthorizationNotFoundException.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/exception/FleetAuthorizationNotFoundException.java
@@ -1,0 +1,14 @@
+package com.positivity.workorder.internal.exception;
+
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/** No fleet payment authorization is recorded for a workorder (#1346). */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class FleetAuthorizationNotFoundException extends RuntimeException {
+
+    public FleetAuthorizationNotFoundException(UUID workorderId) {
+        super("Workorder " + workorderId + " has no fleet payment authorization to resolve");
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/ExtVehicleReplicaRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/ExtVehicleReplicaRepository.java
@@ -1,0 +1,10 @@
+package com.positivity.workorder.internal.repository;
+
+import com.positivity.workorder.internal.entity.ExtVehicleReplica;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Replicated vehicle identity, for naming a vehicle to a fleet program (#1346). */
+@Repository
+public interface ExtVehicleReplicaRepository extends JpaRepository<ExtVehicleReplica, UUID> {}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/WorkorderFleetAuthorizationRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/WorkorderFleetAuthorizationRepository.java
@@ -1,0 +1,56 @@
+package com.positivity.workorder.internal.repository;
+
+import com.positivity.workorder.internal.entity.WorkorderFleetAuthorization;
+import com.positivity.workorder.internal.enums.FleetAuthorizationStatus;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Limit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/** Fleet payment authorizations (#1346). */
+@Repository
+public interface WorkorderFleetAuthorizationRepository extends JpaRepository<WorkorderFleetAuthorization, UUID> {
+
+    /**
+     * The authorization for a workorder, if one was ever opened.
+     *
+     * <p>One per workorder by unique index. That is what makes a re-request an update rather than a
+     * second opinion: two rows would let a refusal and a grant coexist with nothing to say which the
+     * start gate should honour.
+     */
+    @NonNull
+    Optional<WorkorderFleetAuthorization> findByWorkorderId(@NonNull UUID workorderId);
+
+    /** Authorizations awaiting a person, for an advisor's queue. */
+    @NonNull
+    List<WorkorderFleetAuthorization> findByStatusInOrderByUpdatedAtDesc(
+            @NonNull Collection<FleetAuthorizationStatus> statuses, @NonNull Limit limit);
+
+    /**
+     * Blocked authorizations whose held resources are now due for release.
+     *
+     * <p>Measured from {@code firstBlockedAt} — when somebody first tried to start the job — rather
+     * than from the request. A job nobody has tried to start is not holding a bay up, and releasing
+     * its assignment would cost capacity to solve a problem that does not exist yet.
+     */
+    @Query("""
+            select a from WorkorderFleetAuthorization a
+            where a.resourcesReleasedAt is null
+              and a.firstBlockedAt is not null
+              and a.firstBlockedAt < :releaseDueBefore
+              and a.status in :blockingStatuses
+            order by a.firstBlockedAt asc
+            """)
+    @NonNull
+    List<WorkorderFleetAuthorization> findDueForResourceRelease(
+            @Param("releaseDueBefore") @NonNull Instant releaseDueBefore,
+            @Param("blockingStatuses") @NonNull Collection<FleetAuthorizationStatus> blockingStatuses,
+            @NonNull Limit limit);
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/security/WorkorderPermissions.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/security/WorkorderPermissions.java
@@ -170,6 +170,24 @@ public final class WorkorderPermissions {
     /** Owned by the timekeeping domain. */
     public static final String TIMEKEEPING_WORK_SESSION_STOP = "timekeeping:work_session:stop";
 
+    /**
+     * Requesting a fleet payment authorization, and reading its status.
+     *
+     * <p>Requesting is its own permission rather than folded into general workorder editing: it
+     * reaches another domain and can affect whether a job may start, and the people who may
+     * investigate a stuck authorization are not necessarily the people who may edit a workorder.
+     */
+    public static final String FLEET_AUTHORIZATION_REQUEST = "workorder:fleet_auth:request";
+
+    /**
+     * Resolving a fleet payment authorization that did not come back granted.
+     *
+     * <p>Separate from requesting, per the domain ruling that a refusal is resolved explicitly by an
+     * advisor selecting revised scope or cancellation, each needing its own permission and audit
+     * record.
+     */
+    public static final String FLEET_AUTHORIZATION_RESOLVE = "workorder:fleet_auth:resolve";
+
     private WorkorderPermissions() {
         // Utility class - prevent instantiation
     }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaseRunner.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaseRunner.java
@@ -1,0 +1,120 @@
+package com.positivity.workorder.internal.service;
+
+import com.positivity.workorder.internal.entity.WorkorderFleetAuthorization;
+import com.positivity.workorder.internal.enums.FleetAuthorizationStatus;
+import com.positivity.workorder.internal.repository.WorkorderFleetAuthorizationRepository;
+import com.positivity.workorder.service.TechnicianAssignmentService;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Limit;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Frees capacity a blocked job cannot currently use (#1346).
+ *
+ * <h2>Delayed, and measured from the block, not the request</h2>
+ *
+ * A job whose fleet authorization is unresolved keeps its technician assignment for a configurable
+ * grace period, then releases it. The delay exists because authorization can resolve in minutes and
+ * releasing immediately would drop a booking that was about to become usable, at the cost of
+ * re-assignment work nobody needed. It is measured from
+ * {@link WorkorderFleetAuthorization#getFirstBlockedAt()} — the first time somebody tried to start
+ * the job and could not — rather than from when the authorization was requested, because a job
+ * nobody has tried to start is not holding a bay up regardless of how long the request has been
+ * outstanding.
+ *
+ * <h2>The delay is configuration, not a constant</h2>
+ *
+ * The domain ruled that pending, retry, timeout and escalation rules differ by deployment and must
+ * be configurable. This is the concrete instance: a shop with tight bay capacity wants a short grace
+ * period, one with slack wants a long one, and neither should require a code change.
+ *
+ * <h2>Released once, and only while still blocking</h2>
+ *
+ * A row is released at most once, recorded by {@code resourcesReleasedAt}. If the authorization has
+ * since been granted, cancelled, or resolved, nothing is released — releasing a resource that
+ * belongs to a job now cleared to start would be actively wrong, not merely late.
+ */
+@Slf4j
+@Service
+public class FleetAuthorizationResourceReleaseRunner {
+
+    /** Statuses under which held resources are still blocked and eligible for release. */
+    private static final Set<FleetAuthorizationStatus> BLOCKING_STATUSES = Set.of(
+            FleetAuthorizationStatus.NOT_REQUESTED,
+            FleetAuthorizationStatus.PENDING,
+            FleetAuthorizationStatus.REFUSED,
+            FleetAuthorizationStatus.MANUAL_REVIEW);
+
+    private static final String RELEASED_BY = "fleet-authorization-resource-release";
+
+    private final WorkorderFleetAuthorizationRepository authorizationRepository;
+    private final TechnicianAssignmentService technicianAssignmentService;
+    private final Clock clock;
+    private final Duration releaseAfter;
+    private final int batchSize;
+
+    public FleetAuthorizationResourceReleaseRunner(
+            WorkorderFleetAuthorizationRepository authorizationRepository,
+            TechnicianAssignmentService technicianAssignmentService,
+            Clock clock,
+            @Value("${workorder.fleetauth.resource-release-after:PT4H}") Duration releaseAfter,
+            @Value("${workorder.fleetauth.resource-release-batch-size:50}") int batchSize) {
+        this.authorizationRepository = authorizationRepository;
+        this.technicianAssignmentService = technicianAssignmentService;
+        this.clock = clock;
+        this.releaseAfter = releaseAfter;
+        this.batchSize = batchSize;
+    }
+
+    @Scheduled(fixedDelayString = "${workorder.fleetauth.resource-release-interval-ms:900000}")
+    public void releaseOverdue() {
+        Instant releaseDueBefore = Instant.now(clock).minus(releaseAfter);
+        List<WorkorderFleetAuthorization> due = authorizationRepository.findDueForResourceRelease(
+                releaseDueBefore, BLOCKING_STATUSES, Limit.of(batchSize));
+
+        for (WorkorderFleetAuthorization authorization : due) {
+            try {
+                releaseOne(authorization);
+            } catch (Exception e) {
+                // One workorder's release failing must not stop the others. Nothing here is lost:
+                // resourcesReleasedAt stays null, so this row is picked up again next tick.
+                log.warn(
+                        "Releasing resources for workorder {} blocked on fleet authorization failed: {}",
+                        authorization.getWorkorderId(),
+                        e.toString());
+            }
+        }
+    }
+
+    @Transactional
+    void releaseOne(@NonNull WorkorderFleetAuthorization authorization) {
+        // Re-read the guard inside the transaction: the status may have changed between the query
+        // above and this write, and releasing a resource for a now-granted authorization would be
+        // wrong rather than merely late.
+        if (!BLOCKING_STATUSES.contains(authorization.getStatus()) || authorization.getResourcesReleasedAt() != null) {
+            return;
+        }
+
+        technicianAssignmentService.releaseAssignment(
+                authorization.getWorkorderId(),
+                RELEASED_BY,
+                "fleet payment authorization has been unresolved for over " + releaseAfter);
+
+        authorization.setResourcesReleasedAt(Instant.now(clock));
+        authorizationRepository.save(authorization);
+        log.info(
+                "Released held resources for workorder {}: fleet authorization has been {} since {}",
+                authorization.getWorkorderId(),
+                authorization.getStatus(),
+                authorization.getFirstBlockedAt());
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/FleetAuthorizationService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/FleetAuthorizationService.java
@@ -1,0 +1,348 @@
+package com.positivity.workorder.internal.service;
+
+import com.positivity.domainevents.workorder.WorkorderFleetAuthRequestedV1;
+import com.positivity.workorder.internal.config.OutboxEventWriter;
+import com.positivity.workorder.internal.entity.ExtBillingRulesReplica;
+import com.positivity.workorder.internal.entity.ExtVehicleReplica;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderFleetAuthorization;
+import com.positivity.workorder.internal.enums.FleetAuthorizationResolution;
+import com.positivity.workorder.internal.enums.FleetAuthorizationStatus;
+import com.positivity.workorder.internal.repository.ExtBillingRulesReplicaRepository;
+import com.positivity.workorder.internal.repository.ExtVehicleReplicaRepository;
+import com.positivity.workorder.internal.repository.WorkorderFleetAuthorizationRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Fleet payment authorization: whether the payer has agreed to fund this workorder (#1346).
+ *
+ * <h2>What this is, in the domain's words</h2>
+ *
+ * <em>Fleet payment authorization</em> — a Commercial Customer agreeing to pay. It is not estimate
+ * customer consent, not change-request customer consent, and not workorder acceptance.
+ * {@code AWAITING_APPROVAL} keeps its existing meaning and is untouched, because renaming or
+ * overloading an existing state would need a state-machine migration and would conflate "who is
+ * paying" with "how far along is the work".
+ *
+ * <h2>Required by policy, not per job</h2>
+ *
+ * Whether authorization is needed comes from the payer's billing rules, replicated from pos-invoice.
+ * The same commercial account answers the same way for every workorder it pays for. Deciding it per
+ * workorder would make it something an advisor can forget — and an unset gate is an open gate.
+ *
+ * <h2>The gate is closed by default and opens only on a grant</h2>
+ *
+ * Pending, manual review, refused, cancelled and never-asked all keep it shut. Two of those are not
+ * the fleet's fault, and the distinction is preserved everywhere it is shown, but none of them is
+ * permission to spend somebody else's money.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FleetAuthorizationService {
+
+    private final WorkorderRepository workorderRepository;
+    private final WorkorderFleetAuthorizationRepository authorizationRepository;
+    private final ExtBillingRulesReplicaRepository billingRulesRepository;
+    private final ExtVehicleReplicaRepository vehicleRepository;
+    private final ObjectProvider<OutboxEventWriter> outboxEventWriter;
+    private final Clock clock;
+
+    /**
+     * Refuses the start of a workorder whose fleet payment authorization is unresolved.
+     *
+     * <p>Called from the state machine rather than a controller, so the rule holds however work is
+     * started — the domain ruled this must be enforced in the backend command and that no role may
+     * bypass it. There is deliberately no override: a financial-risk override was considered and
+     * declined.
+     *
+     * <p>Also stamps when the block first happened, which is what the delayed release of held
+     * resources is measured from. A job nobody has tried to start is not holding a bay up.
+     *
+     * @throws IllegalStateException when authorization is required and not granted
+     */
+    @Transactional
+    public void assertMayStart(@NonNull UUID workorderId) {
+        Optional<WorkorderFleetAuthorization> authorization = authorizationRepository.findByWorkorderId(workorderId);
+
+        if (!isRequired(workorderId)) {
+            return;
+        }
+
+        FleetAuthorizationStatus status = authorization
+                .map(WorkorderFleetAuthorization::getStatus)
+                .orElse(FleetAuthorizationStatus.NOT_REQUESTED);
+        if (status.permitsStart()) {
+            return;
+        }
+
+        authorization.ifPresent(this::stampFirstBlocked);
+        throw new IllegalStateException(String.format(
+                "Workorder %s cannot be started: fleet payment authorization is %s. %s",
+                workorderId, status, explain(status, authorization.orElse(null))));
+    }
+
+    /** Whether this workorder's payer requires fleet authorization before work may start. */
+    @Transactional(readOnly = true)
+    public boolean isRequired(@NonNull UUID workorderId) {
+        return billingRulesFor(workorderId)
+                .map(ExtBillingRulesReplica::isFleetAuthorizationRequired)
+                .orElse(false);
+    }
+
+    /**
+     * Opens an authorization for a workorder and asks the fleet program, if one is required.
+     *
+     * <p>Called automatically when a fleet-covered workorder is approved, and again by an advisor
+     * after a scope revision. Idempotent in the direction that matters: an authorization already
+     * granted or already awaiting an answer is not asked again, because a second request opens a
+     * second authorization at the vendor and somebody has to unpick that with a fleet manager.
+     *
+     * @return the authorization as it now stands, or empty when none is required
+     */
+    @Transactional
+    @NonNull
+    public Optional<WorkorderFleetAuthorization> requestAuthorization(@NonNull UUID workorderId) {
+        Optional<ExtBillingRulesReplica> rules = billingRulesFor(workorderId);
+        if (rules.isEmpty() || !rules.get().isFleetAuthorizationRequired()) {
+            return Optional.empty();
+        }
+        String supplierRef = rules.get().getFleetSupplierRef();
+
+        Optional<WorkorderFleetAuthorization> existing = authorizationRepository.findByWorkorderId(workorderId);
+        if (existing.isPresent() && !mayAskAgain(existing.get().getStatus())) {
+            // Already granted, or already waiting on the fleet. Asking again would open a second
+            // authorization at the vendor against the same contract.
+            log.debug(
+                    "Not re-requesting fleet authorization for workorder {}: status is {}",
+                    workorderId,
+                    existing.get().getStatus());
+            return existing;
+        }
+
+        Instant now = Instant.now(clock);
+        WorkorderFleetAuthorization authorization = existing.orElseGet(() -> WorkorderFleetAuthorization.builder()
+                .workorderId(workorderId)
+                .supplierRef(supplierRef)
+                .build());
+        authorization.setSupplierRef(supplierRef);
+        authorization.setRequestedAt(now);
+        // Cleared on a re-request: a stale refusal reason beside a fresh request reads as if the
+        // fleet had just refused again.
+        authorization.setVendorReasonCode(null);
+        authorization.setVendorReasonText(null);
+        authorization.setReviewReason(null);
+        authorization.setDecidedAt(null);
+
+        Optional<WorkorderFleetAuthRequestedV1> command = buildCommand(workorderId, supplierRef, authorization);
+        if (command.isEmpty()) {
+            // Required, but this side cannot name the vehicle, so nobody can be asked. Parked for a
+            // person rather than sent: an unnamed vehicle would come back as a refusal, and a
+            // refusal means the fleet declined — which it did not.
+            authorization.setStatus(FleetAuthorizationStatus.MANUAL_REVIEW);
+            authorization.setReviewReason(
+                    "no vehicle identity is known for this workorder, so no fleet program can be asked");
+            log.warn("Cannot request fleet authorization for workorder {}: vehicle identity unknown", workorderId);
+            return Optional.of(authorizationRepository.save(authorization));
+        }
+
+        authorization.setStatus(FleetAuthorizationStatus.PENDING);
+        WorkorderFleetAuthorization saved = authorizationRepository.save(authorization);
+
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer != null) {
+            writer.publish(
+                    WorkorderFleetAuthRequestedV1.EVENT_TYPE,
+                    WorkorderFleetAuthRequestedV1.SCHEMA_VERSION,
+                    workorderId,
+                    command.get());
+        }
+        log.info("Requested fleet payment authorization for workorder {} from {}", workorderId, supplierRef);
+        return Optional.of(saved);
+    }
+
+    /**
+     * Records the fleet program's decision, exactly as it was given.
+     *
+     * <p>Granted, refused and pending are preserved without reinterpretation, per the domain ruling.
+     * Nothing here changes a workorder's status: an authorization outcome is an input to workexec's
+     * workflow, not a transition in it.
+     */
+    @Transactional
+    public void recordDecision(
+            @NonNull UUID workorderId,
+            @NonNull UUID vendorProfileId,
+            @NonNull FleetAuthorizationStatus status,
+            @Nullable String reasonCode,
+            @Nullable String reasonText,
+            @Nullable String contractReference) {
+        Optional<WorkorderFleetAuthorization> found = authorizationRepository.findByWorkorderId(workorderId);
+        if (found.isEmpty()) {
+            // A decision for a workorder nobody asked about. Recorded rather than dropped: the fleet
+            // answered, and an answer nobody can see is worse than an unexpected one.
+            log.warn("Fleet authorization decision for workorder {} that has no request recorded", workorderId);
+            return;
+        }
+
+        WorkorderFleetAuthorization authorization = found.get();
+        authorization.setVendorProfileId(vendorProfileId);
+        authorization.setStatus(status);
+        authorization.setVendorReasonCode(reasonCode);
+        authorization.setVendorReasonText(reasonText);
+        authorization.setContractReference(contractReference);
+        authorization.setDecidedAt(Instant.now(clock));
+        authorizationRepository.save(authorization);
+
+        log.info("Fleet payment authorization for workorder {} is {}", workorderId, status);
+    }
+
+    /**
+     * Records an advisor's decision about an authorization that did not come back granted.
+     *
+     * <p>Nothing is automatic. The domain ruled a refusal leaves the workorder open, is not
+     * cancelled and is not converted to customer-pay, so the choice is recorded with who made it and
+     * why rather than inferred from the workorder's later shape.
+     */
+    @Transactional
+    @NonNull
+    public WorkorderFleetAuthorization resolve(
+            @NonNull UUID workorderId,
+            @NonNull FleetAuthorizationResolution resolution,
+            @NonNull String reason,
+            @NonNull String actorId) {
+        WorkorderFleetAuthorization authorization = authorizationRepository
+                .findByWorkorderId(workorderId)
+                .orElseThrow(() -> new com.positivity.workorder.internal.exception.FleetAuthorizationNotFoundException(
+                        workorderId));
+
+        if (authorization.getStatus() == FleetAuthorizationStatus.GRANTED) {
+            // Resolving a granted authorization would discard permission the fleet actually gave.
+            throw new IllegalStateException(
+                    "Workorder " + workorderId + " has a granted fleet payment authorization and needs no resolution");
+        }
+
+        authorization.setResolution(resolution);
+        authorization.setResolutionReason(reason);
+        authorization.setResolvedBy(actorId);
+        authorization.setResolvedAt(Instant.now(clock));
+        if (resolution == FleetAuthorizationResolution.CANCELLED) {
+            authorization.setStatus(FleetAuthorizationStatus.CANCELLED);
+        }
+        log.info("Fleet payment authorization for workorder {} resolved as {} by {}", workorderId, resolution, actorId);
+        return authorizationRepository.save(authorization);
+    }
+
+    /** The authorization recorded for a workorder, if any. */
+    @Transactional(readOnly = true)
+    @NonNull
+    public Optional<WorkorderFleetAuthorization> find(@NonNull UUID workorderId) {
+        return authorizationRepository.findByWorkorderId(workorderId);
+    }
+
+    /**
+     * Whether a fresh request may be sent.
+     *
+     * <p>Granted needs nothing. Pending is already waiting, and asking again while a fleet is
+     * deciding opens a second authorization against one contract.
+     */
+    private static boolean mayAskAgain(@NonNull FleetAuthorizationStatus status) {
+        return status != FleetAuthorizationStatus.GRANTED && status != FleetAuthorizationStatus.PENDING;
+    }
+
+    /** Stamps when a start was first refused, leaving an earlier stamp alone. */
+    private void stampFirstBlocked(@NonNull WorkorderFleetAuthorization authorization) {
+        if (authorization.getFirstBlockedAt() == null) {
+            authorization.setFirstBlockedAt(Instant.now(clock));
+            authorizationRepository.save(authorization);
+        }
+    }
+
+    @NonNull
+    private Optional<ExtBillingRulesReplica> billingRulesFor(@NonNull UUID workorderId) {
+        return workorderRepository
+                .findById(workorderId)
+                .map(Workorder::getCrmPartyId)
+                .filter(partyId -> partyId != null && !partyId.isBlank())
+                .flatMap(billingRulesRepository::findById);
+    }
+
+    /**
+     * Builds the request, or empty when this side cannot name the vehicle.
+     *
+     * <p>Identity comes from the replicated vehicle fact. Empty is a real outcome rather than an
+     * error: the replica may not yet hold a vehicle this workorder references, and that is a gap to
+     * report, not a reason to send a fleet program a request it can only refuse.
+     */
+    @NonNull
+    private Optional<WorkorderFleetAuthRequestedV1> buildCommand(
+            @NonNull UUID workorderId,
+            @NonNull String supplierRef,
+            @NonNull WorkorderFleetAuthorization authorization) {
+        Optional<ExtVehicleReplica> vehicle = workorderRepository
+                .findById(workorderId)
+                .map(Workorder::getVehicleId)
+                .filter(java.util.Objects::nonNull)
+                .flatMap(vehicleRepository::findById);
+        if (vehicle.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ExtVehicleReplica identity = vehicle.get();
+        try {
+            return Optional.of(new WorkorderFleetAuthRequestedV1(
+                    workorderId,
+                    supplierRef,
+                    null,
+                    identity.getLicensePlate(),
+                    identity.getVin(),
+                    identity.getUnitNumber(),
+                    identity.getOdometerValue() == null ? null : String.valueOf(identity.getOdometerValue()),
+                    nextAttempt(authorization),
+                    List.of()));
+        } catch (IllegalArgumentException e) {
+            // The replica holds the vehicle but none of the fields a fleet identifies it by.
+            log.warn("Vehicle for workorder {} carries no plate, VIN or unit number", workorderId);
+            return Optional.empty();
+        }
+    }
+
+    private static int nextAttempt(@NonNull WorkorderFleetAuthorization authorization) {
+        return authorization.getRequestedAt() == null ? 1 : 2;
+    }
+
+    /** Operator-facing explanation, kept distinct for the statuses that are not the fleet's doing. */
+    @NonNull
+    private static String explain(
+            @NonNull FleetAuthorizationStatus status, @Nullable WorkorderFleetAuthorization authorization) {
+        return switch (status) {
+            case NOT_REQUESTED -> "It has not been requested yet.";
+            case PENDING -> "The fleet program has not answered yet.";
+            case REFUSED ->
+                "The fleet program declined to pay"
+                        + (authorization == null || authorization.getVendorReasonText() == null
+                                ? "."
+                                : ": " + authorization.getVendorReasonText());
+            // Deliberately not phrased as a refusal: nobody could get an answer, which is a
+            // different thing and leads an advisor somewhere different.
+            case MANUAL_REVIEW ->
+                "No answer could be obtained and it needs review"
+                        + (authorization == null || authorization.getReviewReason() == null
+                                ? "."
+                                : ": " + authorization.getReviewReason());
+            case CANCELLED -> "It was cancelled; this workorder needs another payer.";
+            case GRANTED -> "";
+        };
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InvoiceEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InvoiceEventsListener.java
@@ -140,6 +140,8 @@ public class InvoiceEventsListener {
         extBillingRulesReplicaRepository.save(ExtBillingRulesReplica.builder()
                 .partyId(payload.partyId())
                 .purchaseOrderRequired(payload.purchaseOrderRequired())
+                .fleetAuthorizationRequired(payload.fleetAuthorizationRequired())
+                .fleetSupplierRef(payload.fleetSupplierRef())
                 .paymentTermsCode(payload.paymentTermsCode())
                 .invoiceDeliveryMethod(payload.invoiceDeliveryMethod())
                 .invoiceGroupingStrategy(payload.invoiceGroupingStrategy())

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/SupplierFleetAuthEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/SupplierFleetAuthEventsListener.java
@@ -1,0 +1,126 @@
+package com.positivity.workorder.internal.service;
+
+import com.positivity.domainevents.supplier.SupplierWorkorderAuthDeniedV1;
+import com.positivity.domainevents.supplier.SupplierWorkorderAuthGrantedV1;
+import com.positivity.workorder.internal.entity.ProcessedEvent;
+import com.positivity.workorder.internal.enums.FleetAuthorizationStatus;
+import com.positivity.workorder.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Records what a fleet program decided about paying for a workorder (#1346, ADR-0044 R1).
+ *
+ * <h2>Preserved, not reinterpreted</h2>
+ *
+ * pos-supplier evaluates the authorization; this domain owns the record and the execution gate. The
+ * supplier result distinguishes granted, refused and pending, and that distinction survives intact
+ * here — a listener that collapsed "the fleet declined" into "not authorized" would lose the only
+ * information an advisor can act on.
+ *
+ * <h2>Nothing here transitions a workorder</h2>
+ *
+ * An authorization outcome is an input to workexec's workflow, not a step in it. A refusal does not
+ * cancel the job and does not convert it to customer-pay; the domain ruled an advisor decides that
+ * explicitly. All this does is write down what the fleet said.
+ *
+ * <h2>Absence of an event is not a decision</h2>
+ *
+ * Most workorders are not fleet work and will never receive one of these. pos-supplier also
+ * deliberately publishes nothing when it could not reach the vendor, so silence here means "no news"
+ * rather than "refused" — which is why the start gate is closed by default rather than opened by
+ * default and shut on a refusal.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
+public class SupplierFleetAuthEventsListener {
+
+    private static final String OWNER = "workorder-fleetauth";
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final ProcessedEventRepository processedEventRepository;
+    private final FleetAuthorizationService fleetAuthorizationService;
+
+    @KafkaListener(
+            topics = "${workorder.kafka.supplier-events-topic:supplier.events.v1}",
+            groupId = "${workorder.kafka.supplier-events-consumer-group:pos-workorder-supplier-events}")
+    @Transactional
+    public void onSupplierEvent(@NonNull String message) {
+        JsonNode envelope;
+        try {
+            envelope = objectMapper.readTree(message);
+        } catch (Exception e) {
+            log.warn("Skipping unparsable supplier event", e);
+            return;
+        }
+        String eventType = envelope.path("eventType").stringValue(null);
+        String eventId = envelope.path("eventId").stringValue(null);
+        if (eventId == null || eventId.isBlank()) {
+            log.warn("Skipping supplier event without eventId");
+            return;
+        }
+        if (processedEventRepository.existsById(eventId)) {
+            return;
+        }
+
+        try {
+            if (SupplierWorkorderAuthGrantedV1.EVENT_TYPE.equals(eventType)) {
+                applyGranted(envelope);
+            } else if (SupplierWorkorderAuthDeniedV1.EVENT_TYPE.equals(eventType)) {
+                applyDenied(envelope);
+            } else {
+                log.debug("Ignoring supplier event type={} eventId={}", eventType, eventId);
+            }
+        } catch (TransientDataAccessException e) {
+            // Rethrown so the container retries. Marking this processed would leave a workorder
+            // gated on an authorization the fleet has already granted, with nothing to correct it.
+            throw e;
+        } catch (Exception e) {
+            log.warn("Skipping malformed supplier fleet-authorization event eventId={}", eventId, e);
+        }
+        processedEventRepository.save(ProcessedEvent.builder()
+                .eventId(eventId)
+                .owner(OWNER)
+                .processedAt(Instant.now(clock))
+                .build());
+    }
+
+    private void applyGranted(@NonNull JsonNode envelope) {
+        SupplierWorkorderAuthGrantedV1 payload =
+                objectMapper.treeToValue(envelope.path("payload"), SupplierWorkorderAuthGrantedV1.class);
+        fleetAuthorizationService.recordDecision(
+                payload.workorderId(),
+                payload.vendorProfileId(),
+                FleetAuthorizationStatus.GRANTED,
+                null,
+                null,
+                payload.contractReference());
+    }
+
+    private void applyDenied(@NonNull JsonNode envelope) {
+        SupplierWorkorderAuthDeniedV1 payload =
+                objectMapper.treeToValue(envelope.path("payload"), SupplierWorkorderAuthDeniedV1.class);
+        // The vendor's own words, kept unchanged: a refusal reason is what an advisor quotes back to
+        // a fleet manager, so translating it would cost the conversation its evidence.
+        fleetAuthorizationService.recordDecision(
+                payload.workorderId(),
+                payload.vendorProfileId(),
+                FleetAuthorizationStatus.REFUSED,
+                payload.reasonCode(),
+                payload.reasonText(),
+                null);
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/TechnicianAssignmentServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/TechnicianAssignmentServiceImpl.java
@@ -179,6 +179,26 @@ public class TechnicianAssignmentServiceImpl implements TechnicianAssignmentServ
         return saved;
     }
 
+    @Override
+    public Optional<TechnicianAssignment> releaseAssignment(
+            @NonNull UUID workorderId, @NonNull String releasedBy, @Nullable String reason) {
+        Optional<TechnicianAssignment> currentAssignment =
+                assignmentRepository.findByWorkorder_IdAndCurrentTrue(workorderId);
+        if (currentAssignment.isEmpty()) {
+            return Optional.empty();
+        }
+        TechnicianAssignment assignment = currentAssignment.get();
+        assignment.markAsNotCurrent(LocalDateTime.now(clock), reason);
+        TechnicianAssignment saved = assignmentRepository.save(assignment);
+        log.info(
+                "Released technician {} from workorder {} by {}: {}",
+                assignment.getTechnicianId(),
+                workorderId,
+                releasedBy,
+                reason);
+        return Optional.of(saved);
+    }
+
     /**
      * Get the current assignment for a workorder.
      *

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/VehicleEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/VehicleEventsListener.java
@@ -1,0 +1,113 @@
+package com.positivity.workorder.internal.service;
+
+import com.positivity.domainevents.vehicle.VehicleUpdatedV1;
+import com.positivity.workorder.internal.entity.ExtVehicleReplica;
+import com.positivity.workorder.internal.entity.ProcessedEvent;
+import com.positivity.workorder.internal.repository.ExtVehicleReplicaRepository;
+import com.positivity.workorder.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Consumes {@code vehicle.events.v1} into the {@code ext_vehicle} replica (#1346, ADR-0044 R3).
+ *
+ * <h2>Why this domain needs vehicle identity</h2>
+ *
+ * A fleet program identifies a vehicle by plate, VIN or its own unit number. This domain holds only
+ * a {@code vehicleId} UUID on the workorder, so without this replica a fleet payment authorization
+ * request cannot be built — CAP-323's canonical request refuses to be constructed without at least
+ * one identifier. pos-warranty already reads the same fact for the same reason; this listener is
+ * that precedent, not a new pattern.
+ *
+ * <p>Consumer contract mirrors the module's other listeners: {@code processed_events} idempotency
+ * (owner {@code vehicle-fleetauth}) in the apply transaction, a strictly-below stale guard on
+ * {@code aggregateVersion}, transient database errors rethrown for container retry.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
+public class VehicleEventsListener {
+
+    private static final String OWNER = "vehicle-fleetauth";
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final ProcessedEventRepository processedEventRepository;
+    private final ExtVehicleReplicaRepository vehicleReplicaRepository;
+
+    @KafkaListener(
+            topics = "${workorder.kafka.vehicle-events-topic:vehicle.events.v1}",
+            groupId = "${workorder.kafka.vehicle-events-consumer-group:pos-workorder-vehicle-events}")
+    @Transactional
+    public void onVehicleEvent(@NonNull String message) {
+        JsonNode envelope;
+        try {
+            envelope = objectMapper.readTree(message);
+        } catch (Exception e) {
+            log.warn("Skipping unparsable vehicle event", e);
+            return;
+        }
+        String eventType = envelope.path("eventType").stringValue(null);
+        String eventId = envelope.path("eventId").stringValue(null);
+        if (eventId == null || eventId.isBlank()) {
+            log.warn("Skipping vehicle event without eventId");
+            return;
+        }
+        if (processedEventRepository.existsById(eventId)) {
+            return;
+        }
+
+        try {
+            if (VehicleUpdatedV1.EVENT_TYPE.equals(eventType)) {
+                applyVehicleUpdated(envelope);
+            } else {
+                // Ignored types still fall through to the processed_events insert below: the
+                // owner's manifest counts every fact in the window.
+                log.debug("Ignoring vehicle event type={} eventId={}", eventType, eventId);
+            }
+        } catch (TransientDataAccessException e) {
+            // Rethrown so the container retries: recording this processed would leave a fleet
+            // authorization request unable to name a vehicle for a reason unrelated to the vehicle.
+            throw e;
+        } catch (Exception e) {
+            log.warn("Skipping malformed vehicle event eventId={}", eventId, e);
+        }
+        processedEventRepository.save(ProcessedEvent.builder()
+                .eventId(eventId)
+                .owner(OWNER)
+                .processedAt(Instant.now(clock))
+                .build());
+    }
+
+    private void applyVehicleUpdated(@NonNull JsonNode envelope) {
+        VehicleUpdatedV1 payload = objectMapper.treeToValue(envelope.path("payload"), VehicleUpdatedV1.class);
+        long aggregateVersion = envelope.path("aggregateVersion").longValue(0);
+        ExtVehicleReplica existing =
+                vehicleReplicaRepository.findById(payload.vehicleId()).orElse(null);
+        if (existing != null && existing.getAggregateVersion() > aggregateVersion) {
+            return;
+        }
+        vehicleReplicaRepository.save(ExtVehicleReplica.builder()
+                .vehicleId(payload.vehicleId())
+                .vin(payload.vin())
+                .licensePlate(payload.licensePlate())
+                .unitNumber(payload.unitNumber())
+                .odometerValue(payload.odometerValue())
+                .odometerUnit(payload.odometerUnit())
+                .aggregateVersion(aggregateVersion)
+                .updatedAt(Instant.now(clock))
+                .build());
+        log.info("Updated ext_vehicle vehicleId={} version={}", payload.vehicleId(), aggregateVersion);
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
@@ -81,6 +81,7 @@ public class WorkorderServiceImpl implements WorkorderService {
     private final IdempotencyService idempotencyService;
     private final PromotionValidationService promotionValidationService;
     private final PeopleAvailabilityLocalService peopleAvailabilityLocalService;
+    private final FleetAuthorizationService fleetAuthorizationService;
 
     @Override
     public List<Workorder> getAllWorkorders() {
@@ -517,6 +518,13 @@ public class WorkorderServiceImpl implements WorkorderService {
         log.info("Workorder {} approved by customer {} with signature capture", workorderId, customerId);
         Workorder saved = workorderRepository.save(workorder);
         workorderFactPublisher.markChanged(saved.getId());
+
+        // Fleet payment authorization (#1346): requested automatically on approval when this
+        // workorder's payer requires one, so an advisor is not the only path to a request ever
+        // being sent. A no-op for every non-fleet workorder, and a no-op again if this workorder
+        // was already asked -- requestAuthorization does not re-ask a granted or pending one.
+        fleetAuthorizationService.requestAuthorization(saved.getId());
+
         return saved;
     }
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderStateMachine.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderStateMachine.java
@@ -46,6 +46,7 @@ public class WorkorderStateMachine {
     private final WorkorderServiceRepository workorderServiceRepository;
     private final WorkorderPartRepository workorderPartRepository;
     private final ChangeRequestRepository changeRequestRepository;
+    private final FleetAuthorizationService fleetAuthorizationService;
     private final AuditEventRepository auditEventRepository;
     private final ObjectMapper objectMapper;
     private final ChangeRequestService changeRequestService;
@@ -292,6 +293,12 @@ public class WorkorderStateMachine {
                     "Workorder %s cannot be started. There are %s pending change request(s) awaiting approval",
                     workorderId, pendingApprovalRequests.size()));
         }
+
+        // Fleet payment authorization (#1346). Enforced here rather than in a controller so the rule
+        // holds however work is started, and with no override: the domain ruled that nobody may
+        // begin work while a required authorization is unresolved, and that no existing role may
+        // bypass it. A financial-risk override was considered and declined.
+        fleetAuthorizationService.assertMayStart(workorderId);
 
         captureSnapshot(workorder, actorId, "WORK_START", reason);
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/service/TechnicianAssignmentService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/service/TechnicianAssignmentService.java
@@ -23,6 +23,18 @@ public interface TechnicianAssignmentService {
             @Nullable String notes);
 
     @NonNull
+    /**
+     * Releases the current technician assignment without creating a new one.
+     *
+     * <p>Distinct from {@link #reassignTechnician}, which always names a replacement: this is for
+     * freeing capacity a job cannot currently use — a workorder blocked on an unresolved fleet
+     * payment authorization, for instance — where there is nothing to reassign to yet.
+     *
+     * @return the released assignment, or empty when there was no current assignment
+     */
+    Optional<TechnicianAssignment> releaseAssignment(
+            @NonNull UUID workorderId, @NonNull String releasedBy, @Nullable String reason);
+
     Optional<TechnicianAssignment> getCurrentAssignment(@NonNull UUID workorderId);
 
     @NonNull

--- a/pos-workorder/src/main/resources/application.yml
+++ b/pos-workorder/src/main/resources/application.yml
@@ -86,8 +86,23 @@ pos:
     service-id: ${POS_DOCUMENTS_SERVICE_ID:documents}
 
 workorder:
+  fleetauth:
+    # How long a job's held resources (a technician assignment) survive an unresolved fleet
+    # payment authorization before they are released. Configurable because the domain ruled retry,
+    # timeout and escalation rules differ by deployment -- a shop with tight bay capacity wants a
+    # short grace period, one with slack wants a long one.
+    resource-release-after: ${WORKORDER_FLEETAUTH_RESOURCE_RELEASE_AFTER:PT4H}
+    resource-release-interval-ms: ${WORKORDER_FLEETAUTH_RESOURCE_RELEASE_INTERVAL_MS:900000}
+    resource-release-batch-size: ${WORKORDER_FLEETAUTH_RESOURCE_RELEASE_BATCH_SIZE:50}
   kafka:
     enabled: ${WORKORDER_KAFKA_ENABLED:false}
+    # Fleet payment authorization (#1346): decisions from pos-supplier, vehicle identity from
+    # pos-vehicle-inventory (ADR-0044 R3), and the delayed release of resources held by a job
+    # blocked on an unresolved authorization.
+    supplier-events-topic: ${WORKORDER_SUPPLIER_EVENTS_TOPIC:supplier.events.v1}
+    supplier-events-consumer-group: ${WORKORDER_SUPPLIER_EVENTS_CONSUMER_GROUP:pos-workorder-supplier-events}
+    vehicle-events-topic: ${WORKORDER_VEHICLE_EVENTS_TOPIC:vehicle.events.v1}
+    vehicle-events-consumer-group: ${WORKORDER_VEHICLE_EVENTS_CONSUMER_GROUP:pos-workorder-vehicle-events}
     events-topic: ${WORKORDER_KAFKA_EVENTS_TOPIC:workorder.events.v1}
     # People replicas (ADR-0044 §6, #877)
     people-contact-events-topic: ${WORKORDER_PC_EVENTS_TOPIC:people-contact.events.v1}

--- a/pos-workorder/src/main/resources/db/migration/V15__fleet_payment_authorization.sql
+++ b/pos-workorder/src/main/resources/db/migration/V15__fleet_payment_authorization.sql
@@ -1,0 +1,111 @@
+-- CAP-323 (#1346): fleet payment authorization — the payer's permission to do the work.
+--
+-- Named for what the domain calls it. "Fleet payment authorization" is a Commercial Customer
+-- agreeing to pay; it is NOT workorder approval, NOT estimate customer consent, and NOT
+-- change-request customer consent. AWAITING_APPROVAL keeps its existing meaning (customer consent
+-- for added scope during execution) and is deliberately untouched.
+
+-- The policy flag, replicated from pos-invoice's billing rules (ADR-0044 R3).
+-- A policy of the payer rather than of the job: the same commercial account answers the same way for
+-- every workorder it pays for.
+ALTER TABLE ext_billing_rules
+    ADD COLUMN IF NOT EXISTS fleet_authorization_required BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Which fleet program authorises for this party. Useless apart from the flag: knowing authorization
+-- is required without knowing who to ask blocks every workorder with nowhere to go.
+ALTER TABLE ext_billing_rules
+    ADD COLUMN IF NOT EXISTS fleet_supplier_ref VARCHAR(100);
+
+
+-- Vehicle identity, replicated from vehicle.events.v1 (ADR-0044 R3).
+--
+-- Needed because a fleet program identifies a vehicle by plate, VIN or fleet unit number, and this
+-- domain holds only a vehicleId UUID. pos-vehicle-inventory is a Domain module under ADR-0044, so it
+-- is read through its published facts rather than called — the same way pos-warranty already reads
+-- vehicle data.
+--
+-- Only the identifying fields are replicated. This is not a second vehicle registry: nothing here is
+-- authoritative, nothing is written back, and anything not needed to name a vehicle to a fleet
+-- program is deliberately absent.
+CREATE TABLE IF NOT EXISTS ext_vehicle (
+    vehicle_id        UUID         PRIMARY KEY,
+    vin               VARCHAR(64),
+    license_plate     VARCHAR(32),
+    unit_number       VARCHAR(64),
+    odometer_value    INTEGER,
+    odometer_unit     VARCHAR(16),
+    aggregate_version BIGINT       NOT NULL,
+    updated_at        timestamp(6) with time zone NOT NULL
+);
+
+
+-- One authorization lifecycle per workorder. Separate from workorder_status on purpose: the domain
+-- ruled this is a payer-authorization lifecycle, not an execution state, and folding it into the
+-- state machine would have made "who is paying" and "how far along is the work" the same question.
+CREATE TABLE workorder_fleet_authorization (
+    workorder_fleet_authorization_id UUID         PRIMARY KEY,
+    workorder_id                     UUID         NOT NULL,
+
+    -- The fleet program asked, and its profile id once a decision names one.
+    supplier_ref                     VARCHAR(100) NOT NULL,
+    vendor_profile_id                UUID,
+
+    -- NOT_REQUESTED, PENDING, GRANTED, REFUSED, MANUAL_REVIEW, CANCELLED.
+    --
+    -- GRANTED, REFUSED and PENDING are the vendor's three answers and are preserved without
+    -- reinterpretation, per the domain ruling. MANUAL_REVIEW is a *pending disposition*, never a
+    -- denial: it means nobody could get an answer, and it keeps the start gate closed exactly as
+    -- PENDING does. A timeout or a communication failure must never manufacture a refusal.
+    status                           VARCHAR(20)  NOT NULL,
+
+    -- The vendor's own words, kept unchanged. A refusal reason is what an advisor quotes back to a
+    -- fleet manager, so translating it would cost the conversation its evidence.
+    vendor_reason_code               VARCHAR(50),
+    vendor_reason_text               VARCHAR(1000),
+
+    -- Why this needs a person, when no vendor answer could be obtained. Never presented as a
+    -- vendor decision.
+    review_reason                    VARCHAR(1000),
+
+    contract_reference               VARCHAR(100),
+    authorized_amount                NUMERIC(19, 4),
+    currency                         VARCHAR(3),
+
+    -- Advisor resolution of a refusal: what they did and why. Nothing is automatic — the domain
+    -- ruled a refusal leaves the workorder open for an explicit decision.
+    resolution                       VARCHAR(30),
+    resolution_reason                VARCHAR(1000),
+    resolved_by                      VARCHAR(100),
+    resolved_at                      timestamp(6) with time zone,
+
+    requested_at                     timestamp(6) with time zone,
+    decided_at                       timestamp(6) with time zone,
+
+    -- When the start gate first refused a start on this workorder. The delayed release of held
+    -- resources is measured from here rather than from the request, because a job nobody has tried
+    -- to start is not holding anything up.
+    first_blocked_at                 timestamp(6) with time zone,
+    resources_released_at            timestamp(6) with time zone,
+
+    created_at                       timestamp(6) with time zone NOT NULL,
+    updated_at                       timestamp(6) with time zone NOT NULL,
+    created_by                       VARCHAR(100),
+    updated_by                       VARCHAR(100),
+
+    CONSTRAINT ck_wfa_status CHECK (
+        status IN ('NOT_REQUESTED', 'PENDING', 'GRANTED', 'REFUSED', 'MANUAL_REVIEW', 'CANCELLED')
+    ),
+    CONSTRAINT ck_wfa_resolution CHECK (
+        resolution IS NULL OR resolution IN ('SCOPE_REVISED', 'CANCELLED')
+    ),
+    -- An amount without a currency is not a sum of money.
+    CONSTRAINT ck_wfa_amount_currency CHECK (authorized_amount IS NULL OR currency IS NOT NULL)
+);
+
+-- One live authorization per workorder. This is what makes a re-request an update rather than a
+-- second opinion: two rows would let a refusal and a grant coexist with nothing to say which one
+-- the start gate should honour.
+CREATE UNIQUE INDEX ux_wfa_workorder ON workorder_fleet_authorization (workorder_id);
+
+-- The gate's lookup, and the release runner's working set.
+CREATE INDEX ix_wfa_status ON workorder_fleet_authorization (status, first_blocked_at);

--- a/pos-workorder/src/main/resources/permissions.yaml
+++ b/pos-workorder/src/main/resources/permissions.yaml
@@ -104,3 +104,7 @@ permissions:
     description: "Start work on workorders"
   - name: "workorder:workorder:view"
     description: "View workorders"
+  - name: "workorder:fleet_auth:request"
+    description: "Request or re-request a fleet payment authorization for a workorder"
+  - name: "workorder:fleet_auth:resolve"
+    description: "Resolve a fleet payment authorization that was refused, by revising scope or cancelling"

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaseRunnerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/FleetAuthorizationResourceReleaseRunnerTest.java
@@ -1,0 +1,134 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.entity.WorkorderFleetAuthorization;
+import com.positivity.workorder.internal.enums.FleetAuthorizationStatus;
+import com.positivity.workorder.internal.repository.WorkorderFleetAuthorizationRepository;
+import com.positivity.workorder.service.TechnicianAssignmentService;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * Freeing capacity a blocked job cannot currently use (#1346).
+ *
+ * <p>The rule that matters is the re-check inside the write: a row selected as overdue may have been
+ * granted in the interval between the query and the release, and releasing a resource that belongs
+ * to a now-cleared job would be actively wrong, not merely late.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("FleetAuthorizationResourceReleaseRunner — released once, and only while still blocking (#1346)")
+class FleetAuthorizationResourceReleaseRunnerTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-17T14:00:00Z");
+    private static final UUID WORKORDER_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000c1");
+
+    @Mock
+    private WorkorderFleetAuthorizationRepository authorizationRepository;
+
+    @Mock
+    private TechnicianAssignmentService technicianAssignmentService;
+
+    private FleetAuthorizationResourceReleaseRunner runner;
+
+    @BeforeEach
+    void setUp() {
+        runner = new FleetAuthorizationResourceReleaseRunner(
+                authorizationRepository,
+                technicianAssignmentService,
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                Duration.ofHours(4),
+                50);
+        when(authorizationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    @DisplayName("an overdue blocked authorization releases its assignment and is marked released")
+    void overdueBlockedAuthorizationIsReleased() {
+        WorkorderFleetAuthorization authorization =
+                row(FleetAuthorizationStatus.PENDING, NOW.minus(Duration.ofHours(5)));
+        when(authorizationRepository.findDueForResourceRelease(any(), any(), any()))
+                .thenReturn(List.of(authorization));
+
+        runner.releaseOverdue();
+
+        verify(technicianAssignmentService).releaseAssignment(eq(WORKORDER_ID), any(), any());
+        assertThat(authorization.getResourcesReleasedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("an authorization granted between the query and the write is not released")
+    void grantedBetweenQueryAndWriteIsNotReleased() {
+        // The query result is stale by the time the write runs. Re-checking inside the write is
+        // what stops a resource being pulled from a job that is now cleared to start.
+        WorkorderFleetAuthorization authorization =
+                row(FleetAuthorizationStatus.PENDING, NOW.minus(Duration.ofHours(5)));
+        when(authorizationRepository.findDueForResourceRelease(any(), any(), any()))
+                .thenReturn(List.of(authorization));
+        authorization.setStatus(FleetAuthorizationStatus.GRANTED);
+
+        runner.releaseOverdue();
+
+        verify(technicianAssignmentService, never()).releaseAssignment(any(), any(), any());
+        assertThat(authorization.getResourcesReleasedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("an authorization already released is not released again")
+    void alreadyReleasedIsNotReleasedAgain() {
+        WorkorderFleetAuthorization authorization =
+                row(FleetAuthorizationStatus.PENDING, NOW.minus(Duration.ofHours(5)));
+        authorization.setResourcesReleasedAt(NOW.minus(Duration.ofMinutes(30)));
+        when(authorizationRepository.findDueForResourceRelease(any(), any(), any()))
+                .thenReturn(List.of(authorization));
+
+        runner.releaseOne(authorization);
+
+        verify(technicianAssignmentService, never()).releaseAssignment(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("one failing release does not stop the rest of the batch")
+    void oneFailureDoesNotStopTheBatch() {
+        WorkorderFleetAuthorization first = row(FleetAuthorizationStatus.PENDING, NOW.minus(Duration.ofHours(5)));
+        WorkorderFleetAuthorization second = row(FleetAuthorizationStatus.REFUSED, NOW.minus(Duration.ofHours(6)));
+        second.setWorkorderId(UUID.fromString("019200aa-0000-7000-8000-0000000000c2"));
+        when(authorizationRepository.findDueForResourceRelease(any(), any(), any()))
+                .thenReturn(List.of(first, second));
+        when(technicianAssignmentService.releaseAssignment(eq(WORKORDER_ID), any(), any()))
+                .thenThrow(new RuntimeException("boom"));
+
+        runner.releaseOverdue();
+
+        verify(technicianAssignmentService).releaseAssignment(eq(second.getWorkorderId()), any(), any());
+        assertThat(second.getResourcesReleasedAt()).isEqualTo(NOW);
+    }
+
+    private static WorkorderFleetAuthorization row(FleetAuthorizationStatus status, Instant firstBlockedAt) {
+        return WorkorderFleetAuthorization.builder()
+                .workorderFleetAuthorizationId(UUID.fromString("019200aa-0000-7000-8000-0000000000a1"))
+                .workorderId(WORKORDER_ID)
+                .supplierRef("michelin-de")
+                .status(status)
+                .firstBlockedAt(firstBlockedAt)
+                .build();
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/FleetAuthorizationServiceTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/FleetAuthorizationServiceTest.java
@@ -1,0 +1,416 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.workorder.WorkorderFleetAuthRequestedV1;
+import com.positivity.workorder.internal.config.OutboxEventWriter;
+import com.positivity.workorder.internal.entity.ExtBillingRulesReplica;
+import com.positivity.workorder.internal.entity.ExtVehicleReplica;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderFleetAuthorization;
+import com.positivity.workorder.internal.enums.FleetAuthorizationResolution;
+import com.positivity.workorder.internal.enums.FleetAuthorizationStatus;
+import com.positivity.workorder.internal.repository.ExtBillingRulesReplicaRepository;
+import com.positivity.workorder.internal.repository.ExtVehicleReplicaRepository;
+import com.positivity.workorder.internal.repository.WorkorderFleetAuthorizationRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+
+/**
+ * Fleet payment authorization (#1346).
+ *
+ * <p>The behaviours pinned here are the domain ruling in code form: the gate closes on everything
+ * but a grant, a refusal is never automatic, and a re-request is refused while one is already live.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("FleetAuthorizationService — the payer-authorization lifecycle (#1346)")
+class FleetAuthorizationServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-17T10:00:00Z");
+    private static final UUID WORKORDER_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000c1");
+    private static final String PARTY_ID = "party-fleet-1";
+
+    @Mock
+    private WorkorderRepository workorderRepository;
+
+    @Mock
+    private WorkorderFleetAuthorizationRepository authorizationRepository;
+
+    @Mock
+    private ExtBillingRulesReplicaRepository billingRulesRepository;
+
+    @Mock
+    private ExtVehicleReplicaRepository vehicleRepository;
+
+    @Mock
+    private ObjectProvider<OutboxEventWriter> outboxEventWriterProvider;
+
+    @Mock
+    private OutboxEventWriter outboxEventWriter;
+
+    private FleetAuthorizationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new FleetAuthorizationService(
+                workorderRepository,
+                authorizationRepository,
+                billingRulesRepository,
+                vehicleRepository,
+                outboxEventWriterProvider,
+                Clock.fixed(NOW, ZoneOffset.UTC));
+        when(outboxEventWriterProvider.getIfAvailable()).thenReturn(outboxEventWriter);
+        when(authorizationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Nested
+    @DisplayName("the start gate")
+    class StartGate {
+
+        @Test
+        @DisplayName("a workorder whose payer does not require fleet authorization may start")
+        void nonFleetWorkorderIsUnaffected() {
+            withWorkorder(null);
+            when(billingRulesRepository.findById(PARTY_ID)).thenReturn(Optional.empty());
+
+            service.assertMayStart(WORKORDER_ID);
+
+            verify(authorizationRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("granted opens the gate")
+        void grantedPermitsStart() {
+            withWorkorder(null);
+            withRequiredPolicy();
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID))
+                    .thenReturn(Optional.of(authorization(FleetAuthorizationStatus.GRANTED)));
+
+            service.assertMayStart(WORKORDER_ID);
+        }
+
+        @Test
+        @DisplayName("never requested refuses the start")
+        void neverRequestedRefusesStart() {
+            withWorkorder(null);
+            withRequiredPolicy();
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.assertMayStart(WORKORDER_ID))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("NOT_REQUESTED");
+        }
+
+        @Test
+        @DisplayName("pending refuses the start")
+        void pendingRefusesStart() {
+            withWorkorder(null);
+            withRequiredPolicy();
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID))
+                    .thenReturn(Optional.of(authorization(FleetAuthorizationStatus.PENDING)));
+
+            assertThatThrownBy(() -> service.assertMayStart(WORKORDER_ID)).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        @DisplayName("refused refuses the start, and does not cancel or convert automatically")
+        void refusedRefusesStartWithoutSideEffects() {
+            // The domain ruled: no automatic cancellation, no automatic conversion to customer-pay.
+            // The only observable effect of a refusal here is that the start is refused.
+            withWorkorder(null);
+            withRequiredPolicy();
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID))
+                    .thenReturn(Optional.of(authorization(FleetAuthorizationStatus.REFUSED)));
+
+            assertThatThrownBy(() -> service.assertMayStart(WORKORDER_ID)).isInstanceOf(IllegalStateException.class);
+            verify(workorderRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("manual review refuses the start but is never described as a denial")
+        void manualReviewIsNotADenial() {
+            withWorkorder(null);
+            withRequiredPolicy();
+            WorkorderFleetAuthorization stuck = authorization(FleetAuthorizationStatus.MANUAL_REVIEW);
+            stuck.setReviewReason("vendor unreachable");
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID)).thenReturn(Optional.of(stuck));
+
+            assertThatThrownBy(() -> service.assertMayStart(WORKORDER_ID))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("MANUAL_REVIEW")
+                    .hasMessageNotContaining("declined")
+                    .hasMessageNotContaining("refused");
+        }
+
+        @Test
+        @DisplayName("a refused start stamps when the block first happened, once")
+        void firstBlockIsStampedOnce() {
+            withWorkorder(null);
+            withRequiredPolicy();
+            WorkorderFleetAuthorization pending = authorization(FleetAuthorizationStatus.PENDING);
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID)).thenReturn(Optional.of(pending));
+
+            assertThatThrownBy(() -> service.assertMayStart(WORKORDER_ID)).isInstanceOf(IllegalStateException.class);
+            assertThat(pending.getFirstBlockedAt()).isEqualTo(NOW);
+
+            // A second refused start must not move an already-stamped time forward: the release
+            // delay is measured from the first attempt, and re-stamping would reset the clock every
+            // time someone tried and failed to start the job.
+            Instant firstStamp = pending.getFirstBlockedAt();
+            assertThatThrownBy(() -> service.assertMayStart(WORKORDER_ID)).isInstanceOf(IllegalStateException.class);
+            assertThat(pending.getFirstBlockedAt()).isEqualTo(firstStamp);
+        }
+    }
+
+    @Nested
+    @DisplayName("requesting authorization")
+    class Requesting {
+
+        @Test
+        @DisplayName("a vehicle with plate, VIN or unit number produces a real request")
+        void identifiedVehicleIsRequested() {
+            withWorkorder(vehicleId());
+            withRequiredPolicy();
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID)).thenReturn(Optional.empty());
+            when(vehicleRepository.findById(vehicleId())).thenReturn(Optional.of(vehicle("ABC-123", null, null)));
+
+            Optional<WorkorderFleetAuthorization> result = service.requestAuthorization(WORKORDER_ID);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().getStatus()).isEqualTo(FleetAuthorizationStatus.PENDING);
+            ArgumentCaptor<Object> payload = ArgumentCaptor.forClass(Object.class);
+            verify(outboxEventWriter)
+                    .publish(
+                            org.mockito.ArgumentMatchers.eq(WorkorderFleetAuthRequestedV1.EVENT_TYPE),
+                            org.mockito.ArgumentMatchers.anyInt(),
+                            org.mockito.ArgumentMatchers.eq(WORKORDER_ID),
+                            payload.capture());
+            assertThat(payload.getValue())
+                    .isInstanceOfSatisfying(
+                            WorkorderFleetAuthRequestedV1.class,
+                            command -> assertThat(command.licensePlate()).isEqualTo("ABC-123"));
+        }
+
+        @Test
+        @DisplayName("no known vehicle identity parks the row for review instead of sending an unnamed request")
+        void unidentifiableVehicleIsNotSent() {
+            withWorkorder(vehicleId());
+            withRequiredPolicy();
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID)).thenReturn(Optional.empty());
+            when(vehicleRepository.findById(vehicleId())).thenReturn(Optional.empty());
+
+            Optional<WorkorderFleetAuthorization> result = service.requestAuthorization(WORKORDER_ID);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().getStatus()).isEqualTo(FleetAuthorizationStatus.MANUAL_REVIEW);
+            verify(outboxEventWriter, never()).publish(any(), org.mockito.ArgumentMatchers.anyInt(), any(), any());
+        }
+
+        @Test
+        @DisplayName("a vehicle replica with none of plate, VIN or unit number is also not sent")
+        void replicaWithNoIdentifyingFieldsIsNotSent() {
+            withWorkorder(vehicleId());
+            withRequiredPolicy();
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID)).thenReturn(Optional.empty());
+            when(vehicleRepository.findById(vehicleId())).thenReturn(Optional.of(vehicle(null, null, null)));
+
+            Optional<WorkorderFleetAuthorization> result = service.requestAuthorization(WORKORDER_ID);
+
+            assertThat(result.get().getStatus()).isEqualTo(FleetAuthorizationStatus.MANUAL_REVIEW);
+        }
+
+        @Test
+        @DisplayName("already granted is not asked again")
+        void grantedIsNotReRequested() {
+            withWorkorder(vehicleId());
+            withRequiredPolicy();
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID))
+                    .thenReturn(Optional.of(authorization(FleetAuthorizationStatus.GRANTED)));
+
+            service.requestAuthorization(WORKORDER_ID);
+
+            verify(outboxEventWriter, never()).publish(any(), org.mockito.ArgumentMatchers.anyInt(), any(), any());
+        }
+
+        @Test
+        @DisplayName("already pending is not asked again, because a second ask can open a second authorization")
+        void pendingIsNotReRequested() {
+            withWorkorder(vehicleId());
+            withRequiredPolicy();
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID))
+                    .thenReturn(Optional.of(authorization(FleetAuthorizationStatus.PENDING)));
+
+            service.requestAuthorization(WORKORDER_ID);
+
+            verify(outboxEventWriter, never()).publish(any(), org.mockito.ArgumentMatchers.anyInt(), any(), any());
+        }
+
+        @Test
+        @DisplayName("a refused authorization may be re-requested, and the stale refusal is cleared")
+        void refusedMayBeReRequested() {
+            withWorkorder(vehicleId());
+            withRequiredPolicy();
+            when(vehicleRepository.findById(vehicleId())).thenReturn(Optional.of(vehicle("ABC-123", null, null)));
+            WorkorderFleetAuthorization refused = authorization(FleetAuthorizationStatus.REFUSED);
+            refused.setVendorReasonText("Contract expired");
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID)).thenReturn(Optional.of(refused));
+
+            Optional<WorkorderFleetAuthorization> result = service.requestAuthorization(WORKORDER_ID);
+
+            assertThat(result.get().getStatus()).isEqualTo(FleetAuthorizationStatus.PENDING);
+            // A stale refusal reason beside a fresh request would read as if the fleet had just
+            // refused again.
+            assertThat(result.get().getVendorReasonText()).isNull();
+        }
+
+        @Test
+        @DisplayName("a non-fleet workorder is not requested at all")
+        void nonFleetWorkorderIsNotRequested() {
+            withWorkorder(vehicleId());
+            when(billingRulesRepository.findById(PARTY_ID)).thenReturn(Optional.empty());
+
+            assertThat(service.requestAuthorization(WORKORDER_ID)).isEmpty();
+            verify(authorizationRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("resolving a refusal")
+    class Resolving {
+
+        @Test
+        @DisplayName("cancelling records who and why, and moves the status")
+        void cancelIsRecorded() {
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID))
+                    .thenReturn(Optional.of(authorization(FleetAuthorizationStatus.REFUSED)));
+
+            WorkorderFleetAuthorization resolved = service.resolve(
+                    WORKORDER_ID, FleetAuthorizationResolution.CANCELLED, "customer will self-pay", "advisor-1");
+
+            assertThat(resolved.getStatus()).isEqualTo(FleetAuthorizationStatus.CANCELLED);
+            assertThat(resolved.getResolvedBy()).isEqualTo("advisor-1");
+            assertThat(resolved.getResolutionReason()).isEqualTo("customer will self-pay");
+        }
+
+        @Test
+        @DisplayName("a granted authorization cannot be resolved, because there is nothing to resolve")
+        void grantedCannotBeResolved() {
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID))
+                    .thenReturn(Optional.of(authorization(FleetAuthorizationStatus.GRANTED)));
+
+            assertThatThrownBy(() -> service.resolve(
+                            WORKORDER_ID, FleetAuthorizationResolution.CANCELLED, "reason", "advisor-1"))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        @DisplayName("resolving an unrequested authorization is refused with a 404-shaped exception")
+        void unrequestedCannotBeResolved() {
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.resolve(
+                            WORKORDER_ID, FleetAuthorizationResolution.CANCELLED, "reason", "advisor-1"))
+                    .isInstanceOf(
+                            com.positivity.workorder.internal.exception.FleetAuthorizationNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("recording a vendor decision")
+    class RecordingDecision {
+
+        @Test
+        @DisplayName("granted and refused are preserved without reinterpretation")
+        void decisionsArePreservedAsGiven() {
+            WorkorderFleetAuthorization pending = authorization(FleetAuthorizationStatus.PENDING);
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID)).thenReturn(Optional.of(pending));
+
+            service.recordDecision(
+                    WORKORDER_ID,
+                    UUID.fromString("019200aa-0000-7000-8000-0000000000d1"),
+                    FleetAuthorizationStatus.REFUSED,
+                    "NO_COVER",
+                    "Vehicle not on an active fleet contract",
+                    null);
+
+            assertThat(pending.getStatus()).isEqualTo(FleetAuthorizationStatus.REFUSED);
+            assertThat(pending.getVendorReasonCode()).isEqualTo("NO_COVER");
+        }
+
+        @Test
+        @DisplayName("a decision for a workorder that was never asked is not silently dropped nor does it crash")
+        void decisionForUnknownWorkorderIsHandled() {
+            when(authorizationRepository.findByWorkorderId(WORKORDER_ID)).thenReturn(Optional.empty());
+
+            service.recordDecision(
+                    WORKORDER_ID,
+                    UUID.fromString("019200aa-0000-7000-8000-0000000000d1"),
+                    FleetAuthorizationStatus.GRANTED,
+                    null,
+                    null,
+                    null);
+
+            verify(authorizationRepository, never()).save(any());
+        }
+    }
+
+    private void withWorkorder(UUID vehicleId) {
+        Workorder workorder = new Workorder();
+        workorder.setId(WORKORDER_ID);
+        workorder.setCrmPartyId(PARTY_ID);
+        workorder.setVehicleId(vehicleId);
+        when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(workorder));
+    }
+
+    private void withRequiredPolicy() {
+        ExtBillingRulesReplica rules = new ExtBillingRulesReplica();
+        rules.setPartyId(PARTY_ID);
+        rules.setFleetAuthorizationRequired(true);
+        rules.setFleetSupplierRef("michelin-de");
+        when(billingRulesRepository.findById(PARTY_ID)).thenReturn(Optional.of(rules));
+    }
+
+    private static UUID vehicleId() {
+        return UUID.fromString("019200aa-0000-7000-8000-0000000000e1");
+    }
+
+    private static ExtVehicleReplica vehicle(String plate, String vin, String unitNumber) {
+        ExtVehicleReplica replica = new ExtVehicleReplica();
+        replica.setVehicleId(vehicleId());
+        replica.setLicensePlate(plate);
+        replica.setVin(vin);
+        replica.setUnitNumber(unitNumber);
+        return replica;
+    }
+
+    private static WorkorderFleetAuthorization authorization(FleetAuthorizationStatus status) {
+        return WorkorderFleetAuthorization.builder()
+                .workorderFleetAuthorizationId(UUID.fromString("019200aa-0000-7000-8000-0000000000a1"))
+                .workorderId(WORKORDER_ID)
+                .supplierRef("michelin-de")
+                .status(status)
+                .requestedAt(NOW.minusSeconds(60))
+                .build();
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/SupplierFleetAuthEventsListenerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/SupplierFleetAuthEventsListenerTest.java
@@ -1,0 +1,158 @@
+package com.positivity.workorder.internal.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.entity.ProcessedEvent;
+import com.positivity.workorder.internal.enums.FleetAuthorizationStatus;
+import com.positivity.workorder.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.TransientDataAccessException;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Recording what a fleet program decided, unchanged (#1346).
+ *
+ * <p>The behaviour worth pinning is that granted and refused are passed through verbatim and that a
+ * transient failure is retried rather than silently marked processed -- the same discipline every
+ * other replica consumer in this codebase follows.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("SupplierFleetAuthEventsListener — preserved, not reinterpreted (#1346)")
+class SupplierFleetAuthEventsListenerTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-17T10:00:00Z");
+    private static final UUID WORKORDER_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000c1");
+    private static final UUID PROFILE_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000d1");
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private FleetAuthorizationService fleetAuthorizationService;
+
+    private SupplierFleetAuthEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new SupplierFleetAuthEventsListener(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                JsonMapper.builder().build(),
+                processedEventRepository,
+                fleetAuthorizationService);
+        when(processedEventRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    @DisplayName("a grant is recorded as granted, unchanged")
+    void grantIsRecorded() {
+        when(processedEventRepository.existsById("e-1")).thenReturn(false);
+
+        listener.onSupplierEvent("""
+                {"eventId":"e-1","eventType":"supplier.workorderauth.granted","schemaVersion":1,
+                 "aggregateId":"019200aa-0000-7000-8000-0000000000a1","aggregateVersion":1,
+                 "payload":{"vendorProfileId":"019200aa-0000-7000-8000-0000000000d1",
+                            "supplierRef":"michelin-de","workorderId":"019200aa-0000-7000-8000-0000000000c1",
+                            "vendorAuthorizationId":"WO-42","contractReference":"C-1",
+                            "authorizedAmount":null,"currency":null,"occurredAt":"2026-08-17T09:00:00Z"}}
+                """);
+
+        verify(fleetAuthorizationService)
+                .recordDecision(
+                        eq(WORKORDER_ID),
+                        eq(PROFILE_ID),
+                        eq(FleetAuthorizationStatus.GRANTED),
+                        any(),
+                        any(),
+                        eq("C-1"));
+    }
+
+    @Test
+    @DisplayName("a denial is recorded as refused, with the vendor's own reason unchanged")
+    void denialIsRecordedAsRefused() {
+        when(processedEventRepository.existsById("e-2")).thenReturn(false);
+
+        listener.onSupplierEvent("""
+                {"eventId":"e-2","eventType":"supplier.workorderauth.denied","schemaVersion":1,
+                 "aggregateId":"019200aa-0000-7000-8000-0000000000a1","aggregateVersion":1,
+                 "payload":{"vendorProfileId":"019200aa-0000-7000-8000-0000000000d1",
+                            "supplierRef":"michelin-de","workorderId":"019200aa-0000-7000-8000-0000000000c1",
+                            "vendorAuthorizationId":null,"reasonCode":"NO_COVER",
+                            "reasonText":"Vehicle not on an active contract","occurredAt":"2026-08-17T09:00:00Z"}}
+                """);
+
+        verify(fleetAuthorizationService)
+                .recordDecision(
+                        eq(WORKORDER_ID),
+                        eq(PROFILE_ID),
+                        eq(FleetAuthorizationStatus.REFUSED),
+                        eq("NO_COVER"),
+                        eq("Vehicle not on an active contract"),
+                        any());
+    }
+
+    @Test
+    @DisplayName("an already-processed event is not applied twice")
+    void redeliveryIsANoOp() {
+        when(processedEventRepository.existsById("e-3")).thenReturn(true);
+
+        listener.onSupplierEvent("""
+                {"eventId":"e-3","eventType":"supplier.workorderauth.granted","schemaVersion":1,
+                 "payload":{}}
+                """);
+
+        verify(fleetAuthorizationService, never()).recordDecision(any(), any(), any(), any(), any(), any());
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("a transient failure is rethrown for retry rather than marked processed")
+    void transientFailureIsRethrown() {
+        when(processedEventRepository.existsById("e-4")).thenReturn(false);
+        org.mockito.Mockito.doThrow(new TransientDataAccessException("db down") {})
+                .when(fleetAuthorizationService)
+                .recordDecision(any(), any(), any(), any(), any(), any());
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> listener.onSupplierEvent("""
+                        {"eventId":"e-4","eventType":"supplier.workorderauth.granted","schemaVersion":1,
+                         "aggregateId":"019200aa-0000-7000-8000-0000000000a1","aggregateVersion":1,
+                         "payload":{"vendorProfileId":"019200aa-0000-7000-8000-0000000000d1",
+                                    "supplierRef":"michelin-de","workorderId":"019200aa-0000-7000-8000-0000000000c1",
+                                    "vendorAuthorizationId":"WO-42","contractReference":null,
+                                    "authorizedAmount":null,"currency":null,"occurredAt":"2026-08-17T09:00:00Z"}}
+                        """))
+                .isInstanceOf(TransientDataAccessException.class);
+
+        // Marking this processed would leave a workorder gated on an authorization the fleet
+        // already granted, with nothing to correct it.
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("an unrecognised event type is still recorded as processed")
+    void unrecognisedTypeIsStillProcessed() {
+        when(processedEventRepository.existsById("e-5")).thenReturn(false);
+
+        listener.onSupplierEvent("""
+                {"eventId":"e-5","eventType":"supplier.something.else","schemaVersion":1,"payload":{}}
+                """);
+
+        verify(processedEventRepository).save(any(ProcessedEvent.class));
+        verify(fleetAuthorizationService, never()).recordDecision(any(), any(), any(), any(), any(), any());
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/VehicleEventsListenerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/VehicleEventsListenerTest.java
@@ -1,0 +1,103 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.entity.ExtVehicleReplica;
+import com.positivity.workorder.internal.repository.ExtVehicleReplicaRepository;
+import com.positivity.workorder.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Replicating vehicle identity, for naming a vehicle to a fleet program (#1346).
+ *
+ * <p>This is not a general-purpose vehicle mirror; only what identifies a vehicle to a fleet is
+ * copied. The stale-version guard is the one behaviour shared with every other replica consumer.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("VehicleEventsListener — the ext_vehicle replica (#1346)")
+class VehicleEventsListenerTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-17T10:00:00Z");
+    private static final UUID VEHICLE_ID = UUID.fromString("019200aa-0000-7000-8000-0000000000e1");
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private ExtVehicleReplicaRepository vehicleRepository;
+
+    private VehicleEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new VehicleEventsListener(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                JsonMapper.builder().build(),
+                processedEventRepository,
+                vehicleRepository);
+        when(processedEventRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(vehicleRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    @DisplayName("identifying fields are replicated: plate, VIN, unit number")
+    void identifyingFieldsAreReplicated() {
+        when(processedEventRepository.existsById("e-1")).thenReturn(false);
+        when(vehicleRepository.findById(VEHICLE_ID)).thenReturn(Optional.empty());
+
+        listener.onVehicleEvent("""
+                {"eventId":"e-1","eventType":"vehicle.vehicle.updated","schemaVersion":1,
+                 "aggregateId":"019200aa-0000-7000-8000-0000000000e1","aggregateVersion":5,
+                 "payload":{"vehicleId":"019200aa-0000-7000-8000-0000000000e1",
+                            "accountId":"019200aa-0000-7000-8000-0000000000f1",
+                            "vin":"1HGCM82633A004352","vinNormalized":"1HGCM82633A004352","active":true,
+                            "licensePlate":"ABC-123","unitNumber":"FLEET-9"}}
+                """);
+
+        ArgumentCaptor<ExtVehicleReplica> saved = ArgumentCaptor.forClass(ExtVehicleReplica.class);
+        verify(vehicleRepository).save(saved.capture());
+        assertThat(saved.getValue().getVin()).isEqualTo("1HGCM82633A004352");
+        assertThat(saved.getValue().getLicensePlate()).isEqualTo("ABC-123");
+        assertThat(saved.getValue().getUnitNumber()).isEqualTo("FLEET-9");
+        assertThat(saved.getValue().getAggregateVersion()).isEqualTo(5L);
+    }
+
+    @Test
+    @DisplayName("a strictly-lower version is not applied over a newer replica row")
+    void staleVersionIsIgnored() {
+        when(processedEventRepository.existsById("e-2")).thenReturn(false);
+        ExtVehicleReplica existing = new ExtVehicleReplica();
+        existing.setVehicleId(VEHICLE_ID);
+        existing.setAggregateVersion(10L);
+        when(vehicleRepository.findById(VEHICLE_ID)).thenReturn(Optional.of(existing));
+
+        listener.onVehicleEvent("""
+                {"eventId":"e-2","eventType":"vehicle.vehicle.updated","schemaVersion":1,
+                 "aggregateId":"019200aa-0000-7000-8000-0000000000e1","aggregateVersion":3,
+                 "payload":{"vehicleId":"019200aa-0000-7000-8000-0000000000e1",
+                            "accountId":"019200aa-0000-7000-8000-0000000000f1",
+                            "vin":"1HGCM82633A004352","vinNormalized":"1HGCM82633A004352","active":true}}
+                """);
+
+        verify(vehicleRepository, never()).save(any());
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/InvoiceEventsListenerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/InvoiceEventsListenerTest.java
@@ -130,7 +130,8 @@ class InvoiceEventsListenerTest {
                  "aggregateId":"00000000-0000-0000-0000-00000000000b","aggregateVersion":3,
                  "payload":{"partyId":"party-001","purchaseOrderRequired":true,
                             "paymentTermsCode":"NET_30","invoiceDeliveryMethod":"EMAIL",
-                            "invoiceGroupingStrategy":"PER_WORKORDER"}}
+                            "invoiceGroupingStrategy":"PER_WORKORDER",
+                            "fleetAuthorizationRequired":false,"fleetSupplierRef":null}}
                 """);
 
         ArgumentCaptor<ExtBillingRulesReplica> saved = ArgumentCaptor.forClass(ExtBillingRulesReplica.class);

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderCompletionTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderCompletionTest.java
@@ -177,7 +177,8 @@ class WorkorderCompletionTest {
                 auditEventRepository,
                 idempotencyService,
                 promotionValidationService,
-                peopleAvailabilityLocalService);
+                peopleAvailabilityLocalService,
+                org.mockito.Mockito.mock(com.positivity.workorder.internal.service.FleetAuthorizationService.class));
     }
 
     @AfterEach

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderStateMachineTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderStateMachineTest.java
@@ -71,6 +71,9 @@ class WorkorderStateMachineTest {
     @org.mockito.Mock
     private com.positivity.workorder.internal.service.ServiceCompletionFactPublisher serviceCompletionFactPublisher;
 
+    @Mock
+    private com.positivity.workorder.internal.service.FleetAuthorizationService fleetAuthorizationService;
+
     @InjectMocks
     private WorkorderStateMachine stateMachine;
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:323` (CAP-323 follow-on: fleet workorder authorization consumer)
- Child issue: louisburroughs/durion-positivity-backend#1346
- Domain: `domain:workexec`, `domain:positivity`, `domain:billing`

## Contract References
- Contract guide entry (durion): `domains/workexec/.business-rules/BACKEND_CONTRACT_GUIDE.md`, plus the domain rules it points to for this capability — `WORKORDER_STATE_MACHINE.md`, `CUSTOMER_APPROVAL_WORKFLOW.md`, `CHANGE_REQUEST_WORKFLOW.md`
- Domain ruling: #1346 comment thread (Workorder Execution domain agent + user)

## Contract Chain
- [x] OpenAPI annotations updated on the controller
- [x] `pos-workorder/openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated — handled separately

## Scope

**What changed:** the Workorder Execution domain's ruling on #1346, implemented in full. Fleet
payment authorization — whether a Commercial Customer agrees to pay for a workorder — is now a
separate lifecycle enforced at the start gate, with no automatic denial handling and a delayed
release of resources a blocked job can't use.

**Why:** CAP-323 built the vendor half (pos-supplier asks a fleet program, publishes the decision).
Nothing consumed it. This is that consumer, built against an explicit domain ruling rather than
inferred.

### The ruling, in code

| Ruling | Where |
|---|---|
| Separate lifecycle, not a `WorkorderStatus` | `FleetAuthorizationStatus` enum, own table, own repository |
| `AWAITING_APPROVAL` untouched | Not referenced anywhere in this change |
| Enforced in the backend command, no override | `WorkorderStateMachine.startWork` calls `FleetAuthorizationService.assertMayStart` before the transition; no financial-risk override exists |
| Refusal leaves the workorder open, never automatic | `recordDecision` only ever writes the vendor's status; nothing else changes |
| Advisor resolves explicitly (revise scope / cancel), each auditable | `POST .../resolution` with `FleetAuthorizationResolution`, own permission (`workorder:fleet_auth:resolve`), records who/when/why |
| No answer ≠ denial | `MANUAL_REVIEW` is a distinct status; the gate's message never uses "declined" or "refused" for it |
| Retry/timeout/escalation configurable per deployment | `workorder.fleetauth.resource-release-after` etc. in `application.yml` |

### Two real gaps found by inspection, both resolved without a wall breach

**Vehicle identity.** CAP-323's request refuses construction without a vehicle identifier. Workexec
held only a `vehicleId` UUID. Rather than call `pos-vehicle-inventory` (a Domain module under
ADR-0044 — synchronous calls are not permitted), I found `vehicle.events.v1` already publishes VIN,
plate and unit number, and `pos-warranty` already replicates it for the same reason. Workexec now
has the same `ext_vehicle` replica. **Per your direction, cross-domain vehicle creation for a missing
replica row is deliberately not attempted here** — a miss falls back to `MANUAL_REVIEW` with a
review reason rather than inventing a vehicle.

**The policy source.** `fleetAuthorizationRequired` / `fleetSupplierRef` were added to pos-invoice's
`BillingRules` — the same shape as the existing `purchaseOrderRequired` — and flow through the
already-existing `invoice.billing-rules.updated` → `ext_billing_rules` replication path. No new
cross-domain wiring; extended what was already there.

### Design decisions worth your eye

- **The gate is closed by default.** `NOT_REQUESTED`, `PENDING`, `REFUSED`, `MANUAL_REVIEW`,
  `CANCELLED` all refuse a start — only `GRANTED` opens it.
- **Re-request is refused while already granted or pending.** Asking twice can open a second
  authorization at the vendor against one contract.
- **The resource release re-checks status inside its own write**, not just the query that selected
  it. A row queried as overdue may have been granted in the interval; releasing a resource from a
  now-cleared job would be actively wrong, not merely late.
- **`TechnicianAssignmentService` gained a real `releaseAssignment` method.** The only prior write
  path (`reassignTechnician`) always names a replacement; there was no way to free capacity with
  nothing to reassign to.
- **The decision is preserved verbatim.** `supplier.workorderauth.granted`/`.denied` are applied with
  no reinterpretation — the vendor's own reason code and text pass through unchanged, since that's
  what an advisor quotes back to a fleet manager.

## Tests
- [x] Unit tests added — 30 new across three modules (service 19, resource release 4, supplier
  listener 5, vehicle listener 2 in pos-workorder; domain-event validation 5 in pos-domain-events)
- [ ] Integration tests — none added; consumer/gate logic covered at the service boundary
- How to run:
```bash
./mvnw -pl pos-workorder,pos-invoice,pos-domain-events -am test
./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test
```

Verified: pos-workorder 388, pos-invoice 349, pos-domain-events 849, gateway 79, security-service
483, security-common 103, architecture gates 22 — all pass. Spec regenerated, permission catalog
synced (bits 466–467, v56).

## Risk & Rollback
- Risk level: Medium — touches `WorkorderStateMachine.startWork`, on the path of every workorder
  start. Guarded by `isRequired` short-circuiting to `false` for any non-fleet payer (the overwhelming
  majority), so the added cost for an ordinary workorder is one indexed replica lookup.
- Rollback plan: revert the commit. `V17__billing_rules_fleet_authorization.sql` and
  `V15__fleet_payment_authorization.sql` only add nullable/defaulted columns and new tables nothing
  else references, so both can be left in place or dropped independently.

## Checklist
- [x] Branch name matches the work
- [x] Links to the issue are present
- [x] Contract guide updated (no contract semantics changed outside this capability)
- [ ] Required CI checks passing — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mv7zVYjwbVu5GRqrfkfHc7

