### PR TITLE
feat(catalog): consume MKCAT tread-design enrichment, matched to products by vendor-scoped fuzzy match (#1352)

### DIFF
--- a/pos-api-gateway/docs/openapi-aggregate.yaml
+++ b/pos-api-gateway/docs/openapi-aggregate.yaml
@@ -267,6 +267,10 @@ paths:
     $ref: ../../pos-catalog/openapi.yaml#/paths/~1v1~1catalog~1supplier-prices~1imports~1incomplete
   /v1/catalog/supplier-prices/latest:
     $ref: ../../pos-catalog/openapi.yaml#/paths/~1v1~1catalog~1supplier-prices~1latest
+  /v1/catalog/tread-designs/for-product/{productId}:
+    $ref: ../../pos-catalog/openapi.yaml#/paths/~1v1~1catalog~1tread-designs~1for-product~1{productId}
+  /v1/catalog/tread-designs/unmatched:
+    $ref: ../../pos-catalog/openapi.yaml#/paths/~1v1~1catalog~1tread-designs~1unmatched
   /v1/catalogs:
     $ref: ../../pos-catalog/openapi.yaml#/paths/~1v1~1catalogs
   /v1/catalogs/name/{name}:

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -14,26 +14,28 @@ tags:
   description: Groups of mutually interchangeable products; a product belongs to at most one group
 - name: UOM Conversion API
   description: Unit of measure conversion API
+- name: Item Cost API
+  description: Manage standard, last, and average item costs
+- name: Supplier Prices
+  description: 'Vendor price entries applied from supplier PRICAT imports: latest applicable cost, full cost history, and import application state. Read-only.'
+- name: Product UoM API
+  description: Per-product unit-of-measure conversion set (purchase/pack UoMs with factor to base UoM)
 - name: Catalog Bulk Ingest API
   description: Bulk import catalog products
 - name: Supplier Article Codes
   description: Replay of vendor-specific article-code facts derived from PRICAT imports, for seeding or repairing consumer replicas such as pos-order's purchase-order transmission.
 - name: Products API
   description: API for products, lifecycle, and pricing
-- name: Item Cost API
-  description: Manage standard, last, and average item costs
-- name: Supplier Prices
-  description: 'Vendor price entries applied from supplier PRICAT imports: latest applicable cost, full cost history, and import application state. Read-only.'
 - name: Product MSRP API
   description: Manage MSRP values with effective dates
 - name: Catalog API
   description: API for managing catalogs
 - name: Price Book API
   description: Manage price books, pricing rules, and resolution
-- name: Product UoM API
-  description: Per-product unit-of-measure conversion set (purchase/pack UoMs with factor to base UoM)
 - name: Catalog Items API
   description: API for managing catalog items by type
+- name: Tread Design Enrichment
+  description: Vendor-supplied MKCAT marketing content — names, copy per language, artwork — attached to catalog products by matching, not by identifier. Read-only.
 paths:
   /v1/products/{productId}:
     get:
@@ -3373,6 +3375,115 @@ paths:
       - bearerAuth:
         - ROLE_ADMIN
         - ROLE_CATALOG_VIEW
+  /v1/catalog/tread-designs/unmatched:
+    get:
+      tags:
+      - Tread Design Enrichment
+      summary: List Vendor Tread Designs Matched to No Product
+      description: 'Returns tread designs that fuzzy matching, scoped to each design''s own vendor''s priced products,
+
+        could not resolve to any catalog product, newest applied first.
+
+        Use this tool to review enrichment a person needs to connect manually; do not use it to look up one
+
+        product''s enrichment, which is getTreadDesignForProduct. A design matching nothing is an ordinary
+
+        outcome here, not a failure of ingestion.
+
+        Preconditions: none; an empty result means every applied design has matched at least one product.
+
+        Required inputs: none; page and size are optional, with size defaulting to 50 and capped at 200.
+
+        Emits a CATALOG_TREAD_DESIGN_UNMATCHED_LIST event; no state changes.
+
+        Returns 200 with an empty items array when nothing is unmatched.
+
+        '
+      operationId: listUnmatchedTreadDesigns
+      parameters:
+      - name: page
+        in: query
+        description: Zero-based page index.
+        required: false
+        schema:
+          type: integer
+          example: 0
+          minimum: 0
+      - name: size
+        in: query
+        description: Page size, 1-200.
+        required: false
+        schema:
+          type: integer
+          default: 50
+          example: 50
+          maximum: 200
+          minimum: 1
+      responses:
+        '200':
+          description: A page of unmatched tread designs, newest applied first.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Page'
+        '400':
+          description: The page size is out of range.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_VIEW
+  /v1/catalog/tread-designs/for-product/{productId}:
+    get:
+      tags:
+      - Tread Design Enrichment
+      summary: Get Vendor Tread-Design Enrichment for a Product
+      description: 'Returns the manufacturer marketing content matched to a product — names, copy per language, artwork —
+
+        distinguishable from catalog-owned product data because it lives here rather than on the product itself.
+
+        Use this tool to show manufacturer marketing copy alongside a product; do not use it as a source for
+
+        any structural or identity field, since a supplier fact never changes what a product is.
+
+        Preconditions: the product must exist and must have matched a tread design; fuzzy matching on vendor
+
+        brand and design names means many products, especially newly priced ones, match nothing yet.
+
+        Required inputs: productId path parameter; there is no request body.
+
+        Emits a CATALOG_TREAD_DESIGN_FOR_PRODUCT event; no state changes.
+
+        Returns 404 when the product does not exist or matches no tread design — an ordinary outcome, not
+
+        an error condition.
+
+        '
+      operationId: getTreadDesignForProduct
+      parameters:
+      - name: productId
+        in: path
+        description: Product to look up enrichment for.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: The matched design's enrichment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TreadDesignDto'
+        '404':
+          description: The product does not exist, or matches no tread design. The response has NO body.
+      security:
+      - bearerAuth:
+        - ROLE_ADMIN
+        - ROLE_CATALOG_VIEW
   /v1/catalog/supplier-prices/latest:
     get:
       tags:
@@ -5986,6 +6097,147 @@ components:
           type: string
           description: Manufacturer part number of the matched product, null when unknown.
           example: HDW-001
+    Page:
+      type: object
+      properties:
+        totalPages:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        size:
+          type: integer
+          format: int32
+        content:
+          type: array
+        number:
+          type: integer
+          format: int32
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        pageable:
+          $ref: '#/components/schemas/PageableObject'
+        numberOfElements:
+          type: integer
+          format: int32
+        first:
+          type: boolean
+        last:
+          type: boolean
+        empty:
+          type: boolean
+    PageableObject:
+      type: object
+      properties:
+        offset:
+          type: integer
+          format: int64
+        paged:
+          type: boolean
+        pageNumber:
+          type: integer
+          format: int32
+        pageSize:
+          type: integer
+          format: int32
+        sort:
+          $ref: '#/components/schemas/SortObject'
+        unpaged:
+          type: boolean
+    SortObject:
+      type: object
+      properties:
+        empty:
+          type: boolean
+        sorted:
+          type: boolean
+        unsorted:
+          type: boolean
+    TreadDesignDto:
+      type: object
+      description: Vendor-supplied tread-design marketing enrichment, distinct from catalog-owned product data.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: This design's id.
+        vendorProfileId:
+          type: string
+          format: uuid
+          description: Vendor profile the enrichment was fetched from.
+        supplierRef:
+          type: string
+          description: That profile's alias, descriptive only.
+        vendorVariantId:
+          type: string
+          description: The vendor's own tread design variant identifier.
+        brand:
+          type: string
+          description: Brand as stated by the vendor.
+        treadDesign:
+          type: string
+          description: Primary tread design name as stated.
+        treadDesign2:
+          type: string
+          description: Secondary tread design name, where the vendor uses one.
+        productName:
+          type: string
+          description: Vendor's product name, where given.
+        vehicleType:
+          type: string
+          description: Vehicle class as stated.
+        seasonality:
+          type: string
+          description: Seasonality as the vendor states it, not mapped to a Durion vocabulary.
+        hasUnresolvedImages:
+          type: boolean
+          description: Whether any artwork on this design is still missing and awaiting retry.
+        texts:
+          type: array
+          description: Marketing copy per language.
+          items:
+            $ref: '#/components/schemas/TreadDesignTextDto'
+        images:
+          type: array
+          description: Artwork references.
+          items:
+            $ref: '#/components/schemas/TreadDesignImageDto'
+        updatedAt:
+          type: string
+          format: date-time
+          description: When this enrichment was last applied.
+    TreadDesignImageDto:
+      type: object
+      description: Vendor-supplied artwork reference.
+      properties:
+        imageType:
+          type: string
+          description: Vendor's own classification of the image.
+        imageId:
+          type: integer
+          format: int64
+          description: pos-image identifier for the stored bytes; absent when unresolved.
+        unresolved:
+          type: boolean
+          description: Whether the artwork is still missing and awaiting a future republication.
+    TreadDesignTextDto:
+      type: object
+      description: Vendor-supplied marketing copy in one language.
+      properties:
+        languageCode:
+          type: string
+          description: Vendor's own language code, as stated.
+          example: en-US
+        name:
+          type: string
+          description: Product name in that language.
+        description:
+          type: string
+          description: Marketing description in that language.
+        footNotes:
+          type: string
+          description: Legal or qualifying text, when given.
     SupplierPriceEntryDto:
       type: object
       description: A vendor price for a product in one market, effective from a date.
@@ -6132,63 +6384,6 @@ components:
           type: string
           format: date-time
           description: When this row last changed.
-    Page:
-      type: object
-      properties:
-        totalPages:
-          type: integer
-          format: int32
-        totalElements:
-          type: integer
-          format: int64
-        size:
-          type: integer
-          format: int32
-        content:
-          type: array
-        number:
-          type: integer
-          format: int32
-        sort:
-          $ref: '#/components/schemas/SortObject'
-        pageable:
-          $ref: '#/components/schemas/PageableObject'
-        numberOfElements:
-          type: integer
-          format: int32
-        first:
-          type: boolean
-        last:
-          type: boolean
-        empty:
-          type: boolean
-    PageableObject:
-      type: object
-      properties:
-        offset:
-          type: integer
-          format: int64
-        sort:
-          $ref: '#/components/schemas/SortObject'
-        pageNumber:
-          type: integer
-          format: int32
-        pageSize:
-          type: integer
-          format: int32
-        paged:
-          type: boolean
-        unpaged:
-          type: boolean
-    SortObject:
-      type: object
-      properties:
-        empty:
-          type: boolean
-        sorted:
-          type: boolean
-        unsorted:
-          type: boolean
   securitySchemes:
     bearerAuth:
       type: http

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogEventTypes.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/config/CatalogEventTypes.java
@@ -60,6 +60,13 @@ public final class CatalogEventTypes {
                                 "CATALOG_SUPPLIER_ARTICLE_CODE_REPLAY",
                                 "Re-emit vendor article code facts for event-fed replica consumers")
                         .build(),
+                // MKCAT tread-design enrichment reads (CAP-324 #1352)
+                EventTypeRegistration.fastRead(
+                                "CATALOG_TREAD_DESIGN_FOR_PRODUCT", "Get vendor tread-design enrichment for a product")
+                        .build(),
+                EventTypeRegistration.search(
+                                "CATALOG_TREAD_DESIGN_UNMATCHED_LIST", "List tread designs matched to no product")
+                        .build(),
                 EventTypeRegistration.write(
                                 "CATALOG_PRODUCT_LIFECYCLE_UPDATE", "Set product lifecycle state with effective date")
                         .build(),

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/TreadDesignController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/TreadDesignController.java
@@ -1,0 +1,127 @@
+package com.positivity.catalog.internal.controller;
+
+import com.positivity.catalog.internal.dto.TreadDesignDto;
+import com.positivity.catalog.service.TreadDesignService;
+import com.positivity.events.EmitEvent;
+import com.positivity.shared.error.ApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Read API over MKCAT tread-design marketing enrichment (CAP-324 #1352).
+ *
+ * <p>Everything here is vendor-supplied, applied from {@code supplier.catalog.updated} events —
+ * never catalog-owned product identity or structure. No write endpoint exists because an
+ * enrichment exists only because a vendor said so.
+ */
+@Tag(
+        name = "Tread Design Enrichment",
+        description = "Vendor-supplied MKCAT marketing content — names, copy per language, artwork — attached to"
+                + " catalog products by matching, not by identifier. Read-only.")
+@RestController
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/v1/catalog/tread-designs")
+public class TreadDesignController {
+
+    private final TreadDesignService treadDesignService;
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_VIEW')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
+    @GetMapping("/for-product/{productId}")
+    @EmitEvent(id = "CATALOG_TREAD_DESIGN_FOR_PRODUCT", apiVersion = "1")
+    @Operation(
+            operationId = "getTreadDesignForProduct",
+            summary = "Get Vendor Tread-Design Enrichment for a Product",
+            description = """
+            Returns the manufacturer marketing content matched to a product — names, copy per language, artwork —
+            distinguishable from catalog-owned product data because it lives here rather than on the product itself.
+            Use this tool to show manufacturer marketing copy alongside a product; do not use it as a source for
+            any structural or identity field, since a supplier fact never changes what a product is.
+            Preconditions: the product must exist and must have matched a tread design; fuzzy matching on vendor
+            brand and design names means many products, especially newly priced ones, match nothing yet.
+            Required inputs: productId path parameter; there is no request body.
+            Emits a CATALOG_TREAD_DESIGN_FOR_PRODUCT event; no state changes.
+            Returns 404 when the product does not exist or matches no tread design — an ordinary outcome, not
+            an error condition.
+            """)
+    @ApiResponse(
+            responseCode = "200",
+            description = "The matched design's enrichment.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = TreadDesignDto.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "The product does not exist, or matches no tread design. The response has NO body.",
+            content = @Content(schema = @Schema(hidden = true)))
+    public ResponseEntity<TreadDesignDto> getTreadDesignForProduct(
+            @Parameter(description = "Product to look up enrichment for.", required = true) @PathVariable
+                    UUID productId) {
+        return treadDesignService
+                .findForProduct(productId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_VIEW')")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
+    @GetMapping("/unmatched")
+    @EmitEvent(id = "CATALOG_TREAD_DESIGN_UNMATCHED_LIST", apiVersion = "1")
+    @Operation(
+            operationId = "listUnmatchedTreadDesigns",
+            summary = "List Vendor Tread Designs Matched to No Product",
+            description = """
+            Returns tread designs that fuzzy matching, scoped to each design's own vendor's priced products,
+            could not resolve to any catalog product, newest applied first.
+            Use this tool to review enrichment a person needs to connect manually; do not use it to look up one
+            product's enrichment, which is getTreadDesignForProduct. A design matching nothing is an ordinary
+            outcome here, not a failure of ingestion.
+            Preconditions: none; an empty result means every applied design has matched at least one product.
+            Required inputs: none; page and size are optional, with size defaulting to 50 and capped at 200.
+            Emits a CATALOG_TREAD_DESIGN_UNMATCHED_LIST event; no state changes.
+            Returns 200 with an empty items array when nothing is unmatched.
+            """)
+    @ApiResponse(
+            responseCode = "200",
+            description = "A page of unmatched tread designs, newest applied first.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Page.class)))
+    @ApiResponse(
+            responseCode = "400",
+            description = "The page size is out of range.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<Page<TreadDesignDto>> listUnmatchedTreadDesigns(
+            @Parameter(description = "Zero-based page index.", schema = @Schema(type = "integer", example = "0"))
+                    @RequestParam(defaultValue = "0")
+                    @Min(0)
+                    int page,
+            @Parameter(
+                            description = "Page size, 1-200.",
+                            schema = @Schema(type = "integer", example = "50", defaultValue = "50"))
+                    @RequestParam(defaultValue = "50")
+                    @Min(1)
+                    @Max(200)
+                    int size) {
+        return ResponseEntity.ok(treadDesignService.findUnmatched(PageRequest.of(page, size)));
+    }
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/TreadDesignDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/TreadDesignDto.java
@@ -1,0 +1,59 @@
+package com.positivity.catalog.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Manufacturer marketing enrichment for a tread design (CAP-324 #1352).
+ *
+ * <p>Every field here is vendor-supplied, published as MKCAT stated it — distinguishable from
+ * catalog-owned product data by virtue of living on this DTO at all rather than on the product's own
+ * fields. A shop can tell what the manufacturer said from what the business entered because the two
+ * are never merged into one record.
+ */
+@Schema(description = "Vendor-supplied tread-design marketing enrichment, distinct from catalog-owned product data.")
+public record TreadDesignDto(
+        @Schema(description = "This design's id.") @NonNull UUID id,
+
+        @Schema(description = "Vendor profile the enrichment was fetched from.") @NonNull
+        UUID vendorProfileId,
+
+        @Schema(description = "That profile's alias, descriptive only.") @NonNull
+        String supplierRef,
+
+        @Schema(description = "The vendor's own tread design variant identifier.") @NonNull
+        String vendorVariantId,
+
+        @Schema(description = "Brand as stated by the vendor.") @Nullable
+        String brand,
+
+        @Schema(description = "Primary tread design name as stated.") @Nullable
+        String treadDesign,
+
+        @Schema(description = "Secondary tread design name, where the vendor uses one.") @Nullable
+        String treadDesign2,
+
+        @Schema(description = "Vendor's product name, where given.") @Nullable
+        String productName,
+
+        @Schema(description = "Vehicle class as stated.") @Nullable
+        String vehicleType,
+
+        @Schema(description = "Seasonality as the vendor states it, not mapped to a Durion vocabulary.") @Nullable
+        String seasonality,
+
+        @Schema(description = "Whether any artwork on this design is still missing and awaiting retry.")
+        boolean hasUnresolvedImages,
+
+        @Schema(description = "Marketing copy per language.") @NonNull
+        List<TreadDesignTextDto> texts,
+
+        @Schema(description = "Artwork references.") @NonNull
+        List<TreadDesignImageDto> images,
+
+        @Schema(description = "When this enrichment was last applied.") @NonNull
+        Instant updatedAt) {}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/TreadDesignImageDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/TreadDesignImageDto.java
@@ -1,0 +1,20 @@
+package com.positivity.catalog.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One piece of artwork on a tread design (CAP-324 #1352). {@code unresolved} true means the bytes
+ * are still missing and will arrive on a later republication — never that the artwork does not
+ * exist.
+ */
+@Schema(description = "Vendor-supplied artwork reference.")
+public record TreadDesignImageDto(
+        @Schema(description = "Vendor's own classification of the image.") @Nullable
+        String imageType,
+
+        @Schema(description = "pos-image identifier for the stored bytes; absent when unresolved.") @Nullable
+        Long imageId,
+
+        @Schema(description = "Whether the artwork is still missing and awaiting a future republication.")
+        boolean unresolved) {}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/TreadDesignTextDto.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/TreadDesignTextDto.java
@@ -1,0 +1,20 @@
+package com.positivity.catalog.internal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/** Marketing copy in one language, as the vendor stated it (CAP-324 #1352). */
+@Schema(description = "Vendor-supplied marketing copy in one language.")
+public record TreadDesignTextDto(
+        @Schema(description = "Vendor's own language code, as stated.", example = "en-US") @NonNull
+        String languageCode,
+
+        @Schema(description = "Product name in that language.") @Nullable
+        String name,
+
+        @Schema(description = "Marketing description in that language.") @Nullable
+        String description,
+
+        @Schema(description = "Legal or qualifying text, when given.") @Nullable
+        String footNotes) {}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductEntity.java
@@ -105,6 +105,16 @@ public class ProductEntity implements CatalogItem {
     @Schema(description = "Brand of the manufacturer", example = "AcmePro")
     private String manufacturerBrand;
 
+    /**
+     * The tread design this product matches, when one has been resolved (CAP-324 #1352). Vendor
+     * marketing enrichment, distinguishable at read time from catalog-owned content; a supplier fact
+     * that could redefine identity or structure is never permitted here — this is an association
+     * only, the same shape as {@link #manufacturerId}/{@link #category}.
+     */
+    @Column(name = "tread_design_id", columnDefinition = "UUID")
+    @Schema(description = "Matched tread design enrichment id (vendor-supplied), when resolved")
+    private UUID treadDesignId;
+
     @Override
     public String getLongDescription() {
         return this.longDescription;

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/TreadDesignEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/TreadDesignEntity.java
@@ -1,0 +1,104 @@
+package com.positivity.catalog.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * A manufacturer tread design, as MKCAT last published it (CAP-324 #1352, ADR-0044 R1).
+ *
+ * <h2>A design, not a product</h2>
+ *
+ * One tread design spans many sizes, each a distinct catalog product with its own EAN — MKCAT
+ * carries none of them. This row is the design MKCAT described; {@code product.tread_design_id}
+ * (nullable) is how zero or more catalog products get associated with it, never the reverse. Nothing
+ * here may alter a product's identity or structure: no dimensions, no load index, no article code,
+ * no price. A supplier fact that could redefine a product would hand a vendor edit rights over the
+ * catalogue.
+ *
+ * <h2>Keyed for redelivery, not for ordering</h2>
+ *
+ * {@code (vendorProfileId, vendorVariantId)} is the identity a redelivery must resolve to the same
+ * row. {@code SupplierCatalogUpdatedV1} carries no per-variant version — pos-supplier always
+ * publishes {@code aggregateVersion=0} — so staleness here is judged by {@code contentHash}, not by
+ * a monotonic counter: an unchanged republication is a no-op, and any changed one is applied,
+ * last-write-wins. That is safe because content, unlike a price or a quantity, has no ordering
+ * requirement a stale write could violate.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "tread_design",
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uk_tread_design_vendor_variant",
+                        columnNames = {"vendor_profile_id", "vendor_variant_id"}))
+public class TreadDesignEntity {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "vendor_profile_id", nullable = false, updatable = false)
+    private UUID vendorProfileId;
+
+    /** Profile alias as at the last applied event; descriptive snapshot only. */
+    @Column(name = "supplier_ref", nullable = false, length = 100)
+    private String supplierRef;
+
+    @Column(name = "vendor_variant_id", nullable = false, updatable = false, length = 100)
+    private String vendorVariantId;
+
+    @Column(name = "brand", length = 200)
+    private String brand;
+
+    @Column(name = "tread_design", length = 200)
+    private String treadDesign;
+
+    @Column(name = "tread_design_2", length = 200)
+    private String treadDesign2;
+
+    @Column(name = "product_name", length = 300)
+    private String productName;
+
+    @Column(name = "vehicle_type", length = 100)
+    private String vehicleType;
+
+    @Column(name = "seasonality", length = 100)
+    private String seasonality;
+
+    @Column(name = "content_hash", nullable = false, length = 64)
+    private String contentHash;
+
+    /** Whether any artwork on this design is still missing and awaiting retry (AC: "not as none"). */
+    @Column(name = "has_unresolved_images", nullable = false)
+    private boolean hasUnresolvedImages;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/TreadDesignImageEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/TreadDesignImageEntity.java
@@ -1,0 +1,56 @@
+package com.positivity.catalog.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * One piece of artwork on a {@link TreadDesignEntity} (CAP-324 #1352).
+ *
+ * <p>{@code imageId} is a pos-image identifier — a reference, never fetched or re-stored here.
+ * {@code unresolved} mirrors {@code SupplierCatalogEnrichmentImage}: a true value means the bytes
+ * are still missing and pos-supplier's own retry runner will republish this design once they land,
+ * not that the artwork does not exist. Replaced wholesale per design on every apply, same reasoning
+ * as {@link TreadDesignTextEntity}.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "tread_design_image")
+public class TreadDesignImageEntity {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "tread_design_id", nullable = false, updatable = false)
+    private UUID treadDesignId;
+
+    @Column(name = "image_type", length = 100)
+    private String imageType;
+
+    /** pos-image identifier for the stored bytes; absent when {@link #unresolved}. */
+    @Column(name = "image_id")
+    private Long imageId;
+
+    @Column(name = "content_hash", length = 64)
+    private String contentHash;
+
+    @Column(name = "source_uri", length = 1000)
+    private String sourceUri;
+
+    @Column(name = "unresolved", nullable = false)
+    private boolean unresolved;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/TreadDesignTextEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/TreadDesignTextEntity.java
@@ -1,0 +1,58 @@
+package com.positivity.catalog.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Marketing copy for a {@link TreadDesignEntity}, in one language (CAP-324 #1352).
+ *
+ * <p>Kept per language rather than flattened to a single description, mirroring
+ * {@code SupplierCatalogEnrichmentText}: collapsing to one language at ingestion would force a
+ * choice before any shop is known to read it. Replaced wholesale per design on every apply — the
+ * event carries the design's full text set each time, so a language dropped by the vendor is a
+ * language this table should stop holding, not one left stale.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(
+        name = "tread_design_text",
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uk_tread_design_text_design_language",
+                        columnNames = {"tread_design_id", "language_code"}))
+public class TreadDesignTextEntity {
+
+    @Id
+    @GeneratedValue
+    @UUIDv7Id
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "tread_design_id", nullable = false, updatable = false)
+    private UUID treadDesignId;
+
+    @Column(name = "language_code", nullable = false, updatable = false, length = 16)
+    private String languageCode;
+
+    @Column(name = "name", length = 300)
+    private String name;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "foot_notes", columnDefinition = "TEXT")
+    private String footNotes;
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/SupplierPriceEntryRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/SupplierPriceEntryRepository.java
@@ -50,4 +50,12 @@ public interface SupplierPriceEntryRepository extends JpaRepository<SupplierPric
             @Param("productId") UUID productId, @Param("vendorProfileId") UUID vendorProfileId, Pageable pageable);
 
     long countByImportManifestId(UUID importManifestId);
+
+    /**
+     * Every product this vendor has ever priced (CAP-324 #1352). Scopes tread-design matching to
+     * products a real relationship exists with, rather than fuzzy-matching against the whole
+     * catalog — a Michelin design cannot match a product no Michelin PRICAT line ever priced.
+     */
+    @Query("SELECT DISTINCT e.productId FROM SupplierPriceEntryEntity e WHERE e.vendorProfileId = :vendorProfileId")
+    List<UUID> findDistinctProductIdsByVendorProfileId(@Param("vendorProfileId") UUID vendorProfileId);
 }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/TreadDesignImageRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/TreadDesignImageRepository.java
@@ -1,0 +1,13 @@
+package com.positivity.catalog.internal.repository;
+
+import com.positivity.catalog.internal.entity.TreadDesignImageEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TreadDesignImageRepository extends JpaRepository<TreadDesignImageEntity, UUID> {
+
+    List<TreadDesignImageEntity> findByTreadDesignId(UUID treadDesignId);
+
+    void deleteByTreadDesignId(UUID treadDesignId);
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/TreadDesignImageRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/TreadDesignImageRepository.java
@@ -1,6 +1,7 @@
 package com.positivity.catalog.internal.repository;
 
 import com.positivity.catalog.internal.entity.TreadDesignImageEntity;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +9,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TreadDesignImageRepository extends JpaRepository<TreadDesignImageEntity, UUID> {
 
     List<TreadDesignImageEntity> findByTreadDesignId(UUID treadDesignId);
+
+    /** Bulk fetch for a page of designs (CAP-324 #1352), so listing unmatched designs is not N+1. */
+    List<TreadDesignImageEntity> findByTreadDesignIdIn(Collection<UUID> treadDesignIds);
 
     void deleteByTreadDesignId(UUID treadDesignId);
 }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/TreadDesignRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/TreadDesignRepository.java
@@ -1,0 +1,25 @@
+package com.positivity.catalog.internal.repository;
+
+import com.positivity.catalog.internal.entity.TreadDesignEntity;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface TreadDesignRepository extends JpaRepository<TreadDesignEntity, UUID> {
+
+    Optional<TreadDesignEntity> findByVendorProfileIdAndVendorVariantId(UUID vendorProfileId, String vendorVariantId);
+
+    /**
+     * Designs matched to zero products, newest first (CAP-324 #1352). An ordinary outcome, visible
+     * for review rather than surfaced as an error — see {@code SupplierCatalogEnrichmentListener}.
+     */
+    @Query("""
+      SELECT td FROM TreadDesignEntity td
+      WHERE NOT EXISTS (SELECT 1 FROM ProductEntity p WHERE p.treadDesignId = td.id)
+      ORDER BY td.updatedAt DESC
+      """)
+    Page<TreadDesignEntity> findUnmatched(Pageable pageable);
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/TreadDesignTextRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/TreadDesignTextRepository.java
@@ -1,0 +1,13 @@
+package com.positivity.catalog.internal.repository;
+
+import com.positivity.catalog.internal.entity.TreadDesignTextEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TreadDesignTextRepository extends JpaRepository<TreadDesignTextEntity, UUID> {
+
+    List<TreadDesignTextEntity> findByTreadDesignId(UUID treadDesignId);
+
+    void deleteByTreadDesignId(UUID treadDesignId);
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/TreadDesignTextRepository.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/repository/TreadDesignTextRepository.java
@@ -1,6 +1,7 @@
 package com.positivity.catalog.internal.repository;
 
 import com.positivity.catalog.internal.entity.TreadDesignTextEntity;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +9,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TreadDesignTextRepository extends JpaRepository<TreadDesignTextEntity, UUID> {
 
     List<TreadDesignTextEntity> findByTreadDesignId(UUID treadDesignId);
+
+    /** Bulk fetch for a page of designs (CAP-324 #1352), so listing unmatched designs is not N+1. */
+    List<TreadDesignTextEntity> findByTreadDesignIdIn(Collection<UUID> treadDesignIds);
 
     void deleteByTreadDesignId(UUID treadDesignId);
 }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SupplierCatalogEnrichmentListener.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/SupplierCatalogEnrichmentListener.java
@@ -1,0 +1,211 @@
+package com.positivity.catalog.internal.service;
+
+import com.positivity.catalog.internal.entity.ProcessedEvent;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.TreadDesignEntity;
+import com.positivity.catalog.internal.entity.TreadDesignImageEntity;
+import com.positivity.catalog.internal.entity.TreadDesignTextEntity;
+import com.positivity.catalog.internal.repository.ProcessedEventRepository;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import com.positivity.catalog.internal.repository.SupplierPriceEntryRepository;
+import com.positivity.catalog.internal.repository.TreadDesignImageRepository;
+import com.positivity.catalog.internal.repository.TreadDesignRepository;
+import com.positivity.catalog.internal.repository.TreadDesignTextRepository;
+import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentImage;
+import com.positivity.domainevents.supplier.SupplierCatalogEnrichmentText;
+import com.positivity.domainevents.supplier.SupplierCatalogUpdatedV1;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Applies MKCAT tread-design enrichment from {@code supplier.events.v1} (CAP-324 #1352,
+ * ADR-0044 §6, R1).
+ *
+ * <h2>A separate consumer group from the PRICAT listener, on the same topic</h2>
+ *
+ * {@link SupplierPriceCatalogEventsListener} already consumes {@code supplier.events.v1} for a
+ * different event type. Two independent listeners on one topic each need their own Kafka consumer
+ * group, or one would silently steal deliveries meant for the other's filter.
+ *
+ * <h2>Content-hash staleness, not a version counter</h2>
+ *
+ * {@code SupplierCatalogUpdatedV1} carries no per-design version — pos-supplier always publishes
+ * {@code aggregateVersion=0} — because content has no ordering requirement a stale write could
+ * violate the way a price or a quantity would. An unchanged republication (same
+ * {@code contentHash}) is a no-op; any changed one is applied, last write wins.
+ *
+ * <h2>Matching is scoped, never run against the whole catalog</h2>
+ *
+ * Candidates are the products this exact vendor has actually priced via PRICAT
+ * ({@link SupplierPriceEntryRepository#findDistinctProductIdsByVendorProfileId}), scored by
+ * {@link TreadDesignMatcher}. A design matching nothing is an ordinary outcome — the row stays,
+ * queryable for review, and nothing is treated as an error.
+ *
+ * <h2>What this never does</h2>
+ *
+ * Only {@code product.tread_design_id} is written on a product. No dimension, load index, article
+ * code or price field is ever touched here — a supplier fact that could redefine a product's
+ * identity or structure would hand a vendor edit rights over the catalogue.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "pos.catalog.kafka", name = "enabled", havingValue = "true")
+public class SupplierCatalogEnrichmentListener {
+
+    /** Producing domain, per the repo-wide processed_events convention. */
+    static final String OWNER = "supplier";
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final ProcessedEventRepository processedEventRepository;
+    private final TreadDesignRepository treadDesignRepository;
+    private final TreadDesignTextRepository treadDesignTextRepository;
+    private final TreadDesignImageRepository treadDesignImageRepository;
+    private final SupplierPriceEntryRepository supplierPriceEntryRepository;
+    private final ProductRepository productRepository;
+    private final TreadDesignMatcher treadDesignMatcher;
+
+    @KafkaListener(
+            topics = "${pos.catalog.kafka.supplier-events-topic:supplier.events.v1}",
+            groupId =
+                    "${pos.catalog.kafka.supplier-catalog-enrichment-consumer-group:pos-catalog-supplier-catalog-enrichment}")
+    @Transactional
+    public void onSupplierEvent(@NonNull String message) {
+        JsonNode envelope;
+        try {
+            envelope = objectMapper.readTree(message);
+        } catch (Exception e) {
+            log.warn("Skipping unparsable supplier event", e);
+            return;
+        }
+        if (!SupplierCatalogUpdatedV1.EVENT_TYPE.equals(
+                envelope.path("eventType").stringValue(null))) {
+            return;
+        }
+        String eventId = envelope.path("eventId").stringValue(null);
+        if (eventId == null || eventId.isBlank()) {
+            log.warn("Skipping supplier event without eventId");
+            return;
+        }
+        if (processedEventRepository.existsById(eventId)) {
+            return;
+        }
+
+        try {
+            applyUpdate(envelope);
+            processedEventRepository.save(ProcessedEvent.builder()
+                    .eventId(eventId)
+                    .owner(OWNER)
+                    .processedAt(Instant.now(clock))
+                    .build());
+        } catch (TransientDataAccessException e) {
+            // Rethrown for container retry. Recording this as processed would lose the enrichment
+            // with no way to notice: the design would simply never appear.
+            throw e;
+        } catch (Exception e) {
+            log.warn("Skipping malformed supplier catalog event eventId={}", eventId, e);
+        }
+    }
+
+    private void applyUpdate(JsonNode envelope) {
+        SupplierCatalogUpdatedV1 payload =
+                objectMapper.treeToValue(envelope.path("payload"), SupplierCatalogUpdatedV1.class);
+
+        TreadDesignEntity existing = treadDesignRepository
+                .findByVendorProfileIdAndVendorVariantId(payload.vendorProfileId(), payload.vendorVariantId())
+                .orElse(null);
+        if (existing != null && payload.contentHash().equals(existing.getContentHash())) {
+            log.debug(
+                    "Skipping unchanged tread design vendorProfileId={} vendorVariantId={}",
+                    payload.vendorProfileId(),
+                    payload.vendorVariantId());
+            return;
+        }
+
+        TreadDesignEntity design = existing != null ? existing : new TreadDesignEntity();
+        design.setVendorProfileId(payload.vendorProfileId());
+        design.setSupplierRef(payload.supplierRef());
+        design.setVendorVariantId(payload.vendorVariantId());
+        design.setBrand(payload.brand());
+        design.setTreadDesign(payload.treadDesign());
+        design.setTreadDesign2(payload.treadDesign2());
+        design.setProductName(payload.productName());
+        design.setVehicleType(payload.vehicleType());
+        design.setSeasonality(payload.seasonality());
+        design.setContentHash(payload.contentHash());
+        design.setHasUnresolvedImages(payload.hasUnresolvedImages());
+        TreadDesignEntity saved = treadDesignRepository.save(design);
+
+        replaceTexts(saved.getId(), payload.texts());
+        replaceImages(saved.getId(), payload.images());
+        matchProducts(saved);
+
+        log.debug(
+                "Applied tread design vendorProfileId={} vendorVariantId={}",
+                payload.vendorProfileId(),
+                payload.vendorVariantId());
+    }
+
+    /** Wholesale replacement: the event carries the design's full text set on every apply. */
+    private void replaceTexts(UUID treadDesignId, List<SupplierCatalogEnrichmentText> texts) {
+        treadDesignTextRepository.deleteByTreadDesignId(treadDesignId);
+        for (SupplierCatalogEnrichmentText text : texts) {
+            treadDesignTextRepository.save(TreadDesignTextEntity.builder()
+                    .treadDesignId(treadDesignId)
+                    .languageCode(text.languageCode())
+                    .name(text.name())
+                    .description(text.description())
+                    .footNotes(text.footNotes())
+                    .build());
+        }
+    }
+
+    /** Wholesale replacement, same reasoning as {@link #replaceTexts}. */
+    private void replaceImages(UUID treadDesignId, List<SupplierCatalogEnrichmentImage> images) {
+        treadDesignImageRepository.deleteByTreadDesignId(treadDesignId);
+        for (SupplierCatalogEnrichmentImage image : images) {
+            treadDesignImageRepository.save(TreadDesignImageEntity.builder()
+                    .treadDesignId(treadDesignId)
+                    .imageType(image.imageType())
+                    .imageId(image.imageId())
+                    .contentHash(image.contentHash())
+                    .sourceUri(image.sourceUri())
+                    .unresolved(image.unresolved())
+                    .build());
+        }
+    }
+
+    /**
+     * Attaches this design to every candidate product that matches. Candidates are restricted to
+     * products this vendor has actually priced (see class javadoc) — an empty candidate set (a
+     * vendor with a marketing feed but no PRICAT prices yet) is not searched further, since nothing
+     * in the whole catalog is a scoped candidate.
+     */
+    private void matchProducts(TreadDesignEntity design) {
+        List<UUID> candidateIds =
+                supplierPriceEntryRepository.findDistinctProductIdsByVendorProfileId(design.getVendorProfileId());
+        if (candidateIds.isEmpty()) {
+            return;
+        }
+        List<ProductEntity> candidates = productRepository.findAllById(candidateIds);
+        for (ProductEntity product : treadDesignMatcher.matchingProducts(design, candidates)) {
+            if (!design.getId().equals(product.getTreadDesignId())) {
+                product.setTreadDesignId(design.getId());
+                productRepository.save(product);
+            }
+        }
+    }
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/TreadDesignMatcher.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/TreadDesignMatcher.java
@@ -4,7 +4,6 @@ import com.positivity.catalog.internal.entity.ProductEntity;
 import com.positivity.catalog.internal.entity.TreadDesignEntity;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Component;
@@ -74,10 +73,20 @@ public class TreadDesignMatcher {
     }
 
     private static Set<String> trigrams(String... texts) {
+        // A manual character filter rather than a regex: score() runs once per candidate per
+        // design, so a vendor with many priced products means this recompiling and re-matching a
+        // pattern on every call — a plain loop over already-known ASCII ranges avoids both the
+        // regex engine and the intermediate strings replaceAll would allocate.
         StringBuilder normalized = new StringBuilder();
         for (String text : texts) {
-            if (text != null) {
-                normalized.append(text.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", ""));
+            if (text == null) {
+                continue;
+            }
+            for (int i = 0; i < text.length(); i++) {
+                char c = Character.toLowerCase(text.charAt(i));
+                if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+                    normalized.append(c);
+                }
             }
         }
         String text = normalized.toString();

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/TreadDesignMatcher.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/TreadDesignMatcher.java
@@ -1,0 +1,96 @@
+package com.positivity.catalog.internal.service;
+
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.TreadDesignEntity;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scores a tread design against catalog products by character-trigram overlap (CAP-324 #1352).
+ *
+ * <h2>Why trigrams rather than word tokens</h2>
+ *
+ * MKCAT's {@code brand}/{@code treadDesign}/{@code treadDesign2}/{@code productName} and a product's
+ * own {@code manufacturerBrand}/{@code name} are independently authored free text, and the gap
+ * between them is often a single space or hyphen rather than a different word — "Pilot Sport 4S" on
+ * one side, "Pilot Sport 4 S" on the other. Word-token Jaccard treats that as two different tokens
+ * ("4s" vs. "4" and "s") and loses most of the match; character trigrams over the whole
+ * whitespace-stripped string are close to unaffected by exactly this kind of spacing/punctuation
+ * drift, because removing one space changes only the handful of trigrams that crossed it.
+ *
+ * <h2>Why this alone is not enough, and is never run unscoped</h2>
+ *
+ * Free-text similarity against the whole catalog would produce both misses (real matches scored just
+ * under threshold) and false hits (an unrelated product with coincidentally similar characters).
+ * Callers must restrict {@code candidates} to products a real relationship already exists with — in
+ * practice, products the design's own vendor has priced via PRICAT
+ * ({@code SupplierPriceEntryRepository}). Scoring is this class's whole job; choosing the candidate
+ * set is deliberately the caller's.
+ */
+@Component
+public class TreadDesignMatcher {
+
+    /**
+     * Minimum trigram-overlap ratio to accept a match. High enough that two unrelated short brand
+     * names cannot cross it by chance, low enough that spacing/punctuation drift between
+     * independently authored text does not defeat a real match.
+     */
+    static final double MATCH_THRESHOLD = 0.5;
+
+    /** Trigram count; short enough to tolerate a one-word difference, long enough to avoid noise. */
+    private static final int NGRAM_SIZE = 3;
+
+    /** Trigram-overlap score in {@code [0.0, 1.0]}; 0.0 when either side has no usable text. */
+    public double score(@NonNull TreadDesignEntity design, @NonNull ProductEntity product) {
+        Set<String> designGrams =
+                trigrams(design.getBrand(), design.getTreadDesign(), design.getTreadDesign2(), design.getProductName());
+        Set<String> productGrams = trigrams(product.getManufacturerBrand(), product.getName());
+        if (designGrams.isEmpty() || productGrams.isEmpty()) {
+            return 0.0;
+        }
+        Set<String> intersection = new HashSet<>(designGrams);
+        intersection.retainAll(productGrams);
+        Set<String> union = new HashSet<>(designGrams);
+        union.addAll(productGrams);
+        return (double) intersection.size() / union.size();
+    }
+
+    /** Whether {@code product} scores at or above {@link #MATCH_THRESHOLD} for {@code design}. */
+    public boolean matches(@NonNull TreadDesignEntity design, @NonNull ProductEntity product) {
+        return score(design, product) >= MATCH_THRESHOLD;
+    }
+
+    /** Every candidate scoring at or above threshold; a design may legitimately match several sizes. */
+    @NonNull
+    public List<ProductEntity> matchingProducts(
+            @NonNull TreadDesignEntity design, @NonNull List<ProductEntity> candidates) {
+        return candidates.stream()
+                .filter(candidate -> matches(design, candidate))
+                .toList();
+    }
+
+    private static Set<String> trigrams(String... texts) {
+        StringBuilder normalized = new StringBuilder();
+        for (String text : texts) {
+            if (text != null) {
+                normalized.append(text.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", ""));
+            }
+        }
+        String text = normalized.toString();
+        if (text.isEmpty()) {
+            return Set.of();
+        }
+        if (text.length() < NGRAM_SIZE) {
+            return Set.of(text);
+        }
+        Set<String> grams = new HashSet<>();
+        for (int i = 0; i <= text.length() - NGRAM_SIZE; i++) {
+            grams.add(text.substring(i, i + NGRAM_SIZE));
+        }
+        return grams;
+    }
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/TreadDesignServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/TreadDesignServiceImpl.java
@@ -1,0 +1,80 @@
+package com.positivity.catalog.internal.service;
+
+import com.positivity.catalog.internal.dto.TreadDesignDto;
+import com.positivity.catalog.internal.dto.TreadDesignImageDto;
+import com.positivity.catalog.internal.dto.TreadDesignTextDto;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.TreadDesignEntity;
+import com.positivity.catalog.internal.entity.TreadDesignImageEntity;
+import com.positivity.catalog.internal.entity.TreadDesignTextEntity;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import com.positivity.catalog.internal.repository.TreadDesignImageRepository;
+import com.positivity.catalog.internal.repository.TreadDesignRepository;
+import com.positivity.catalog.internal.repository.TreadDesignTextRepository;
+import com.positivity.catalog.service.TreadDesignService;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TreadDesignServiceImpl implements TreadDesignService {
+
+    private final ProductRepository productRepository;
+    private final TreadDesignRepository treadDesignRepository;
+    private final TreadDesignTextRepository treadDesignTextRepository;
+    private final TreadDesignImageRepository treadDesignImageRepository;
+
+    @Override
+    @NonNull
+    public Optional<TreadDesignDto> findForProduct(@NonNull UUID productId) {
+        return productRepository
+                .findById(productId)
+                .map(ProductEntity::getTreadDesignId)
+                .flatMap(treadDesignRepository::findById)
+                .map(this::toDto);
+    }
+
+    @Override
+    @NonNull
+    public Page<TreadDesignDto> findUnmatched(@NonNull Pageable pageable) {
+        return treadDesignRepository.findUnmatched(pageable).map(this::toDto);
+    }
+
+    private TreadDesignDto toDto(TreadDesignEntity design) {
+        return new TreadDesignDto(
+                design.getId(),
+                design.getVendorProfileId(),
+                design.getSupplierRef(),
+                design.getVendorVariantId(),
+                design.getBrand(),
+                design.getTreadDesign(),
+                design.getTreadDesign2(),
+                design.getProductName(),
+                design.getVehicleType(),
+                design.getSeasonality(),
+                design.isHasUnresolvedImages(),
+                treadDesignTextRepository.findByTreadDesignId(design.getId()).stream()
+                        .map(this::toTextDto)
+                        .toList(),
+                treadDesignImageRepository.findByTreadDesignId(design.getId()).stream()
+                        .map(this::toImageDto)
+                        .toList(),
+                design.getUpdatedAt());
+    }
+
+    private TreadDesignTextDto toTextDto(TreadDesignTextEntity text) {
+        return new TreadDesignTextDto(
+                text.getLanguageCode(), text.getName(), text.getDescription(), text.getFootNotes());
+    }
+
+    private TreadDesignImageDto toImageDto(TreadDesignImageEntity image) {
+        return new TreadDesignImageDto(image.getImageType(), image.getImageId(), image.isUnresolved());
+    }
+}

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/TreadDesignServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/TreadDesignServiceImpl.java
@@ -50,7 +50,8 @@ public class TreadDesignServiceImpl implements TreadDesignService {
     @NonNull
     public Page<TreadDesignDto> findUnmatched(@NonNull Pageable pageable) {
         Page<TreadDesignEntity> page = treadDesignRepository.findUnmatched(pageable);
-        List<UUID> designIds = page.getContent().stream().map(TreadDesignEntity::getId).toList();
+        List<UUID> designIds =
+                page.getContent().stream().map(TreadDesignEntity::getId).toList();
         if (designIds.isEmpty()) {
             return page.map(design -> toDto(design, List.of(), List.of()));
         }

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/TreadDesignServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/TreadDesignServiceImpl.java
@@ -12,8 +12,10 @@ import com.positivity.catalog.internal.repository.TreadDesignImageRepository;
 import com.positivity.catalog.internal.repository.TreadDesignRepository;
 import com.positivity.catalog.internal.repository.TreadDesignTextRepository;
 import com.positivity.catalog.service.TreadDesignService;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
 import org.springframework.data.domain.Page;
@@ -38,16 +40,37 @@ public class TreadDesignServiceImpl implements TreadDesignService {
                 .findById(productId)
                 .map(ProductEntity::getTreadDesignId)
                 .flatMap(treadDesignRepository::findById)
-                .map(this::toDto);
+                .map(design -> toDto(
+                        design,
+                        treadDesignTextRepository.findByTreadDesignId(design.getId()),
+                        treadDesignImageRepository.findByTreadDesignId(design.getId())));
     }
 
     @Override
     @NonNull
     public Page<TreadDesignDto> findUnmatched(@NonNull Pageable pageable) {
-        return treadDesignRepository.findUnmatched(pageable).map(this::toDto);
+        Page<TreadDesignEntity> page = treadDesignRepository.findUnmatched(pageable);
+        List<UUID> designIds = page.getContent().stream().map(TreadDesignEntity::getId).toList();
+        if (designIds.isEmpty()) {
+            return page.map(design -> toDto(design, List.of(), List.of()));
+        }
+
+        // Two queries for the whole page rather than two per design (CAP-324 #1352 review): a
+        // review list defaults to size=50 and is capped at 200, so a naive per-design lookup here
+        // would be the one query on this endpoint guaranteed to get slower as the catalog grows.
+        var textsByDesign = treadDesignTextRepository.findByTreadDesignIdIn(designIds).stream()
+                .collect(Collectors.groupingBy(TreadDesignTextEntity::getTreadDesignId));
+        var imagesByDesign = treadDesignImageRepository.findByTreadDesignIdIn(designIds).stream()
+                .collect(Collectors.groupingBy(TreadDesignImageEntity::getTreadDesignId));
+
+        return page.map(design -> toDto(
+                design,
+                textsByDesign.getOrDefault(design.getId(), List.of()),
+                imagesByDesign.getOrDefault(design.getId(), List.of())));
     }
 
-    private TreadDesignDto toDto(TreadDesignEntity design) {
+    private TreadDesignDto toDto(
+            TreadDesignEntity design, List<TreadDesignTextEntity> texts, List<TreadDesignImageEntity> images) {
         return new TreadDesignDto(
                 design.getId(),
                 design.getVendorProfileId(),
@@ -60,12 +83,8 @@ public class TreadDesignServiceImpl implements TreadDesignService {
                 design.getVehicleType(),
                 design.getSeasonality(),
                 design.isHasUnresolvedImages(),
-                treadDesignTextRepository.findByTreadDesignId(design.getId()).stream()
-                        .map(this::toTextDto)
-                        .toList(),
-                treadDesignImageRepository.findByTreadDesignId(design.getId()).stream()
-                        .map(this::toImageDto)
-                        .toList(),
+                texts.stream().map(this::toTextDto).toList(),
+                images.stream().map(this::toImageDto).toList(),
                 design.getUpdatedAt());
     }
 

--- a/pos-catalog/src/main/java/com/positivity/catalog/service/TreadDesignService.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/service/TreadDesignService.java
@@ -1,0 +1,38 @@
+package com.positivity.catalog.service;
+
+import com.positivity.catalog.internal.dto.TreadDesignDto;
+import java.util.Optional;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Read access to MKCAT tread-design enrichment (CAP-324 #1352).
+ *
+ * <p>Everything returned here is vendor-supplied marketing content, never catalog-owned product
+ * data — this module never writes to a product's identity or structural fields from it. No write
+ * method exists here for the same reason {@code SupplierPriceEntryService} has none: an enrichment
+ * exists only because a vendor said so, applied from {@code supplier.catalog.updated} events.
+ */
+public interface TreadDesignService {
+
+    /**
+     * The enrichment matched to a product, when one has been resolved.
+     *
+     * @param productId the catalog product
+     * @return the design's enrichment, or empty when the product matches no design
+     */
+    @NonNull
+    Optional<TreadDesignDto> findForProduct(@NonNull UUID productId);
+
+    /**
+     * Designs that currently match no product, newest first — an ordinary outcome (fuzzy matching
+     * on brand and design names produces misses), surfaced for manual review rather than dropped.
+     *
+     * @param pageable paging
+     * @return a page of unmatched designs
+     */
+    @NonNull
+    Page<TreadDesignDto> findUnmatched(@NonNull Pageable pageable);
+}

--- a/pos-catalog/src/main/resources/db/migration/V12__tread_design_enrichment.sql
+++ b/pos-catalog/src/main/resources/db/migration/V12__tread_design_enrichment.sql
@@ -63,5 +63,10 @@ CREATE TABLE tread_design_image (
 );
 
 -- ── The association: nullable, additive, and the only column this story touches on product ─────
+-- ON DELETE SET NULL rather than CASCADE or RESTRICT: a design row being cleaned up or re-keyed
+-- must not delete a product, nor block the cleanup — it should simply leave the product
+-- unmatched again, the same state it was in before a match was ever found.
 ALTER TABLE product ADD COLUMN tread_design_id uuid;
+ALTER TABLE product ADD CONSTRAINT fk_product_tread_design
+    FOREIGN KEY (tread_design_id) REFERENCES tread_design (id) ON DELETE SET NULL;
 CREATE INDEX idx_product_tread_design ON product (tread_design_id);

--- a/pos-catalog/src/main/resources/db/migration/V12__tread_design_enrichment.sql
+++ b/pos-catalog/src/main/resources/db/migration/V12__tread_design_enrichment.sql
@@ -1,0 +1,67 @@
+-- CAP-324 #1352: MKCAT marketing enrichment attaches to a design, not to a product. One tread
+-- design spans many product sizes; product.tread_design_id is the only place that association is
+-- recorded, and it is nullable and does nothing else — the columns that make a product what it is
+-- (dimensions, load index, article code, price) are untouched here and always will be.
+
+CREATE TABLE tread_design (
+    id uuid NOT NULL,
+
+    vendor_profile_id uuid NOT NULL,
+    supplier_ref character varying(100) NOT NULL,
+    vendor_variant_id character varying(100) NOT NULL,
+
+    brand character varying(200),
+    tread_design character varying(200),
+    tread_design_2 character varying(200),
+    product_name character varying(300),
+    vehicle_type character varying(100),
+    seasonality character varying(100),
+
+    content_hash character varying(64) NOT NULL,
+    has_unresolved_images boolean NOT NULL,
+
+    created_at timestamp(6) with time zone NOT NULL,
+    updated_at timestamp(6) with time zone NOT NULL,
+
+    CONSTRAINT pk_tread_design PRIMARY KEY (id),
+    CONSTRAINT uk_tread_design_vendor_variant UNIQUE (vendor_profile_id, vendor_variant_id)
+);
+
+CREATE INDEX idx_tread_design_brand ON tread_design (brand);
+
+-- ── Localized marketing copy, replaced wholesale per design on every apply ────────────────────
+CREATE TABLE tread_design_text (
+    id uuid NOT NULL,
+    tread_design_id uuid NOT NULL,
+    language_code character varying(16) NOT NULL,
+
+    name character varying(300),
+    description text,
+    foot_notes text,
+
+    CONSTRAINT pk_tread_design_text PRIMARY KEY (id),
+    CONSTRAINT uk_tread_design_text_design_language UNIQUE (tread_design_id, language_code),
+    CONSTRAINT fk_tread_design_text_design
+        FOREIGN KEY (tread_design_id) REFERENCES tread_design (id) ON DELETE CASCADE
+);
+
+-- ── Artwork references, replaced wholesale per design on every apply ───────────────────────────
+CREATE TABLE tread_design_image (
+    id uuid NOT NULL,
+    tread_design_id uuid NOT NULL,
+
+    image_type character varying(100),
+    -- pos-image identifier; absent while unresolved.
+    image_id bigint,
+    content_hash character varying(64),
+    source_uri character varying(1000),
+    unresolved boolean NOT NULL,
+
+    CONSTRAINT pk_tread_design_image PRIMARY KEY (id),
+    CONSTRAINT fk_tread_design_image_design
+        FOREIGN KEY (tread_design_id) REFERENCES tread_design (id) ON DELETE CASCADE
+);
+
+-- ── The association: nullable, additive, and the only column this story touches on product ─────
+ALTER TABLE product ADD COLUMN tread_design_id uuid;
+CREATE INDEX idx_product_tread_design ON product (tread_design_id);

--- a/pos-catalog/src/test/java/com/positivity/catalog/ArchitectureTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/ArchitectureTest.java
@@ -41,6 +41,10 @@ public class ArchitectureTest {
             .haveSimpleNameNotEndingWith("SupplierPriceEntryServiceImpl")
             .and()
             .haveSimpleNameNotEndingWith("SupplierPriceCatalogEventsListener")
+            .and()
+            // Reads only findDistinctProductIdsByVendorProfileId to scope tread-design matching
+            // candidates (CAP-324 #1352) — never a price or cost value, and never a sell-price input.
+            .haveSimpleNameNotEndingWith("SupplierCatalogEnrichmentListener")
             .should()
             .dependOnClassesThat()
             .haveSimpleName("SupplierPriceEntryRepository")

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/SupplierCatalogEnrichmentListenerTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/SupplierCatalogEnrichmentListenerTest.java
@@ -1,0 +1,334 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.entity.ProcessedEvent;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.TreadDesignEntity;
+import com.positivity.catalog.internal.entity.TreadDesignImageEntity;
+import com.positivity.catalog.internal.entity.TreadDesignTextEntity;
+import com.positivity.catalog.internal.repository.ProcessedEventRepository;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import com.positivity.catalog.internal.repository.SupplierPriceEntryRepository;
+import com.positivity.catalog.internal.repository.TreadDesignImageRepository;
+import com.positivity.catalog.internal.repository.TreadDesignRepository;
+import com.positivity.catalog.internal.repository.TreadDesignTextRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.QueryTimeoutException;
+import tools.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("supplier.events.v1 -> tread design enrichment (CAP-324 #1352)")
+class SupplierCatalogEnrichmentListenerTest {
+
+    private static final UUID VENDOR_PROFILE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b01");
+    private static final UUID DESIGN_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b02");
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4b03");
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-18T09:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    private ProcessedEventRepository processedEventRepository;
+
+    @Mock
+    private TreadDesignRepository treadDesignRepository;
+
+    @Mock
+    private TreadDesignTextRepository treadDesignTextRepository;
+
+    @Mock
+    private TreadDesignImageRepository treadDesignImageRepository;
+
+    @Mock
+    private SupplierPriceEntryRepository supplierPriceEntryRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    private SupplierCatalogEnrichmentListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new SupplierCatalogEnrichmentListener(
+                CLOCK,
+                new ObjectMapper(),
+                processedEventRepository,
+                treadDesignRepository,
+                treadDesignTextRepository,
+                treadDesignImageRepository,
+                supplierPriceEntryRepository,
+                productRepository,
+                new TreadDesignMatcher());
+        when(treadDesignRepository.findByVendorProfileIdAndVendorVariantId(any(), any()))
+                .thenReturn(Optional.empty());
+        when(treadDesignRepository.save(any(TreadDesignEntity.class))).thenAnswer(inv -> {
+            TreadDesignEntity entity = inv.getArgument(0);
+            if (entity.getId() == null) {
+                entity.setId(DESIGN_ID);
+            }
+            return entity;
+        });
+        when(supplierPriceEntryRepository.findDistinctProductIdsByVendorProfileId(any()))
+                .thenReturn(List.of());
+    }
+
+    private static String enrichmentEvent(
+            String eventId, String vendorVariantId, String contentHash, boolean unresolvedImage) {
+        return """
+                {"eventId":"%s","eventType":"supplier.catalog.updated","schemaVersion":1,
+                 "aggregateId":"%s","aggregateVersion":0,"occurredAtUtc":"2026-08-18T08:59:00Z",
+                 "sourceService":"pos-supplier",
+                 "payload":{"vendorProfileId":"%s","supplierRef":"michelin-eu","vendorVariantId":"%s",
+                   "brand":"Michelin","treadDesign":"Pilot Sport 4S","treadDesign2":null,
+                   "productName":"Michelin Pilot Sport 4S","vehicleType":"passenger","seasonality":"summer",
+                   "contentHash":"%s",
+                   "texts":[{"languageCode":"en-US","name":"Pilot Sport 4S","description":"High performance",
+                     "footNotes":null}],
+                   "images":[{"imageType":"HERO","imageId":%s,"contentHash":%s,
+                     "sourceUri":"https://vendor.example/img.jpg","unresolved":%s}],
+                   "occurredAt":"2026-08-18T08:59:00Z"}}
+                """.formatted(
+                        eventId,
+                        VENDOR_PROFILE_ID,
+                        VENDOR_PROFILE_ID,
+                        vendorVariantId,
+                        contentHash,
+                        unresolvedImage ? "null" : "42",
+                        unresolvedImage ? "null" : "\"abc123\"",
+                        unresolvedImage);
+    }
+
+    @Nested
+    @DisplayName("applying an enrichment")
+    class Applying {
+
+        @Test
+        void appliesAWellFormedEnrichmentAndRecordsProcessed() {
+            listener.onSupplierEvent(enrichmentEvent("e-1", "VAR-1", "hash-1", false));
+
+            ArgumentCaptor<TreadDesignEntity> designCaptor = ArgumentCaptor.forClass(TreadDesignEntity.class);
+            verify(treadDesignRepository).save(designCaptor.capture());
+            TreadDesignEntity saved = designCaptor.getValue();
+            assertThat(saved.getVendorProfileId()).isEqualTo(VENDOR_PROFILE_ID);
+            assertThat(saved.getVendorVariantId()).isEqualTo("VAR-1");
+            assertThat(saved.getBrand()).isEqualTo("Michelin");
+            assertThat(saved.getTreadDesign()).isEqualTo("Pilot Sport 4S");
+            assertThat(saved.getContentHash()).isEqualTo("hash-1");
+            assertThat(saved.isHasUnresolvedImages()).isFalse();
+
+            verify(treadDesignTextRepository).deleteByTreadDesignId(DESIGN_ID);
+            ArgumentCaptor<TreadDesignTextEntity> textCaptor = ArgumentCaptor.forClass(TreadDesignTextEntity.class);
+            verify(treadDesignTextRepository).save(textCaptor.capture());
+            assertThat(textCaptor.getValue().getLanguageCode()).isEqualTo("en-US");
+            assertThat(textCaptor.getValue().getDescription()).isEqualTo("High performance");
+
+            verify(treadDesignImageRepository).deleteByTreadDesignId(DESIGN_ID);
+            ArgumentCaptor<TreadDesignImageEntity> imageCaptor = ArgumentCaptor.forClass(TreadDesignImageEntity.class);
+            verify(treadDesignImageRepository).save(imageCaptor.capture());
+            assertThat(imageCaptor.getValue().getImageId()).isEqualTo(42L);
+            assertThat(imageCaptor.getValue().isUnresolved()).isFalse();
+
+            ArgumentCaptor<ProcessedEvent> processedCaptor = ArgumentCaptor.forClass(ProcessedEvent.class);
+            verify(processedEventRepository).save(processedCaptor.capture());
+            assertThat(processedCaptor.getValue().getEventId()).isEqualTo("e-1");
+        }
+
+        @Test
+        void treatsAnUnresolvedImageAsNotYetRatherThanAbsent() {
+            listener.onSupplierEvent(enrichmentEvent("e-2", "VAR-2", "hash-1", true));
+
+            ArgumentCaptor<TreadDesignEntity> designCaptor = ArgumentCaptor.forClass(TreadDesignEntity.class);
+            verify(treadDesignRepository).save(designCaptor.capture());
+            assertThat(designCaptor.getValue().isHasUnresolvedImages()).isTrue();
+
+            ArgumentCaptor<TreadDesignImageEntity> imageCaptor = ArgumentCaptor.forClass(TreadDesignImageEntity.class);
+            verify(treadDesignImageRepository).save(imageCaptor.capture());
+            assertThat(imageCaptor.getValue().isUnresolved()).isTrue();
+            assertThat(imageCaptor.getValue().getImageId()).isNull();
+            // The record is still applied whole -- a missing picture never drops the rest.
+            verify(processedEventRepository).save(any(ProcessedEvent.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("redelivery and content staleness")
+    class Redelivery {
+
+        @Test
+        void redeliveredEventIdIsANoOp() {
+            when(processedEventRepository.existsById("e-3")).thenReturn(true);
+
+            listener.onSupplierEvent(enrichmentEvent("e-3", "VAR-1", "hash-1", false));
+
+            verify(treadDesignRepository, never()).save(any());
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        void unchangedContentHashOnANewEventIdIsANoOpButStillRecordsTheEvent() {
+            when(treadDesignRepository.findByVendorProfileIdAndVendorVariantId(VENDOR_PROFILE_ID, "VAR-1"))
+                    .thenReturn(Optional.of(TreadDesignEntity.builder()
+                            .id(DESIGN_ID)
+                            .vendorProfileId(VENDOR_PROFILE_ID)
+                            .vendorVariantId("VAR-1")
+                            .contentHash("hash-1")
+                            .build()));
+
+            // A republication of unchanged content still arrives as a new event and is legitimately
+            // processed -- the domain-level action is a no-op, but the delivery itself is not.
+            listener.onSupplierEvent(enrichmentEvent("e-4", "VAR-1", "hash-1", false));
+
+            verify(treadDesignRepository, never()).save(any());
+            verify(treadDesignTextRepository, never()).save(any());
+            verify(processedEventRepository).save(any(ProcessedEvent.class));
+        }
+
+        @Test
+        void changedContentHashIsAppliedLastWriteWins() {
+            when(treadDesignRepository.findByVendorProfileIdAndVendorVariantId(VENDOR_PROFILE_ID, "VAR-1"))
+                    .thenReturn(Optional.of(TreadDesignEntity.builder()
+                            .id(DESIGN_ID)
+                            .vendorProfileId(VENDOR_PROFILE_ID)
+                            .vendorVariantId("VAR-1")
+                            .contentHash("old-hash")
+                            .build()));
+
+            listener.onSupplierEvent(enrichmentEvent("e-5", "VAR-1", "new-hash", false));
+
+            ArgumentCaptor<TreadDesignEntity> captor = ArgumentCaptor.forClass(TreadDesignEntity.class);
+            verify(treadDesignRepository).save(captor.capture());
+            assertThat(captor.getValue().getContentHash()).isEqualTo("new-hash");
+        }
+    }
+
+    @Nested
+    @DisplayName("matching to products")
+    class Matching {
+
+        @Test
+        void aDesignThatMatchesNothingIsParkedForReviewNotAnError() {
+            when(supplierPriceEntryRepository.findDistinctProductIdsByVendorProfileId(VENDOR_PROFILE_ID))
+                    .thenReturn(List.of());
+
+            listener.onSupplierEvent(enrichmentEvent("e-6", "VAR-1", "hash-1", false));
+
+            verify(productRepository, never()).findAllById(any());
+            verify(productRepository, never()).save(any());
+            // Still applied and recorded -- an unmatched design is an ordinary outcome.
+            verify(treadDesignRepository).save(any(TreadDesignEntity.class));
+            verify(processedEventRepository).save(any(ProcessedEvent.class));
+        }
+
+        @Test
+        void aMatchedCandidateGetsTheDesignIdAndNothingElseChanges() {
+            ProductEntity candidate = new ProductEntity();
+            candidate.setId(PRODUCT_ID);
+            candidate.setManufacturerBrand("Michelin");
+            candidate.setName("Michelin Pilot Sport 4S 245/40R18");
+            candidate.setSku("SKU-KEEP");
+            candidate.setManufacturerPartNumber("MPN-KEEP");
+
+            when(supplierPriceEntryRepository.findDistinctProductIdsByVendorProfileId(VENDOR_PROFILE_ID))
+                    .thenReturn(List.of(PRODUCT_ID));
+            when(productRepository.findAllById(List.of(PRODUCT_ID))).thenReturn(List.of(candidate));
+
+            listener.onSupplierEvent(enrichmentEvent("e-7", "VAR-1", "hash-1", false));
+
+            ArgumentCaptor<ProductEntity> productCaptor = ArgumentCaptor.forClass(ProductEntity.class);
+            verify(productRepository).save(productCaptor.capture());
+            assertThat(productCaptor.getValue().getTreadDesignId()).isEqualTo(DESIGN_ID);
+            // Product identity and structure are untouched -- only the association was written.
+            assertThat(productCaptor.getValue().getSku()).isEqualTo("SKU-KEEP");
+            assertThat(productCaptor.getValue().getManufacturerPartNumber()).isEqualTo("MPN-KEEP");
+        }
+
+        @Test
+        void anUnrelatedCandidateIsNotMatched() {
+            ProductEntity unrelated = new ProductEntity();
+            unrelated.setId(PRODUCT_ID);
+            unrelated.setManufacturerBrand("Continental");
+            unrelated.setName("Continental ExtremeContact");
+
+            when(supplierPriceEntryRepository.findDistinctProductIdsByVendorProfileId(VENDOR_PROFILE_ID))
+                    .thenReturn(List.of(PRODUCT_ID));
+            when(productRepository.findAllById(List.of(PRODUCT_ID))).thenReturn(List.of(unrelated));
+
+            listener.onSupplierEvent(enrichmentEvent("e-8", "VAR-1", "hash-1", false));
+
+            verify(productRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("the shared consumer contract")
+    class Contract {
+
+        @Test
+        void skipsAnUnrelatedEventTypeWithoutRecordingIt() {
+            listener.onSupplierEvent("""
+                    {"eventId":"e-9","eventType":"supplier.pricecatalog.updated","aggregateVersion":1,"payload":{}}
+                    """);
+
+            verify(treadDesignRepository, never()).save(any());
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        void ignoresAnEventWithoutAnEventId() {
+            listener.onSupplierEvent("""
+                    {"eventType":"supplier.catalog.updated","payload":{}}
+                    """);
+
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        void ignoresAnUnparsableMessage() {
+            listener.onSupplierEvent("not json");
+
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        void swallowsAMalformedPayloadButLeavesItUnrecorded() {
+            listener.onSupplierEvent("""
+                    {"eventId":"e-10","eventType":"supplier.catalog.updated","aggregateVersion":0,
+                     "payload":{"vendorVariantId":"VAR-1"}}
+                    """);
+
+            verify(treadDesignRepository, never()).save(any());
+            verify(processedEventRepository, never()).save(any());
+        }
+
+        @Test
+        void rethrowsATransientDatabaseErrorSoTheContainerRetries() {
+            when(treadDesignRepository.findByVendorProfileIdAndVendorVariantId(any(), any()))
+                    .thenThrow(new QueryTimeoutException("db busy"));
+
+            assertThatThrownBy(() -> listener.onSupplierEvent(enrichmentEvent("e-11", "VAR-1", "hash-1", false)))
+                    .isInstanceOf(QueryTimeoutException.class);
+
+            verify(processedEventRepository, never()).save(any());
+        }
+    }
+}

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/TreadDesignMatcherTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/TreadDesignMatcherTest.java
@@ -1,0 +1,72 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.TreadDesignEntity;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TreadDesignMatcher — token-overlap scoring (CAP-324 #1352)")
+class TreadDesignMatcherTest {
+
+    private final TreadDesignMatcher matcher = new TreadDesignMatcher();
+
+    private static TreadDesignEntity design(String brand, String treadDesign, String treadDesign2, String productName) {
+        return TreadDesignEntity.builder()
+                .brand(brand)
+                .treadDesign(treadDesign)
+                .treadDesign2(treadDesign2)
+                .productName(productName)
+                .build();
+    }
+
+    private static ProductEntity product(String manufacturerBrand, String name) {
+        ProductEntity product = new ProductEntity();
+        product.setManufacturerBrand(manufacturerBrand);
+        product.setName(name);
+        return product;
+    }
+
+    @Test
+    @DisplayName("word-order and punctuation differences still match")
+    void toleratesWordOrderAndPunctuation() {
+        TreadDesignEntity design = design("Michelin", "Pilot Sport 4S", null, null);
+        ProductEntity product = product("Michelin", "Michelin Pilot Sport 4 S 245/40R18");
+
+        assertThat(matcher.matches(design, product)).isTrue();
+    }
+
+    @Test
+    @DisplayName("an unrelated product does not match on a shared generic word alone")
+    void doesNotMatchOnAGenericWordAlone() {
+        TreadDesignEntity design = design("Michelin", "Pilot Sport 4S", null, null);
+        ProductEntity product = product("Continental", "Continental Tire 225/45R17");
+
+        assertThat(matcher.matches(design, product)).isFalse();
+    }
+
+    @Test
+    @DisplayName("neither side having usable text scores zero rather than throwing")
+    void blankTextScoresZero() {
+        TreadDesignEntity design = design(null, null, null, null);
+        ProductEntity product = product(null, null);
+
+        assertThat(matcher.score(design, product)).isZero();
+        assertThat(matcher.matches(design, product)).isFalse();
+    }
+
+    @Test
+    @DisplayName("a design may legitimately match several sizes of the same product line")
+    void matchingProductsReturnsEveryCandidateAboveThreshold() {
+        TreadDesignEntity design = design("Michelin", "Pilot Sport 4S", null, null);
+        ProductEntity sizeA = product("Michelin", "Michelin Pilot Sport 4S 245/40R18");
+        ProductEntity sizeB = product("Michelin", "Michelin Pilot Sport 4S 255/35R19");
+        ProductEntity unrelated = product("Continental", "Continental ExtremeContact");
+
+        List<ProductEntity> matches = matcher.matchingProducts(design, List.of(sizeA, sizeB, unrelated));
+
+        assertThat(matches).containsExactlyInAnyOrder(sizeA, sizeB);
+    }
+}

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/TreadDesignServiceImplTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/TreadDesignServiceImplTest.java
@@ -1,0 +1,131 @@
+package com.positivity.catalog.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.positivity.catalog.internal.dto.TreadDesignDto;
+import com.positivity.catalog.internal.entity.ProductEntity;
+import com.positivity.catalog.internal.entity.TreadDesignEntity;
+import com.positivity.catalog.internal.entity.TreadDesignImageEntity;
+import com.positivity.catalog.internal.entity.TreadDesignTextEntity;
+import com.positivity.catalog.internal.repository.ProductRepository;
+import com.positivity.catalog.internal.repository.TreadDesignImageRepository;
+import com.positivity.catalog.internal.repository.TreadDesignRepository;
+import com.positivity.catalog.internal.repository.TreadDesignTextRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("TreadDesignServiceImpl — enrichment read surface (CAP-324 #1352)")
+class TreadDesignServiceImplTest {
+
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4c01");
+    private static final UUID DESIGN_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4c02");
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private TreadDesignRepository treadDesignRepository;
+
+    @Mock
+    private TreadDesignTextRepository treadDesignTextRepository;
+
+    @Mock
+    private TreadDesignImageRepository treadDesignImageRepository;
+
+    private TreadDesignServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TreadDesignServiceImpl(
+                productRepository, treadDesignRepository, treadDesignTextRepository, treadDesignImageRepository);
+    }
+
+    private static TreadDesignEntity design() {
+        return TreadDesignEntity.builder()
+                .id(DESIGN_ID)
+                .vendorProfileId(UUID.randomUUID())
+                .supplierRef("michelin-eu")
+                .vendorVariantId("VAR-1")
+                .brand("Michelin")
+                .treadDesign("Pilot Sport 4S")
+                .hasUnresolvedImages(false)
+                .updatedAt(Instant.parse("2026-08-18T09:00:00Z"))
+                .build();
+    }
+
+    @Test
+    @DisplayName("a product with no matched design returns empty rather than throwing")
+    void unmatchedProductReturnsEmpty() {
+        ProductEntity product = new ProductEntity();
+        product.setId(PRODUCT_ID);
+        product.setTreadDesignId(null);
+        when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product));
+
+        assertThat(service.findForProduct(PRODUCT_ID)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a matched product returns the design's texts and images, vendor-supplied")
+    void matchedProductReturnsEnrichment() {
+        ProductEntity product = new ProductEntity();
+        product.setId(PRODUCT_ID);
+        product.setTreadDesignId(DESIGN_ID);
+        when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.of(product));
+        when(treadDesignRepository.findById(DESIGN_ID)).thenReturn(Optional.of(design()));
+        when(treadDesignTextRepository.findByTreadDesignId(DESIGN_ID))
+                .thenReturn(List.of(TreadDesignTextEntity.builder()
+                        .treadDesignId(DESIGN_ID)
+                        .languageCode("en-US")
+                        .name("Pilot Sport 4S")
+                        .build()));
+        when(treadDesignImageRepository.findByTreadDesignId(DESIGN_ID))
+                .thenReturn(List.of(TreadDesignImageEntity.builder()
+                        .treadDesignId(DESIGN_ID)
+                        .imageId(42L)
+                        .unresolved(false)
+                        .build()));
+
+        Optional<TreadDesignDto> result = service.findForProduct(PRODUCT_ID);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().brand()).isEqualTo("Michelin");
+        assertThat(result.get().texts())
+                .singleElement()
+                .satisfies(text -> assertThat(text.languageCode()).isEqualTo("en-US"));
+        assertThat(result.get().images())
+                .singleElement()
+                .satisfies(image -> assertThat(image.imageId()).isEqualTo(42L));
+    }
+
+    @Test
+    @DisplayName("a product that does not exist returns empty rather than throwing")
+    void missingProductReturnsEmpty() {
+        when(productRepository.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+
+        assertThat(service.findForProduct(PRODUCT_ID)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("unmatched designs are listed for review")
+    void findUnmatchedDelegatesToRepository() {
+        when(treadDesignRepository.findUnmatched(any()))
+                .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(design())));
+
+        assertThat(service.findUnmatched(PageRequest.of(0, 50)).getContent()).hasSize(1);
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:324`
- Parent STORY (durion): louisburroughs/durion#379
- Child issue: louisburroughs/durion-positivity-backend#1352
- Domain: `domain:product`, `domain:positivity`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/product/.business-rules/BACKEND_CONTRACT_GUIDE.md` → tread-design enrichment attachment model
- New consumer (no new event contract): `SupplierCatalogEnrichmentListener` consumes the existing `supplier.catalog.updated` (`SupplierCatalogUpdatedV1`) published by pos-supplier since #1230/#1257 — no schema change.
- New endpoints: `GET /v1/catalog/tread-designs/for-product/{productId}`, `GET /v1/catalog/tread-designs/unmatched` (pos-catalog) — read-only.
- `pos-catalog/openapi.yaml` and `pos-api-gateway/docs/openapi-aggregate.yaml` regenerated via `scripts/generate-openapi.sh pos-catalog`.

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller
- [x] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated
- [ ] Angular SDK regenerated — not requested for this story; read-only admin/review surface.

## Scope
- What changed:
  - **Attachment model** (the blocker #1230 named and #1352 exists to resolve): `TreadDesignEntity` (+ `TreadDesignTextEntity`, `TreadDesignImageEntity`) holds MKCAT's vendor-supplied content, keyed on `(vendorProfileId, vendorVariantId)`. `product.tread_design_id` (nullable) is the only touch point on `ProductEntity` — an association, never a source for identity or structure.
  - **Matching**: `TreadDesignMatcher` scores candidates by character-trigram overlap (tolerant of independently-authored spacing/punctuation differences, e.g. "Pilot Sport 4S" vs "Pilot Sport 4 S"). Candidates are never the whole catalog — `SupplierCatalogEnrichmentListener` scopes them to products the design's own vendor has actually priced via PRICAT (`SupplierPriceEntryRepository.findDistinctProductIdsByVendorProfileId`, landed in #1347). A design matching nothing is stored and queryable for review, never dropped or errored.
  - **Consumer**: `SupplierCatalogEnrichmentListener` on its own Kafka consumer group (a second listener already reads `supplier.events.v1` for PRICAT). Staleness is judged by `contentHash`, not a version counter — the event carries none (`aggregateVersion` is always 0 from pos-supplier), and content has no ordering requirement a stale write could violate.
  - **Unresolved images**: stored as `unresolved=true` with no `imageId`, exposed as "not yet" on the DTO — never treated as absent. pos-supplier's own retry runner republishes once artwork lands.
  - **Read surface**: `TreadDesignController` — one endpoint for a product's matched enrichment, one to list unmatched designs for manual review.
  - **ArchUnit**: extended the existing `supplier_price_entries_must_not_reach_any_price_resolver` allowlist for the new listener — it reads only a product-id set for candidate scoping, never a price/cost value, so it's not the sell-price-resolution case that rule guards against.
- Why: closes #1352. #1230 delivered the supplier half and deliberately left the consumer blocked pending this domain decision, to avoid inventing the attachment model just to unblock ingestion.

## Tests
- [x] Unit tests added: `SupplierCatalogEnrichmentListenerTest` (applied, redelivery no-op, unchanged-content-hash no-op but still recorded, changed-hash last-write-wins, unresolved image handled as not-yet, unmatched design parked not errored, matched candidate gets only the association written — identity/structure fields verified untouched, unrelated candidate not matched, full shared consumer contract: unrelated event type/no eventId/unparsable/malformed payload/transient-error rethrow), `TreadDesignMatcherTest` (spacing/punctuation tolerance, no false match on a generic shared word, blank text scores zero, one design matching several sizes), `TreadDesignServiceImplTest`.
- [ ] Integration tests — not needed; no new I/O pattern beyond the established replica-listener/outbox conventions.
- [ ] Provider behavioral contract tests — n/a, no cross-service REST contract touched (event-only consumer, read-only new endpoints).
- How to run: `./mvnw -pl pos-catalog -am test`

## Risk & Rollback
- Risk level: Low — additive tables/columns/endpoints; the new `product.tread_design_id` column is nullable and written nowhere except this listener's matching step, so it cannot regress any existing product read/write path.
- Rollback plan: revert this commit. New tables and the new product column are additive with no destructive migration; the consumer is gated by the same `pos.catalog.kafka.enabled` flag as every other listener in this module.

## Checklist
- [x] Branch name matches `cap/<cap-id>` (`cap/324-catalog-enrichment-consumer`, per the issue's own stated branch name)
- [ ] PR title starts with `[CAP:<cap-id>]` — using conventional-commit style, per this repo's existing merged PR history for CAP work
- [x] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed) — not applicable; no request/response shape changed on an existing endpoint, and no event schema changed
- [x] Required CI checks passing (local: pos-catalog unit tests, cross-module ArchUnit `pos-archunit -Dtest=ArchitectureTests`, `spotless:apply`, OpenAPI regeneration + validation)