### PR TITLE
fix(supplier): drop import-manifest-id leak from SupplierPriceCatalogEntry (#1354)

### DIFF
--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb/EdiwheelB40PricatCodec.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/adapter/ediwheelb/EdiwheelB40PricatCodec.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -103,13 +102,12 @@ public class EdiwheelB40PricatCodec implements SupplierAdapterCodec {
      * decoded.
      *
      * @param body             response body as received
-     * @param importManifestId the import this decode belongs to; stamped on every entry
      * @return the decoded document; never null, and never partially silent
      * @throws PricatDecodeException when the body is not a PRICAT document at all, or the vendor
      *                               signalled a document-level error code
      */
     @NonNull
-    public PricatDocument decode(@Nullable String body, @NonNull UUID importManifestId) {
+    public PricatDocument decode(@Nullable String body) {
         if (body == null || body.isBlank()) {
             throw new PricatDecodeException("PRICAT response body was empty");
         }
@@ -146,7 +144,7 @@ public class EdiwheelB40PricatCodec implements SupplierAdapterCodec {
                 continue;
             }
             try {
-                entries.add(toEntry(article, documentId, documentDate, countryCode, currency, importManifestId));
+                entries.add(toEntry(article, documentId, documentDate, countryCode, currency));
             } catch (IllegalArgumentException e) {
                 rejected.add(new PricatDocument.RejectedLine(
                         article.pos(),
@@ -164,8 +162,7 @@ public class EdiwheelB40PricatCodec implements SupplierAdapterCodec {
             String documentId,
             LocalDate documentDate,
             String countryCode,
-            String currency,
-            UUID importManifestId) {
+            String currency) {
         BigDecimal netPrice = parseAmount(article.netValue(), "netValue");
         BigDecimal grossPrice = parseAmount(article.grossPrice(), "grossPrice");
         LocalDate netFrom = parseVendorDate(article.netValueValidFrom(), "netValueValidFrom");
@@ -200,7 +197,6 @@ public class EdiwheelB40PricatCodec implements SupplierAdapterCodec {
                 currency,
                 documentId,
                 documentDate,
-                importManifestId,
                 article.pos());
     }
 

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/SupplierPriceCatalogEntry.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/domain/model/SupplierPriceCatalogEntry.java
@@ -3,7 +3,6 @@ package com.positivity.supplier.internal.domain.model;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Objects;
-import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -29,7 +28,6 @@ import org.jspecify.annotations.Nullable;
  * @param recyclingFee recycling fee amount the vendor stated, when stated
  * @param sourceDocumentId vendor catalog document id the row came from, when stated
  * @param sourceDocumentDate vendor catalog document date, when stated
- * @param importManifestId identity of the import run that produced this row
  * @param positionNumber 1-based line position within the vendor document, when stated; lets a
  *     staged row or a quarantined line be cited back to the vendor by document position
  */
@@ -47,14 +45,12 @@ public record SupplierPriceCatalogEntry(
         @NonNull String currency,
         @Nullable String sourceDocumentId,
         @Nullable LocalDate sourceDocumentDate,
-        @NonNull UUID importManifestId,
         @Nullable Integer positionNumber) {
 
     public SupplierPriceCatalogEntry {
         Objects.requireNonNull(effectiveFrom, "effectiveFrom must not be null");
         Objects.requireNonNull(countryCode, "countryCode must not be null");
         Objects.requireNonNull(currency, "currency must not be null");
-        Objects.requireNonNull(importManifestId, "importManifestId must not be null");
         if (countryCode.isBlank()) {
             throw new IllegalArgumentException("countryCode must not be blank");
         }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/PriceCatalogImporter.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/PriceCatalogImporter.java
@@ -106,7 +106,7 @@ public class PriceCatalogImporter implements SupplierPriceCatalogPort {
 
         PricatDocument document;
         try {
-            document = readCatalogue(binding, codec, billing, importManifestId);
+            document = readCatalogue(binding, codec, billing);
         } catch (PriceCatalogFetchException e) {
             // Recorded rather than raised: an import run is scheduled work, and an operator needs
             // the manifest row saying this vendor was asked and did not answer usably.
@@ -279,15 +279,14 @@ public class PriceCatalogImporter implements SupplierPriceCatalogPort {
      * of those is worth anybody's attention.
      */
     @Override
-    public SupplierPriceCatalogPort.@NonNull Fetched fetchPriceCatalog(
-            @NonNull SupplierRef supplierRef, @NonNull UUID importManifestId) {
+    public SupplierPriceCatalogPort.@NonNull Fetched fetchPriceCatalog(@NonNull SupplierRef supplierRef) {
         ResolvedBinding binding = profileResolver.resolveBinding(supplierRef, SupplierCapability.PRICE_CATALOG);
         EdiwheelB40PricatCodec codec = SupplierCodecs.require(
                 adapterRegistry, binding, SupplierCapability.PRICE_CATALOG, EdiwheelB40PricatCodec.class);
         SupplierAccountEntity billing =
                 profileResolver.resolvePartyContext(supplierRef, null).billing();
 
-        PricatDocument document = readCatalogue(binding, codec, billing, importManifestId);
+        PricatDocument document = readCatalogue(binding, codec, billing);
         return new SupplierPriceCatalogPort.Fetched(
                 document.entries(),
                 document.rejectedLines().stream()
@@ -312,8 +311,7 @@ public class PriceCatalogImporter implements SupplierPriceCatalogPort {
     private PricatDocument readCatalogue(
             @NonNull ResolvedBinding binding,
             @NonNull EdiwheelB40PricatCodec codec,
-            @NonNull SupplierAccountEntity billing,
-            @NonNull UUID importManifestId) {
+            @NonNull SupplierAccountEntity billing) {
         PartyContext partyContext = new PartyContext(billing.getAccountNumber(), billing.getAgencyCode(), null);
         SupplierRequestSpec spec = codec.buildRequest(partyContext, null);
         SupplierHttpResponse response = baseClient.exchange(SupplierRequests.toHttpRequest(binding, spec));
@@ -323,7 +321,7 @@ public class PriceCatalogImporter implements SupplierPriceCatalogPort {
                     + (response.failureDetail() == null ? "" : " — " + response.failureDetail()));
         }
         try {
-            return codec.decode(response.body(), importManifestId);
+            return codec.decode(response.body());
         } catch (PricatDecodeException e) {
             throw new PriceCatalogFetchException(e.getMessage(), e);
         }

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplier.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplier.java
@@ -189,7 +189,6 @@ public class QuarantineReapplier {
                 line.getCurrency(),
                 line.getSourceDocumentId(),
                 line.getSourceDocumentDate(),
-                line.getImportManifestId(),
                 line.getPositionNumber());
     }
 

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/spi/SupplierPriceCatalogPort.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/spi/SupplierPriceCatalogPort.java
@@ -3,7 +3,6 @@ package com.positivity.supplier.internal.spi;
 import com.positivity.supplier.internal.domain.model.SupplierPriceCatalogEntry;
 import com.positivity.supplier.internal.domain.model.SupplierRef;
 import java.util.List;
-import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -18,29 +17,17 @@ import org.jspecify.annotations.NonNull;
  * is a product that quietly has no vendor price, and nothing downstream could tell that from a
  * vendor that never listed it. Matching entries to products and quarantining the rest is the
  * caller's — a port that matched would be deciding catalogue questions inside the protocol layer.
- *
- * <h2>The manifest id, which should not be here</h2>
- *
- * {@code SupplierPriceCatalogEntry.importManifestId} is {@code @NonNull}, so an entry cannot be
- * constructed without one — which forces this port to accept a piece of <em>this platform's import
- * bookkeeping</em> in order to return vendor data. That is backwards: the canonical model of what a
- * vendor published should not carry the identity of the run that fetched it.
- *
- * <p>It is a parameter rather than something invented here because inventing one would produce
- * entries stamped with a run that does not exist. The model is the thing to fix, and it is recorded
- * as such rather than worked around silently (#1349).
  */
 public interface SupplierPriceCatalogPort {
 
     /**
      * Fetches the vendor's current price catalogue.
      *
-     * @param supplierRef      the vendor profile alias to read
-     * @param importManifestId the import run these entries belong to — see the note above
+     * @param supplierRef the vendor profile alias to read
      * @return what the vendor published, entries and unreadable lines alike
      */
     @NonNull
-    Fetched fetchPriceCatalog(@NonNull SupplierRef supplierRef, @NonNull UUID importManifestId);
+    Fetched fetchPriceCatalog(@NonNull SupplierRef supplierRef);
 
     /**
      * A fetched catalogue, including what could not be read.

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/spi/package-info.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/spi/package-info.java
@@ -68,12 +68,6 @@
  * intent through its ledger", and that is orchestration rather than a protocol capability. A port
  * describing it would be fiction, which is the defect this whole exercise existed to end.
  *
- * <p><strong>{@code SupplierPriceCatalogPort} takes an import manifest id</strong>, which it should
- * not. {@code SupplierPriceCatalogEntry.importManifestId} is non-null, so an entry cannot exist
- * without one — this platform's import bookkeeping is baked into the canonical model of what a
- * vendor published. The parameter is documented as the leak it is rather than hidden by inventing an
- * id here, which would stamp entries with a run that never happened.
- *
  * <p>{@link com.positivity.supplier.internal.spi.TireIdentificationPort} is the one deliberate
  * exception to "every port is implemented": it is a placeholder pending confirmation that DOT
  * scanning is required (§12 decision 10), and {@code TireIdentificationDormancyTest} asserts it

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheelb/EdiwheelB40PricatCodecTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/adapter/ediwheelb/EdiwheelB40PricatCodecTest.java
@@ -14,7 +14,6 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -22,8 +21,6 @@ import tools.jackson.databind.ObjectMapper;
 
 @DisplayName("EDIWheel PRICAT B4.0 codec (#1224)")
 class EdiwheelB40PricatCodecTest {
-
-    private static final UUID MANIFEST_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b");
 
     private final EdiwheelB40PricatCodec codec = new EdiwheelB40PricatCodec(new ObjectMapper());
 
@@ -95,7 +92,7 @@ class EdiwheelB40PricatCodecTest {
 
         @Test
         void readsHeaderFactsFromTheGoldenDocument() throws IOException {
-            PricatDocument document = codec.decode(goldenDocument(), MANIFEST_ID);
+            PricatDocument document = codec.decode(goldenDocument());
 
             assertThat(document.documentId()).isEqualTo("PRICAT-4046266_202305120844");
             assertThat(document.documentDate()).isEqualTo(LocalDate.of(2023, 5, 12));
@@ -107,7 +104,7 @@ class EdiwheelB40PricatCodecTest {
         @Test
         void mapsIdentityPricesAndFeesVerbatim() throws IOException {
             SupplierPriceCatalogEntry first =
-                    codec.decode(goldenDocument(), MANIFEST_ID).entries().getFirst();
+                    codec.decode(goldenDocument()).entries().getFirst();
 
             assertThat(first.articleEan()).isEqualTo("3528709999083");
             assertThat(first.supplierArticleCode()).isEqualTo("999908");
@@ -118,14 +115,13 @@ class EdiwheelB40PricatCodecTest {
             assertThat(first.recyclingFee()).isEqualByComparingTo(new BigDecimal("35.00"));
             assertThat(first.countryCode()).isEqualTo("SE");
             assertThat(first.currency()).isEqualTo("SEK");
-            assertThat(first.importManifestId()).isEqualTo(MANIFEST_ID);
             assertThat(first.positionNumber()).isEqualTo(1);
         }
 
         @Test
         void prefersTheNetValidityDateWhenANetPriceIsStated() throws IOException {
             SupplierPriceCatalogEntry first =
-                    codec.decode(goldenDocument(), MANIFEST_ID).entries().getFirst();
+                    codec.decode(goldenDocument()).entries().getFirst();
 
             // Gross says 2021-01-01, net says 2026-02-01; the net price is what a buyer pays.
             assertThat(first.effectiveFrom()).isEqualTo(LocalDate.of(2026, 2, 1));
@@ -134,7 +130,7 @@ class EdiwheelB40PricatCodecTest {
         @Test
         void fallsBackToTheGrossValidityDateWhenNoNetPriceIsStated() throws IOException {
             SupplierPriceCatalogEntry second =
-                    codec.decode(goldenDocument(), MANIFEST_ID).entries().get(1);
+                    codec.decode(goldenDocument()).entries().get(1);
 
             assertThat(second.netPrice()).isNull();
             assertThat(second.effectiveFrom()).isEqualTo(LocalDate.of(2026, 1, 15));
@@ -143,7 +139,7 @@ class EdiwheelB40PricatCodecTest {
         @Test
         void acceptsCommaDecimalsAsSomeMarketsStateThem() throws IOException {
             SupplierPriceCatalogEntry second =
-                    codec.decode(goldenDocument(), MANIFEST_ID).entries().get(1);
+                    codec.decode(goldenDocument()).entries().get(1);
 
             assertThat(second.grossPrice()).isEqualByComparingTo(new BigDecimal("1450.00"));
         }
@@ -151,7 +147,7 @@ class EdiwheelB40PricatCodecTest {
         @Test
         void carriesTheCrossReferenceCodeAsASecondIdentity() throws IOException {
             SupplierPriceCatalogEntry second =
-                    codec.decode(goldenDocument(), MANIFEST_ID).entries().get(1);
+                    codec.decode(goldenDocument()).entries().get(1);
 
             assertThat(second.articleEan()).isNull();
             assertThat(second.xReferenceCode()).isEqualTo("0123456789012");
@@ -159,7 +155,7 @@ class EdiwheelB40PricatCodecTest {
 
         @Test
         void rejectsUnusableLinesWithoutDiscardingTheDocument() throws IOException {
-            PricatDocument document = codec.decode(goldenDocument(), MANIFEST_ID);
+            PricatDocument document = codec.decode(goldenDocument());
 
             assertThat(document.entries()).hasSize(2);
             assertThat(document.rejectedLines()).hasSize(2);
@@ -179,19 +175,19 @@ class EdiwheelB40PricatCodecTest {
                      "articles":[]}
                     """;
 
-            assertThatThrownBy(() -> codec.decode(body, MANIFEST_ID))
+            assertThatThrownBy(() -> codec.decode(body))
                     .isInstanceOf(PricatDecodeException.class)
                     .hasMessageContaining("vendor error code 42");
         }
 
         @Test
         void failsOnAnEmptyBodyRatherThanReportingAnEmptyCatalog() {
-            assertThatThrownBy(() -> codec.decode("   ", MANIFEST_ID)).isInstanceOf(PricatDecodeException.class);
+            assertThatThrownBy(() -> codec.decode("   ")).isInstanceOf(PricatDecodeException.class);
         }
 
         @Test
         void failsOnABodyThatIsNotACatalogDocument() {
-            assertThatThrownBy(() -> codec.decode("<html>gateway timeout</html>", MANIFEST_ID))
+            assertThatThrownBy(() -> codec.decode("<html>gateway timeout</html>"))
                     .isInstanceOf(PricatDecodeException.class)
                     .hasMessageContaining("not a B4.0 catalog document");
         }
@@ -203,7 +199,7 @@ class EdiwheelB40PricatCodecTest {
                      "articles":[]}
                     """;
 
-            PricatDocument document = codec.decode(body, MANIFEST_ID);
+            PricatDocument document = codec.decode(body);
 
             assertThat(document.entries()).isEmpty();
             assertThat(document.linesFetched()).isZero();
@@ -216,7 +212,7 @@ class EdiwheelB40PricatCodecTest {
                      "articles":[{"pos":1,"ean":"3528709999083","grossPrice":"10.00","grossPriceValidFrom":"20260101"}]}
                     """;
 
-            PricatDocument document = codec.decode(body, MANIFEST_ID);
+            PricatDocument document = codec.decode(body);
 
             assertThat(document.entries()).isEmpty();
             assertThat(document.rejectedLines())

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/PriceCatalogMatchingTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/PriceCatalogMatchingTest.java
@@ -75,7 +75,6 @@ class PriceCatalogMatchingTest {
                 "SEK",
                 "DOC-1",
                 LocalDate.of(2026, 1, 1),
-                MANIFEST_ID,
                 position);
     }
 

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/PriceCatalogStagingWriterTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/PriceCatalogStagingWriterTest.java
@@ -134,7 +134,6 @@ class PriceCatalogStagingWriterTest {
                 "SEK",
                 "DOC-1",
                 LocalDate.of(2026, 1, 30),
-                MANIFEST_ID,
                 position);
     }
 

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplicationWriterTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/pricecatalog/service/QuarantineReapplicationWriterTest.java
@@ -138,7 +138,6 @@ class QuarantineReapplicationWriterTest {
                 row.getCurrency(),
                 row.getSourceDocumentId(),
                 row.getSourceDocumentDate(),
-                row.getImportManifestId(),
                 position);
         return new ResolvedLine(row, entry, PRODUCT_ID, PriceCatalogMatchMethod.EAN);
     }


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (internal cleanup, not a CAP)
- Child issue: louisburroughs/durion-positivity-backend#1354
- Domain: `domain:integrations` (pos-supplier)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
No controller, DTO, event, or openapi.yaml changed — internal SPI port and domain model only.
Not contract-relevant per `BACKEND_CONTRACT_GUIDE.md`; no guide entry needed.

## Scope
- What changed: Removed `SupplierPriceCatalogEntry.importManifestId` — this platform's import-run
  bookkeeping baked into the canonical model of what a vendor published. Dropped the corresponding
  parameter from `SupplierPriceCatalogPort.fetchPriceCatalog`, `EdiwheelB40PricatCodec.decode`, and
  the private `toEntry` helpers in the codec and in `QuarantineReapplier`. Removed the javadoc note
  in `SupplierPriceCatalogPort`/`spi/package-info.java` that documented the leak (#1349), since it's
  now fixed.
- Why: closes #1354. The entry is vendor data verbatim; the import run that fetched it is platform
  bookkeeping that belongs where it was already tracked independently — `PriceCatalogImporter`,
  `PriceCatalogStagingWriter` and `PriceCatalogImportEntity` all already carried `importManifestId`
  as their own parameter/field and never read it from the entry, so this is a pure signature cleanup,
  not a rewiring of the quarantine or republish repair paths (traced call chains for both, #1309,
  #1310, #1321 — unaffected).

## Tests
- [x] Unit tests updated (mechanical: dropped the trailing constructor arg / method arg in
      `EdiwheelB40PricatCodecTest`, `PriceCatalogMatchingTest`, `PriceCatalogStagingWriterTest`,
      `QuarantineReapplicationWriterTest`)
- [ ] Integration tests added/updated (none needed — no I/O or transactional behavior changed)
- [ ] Provider behavioral contract tests added/updated (n/a, no contract change)
- How to run: `./mvnw -pl pos-supplier -am test`

## Risk & Rollback
- Risk level: Low — internal signature change, no behavior change; existing tests pass unchanged in
  assertions, only construction/method-call arity updated.
- Rollback plan: revert this commit; the removed field/parameter can be reinstated without data loss
  since nothing downstream ever read it from the entry.

## Checklist
- [x] Links to child issue present
- [ ] Contract guide updated (n/a — no contract semantics changed)
- [x] Required CI checks passing (local: `pos-supplier` unit tests, cross-module ArchUnit
      `pos-archunit -Dtest=ArchitectureTests`, `spotless:apply`)