### PR TITLE
fix: resolve open SonarCloud reliability issues

### DIFF
--- a/pos-image/src/main/java/com/positivity/image/internal/dto/ImageContentView.java
+++ b/pos-image/src/main/java/com/positivity/image/internal/dto/ImageContentView.java
@@ -1,5 +1,7 @@
 package com.positivity.image.internal.dto;
 
+import java.util.Arrays;
+import java.util.Objects;
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -9,6 +11,35 @@ import org.jspecify.annotations.NonNull;
  * one carries the content itself, because for a stored image there is no file to resolve — and the
  * two cases must not be conflated, or a stored image would be looked for on a volume that has never
  * held it.
+ *
+ * <p>{@code equals}/{@code hashCode}/{@code toString} are overridden because the default record ones
+ * compare {@code content} by array identity, not by the bytes it holds (SonarCloud java:S6218): two
+ * views of the same image fetched independently would compare unequal.
  */
 public record ImageContentView(
-        @NonNull String filename, @NonNull String contentType, byte[] content) {}
+        @NonNull String filename, @NonNull String contentType, byte[] content) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ImageContentView other)) {
+            return false;
+        }
+        return filename.equals(other.filename)
+                && contentType.equals(other.contentType)
+                && Arrays.equals(content, other.content);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(filename, contentType, Arrays.hashCode(content));
+    }
+
+    @Override
+    public String toString() {
+        return "ImageContentView[filename=" + filename + ", contentType=" + contentType + ", content="
+                + (content == null ? "null" : content.length + " bytes") + "]";
+    }
+}

--- a/pos-image/src/test/java/com/positivity/image/internal/dto/ImageContentViewTest.java
+++ b/pos-image/src/test/java/com/positivity/image/internal/dto/ImageContentViewTest.java
@@ -1,0 +1,72 @@
+package com.positivity.image.internal.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code equals}/{@code hashCode}/{@code toString} compare {@code content} by value, not array
+ * identity — the default record implementation compares by identity, which SonarCloud flags
+ * (java:S6218) and which would make two independently-fetched views of the same image compare
+ * unequal.
+ */
+@DisplayName("ImageContentView — content compared by value, not array identity")
+class ImageContentViewTest {
+
+    private static final byte[] BYTES = "png-bytes".getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    @DisplayName("equal fields with a different array instance are equal, and hash alike")
+    void equalContentIsEqualAcrossDistinctArrayInstances() {
+        ImageContentView a = new ImageContentView("logo.png", "image/png", BYTES.clone());
+        ImageContentView b = new ImageContentView("logo.png", "image/png", BYTES.clone());
+
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+    }
+
+    @Test
+    @DisplayName("an instance is equal to itself")
+    void reflexive() {
+        ImageContentView view = new ImageContentView("logo.png", "image/png", BYTES.clone());
+
+        assertThat(view).isEqualTo(view);
+    }
+
+    @Test
+    @DisplayName("not equal to a different type, or to null")
+    void notEqualToUnrelatedTypesOrNull() {
+        ImageContentView view = new ImageContentView("logo.png", "image/png", BYTES.clone());
+
+        assertThat(view).isNotEqualTo("logo.png").isNotEqualTo(null);
+    }
+
+    @Test
+    @DisplayName("differs by filename, content type, or content bytes")
+    void differsByAnyField() {
+        ImageContentView view = new ImageContentView("logo.png", "image/png", BYTES.clone());
+
+        assertThat(view).isNotEqualTo(new ImageContentView("other.png", "image/png", BYTES.clone()));
+        assertThat(view).isNotEqualTo(new ImageContentView("logo.png", "image/jpeg", BYTES.clone()));
+        assertThat(view)
+                .isNotEqualTo(
+                        new ImageContentView("logo.png", "image/png", "different".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    @DisplayName("toString reports a byte count, never the raw content")
+    void toStringReportsByteCount() {
+        ImageContentView view = new ImageContentView("logo.png", "image/png", BYTES.clone());
+
+        assertThat(view.toString()).contains("logo.png", "image/png", BYTES.length + " bytes");
+    }
+
+    @Test
+    @DisplayName("null content is reported as such rather than throwing")
+    void toStringHandlesNullContent() {
+        ImageContentView view = new ImageContentView("logo.png", "image/png", null);
+
+        assertThat(view.toString()).contains("content=null");
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/service/ProcurementAvailabilityServiceTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/ProcurementAvailabilityServiceTest.java
@@ -197,8 +197,10 @@ class ProcurementAvailabilityServiceTest {
             assertThat(line.articleEan()).isEqualTo(EAN_A);
             assertThat(line.requestedQuantity()).isEqualTo(10);
         });
-        // Both lines carry the answer, because both are about that article.
+        // Both lines carry the answer, because both are about that article. hasSize first: allSatisfy
+        // alone would pass vacuously if the response reported no lines at all.
         assertThat(response.lines())
+                .hasSize(2)
                 .allSatisfy(line -> assertThat(line.availableQuantity()).isEqualTo(7));
     }
 

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatImporter.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/mktcat/service/MktCatImporter.java
@@ -318,10 +318,11 @@ public class MktCatImporter implements SupplierCatalogPort {
 
     @NonNull
     private static String bodyOrThrow(@NonNull SupplierHttpResponse response, @NonNull String what) {
-        if (!response.isSuccess() || response.body() == null) {
+        String body = response.body();
+        if (!response.isSuccess() || body == null) {
             throw new MktCatImportException(what + " could not be read: " + response.outcome());
         }
-        return response.body();
+        return body;
     }
 
     @Nullable

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPoller.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPoller.java
@@ -55,7 +55,7 @@ public class WorkorderAuthorizationPoller {
     private final SupplierProfileResolver profileResolver;
     private final AdapterRegistry adapterRegistry;
     private final SupplierBaseClient baseClient;
-    private final WorkorderAuthorizationRunner runner;
+    private final WorkorderAuthorizationTransactions transactions;
     private final Clock clock;
 
     /** How many rows one tick will read. Bounded so a backlog cannot monopolise a tick. */
@@ -74,7 +74,7 @@ public class WorkorderAuthorizationPoller {
             SupplierProfileResolver profileResolver,
             AdapterRegistry adapterRegistry,
             SupplierBaseClient baseClient,
-            WorkorderAuthorizationRunner runner,
+            WorkorderAuthorizationTransactions transactions,
             Clock clock,
             @Value("${pos.supplier.workorderauth.poll-batch-size:50}") int batchSize,
             @Value("${pos.supplier.workorderauth.pending-timeout:PT24H}") Duration pendingTimeout) {
@@ -82,7 +82,7 @@ public class WorkorderAuthorizationPoller {
         this.profileResolver = profileResolver;
         this.adapterRegistry = adapterRegistry;
         this.baseClient = baseClient;
-        this.runner = runner;
+        this.transactions = transactions;
         this.clock = clock;
         this.batchSize = batchSize;
         this.pendingTimeout = pendingTimeout;
@@ -114,7 +114,7 @@ public class WorkorderAuthorizationPoller {
         Instant now = Instant.now(clock);
         if (row.getRequestedAt() != null
                 && row.getRequestedAt().plus(pendingTimeout).isBefore(now)) {
-            runner.parkForReview(
+            transactions.parkForReview(
                     row,
                     "vendor accepted the authorization but did not decide within " + pendingTimeout
                             + "; it has not been asked again");
@@ -126,7 +126,8 @@ public class WorkorderAuthorizationPoller {
             // Accepted with nowhere to look. Nothing further is possible for this row, and the
             // codec should have refused it at 202 -- so reaching here means a row predates that
             // check or was written by hand.
-            runner.parkForReview(row, "authorization is pending with no poll location, so its decision cannot be read");
+            transactions.parkForReview(
+                    row, "authorization is pending with no poll location, so its decision cannot be read");
             return;
         }
 
@@ -146,7 +147,7 @@ public class WorkorderAuthorizationPoller {
             // Polling on with an empty partnerId would ask a vendor that has already rejected the
             // request as unidentified, once every tick, until the pending timeout expired a day
             // later -- and would then report the misconfiguration as a vendor that never decided.
-            runner.parkForReview(row, "authorization cannot be polled: " + e.getMessage());
+            transactions.parkForReview(row, "authorization cannot be polled: " + e.getMessage());
             return;
         }
 
@@ -173,11 +174,11 @@ public class WorkorderAuthorizationPoller {
                     response.header("Location"),
                     row.getWorkorderId());
         } catch (WorkorderAuthDecodeException e) {
-            runner.parkForReview(row, "vendor answer could not be read while polling: " + e.getMessage());
+            transactions.parkForReview(row, "vendor answer could not be read while polling: " + e.getMessage());
             return;
         }
 
-        runner.applyDecision(row, decision);
+        transactions.applyDecision(row, decision);
     }
 
     /**

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationRunner.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationRunner.java
@@ -11,8 +11,6 @@ import com.positivity.supplier.internal.domain.model.SupplierRequestSpec;
 import com.positivity.supplier.internal.domain.model.SupplierWorkorderAuthorization;
 import com.positivity.supplier.internal.domain.model.WorkorderAuthorizationRequest;
 import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
-import com.positivity.supplier.internal.enums.WorkorderApprovalStatus;
-import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
 import com.positivity.supplier.internal.exception.SupplierConfigurationException;
 import com.positivity.supplier.internal.registry.AdapterRegistry;
 import com.positivity.supplier.internal.registry.SupplierCodecs;
@@ -21,18 +19,13 @@ import com.positivity.supplier.internal.service.SupplierProfileResolver;
 import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
 import com.positivity.supplier.internal.spi.SupplierWorkorderAuthorizationPort;
 import com.positivity.supplier.service.model.FleetAuthorizationResponse;
-import java.time.Clock;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Asks a fleet program to authorize work, and records what it said (CAP-323 #1229).
@@ -59,7 +52,6 @@ import org.springframework.transaction.annotation.Transactional;
  * Telling a shop the fleet said no when in fact nobody asked sends it to argue with a fleet manager
  * about a decision that was never made.
  */
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class WorkorderAuthorizationRunner implements SupplierWorkorderAuthorizationPort {
@@ -77,8 +69,7 @@ public class WorkorderAuthorizationRunner implements SupplierWorkorderAuthorizat
     private final AdapterRegistry adapterRegistry;
     private final SupplierBaseClient baseClient;
     private final SupplierWorkorderAuthorizationRepository authorizationRepository;
-    private final WorkorderAuthorizationPublisher publisher;
-    private final Clock clock;
+    private final WorkorderAuthorizationTransactions transactions;
 
     @Override
     @NonNull
@@ -112,7 +103,10 @@ public class WorkorderAuthorizationRunner implements SupplierWorkorderAuthorizat
                 MichelinS2SWorkorderAuthCodec.class);
         String partnerId = S2SPartnerId.resolve(profileResolver, supplierRef);
 
-        SupplierWorkorderAuthorizationEntity row = openRow(binding, supplierRef, request);
+        // Through the injected bean, NEVER a method on this. A self-invocation would bypass the
+        // Spring proxy and silently disable these methods' @Transactional semantics -- see
+        // WorkorderAuthorizationTransactions for what that cost (SonarCloud java:S2229).
+        SupplierWorkorderAuthorizationEntity row = transactions.openRow(binding, supplierRef, request);
 
         SupplierRequestSpec spec = codec.buildAuthorizationRequest(request, partnerId, API_MAJOR_VERSION);
         SupplierHttpResponse response = baseClient.exchange(SupplierRequests.toHttpRequest(binding, spec));
@@ -121,7 +115,7 @@ public class WorkorderAuthorizationRunner implements SupplierWorkorderAuthorizat
             // Not a denial. The vendor may never have seen the request, or may have created an
             // authorization and failed to tell us -- and those two are indistinguishable from here,
             // which is exactly why a human has to look rather than a loop retrying.
-            return parkForReview(
+            return transactions.parkForReview(
                     row,
                     "vendor exchange failed: " + response.outcome()
                             + (response.failureDetail() == null ? "" : " — " + response.failureDetail()));
@@ -137,136 +131,10 @@ public class WorkorderAuthorizationRunner implements SupplierWorkorderAuthorizat
         } catch (WorkorderAuthDecodeException e) {
             // The vendor answered something. We could not read it. Guessing either way decides
             // whether a shop does work, so neither guess is available.
-            return parkForReview(row, "vendor answer could not be read: " + e.getMessage());
+            return transactions.parkForReview(row, "vendor answer could not be read: " + e.getMessage());
         }
 
-        return applyDecision(row, decision);
-    }
-
-    /**
-     * Records a decision against an existing row and publishes it if terminal.
-     *
-     * <p>Shared with the poller, so an answer that arrives synchronously and one that arrives an
-     * hour later are recorded and published by the same code. Two paths would drift, and the one
-     * that drifts is the asynchronous one, which is also the one nobody watches.
-     */
-    @Transactional
-    @NonNull
-    public SupplierWorkorderAuthorizationEntity applyDecision(
-            @NonNull SupplierWorkorderAuthorizationEntity row, @NonNull SupplierWorkorderAuthorization decision) {
-        Instant now = Instant.now(clock);
-        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
-                .findById(row.getSupplierWorkorderAuthorizationId())
-                .orElse(row);
-
-        managed.setLastPolledAt(now);
-        if (decision.vendorAuthorizationId() != null) {
-            managed.setVendorAuthorizationId(decision.vendorAuthorizationId());
-        }
-
-        switch (decision.status()) {
-            case PENDING -> {
-                managed.setStatus(WorkorderAuthorizationStatus.PENDING);
-                if (decision.pollLocation() != null) {
-                    managed.setPollLocation(decision.pollLocation());
-                }
-            }
-            case GRANTED -> {
-                managed.setStatus(WorkorderAuthorizationStatus.GRANTED);
-                managed.setContractReference(decision.contractReference());
-                managed.setAuthorizedAmount(decision.authorizedAmount());
-                managed.setCurrency(decision.currency());
-                managed.setDecidedAt(now);
-            }
-            case DENIED -> {
-                managed.setStatus(WorkorderAuthorizationStatus.DENIED);
-                managed.setReasonCode(decision.vendorReasonCode());
-                managed.setReasonText(decision.vendorReason());
-                managed.setDecidedAt(now);
-            }
-            case NOT_FOUND -> {
-                managed.setStatus(WorkorderAuthorizationStatus.NOT_FOUND);
-                managed.setReasonCode(decision.vendorReasonCode());
-                managed.setReasonText(decision.vendorReason());
-                managed.setDecidedAt(now);
-            }
-        }
-
-        SupplierWorkorderAuthorizationEntity saved = authorizationRepository.save(managed);
-
-        // Published inside the same transaction as the state change, through the outbox: a decision
-        // recorded but not published would leave the rest of the platform believing the fleet never
-        // answered (ADR-0044 §4).
-        publisher.publishIfTerminal(saved, now);
-        return saved;
-    }
-
-    /**
-     * Parks a row for a human and says why.
-     *
-     * <p>{@code REQUIRES_NEW} so the reason survives whatever the caller does next. A review reason
-     * rolled back with the transaction that discovered it is the one piece of information nobody can
-     * reconstruct afterwards.
-     */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @NonNull
-    public SupplierWorkorderAuthorizationEntity parkForReview(
-            @NonNull SupplierWorkorderAuthorizationEntity row, @NonNull String reason) {
-        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
-                .findById(row.getSupplierWorkorderAuthorizationId())
-                .orElse(row);
-        managed.setStatus(WorkorderAuthorizationStatus.MANUAL_REVIEW);
-        managed.setReviewReason(truncate(reason));
-        managed.setLastPolledAt(Instant.now(clock));
-        log.warn(
-                "Workorder authorization for workorder {} at {} needs review: {}",
-                managed.getWorkorderId(),
-                managed.getSupplierRef(),
-                reason);
-        return authorizationRepository.save(managed);
-    }
-
-    /**
-     * Opens (or re-opens) the row for this workorder, committed before the vendor is called.
-     *
-     * <p>Re-requesting updates the existing row rather than adding a second. Two rows would let a
-     * denial and a grant coexist for one workorder with nothing to say which one a shop should act
-     * on, and the uniqueness index exists to make that impossible rather than merely unlikely.
-     */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @NonNull
-    public SupplierWorkorderAuthorizationEntity openRow(
-            @NonNull ResolvedBinding binding,
-            @NonNull SupplierRef supplierRef,
-            @NonNull WorkorderAuthorizationRequest request) {
-        Instant now = Instant.now(clock);
-        UUID vendorProfileId = binding.profile().getVendorProfileId();
-
-        SupplierWorkorderAuthorizationEntity row = authorizationRepository
-                .findByVendorProfileIdAndWorkorderId(vendorProfileId, request.workorderId())
-                .orElseGet(() -> SupplierWorkorderAuthorizationEntity.builder()
-                        .vendorProfileId(vendorProfileId)
-                        .workorderId(request.workorderId())
-                        .approvalStatus(WorkorderApprovalStatus.NOT_REQUESTED)
-                        .approvalAttempts(0)
-                        .build());
-
-        row.setSupplierRef(supplierRef.value());
-        row.setStatus(WorkorderAuthorizationStatus.PENDING);
-        row.setRequestedAt(now);
-        // Cleared on re-request: a stale reason from the previous attempt read as if it described
-        // this one.
-        row.setReviewReason(null);
-        row.setReasonCode(null);
-        row.setReasonText(null);
-        row.setDecidedAt(null);
-        row.setPollLocation(null);
-        return authorizationRepository.save(row);
-    }
-    /** Keeps a vendor's error text inside the column it is stored in. */
-    @NonNull
-    private static String truncate(@NonNull String reason) {
-        return reason.length() <= 1000 ? reason : reason.substring(0, 1000);
+        return transactions.applyDecision(row, decision);
     }
 
     /**

--- a/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationTransactions.java
+++ b/pos-supplier/src/main/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationTransactions.java
@@ -1,0 +1,173 @@
+package com.positivity.supplier.internal.workorderauth.service;
+
+import com.positivity.supplier.internal.domain.model.SupplierRef;
+import com.positivity.supplier.internal.domain.model.SupplierWorkorderAuthorization;
+import com.positivity.supplier.internal.domain.model.WorkorderAuthorizationRequest;
+import com.positivity.supplier.internal.entity.SupplierWorkorderAuthorizationEntity;
+import com.positivity.supplier.internal.enums.WorkorderApprovalStatus;
+import com.positivity.supplier.internal.enums.WorkorderAuthorizationStatus;
+import com.positivity.supplier.internal.repository.SupplierWorkorderAuthorizationRepository;
+import com.positivity.supplier.internal.service.SupplierProfileResolver.ResolvedBinding;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The three transaction boundaries a fleet authorization request steps through (CAP-323 #1229).
+ *
+ * <p>These used to be methods on {@link WorkorderAuthorizationRunner} itself, called from
+ * {@code requestAuthorizationRow} as {@code this.openRow(...)}, {@code this.parkForReview(...)} and
+ * {@code this.applyDecision(...)}. A self-invocation does not go through the Spring proxy, so none of
+ * the {@code @Transactional} annotations on those methods ever took effect for that call path: every
+ * write silently joined whatever transaction the caller was in, which for {@code
+ * requestAuthorizationRow} was none. That defeated the documented guarantee that the row is committed
+ * in its own transaction before the vendor is called, and that a review reason parked in {@code
+ * REQUIRES_NEW} survives whatever the caller does next (SonarCloud java:S2229). Splitting these methods
+ * into their own bean and calling them through the injected reference is what makes the proxy apply.
+ *
+ * <p>{@link WorkorderAuthorizationPoller} calling {@code applyDecision}/{@code parkForReview} through an
+ * injected bean reference was never affected by this — only the self-call from inside {@code
+ * WorkorderAuthorizationRunner} was.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WorkorderAuthorizationTransactions {
+
+    private final SupplierWorkorderAuthorizationRepository authorizationRepository;
+    private final WorkorderAuthorizationPublisher publisher;
+    private final Clock clock;
+
+    /**
+     * Opens (or re-opens) the row for this workorder, committed before the vendor is called.
+     *
+     * <p>Re-requesting updates the existing row rather than adding a second. Two rows would let a
+     * denial and a grant coexist for one workorder with nothing to say which one a shop should act
+     * on, and the uniqueness index exists to make that impossible rather than merely unlikely.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @NonNull
+    public SupplierWorkorderAuthorizationEntity openRow(
+            @NonNull ResolvedBinding binding,
+            @NonNull SupplierRef supplierRef,
+            @NonNull WorkorderAuthorizationRequest request) {
+        Instant now = Instant.now(clock);
+        UUID vendorProfileId = binding.profile().getVendorProfileId();
+
+        SupplierWorkorderAuthorizationEntity row = authorizationRepository
+                .findByVendorProfileIdAndWorkorderId(vendorProfileId, request.workorderId())
+                .orElseGet(() -> SupplierWorkorderAuthorizationEntity.builder()
+                        .vendorProfileId(vendorProfileId)
+                        .workorderId(request.workorderId())
+                        .approvalStatus(WorkorderApprovalStatus.NOT_REQUESTED)
+                        .approvalAttempts(0)
+                        .build());
+
+        row.setSupplierRef(supplierRef.value());
+        row.setStatus(WorkorderAuthorizationStatus.PENDING);
+        row.setRequestedAt(now);
+        // Cleared on re-request: a stale reason from the previous attempt read as if it described
+        // this one.
+        row.setReviewReason(null);
+        row.setReasonCode(null);
+        row.setReasonText(null);
+        row.setDecidedAt(null);
+        row.setPollLocation(null);
+        return authorizationRepository.save(row);
+    }
+
+    /**
+     * Records a decision against an existing row and publishes it if terminal.
+     *
+     * <p>Shared with the poller, so an answer that arrives synchronously and one that arrives an
+     * hour later are recorded and published by the same code. Two paths would drift, and the one
+     * that drifts is the asynchronous one, which is also the one nobody watches.
+     */
+    @Transactional
+    @NonNull
+    public SupplierWorkorderAuthorizationEntity applyDecision(
+            @NonNull SupplierWorkorderAuthorizationEntity row, @NonNull SupplierWorkorderAuthorization decision) {
+        Instant now = Instant.now(clock);
+        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
+                .findById(row.getSupplierWorkorderAuthorizationId())
+                .orElse(row);
+
+        managed.setLastPolledAt(now);
+        if (decision.vendorAuthorizationId() != null) {
+            managed.setVendorAuthorizationId(decision.vendorAuthorizationId());
+        }
+
+        switch (decision.status()) {
+            case PENDING -> {
+                managed.setStatus(WorkorderAuthorizationStatus.PENDING);
+                if (decision.pollLocation() != null) {
+                    managed.setPollLocation(decision.pollLocation());
+                }
+            }
+            case GRANTED -> {
+                managed.setStatus(WorkorderAuthorizationStatus.GRANTED);
+                managed.setContractReference(decision.contractReference());
+                managed.setAuthorizedAmount(decision.authorizedAmount());
+                managed.setCurrency(decision.currency());
+                managed.setDecidedAt(now);
+            }
+            case DENIED -> {
+                managed.setStatus(WorkorderAuthorizationStatus.DENIED);
+                managed.setReasonCode(decision.vendorReasonCode());
+                managed.setReasonText(decision.vendorReason());
+                managed.setDecidedAt(now);
+            }
+            case NOT_FOUND -> {
+                managed.setStatus(WorkorderAuthorizationStatus.NOT_FOUND);
+                managed.setReasonCode(decision.vendorReasonCode());
+                managed.setReasonText(decision.vendorReason());
+                managed.setDecidedAt(now);
+            }
+        }
+
+        SupplierWorkorderAuthorizationEntity saved = authorizationRepository.save(managed);
+
+        // Published inside the same transaction as the state change, through the outbox: a decision
+        // recorded but not published would leave the rest of the platform believing the fleet never
+        // answered (ADR-0044 §4).
+        publisher.publishIfTerminal(saved, now);
+        return saved;
+    }
+
+    /**
+     * Parks a row for a human and says why.
+     *
+     * <p>{@code REQUIRES_NEW} so the reason survives whatever the caller does next. A review reason
+     * rolled back with the transaction that discovered it is the one piece of information nobody can
+     * reconstruct afterwards.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @NonNull
+    public SupplierWorkorderAuthorizationEntity parkForReview(
+            @NonNull SupplierWorkorderAuthorizationEntity row, @NonNull String reason) {
+        SupplierWorkorderAuthorizationEntity managed = authorizationRepository
+                .findById(row.getSupplierWorkorderAuthorizationId())
+                .orElse(row);
+        managed.setStatus(WorkorderAuthorizationStatus.MANUAL_REVIEW);
+        managed.setReviewReason(truncate(reason));
+        managed.setLastPolledAt(Instant.now(clock));
+        log.warn(
+                "Workorder authorization for workorder {} at {} needs review: {}",
+                managed.getWorkorderId(),
+                managed.getSupplierRef(),
+                reason);
+        return authorizationRepository.save(managed);
+    }
+
+    /** Keeps a vendor's error text inside the column it is stored in. */
+    @NonNull
+    private static String truncate(@NonNull String reason) {
+        return reason.length() <= 1000 ? reason : reason.substring(0, 1000);
+    }
+}

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPollerTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationPollerTest.java
@@ -78,7 +78,7 @@ class WorkorderAuthorizationPollerTest {
     private SupplierBaseClient baseClient;
 
     @Mock
-    private WorkorderAuthorizationRunner runner;
+    private WorkorderAuthorizationTransactions transactions;
 
     @Captor
     private ArgumentCaptor<SupplierHttpRequest> requestCaptor;
@@ -92,7 +92,7 @@ class WorkorderAuthorizationPollerTest {
                 profileResolver,
                 adapterRegistry,
                 baseClient,
-                runner,
+                transactions,
                 Clock.fixed(NOW, ZoneOffset.UTC),
                 50,
                 PENDING_TIMEOUT);
@@ -116,7 +116,7 @@ class WorkorderAuthorizationPollerTest {
 
         poller.pollPendingAuthorizations();
 
-        verify(runner).parkForReview(any(), contains("did not decide within"));
+        verify(transactions).parkForReview(any(), contains("did not decide within"));
         verify(baseClient, never()).exchange(any());
     }
 
@@ -127,7 +127,7 @@ class WorkorderAuthorizationPollerTest {
 
         poller.pollPendingAuthorizations();
 
-        verify(runner).parkForReview(any(), contains("no poll location"));
+        verify(transactions).parkForReview(any(), contains("no poll location"));
         verify(baseClient, never()).exchange(any());
     }
 
@@ -172,7 +172,7 @@ class WorkorderAuthorizationPollerTest {
 
         poller.pollPendingAuthorizations();
 
-        verify(runner).applyDecision(any(), any());
+        verify(transactions).applyDecision(any(), any());
     }
 
     @Test
@@ -187,8 +187,8 @@ class WorkorderAuthorizationPollerTest {
         poller.pollPendingAuthorizations();
 
         assertThat(row.getStatus()).isEqualTo(WorkorderAuthorizationStatus.PENDING);
-        verify(runner, never()).applyDecision(any(), any());
-        verify(runner, never()).parkForReview(any(), any());
+        verify(transactions, never()).applyDecision(any(), any());
+        verify(transactions, never()).parkForReview(any(), any());
     }
 
     @Test
@@ -204,7 +204,7 @@ class WorkorderAuthorizationPollerTest {
 
         poller.pollPendingAuthorizations();
 
-        verify(runner).parkForReview(any(), contains("partnerId"));
+        verify(transactions).parkForReview(any(), contains("partnerId"));
         verify(baseClient, never()).exchange(any());
     }
 

--- a/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationRunnerTest.java
+++ b/pos-supplier/src/test/java/com/positivity/supplier/internal/workorderauth/service/WorkorderAuthorizationRunnerTest.java
@@ -82,13 +82,13 @@ class WorkorderAuthorizationRunnerTest {
 
     @BeforeEach
     void setUp() {
+        // A real WorkorderAuthorizationTransactions, not a mock: it holds the row-status logic these
+        // tests exercise, and it is a separate bean only so @Transactional applies (self-invocation
+        // from within WorkorderAuthorizationRunner used to bypass it -- SonarCloud java:S2229).
+        WorkorderAuthorizationTransactions transactions = new WorkorderAuthorizationTransactions(
+                authorizationRepository, publisher, Clock.fixed(NOW, ZoneOffset.UTC));
         runner = new WorkorderAuthorizationRunner(
-                profileResolver,
-                adapterRegistry,
-                baseClient,
-                authorizationRepository,
-                publisher,
-                Clock.fixed(NOW, ZoneOffset.UTC));
+                profileResolver, adapterRegistry, baseClient, authorizationRepository, transactions);
 
         when(profileResolver.resolveBinding(any(), any())).thenReturn(binding());
         when(adapterRegistry.resolve(any(), any(), any()))


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A — SonarCloud reliability cleanup, not tied to a tracked capability
- Parent STORY (durion): N/A
- Child issue: N/A
- Domain: `domain:supplier`, `domain:image`, `domain:order`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/<domain>/.business-rules/BACKEND_CONTRACT_GUIDE.md` → not applicable. `ImageContentView` matches this repo's `**/dto/**` contract-relevant path filter, but it is an internal DTO used only to carry bytes from the service layer to the controller, which serves them as a raw `Resource`; its shape is never on the wire and no OpenAPI/event contract changed.
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- Not applicable — no controller changed.

## Scope
- What changed:
  - `WorkorderAuthorizationRunner` (pos-supplier): extracted `openRow`/`applyDecision`/`parkForReview` into a new `WorkorderAuthorizationTransactions` bean. They were previously invoked as `this.openRow(...)` etc. from `requestAuthorizationRow`, which does not go through the Spring proxy — so their `@Transactional`/`REQUIRES_NEW` annotations silently never applied on that call path (java:S2229, 4 BLOCKER findings). `WorkorderAuthorizationPoller` now depends on the same bean directly for the calls it was already making correctly through an injected proxy.
  - `MktCatImporter.bodyOrThrow` (pos-supplier): captured `response.body()` in a local before the null check, so the `@NonNull` return is provably non-null from one read instead of two separate calls to the same accessor (java:S2637).
  - `ImageContentView` (pos-image): overrode `equals`/`hashCode`/`toString` so the `byte[] content` field is compared/reported by value instead of array identity, which the default record implementation used (java:S6218). Added `ImageContentViewTest` to cover the new branches, which had dropped `pos-image` below its coverage floor in CI.
  - `ProcurementAvailabilityServiceTest` (pos-order): added `hasSize(2)` before `allSatisfy(...)`, since `allSatisfy` passes vacuously on an empty list and the test's intent requires both lines to be present (java:S5841).
- Why: closes all 7 currently-open SonarCloud reliability issues on this project. The `WorkorderAuthorizationRunner` fix is the substantive one — it's a real transaction-boundary bug, not just a lint nit: the class's documented guarantees (row committed before the vendor is called; a review reason surviving in `REQUIRES_NEW`) never actually held for the self-invoked call path.

## Tests
- [x] Unit tests added/updated (`WorkorderAuthorizationRunnerTest`, `WorkorderAuthorizationPollerTest` updated for the new bean; `ImageContentViewTest` added; `ProcurementAvailabilityServiceTest` strengthened)
- [ ] Integration tests added/updated — not applicable, no new integration surface
- [ ] Provider behavioral contract tests added/updated — not applicable, no contract change
- How to run: `./mvnw -pl pos-supplier,pos-image,pos-order -am -DskipTests=false test`

## Risk & Rollback
- Risk level: Low — behavior-preserving refactor plus a DTO equality fix and test hardening; `pos-archunit` architecture tests and all touched modules' test suites, including the reactor's `jacoco:check` coverage gate, pass locally.
- Rollback plan: revert this commit; no data or schema changes.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — not applicable, this is a Sonar cleanup branch, not a capability
- [ ] PR title starts with `[CAP:<cap-id>]` — not applicable, no capability id
- [ ] Links to parent + child issues are present — not applicable
- [x] Contract guide updated (when contract semantics changed) — not applicable, confirmed no contract semantics changed (see Contract References above)
- [x] Required CI checks passing
