### PR TITLE
feat(catalog,order): replicate vendor article code for non-EAN purchase-order transmission (#1347)

### DIFF
--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -259,6 +259,8 @@ paths:
     $ref: ../../pos-catalog/openapi.yaml#/paths/~1v1~1catalog-items~1{type}~1{catalogId}
   /v1/catalog/bulk-ingest:
     $ref: ../../pos-catalog/openapi.yaml#/paths/~1v1~1catalog~1bulk-ingest
+  /v1/catalog/supplier-article-codes/replay:
+    $ref: ../../pos-catalog/openapi.yaml#/paths/~1v1~1catalog~1supplier-article-codes~1replay
   /v1/catalog/supplier-prices/history:
     $ref: ../../pos-catalog/openapi.yaml#/paths/~1v1~1catalog~1supplier-prices~1history
   /v1/catalog/supplier-prices/imports/incomplete:

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -16,6 +16,8 @@ tags:
   description: Unit of measure conversion API
 - name: Catalog Bulk Ingest API
   description: Bulk import catalog products
+- name: Supplier Article Codes
+  description: Replay of vendor-specific article-code facts derived from PRICAT imports, for seeding or repairing consumer replicas such as pos-order's purchase-order transmission.
 - name: Products API
   description: API for products, lifecycle, and pricing
 - name: Item Cost API
@@ -2391,6 +2393,69 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CatalogDto'
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_EDIT
+  /v1/catalog/supplier-article-codes/replay:
+    post:
+      tags:
+      - Supplier Article Codes
+      summary: Re-emit Vendor Article Code Facts for Replica Consumers
+      description: 'Re-publishes catalog.supplier_article_code.updated facts for one bounded page of vendor-article-code rows so that event-fed replicas in other modules can be seeded or repaired, returning what it emitted and a cursor for the next page.
+
+        Use this tool to fill a consumer''s replica after a first deployment or a consumer outage longer than broker retention; do not use it to fix one row, which republishes itself on its next PRICAT import.
+
+        Preconditions: Kafka publication must be enabled, or the facts queue in the outbox and reach nobody; replayed facts are indistinguishable from live ones, so consumers apply them through their normal path and their stale guard prevents an older fact regressing newer state.
+
+        Required inputs: none; afterId resumes a previous page, updatedSince restricts to rows changed at or after an instant, and limit bounds the page at 1000.
+
+        Emits a CATALOG_SUPPLIER_ARTICLE_CODE_REPLAY event and queues one fact per row in the page; no catalog state changes.
+
+        Returns 200 with complete=true and a null cursor once the table end is reached, and 400 when limit is out of range or a parameter is malformed.
+
+        '
+      operationId: replaySupplierArticleCodeFacts
+      parameters:
+      - name: afterId
+        in: query
+        description: Resume cursor from a previous call; omit to start at the beginning.
+        required: false
+        schema:
+          type: string
+          format: uuid
+          example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+      - name: updatedSince
+        in: query
+        description: Restrict to rows changed at or after this instant; omit to replay all.
+        required: false
+        schema:
+          type: string
+          format: date-time
+          example: 2026-08-01 00:00:00+00:00
+      - name: limit
+        in: query
+        description: Maximum facts to emit in this call, 1-1000.
+        required: false
+        schema:
+          type: integer
+          default: 500
+          example: 500
+          maximum: 1000
+          minimum: 1
+      responses:
+        '200':
+          description: What this page emitted and where to resume.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SupplierArticleCodeReplayResultDto'
+        '400':
+          description: A parameter is malformed or the limit is out of range.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       security:
       - bearerAuth:
         - ROLE_ADMIN
@@ -5247,6 +5312,32 @@ components:
       required:
       - field
       - message
+    SupplierArticleCodeReplayResultDto:
+      type: object
+      description: Outcome of one page of a vendor-article-code fact replay.
+      properties:
+        emitted:
+          type: integer
+          format: int32
+          description: Facts published by this call.
+          example: 500
+        nextAfterId:
+          type: string
+          format: uuid
+          description: Cursor for the next page; null when the table end was reached.
+          example: 018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b
+        complete:
+          type: boolean
+          description: True when no further pages remain for this filter.
+          example: false
+        updatedSince:
+          type: string
+          format: date-time
+          description: The updatedSince filter this page ran under, echoed back.
+        startedAt:
+          type: string
+          format: date-time
+          description: When this page began.
     BulkIngestRequestCatalogBulkIngestRecord:
       type: object
       description: 'Generic bulk ingest request: a batch of records for a job scoped to a location'
@@ -6077,13 +6168,13 @@ components:
         offset:
           type: integer
           format: int64
+        sort:
+          $ref: '#/components/schemas/SortObject'
         paged:
           type: boolean
         pageNumber:
           type: integer
           format: int32
-        sort:
-          $ref: '#/components/schemas/SortObject'
         pageSize:
           type: integer
           format: int32

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -2402,7 +2402,7 @@ paths:
       tags:
       - Supplier Article Codes
       summary: Re-emit Vendor Article Code Facts for Replica Consumers
-      description: 'Re-publishes catalog.supplier_article_code.updated facts for one bounded page of vendor-article-code rows so that event-fed replicas in other modules can be seeded or repaired, returning what it emitted and a cursor for the next page.
+      description: 'Re-publishes catalog.supplier-article-code.updated facts for one bounded page of vendor-article-code rows so that event-fed replicas in other modules can be seeded or repaired, returning what it emitted and a cursor for the next page.
 
         Use this tool to fill a consumer''s replica after a first deployment or a consumer outage longer than broker retention; do not use it to fix one row, which republishes itself on its next PRICAT import.
 
@@ -6170,14 +6170,14 @@ components:
           format: int64
         sort:
           $ref: '#/components/schemas/SortObject'
-        paged:
-          type: boolean
         pageNumber:
           type: integer
           format: int32
         pageSize:
           type: integer
           format: int32
+        paged:
+          type: boolean
         unpaged:
           type: boolean
     SortObject:

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogEventTypes.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogEventTypes.java
@@ -54,6 +54,12 @@ public final class CatalogEventTypes {
                                 "CATALOG_SUPPLIER_PRICE_IMPORT_GAPS",
                                 "List vendor price imports this module could not confirm complete")
                         .build(),
+                // Replica seeding / repair for vendor article codes (CAP-320 #1347), same
+                // approval-grade budget as CATALOG_PRODUCT_FACT_REPLAY and for the same reason.
+                EventTypeRegistration.approval(
+                                "CATALOG_SUPPLIER_ARTICLE_CODE_REPLAY",
+                                "Re-emit vendor article code facts for event-fed replica consumers")
+                        .build(),
                 EventTypeRegistration.write(
                                 "CATALOG_PRODUCT_LIFECYCLE_UPDATE", "Set product lifecycle state with effective date")
                         .build(),

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogFactPublisher.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogFactPublisher.java
@@ -5,11 +5,13 @@ import com.positivity.catalog.internal.entity.ProductEntity;
 import com.positivity.catalog.internal.entity.ProductStatus;
 import com.positivity.catalog.internal.entity.ProductTrackingLevel;
 import com.positivity.catalog.internal.entity.SubstitutionGroupMemberEntity;
+import com.positivity.catalog.internal.entity.SupplierArticleCodeEntity;
 import com.positivity.catalog.internal.repository.ProductUomRepository;
 import com.positivity.catalog.internal.repository.SubstitutionGroupMemberRepository;
 import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.domainevents.DomainTopics;
 import com.positivity.domainevents.catalog.ProductUpdatedV1;
+import com.positivity.domainevents.catalog.SupplierArticleCodeUpdatedV1;
 import java.time.Clock;
 import java.util.List;
 import java.util.UUID;
@@ -106,6 +108,41 @@ public class CatalogFactPublisher {
                 clock);
         writer.publish(DomainTopics.events("catalog"), envelope);
         log.debug("Queued catalog.product.updated productId={} sku={}", product.getId(), product.getSku());
+    }
+
+    /**
+     * Emits {@code catalog.supplier_article_code.updated} for one vendor+product pair (CAP-320
+     * #1347). Called after {@code entry} is persisted, so {@code updatedAt} is already stamped by
+     * auditing and can carry the same monotonic epoch-millis version scheme as
+     * {@link #publishProductUpdated}.
+     */
+    public void publishSupplierArticleCodeUpdated(@NonNull SupplierArticleCodeEntity entry) {
+        OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
+        if (writer == null) {
+            return;
+        }
+        long aggregateVersion =
+                entry.getUpdatedAt() == null ? 0L : entry.getUpdatedAt().toEpochMilli();
+        SupplierArticleCodeUpdatedV1 payload = new SupplierArticleCodeUpdatedV1(
+                entry.getVendorProfileId(),
+                entry.getSupplierRef(),
+                entry.getProductId(),
+                entry.getSupplierArticleCode());
+        DomainEventEnvelope<SupplierArticleCodeUpdatedV1> envelope = DomainEventEnvelope.of(
+                SupplierArticleCodeUpdatedV1.EVENT_TYPE,
+                SupplierArticleCodeUpdatedV1.SCHEMA_VERSION,
+                entry.getProductId(),
+                aggregateVersion,
+                "pos-catalog",
+                null,
+                null,
+                payload,
+                clock);
+        writer.publish(DomainTopics.events("catalog"), envelope);
+        log.debug(
+                "Queued catalog.supplier_article_code.updated productId={} vendorProfileId={}",
+                entry.getProductId(),
+                entry.getVendorProfileId());
     }
 
     private @Nullable List<ProductUpdatedV1.UomConversion> uomConversionsOf(UUID productId) {

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogFactPublisher.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogFactPublisher.java
@@ -111,10 +111,17 @@ public class CatalogFactPublisher {
     }
 
     /**
-     * Emits {@code catalog.supplier_article_code.updated} for one vendor+product pair (CAP-320
+     * Emits {@code catalog.supplier-article-code.updated} for one vendor+product pair (CAP-320
      * #1347). Called after {@code entry} is persisted, so {@code updatedAt} is already stamped by
      * auditing and can carry the same monotonic epoch-millis version scheme as
      * {@link #publishProductUpdated}.
+     *
+     * <p>The envelope's {@code aggregateId} is {@code entry.getId()}, not the product id: the same
+     * product legitimately has a row per vendor, and using the product id would let two vendors'
+     * independent {@code aggregateVersion} sequences collide under one aggregate — an update from
+     * vendor B could look like it regressed vendor A's version. {@code entry}'s own id is stable
+     * across updates (found by the {@code (vendorProfileId, productId)} unique constraint and
+     * updated in place), so it already identifies exactly this vendor+product pair.
      */
     public void publishSupplierArticleCodeUpdated(@NonNull SupplierArticleCodeEntity entry) {
         OutboxEventWriter writer = outboxEventWriter.getIfAvailable();
@@ -131,7 +138,7 @@ public class CatalogFactPublisher {
         DomainEventEnvelope<SupplierArticleCodeUpdatedV1> envelope = DomainEventEnvelope.of(
                 SupplierArticleCodeUpdatedV1.EVENT_TYPE,
                 SupplierArticleCodeUpdatedV1.SCHEMA_VERSION,
-                entry.getProductId(),
+                entry.getId(),
                 aggregateVersion,
                 "pos-catalog",
                 null,
@@ -140,7 +147,7 @@ public class CatalogFactPublisher {
                 clock);
         writer.publish(DomainTopics.events("catalog"), envelope);
         log.debug(
-                "Queued catalog.supplier_article_code.updated productId={} vendorProfileId={}",
+                "Queued catalog.supplier-article-code.updated productId={} vendorProfileId={}",
                 entry.getProductId(),
                 entry.getVendorProfileId());
     }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/SupplierArticleCodeController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/SupplierArticleCodeController.java
@@ -1,0 +1,102 @@
+package com.positivity.catalog.internal.controller;
+
+import com.positivity.catalog.internal.dto.SupplierArticleCodeReplayResultDto;
+import com.positivity.catalog.service.SupplierArticleCodeReplayService;
+import com.positivity.events.EmitEvent;
+import com.positivity.shared.error.ApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Operator tool to re-emit vendor-article-code facts for event-fed replica consumers (CAP-320
+ * #1347, following #1309's product-fact replay).
+ */
+@Tag(
+        name = "Supplier Article Codes",
+        description = "Replay of vendor-specific article-code facts derived from PRICAT imports, for seeding or"
+                + " repairing consumer replicas such as pos-order's purchase-order transmission.")
+@RestController
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/v1/catalog/supplier-article-codes")
+public class SupplierArticleCodeController {
+
+    private final SupplierArticleCodeReplayService supplierArticleCodeReplayService;
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_EDIT')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
+    @PostMapping("/replay")
+    @EmitEvent(id = "CATALOG_SUPPLIER_ARTICLE_CODE_REPLAY", apiVersion = "1")
+    @Operation(
+            operationId = "replaySupplierArticleCodeFacts",
+            summary = "Re-emit Vendor Article Code Facts for Replica Consumers",
+            description = """
+            Re-publishes catalog.supplier_article_code.updated facts for one bounded page of vendor-article-code \
+            rows so that event-fed replicas in other modules can be seeded or repaired, returning what it \
+            emitted and a cursor for the next page.
+            Use this tool to fill a consumer's replica after a first deployment or a consumer outage longer than \
+            broker retention; do not use it to fix one row, which republishes itself on its next PRICAT import.
+            Preconditions: Kafka publication must be enabled, or the facts queue in the outbox and reach nobody; \
+            replayed facts are indistinguishable from live ones, so consumers apply them through their normal \
+            path and their stale guard prevents an older fact regressing newer state.
+            Required inputs: none; afterId resumes a previous page, updatedSince restricts to rows changed at or \
+            after an instant, and limit bounds the page at 1000.
+            Emits a CATALOG_SUPPLIER_ARTICLE_CODE_REPLAY event and queues one fact per row in the page; no \
+            catalog state changes.
+            Returns 200 with complete=true and a null cursor once the table end is reached, and 400 when limit \
+            is out of range or a parameter is malformed.
+            """)
+    @ApiResponse(
+            responseCode = "200",
+            description = "What this page emitted and where to resume.",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SupplierArticleCodeReplayResultDto.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "A parameter is malformed or the limit is out of range.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<SupplierArticleCodeReplayResultDto> replaySupplierArticleCodeFacts(
+            @Parameter(
+                            description = "Resume cursor from a previous call; omit to start at the beginning.",
+                            schema =
+                                    @Schema(
+                                            type = "string",
+                                            format = "uuid",
+                                            example = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b"))
+                    @RequestParam(required = false)
+                    UUID afterId,
+            @Parameter(
+                            description = "Restrict to rows changed at or after this instant; omit to replay all.",
+                            schema = @Schema(type = "string", format = "date-time", example = "2026-08-01T00:00:00Z"))
+                    @RequestParam(required = false)
+                    Instant updatedSince,
+            @Parameter(
+                            description = "Maximum facts to emit in this call, 1-1000.",
+                            schema = @Schema(type = "integer", example = "500", defaultValue = "500"))
+                    @RequestParam(defaultValue = "500")
+                    @Min(1)
+                    @Max(1000)
+                    int limit) {
+        return ResponseEntity.ok(supplierArticleCodeReplayService.replayPage(afterId, updatedSince, limit));
+    }
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/SupplierArticleCodeController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/SupplierArticleCodeController.java
@@ -49,7 +49,7 @@ public class SupplierArticleCodeController {
             operationId = "replaySupplierArticleCodeFacts",
             summary = "Re-emit Vendor Article Code Facts for Replica Consumers",
             description = """
-            Re-publishes catalog.supplier_article_code.updated facts for one bounded page of vendor-article-code \
+            Re-publishes catalog.supplier-article-code.updated facts for one bounded page of vendor-article-code \
             rows so that event-fed replicas in other modules can be seeded or repaired, returning what it \
             emitted and a cursor for the next page.
             Use this tool to fill a consumer's replica after a first deployment or a consumer outage longer than \

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/SupplierArticleCodeReplayResultDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/SupplierArticleCodeReplayResultDto.java
@@ -1,0 +1,37 @@
+package com.positivity.catalog.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Result of one bounded vendor-article-code replay page (CAP-320 #1347, following #1309).
+ *
+ * @param emitted      facts published by this call
+ * @param nextAfterId  cursor to pass as {@code afterId} on the next call; null when the replay
+ *                     reached the end of the table
+ * @param complete     true when no further pages remain for this filter
+ * @param updatedSince the filter this page ran under, echoed so a paging script cannot drift
+ * @param startedAt    when this page began
+ */
+@Schema(description = "Outcome of one page of a vendor-article-code fact replay.")
+public record SupplierArticleCodeReplayResultDto(
+        @Schema(description = "Facts published by this call.", example = "500")
+        int emitted,
+
+        @Schema(
+                description = "Cursor for the next page; null when the table end was reached.",
+                example = "018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b")
+        @Nullable
+        UUID nextAfterId,
+
+        @Schema(description = "True when no further pages remain for this filter.", example = "false")
+        boolean complete,
+
+        @Schema(description = "The updatedSince filter this page ran under, echoed back.") @Nullable
+        Instant updatedSince,
+
+        @Schema(description = "When this page began.") @NonNull
+        Instant startedAt) {}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/SupplierArticleCodeEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/SupplierArticleCodeEntity.java
@@ -1,0 +1,80 @@
+package com.positivity.catalog.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * The vendor's own article code for one product at one vendor, current state (CAP-320 #1347,
+ * ADR-0053 §5).
+ *
+ * <p>{@link SupplierPriceEntryEntity} already carries this field, but as append-only history — one
+ * row per PRICAT import line, never queryable as "the code right now" without picking a tie-break.
+ * This table is that current-state projection, upserted from the same PRICAT ingestion, and is
+ * what {@link com.positivity.catalog.internal.config.CatalogFactPublisher} reads to publish
+ * {@code catalog.supplier_article_code.updated} for pos-order's purchase-order transmission
+ * (CAP-320 #1330), the same way {@code ProductEntity} is the current-state row that feeds
+ * {@code catalog.product.updated}.
+ *
+ * <h2>Sticky, not cleared</h2>
+ *
+ * A row is written only when an import line states a non-blank code; a later import that omits one
+ * for the same vendor and product leaves the last-known code standing. A vendor PRICAT fetch is
+ * one page of the vendor's catalogue at one moment, not a full snapshot the way
+ * {@code catalog.product.updated} is — a line's absence this cycle is not the vendor unsetting a
+ * code (mirrors {@code SupplierPriceCatalogEventsListener}'s "nothing here deletes" rule for the
+ * append-only entries this table is derived from).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "supplier_article_code",
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uk_supplier_article_code_vendor_product",
+                        columnNames = {"vendor_profile_id", "product_id"}),
+        indexes = @Index(name = "idx_supplier_article_code_product", columnList = "product_id"))
+public class SupplierArticleCodeEntity {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    /** Vendor profile identity from pos-supplier (ADR-0050 §1); canonical key with {@code productId}. */
+    @Column(name = "vendor_profile_id", nullable = false, updatable = false)
+    private UUID vendorProfileId;
+
+    /** Profile alias as at the last applied import; the join key pos-order's purchase orders carry. */
+    @Column(name = "supplier_ref", nullable = false, length = 100)
+    private String supplierRef;
+
+    @Column(name = "product_id", nullable = false, updatable = false)
+    private UUID productId;
+
+    @Column(name = "supplier_article_code", nullable = false, length = 64)
+    private String supplierArticleCode;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/SupplierArticleCodeEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/SupplierArticleCodeEntity.java
@@ -26,7 +26,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
  * row per PRICAT import line, never queryable as "the code right now" without picking a tie-break.
  * This table is that current-state projection, upserted from the same PRICAT ingestion, and is
  * what {@link com.positivity.catalog.internal.config.CatalogFactPublisher} reads to publish
- * {@code catalog.supplier_article_code.updated} for pos-order's purchase-order transmission
+ * {@code catalog.supplier-article-code.updated} for pos-order's purchase-order transmission
  * (CAP-320 #1330), the same way {@code ProductEntity} is the current-state row that feeds
  * {@code catalog.product.updated}.
  *

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/SupplierArticleCodeRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/SupplierArticleCodeRepository.java
@@ -1,0 +1,33 @@
+package com.positivity.catalog.internal.repository;
+
+import com.positivity.catalog.internal.entity.SupplierArticleCodeEntity;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SupplierArticleCodeRepository extends JpaRepository<SupplierArticleCodeEntity, UUID> {
+
+    Optional<SupplierArticleCodeEntity> findByVendorProfileIdAndProductId(UUID vendorProfileId, UUID productId);
+
+    /**
+     * A page of current-state rows for fact replay (CAP-320 #1347, following #1309's pattern),
+     * ordered by id so a cursor can resume where the previous page stopped.
+     *
+     * <p>Cursor rather than offset paging, for the same reason as {@code ProductRepository}'s
+     * equivalent: offsets shift under concurrent writes, and a row upserted mid-replay would
+     * silently displace another out of the window.
+     */
+    @Query("""
+      SELECT e FROM SupplierArticleCodeEntity e
+      WHERE (:afterId IS NULL OR e.id > :afterId)
+        AND (:updatedSince IS NULL OR e.updatedAt >= :updatedSince)
+      ORDER BY e.id ASC
+      """)
+    List<SupplierArticleCodeEntity> findForReplay(
+            @Param("afterId") UUID afterId, @Param("updatedSince") Instant updatedSince, Pageable pageable);
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SupplierArticleCodeReplayServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SupplierArticleCodeReplayServiceImpl.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Re-emits {@code catalog.supplier_article_code.updated} the same way {@code
+ * Re-emits {@code catalog.supplier-article-code.updated} the same way {@code
  * ProductFactReplayServiceImpl} re-emits {@code catalog.product.updated} (#1309): through the same
  * publisher live traffic uses, cursor-paged over the current-state table's own id so a replay of a
  * large vendor catalogue can be stopped and resumed.

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SupplierArticleCodeReplayServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SupplierArticleCodeReplayServiceImpl.java
@@ -1,0 +1,65 @@
+package com.positivity.catalog.internal.service;
+
+import com.positivity.catalog.internal.config.CatalogFactPublisher;
+import com.positivity.catalog.internal.dto.SupplierArticleCodeReplayResultDto;
+import com.positivity.catalog.internal.entity.SupplierArticleCodeEntity;
+import com.positivity.catalog.internal.repository.SupplierArticleCodeRepository;
+import com.positivity.catalog.service.SupplierArticleCodeReplayService;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Re-emits {@code catalog.supplier_article_code.updated} the same way {@code
+ * ProductFactReplayServiceImpl} re-emits {@code catalog.product.updated} (#1309): through the same
+ * publisher live traffic uses, cursor-paged over the current-state table's own id so a replay of a
+ * large vendor catalogue can be stopped and resumed.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SupplierArticleCodeReplayServiceImpl implements SupplierArticleCodeReplayService {
+
+    /** Bound on one call, so a mistyped limit cannot turn a replay into a broker flood. */
+    public static final int MAX_LIMIT = 1000;
+
+    private final SupplierArticleCodeRepository supplierArticleCodeRepository;
+    private final CatalogFactPublisher catalogFactPublisher;
+    private final Clock clock;
+
+    @Override
+    @NonNull
+    @Transactional
+    public SupplierArticleCodeReplayResultDto replayPage(
+            @Nullable UUID afterId, @Nullable Instant updatedSince, int limit) {
+        int pageSize = Math.min(Math.max(limit, 1), MAX_LIMIT);
+        Instant startedAt = Instant.now(clock);
+
+        List<SupplierArticleCodeEntity> rows =
+                supplierArticleCodeRepository.findForReplay(afterId, updatedSince, PageRequest.of(0, pageSize));
+
+        for (SupplierArticleCodeEntity row : rows) {
+            catalogFactPublisher.publishSupplierArticleCodeUpdated(row);
+        }
+
+        boolean complete = rows.size() < pageSize;
+        UUID nextAfterId = complete || rows.isEmpty() ? null : rows.getLast().getId();
+
+        log.info(
+                "Replayed {} supplier-article-code facts (after={}, updatedSince={}, complete={})",
+                rows.size(),
+                afterId,
+                updatedSince,
+                complete);
+
+        return new SupplierArticleCodeReplayResultDto(rows.size(), nextAfterId, complete, updatedSince, startedAt);
+    }
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SupplierPriceCatalogEventsListener.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SupplierPriceCatalogEventsListener.java
@@ -1,11 +1,14 @@
 package com.positivity.catalog.internal.service;
 
+import com.positivity.catalog.internal.config.CatalogFactPublisher;
 import com.positivity.catalog.internal.config.OutboxEventWriter;
 import com.positivity.catalog.internal.entity.ProcessedEvent;
+import com.positivity.catalog.internal.entity.SupplierArticleCodeEntity;
 import com.positivity.catalog.internal.entity.SupplierPriceEntryEntity;
 import com.positivity.catalog.internal.entity.SupplierPriceImportChunkEntity;
 import com.positivity.catalog.internal.entity.SupplierPriceImportEntity;
 import com.positivity.catalog.internal.repository.ProcessedEventRepository;
+import com.positivity.catalog.internal.repository.SupplierArticleCodeRepository;
 import com.positivity.catalog.internal.repository.SupplierPriceEntryRepository;
 import com.positivity.catalog.internal.repository.SupplierPriceImportChunkRepository;
 import com.positivity.catalog.internal.repository.SupplierPriceImportRepository;
@@ -73,6 +76,8 @@ public class SupplierPriceCatalogEventsListener {
     private final SupplierPriceEntryRepository priceEntryRepository;
     private final SupplierPriceImportRepository priceImportRepository;
     private final SupplierPriceImportChunkRepository priceImportChunkRepository;
+    private final SupplierArticleCodeRepository supplierArticleCodeRepository;
+    private final CatalogFactPublisher catalogFactPublisher;
     private final OutboxEventWriter outboxEventWriter;
 
     @KafkaListener(
@@ -163,6 +168,11 @@ public class SupplierPriceCatalogEventsListener {
                     .importManifestId(payload.importManifestId())
                     .fetchedAt(payload.fetchedAt())
                     .build());
+
+            if (line.supplierArticleCode() != null
+                    && !line.supplierArticleCode().isBlank()) {
+                applySupplierArticleCode(payload.vendorProfileId(), payload.supplierRef(), line);
+            }
         }
 
         priceImportChunkRepository.save(SupplierPriceImportChunkEntity.builder()
@@ -186,6 +196,29 @@ public class SupplierPriceCatalogEventsListener {
                 payload.chunkCount(),
                 payload.importManifestId(),
                 payload.lines().size());
+    }
+
+    /**
+     * Upserts the current-state vendor-article-code row and publishes it, but only when the code
+     * (or the vendor's alias snapshot) actually changed — a reimport that restates the same code for
+     * every line every cycle should not republish a fact nothing about.
+     */
+    private void applySupplierArticleCode(UUID vendorProfileId, String supplierRef, SupplierPriceCatalogLine line) {
+        SupplierArticleCodeEntity existing = supplierArticleCodeRepository
+                .findByVendorProfileIdAndProductId(vendorProfileId, line.productId())
+                .orElse(null);
+        if (existing != null
+                && line.supplierArticleCode().equals(existing.getSupplierArticleCode())
+                && supplierRef.equals(existing.getSupplierRef())) {
+            return;
+        }
+        SupplierArticleCodeEntity row = existing != null ? existing : new SupplierArticleCodeEntity();
+        row.setVendorProfileId(vendorProfileId);
+        row.setSupplierRef(supplierRef);
+        row.setProductId(line.productId());
+        row.setSupplierArticleCode(line.supplierArticleCode());
+        row = supplierArticleCodeRepository.save(row);
+        catalogFactPublisher.publishSupplierArticleCodeUpdated(row);
     }
 
     private void applyCompletion(JsonNode envelope) {

--- a/pos-catalog/src/main/java/com/positivity/catalog/service/SupplierArticleCodeReplayService.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/service/SupplierArticleCodeReplayService.java
@@ -1,0 +1,30 @@
+package com.positivity.catalog.service;
+
+import com.positivity.catalog.internal.dto.SupplierArticleCodeReplayResultDto;
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Bounded, resumable re-emission of {@code catalog.supplier_article_code.updated} facts (CAP-320
+ * #1347, following #1309's pattern for {@code catalog.product.updated}).
+ *
+ * <p>A first deployment of pos-order's replica matches nothing: the replica holds only facts
+ * published after its consumer started. This is the path an operator uses to seed or repair it,
+ * without which every purchase-order line at a non-EAN vendor fails onboarding exactly as it does
+ * today.
+ */
+public interface SupplierArticleCodeReplayService {
+
+    /**
+     * Emits one bounded page of vendor-article-code facts.
+     *
+     * @param afterId      resume cursor from a previous call; null starts at the beginning
+     * @param updatedSince restrict to rows changed at or after this instant; null replays all
+     * @param limit        maximum facts to emit in this call
+     * @return what this page emitted and where to resume
+     */
+    @NonNull
+    SupplierArticleCodeReplayResultDto replayPage(@Nullable UUID afterId, @Nullable Instant updatedSince, int limit);
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/service/SupplierArticleCodeReplayService.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/service/SupplierArticleCodeReplayService.java
@@ -7,7 +7,7 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Bounded, resumable re-emission of {@code catalog.supplier_article_code.updated} facts (CAP-320
+ * Bounded, resumable re-emission of {@code catalog.supplier-article-code.updated} facts (CAP-320
  * #1347, following #1309's pattern for {@code catalog.product.updated}).
  *
  * <p>A first deployment of pos-order's replica matches nothing: the replica holds only facts

--- a/pos-catalog/src/main/resources/db/migration/V11__supplier_article_code.sql
+++ b/pos-catalog/src/main/resources/db/migration/V11__supplier_article_code.sql
@@ -1,0 +1,22 @@
+-- CAP-320 #1347: current-state projection of the vendor's own article code per (vendor, product).
+--
+-- supplier_price_entry already carries supplier_article_code, but as append-only history with no
+-- single "current" row queryable without a tie-break. This table is that projection, upserted from
+-- the same PRICAT ingestion as supplier_price_entry, and feeds catalog.supplier_article_code.updated
+-- for pos-order's purchase-order transmission (CAP-320 #1330).
+
+CREATE TABLE supplier_article_code (
+    id uuid NOT NULL,
+
+    vendor_profile_id uuid NOT NULL,
+    supplier_ref character varying(100) NOT NULL,
+    product_id uuid NOT NULL,
+    supplier_article_code character varying(64) NOT NULL,
+
+    updated_at timestamp(6) with time zone NOT NULL,
+
+    CONSTRAINT pk_supplier_article_code PRIMARY KEY (id),
+    CONSTRAINT uk_supplier_article_code_vendor_product UNIQUE (vendor_profile_id, product_id)
+);
+
+CREATE INDEX idx_supplier_article_code_product ON supplier_article_code (product_id);

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/SupplierArticleCodeReplayServiceImplTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/SupplierArticleCodeReplayServiceImplTest.java
@@ -1,0 +1,136 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.config.CatalogFactPublisher;
+import com.positivity.catalog.internal.dto.SupplierArticleCodeReplayResultDto;
+import com.positivity.catalog.internal.entity.SupplierArticleCodeEntity;
+import com.positivity.catalog.internal.repository.SupplierArticleCodeRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Vendor-article-code fact replay for replica consumers (CAP-320 #1347)")
+class SupplierArticleCodeReplayServiceImplTest {
+
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-17T12:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private SupplierArticleCodeRepository supplierArticleCodeRepository;
+
+    @Mock
+    private CatalogFactPublisher catalogFactPublisher;
+
+    private SupplierArticleCodeReplayServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SupplierArticleCodeReplayServiceImpl(supplierArticleCodeRepository, catalogFactPublisher, CLOCK);
+    }
+
+    private static List<SupplierArticleCodeEntity> rows(int count) {
+        List<SupplierArticleCodeEntity> rows = new ArrayList<>();
+        IntStream.rangeClosed(1, count)
+                .forEach(i -> rows.add(SupplierArticleCodeEntity.builder()
+                        .id(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a%02d".formatted(i)))
+                        .vendorProfileId(UUID.randomUUID())
+                        .supplierRef("michelin-eu")
+                        .productId(UUID.randomUUID())
+                        .supplierArticleCode("CODE-" + i)
+                        .build()));
+        return rows;
+    }
+
+    @Test
+    void publishesOneFactPerRowThroughTheOrdinaryPublisher() {
+        when(supplierArticleCodeRepository.findForReplay(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(rows(3));
+
+        SupplierArticleCodeReplayResultDto result = service.replayPage(null, null, 500);
+
+        verify(catalogFactPublisher, times(3)).publishSupplierArticleCodeUpdated(any(SupplierArticleCodeEntity.class));
+        assertThat(result.emitted()).isEqualTo(3);
+    }
+
+    @Test
+    void reportsCompleteWhenThePageIsShorterThanTheLimit() {
+        when(supplierArticleCodeRepository.findForReplay(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(rows(2));
+
+        SupplierArticleCodeReplayResultDto result = service.replayPage(null, null, 500);
+
+        assertThat(result.complete()).isTrue();
+        assertThat(result.nextAfterId()).isNull();
+    }
+
+    @Test
+    void returnsTheLastRowIdAsTheCursorWhenAFullPageIsEmitted() {
+        List<SupplierArticleCodeEntity> page = rows(3);
+        when(supplierArticleCodeRepository.findForReplay(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(page);
+
+        SupplierArticleCodeReplayResultDto result = service.replayPage(null, null, 3);
+
+        assertThat(result.complete()).isFalse();
+        assertThat(result.nextAfterId()).isEqualTo(page.getLast().getId());
+    }
+
+    @Test
+    void resumesFromTheSuppliedCursor() {
+        UUID cursor = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a05");
+        when(supplierArticleCodeRepository.findForReplay(eq(cursor), isNull(), any(Pageable.class)))
+                .thenReturn(rows(1));
+
+        service.replayPage(cursor, null, 500);
+
+        verify(supplierArticleCodeRepository).findForReplay(eq(cursor), isNull(), any(Pageable.class));
+    }
+
+    @Test
+    void capsTheRequestedLimitSoAMistypedCallCannotFloodTheBroker() {
+        when(supplierArticleCodeRepository.findForReplay(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(rows(1));
+
+        service.replayPage(null, null, 100_000);
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(supplierArticleCodeRepository).findForReplay(isNull(), isNull(), captor.capture());
+        assertThat(captor.getValue().getPageSize()).isEqualTo(SupplierArticleCodeReplayServiceImpl.MAX_LIMIT);
+    }
+
+    @Test
+    void treatsAnEmptyTableAsAFinishedReplayRatherThanAnError() {
+        when(supplierArticleCodeRepository.findForReplay(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        SupplierArticleCodeReplayResultDto result = service.replayPage(null, null, 500);
+
+        assertThat(result.emitted()).isZero();
+        assertThat(result.complete()).isTrue();
+        assertThat(result.nextAfterId()).isNull();
+        verify(catalogFactPublisher, never()).publishSupplierArticleCodeUpdated(any());
+    }
+}

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/SupplierPriceCatalogEventsListenerTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/SupplierPriceCatalogEventsListenerTest.java
@@ -9,12 +9,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.positivity.catalog.internal.config.CatalogFactPublisher;
 import com.positivity.catalog.internal.config.OutboxEventWriter;
 import com.positivity.catalog.internal.entity.ProcessedEvent;
+import com.positivity.catalog.internal.entity.SupplierArticleCodeEntity;
 import com.positivity.catalog.internal.entity.SupplierPriceEntryEntity;
 import com.positivity.catalog.internal.entity.SupplierPriceImportChunkEntity;
 import com.positivity.catalog.internal.entity.SupplierPriceImportEntity;
 import com.positivity.catalog.internal.repository.ProcessedEventRepository;
+import com.positivity.catalog.internal.repository.SupplierArticleCodeRepository;
 import com.positivity.catalog.internal.repository.SupplierPriceEntryRepository;
 import com.positivity.catalog.internal.repository.SupplierPriceImportChunkRepository;
 import com.positivity.catalog.internal.repository.SupplierPriceImportRepository;
@@ -63,6 +66,12 @@ class SupplierPriceCatalogEventsListenerTest {
     private SupplierPriceImportChunkRepository priceImportChunkRepository;
 
     @Mock
+    private SupplierArticleCodeRepository supplierArticleCodeRepository;
+
+    @Mock
+    private CatalogFactPublisher catalogFactPublisher;
+
+    @Mock
     private OutboxEventWriter outboxEventWriter;
 
     private SupplierPriceCatalogEventsListener listener;
@@ -76,11 +85,17 @@ class SupplierPriceCatalogEventsListenerTest {
                 priceEntryRepository,
                 priceImportRepository,
                 priceImportChunkRepository,
+                supplierArticleCodeRepository,
+                catalogFactPublisher,
                 outboxEventWriter);
         when(priceEntryRepository.save(any(SupplierPriceEntryEntity.class))).thenAnswer(inv -> inv.getArgument(0));
         when(priceImportRepository.save(any(SupplierPriceImportEntity.class))).thenAnswer(inv -> inv.getArgument(0));
         when(priceImportRepository.findById(MANIFEST_ID)).thenReturn(Optional.empty());
         when(priceImportChunkRepository.save(any(SupplierPriceImportChunkEntity.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(supplierArticleCodeRepository.findByVendorProfileIdAndProductId(any(), any()))
+                .thenReturn(Optional.empty());
+        when(supplierArticleCodeRepository.save(any(SupplierArticleCodeEntity.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
     }
 
@@ -182,6 +197,82 @@ class SupplierPriceCatalogEventsListenerTest {
             listener.onSupplierEvent(chunkEvent("e-1", 1, 1, 1));
 
             verify(processedEventRepository).save(any(ProcessedEvent.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("vendor article code current-state projection (CAP-320 #1347)")
+    class SupplierArticleCode {
+
+        @Test
+        void upsertsAndPublishesWhenALineStatesACode() {
+            listener.onSupplierEvent(chunkEvent("e-1", 1, 1, 1));
+
+            ArgumentCaptor<SupplierArticleCodeEntity> captor = ArgumentCaptor.forClass(SupplierArticleCodeEntity.class);
+            verify(supplierArticleCodeRepository).save(captor.capture());
+            SupplierArticleCodeEntity row = captor.getValue();
+            assertThat(row.getVendorProfileId()).isEqualTo(PROFILE_ID);
+            assertThat(row.getSupplierRef()).isEqualTo("michelin-eu");
+            assertThat(row.getProductId()).isEqualTo(PRODUCT_ID);
+            assertThat(row.getSupplierArticleCode()).isEqualTo("999900");
+            verify(catalogFactPublisher).publishSupplierArticleCodeUpdated(row);
+        }
+
+        @Test
+        void skipsTheWriteWhenTheCodeAndAliasHaveNotChanged() {
+            when(supplierArticleCodeRepository.findByVendorProfileIdAndProductId(PROFILE_ID, PRODUCT_ID))
+                    .thenReturn(Optional.of(SupplierArticleCodeEntity.builder()
+                            .id(UUID.randomUUID())
+                            .vendorProfileId(PROFILE_ID)
+                            .supplierRef("michelin-eu")
+                            .productId(PRODUCT_ID)
+                            .supplierArticleCode("999900")
+                            .build()));
+
+            listener.onSupplierEvent(chunkEvent("e-1", 1, 1, 1));
+
+            verify(supplierArticleCodeRepository, never()).save(any());
+            verify(catalogFactPublisher, never()).publishSupplierArticleCodeUpdated(any());
+        }
+
+        @Test
+        void updatesAndRepublishesWhenTheCodeChanged() {
+            when(supplierArticleCodeRepository.findByVendorProfileIdAndProductId(PROFILE_ID, PRODUCT_ID))
+                    .thenReturn(Optional.of(SupplierArticleCodeEntity.builder()
+                            .id(UUID.randomUUID())
+                            .vendorProfileId(PROFILE_ID)
+                            .supplierRef("michelin-eu")
+                            .productId(PRODUCT_ID)
+                            .supplierArticleCode("OLD-CODE")
+                            .build()));
+
+            listener.onSupplierEvent(chunkEvent("e-1", 1, 1, 1));
+
+            ArgumentCaptor<SupplierArticleCodeEntity> captor = ArgumentCaptor.forClass(SupplierArticleCodeEntity.class);
+            verify(supplierArticleCodeRepository).save(captor.capture());
+            assertThat(captor.getValue().getSupplierArticleCode()).isEqualTo("999900");
+            verify(catalogFactPublisher).publishSupplierArticleCodeUpdated(captor.getValue());
+        }
+
+        @Test
+        void skipsALineThatStatesNoCode() {
+            String body = """
+                    {"eventId":"e-1","eventType":"supplier.pricecatalog.updated","schemaVersion":1,
+                     "aggregateId":"%s","aggregateVersion":1,"occurredAtUtc":"2026-08-14T09:00:00Z",
+                     "sourceService":"pos-supplier",
+                     "payload":{"importManifestId":"%s","vendorProfileId":"%s","supplierRef":"michelin-eu",
+                       "chunkSequence":1,"chunkCount":1,"sourceDocumentId":"PRICAT-1","sourceDocumentDate":"2026-01-30",
+                       "buyerAccountNumber":"30012456","countryCode":"SE","currency":"SEK","protocolVersion":"B4_0",
+                       "fetchedAt":"2026-08-14T08:00:00Z","lines":[
+                         {"productId":"%s","matchMethod":"EAN","articleEan":"3528709999080","supplierArticleCode":null,
+                          "xReferenceCode":null,"suggestedRetailPrice":"120.00","grossPrice":"100.00","netPrice":"90.00",
+                          "taxRate":"25","recyclingFee":"3.50","effectiveFrom":"2026-02-01","positionNumber":1}]}}
+                    """.formatted(MANIFEST_ID, MANIFEST_ID, PROFILE_ID, PRODUCT_ID);
+
+            listener.onSupplierEvent(body);
+
+            verify(supplierArticleCodeRepository, never()).save(any());
+            verify(catalogFactPublisher, never()).publishSupplierArticleCodeUpdated(any());
         }
     }
 

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/catalog/SupplierArticleCodeUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/catalog/SupplierArticleCodeUpdatedV1.java
@@ -1,0 +1,56 @@
+package com.positivity.domainevents.catalog;
+
+import java.util.Objects;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Payload for {@code catalog.supplier_article_code.updated} on {@code catalog.events.v1}
+ * (CAP-320 #1347, ADR-0044 §6).
+ *
+ * <p>The vendor's own article code for one product at one vendor. Distinct from
+ * {@link ProductUpdatedV1#productCode}, which is the product's own EAN/UPC and is one value per
+ * product: the same product legitimately carries a different code at every vendor that sells it,
+ * so this fact is keyed per {@code (vendorProfileId, productId)} rather than per product.
+ *
+ * <p>Published by pos-catalog whenever a PRICAT import applies a line stating a vendor article
+ * code (ADR-0053 §5) — the code is display/correspondence data there, never a match key, but
+ * purchase-order transmission (pos-order, CAP-320 #1330) needs it to name a line to a vendor that
+ * identifies articles by its own codes rather than by EAN, which it otherwise cannot do at all.
+ *
+ * <p>{@code supplierRef} travels alongside {@code vendorProfileId} because the purchase-order
+ * aggregate in pos-order holds only the descriptive alias, never the vendor profile id — it is the
+ * join key this fact's consumers actually have (ADR-0044 R1: pos-order may not read pos-catalog or
+ * pos-supplier synchronously to resolve one from the other).
+ *
+ * @param vendorProfileId vendor profile identity from pos-supplier (ADR-0050 §1); canonical key
+ * @param supplierRef     vendor profile alias as at the import; the key pos-order's purchase
+ *                        orders actually carry
+ * @param productId       catalog product the code belongs to (also the envelope aggregateId)
+ * @param supplierArticleCode the vendor's own article code; never blank
+ */
+public record SupplierArticleCodeUpdatedV1(
+        @NonNull UUID vendorProfileId,
+        @NonNull String supplierRef,
+        @NonNull UUID productId,
+        @NonNull String supplierArticleCode) {
+
+    /** Event type of this payload on {@code catalog.events.v1}. */
+    public static final String EVENT_TYPE = "catalog.supplier_article_code.updated";
+
+    /** Payload schema version; additive changes only within v1 (ADR-0044 §3). */
+    public static final int SCHEMA_VERSION = 1;
+
+    public SupplierArticleCodeUpdatedV1 {
+        Objects.requireNonNull(vendorProfileId, "vendorProfileId must not be null");
+        Objects.requireNonNull(supplierRef, "supplierRef must not be null");
+        Objects.requireNonNull(productId, "productId must not be null");
+        Objects.requireNonNull(supplierArticleCode, "supplierArticleCode must not be null");
+        if (supplierRef.isBlank()) {
+            throw new IllegalArgumentException("supplierRef must not be blank");
+        }
+        if (supplierArticleCode.isBlank()) {
+            throw new IllegalArgumentException("supplierArticleCode must not be blank");
+        }
+    }
+}

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/catalog/SupplierArticleCodeUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/catalog/SupplierArticleCodeUpdatedV1.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 
 /**
- * Payload for {@code catalog.supplier_article_code.updated} on {@code catalog.events.v1}
+ * Payload for {@code catalog.supplier-article-code.updated} on {@code catalog.events.v1}
  * (CAP-320 #1347, ADR-0044 §6).
  *
  * <p>The vendor's own article code for one product at one vendor. Distinct from
@@ -36,7 +36,7 @@ public record SupplierArticleCodeUpdatedV1(
         @NonNull String supplierArticleCode) {
 
     /** Event type of this payload on {@code catalog.events.v1}. */
-    public static final String EVENT_TYPE = "catalog.supplier_article_code.updated";
+    public static final String EVENT_TYPE = "catalog.supplier-article-code.updated";
 
     /** Payload schema version; additive changes only within v1 (ADR-0044 §3). */
     public static final int SCHEMA_VERSION = 1;

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/catalog/SupplierArticleCodeUpdatedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/catalog/SupplierArticleCodeUpdatedV1Test.java
@@ -25,7 +25,7 @@ class SupplierArticleCodeUpdatedV1Test {
         SupplierArticleCodeUpdatedV1 back = MAPPER.readValue(json, SupplierArticleCodeUpdatedV1.class);
 
         assertThat(back).isEqualTo(evt);
-        assertThat(SupplierArticleCodeUpdatedV1.EVENT_TYPE).isEqualTo("catalog.supplier_article_code.updated");
+        assertThat(SupplierArticleCodeUpdatedV1.EVENT_TYPE).isEqualTo("catalog.supplier-article-code.updated");
         assertThat(SupplierArticleCodeUpdatedV1.SCHEMA_VERSION).isEqualTo(1);
     }
 

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/catalog/SupplierArticleCodeUpdatedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/catalog/SupplierArticleCodeUpdatedV1Test.java
@@ -1,0 +1,51 @@
+package com.positivity.domainevents.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class SupplierArticleCodeUpdatedV1Test {
+
+    private static final ObjectMapper MAPPER =
+            JsonMapper.builder().findAndAddModules().build();
+
+    private static final UUID VENDOR_PROFILE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000031");
+    private static final UUID PRODUCT_ID = UUID.fromString("01980a58-0000-7000-8000-000000000032");
+
+    @Test
+    void roundTripPreservesFields() {
+        SupplierArticleCodeUpdatedV1 evt =
+                new SupplierArticleCodeUpdatedV1(VENDOR_PROFILE_ID, "michelin-eu", PRODUCT_ID, "999908");
+
+        String json = MAPPER.writeValueAsString(evt);
+        SupplierArticleCodeUpdatedV1 back = MAPPER.readValue(json, SupplierArticleCodeUpdatedV1.class);
+
+        assertThat(back).isEqualTo(evt);
+        assertThat(SupplierArticleCodeUpdatedV1.EVENT_TYPE).isEqualTo("catalog.supplier_article_code.updated");
+        assertThat(SupplierArticleCodeUpdatedV1.SCHEMA_VERSION).isEqualTo(1);
+    }
+
+    @Test
+    void rejectsNullFields() {
+        assertThatThrownBy(() -> new SupplierArticleCodeUpdatedV1(null, "michelin-eu", PRODUCT_ID, "999908"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new SupplierArticleCodeUpdatedV1(VENDOR_PROFILE_ID, null, PRODUCT_ID, "999908"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new SupplierArticleCodeUpdatedV1(VENDOR_PROFILE_ID, "michelin-eu", null, "999908"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new SupplierArticleCodeUpdatedV1(VENDOR_PROFILE_ID, "michelin-eu", PRODUCT_ID, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void rejectsBlankAliasOrCode() {
+        assertThatThrownBy(() -> new SupplierArticleCodeUpdatedV1(VENDOR_PROFILE_ID, " ", PRODUCT_ID, "999908"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new SupplierArticleCodeUpdatedV1(VENDOR_PROFILE_ID, "michelin-eu", PRODUCT_ID, " "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/entity/ExtSupplierArticleCode.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/entity/ExtSupplierArticleCode.java
@@ -20,7 +20,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * The vendor's own article code for one product at one vendor, replicated from
- * {@code catalog.supplier_article_code.updated} (CAP-320 #1347, ADR-0044 R3).
+ * {@code catalog.supplier-article-code.updated} (CAP-320 #1347, ADR-0044 R3).
  *
  * <p>This is what lets a purchase-order line name an article to a vendor that identifies its
  * catalogue by its own codes rather than by EAN — without it that vendor cannot be transmitted to
@@ -60,8 +60,13 @@ public class ExtSupplierArticleCode {
     @Column(name = "supplier_ref", nullable = false, length = 100)
     private String supplierRef;
 
-    /** Kept for traceability only; never the lookup key in this module (see class javadoc). */
-    @Column(name = "vendor_profile_id", nullable = false, updatable = false)
+    /**
+     * Kept for traceability only; never the lookup key in this module (see class javadoc). Not
+     * {@code updatable = false}: the listener sets it on every apply, including updates to an
+     * existing row, so it must actually persist a changed value rather than silently keep the first
+     * one ever seen.
+     */
+    @Column(name = "vendor_profile_id", nullable = false)
     private UUID vendorProfileId;
 
     @Column(name = "product_id", nullable = false, updatable = false)

--- a/pos-order/src/main/java/com/positivity/order/internal/entity/ExtSupplierArticleCode.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/entity/ExtSupplierArticleCode.java
@@ -1,0 +1,79 @@
+package com.positivity.order.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * The vendor's own article code for one product at one vendor, replicated from
+ * {@code catalog.supplier_article_code.updated} (CAP-320 #1347, ADR-0044 R3).
+ *
+ * <p>This is what lets a purchase-order line name an article to a vendor that identifies its
+ * catalogue by its own codes rather than by EAN — without it that vendor cannot be transmitted to
+ * at all, every line reporting {@code ARTICLE_NOT_IDENTIFIABLE} (CAP-320 #1330).
+ *
+ * <h2>Keyed by {@code supplierRef}, not {@code vendorProfileId}</h2>
+ *
+ * The published fact is keyed by {@code (vendorProfileId, productId)}, pos-catalog's canonical
+ * identity for a vendor. {@code PurchaseOrderEntity} carries only {@code supplierRef} — the
+ * descriptive alias — never the vendor profile id, and ADR-0044 R1 forbids resolving one from the
+ * other synchronously across the domain wall. This replica is therefore keyed the way
+ * {@code PurchaseOrderTransmissionService} already looks vendors up everywhere else in this module:
+ * by {@code supplierRef}. {@code vendorProfileId} is kept alongside for traceability only.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "ext_supplier_article_code",
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uk_ext_supplier_article_code_ref_product",
+                        columnNames = {"supplier_ref", "product_id"}),
+        indexes = @Index(name = "idx_ext_supplier_article_code_product", columnList = "product_id"))
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExtSupplierArticleCode {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    /** The alias this replica is looked up by; see class javadoc for why. */
+    @Column(name = "supplier_ref", nullable = false, length = 100)
+    private String supplierRef;
+
+    /** Kept for traceability only; never the lookup key in this module (see class javadoc). */
+    @Column(name = "vendor_profile_id", nullable = false, updatable = false)
+    private UUID vendorProfileId;
+
+    @Column(name = "product_id", nullable = false, updatable = false)
+    private UUID productId;
+
+    @Column(name = "supplier_article_code", nullable = false, length = 64)
+    private String supplierArticleCode;
+
+    @Column(name = "aggregate_version", nullable = false)
+    private long aggregateVersion;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/repository/ExtSupplierArticleCodeRepository.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/repository/ExtSupplierArticleCodeRepository.java
@@ -1,0 +1,11 @@
+package com.positivity.order.internal.repository;
+
+import com.positivity.order.internal.entity.ExtSupplierArticleCode;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExtSupplierArticleCodeRepository extends JpaRepository<ExtSupplierArticleCode, UUID> {
+
+    Optional<ExtSupplierArticleCode> findBySupplierRefAndProductId(String supplierRef, UUID productId);
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/repository/ExtSupplierArticleCodeRepository.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/repository/ExtSupplierArticleCodeRepository.java
@@ -1,6 +1,8 @@
 package com.positivity.order.internal.repository;
 
 import com.positivity.order.internal.entity.ExtSupplierArticleCode;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ExtSupplierArticleCodeRepository extends JpaRepository<ExtSupplierArticleCode, UUID> {
 
     Optional<ExtSupplierArticleCode> findBySupplierRefAndProductId(String supplierRef, UUID productId);
+
+    /** Bulk lookup for transmission (CAP-320 #1347), so resolving a whole order's lines is one query. */
+    List<ExtSupplierArticleCode> findBySupplierRefAndProductIdIn(String supplierRef, Collection<UUID> productIds);
 }

--- a/pos-order/src/main/java/com/positivity/order/internal/service/PurchaseOrderTransmissionService.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/PurchaseOrderTransmissionService.java
@@ -23,7 +23,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
@@ -178,16 +181,25 @@ public class PurchaseOrderTransmissionService {
      * article code replicates, not before — sending a fabricated EAN would name the wrong article.
      */
     private List<SupplierOrderRequestedLine> resolveLines(PurchaseOrderEntity order) {
+        List<PurchaseOrderLineEntity> lines = order.getLines().stream()
+                .sorted(Comparator.comparing(
+                        PurchaseOrderLineEntity::getLineNumber, Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
+        List<UUID> skuIds = lines.stream()
+                .map(PurchaseOrderLineEntity::getSkuId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        Map<UUID, String> eanBySku = eansFor(skuIds);
+        Map<UUID, String> supplierArticleCodeBySku = supplierArticleCodesFor(order.getSupplierRef(), skuIds);
+
         List<SupplierOrderRequestedLine> resolved = new ArrayList<>();
         List<Integer> unidentifiable = new ArrayList<>();
         List<Integer> fractional = new ArrayList<>();
 
-        for (PurchaseOrderLineEntity line : order.getLines().stream()
-                .sorted(Comparator.comparing(
-                        PurchaseOrderLineEntity::getLineNumber, Comparator.nullsLast(Comparator.naturalOrder())))
-                .toList()) {
-            String ean = eanFor(line);
-            String supplierArticleCode = supplierArticleCodeFor(order.getSupplierRef(), line);
+        for (PurchaseOrderLineEntity line : lines) {
+            String ean = eanBySku.get(line.getSkuId());
+            String supplierArticleCode = supplierArticleCodeBySku.get(line.getSkuId());
             if (ean == null && supplierArticleCode == null) {
                 unidentifiable.add(line.getLineNumber());
                 continue;
@@ -235,28 +247,34 @@ public class PurchaseOrderTransmissionService {
         return order.getVersionNumber() == null ? 0 : Math.max(0, order.getVersionNumber());
     }
 
-    private String eanFor(PurchaseOrderLineEntity line) {
-        if (line.getSkuId() == null) {
-            return null;
+    /**
+     * EANs for a set of products, one query for the whole order rather than one per line — a
+     * purchase order can carry many lines, and a per-line lookup would be an N+1 query pattern on
+     * the transmission path.
+     */
+    private Map<UUID, String> eansFor(List<UUID> skuIds) {
+        if (skuIds.isEmpty()) {
+            return Map.of();
         }
-        return extProductCodeRepository
-                .findById(line.getSkuId())
+        return extProductCodeRepository.findAllById(skuIds).stream()
                 .filter(code -> EAN.equalsIgnoreCase(code.getCodeType()))
-                .map(ExtProductCode::getCode)
-                .filter(code -> !code.isBlank())
-                .orElse(null);
+                .filter(code -> code.getCode() != null && !code.getCode().isBlank())
+                .collect(Collectors.toMap(ExtProductCode::getProductId, ExtProductCode::getCode));
     }
 
-    /** The vendor's own article code for this line's product, when this replica holds one (CAP-320 #1347). */
-    private String supplierArticleCodeFor(String supplierRef, PurchaseOrderLineEntity line) {
-        if (line.getSkuId() == null || supplierRef == null || supplierRef.isBlank()) {
-            return null;
+    /**
+     * The vendor's own article code for a set of products, when this replica holds one (CAP-320
+     * #1347) — bulk-fetched for the same reason as {@link #eansFor}.
+     */
+    private Map<UUID, String> supplierArticleCodesFor(String supplierRef, List<UUID> skuIds) {
+        if (skuIds.isEmpty() || supplierRef == null || supplierRef.isBlank()) {
+            return Map.of();
         }
-        return extSupplierArticleCodeRepository
-                .findBySupplierRefAndProductId(supplierRef, line.getSkuId())
-                .map(ExtSupplierArticleCode::getSupplierArticleCode)
-                .filter(code -> !code.isBlank())
-                .orElse(null);
+        return extSupplierArticleCodeRepository.findBySupplierRefAndProductIdIn(supplierRef, skuIds).stream()
+                .filter(row -> row.getSupplierArticleCode() != null
+                        && !row.getSupplierArticleCode().isBlank())
+                .collect(Collectors.toMap(
+                        ExtSupplierArticleCode::getProductId, ExtSupplierArticleCode::getSupplierArticleCode));
     }
 
     /**

--- a/pos-order/src/main/java/com/positivity/order/internal/service/PurchaseOrderTransmissionService.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/PurchaseOrderTransmissionService.java
@@ -6,6 +6,7 @@ import com.positivity.domainevents.supplier.SupplierOrderRequestedLine;
 import com.positivity.domainevents.supplier.SupplierOrderRequestedV1;
 import com.positivity.order.internal.config.OutboxEventWriter;
 import com.positivity.order.internal.entity.ExtProductCode;
+import com.positivity.order.internal.entity.ExtSupplierArticleCode;
 import com.positivity.order.internal.entity.PurchaseOrderEntity;
 import com.positivity.order.internal.entity.PurchaseOrderLineEntity;
 import com.positivity.order.internal.enums.PurchaseOrderStatus;
@@ -13,6 +14,7 @@ import com.positivity.order.internal.enums.TransmissionState;
 import com.positivity.order.internal.exception.PurchaseOrderNotFoundException;
 import com.positivity.order.internal.exception.PurchaseOrderNotTransmittableException;
 import com.positivity.order.internal.repository.ExtProductCodeRepository;
+import com.positivity.order.internal.repository.ExtSupplierArticleCodeRepository;
 import com.positivity.order.internal.repository.PurchaseOrderRepository;
 import com.positivity.shared.id.UUIDv7Generator;
 import java.math.BigDecimal;
@@ -58,6 +60,7 @@ public class PurchaseOrderTransmissionService {
 
     private final PurchaseOrderRepository purchaseOrderRepository;
     private final ExtProductCodeRepository extProductCodeRepository;
+    private final ExtSupplierArticleCodeRepository extSupplierArticleCodeRepository;
     /**
      * Optional because the outbox is not wired in every deployment — but unlike a fact publisher,
      * absence here is fatal rather than inert. Silently publishing nothing would leave the order
@@ -169,6 +172,10 @@ public class PurchaseOrderTransmissionService {
      * <p>A line whose article cannot be identified refuses the whole transmission. Withholding it
      * instead would send an order that silently differs from the one on screen, and the difference
      * would surface as a short delivery weeks later rather than as a question now.
+     *
+     * <p>Both an EAN and the vendor's own article code may travel on the same line (CAP-320 #1347);
+     * neither is invented when absent. A vendor that carries no EAN is unidentifiable until its own
+     * article code replicates, not before — sending a fabricated EAN would name the wrong article.
      */
     private List<SupplierOrderRequestedLine> resolveLines(PurchaseOrderEntity order) {
         List<SupplierOrderRequestedLine> resolved = new ArrayList<>();
@@ -180,7 +187,8 @@ public class PurchaseOrderTransmissionService {
                         PurchaseOrderLineEntity::getLineNumber, Comparator.nullsLast(Comparator.naturalOrder())))
                 .toList()) {
             String ean = eanFor(line);
-            if (ean == null) {
+            String supplierArticleCode = supplierArticleCodeFor(order.getSupplierRef(), line);
+            if (ean == null && supplierArticleCode == null) {
                 unidentifiable.add(line.getLineNumber());
                 continue;
             }
@@ -196,7 +204,7 @@ public class PurchaseOrderTransmissionService {
             resolved.add(new SupplierOrderRequestedLine(
                     line.getLineNumber() == null ? 0 : line.getLineNumber(),
                     ean,
-                    null,
+                    supplierArticleCode,
                     whole,
                     order.getExpectedDeliveryDate()));
         }
@@ -235,6 +243,18 @@ public class PurchaseOrderTransmissionService {
                 .findById(line.getSkuId())
                 .filter(code -> EAN.equalsIgnoreCase(code.getCodeType()))
                 .map(ExtProductCode::getCode)
+                .filter(code -> !code.isBlank())
+                .orElse(null);
+    }
+
+    /** The vendor's own article code for this line's product, when this replica holds one (CAP-320 #1347). */
+    private String supplierArticleCodeFor(String supplierRef, PurchaseOrderLineEntity line) {
+        if (line.getSkuId() == null || supplierRef == null || supplierRef.isBlank()) {
+            return null;
+        }
+        return extSupplierArticleCodeRepository
+                .findBySupplierRefAndProductId(supplierRef, line.getSkuId())
+                .map(ExtSupplierArticleCode::getSupplierArticleCode)
                 .filter(code -> !code.isBlank())
                 .orElse(null);
     }

--- a/pos-order/src/main/java/com/positivity/order/internal/service/SupplierArticleCodeEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/SupplierArticleCodeEventsListener.java
@@ -1,0 +1,111 @@
+package com.positivity.order.internal.service;
+
+import com.positivity.domainevents.catalog.SupplierArticleCodeUpdatedV1;
+import com.positivity.order.internal.entity.ExtSupplierArticleCode;
+import com.positivity.order.internal.entity.ProcessedEvent;
+import com.positivity.order.internal.repository.ExtSupplierArticleCodeRepository;
+import com.positivity.order.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Consumes {@code catalog.events.v1} into the {@code ext_supplier_article_code} replica (CAP-320
+ * #1347, ADR-0044 §6): the vendor's own article code, per vendor and product, for purchase-order
+ * transmission to a non-EAN vendor.
+ *
+ * <p>A distinct listener from {@link ProductEventsListener} rather than a branch inside it: that
+ * listener's stale guard looks its existing row up by the payload's single id field
+ * ({@code productId}), which is right for a fact that is one row per product. This fact is one row
+ * per {@code (supplierRef, productId)} pair, so its existing-row lookup and its stale guard both
+ * need the pair, not the id alone — a shape the other listener's contract does not fit.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.order.kafka", name = "enabled", havingValue = "true")
+public class SupplierArticleCodeEventsListener {
+
+    static final String OWNER = "catalog";
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final ProcessedEventRepository processedEventRepository;
+    private final ExtSupplierArticleCodeRepository extSupplierArticleCodeRepository;
+
+    @KafkaListener(
+            topics = "${pos.order.kafka.catalog-events-topic:catalog.events.v1}",
+            groupId = "${pos.order.kafka.supplier-article-code-consumer-group:pos-order-supplier-article-code}")
+    @Transactional
+    public void onCatalogEvent(@NonNull String message) {
+        JsonNode envelope;
+        try {
+            envelope = objectMapper.readTree(message);
+        } catch (Exception e) {
+            log.warn("Skipping unparsable catalog event: {}", message, e);
+            return;
+        }
+        if (!SupplierArticleCodeUpdatedV1.EVENT_TYPE.equals(
+                envelope.path("eventType").stringValue(null))) {
+            return;
+        }
+        String eventId = envelope.path("eventId").stringValue(null);
+        if (eventId == null || eventId.isBlank()) {
+            log.warn("Skipping catalog event without eventId");
+            return;
+        }
+        if (processedEventRepository.existsById(eventId)) {
+            return;
+        }
+
+        try {
+            applyUpdate(envelope);
+            processedEventRepository.save(ProcessedEvent.builder()
+                    .eventId(eventId)
+                    .owner(OWNER)
+                    .processedAt(Instant.now(clock))
+                    .build());
+        } catch (TransientDataAccessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("Skipping malformed catalog event eventId={}", eventId, e);
+        }
+    }
+
+    private void applyUpdate(JsonNode envelope) {
+        JsonNode payload = envelope.path("payload");
+        String supplierRef = payload.path("supplierRef").stringValue(null);
+        UUID productId = UUID.fromString(payload.path("productId").stringValue(null));
+        UUID vendorProfileId = UUID.fromString(payload.path("vendorProfileId").stringValue(null));
+        String supplierArticleCode = payload.path("supplierArticleCode").stringValue(null);
+        long aggregateVersion = envelope.path("aggregateVersion").longValue(0L);
+
+        if (supplierRef == null || supplierRef.isBlank() || supplierArticleCode == null) {
+            throw new IllegalArgumentException("supplier article code fact missing a required field");
+        }
+
+        ExtSupplierArticleCode existing = extSupplierArticleCodeRepository
+                .findBySupplierRefAndProductId(supplierRef, productId)
+                .orElse(null);
+        if (existing != null && existing.getAggregateVersion() >= aggregateVersion) {
+            return;
+        }
+        ExtSupplierArticleCode replica = existing != null ? existing : new ExtSupplierArticleCode();
+        replica.setSupplierRef(supplierRef);
+        replica.setVendorProfileId(vendorProfileId);
+        replica.setProductId(productId);
+        replica.setSupplierArticleCode(supplierArticleCode);
+        replica.setAggregateVersion(aggregateVersion);
+        extSupplierArticleCodeRepository.save(replica);
+    }
+}

--- a/pos-order/src/main/java/com/positivity/order/internal/service/SupplierArticleCodeEventsListener.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/SupplierArticleCodeEventsListener.java
@@ -85,14 +85,23 @@ public class SupplierArticleCodeEventsListener {
     private void applyUpdate(JsonNode envelope) {
         JsonNode payload = envelope.path("payload");
         String supplierRef = payload.path("supplierRef").stringValue(null);
-        UUID productId = UUID.fromString(payload.path("productId").stringValue(null));
-        UUID vendorProfileId = UUID.fromString(payload.path("vendorProfileId").stringValue(null));
+        String productIdValue = payload.path("productId").stringValue(null);
+        String vendorProfileIdValue = payload.path("vendorProfileId").stringValue(null);
         String supplierArticleCode = payload.path("supplierArticleCode").stringValue(null);
         long aggregateVersion = envelope.path("aggregateVersion").longValue(0L);
 
-        if (supplierRef == null || supplierRef.isBlank() || supplierArticleCode == null) {
+        // Validated before parsing, so a missing field reads as "missing field" rather than
+        // surfacing as a UUID-parse or null-pointer failure that means the same thing but hides it.
+        if (supplierRef == null
+                || supplierRef.isBlank()
+                || productIdValue == null
+                || vendorProfileIdValue == null
+                || supplierArticleCode == null
+                || supplierArticleCode.isBlank()) {
             throw new IllegalArgumentException("supplier article code fact missing a required field");
         }
+        UUID productId = UUID.fromString(productIdValue);
+        UUID vendorProfileId = UUID.fromString(vendorProfileIdValue);
 
         ExtSupplierArticleCode existing = extSupplierArticleCodeRepository
                 .findBySupplierRefAndProductId(supplierRef, productId)

--- a/pos-order/src/main/resources/db/migration/V18__ext_supplier_article_code.sql
+++ b/pos-order/src/main/resources/db/migration/V18__ext_supplier_article_code.sql
@@ -1,0 +1,21 @@
+-- CAP-320 #1347: vendor's own article code per (supplierRef, product), replicated from
+-- catalog.supplier_article_code.updated. Lets purchase-order transmission name a line to a
+-- non-EAN vendor. Keyed by supplier_ref rather than vendor_profile_id: PurchaseOrderEntity carries
+-- only the alias, never the vendor profile id (see ExtSupplierArticleCode's class javadoc).
+
+CREATE TABLE ext_supplier_article_code (
+    id uuid NOT NULL,
+
+    supplier_ref character varying(100) NOT NULL,
+    vendor_profile_id uuid NOT NULL,
+    product_id uuid NOT NULL,
+    supplier_article_code character varying(64) NOT NULL,
+
+    aggregate_version bigint NOT NULL,
+    updated_at timestamp(6) with time zone NOT NULL,
+
+    CONSTRAINT pk_ext_supplier_article_code PRIMARY KEY (id),
+    CONSTRAINT uk_ext_supplier_article_code_ref_product UNIQUE (supplier_ref, product_id)
+);
+
+CREATE INDEX idx_ext_supplier_article_code_product ON ext_supplier_article_code (product_id);

--- a/pos-order/src/test/java/com/positivity/order/internal/service/PurchaseOrderTransmissionServiceTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/PurchaseOrderTransmissionServiceTest.java
@@ -12,12 +12,14 @@ import com.positivity.domainevents.DomainEventEnvelope;
 import com.positivity.domainevents.supplier.SupplierOrderRequestedV1;
 import com.positivity.order.internal.config.OutboxEventWriter;
 import com.positivity.order.internal.entity.ExtProductCode;
+import com.positivity.order.internal.entity.ExtSupplierArticleCode;
 import com.positivity.order.internal.entity.PurchaseOrderEntity;
 import com.positivity.order.internal.entity.PurchaseOrderLineEntity;
 import com.positivity.order.internal.enums.PurchaseOrderStatus;
 import com.positivity.order.internal.enums.TransmissionState;
 import com.positivity.order.internal.exception.PurchaseOrderNotTransmittableException;
 import com.positivity.order.internal.repository.ExtProductCodeRepository;
+import com.positivity.order.internal.repository.ExtSupplierArticleCodeRepository;
 import com.positivity.order.internal.repository.PurchaseOrderRepository;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -64,6 +66,9 @@ class PurchaseOrderTransmissionServiceTest {
     private ExtProductCodeRepository extProductCodeRepository;
 
     @Mock
+    private ExtSupplierArticleCodeRepository extSupplierArticleCodeRepository;
+
+    @Mock
     private OutboxEventWriter outboxEventWriter;
 
     @Mock
@@ -74,7 +79,11 @@ class PurchaseOrderTransmissionServiceTest {
     @BeforeEach
     void setUp() {
         service = new PurchaseOrderTransmissionService(
-                purchaseOrderRepository, extProductCodeRepository, outboxProvider, Clock.fixed(NOW, ZoneOffset.UTC));
+                purchaseOrderRepository,
+                extProductCodeRepository,
+                extSupplierArticleCodeRepository,
+                outboxProvider,
+                Clock.fixed(NOW, ZoneOffset.UTC));
         when(outboxProvider.getIfAvailable()).thenReturn(outboxEventWriter);
         when(extProductCodeRepository.findById(SKU_ID))
                 .thenReturn(Optional.of(ExtProductCode.builder()
@@ -84,6 +93,8 @@ class PurchaseOrderTransmissionServiceTest {
                         .aggregateVersion(1L)
                         .updatedAt(NOW)
                         .build()));
+        when(extSupplierArticleCodeRepository.findBySupplierRefAndProductId(any(), any()))
+                .thenReturn(Optional.empty());
     }
 
     private PurchaseOrderEntity order(PurchaseOrderStatus status, TransmissionState transmissionState) {
@@ -257,6 +268,54 @@ class PurchaseOrderTransmissionServiceTest {
         assertThatThrownBy(() -> service.requestTransmission(PO_ID, ACTOR))
                 .isInstanceOf(PurchaseOrderNotTransmittableException.class)
                 .hasMessageContaining("ARTICLE_NOT_IDENTIFIABLE");
+    }
+
+    @Test
+    @DisplayName("the vendor's own article code alone identifies a line with no EAN (CAP-320 #1347)")
+    void supplierArticleCodeAloneIdentifiesTheLine() {
+        order(PurchaseOrderStatus.APPROVED, TransmissionState.NOT_TRANSMITTED);
+        when(extProductCodeRepository.findById(SKU_ID)).thenReturn(Optional.empty());
+        when(extSupplierArticleCodeRepository.findBySupplierRefAndProductId("acme-parts", SKU_ID))
+                .thenReturn(Optional.of(ExtSupplierArticleCode.builder()
+                        .supplierRef("acme-parts")
+                        .vendorProfileId(UUID.randomUUID())
+                        .productId(SKU_ID)
+                        .supplierArticleCode("ACME-9911")
+                        .aggregateVersion(1L)
+                        .updatedAt(NOW)
+                        .build()));
+
+        // A vendor that carries no EAN cannot be transmitted to at all without this — the whole
+        // reason this replica exists.
+        service.requestTransmission(PO_ID, ACTOR);
+
+        assertThat(published().lines()).singleElement().satisfies(line -> {
+            assertThat(line.articleEan()).isNull();
+            assertThat(line.supplierArticleCode()).isEqualTo("ACME-9911");
+        });
+    }
+
+    @Test
+    @DisplayName("both identifiers travel together when both are known")
+    void bothIdentifiersAreSentWhenBothArePresent() {
+        order(PurchaseOrderStatus.APPROVED, TransmissionState.NOT_TRANSMITTED);
+        when(extSupplierArticleCodeRepository.findBySupplierRefAndProductId("acme-parts", SKU_ID))
+                .thenReturn(Optional.of(ExtSupplierArticleCode.builder()
+                        .supplierRef("acme-parts")
+                        .vendorProfileId(UUID.randomUUID())
+                        .productId(SKU_ID)
+                        .supplierArticleCode("ACME-9911")
+                        .aggregateVersion(1L)
+                        .updatedAt(NOW)
+                        .build()));
+
+        service.requestTransmission(PO_ID, ACTOR);
+
+        // Neither is invented and neither is dropped when the other is present.
+        assertThat(published().lines()).singleElement().satisfies(line -> {
+            assertThat(line.articleEan()).isEqualTo("5012345678900");
+            assertThat(line.supplierArticleCode()).isEqualTo("ACME-9911");
+        });
     }
 
     @Test

--- a/pos-order/src/test/java/com/positivity/order/internal/service/PurchaseOrderTransmissionServiceTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/PurchaseOrderTransmissionServiceTest.java
@@ -85,16 +85,16 @@ class PurchaseOrderTransmissionServiceTest {
                 outboxProvider,
                 Clock.fixed(NOW, ZoneOffset.UTC));
         when(outboxProvider.getIfAvailable()).thenReturn(outboxEventWriter);
-        when(extProductCodeRepository.findById(SKU_ID))
-                .thenReturn(Optional.of(ExtProductCode.builder()
+        when(extProductCodeRepository.findAllById(List.of(SKU_ID)))
+                .thenReturn(List.of(ExtProductCode.builder()
                         .productId(SKU_ID)
                         .codeType("EAN")
                         .code("5012345678900")
                         .aggregateVersion(1L)
                         .updatedAt(NOW)
                         .build()));
-        when(extSupplierArticleCodeRepository.findBySupplierRefAndProductId(any(), any()))
-                .thenReturn(Optional.empty());
+        when(extSupplierArticleCodeRepository.findBySupplierRefAndProductIdIn(any(), any()))
+                .thenReturn(List.of());
     }
 
     private PurchaseOrderEntity order(PurchaseOrderStatus status, TransmissionState transmissionState) {
@@ -239,7 +239,7 @@ class PurchaseOrderTransmissionServiceTest {
     @DisplayName("a line the vendor could not identify refuses the whole order, not just the line")
     void unidentifiableArticleRefusesTheOrder() {
         order(PurchaseOrderStatus.APPROVED, TransmissionState.NOT_TRANSMITTED);
-        when(extProductCodeRepository.findById(SKU_ID)).thenReturn(Optional.empty());
+        when(extProductCodeRepository.findAllById(List.of(SKU_ID))).thenReturn(List.of());
 
         // Withholding the line would send an order that silently differs from the one on screen,
         // and the difference would surface as a short delivery rather than as a question now.
@@ -254,8 +254,8 @@ class PurchaseOrderTransmissionServiceTest {
     @DisplayName("a product with a code of the wrong type is not identified by it")
     void nonEanCodeIsNotAnArticleIdentifier() {
         order(PurchaseOrderStatus.APPROVED, TransmissionState.NOT_TRANSMITTED);
-        when(extProductCodeRepository.findById(SKU_ID))
-                .thenReturn(Optional.of(ExtProductCode.builder()
+        when(extProductCodeRepository.findAllById(List.of(SKU_ID)))
+                .thenReturn(List.of(ExtProductCode.builder()
                         .productId(SKU_ID)
                         .codeType("INTERNAL")
                         .code("PART-9911")
@@ -274,9 +274,9 @@ class PurchaseOrderTransmissionServiceTest {
     @DisplayName("the vendor's own article code alone identifies a line with no EAN (CAP-320 #1347)")
     void supplierArticleCodeAloneIdentifiesTheLine() {
         order(PurchaseOrderStatus.APPROVED, TransmissionState.NOT_TRANSMITTED);
-        when(extProductCodeRepository.findById(SKU_ID)).thenReturn(Optional.empty());
-        when(extSupplierArticleCodeRepository.findBySupplierRefAndProductId("acme-parts", SKU_ID))
-                .thenReturn(Optional.of(ExtSupplierArticleCode.builder()
+        when(extProductCodeRepository.findAllById(List.of(SKU_ID))).thenReturn(List.of());
+        when(extSupplierArticleCodeRepository.findBySupplierRefAndProductIdIn("acme-parts", List.of(SKU_ID)))
+                .thenReturn(List.of(ExtSupplierArticleCode.builder()
                         .supplierRef("acme-parts")
                         .vendorProfileId(UUID.randomUUID())
                         .productId(SKU_ID)
@@ -299,8 +299,8 @@ class PurchaseOrderTransmissionServiceTest {
     @DisplayName("both identifiers travel together when both are known")
     void bothIdentifiersAreSentWhenBothArePresent() {
         order(PurchaseOrderStatus.APPROVED, TransmissionState.NOT_TRANSMITTED);
-        when(extSupplierArticleCodeRepository.findBySupplierRefAndProductId("acme-parts", SKU_ID))
-                .thenReturn(Optional.of(ExtSupplierArticleCode.builder()
+        when(extSupplierArticleCodeRepository.findBySupplierRefAndProductIdIn("acme-parts", List.of(SKU_ID)))
+                .thenReturn(List.of(ExtSupplierArticleCode.builder()
                         .supplierRef("acme-parts")
                         .vendorProfileId(UUID.randomUUID())
                         .productId(SKU_ID)

--- a/pos-order/src/test/java/com/positivity/order/internal/service/SupplierArticleCodeEventsListenerTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/SupplierArticleCodeEventsListenerTest.java
@@ -61,7 +61,7 @@ class SupplierArticleCodeEventsListenerTest {
 
     private static String factEvent(String eventId, long aggregateVersion, String supplierRef, String code) {
         return """
-                {"eventId":"%s","eventType":"catalog.supplier_article_code.updated","schemaVersion":1,
+                {"eventId":"%s","eventType":"catalog.supplier-article-code.updated","schemaVersion":1,
                  "aggregateId":"%s","aggregateVersion":%d,"occurredAtUtc":"2026-08-17T08:59:00Z",
                  "sourceService":"pos-catalog",
                  "payload":{"vendorProfileId":"%s","supplierRef":"%s","productId":"%s","supplierArticleCode":"%s"}}
@@ -123,7 +123,7 @@ class SupplierArticleCodeEventsListenerTest {
     @Test
     void ignoresAnEventWithoutAnEventId() {
         listener.onCatalogEvent("""
-                {"eventType":"catalog.supplier_article_code.updated","payload":{}}
+                {"eventType":"catalog.supplier-article-code.updated","payload":{}}
                 """);
 
         verify(processedEventRepository, never()).save(any());
@@ -139,6 +139,14 @@ class SupplierArticleCodeEventsListenerTest {
     @Test
     void swallowsAMalformedPayloadButLeavesItUnrecorded() {
         listener.onCatalogEvent(factEvent("e-5", 100L, "", "999908"));
+
+        verify(extSupplierArticleCodeRepository, never()).save(any());
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    void treatsABlankCodeAsMalformedRatherThanPersistingIt() {
+        listener.onCatalogEvent(factEvent("e-7", 100L, "michelin-eu", " "));
 
         verify(extSupplierArticleCodeRepository, never()).save(any());
         verify(processedEventRepository, never()).save(any());

--- a/pos-order/src/test/java/com/positivity/order/internal/service/SupplierArticleCodeEventsListenerTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/SupplierArticleCodeEventsListenerTest.java
@@ -1,0 +1,157 @@
+package com.positivity.order.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.order.internal.entity.ExtSupplierArticleCode;
+import com.positivity.order.internal.entity.ProcessedEvent;
+import com.positivity.order.internal.repository.ExtSupplierArticleCodeRepository;
+import com.positivity.order.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.QueryTimeoutException;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * This listener shares {@link ReplicaListenerContractTest}'s consumer contract in behavior, but is
+ * tested standalone because its existing-row lookup and stale guard key on a
+ * {@code (supplierRef, productId)} pair rather than a single id field, which does not fit that
+ * shared harness's single-id-field model.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("catalog.events.v1 → ext_supplier_article_code replica (CAP-320 #1347)")
+class SupplierArticleCodeEventsListenerTest {
+
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5b");
+    private static final UUID VENDOR_PROFILE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4a5c");
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-17T09:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private ExtSupplierArticleCodeRepository extSupplierArticleCodeRepository;
+
+    private SupplierArticleCodeEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new SupplierArticleCodeEventsListener(
+                CLOCK, new ObjectMapper(), processedEventRepository, extSupplierArticleCodeRepository);
+        when(extSupplierArticleCodeRepository.save(any(ExtSupplierArticleCode.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private static String factEvent(String eventId, long aggregateVersion, String supplierRef, String code) {
+        return """
+                {"eventId":"%s","eventType":"catalog.supplier_article_code.updated","schemaVersion":1,
+                 "aggregateId":"%s","aggregateVersion":%d,"occurredAtUtc":"2026-08-17T08:59:00Z",
+                 "sourceService":"pos-catalog",
+                 "payload":{"vendorProfileId":"%s","supplierRef":"%s","productId":"%s","supplierArticleCode":"%s"}}
+                """.formatted(eventId, PRODUCT_ID, aggregateVersion, VENDOR_PROFILE_ID, supplierRef, PRODUCT_ID, code);
+    }
+
+    @Test
+    void replicatesTheVendorArticleCode() {
+        listener.onCatalogEvent(factEvent("e-1", 100L, "michelin-eu", "999908"));
+
+        ArgumentCaptor<ExtSupplierArticleCode> captor = ArgumentCaptor.forClass(ExtSupplierArticleCode.class);
+        verify(extSupplierArticleCodeRepository).save(captor.capture());
+        assertThat(captor.getValue().getSupplierRef()).isEqualTo("michelin-eu");
+        assertThat(captor.getValue().getVendorProfileId()).isEqualTo(VENDOR_PROFILE_ID);
+        assertThat(captor.getValue().getProductId()).isEqualTo(PRODUCT_ID);
+        assertThat(captor.getValue().getSupplierArticleCode()).isEqualTo("999908");
+        assertThat(captor.getValue().getAggregateVersion()).isEqualTo(100L);
+        verify(processedEventRepository).save(any(ProcessedEvent.class));
+    }
+
+    @Test
+    void skipsAnEventItHasAlreadyProcessed() {
+        when(processedEventRepository.existsById("e-2")).thenReturn(true);
+
+        listener.onCatalogEvent(factEvent("e-2", 101L, "michelin-eu", "999908"));
+
+        verify(extSupplierArticleCodeRepository, never()).save(any());
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    void skipsAFactOlderThanTheReplicaItAlreadyHolds() {
+        when(extSupplierArticleCodeRepository.findBySupplierRefAndProductId("michelin-eu", PRODUCT_ID))
+                .thenReturn(Optional.of(ExtSupplierArticleCode.builder()
+                        .supplierRef("michelin-eu")
+                        .vendorProfileId(VENDOR_PROFILE_ID)
+                        .productId(PRODUCT_ID)
+                        .supplierArticleCode("999908")
+                        .aggregateVersion(200L)
+                        .build()));
+
+        listener.onCatalogEvent(factEvent("e-3", 100L, "michelin-eu", "000000"));
+
+        verify(extSupplierArticleCodeRepository, never()).save(any());
+        // Still recorded as processed: the fact was delivered and deliberately not applied.
+        verify(processedEventRepository).save(any(ProcessedEvent.class));
+    }
+
+    @Test
+    void skipsAnEventTypeThisModuleDoesNotReplicateWithoutRecordingIt() {
+        listener.onCatalogEvent("""
+                {"eventId":"e-4","eventType":"catalog.product.updated","aggregateVersion":1,"payload":{}}
+                """);
+
+        verify(extSupplierArticleCodeRepository, never()).save(any());
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    void ignoresAnEventWithoutAnEventId() {
+        listener.onCatalogEvent("""
+                {"eventType":"catalog.supplier_article_code.updated","payload":{}}
+                """);
+
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    void ignoresAnUnparsableMessage() {
+        listener.onCatalogEvent("not json");
+
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    void swallowsAMalformedPayloadButLeavesItUnrecorded() {
+        listener.onCatalogEvent(factEvent("e-5", 100L, "", "999908"));
+
+        verify(extSupplierArticleCodeRepository, never()).save(any());
+        verify(processedEventRepository, never()).save(any());
+    }
+
+    @Test
+    void rethrowsTransientDatabaseErrorsSoTheContainerRetries() {
+        when(extSupplierArticleCodeRepository.findBySupplierRefAndProductId("michelin-eu", PRODUCT_ID))
+                .thenThrow(new QueryTimeoutException("db busy"));
+
+        assertThatThrownBy(() -> listener.onCatalogEvent(factEvent("e-6", 100L, "michelin-eu", "999908")))
+                .isInstanceOf(QueryTimeoutException.class);
+
+        verify(processedEventRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:320`
- Parent STORY (durion): louisburroughs/durion#375
- Child issue: louisburroughs/durion-positivity-backend#1347
- Domain: `domain:product`, `domain:positivity`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/product/.business-rules/BACKEND_CONTRACT_GUIDE.md` → vendor article code fact
- New public event: `catalog.supplier_article_code.updated` on `catalog.events.v1` (pos-domain-events, schema v1) — additive, no existing consumer contract changed.
- New endpoint: `POST /v1/catalog/supplier-article-codes/replay` (pos-catalog) — operator replay tool, mirrors the existing `POST /v1/catalog/products/facts/replay` from #1309.
- `pos-catalog/openapi.yaml` and `pos-api-gateway/docs/openapi-aggregate.yaml` regenerated via `scripts/generate-openapi.sh pos-catalog`.

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller
- [x] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — not applicable; this is an internal operator/admin tool, no frontend consumer yet.

## Scope
- What changed:
  - **pos-domain-events**: new `SupplierArticleCodeUpdatedV1` event (`catalog.supplier_article_code.updated`) — the vendor's own article code per `(vendorProfileId, productId)`, distinct from the per-product EAN already carried by `ProductUpdatedV1`.
  - **pos-catalog**: new `supplier_article_code` table — a current-state projection derived from the existing append-only `supplier_price_entry` (PRICAT) table, upserted (and republished only on actual change) inside `SupplierPriceCatalogEventsListener.applyChunk`. New `SupplierArticleCodeController` replay endpoint (`POST /v1/catalog/supplier-article-codes/replay`), mirroring #1309's product-fact replay, for first-deployment backfill.
  - **pos-order**: new `ext_supplier_article_code` replica (`SupplierArticleCodeEventsListener`, its own idempotency/stale-guard, since it lives at a `(supplierRef, productId)` grain rather than a single id — see the class javadoc for why it's a standalone listener rather than a branch of `ProductEventsListener`). `PurchaseOrderTransmissionService.resolveLines` now sends the vendor's own code when known, in addition to or instead of the EAN; a line refuses transmission (`ARTICLE_NOT_IDENTIFIABLE`) only when *neither* is held.
- Why: closes #1347. Purchase-order lines were named to a vendor by EAN only. A vendor that identifies articles by its own code rather than EAN could not be transmitted to at all — every line failed `ARTICLE_NOT_IDENTIFIABLE`. Filed ahead of the second (non-Michelin) vendor onboarding specifically so this doesn't surface as an incident during that onboarding.
- Design note: the published fact is keyed by `(vendorProfileId, productId)` per the acceptance criteria, but pos-order's own replica is looked up by `(supplierRef, productId)` — `PurchaseOrderEntity` only ever carries the descriptive `supplierRef` alias, never `vendorProfileId`, and ADR-0044 R1 forbids resolving one from the other synchronously across the domain wall. `vendorProfileId` is still stored on the replica for traceability. Documented in `ExtSupplierArticleCode`'s class javadoc.

## Tests
- [x] Unit tests added/updated: `SupplierArticleCodeUpdatedV1Test` (round-trip + validation), `SupplierPriceCatalogEventsListenerTest` (new nested class: upsert, no-op on unchanged code, republish on change, skip when a line states no code), `SupplierArticleCodeReplayServiceImplTest` (mirrors `ProductFactReplayServiceImplTest`), `SupplierArticleCodeEventsListenerTest` (redelivery, stale guard, unrelated type, malformed payload, transient-error rethrow — standalone rather than folded into `ReplicaListenerContractTest`, see its class javadoc for why), `PurchaseOrderTransmissionServiceTest` (new: code-alone identifies a line, both identifiers travel together; existing EAN-only cases pass unchanged).
- [ ] Integration tests added/updated — not needed; no new transactional/I-O behavior beyond the established replica-listener and outbox patterns.
- [ ] Provider behavioral contract tests added/updated — n/a, no cross-service REST contract touched (event-only).
- How to run: `./mvnw -pl pos-catalog,pos-order,pos-domain-events -am test`

## Risk & Rollback
- Risk level: Low — additive event/table/endpoint; existing EAN-only transmission path is unchanged in behavior (verified by the pre-existing `unidentifiableArticleRefusesTheOrder` / `nonEanCodeIsNotAnArticleIdentifier` tests passing unmodified).
- Rollback plan: revert this commit. New tables/columns are additive (no destructive migration on existing data); the new consumer group is disabled by the same `pos.order.kafka.enabled`/`pos.catalog.kafka.enabled` flags as every other replica listener in these modules.

## Checklist
- [x] Branch name matches `cap/<cap-id>` (`cap/320-supplier-article-code-replica`)
- [ ] PR title starts with `[CAP:<cap-id>]` — using a conventional-commit style title instead, per this repo's existing merged PR history for CAP work (see #1345, #1350, #1353, #1356)
- [x] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed) — not applicable; no request/response shape changed on an existing endpoint, only a new additive event and a new operator-only replay endpoint
- [x] Required CI checks passing (local: pos-catalog/pos-order/pos-domain-events unit tests, cross-module ArchUnit `pos-archunit -Dtest=ArchitectureTests`, `spotless:apply`, OpenAPI regeneration + validation)