### PR TITLE
Fix 4 SonarCloud blocker issues (S2699, S1845)

### DIFF
--- a/pos-domain-events/src/test/java/com/positivity/domainevents/workorder/WorkorderFleetAuthRequestedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/workorder/WorkorderFleetAuthRequestedV1Test.java
@@ -1,5 +1,6 @@
 package com.positivity.domainevents.workorder;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
@@ -40,12 +41,22 @@ class WorkorderFleetAuthRequestedV1Test {
     @Test
     @DisplayName("any single identifier is enough")
     void oneIdentifierIsEnough() {
-        new WorkorderFleetAuthRequestedV1(WORKORDER_ID, "michelin-de", null, "ABC-123", null, null, null, 1, List.of());
-        new WorkorderFleetAuthRequestedV1(
-                WORKORDER_ID, "michelin-de", null, null, "1HGCM82633A004352", null, null, 1, List.of());
-        new WorkorderFleetAuthRequestedV1(WORKORDER_ID, "michelin-de", null, null, null, "FLEET-9", null, 1, List.of());
-        new WorkorderFleetAuthRequestedV1(
-                WORKORDER_ID, "michelin-de", "VENDOR-1", null, null, null, null, 1, List.of());
+        assertThat(new WorkorderFleetAuthRequestedV1(
+                                WORKORDER_ID, "michelin-de", null, "ABC-123", null, null, null, 1, List.of())
+                        .licensePlate())
+                .isEqualTo("ABC-123");
+        assertThat(new WorkorderFleetAuthRequestedV1(
+                                WORKORDER_ID, "michelin-de", null, null, "1HGCM82633A004352", null, null, 1, List.of())
+                        .vin())
+                .isEqualTo("1HGCM82633A004352");
+        assertThat(new WorkorderFleetAuthRequestedV1(
+                                WORKORDER_ID, "michelin-de", null, null, null, "FLEET-9", null, 1, List.of())
+                        .fleetNumber())
+                .isEqualTo("FLEET-9");
+        assertThat(new WorkorderFleetAuthRequestedV1(
+                                WORKORDER_ID, "michelin-de", "VENDOR-1", null, null, null, null, 1, List.of())
+                        .vendorVehicleId())
+                .isEqualTo("VENDOR-1");
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/UomDocumentBoundaryIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/UomDocumentBoundaryIT.java
@@ -225,16 +225,33 @@ class UomDocumentBoundaryIT {
     // ─── B3: HALF_UP rounding at base precision scale ────────────────────────────
 
     @Test
-    @DisplayName("conversion rounds HALF_UP at the base UoM's precision scale (1.5 BAG × 1.005 = 1.51 LB)")
+    @DisplayName("conversion rounds HALF_UP at the base UoM's precision scale (100 BAG × 1.005 = 101 EA, not 100)")
     void conversionRoundsHalfUpAtBasePrecisionScale() {
         UUID productId = UUID.randomUUID();
-        seedProduct(productId, "LB", 2);
+        // Base scale 0: the ledger posts whole base units, so the rounding boundary this test
+        // proves — HALF_UP, not DOWN — has to land on a whole number either way.
+        seedProduct(productId, "EA", 0);
         seedUom(productId, "BAG", "PACK", new BigDecimal("1.005"), 3);
 
-        UUID po = createPo(productId, "1.51", 3_000L);
-        // 1.5 × 1.005 = 1.5075 → HALF_UP at scale 2 → 1.51 (receipts round HALF_UP, not DOWN).
-        // Effective factor reflects the rounding actually applied: 1.51 / 1.5.
-        // Money math unchanged: documentQuantity × unitCostMinor = 1.5 × 2000 = 3000.
+        UUID po = createPo(productId, "101", 3_000L);
+        // 100 × 1.005 = 100.500 → HALF_UP at scale 0 → 101 (receipts round HALF_UP, not DOWN,
+        // which would truncate to 100). Money math unchanged: documentQuantity × unitCostMinor =
+        // 100 × 30 = 3000.
+
+        CreateGoodsReceiptRequest receipt =
+                receiptRequest(po, receiptLine(productId.toString(), "BAG", new BigDecimal("100"), 30L));
+        GoodsReceiptResponse response = asnService.createGoodsReceipt(receipt, ACTOR);
+
+        assertThat(response.getTotalAccruedAmountMinor()).isEqualTo(3_000L);
+        var receiptLine = response.getLines().getFirst();
+        assertThat(receiptLine.getQuantityReceived()).isEqualByComparingTo("101");
+        assertThat(receiptLine.getDocumentUom()).isEqualTo("BAG");
+        assertThat(receiptLine.getDocumentQuantity()).isEqualByComparingTo("100");
+        assertThat(receiptLine.getConversionFactor()).isEqualByComparingTo("1.01");
+
+        List<InventoryLedgerEntry> entries = ledgerEntriesFor(productId);
+        assertThat(entries).hasSize(1);
+        assertThat(entries.getFirst().getChangeInQuantity()).isEqualTo(101);
     }
 
     // ─── ledger funnel unitOfMeasure validation + documented tolerance ───────────

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/SupplierStockHintResolverTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/SupplierStockHintResolverTest.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.internal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -232,6 +233,6 @@ class SupplierStockHintResolverTest {
         when(hints.findByResolutionStatusOrderByFetchedAtAsc(any(), any(Limit.class)))
                 .thenThrow(new IllegalStateException("boom"));
 
-        resolver.resolvePending();
+        assertThatCode(() -> resolver.resolvePending()).doesNotThrowAnyException();
     }
 }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/RagEmbeddingSettings.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/config/RagEmbeddingSettings.java
@@ -27,7 +27,7 @@ public class RagEmbeddingSettings {
     private static final int DIMENSION = 1024;
 
     private final String embeddingColumn;
-    private final int dimension;
+    private final int vectorDimension;
 
     public RagEmbeddingSettings(
             @Value("${mcp.rag.embedding-column:embedding}") @NonNull String embeddingColumn,
@@ -43,7 +43,7 @@ public class RagEmbeddingSettings {
                     + ". The 768-dim nomic path was retired by V33 (#1207); remove any MCP_RAG_DIMENSION override.");
         }
         this.embeddingColumn = normalized;
-        this.dimension = dimension;
+        this.vectorDimension = dimension;
     }
 
     /** Validated vector column name, safe to interpolate into SQL. */
@@ -52,7 +52,7 @@ public class RagEmbeddingSettings {
     }
 
     public int dimension() {
-        return dimension;
+        return vectorDimension;
     }
 
     /**


### PR DESCRIPTION
## Capability & Traceability
- Not applicable: maintenance fix for open SonarCloud blocker-severity findings, not tied to a capability/story.

## Contract References
- Not applicable: no controller/DTO/event/OpenAPI changes.

## Scope
- What changed:
  - `WorkorderFleetAuthRequestedV1Test.oneIdentifierIsEnough`: asserts the preserved identifier field on each constructed record instead of only constructing objects (java:S2699 — test with no assertion).
  - `SupplierStockHintResolverTest.scheduled_pass_swallows_failures`: asserts via `assertThatCode(...).doesNotThrowAnyException()` that `resolvePending()` swallows the thrown exception (java:S2699).
  - `UomDocumentBoundaryIT.conversionRoundsHalfUpAtBasePrecisionScale`: was an empty test body (comments only, no assertions — java:S2699). Implemented it as a real goods-receipt call with assertions on the response and the posted ledger entry. Switched the base UoM to a whole precision scale (100 BAG × 1.005 → 101 EA) because `AsnServiceImpl.toWholeQuantity` requires integer base quantities when posting to the ledger, which the original fractional-scale example (LB, scale 2) could not satisfy.
  - `RagEmbeddingSettings`: renamed the private field `dimension` to `vectorDimension` so it no longer clashes with the `DIMENSION` constant (java:S1845 — conflicting identifier). Public accessor `dimension()` is unchanged.
- Why: close out the 4 open SonarCloud BLOCKER-severity issues on `main` (queried via the public SonarCloud API for project `louisburroughs_durion-positivity-backend`).

## Tests
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated
- How to run:
  - `./mvnw -pl pos-domain-events -am -Dtest=WorkorderFleetAuthRequestedV1Test test`
  - `./mvnw -pl pos-inventory -am -Dtest=SupplierStockHintResolverTest test`
  - `./mvnw -pl pos-inventory -am -Dtest=UomDocumentBoundaryIT test`
  - `./mvnw -pl pos-mcp-server -am -DskipTests compile`

## Risk & Rollback
- Risk level: Low — test-only changes plus a private-field rename with an unchanged public accessor.
- Rollback plan: revert this commit.

## Checklist
- [x] Required CI checks passing (locally verified; awaiting CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CPqQcgLGSakUxsutcYUTb6)_