### PR TITLE
[CAP:1315] Owned-ATP reservation gate — pos-inventory foundation (Phase 1/3)

### DIFF
--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/BackorderCreatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/BackorderCreatedV1.java
@@ -14,29 +14,39 @@ import org.jspecify.annotations.Nullable;
  * read-side for workorder-line shortage visibility (no contract change required from workexec to
  * unblock G1).
  *
+ * <p>Schema v2 (CAP #1315): a backorder's demand line can now be a sales-order line instead of a
+ * workorder line ({@code BackorderRecord} was widened to accept either). Exactly one of
+ * {@code workorderLineId}/{@code salesOrderLineId} is non-null on every event; v1 consumers that
+ * only read {@code workorderLineId} continue to see it populated for every backorder they'd have
+ * seen before, and simply never observe the sales-order-only ones (a null they'd have to check for
+ * regardless, since v1 never guaranteed the field either way for a type it didn't know about).
+ *
  * @param backorderId backorder record identifier (aggregate id of the fact)
- * @param workorderLineId workorder line whose demand was short
+ * @param workorderLineId workorder line whose demand was short, when demand was from a workorder
+ * @param salesOrderLineId sales-order line whose demand was short, when demand was from a sales
+ *     order (additive, schema v2)
  * @param sku stock-item identifier that was short (ledger stock-item string)
  * @param quantityShort quantity that could not be fulfilled (positive)
  * @param occurredAt when the backorder was opened
  */
 public record BackorderCreatedV1(
         @NonNull UUID backorderId,
-        @NonNull UUID workorderLineId,
+        @Nullable UUID workorderLineId,
+        @Nullable UUID salesOrderLineId,
         @NonNull String sku,
         int quantityShort,
         @Nullable UUID locationId,
         @NonNull Instant occurredAt) {
 
     public static final String EVENT_TYPE = "inventory.backorder.created";
-    public static final int SCHEMA_VERSION = 1;
+    public static final int SCHEMA_VERSION = 2;
 
     public BackorderCreatedV1 {
         if (backorderId == null) {
             throw new IllegalArgumentException("backorderId must not be null");
         }
-        if (workorderLineId == null) {
-            throw new IllegalArgumentException("workorderLineId must not be null");
+        if ((workorderLineId == null) == (salesOrderLineId == null)) {
+            throw new IllegalArgumentException("exactly one of workorderLineId/salesOrderLineId must be set");
         }
         if (sku == null || sku.isBlank()) {
             throw new IllegalArgumentException("sku must not be blank");

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/BackorderResolvedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/BackorderResolvedV1.java
@@ -14,8 +14,14 @@ import org.jspecify.annotations.Nullable;
  * fact is emitted exactly once per backorder even under replayed availability signals. pos-workorder
  * consumes it read-side to clear the workorder-line shortage marker.
  *
+ * <p>Schema v2 (CAP #1315): mirrors {@link BackorderCreatedV1}'s widening — a resolved backorder's
+ * demand line can now be a sales-order line instead of a workorder line. Exactly one of
+ * {@code workorderLineId}/{@code salesOrderLineId} is non-null.
+ *
  * @param backorderId backorder record identifier (aggregate id of the fact)
- * @param workorderLineId workorder line whose demand was short
+ * @param workorderLineId workorder line whose demand was short, when demand was from a workorder
+ * @param salesOrderLineId sales-order line whose demand was short, when demand was from a sales
+ *     order (additive, schema v2)
  * @param sku stock-item identifier that was short (ledger stock-item string)
  * @param quantityShort quantity that was resolved (positive; the whole backorder)
  * @param resolutionSource what drove the resolution: {@code AVAILABILITY},
@@ -24,7 +30,8 @@ import org.jspecify.annotations.Nullable;
  */
 public record BackorderResolvedV1(
         @NonNull UUID backorderId,
-        @NonNull UUID workorderLineId,
+        @Nullable UUID workorderLineId,
+        @Nullable UUID salesOrderLineId,
         @NonNull String sku,
         int quantityShort,
         @NonNull String resolutionSource,
@@ -32,14 +39,14 @@ public record BackorderResolvedV1(
         @NonNull Instant occurredAt) {
 
     public static final String EVENT_TYPE = "inventory.backorder.resolved";
-    public static final int SCHEMA_VERSION = 1;
+    public static final int SCHEMA_VERSION = 2;
 
     public BackorderResolvedV1 {
         if (backorderId == null) {
             throw new IllegalArgumentException("backorderId must not be null");
         }
-        if (workorderLineId == null) {
-            throw new IllegalArgumentException("workorderLineId must not be null");
+        if ((workorderLineId == null) == (salesOrderLineId == null)) {
+            throw new IllegalArgumentException("exactly one of workorderLineId/salesOrderLineId must be set");
         }
         if (sku == null || sku.isBlank()) {
             throw new IllegalArgumentException("sku must not be blank");

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/ReservationOutcomeV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/ReservationOutcomeV1.java
@@ -61,6 +61,9 @@ public record ReservationOutcomeV1(
         if (!covered && backorderId == null) {
             throw new IllegalArgumentException("an uncovered outcome must carry the backorderId it opened");
         }
+        if (covered && backorderId != null) {
+            throw new IllegalArgumentException("a covered outcome must not carry a backorderId");
+        }
         if (occurredAt == null) {
             throw new IllegalArgumentException("occurredAt must not be null");
         }

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/ReservationOutcomeV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/ReservationOutcomeV1.java
@@ -1,0 +1,68 @@
+package com.positivity.domainevents.inventory;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Fact: the outcome of a demand line's reservation request (CAP #1315).
+ *
+ * <p>Published by pos-inventory on {@code inventory.events.v1} with
+ * {@code eventType = "inventory.reservation.outcome.recorded"} — one fact per reservation-request
+ * command processed. The requesting module (pos-order at checkout, pos-workorder at part-issue)
+ * consumes this to resolve the demand line out of its provisional state: {@code covered} true
+ * means owned ATP at the requested location currently covers the full quantity; false means it
+ * does not and a backorder ({@code backorderId}) was opened for the shortfall.
+ *
+ * <h2>Not a hard allocation</h2>
+ *
+ * {@code covered = true} means the site-level ledger currently has enough on-hand, net of other
+ * hard allocations there, for this quantity — the same test {@code BackorderService} already uses
+ * to decide whether a shortfall exists. It does not mean stock has been pinned to a shelf: that is
+ * a separate, later action ({@code promoteReservationAllocation}) belonging to the actual pick
+ * flow, which knows a storage location this fact's producer does not.
+ *
+ * @param reservationId the reservation this outcome is for
+ * @param workorderLineId workorder line the demand is for, when demand is from a workorder
+ * @param salesOrderLineId sales-order line the demand is for, when demand is from a sales order
+ * @param stockItemId stock-item identifier that was requested
+ * @param requiredQuantity quantity requested
+ * @param covered whether owned ATP at the requested location currently covers the full quantity
+ * @param backorderId the backorder opened for the shortfall, when {@code covered} is false
+ * @param occurredAt when the outcome was determined
+ */
+public record ReservationOutcomeV1(
+        @NonNull UUID reservationId,
+        @Nullable UUID workorderLineId,
+        @Nullable UUID salesOrderLineId,
+        @NonNull String stockItemId,
+        int requiredQuantity,
+        boolean covered,
+        @Nullable UUID backorderId,
+        @NonNull Instant occurredAt) {
+
+    public static final String EVENT_TYPE = "inventory.reservation.outcome.recorded";
+    public static final int SCHEMA_VERSION = 1;
+
+    public ReservationOutcomeV1 {
+        if (reservationId == null) {
+            throw new IllegalArgumentException("reservationId must not be null");
+        }
+        if ((workorderLineId == null) == (salesOrderLineId == null)) {
+            throw new IllegalArgumentException("exactly one of workorderLineId/salesOrderLineId must be set");
+        }
+        if (stockItemId == null || stockItemId.isBlank()) {
+            throw new IllegalArgumentException("stockItemId must not be blank");
+        }
+        if (requiredQuantity <= 0) {
+            throw new IllegalArgumentException("requiredQuantity must be positive");
+        }
+        if (!covered && backorderId == null) {
+            throw new IllegalArgumentException("an uncovered outcome must carry the backorderId it opened");
+        }
+        if (occurredAt == null) {
+            throw new IllegalArgumentException("occurredAt must not be null");
+        }
+    }
+}

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/DomainEventContractTest.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/DomainEventContractTest.java
@@ -86,7 +86,12 @@ class DomainEventContractTest {
             "com.positivity.domainevents.payment.SettlementReportedV1",
             "com.positivity.domainevents.vehicle.VehicleCarePreferenceUpdatedV1",
             "com.positivity.domainevents.inventory.ExpectedSupplyDroppedV1",
-            "com.positivity.domainevents.inventory.TransferOrderUpdatedV1");
+            "com.positivity.domainevents.inventory.TransferOrderUpdatedV1",
+            // CAP #1315: exactly one of workorderLineId/salesOrderLineId, which the blanket
+            // same-UUID-for-every-field sample generator cannot satisfy.
+            "com.positivity.domainevents.inventory.BackorderCreatedV1",
+            "com.positivity.domainevents.inventory.BackorderResolvedV1",
+            "com.positivity.domainevents.inventory.ReservationOutcomeV1");
 
     static List<Class<?>> constructibleEventRecords() {
         return eventRecords().stream()

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/BackorderCreatedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/BackorderCreatedV1Test.java
@@ -1,0 +1,62 @@
+package com.positivity.domainevents.inventory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class BackorderCreatedV1Test {
+
+    private static final ObjectMapper MAPPER =
+            JsonMapper.builder().findAndAddModules().build();
+
+    private static final UUID BACKORDER_ID = UUID.fromString("01980a58-0000-7000-8000-000000000041");
+    private static final UUID WORKORDER_LINE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000042");
+    private static final UUID SALES_ORDER_LINE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000043");
+    private static final Instant OCCURRED_AT = Instant.parse("2026-08-18T10:00:00Z");
+
+    @Test
+    void roundTripsForAWorkorderLine() {
+        BackorderCreatedV1 evt =
+                new BackorderCreatedV1(BACKORDER_ID, WORKORDER_LINE_ID, null, "SKU-1", 3, null, OCCURRED_AT);
+
+        String json = MAPPER.writeValueAsString(evt);
+        BackorderCreatedV1 back = MAPPER.readValue(json, BackorderCreatedV1.class);
+
+        assertThat(back).isEqualTo(evt);
+        assertThat(BackorderCreatedV1.EVENT_TYPE).isEqualTo("inventory.backorder.created");
+        assertThat(BackorderCreatedV1.SCHEMA_VERSION).isEqualTo(2);
+    }
+
+    @Test
+    void roundTripsForASalesOrderLine() {
+        BackorderCreatedV1 evt =
+                new BackorderCreatedV1(BACKORDER_ID, null, SALES_ORDER_LINE_ID, "SKU-1", 3, null, OCCURRED_AT);
+
+        String json = MAPPER.writeValueAsString(evt);
+        BackorderCreatedV1 back = MAPPER.readValue(json, BackorderCreatedV1.class);
+
+        assertThat(back).isEqualTo(evt);
+        assertThat(back.workorderLineId()).isNull();
+        assertThat(back.salesOrderLineId()).isEqualTo(SALES_ORDER_LINE_ID);
+    }
+
+    @Test
+    void rejectsNeitherDemandLine() {
+        assertThatThrownBy(() -> new BackorderCreatedV1(BACKORDER_ID, null, null, "SKU-1", 3, null, OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+    }
+
+    @Test
+    void rejectsBothDemandLines() {
+        assertThatThrownBy(() -> new BackorderCreatedV1(
+                        BACKORDER_ID, WORKORDER_LINE_ID, SALES_ORDER_LINE_ID, "SKU-1", 3, null, OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+    }
+}

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/BackorderResolvedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/BackorderResolvedV1Test.java
@@ -1,0 +1,71 @@
+package com.positivity.domainevents.inventory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class BackorderResolvedV1Test {
+
+    private static final ObjectMapper MAPPER =
+            JsonMapper.builder().findAndAddModules().build();
+
+    private static final UUID BACKORDER_ID = UUID.fromString("01980a58-0000-7000-8000-000000000051");
+    private static final UUID WORKORDER_LINE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000052");
+    private static final UUID SALES_ORDER_LINE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000053");
+    private static final UUID LOCATION_ID = UUID.fromString("01980a58-0000-7000-8000-000000000054");
+    private static final Instant OCCURRED_AT = Instant.parse("2026-08-18T10:00:00Z");
+
+    @Test
+    void roundTripsForAWorkorderLine() {
+        BackorderResolvedV1 evt = new BackorderResolvedV1(
+                BACKORDER_ID, WORKORDER_LINE_ID, null, "SKU-1", 3, "AVAILABILITY", LOCATION_ID, OCCURRED_AT);
+
+        String json = MAPPER.writeValueAsString(evt);
+        BackorderResolvedV1 back = MAPPER.readValue(json, BackorderResolvedV1.class);
+
+        assertThat(back).isEqualTo(evt);
+        assertThat(BackorderResolvedV1.EVENT_TYPE).isEqualTo("inventory.backorder.resolved");
+        assertThat(BackorderResolvedV1.SCHEMA_VERSION).isEqualTo(2);
+    }
+
+    @Test
+    void roundTripsForASalesOrderLine() {
+        BackorderResolvedV1 evt = new BackorderResolvedV1(
+                BACKORDER_ID, null, SALES_ORDER_LINE_ID, "SKU-1", 3, "REPLENISHMENT_RECEIPT", LOCATION_ID, OCCURRED_AT);
+
+        String json = MAPPER.writeValueAsString(evt);
+        BackorderResolvedV1 back = MAPPER.readValue(json, BackorderResolvedV1.class);
+
+        assertThat(back).isEqualTo(evt);
+        assertThat(back.workorderLineId()).isNull();
+        assertThat(back.salesOrderLineId()).isEqualTo(SALES_ORDER_LINE_ID);
+    }
+
+    @Test
+    void rejectsNeitherDemandLine() {
+        assertThatThrownBy(() -> new BackorderResolvedV1(
+                        BACKORDER_ID, null, null, "SKU-1", 3, "MANUAL", LOCATION_ID, OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+    }
+
+    @Test
+    void rejectsBothDemandLines() {
+        assertThatThrownBy(() -> new BackorderResolvedV1(
+                        BACKORDER_ID,
+                        WORKORDER_LINE_ID,
+                        SALES_ORDER_LINE_ID,
+                        "SKU-1",
+                        3,
+                        "MANUAL",
+                        LOCATION_ID,
+                        OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+    }
+}

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/ReservationOutcomeV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/ReservationOutcomeV1Test.java
@@ -70,4 +70,12 @@ class ReservationOutcomeV1Test {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("backorderId");
     }
+
+    @Test
+    void rejectsCoveredWithBackorderId() {
+        assertThatThrownBy(() -> new ReservationOutcomeV1(
+                        RESERVATION_ID, WORKORDER_LINE_ID, null, "SKU-1", 3, true, BACKORDER_ID, OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("backorderId");
+    }
 }

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/ReservationOutcomeV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/ReservationOutcomeV1Test.java
@@ -1,0 +1,73 @@
+package com.positivity.domainevents.inventory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class ReservationOutcomeV1Test {
+
+    private static final ObjectMapper MAPPER =
+            JsonMapper.builder().findAndAddModules().build();
+
+    private static final UUID RESERVATION_ID = UUID.fromString("01980a58-0000-7000-8000-000000000061");
+    private static final UUID WORKORDER_LINE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000062");
+    private static final UUID SALES_ORDER_LINE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000063");
+    private static final UUID BACKORDER_ID = UUID.fromString("01980a58-0000-7000-8000-000000000064");
+    private static final Instant OCCURRED_AT = Instant.parse("2026-08-18T10:00:00Z");
+
+    @Test
+    void roundTripsCoveredForAWorkorderLine() {
+        ReservationOutcomeV1 evt =
+                new ReservationOutcomeV1(RESERVATION_ID, WORKORDER_LINE_ID, null, "SKU-1", 3, true, null, OCCURRED_AT);
+
+        String json = MAPPER.writeValueAsString(evt);
+        ReservationOutcomeV1 back = MAPPER.readValue(json, ReservationOutcomeV1.class);
+
+        assertThat(back).isEqualTo(evt);
+        assertThat(ReservationOutcomeV1.EVENT_TYPE).isEqualTo("inventory.reservation.outcome.recorded");
+        assertThat(ReservationOutcomeV1.SCHEMA_VERSION).isEqualTo(1);
+    }
+
+    @Test
+    void roundTripsUncoveredForASalesOrderLine() {
+        ReservationOutcomeV1 evt = new ReservationOutcomeV1(
+                RESERVATION_ID, null, SALES_ORDER_LINE_ID, "SKU-1", 3, false, BACKORDER_ID, OCCURRED_AT);
+
+        String json = MAPPER.writeValueAsString(evt);
+        ReservationOutcomeV1 back = MAPPER.readValue(json, ReservationOutcomeV1.class);
+
+        assertThat(back).isEqualTo(evt);
+        assertThat(back.workorderLineId()).isNull();
+        assertThat(back.salesOrderLineId()).isEqualTo(SALES_ORDER_LINE_ID);
+        assertThat(back.backorderId()).isEqualTo(BACKORDER_ID);
+    }
+
+    @Test
+    void rejectsNeitherDemandLine() {
+        assertThatThrownBy(
+                        () -> new ReservationOutcomeV1(RESERVATION_ID, null, null, "SKU-1", 3, true, null, OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+    }
+
+    @Test
+    void rejectsBothDemandLines() {
+        assertThatThrownBy(() -> new ReservationOutcomeV1(
+                        RESERVATION_ID, WORKORDER_LINE_ID, SALES_ORDER_LINE_ID, "SKU-1", 3, true, null, OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+    }
+
+    @Test
+    void rejectsUncoveredWithoutBackorderId() {
+        assertThatThrownBy(() -> new ReservationOutcomeV1(
+                        RESERVATION_ID, WORKORDER_LINE_ID, null, "SKU-1", 3, false, null, OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("backorderId");
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/config/InventoryCommandListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/config/InventoryCommandListener.java
@@ -7,6 +7,7 @@ import com.positivity.inventory.internal.repository.ProcessedEventRepository;
 import com.positivity.inventory.service.ConsumptionService;
 import com.positivity.inventory.service.OutboxReplayService;
 import com.positivity.inventory.service.PickListService;
+import com.positivity.inventory.service.ReservationRequestService;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -44,6 +45,10 @@ import tools.jackson.databind.ObjectMapper;
  * replaces {@code InventoryPickClient.consumePickedItems}); same idempotency, the
  * {@code inventory.consumption.recorded} fact carries the result.</li>
  * <li>{@code inventory.pick-list.release-requested} — async pick-list release (#901).</li>
+ * <li>{@code inventory.reservation.request-requested} — the ATP-gate commitment point for
+ * pos-order (checkout) and pos-workorder (part-issue), CAP #1315. Delegates to
+ * {@code ReservationRequestService}; the resulting {@code inventory.reservation.outcome.recorded}
+ * fact tells the requester whether owned ATP covered the line or a backorder was opened.</li>
  * </ul>
  *
  * <p>Business validation failures (scan mismatch, not-picked, over-consumption) are permanent:
@@ -68,6 +73,9 @@ public class InventoryCommandListener {
     /** Canonical dotted name normalized: inventory.items.consume-requested. */
     private static final String COMMAND_ITEMS_CONSUME_REQUESTED = "INVENTORY_ITEMS_CONSUME_REQUESTED";
 
+    /** Canonical dotted name normalized: inventory.reservation.request-requested (CAP #1315). */
+    private static final String COMMAND_RESERVATION_REQUEST_REQUESTED = "INVENTORY_RESERVATION_REQUEST_REQUESTED";
+
     static final String COMMANDS_OWNER = "inventory-commands";
 
     /** Covers the sub-millisecond skew between outbox createdAt and the eventId timestamp. */
@@ -82,6 +90,7 @@ public class InventoryCommandListener {
     private final OutboxReplayService outboxReplayService;
     private final PickListService pickListService;
     private final ConsumptionService consumptionService;
+    private final ReservationRequestService reservationRequestHandler;
     private final ProcessedEventRepository processedEventRepository;
 
     @KafkaListener(
@@ -114,6 +123,10 @@ public class InventoryCommandListener {
             }
             if (COMMAND_ITEMS_CONSUME_REQUESTED.equals(commandType)) {
                 handleDeduplicated(root, this::handleItemsConsumeRequested);
+                return;
+            }
+            if (COMMAND_RESERVATION_REQUEST_REQUESTED.equals(commandType)) {
+                handleDeduplicated(root, this::handleReservationRequestRequested);
                 return;
             }
             log.debug("Ignoring unsupported commandType={} message={}", commandType, message);
@@ -243,6 +256,32 @@ public class InventoryCommandListener {
                 workorderId,
                 pickListId,
                 response.getTotalItemsConsumed());
+    }
+
+    private void handleReservationRequestRequested(@NonNull JsonNode payload) {
+        UUID workorderLineId = parseUuid(payload, "workorderLineId");
+        UUID salesOrderLineId = parseUuid(payload, "salesOrderLineId");
+        UUID stockItemId = parseUuid(payload, "stockItemId");
+        UUID locationId = parseUuid(payload, "locationId");
+        int requiredQuantity = payload.path("requiredQuantity").intValue(0);
+        if ((workorderLineId == null) == (salesOrderLineId == null)) {
+            log.warn(
+                    "Ignoring reservation-request command: exactly one of workorderLineId/salesOrderLineId must be"
+                            + " set: {}",
+                    payload);
+            return;
+        }
+        if (stockItemId == null || locationId == null || requiredQuantity <= 0) {
+            log.warn("Ignoring reservation-request command with missing/invalid fields: {}", payload);
+            return;
+        }
+        reservationRequestHandler.handle(workorderLineId, salesOrderLineId, stockItemId, requiredQuantity, locationId);
+        log.info(
+                "Reservation request command processed demandLine={} sku={} qty={} locationId={}",
+                workorderLineId != null ? workorderLineId : salesOrderLineId,
+                stockItemId,
+                requiredQuantity,
+                locationId);
     }
 
     private @Nullable UUID parseUuid(@Nullable JsonNode node, @NonNull String field) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/BackorderController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/BackorderController.java
@@ -62,14 +62,15 @@ public class BackorderController {
             operationId = "listBackorders",
             summary = "List backorders",
             description = """
-                    Lists backorders — unfulfilled workorder-line demand held open until availability covers it — \
-                    newest first.
+                    Lists backorders — unfulfilled demand (a workorder line or, since CAP #1315, a sales-order \
+                    line) held open until availability covers it — newest first.
                     Use this tool to monitor open shortages awaiting stock; use getBackorder instead when the \
                     backorderId is already known, and note backorders are opened by the shortage flows \
-                    (resolveShortage with BACKORDER), not by any direct create endpoint.
+                    (resolveShortage with BACKORDER) or the sales-order checkout gate, not by any direct create \
+                    endpoint.
                     Preconditions: none; an empty result is not an error.
-                    Required inputs: none — status (OPEN, RESOLVED or CANCELLED), sku, locationId and \
-                    workorderLineId are optional filters combined with AND.
+                    Required inputs: none — status (OPEN, RESOLVED or CANCELLED), sku, locationId, \
+                    workorderLineId and salesOrderLineId are optional filters combined with AND.
                     No events are emitted and no state changes; this is a read-only projection.
                     Returns 200 with an empty array when nothing matches.
                     """,
@@ -87,8 +88,11 @@ public class BackorderController {
             @Parameter(description = "Filter by SKU / stock-item identifier") @RequestParam(required = false)
                     String sku,
             @Parameter(description = "Filter by site") @RequestParam(required = false) UUID locationId,
-            @Parameter(description = "Filter by workorder line") @RequestParam(required = false) UUID workorderLineId) {
-        return ResponseEntity.ok(backorderService.listBackorders(status, sku, locationId, workorderLineId));
+            @Parameter(description = "Filter by workorder line") @RequestParam(required = false) UUID workorderLineId,
+            @Parameter(description = "Filter by sales-order line (CAP #1315)") @RequestParam(required = false)
+                    UUID salesOrderLineId) {
+        return ResponseEntity.ok(
+                backorderService.listBackorders(status, sku, locationId, workorderLineId, salesOrderLineId));
     }
 
     /**

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReservationController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ReservationController.java
@@ -211,4 +211,39 @@ public class ReservationController {
         reservationService.cancelReservation(workorderLineId);
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/sales-order-line/{salesOrderLineId}")
+    @EmitEvent(id = "INVENTORY_RESERVATION_CANCEL_SALES_ORDER_LINE", apiVersion = "1")
+    @PreAuthorize("hasAuthority('" + InventoryPermissionRegistry.ADJUSTMENT_CREATE + "')")
+    @Operation(
+            operationId = "cancelReservationForSalesOrderLine",
+            summary = "Cancel reservation by sales-order line",
+            description = """
+                    Cancels the reservation for a sales-order line (CAP #1315) and releases every allocation \
+                    under it — the sales-order-demand counterpart of cancelReservation.
+                    Use this tool when sales-order demand is withdrawn; do not use cancelReservation, whose path \
+                    parameter is a workorderLineId and which finds nothing for a sales-order line.
+                    Preconditions: a reservation must exist for the sales-order line.
+                    Required inputs: salesOrderLineId (UUID) path parameter; there is no request body.
+                    Emits an INVENTORY_RESERVATION_CANCEL_SALES_ORDER_LINE event; every allocation is marked \
+                    RELEASED, located HARD allocations get ALLOCATION_RELEASED ledger entries for their \
+                    un-released remainder only, and the reservation ends CANCELLED with allocatedQuantity 0.
+                    Returns 404 when no reservation exists for the sales-order line.
+                    """,
+            tags = {"Inventory Reservations"})
+    @ApiResponse(responseCode = "204", description = "Reservation cancelled")
+    @ApiResponse(
+            responseCode = "403",
+            description = "User lacks required reservation authority",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    @ApiResponse(
+            responseCode = "404",
+            description = "Reservation not found",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)))
+    public ResponseEntity<Void> cancelReservationForSalesOrderLine(
+            @Parameter(description = "Sales-order line identifier", required = true) @PathVariable
+                    UUID salesOrderLineId) {
+        reservationService.cancelReservationForSalesOrderLine(salesOrderLineId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/backorder/BackorderResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/backorder/BackorderResponse.java
@@ -20,8 +20,14 @@ public class BackorderResponse {
     @Schema(description = "Backorder record identifier")
     private UUID backorderId;
 
-    @Schema(description = "Workorder line whose demand was short")
+    @Schema(description = "Workorder line whose demand was short, when demand was from a workorder; null otherwise")
     private UUID workorderLineId;
+
+    @Schema(
+            description =
+                    "Sales-order line whose demand was short (CAP #1315), when demand was from a sales order; null"
+                            + " otherwise")
+    private UUID salesOrderLineId;
 
     @Schema(description = "SKU / stock-item identifier that was short")
     private String sku;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/reservation/CreateReservationRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/reservation/CreateReservationRequest.java
@@ -1,5 +1,6 @@
 package com.positivity.inventory.internal.dto.reservation;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,15 +14,25 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(description = "Request to create an inventory reservation against a workorder line for a stock item")
+@Schema(
+        description = "Request to create an inventory reservation against a demand line (a workorder line or a"
+                + " sales-order line, CAP #1315) for a stock item. Exactly one of workorderLineId/salesOrderLineId"
+                + " must be set; the service rejects a request that sets both or neither.")
 public class CreateReservationRequest {
 
     @Schema(
-            description = "Identifier of the workorder line the reservation fulfils",
+            description = "Identifier of the workorder line the reservation fulfils, when demand is from a"
+                    + " workorder. Exactly one of this and salesOrderLineId must be set.",
             example = "01960003-0000-7000-8000-000000000001",
-            requiredMode = REQUIRED)
-    @NotNull
+            requiredMode = NOT_REQUIRED)
     private UUID workorderLineId;
+
+    @Schema(
+            description = "Identifier of the sales-order line the reservation fulfils, when demand is from a sales"
+                    + " order (CAP #1315). Exactly one of this and workorderLineId must be set.",
+            example = "01960003-0000-7000-8000-000000000004",
+            requiredMode = NOT_REQUIRED)
+    private UUID salesOrderLineId;
 
     @Schema(
             description = "Identifier of the stock item being reserved",
@@ -36,4 +47,12 @@ public class CreateReservationRequest {
             requiredMode = REQUIRED)
     @Positive
     private int requiredQuantity;
+
+    /**
+     * Workorder-line convenience constructor, predating the CAP #1315 sales-order-line addition.
+     * Equivalent to the all-args constructor with {@code salesOrderLineId = null}.
+     */
+    public CreateReservationRequest(UUID workorderLineId, UUID stockItemId, int requiredQuantity) {
+        this(workorderLineId, null, stockItemId, requiredQuantity);
+    }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/reservation/ReservationResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/reservation/ReservationResponse.java
@@ -21,11 +21,16 @@ public class ReservationResponse {
     private UUID reservationId;
 
     @Schema(
-            description = "Identifier of the workorder line the reservation fulfils",
-            example = "01960003-0000-7000-8000-000000000002",
-            requiredMode = REQUIRED)
-    @NotNull
+            description = "Identifier of the workorder line the reservation fulfils, when demand is from a"
+                    + " workorder; null when demand is from a sales order instead.",
+            example = "01960003-0000-7000-8000-000000000002")
     private UUID workorderLineId;
+
+    @Schema(
+            description = "Identifier of the sales-order line the reservation fulfils (CAP #1315), when demand is"
+                    + " from a sales order; null when demand is from a workorder instead.",
+            example = "01960003-0000-7000-8000-000000000005")
+    private UUID salesOrderLineId;
 
     @Schema(
             description = "Identifier of the stock item being reserved",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/BackorderRecord.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/BackorderRecord.java
@@ -45,7 +45,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
         indexes = {
             @Index(name = "idx_backorder_record_status", columnList = "status"),
             @Index(name = "idx_backorder_record_sku_location_status", columnList = "sku, location_id, status"),
-            @Index(name = "idx_backorder_record_workorder_line", columnList = "workorder_line_id")
+            @Index(name = "idx_backorder_record_workorder_line", columnList = "workorder_line_id"),
+            @Index(name = "idx_backorder_record_sales_order_line", columnList = "sales_order_line_id")
         })
 @Data
 @NoArgsConstructor
@@ -59,9 +60,20 @@ public class BackorderRecord {
     @UUIDv7Id
     private UUID backorderId;
 
-    /** Workorder line whose demand was short; the backorder→demand linkage key. */
-    @Column(name = "workorder_line_id", nullable = false)
+    /**
+     * Workorder line whose demand was short, when demand came from a workorder. Exactly one of
+     * this and {@link #salesOrderLineId} is set (CAP #1315 widened this table to accept either
+     * demand source; DB CHECK enforces the invariant).
+     */
+    @Column(name = "workorder_line_id")
     private UUID workorderLineId;
+
+    /**
+     * Sales-order line whose demand was short, when demand came from a sales order (CAP #1315).
+     * Exactly one of this and {@link #workorderLineId} is set.
+     */
+    @Column(name = "sales_order_line_id")
+    private UUID salesOrderLineId;
 
     /** SKU / stock-item identifier that was short (ledger stock-item string). */
     @Column(name = "sku", nullable = false)
@@ -106,4 +118,10 @@ public class BackorderRecord {
     /** When the backorder reached RESOLVED; null otherwise. */
     @Column(name = "resolved_at")
     private Instant resolvedAt;
+
+    /** Whichever demand line this backorder is actually keyed on (CAP #1315). */
+    @jakarta.persistence.Transient
+    public UUID getDemandLineId() {
+        return workorderLineId != null ? workorderLineId : salesOrderLineId;
+    }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ReservationEntity.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ReservationEntity.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,8 +40,21 @@ public class ReservationEntity {
     @UUIDv7Id
     private UUID reservationId;
 
-    @Column(nullable = false, unique = true)
+    /**
+     * The workorder line this reservation fulfils, when demand came from a workorder. Exactly one
+     * of this and {@link #salesOrderLineId} is set (CAP #1315 widened this table to accept either
+     * demand source; DB CHECK enforces the invariant, a partial unique index per column enforces
+     * one reservation per line either way).
+     */
+    @Column(name = "workorder_line_id")
     private UUID workorderLineId;
+
+    /**
+     * The sales-order line this reservation fulfils, when demand came from a sales order (CAP
+     * #1315). Exactly one of this and {@link #workorderLineId} is set.
+     */
+    @Column(name = "sales_order_line_id")
+    private UUID salesOrderLineId;
 
     @Column(name = "stock_item_id", nullable = false)
     private UUID stockItemId;
@@ -80,4 +94,14 @@ public class ReservationEntity {
     @OneToMany(mappedBy = "reservation", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @Builder.Default
     private List<AllocationEntity> allocations = new ArrayList<>();
+
+    /**
+     * Whichever demand line this reservation is actually keyed on (CAP #1315). Fairness/priority
+     * logic that only cares "which demand line" — not which kind — reads this instead of branching
+     * on both fields.
+     */
+    @Transient
+    public UUID getDemandLineId() {
+        return workorderLineId != null ? workorderLineId : salesOrderLineId;
+    }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/BackorderRecordRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/BackorderRecordRepository.java
@@ -21,6 +21,10 @@ public interface BackorderRecordRepository
     Optional<BackorderRecord> findByWorkorderLineIdAndSkuAndStatus(
             UUID workorderLineId, String sku, BackorderStatus status);
 
+    /** Duplicate-open guard for the sales-order demand key (CAP #1315). */
+    Optional<BackorderRecord> findBySalesOrderLineIdAndSkuAndStatus(
+            UUID salesOrderLineId, String sku, BackorderStatus status);
+
     /**
      * Open backorders for one SKU at one site, oldest-first — the auto-resolution candidate set
      * (odoo-parity G1). Base ordering is {@code createdAt ASC}; the service refines it with the

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ReservationRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ReservationRepository.java
@@ -17,6 +17,15 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
 
     Optional<ReservationEntity> findByWorkorderLineId(UUID workorderLineId);
 
+    Optional<ReservationEntity> findBySalesOrderLineId(UUID salesOrderLineId);
+
+    /**
+     * Looks a reservation up by whichever demand line it's keyed on (CAP #1315): pass the same id
+     * for both parameters when the caller only knows "this line id," not which kind it is. Safe
+     * because the two id spaces never collide — each is independently minted by its own module.
+     */
+    Optional<ReservationEntity> findByWorkorderLineIdOrSalesOrderLineId(UUID workorderLineId, UUID salesOrderLineId);
+
     /**
      * Open reservation remainders for one SKU (odoo-parity A2, issue #1028): sum of
      * {@code requiredQuantity - allocatedQuantity} (per reservation, floored at zero) over

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/BackorderServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/BackorderServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
@@ -87,6 +88,47 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
     @Override
     public @NonNull BackorderResponse createBackorder(
             @NonNull UUID workorderLineId, @NonNull String sku, int quantityShort, @Nullable UUID locationId) {
+        return createBackorder(
+                workorderLineId,
+                null,
+                sku,
+                quantityShort,
+                locationId,
+                () -> backorderRepository.findByWorkorderLineIdAndSkuAndStatus(
+                        workorderLineId, sku, BackorderStatus.OPEN),
+                "workorderLine",
+                workorderLineId);
+    }
+
+    @Override
+    public @NonNull BackorderResponse createBackorderForSalesOrderLine(
+            @NonNull UUID salesOrderLineId, @NonNull String sku, int quantityShort, @Nullable UUID locationId) {
+        return createBackorder(
+                null,
+                salesOrderLineId,
+                sku,
+                quantityShort,
+                locationId,
+                () -> backorderRepository.findBySalesOrderLineIdAndSkuAndStatus(
+                        salesOrderLineId, sku, BackorderStatus.OPEN),
+                "salesOrderLine",
+                salesOrderLineId);
+    }
+
+    /**
+     * Shared open-or-create path for both demand kinds (CAP #1315): the idempotent-open-guard
+     * lookup differs by which column is keyed, so the caller supplies it; everything after — the
+     * row shape, the ledger entry, the fact — is identical regardless of demand kind.
+     */
+    private BackorderResponse createBackorder(
+            @Nullable UUID workorderLineId,
+            @Nullable UUID salesOrderLineId,
+            @NonNull String sku,
+            int quantityShort,
+            @Nullable UUID locationId,
+            Supplier<Optional<BackorderRecord>> findExistingOpen,
+            String demandLineLabel,
+            UUID demandLineId) {
         if (sku.isBlank()) {
             throw new IllegalArgumentException("sku must not be blank");
         }
@@ -94,16 +136,16 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
             throw new IllegalArgumentException("quantityShort must be positive");
         }
 
-        Optional<BackorderRecord> existingOpen =
-                backorderRepository.findByWorkorderLineIdAndSkuAndStatus(workorderLineId, sku, BackorderStatus.OPEN);
+        Optional<BackorderRecord> existingOpen = findExistingOpen.get();
         if (existingOpen.isPresent()) {
-            log.info("Backorder already OPEN for workorderLine {} sku {}; returning existing", workorderLineId, sku);
+            log.info("Backorder already OPEN for {} {} sku {}; returning existing", demandLineLabel, demandLineId, sku);
             return toResponse(existingOpen.get());
         }
 
         String actor = SecurityContextHelper.getCurrentUsernameOrDefault(SYSTEM_ACTOR);
         BackorderRecord backorder = backorderRepository.save(BackorderRecord.builder()
                 .workorderLineId(workorderLineId)
+                .salesOrderLineId(salesOrderLineId)
                 .sku(sku)
                 .locationId(locationId)
                 .quantityShort(quantityShort)
@@ -117,12 +159,19 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
         backorder = backorderRepository.save(backorder);
 
         inventoryFactPublisher.recordBackorderCreated(new BackorderCreatedV1(
-                backorder.getBackorderId(), workorderLineId, sku, quantityShort, locationId, Instant.now(clock)));
-
-        log.info(
-                "Backorder {} opened for workorderLine {} sku {} qtyShort {} at {}",
                 backorder.getBackorderId(),
                 workorderLineId,
+                salesOrderLineId,
+                sku,
+                quantityShort,
+                locationId,
+                Instant.now(clock)));
+
+        log.info(
+                "Backorder {} opened for {} {} sku {} qtyShort {} at {}",
+                backorder.getBackorderId(),
+                demandLineLabel,
+                demandLineId,
                 sku,
                 quantityShort,
                 locationId);
@@ -154,7 +203,7 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
                 continue;
             }
             try {
-                resolve(backorder, reservations.get(backorder.getWorkorderLineId()), now);
+                resolve(backorder, reservations.get(backorder.getDemandLineId()), now);
                 budget -= shortage;
             } catch (RuntimeException e) {
                 // Best-effort per candidate: one bad backorder must not roll back the inbound posting.
@@ -187,6 +236,7 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
         inventoryFactPublisher.recordBackorderResolved(new BackorderResolvedV1(
                 backorder.getBackorderId(),
                 backorder.getWorkorderLineId(),
+                backorder.getSalesOrderLineId(),
                 backorder.getSku(),
                 backorder.getQuantityShort(),
                 BackorderResolutionSource.AVAILABILITY.name(),
@@ -194,9 +244,9 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
                 now));
 
         log.info(
-                "Backorder {} auto-resolved (AVAILABILITY) for workorderLine {} sku {} qty {} at {}",
+                "Backorder {} auto-resolved (AVAILABILITY) for demand line {} sku {} qty {} at {}",
                 backorder.getBackorderId(),
-                backorder.getWorkorderLineId(),
+                backorder.getDemandLineId(),
                 backorder.getSku(),
                 backorder.getQuantityShort(),
                 backorder.getLocationId());
@@ -216,7 +266,8 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
             @Nullable BackorderStatus status,
             @Nullable String sku,
             @Nullable UUID locationId,
-            @Nullable UUID workorderLineId) {
+            @Nullable UUID workorderLineId,
+            @Nullable UUID salesOrderLineId) {
         Specification<BackorderRecord> spec = (root, query, cb) -> cb.conjunction();
         if (status != null) {
             spec = spec.and((root, query, cb) -> cb.equal(root.get("status"), status));
@@ -229,6 +280,9 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
         }
         if (workorderLineId != null) {
             spec = spec.and((root, query, cb) -> cb.equal(root.get("workorderLineId"), workorderLineId));
+        }
+        if (salesOrderLineId != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("salesOrderLineId"), salesOrderLineId));
         }
         return backorderRepository.findAll(spec, Sort.by(Sort.Direction.DESC, "createdAt")).stream()
                 .map(this::toResponse)
@@ -273,14 +327,16 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
     }
 
     private Map<UUID, ReservationEntity> loadBackingReservations(List<BackorderRecord> backorders) {
-        Map<UUID, ReservationEntity> byWorkorderLine = new HashMap<>();
+        Map<UUID, ReservationEntity> byDemandLine = new HashMap<>();
         for (BackorderRecord backorder : backorders) {
-            byWorkorderLine.computeIfAbsent(
-                    backorder.getWorkorderLineId(),
-                    lineId ->
-                            reservationRepository.findByWorkorderLineId(lineId).orElse(null));
+            UUID demandLineId = backorder.getDemandLineId();
+            byDemandLine.computeIfAbsent(
+                    demandLineId,
+                    lineId -> reservationRepository
+                            .findByWorkorderLineIdOrSalesOrderLineId(lineId, lineId)
+                            .orElse(null));
         }
-        return byWorkorderLine;
+        return byDemandLine;
     }
 
     /**
@@ -291,10 +347,10 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
      */
     private Comparator<BackorderRecord> oldestPriorityFirst(Map<UUID, ReservationEntity> reservations, Instant now) {
         return Comparator.comparingInt(
-                        (BackorderRecord b) -> effectivePriority(reservations.get(b.getWorkorderLineId()), now))
-                .thenComparing(b -> dueDate(reservations.get(b.getWorkorderLineId())))
-                .thenComparing(b -> waitingSince(reservations.get(b.getWorkorderLineId()), b))
-                .thenComparing(b -> scheduleStart(reservations.get(b.getWorkorderLineId())))
+                        (BackorderRecord b) -> effectivePriority(reservations.get(b.getDemandLineId()), now))
+                .thenComparing(b -> dueDate(reservations.get(b.getDemandLineId())))
+                .thenComparing(b -> waitingSince(reservations.get(b.getDemandLineId()), b))
+                .thenComparing(b -> scheduleStart(reservations.get(b.getDemandLineId())))
                 .thenComparing(BackorderRecord::getCreatedAt);
     }
 
@@ -338,6 +394,7 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
         return BackorderResponse.builder()
                 .backorderId(backorder.getBackorderId())
                 .workorderLineId(backorder.getWorkorderLineId())
+                .salesOrderLineId(backorder.getSalesOrderLineId())
                 .sku(backorder.getSku())
                 .locationId(backorder.getLocationId())
                 .quantityShort(backorder.getQuantityShort())

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryFactPublisher.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryFactPublisher.java
@@ -11,6 +11,7 @@ import com.positivity.domainevents.inventory.LotExpiryAlertV1;
 import com.positivity.domainevents.inventory.PickListUpdatedV1;
 import com.positivity.domainevents.inventory.PickTaskUpdatedV1;
 import com.positivity.domainevents.inventory.ProductValueChangedV1;
+import com.positivity.domainevents.inventory.ReservationOutcomeV1;
 import com.positivity.domainevents.inventory.ScrapPostedV1;
 import com.positivity.domainevents.inventory.StorageLocationOnHandUpdatedV1;
 import com.positivity.domainevents.inventory.TransferOrderUpdatedV1;
@@ -223,6 +224,19 @@ public class InventoryFactPublisher {
             return;
         }
         pending.backorderResolutions.add(fact);
+    }
+
+    /**
+     * Record a reservation-request outcome fact (CAP #1315): the requesting module's demand line
+     * either is currently covered by owned ATP, or was not and a backorder was opened for the
+     * shortfall. Queued as-is — one outcome per reservation-request command processed.
+     */
+    public void recordReservationOutcome(@NonNull ReservationOutcomeV1 fact) {
+        Pending pending = pending();
+        if (pending == null) {
+            return;
+        }
+        pending.reservationOutcomes.add(fact);
     }
 
     /**
@@ -440,6 +454,21 @@ public class InventoryFactPublisher {
                         "Skipping backorder-resolved fact for {}: {}", backorderResolved.backorderId(), e.getMessage());
             }
         }
+        for (ReservationOutcomeV1 reservationOutcome : pending.reservationOutcomes) {
+            try {
+                publish(
+                        writer,
+                        ReservationOutcomeV1.EVENT_TYPE,
+                        ReservationOutcomeV1.SCHEMA_VERSION,
+                        reservationOutcome.reservationId(),
+                        reservationOutcome);
+            } catch (Exception e) {
+                log.warn(
+                        "Skipping reservation-outcome fact for {}: {}",
+                        reservationOutcome.reservationId(),
+                        e.getMessage());
+            }
+        }
         for (LotExpiryAlertV1 lotExpiryAlert : pending.lotExpiryAlerts) {
             try {
                 publish(
@@ -519,6 +548,7 @@ public class InventoryFactPublisher {
         private final List<TransferOrderUpdatedV1> transferOrderUpdates = new ArrayList<>();
         private final List<BackorderCreatedV1> backorderCreations = new ArrayList<>();
         private final List<BackorderResolvedV1> backorderResolutions = new ArrayList<>();
+        private final List<ReservationOutcomeV1> reservationOutcomes = new ArrayList<>();
         private final List<LotExpiryAlertV1> lotExpiryAlerts = new ArrayList<>();
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationRequestHandler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationRequestHandler.java
@@ -1,0 +1,155 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.domainevents.inventory.ReservationOutcomeV1;
+import com.positivity.inventory.internal.dto.backorder.BackorderResponse;
+import com.positivity.inventory.internal.dto.reservation.CreateReservationRequest;
+import com.positivity.inventory.internal.dto.reservation.ReservationResponse;
+import com.positivity.inventory.internal.entity.ReservationEntity;
+import com.positivity.inventory.internal.enums.ReservationStatus;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import com.positivity.inventory.internal.repository.ReservationRepository;
+import com.positivity.inventory.service.BackorderService;
+import com.positivity.inventory.service.ReservationRequestService;
+import com.positivity.inventory.service.ReservationService;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Handles {@code inventory.reservation.request-requested} commands (CAP #1315): the ATP-gate
+ * commitment point for pos-order (checkout) and pos-workorder (part-issue).
+ *
+ * <h2>Site-level, not shelf-level</h2>
+ *
+ * This deliberately never calls {@code ReservationService#promoteToHard}. Hard promotion pins an
+ * allocation to a specific storage location and writes an {@code ALLOCATION_CREATED} ledger entry
+ * — a warehouse-picking decision that belongs to the actual pick flow, which knows which shelf,
+ * not to a checkout or a part-issue action that only knows a site. Sufficiency here is judged the
+ * same way {@link BackorderService}'s own auto-resolution judges it: site-level on-hand net of
+ * existing hard allocations, from {@code InventoryStockSummaryRepository}. A later, separate pick
+ * still hardens the allocation to a real shelf when the goods actually move.
+ *
+ * <h2>Always registers demand, regardless of outcome</h2>
+ *
+ * {@link ReservationService#createOrUpdateReservation} is called first and unconditionally — it
+ * performs no ATP check by design, so the demand is always recorded. Only then is site ATP
+ * evaluated to decide {@code covered} vs. opening a backorder for the shortfall. A caller that
+ * requests the same demand line again (redelivery, or a quantity update) updates the existing
+ * reservation rather than duplicating it.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class ReservationRequestHandler implements ReservationRequestService {
+
+    private final ReservationService reservationService;
+    private final BackorderService backorderService;
+    private final ReservationRepository reservationRepository;
+    private final InventoryStockSummaryRepository summaryRepository;
+    private final InventoryFactPublisher inventoryFactPublisher;
+    private final Clock clock;
+
+    /**
+     * Registers demand for one line and evaluates whether owned ATP at {@code locationId} covers
+     * it, publishing a {@link ReservationOutcomeV1} fact either way.
+     *
+     * @param workorderLineId workorder line the demand is for, when demand is from a workorder
+     * @param salesOrderLineId sales-order line the demand is for, when demand is from a sales order
+     * @param stockItemId stock item requested
+     * @param requiredQuantity quantity requested
+     * @param locationId site the demand must be covered at
+     */
+    @Override
+    public void handle(
+            @Nullable UUID workorderLineId,
+            @Nullable UUID salesOrderLineId,
+            @NonNull UUID stockItemId,
+            int requiredQuantity,
+            @NonNull UUID locationId) {
+        if ((workorderLineId == null) == (salesOrderLineId == null)) {
+            throw new IllegalArgumentException(
+                    "exactly one of workorderLineId/salesOrderLineId must be set (CAP #1315)");
+        }
+
+        ReservationResponse reservation = reservationService.createOrUpdateReservation(
+                new CreateReservationRequest(workorderLineId, salesOrderLineId, stockItemId, requiredQuantity));
+
+        long atp = availableToPromise(stockItemId, locationId);
+        Instant now = Instant.now(clock);
+
+        if (atp >= requiredQuantity) {
+            log.info(
+                    "Reservation {} covered: demandLine={} sku={} qty={} atp={}",
+                    reservation.getReservationId(),
+                    workorderLineId != null ? workorderLineId : salesOrderLineId,
+                    stockItemId,
+                    requiredQuantity,
+                    atp);
+            inventoryFactPublisher.recordReservationOutcome(new ReservationOutcomeV1(
+                    reservation.getReservationId(),
+                    workorderLineId,
+                    salesOrderLineId,
+                    stockItemId.toString(),
+                    requiredQuantity,
+                    true,
+                    null,
+                    now));
+            return;
+        }
+
+        int quantityShort = (int) Math.min(requiredQuantity, requiredQuantity - atp);
+        markBackordered(reservation.getReservationId());
+        BackorderResponse backorder = workorderLineId != null
+                ? backorderService.createBackorder(workorderLineId, stockItemId.toString(), quantityShort, locationId)
+                : backorderService.createBackorderForSalesOrderLine(
+                        salesOrderLineId, stockItemId.toString(), quantityShort, locationId);
+
+        log.info(
+                "Reservation {} not covered: demandLine={} sku={} qty={} atp={} backorder={}",
+                reservation.getReservationId(),
+                workorderLineId != null ? workorderLineId : salesOrderLineId,
+                stockItemId,
+                requiredQuantity,
+                atp,
+                backorder.getBackorderId());
+        inventoryFactPublisher.recordReservationOutcome(new ReservationOutcomeV1(
+                reservation.getReservationId(),
+                workorderLineId,
+                salesOrderLineId,
+                stockItemId.toString(),
+                requiredQuantity,
+                false,
+                backorder.getBackorderId(),
+                now));
+    }
+
+    /**
+     * {@code createBackorder}/{@code createBackorderForSalesOrderLine} post the ledger entry and
+     * fact, but neither flips the reservation's own status — that has only ever been {@code
+     * promoteToHard}'s job (an insufficiency discovered there) until now. A shortfall discovered
+     * here must mark it the same way, or the reservation stays PENDING while a backorder for it is
+     * already open.
+     */
+    private void markBackordered(UUID reservationId) {
+        ReservationEntity reservation =
+                reservationRepository.findById(reservationId).orElse(null);
+        if (reservation != null && reservation.getStatus() != ReservationStatus.BACKORDERED) {
+            reservation.setStatus(ReservationStatus.BACKORDERED);
+            reservationRepository.save(reservation);
+        }
+    }
+
+    private long availableToPromise(UUID stockItemId, UUID locationId) {
+        return summaryRepository
+                .findByStockItemIdAndLocationId(stockItemId.toString(), locationId)
+                .map(row -> row.getAtp())
+                .orElse(0L);
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
@@ -21,6 +21,7 @@ import com.positivity.security.common.SecurityContextHelper;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
@@ -42,9 +43,17 @@ public class ReservationServiceImpl implements ReservationService {
 
     @Override
     public @NonNull ReservationResponse createOrUpdateReservation(@NonNull CreateReservationRequest request) {
-        ReservationEntity reservation = reservationRepository
-                .findByWorkorderLineId(request.getWorkorderLineId())
-                .map(existing -> updateExistingReservation(existing, request))
+        UUID workorderLineId = request.getWorkorderLineId();
+        UUID salesOrderLineId = request.getSalesOrderLineId();
+        if ((workorderLineId == null) == (salesOrderLineId == null)) {
+            throw new IllegalArgumentException(
+                    "exactly one of workorderLineId/salesOrderLineId must be set (CAP #1315)");
+        }
+
+        Optional<ReservationEntity> existing = workorderLineId != null
+                ? reservationRepository.findByWorkorderLineId(workorderLineId)
+                : reservationRepository.findBySalesOrderLineId(salesOrderLineId);
+        ReservationEntity reservation = existing.map(found -> updateExistingReservation(found, request))
                 .orElseGet(() -> createReservationWithSoftAllocation(request));
 
         return toResponse(reservation);
@@ -129,7 +138,18 @@ public class ReservationServiceImpl implements ReservationService {
         ReservationEntity reservation = reservationRepository
                 .findByWorkorderLineId(workorderLineId)
                 .orElseThrow(() -> new ResourceNotFoundException("Reservation", workorderLineId.toString()));
+        cancel(reservation);
+    }
 
+    @Override
+    public void cancelReservationForSalesOrderLine(@NonNull UUID salesOrderLineId) {
+        ReservationEntity reservation = reservationRepository
+                .findBySalesOrderLineId(salesOrderLineId)
+                .orElseThrow(() -> new ResourceNotFoundException("Reservation", salesOrderLineId.toString()));
+        cancel(reservation);
+    }
+
+    private void cancel(ReservationEntity reservation) {
         List<AllocationEntity> allocations = allocationRepository.findByReservation(reservation);
 
         // Only located HARD allocations had a matching ALLOCATION_CREATED ledger
@@ -231,6 +251,7 @@ public class ReservationServiceImpl implements ReservationService {
     private ReservationEntity createReservationWithSoftAllocation(CreateReservationRequest request) {
         ReservationEntity reservation = ReservationEntity.builder()
                 .workorderLineId(request.getWorkorderLineId())
+                .salesOrderLineId(request.getSalesOrderLineId())
                 .stockItemId(request.getStockItemId())
                 .requiredQuantity(request.getRequiredQuantity())
                 .allocatedQuantity(request.getRequiredQuantity())
@@ -260,6 +281,7 @@ public class ReservationServiceImpl implements ReservationService {
         return ReservationResponse.builder()
                 .reservationId(reservation.getReservationId())
                 .workorderLineId(reservation.getWorkorderLineId())
+                .salesOrderLineId(reservation.getSalesOrderLineId())
                 .stockItemId(reservation.getStockItemId())
                 .requiredQuantity(reservation.getRequiredQuantity())
                 .allocatedQuantity(reservation.getAllocatedQuantity())

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/BackorderService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/BackorderService.java
@@ -35,6 +35,21 @@ public interface BackorderService {
             @NonNull UUID workorderLineId, @NonNull String sku, int quantityShort, @Nullable UUID locationId);
 
     /**
+     * Opens a backorder for a sales-order line whose demand was short (CAP #1315), the sales-order
+     * checkout gate's admit-rather-than-reject path. Idempotent per {@code (salesOrderLineId, sku)},
+     * mirroring {@link #createBackorder}.
+     *
+     * @param salesOrderLineId sales-order line whose demand was short
+     * @param sku stock-item identifier that was short (ledger stock-item string)
+     * @param quantityShort quantity that could not be fulfilled (must be positive)
+     * @param locationId site the demand is short at; matched by the auto-resolution trigger
+     * @return the OPEN backorder (existing or newly created)
+     */
+    @NonNull
+    BackorderResponse createBackorderForSalesOrderLine(
+            @NonNull UUID salesOrderLineId, @NonNull String sku, int quantityShort, @Nullable UUID locationId);
+
+    /**
      * Retrieves one backorder.
      *
      * @param backorderId the backorder id
@@ -50,6 +65,7 @@ public interface BackorderService {
      * @param sku optional SKU filter
      * @param locationId optional site filter
      * @param workorderLineId optional workorder-line filter
+     * @param salesOrderLineId optional sales-order-line filter (CAP #1315)
      * @return matching backorders
      */
     @NonNull
@@ -57,5 +73,6 @@ public interface BackorderService {
             @Nullable BackorderStatus status,
             @Nullable String sku,
             @Nullable UUID locationId,
-            @Nullable UUID workorderLineId);
+            @Nullable UUID workorderLineId,
+            @Nullable UUID salesOrderLineId);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/ReservationRequestService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/ReservationRequestService.java
@@ -1,0 +1,29 @@
+package com.positivity.inventory.service;
+
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Handles {@code inventory.reservation.request-requested} commands (CAP #1315): the ATP-gate
+ * commitment point for pos-order (checkout) and pos-workorder (part-issue).
+ */
+public interface ReservationRequestService {
+
+    /**
+     * Registers demand for one line and evaluates whether owned ATP at {@code locationId} covers
+     * it, publishing a reservation-outcome fact either way.
+     *
+     * @param workorderLineId workorder line the demand is for, when demand is from a workorder
+     * @param salesOrderLineId sales-order line the demand is for, when demand is from a sales order
+     * @param stockItemId stock item requested
+     * @param requiredQuantity quantity requested
+     * @param locationId site the demand must be covered at
+     */
+    void handle(
+            @Nullable UUID workorderLineId,
+            @Nullable UUID salesOrderLineId,
+            @NonNull UUID stockItemId,
+            int requiredQuantity,
+            @NonNull UUID locationId);
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/ReservationService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/ReservationService.java
@@ -8,11 +8,20 @@ import org.jspecify.annotations.NonNull;
 
 public interface ReservationService {
 
+    /**
+     * Creates a reservation, or updates the existing one for the request's demand line. Exactly
+     * one of {@code request.workorderLineId}/{@code request.salesOrderLineId} must be set (CAP
+     * #1315); the demand-line kind is fixed at creation and cannot change on update.
+     */
     @NonNull
     ReservationResponse createOrUpdateReservation(@NonNull CreateReservationRequest request);
 
     @NonNull
     ReservationResponse promoteToHard(@NonNull UUID allocationId, @NonNull PromoteAllocationRequest request);
 
+    /** Cancels the reservation for a workorder line. */
     void cancelReservation(@NonNull UUID workorderLineId);
+
+    /** Cancels the reservation for a sales-order line (CAP #1315). */
+    void cancelReservationForSalesOrderLine(@NonNull UUID salesOrderLineId);
 }

--- a/pos-inventory/src/main/resources/db/migration/V38__reservation_backorder_sales_order_demand.sql
+++ b/pos-inventory/src/main/resources/db/migration/V38__reservation_backorder_sales_order_demand.sql
@@ -1,0 +1,38 @@
+-- CAP #1315: owned-ATP gate for order/workorder line creation. Reservations and backorders were
+-- hard-coded to a workorder line as the only possible demand source. A sales order needs the same
+-- machinery (soft reservation, hard promotion, backorder-on-shortfall, auto-resolution as stock
+-- arrives) for its checkout gate, so both tables gain an alternative demand key rather than being
+-- redesigned: workorder_line_id becomes optional, sales_order_line_id is the new alternative, and
+-- exactly one of the two must be set. Existing rows are all workorder-line rows and remain valid
+-- under the new CHECK constraint unchanged.
+
+-- ── inventory_reservation ───────────────────────────────────────────────────────────────────
+ALTER TABLE inventory_reservation
+    DROP CONSTRAINT inventory_reservation_workorder_line_id_key;
+ALTER TABLE inventory_reservation
+    ALTER COLUMN workorder_line_id DROP NOT NULL;
+ALTER TABLE inventory_reservation
+    ADD COLUMN sales_order_line_id uuid;
+ALTER TABLE inventory_reservation
+    ADD CONSTRAINT ck_inventory_reservation_one_demand_line
+        CHECK ((workorder_line_id IS NOT NULL) <> (sales_order_line_id IS NOT NULL));
+
+CREATE UNIQUE INDEX ux_inventory_reservation_workorder_line
+    ON inventory_reservation (workorder_line_id) WHERE workorder_line_id IS NOT NULL;
+CREATE UNIQUE INDEX ux_inventory_reservation_sales_order_line
+    ON inventory_reservation (sales_order_line_id) WHERE sales_order_line_id IS NOT NULL;
+
+-- ── backorder_record ─────────────────────────────────────────────────────────────────────────
+ALTER TABLE backorder_record
+    ALTER COLUMN workorder_line_id DROP NOT NULL;
+ALTER TABLE backorder_record
+    ADD COLUMN sales_order_line_id uuid;
+ALTER TABLE backorder_record
+    ADD CONSTRAINT ck_backorder_record_one_demand_line
+        CHECK ((workorder_line_id IS NOT NULL) <> (sales_order_line_id IS NOT NULL));
+
+-- Duplicate-open guard for the new demand key, mirroring V24's ux_backorder_record_open_line_sku.
+CREATE UNIQUE INDEX ux_backorder_record_open_sales_order_line_sku
+    ON backorder_record (sales_order_line_id, sku) WHERE status = 'OPEN' AND sales_order_line_id IS NOT NULL;
+
+CREATE INDEX idx_backorder_record_sales_order_line ON backorder_record (sales_order_line_id);

--- a/pos-inventory/src/test/java/com/positivity/inventory/config/InventoryCommandListenerTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/config/InventoryCommandListenerTest.java
@@ -24,6 +24,7 @@ import com.positivity.inventory.internal.repository.ProcessedEventRepository;
 import com.positivity.inventory.service.ConsumptionService;
 import com.positivity.inventory.service.OutboxReplayService;
 import com.positivity.inventory.service.PickListService;
+import com.positivity.inventory.service.ReservationRequestService;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -50,6 +51,7 @@ class InventoryCommandListenerTest {
     private final OutboxReplayService replayService = mock(OutboxReplayService.class);
     private final PickListService pickListService = mock(PickListService.class);
     private final ConsumptionService consumptionService = mock(ConsumptionService.class);
+    private final ReservationRequestService reservationRequestHandler = mock(ReservationRequestService.class);
     private final ProcessedEventRepository processedEvents = mock(ProcessedEventRepository.class);
 
     private InventoryCommandListener listener;
@@ -57,7 +59,13 @@ class InventoryCommandListenerTest {
     @BeforeEach
     void setUp() {
         listener = new InventoryCommandListener(
-                TEST_CLOCK, new ObjectMapper(), replayService, pickListService, consumptionService, processedEvents);
+                TEST_CLOCK,
+                new ObjectMapper(),
+                replayService,
+                pickListService,
+                consumptionService,
+                reservationRequestHandler,
+                processedEvents);
         ReflectionTestUtils.setField(listener, "replayMaxLookback", Duration.ofDays(30));
     }
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/controller/BackorderControllerTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/controller/BackorderControllerTest.java
@@ -61,7 +61,7 @@ class BackorderControllerTest {
 
     @Test
     void list_withViewAuthority_returns200() throws Exception {
-        when(backorderService.listBackorders(any(), any(), any(), any())).thenReturn(List.of(sample()));
+        when(backorderService.listBackorders(any(), any(), any(), any(), any())).thenReturn(List.of(sample()));
 
         mockMvc.perform(get("/v1/inventory/backorders").header("X-Authorities", VIEW))
                 .andExpect(status().isOk())

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/BackorderServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/BackorderServiceImplTest.java
@@ -150,6 +150,26 @@ class BackorderServiceImplTest {
     }
 
     @Test
+    @DisplayName("createBackorderForSalesOrderLine opens OPEN record keyed by salesOrderLineId")
+    void createBackorderForSalesOrderLine_opensRecordPostsLedgerAndFact() {
+        UUID salesOrderLineId = UUID.fromString("01960004-0003-7000-8000-000000000001");
+        when(backorderRepository.findBySalesOrderLineIdAndSkuAndStatus(salesOrderLineId, SKU, BackorderStatus.OPEN))
+                .thenReturn(Optional.empty());
+
+        BackorderResponse response = service.createBackorderForSalesOrderLine(salesOrderLineId, SKU, 4, LOCATION_ID);
+
+        assertThat(response.getStatus()).isEqualTo(BackorderStatus.OPEN);
+        assertThat(response.getSalesOrderLineId()).isEqualTo(salesOrderLineId);
+        assertThat(response.getWorkorderLineId()).isNull();
+        assertThat(response.getQuantityShort()).isEqualTo(4);
+
+        ArgumentCaptor<BackorderCreatedV1> factCaptor = ArgumentCaptor.forClass(BackorderCreatedV1.class);
+        verify(inventoryFactPublisher).recordBackorderCreated(factCaptor.capture());
+        assertThat(factCaptor.getValue().salesOrderLineId()).isEqualTo(salesOrderLineId);
+        assertThat(factCaptor.getValue().workorderLineId()).isNull();
+    }
+
+    @Test
     @DisplayName("Stock arrival auto-resolves the older backorder first when only one can be covered")
     void onInboundAvailability_resolvesOldestFirst_whenBudgetCoversOne() {
         BackorderRecord older = openBackorder(WORKORDER_LINE_A, 5, Instant.parse("2026-07-20T00:00:00Z"));
@@ -157,7 +177,8 @@ class BackorderServiceImplTest {
         when(backorderRepository.findBySkuAndLocationIdAndStatusOrderByCreatedAtAsc(
                         SKU, LOCATION_ID, BackorderStatus.OPEN))
                 .thenReturn(List.of(older, newer));
-        when(reservationRepository.findByWorkorderLineId(any())).thenReturn(Optional.empty());
+        when(reservationRepository.findByWorkorderLineIdOrSalesOrderLineId(any(), any()))
+                .thenReturn(Optional.empty());
         // Budget covers exactly one backorder of 5.
         when(summaryRepository.findByStockItemIdAndLocationId(SKU, LOCATION_ID))
                 .thenReturn(Optional.of(summaryWithAtp(5)));
@@ -194,7 +215,8 @@ class BackorderServiceImplTest {
                 .priority(5)
                 .status(ReservationStatus.BACKORDERED)
                 .build();
-        when(reservationRepository.findByWorkorderLineId(WORKORDER_LINE_A)).thenReturn(Optional.of(reservation));
+        when(reservationRepository.findByWorkorderLineIdOrSalesOrderLineId(WORKORDER_LINE_A, WORKORDER_LINE_A))
+                .thenReturn(Optional.of(reservation));
         when(summaryRepository.findByStockItemIdAndLocationId(SKU, LOCATION_ID))
                 .thenReturn(Optional.of(summaryWithAtp(10)));
 
@@ -226,7 +248,8 @@ class BackorderServiceImplTest {
         when(backorderRepository.findBySkuAndLocationIdAndStatusOrderByCreatedAtAsc(
                         SKU, LOCATION_ID, BackorderStatus.OPEN))
                 .thenReturn(List.of(backorder));
-        when(reservationRepository.findByWorkorderLineId(any())).thenReturn(Optional.empty());
+        when(reservationRepository.findByWorkorderLineIdOrSalesOrderLineId(any(), any()))
+                .thenReturn(Optional.empty());
         when(summaryRepository.findByStockItemIdAndLocationId(SKU, LOCATION_ID))
                 .thenReturn(Optional.of(summaryWithAtp(4)));
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ReservationRequestHandlerTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ReservationRequestHandlerTest.java
@@ -1,0 +1,162 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.domainevents.inventory.ReservationOutcomeV1;
+import com.positivity.inventory.internal.dto.backorder.BackorderResponse;
+import com.positivity.inventory.internal.dto.reservation.ReservationResponse;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
+import com.positivity.inventory.internal.entity.ReservationEntity;
+import com.positivity.inventory.internal.enums.BackorderStatus;
+import com.positivity.inventory.internal.enums.ReservationStatus;
+import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import com.positivity.inventory.internal.repository.ReservationRepository;
+import com.positivity.inventory.service.BackorderService;
+import com.positivity.inventory.service.ReservationService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationRequestHandlerTest {
+
+    private static final UUID RESERVATION_ID = UUID.fromString("01960004-0004-7000-8000-000000000001");
+    private static final UUID WORKORDER_LINE_ID = UUID.fromString("01960004-0004-7000-8000-000000000002");
+    private static final UUID SALES_ORDER_LINE_ID = UUID.fromString("01960004-0004-7000-8000-000000000003");
+    private static final UUID STOCK_ITEM_ID = UUID.fromString("01960004-0004-7000-8000-000000000004");
+    private static final UUID LOCATION_ID = UUID.fromString("01960004-0004-7000-8000-000000000005");
+    private static final UUID BACKORDER_ID = UUID.fromString("01960004-0004-7000-8000-000000000006");
+
+    @Mock
+    private ReservationService reservationService;
+
+    @Mock
+    private BackorderService backorderService;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private InventoryStockSummaryRepository summaryRepository;
+
+    @Mock
+    private InventoryFactPublisher inventoryFactPublisher;
+
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-08-18T00:00:00Z"), ZoneOffset.UTC);
+
+    private ReservationRequestHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new ReservationRequestHandler(
+                reservationService,
+                backorderService,
+                reservationRepository,
+                summaryRepository,
+                inventoryFactPublisher,
+                fixedClock);
+    }
+
+    private static InventoryStockSummary summaryWithAtp(long atp) {
+        InventoryStockSummary summary = mock(InventoryStockSummary.class);
+        when(summary.getAtp()).thenReturn(atp);
+        return summary;
+    }
+
+    private ReservationResponse reservationResponse() {
+        return ReservationResponse.builder()
+                .reservationId(RESERVATION_ID)
+                .status(ReservationStatus.PENDING.name())
+                .build();
+    }
+
+    @Test
+    @DisplayName("rejects when neither demand line is set")
+    void handle_neitherDemandLine_throws() {
+        assertThatThrownBy(() -> handler.handle(null, null, STOCK_ITEM_ID, 5, LOCATION_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+    }
+
+    @Test
+    @DisplayName("rejects when both demand lines are set")
+    void handle_bothDemandLines_throws() {
+        assertThatThrownBy(() -> handler.handle(WORKORDER_LINE_ID, SALES_ORDER_LINE_ID, STOCK_ITEM_ID, 5, LOCATION_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exactly one");
+    }
+
+    @Test
+    @DisplayName("covered demand publishes a covered outcome fact and never opens a backorder")
+    void handle_workorderLine_covered_publishesCoveredFact() {
+        when(reservationService.createOrUpdateReservation(any())).thenReturn(reservationResponse());
+        InventoryStockSummary summary = summaryWithAtp(10);
+        when(summaryRepository.findByStockItemIdAndLocationId(STOCK_ITEM_ID.toString(), LOCATION_ID))
+                .thenReturn(Optional.of(summary));
+
+        handler.handle(WORKORDER_LINE_ID, null, STOCK_ITEM_ID, 5, LOCATION_ID);
+
+        verify(backorderService, never()).createBackorder(any(), any(), anyInt(), any());
+        ArgumentCaptor<ReservationOutcomeV1> factCaptor = ArgumentCaptor.forClass(ReservationOutcomeV1.class);
+        verify(inventoryFactPublisher).recordReservationOutcome(factCaptor.capture());
+        ReservationOutcomeV1 fact = factCaptor.getValue();
+        assertThat(fact.covered()).isTrue();
+        assertThat(fact.backorderId()).isNull();
+        assertThat(fact.workorderLineId()).isEqualTo(WORKORDER_LINE_ID);
+        assertThat(fact.salesOrderLineId()).isNull();
+    }
+
+    @Test
+    @DisplayName("uncovered sales-order demand backorders the reservation and publishes an uncovered outcome fact")
+    void handle_salesOrderLine_uncovered_backordersAndPublishesFact() {
+        when(reservationService.createOrUpdateReservation(any())).thenReturn(reservationResponse());
+        InventoryStockSummary summary = summaryWithAtp(2);
+        when(summaryRepository.findByStockItemIdAndLocationId(STOCK_ITEM_ID.toString(), LOCATION_ID))
+                .thenReturn(Optional.of(summary));
+        ReservationEntity reservation = ReservationEntity.builder()
+                .reservationId(RESERVATION_ID)
+                .salesOrderLineId(SALES_ORDER_LINE_ID)
+                .stockItemId(STOCK_ITEM_ID)
+                .requiredQuantity(5)
+                .status(ReservationStatus.PENDING)
+                .build();
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+        when(backorderService.createBackorderForSalesOrderLine(
+                        SALES_ORDER_LINE_ID, STOCK_ITEM_ID.toString(), 3, LOCATION_ID))
+                .thenReturn(BackorderResponse.builder()
+                        .backorderId(BACKORDER_ID)
+                        .salesOrderLineId(SALES_ORDER_LINE_ID)
+                        .status(BackorderStatus.OPEN)
+                        .build());
+
+        handler.handle(null, SALES_ORDER_LINE_ID, STOCK_ITEM_ID, 5, LOCATION_ID);
+
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.BACKORDERED);
+        verify(reservationRepository).save(reservation);
+        verify(backorderService, never()).createBackorder(any(), any(), anyInt(), any());
+
+        ArgumentCaptor<ReservationOutcomeV1> factCaptor = ArgumentCaptor.forClass(ReservationOutcomeV1.class);
+        verify(inventoryFactPublisher).recordReservationOutcome(factCaptor.capture());
+        ReservationOutcomeV1 fact = factCaptor.getValue();
+        assertThat(fact.covered()).isFalse();
+        assertThat(fact.backorderId()).isEqualTo(BACKORDER_ID);
+        assertThat(fact.salesOrderLineId()).isEqualTo(SALES_ORDER_LINE_ID);
+        assertThat(fact.workorderLineId()).isNull();
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
@@ -1016,4 +1016,38 @@ class ReservationServiceImplTest {
         assertThat(entry.getSourceTransactionId())
                 .isEqualTo(locatedHard.getAllocationId().toString());
     }
+
+    // ─── CAP #1315: sales-order demand line ─────────────────────────────────────
+
+    @Test
+    @DisplayName("cancelReservationForSalesOrderLine cancels the reservation found by salesOrderLineId")
+    void cancelReservationForSalesOrderLine_found_marksCancelled() {
+        UUID salesOrderLineId = UUID.fromString("00000000-0000-0000-0000-0000000000d1");
+        ReservationEntity reservation = ReservationEntity.builder()
+                .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .salesOrderLineId(salesOrderLineId)
+                .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .requiredQuantity(3)
+                .allocatedQuantity(3)
+                .status(ReservationStatus.PENDING)
+                .build();
+        when(reservationRepository.findBySalesOrderLineId(salesOrderLineId)).thenReturn(Optional.of(reservation));
+        when(allocationRepository.findByReservation(reservation)).thenReturn(List.of());
+
+        service.cancelReservationForSalesOrderLine(salesOrderLineId);
+
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+        verify(ledgerPostingService, never()).post(any());
+    }
+
+    @Test
+    @DisplayName("cancelReservationForSalesOrderLine throws ResourceNotFoundException when no reservation exists")
+    void cancelReservationForSalesOrderLine_missing_throwsResourceNotFound() {
+        UUID salesOrderLineId = UUID.fromString("00000000-0000-0000-0000-0000000000d2");
+        when(reservationRepository.findBySalesOrderLineId(salesOrderLineId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.cancelReservationForSalesOrderLine(salesOrderLineId))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Reservation not found");
+    }
 }


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:1315`
- Parent STORY (durion): N/A — #1315 is the story itself, filed directly in this repo (split out of #1312)
- Child issue: louisburroughs/durion-positivity-backend#1315
- Domain: `domain:inventory`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` → reservation-by-sales-order-line cancel/create endpoints, `ReservationOutcomeV1` fact, `BackorderCreatedV1`/`BackorderResolvedV1` v2 fields, `inventory.reservation.request-requested` command
- Durion contract PR (if applicable): not yet opened — contract-doc update tracked as a follow-up alongside Phase 2/3

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller (`ReservationController#cancelReservationForSalesOrderLine`, `BackorderController` changes)
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — deferred; no consumer depends on the new endpoint yet, will regenerate alongside Phase 2 wiring
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — deferred for the same reason

## Scope
- What changed (Phase 1 of 3 — pos-inventory foundation for #1315; Phase 2 pos-order checkout gate and Phase 3 pos-workorder per-part issue gate are separate follow-up PRs):
  - Widens `ReservationEntity`/`BackorderRecord` (pos-inventory) so a demand line can be either a `workorderLineId` (existing) or a new `salesOrderLineId` (additive), enforced by a DB CHECK constraint requiring exactly one — migration `V38__reservation_backorder_sales_order_demand.sql`.
  - Widens `BackorderCreatedV1`/`BackorderResolvedV1` domain-event facts the same way (schema v2, additive/nullable fields) and adds a new `ReservationOutcomeV1` fact.
  - Adds a new `inventory.reservation.request-requested` Kafka command (via `InventoryCommandListener`) handled by `ReservationRequestHandler` (exposed through a new public `ReservationRequestService` interface, to keep pos-inventory's internal ArchUnit package-cycle rule satisfied): it always soft-registers the reservation, then checks site-level ATP the same way `BackorderServiceImpl`'s existing auto-resolution does (via `InventoryStockSummaryRepository`), and either publishes a `covered=true` outcome or opens a backorder and publishes `covered=false` with the backorder id. This deliberately does NOT call `promoteToHard` (that stays a separate, shelf-level pick-flow concern with zero behavior change here).
  - Adds `cancelReservationForSalesOrderLine` / `createBackorderForSalesOrderLine` service methods and a `DELETE /v1/inventory/reservations/sales-order-line/{salesOrderLineId}` endpoint, mirroring the existing workorder-line-keyed operations.
- Why: #1315 requires pos-order and pos-workorder to gate line/part creation on owned ATP via a replica + reservation-ack pattern (ADR-0044 §4/§6), instead of the synchronous stub (`AdvisoryInventoryPortAdapter`) that always passes. pos-inventory has to expose the reservation-request command and the outcome fact before either consumer module can be built; this PR is that foundation only. Design decisions (checkout as the sales-order gate point admitting via backorder, per-part issue-time gate for work orders, selling/servicing-location-only scope) are recorded on #1315.

## Tests
- [x] Unit tests added/updated (full coverage for `ReservationRequestHandler`, `ReservationRequestService`, entity/DTO widening, event schema v2, new controller endpoint, `BackorderServiceImpl` changes)
- [ ] Integration tests added/updated — none added in this PR; unit coverage plus existing ArchUnit/contract tests are the gate for this phase
- [ ] Provider behavioral contract tests added/updated — N/A, no cross-service contract changed in this phase
- How to run:
  - `./mvnw -pl pos-inventory,pos-domain-events -am clean test` — 881 tests, 0 failures
  - `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test` — passes (cross-module package-layout rules, incl. the new `ReservationRequestService` public-interface indirection)
  - `./mvnw spotless:apply` — clean, no formatting diff

## Risk & Rollback
- Risk level: Low — additive-only migration (V38, new nullable columns + CHECK constraint), additive-only event schema v2 fields, new command/endpoint with no existing caller yet (pos-order/pos-workorder don't call it until Phase 2/3). Existing workorder-keyed reservation/backorder paths are unchanged (`promoteToHard` untouched, zero behavior change to shelf-level pick flow).
- Rollback plan: revert the merge commit. V38 is additive (new nullable columns + CHECK), safe to leave in place even on rollback of application code; no data backfill performed. No downstream service consumes the new command/fact yet, so rollback has no cross-service blast radius.

## Checklist
- [x] Branch name matches `cap/<cap-id>` — branch is `feat/owned-atp-gate-order-workorder` (pre-existing repo convention for this story used `feat/` per the issue's "Suggested branch"; flagging the mismatch against the template's `cap/<cap-id>` pattern rather than silently renaming)
- [x] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed) — not yet updated in durion repo; tracked as follow-up with Phase 2/3
- [ ] Required CI checks passing — pending CI run on this PR; local `clean test` + ArchUnit + spotless all green (see Tests section)

Part of #1315.
