### PR TITLE
chore(alpha): enable Kafka for customer, invoice, people-contact, workorder (#838)

### DIFF
--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -110,9 +110,9 @@ services:
     image: ${ECR_REGISTRY}/durion/pos-customer:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
-    # #838 flag flip — uncomment in the second deploy, after the broker is verified healthy:
-    # environment:
-    #   POS_CUSTOMER_KAFKA_ENABLED: "true"
+    # #838 second deploy: broker verified healthy, flag flipped on.
+    environment:
+      POS_CUSTOMER_KAFKA_ENABLED: "true"
 
   pos-event-receiver:
     image: ${ECR_REGISTRY}/durion/pos-event-receiver:${BACKEND_TAG}
@@ -137,9 +137,9 @@ services:
     image: ${ECR_REGISTRY}/durion/pos-invoice:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
-    # #838 flag flip — uncomment in the second deploy, after the broker is verified healthy:
-    # environment:
-    #   POS_INVOICE_KAFKA_ENABLED: "true"
+    # #838 second deploy: broker verified healthy, flag flipped on.
+    environment:
+      POS_INVOICE_KAFKA_ENABLED: "true"
 
   pos-location:
     image: ${ECR_REGISTRY}/durion/pos-location:${BACKEND_TAG}
@@ -160,9 +160,9 @@ services:
     image: ${ECR_REGISTRY}/durion/pos-people-contact:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
-    # #838 flag flip — uncomment in the second deploy, after the broker is verified healthy:
-    # environment:
-    #   POS_PEOPLE_CONTACT_KAFKA_ENABLED: "true"
+    # #838 second deploy: broker verified healthy, flag flipped on.
+    environment:
+      POS_PEOPLE_CONTACT_KAFKA_ENABLED: "true"
 
   pos-price:
     image: ${ECR_REGISTRY}/durion/pos-price:${BACKEND_TAG}
@@ -207,9 +207,9 @@ services:
     image: ${ECR_REGISTRY}/durion/pos-workorder:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
-    # #838 flag flip — uncomment in the second deploy, after the broker is verified healthy:
-    # environment:
-    #   WORKORDER_KAFKA_ENABLED: "true"
+    # #838 second deploy: broker verified healthy, flag flipped on.
+    environment:
+      WORKORDER_KAFKA_ENABLED: "true"
 
   # ── Frontend ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:838` (Kafka domain-event backbone rollout, ADR-0044)
- Parent STORY (durion): N/A — alpha environment configuration
- Child issue: louisburroughs/durion-positivity-backend#838
- Domain: `domain:positivity`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
Not applicable — this PR changes no controller, DTO, event schema, or validation model. It flips four
existing feature flags in the alpha compose override; the contracts those flags gate are unchanged and were
introduced under #838 and #927.

## Contract Chain (when a Controller changed)
No controller changed.

## Scope
- **What changed:** uncommented `POS_CUSTOMER_KAFKA_ENABLED`, `POS_INVOICE_KAFKA_ENABLED`,
  `POS_PEOPLE_CONTACT_KAFKA_ENABLED` and `WORKORDER_KAFKA_ENABLED` in `deployment/alpha/docker-compose.prod.yml`,
  and replaced the stale `# uncomment in the second deploy` instruction with the reason each flag is on —
  matching the rationale-comment style the already-live accounting / inventory / warranty blocks use.
- **Why:** the flags were explicitly staged behind "after the broker is verified healthy". It now is. Checked
  on the alpha host (`i-06d434c7593e70f5c`) via SSM:
  - `kafka-positivity` — `apache/kafka:3.9.0`, up and **healthy**; `kafka-exporter-positivity` up
  - broker responsive: `kafka-topics.sh --list` against `localhost:9092` returns
  - **30 topics** (+ `__consumer_offsets`) and **20 consumer groups**, with pos-accounting, pos-inventory and
    pos-warranty already consuming

All seven Kafka flags in the alpha override are now live; none remain commented.

Note that `WORKORDER_KAFKA_ENABLED` carries no `POS_` prefix while the other three do. That is not a typo —
`pos-workorder/src/main/resources/application.yml:98` reads `${WORKORDER_KAFKA_ENABLED:false}`. Verified
against the source rather than normalised to match its neighbours.

## Tests
- [ ] Unit tests added/updated — n/a, configuration only
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a

Verification performed: the compose file parses as YAML, and each flag name was checked against the property
the owning service actually reads.

## Risk & Rollback
- Risk level: **Medium**
- pos-workorder is the significant one. `workorder.kafka.enabled` activates roughly twenty
  `@ConditionalOnProperty` beans in a single deploy — the outbox stack (`OutboxEventWriter`, `OutboxPublisher`,
  `OutboxPurgeJob`, `OutboxMetrics`), `KafkaCommandListener`, `ManifestPublisher`, and a dozen replica
  listeners (customer, invoice, location, people, inventory, supplier-fleet-auth). The other three are much
  narrower. The broker already carries the topics and consumer groups these expect, so the wiring should land,
  but it is a larger surface than the other three combined.
- Worth watching on deploy: consumer-group lag on the newly-joining groups, and the `.dlq` topics for the
  affected domains.
- **Rollback:** revert this commit and redeploy. The flags are read at startup, so reverting fully restores
  the previous behaviour — no data migration is involved. Facts already published to Kafka stay on the topics
  and will be consumed if the flag is re-enabled, which is the intended at-least-once behaviour, not a leak.

## Checklist
- [x] Branch name follows repo practice (`chore/<issue>-...`)
- [x] Links to the governing issue are present
- [ ] PR title starts with `[CAP:<cap-id>]` — this is environment configuration rather than capability work, so the title is a plain conventional-commit subject; say the word if you want it retitled
