### PR TITLE
test(image): document intent of ImageContentViewTest's reflexivity check

### DIFF
--- a/pos-image/src/test/java/com/positivity/image/internal/dto/ImageContentViewTest.java
+++ b/pos-image/src/test/java/com/positivity/image/internal/dto/ImageContentViewTest.java
@@ -29,6 +29,9 @@ class ImageContentViewTest {
     @Test
     @DisplayName("an instance is equal to itself")
     void reflexive() {
+        // Deliberately self-compared: exercises the `this == o` shortcut in equals(), which the
+        // cross-instance check above never reaches. Field-by-field equality is verified there;
+        // this test only pins the reflexivity part of the equals contract.
         ImageContentView view = new ImageContentView("logo.png", "image/png", BYTES.clone());
 
         assertThat(view).isEqualTo(view);


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A — follow-up to the SonarCloud reliability cleanup in #1360, not tied to a tracked capability
- Parent STORY (durion): N/A
- Child issue: N/A
- Domain: `domain:image`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/<domain>/.business-rules/BACKEND_CONTRACT_GUIDE.md` → not applicable. The only changed file is a test class that happens to live under a `dto` package (`ImageContentViewTest.java`, matching this repo's `**/dto/**` contract-relevant path filter), but it adds no production code and changes no wire contract.
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- Not applicable — no controller changed.

## Scope
- What changed: added a one-line comment to `ImageContentViewTest.reflexive()` explaining why it deliberately asserts `view.equals(view)` against itself — a reviewer flagged the self-comparison as looking like a tautological/copy-paste mistake.
- Why: the test is intentional — it exercises the `this == o` shortcut branch in `ImageContentView.equals()` (added in #1360 to fix SonarCloud java:S6218), which the separate cross-instance test (`equalContentIsEqualAcrossDistinctArrayInstances`) never reaches. On its own the assertion is weak (it would pass even without a custom `equals`), so it needed a comment making clear that's expected and that real field-by-field equality is verified elsewhere in the same file.

## Tests
- [x] Unit tests added/updated — comment-only change to an existing test, no new test logic
- [ ] Integration tests added/updated — not applicable
- [ ] Provider behavioral contract tests added/updated — not applicable, no contract change
- How to run: `./mvnw -pl pos-image -am -DskipTests=false test org.jacoco:jacoco-maven-plugin:0.8.14:report org.jacoco:jacoco-maven-plugin:0.8.14:check -Darchunit.skipTests=true -DlowResourceTests=true -DskipITs`

## Risk & Rollback
- Risk level: Trivial — comment-only change, no behavior affected.
- Rollback plan: revert this commit.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — not applicable, this is a Sonar cleanup follow-up, not a capability
- [ ] PR title starts with `[CAP:<cap-id>]` — not applicable, no capability id
- [ ] Links to parent + child issues are present — not applicable
- [x] Contract guide updated (when contract semantics changed) — not applicable, confirmed no contract semantics changed (see Contract References above)
- [x] Required CI checks passing (jacoco coverage gate and full test suite for pos-image verified locally)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QPRNcfBKWWEqyBJrWG42BS)_