### PR TITLE
Grant the assistant entrypoints to every role and MCP administration to the admin roles

### DIFF
--- a/pos-security-service/README.md
+++ b/pos-security-service/README.md
@@ -74,10 +74,33 @@ therefore creates those two roles itself rather than relying on bean lifecycle.
 | Role | Baseline |
 | --- | --- |
 | `ADMIN` | All domains. The intentional blast-radius role. |
-| `SYSTEM_ADMINISTRATOR` | **Security and admin surface only** — `security:*` plus `mcp:chat:execute`. Deliberately *not* a superuser: it holds no accounting, catalog, workorder, inventory, or shop authority, and it does **not** auto-acquire newly registered permissions. Widening it is an explicit edit to the seed. |
+| `SYSTEM_ADMINISTRATOR` | **Security and MCP administration only** — `security:*`, plus MCP administration (`mcp:system_prompt:*`, `mcp:llm_api:*`, `mcp:tool:manage`, `mcp:document:ingest`) and the assistant entrypoints. Deliberately *not* a superuser: it holds no accounting, catalog, workorder, inventory, or shop authority, and it does **not** auto-acquire newly registered permissions. Widening it is an explicit edit to the seed. |
 | `LOCATION_MANAGER`, `SERVICE_ADVISOR`, `TECHNICIAN`, `DISPATCHER`, `ACCOUNTING_ASSOCIATE`, `ACCOUNT_MANAGER`, `MANAGER`, `GENERAL_MANAGER` | Least privilege, scoped to the role's job function. |
 | `ACCOUNTANT`, `AP_CLERK`, `CONTROLLER`, `CSR`, `FLEET_MANAGER`, `GL_ANALYST` | **Not granted, and not created.** The retired hardcoded switch expanded these, but no migration or initializer creates the role, and `user_roles` / `role_assignments` are foreign-keyed to `roles(id)` — so no user could ever hold one. They were unreachable branches, documentation personas rather than security roles. To make one real, create the role first, then grant it. |
-| `CUSTOMER`, `SELF_SERVICE_CUSTOMER`, `SHOP_MANAGER`, `SECURITY_ADMIN`, `READ_ONLY_SCHEDULER`, `INVENTORY_LEAD`, `INVENTORY_MANAGER`, `INVENTORY_CONTROLLER` | No grants. Seeded as identity only; granting them capability is a product decision. |
+| `CUSTOMER`, `SELF_SERVICE_CUSTOMER`, `SHOP_MANAGER`, `SECURITY_ADMIN`, `READ_ONLY_SCHEDULER`, `INVENTORY_LEAD`, `INVENTORY_MANAGER`, `INVENTORY_CONTROLLER` | **Assistant entrypoints only.** No domain capability; granting them any is still a product decision. |
+
+### Assistant baseline
+
+Every role that exists receives four conversational entrypoints:
+
+| Permission | Meaning |
+| --- | --- |
+| `mcp:chat:execute` | Synchronous chat request via the Spring AI assistant runtime |
+| `mcp:chat:stream` | Streaming SSE chat request |
+| `nlti:request:submit` | Submit a natural-language task-interface request |
+| `nlti:request:read` | Read submitted NLTI request status |
+
+These grant reach to the assistant, not to data: the assistant enforces domain permissions per
+request, so a role that cannot read an invoice still cannot read one by asking for it. They are
+applied to **all** roles, including the customer-facing `CUSTOMER` and `SELF_SERVICE_CUSTOMER`,
+which previously held nothing at all — so external self-service users can now reach the assistant
+and submit NLTI requests. If that is not wanted, remove those two roles from the universal list in
+the seed; `RolePermissionBaselineTest.everyRoleReceivesTheAssistantBaseline` pins the current
+policy and will need updating alongside.
+
+MCP administration — `mcp:system_prompt:*`, `mcp:llm_api:*`, `mcp:tool:manage`,
+`mcp:document:ingest`, and for `ADMIN` also `mcp:tool:view` — is restricted to `ADMIN` and
+`SYSTEM_ADMINISTRATOR`, and a test asserts no other role holds any of it.
 
 ### Role grants vs. role assignments
 

--- a/pos-security-service/README.md
+++ b/pos-security-service/README.md
@@ -81,7 +81,7 @@ therefore creates those two roles itself rather than relying on bean lifecycle.
 
 ### Assistant baseline
 
-Every role that exists receives four conversational entrypoints:
+Every role in the baseline seed receives four conversational entrypoints:
 
 | Permission | Meaning |
 | --- | --- |
@@ -92,9 +92,14 @@ Every role that exists receives four conversational entrypoints:
 
 These grant reach to the assistant, not to data: the assistant enforces domain permissions per
 request, so a role that cannot read an invoice still cannot read one by asking for it. They are
-applied to **all** roles, including the customer-facing `CUSTOMER` and `SELF_SERVICE_CUSTOMER`,
-which previously held nothing at all — so external self-service users can now reach the assistant
-and submit NLTI requests. If that is not wanted, remove those two roles from the universal list in
+applied to every role the seed knows about, including the customer-facing `CUSTOMER` and
+`SELF_SERVICE_CUSTOMER`, which previously held nothing at all — so external self-service users can
+now reach the assistant and submit NLTI requests.
+
+This is a list of explicit grants, not a rule the database enforces. A role created later through
+`POST /v1/roles` or the role-permission admin API starts with **no** grants at all, assistant
+entrypoints included, until something grants them; add it to the seed to make it part of the
+baseline. If that is not wanted, remove those two roles from the universal list in
 the seed; `RolePermissionBaselineTest.everyRoleReceivesTheAssistantBaseline` pins the current
 policy and will need updating alongside.
 

--- a/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
+++ b/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
@@ -8,26 +8,26 @@
 -- so this baseline must stay complete.
 --
 -- POLICY
--- * Least privilege for operational roles. Each grant below mirrors a capability
---   the role already exercised through the retired hardcoded expansion, or (for
+-- * Least privilege for operational roles. Domain grants mirror a capability the
+--   role already exercised through the retired hardcoded expansion, or (for
 --   SYSTEM_ADMINISTRATOR and DISPATCHER, which the hardcoded switch never
 --   covered) the role's documented job function.
--- * SYSTEM_ADMINISTRATOR is deliberately NOT a superuser. It receives the
---   security/admin surface only (security:*, plus mcp:chat:execute) and holds no
---   accounting, catalog, workorder, inventory, or shop authority. ADMIN remains
---   the all-domain role. Granting SYSTEM_ADMINISTRATOR a new permission is an
---   explicit decision recorded here, never an automatic consequence of a new
---   permission being registered.
--- * Roles intentionally left with zero grants: CUSTOMER, SELF_SERVICE_CUSTOMER,
---   SHOP_MANAGER, SECURITY_ADMIN, READ_ONLY_SCHEDULER, INVENTORY_LEAD,
---   INVENTORY_MANAGER, INVENTORY_CONTROLLER. They had none under the hardcoded
---   expansion either; adding grants is a product decision, not a migration.
+-- * Assistant baseline: EVERY role that exists receives mcp:chat:execute,
+--   mcp:chat:stream, nlti:request:submit and nlti:request:read. These are the
+--   conversational entrypoints; the assistant still enforces domain permissions
+--   per request, so holding them grants reach to the assistant, not to data.
+--   NOTE this includes the customer-facing CUSTOMER and SELF_SERVICE_CUSTOMER
+--   roles, which previously held nothing at all.
+-- * SYSTEM_ADMINISTRATOR is deliberately NOT a superuser. It holds the
+--   security/admin surface plus MCP administration (system prompts, LLM API
+--   configuration, tool management, document ingest) and no accounting, catalog,
+--   workorder, inventory or shop authority. ADMIN remains the all-domain role
+--   and is a strict superset.
 -- * The retired switch also expanded ACCOUNTANT, AP_CLERK, CONTROLLER, CSR,
---   FLEET_MANAGER and GL_ANALYST. Those rows are NOT reproduced here: no
---   migration and no runtime initializer ever creates them, and both user_roles
---   and role_assignments are foreign-keyed to roles(id), so no user could hold
---   one. They were unreachable branches. If a persona is ever wanted for real,
---   create the role first, then grant it here.
+--   FLEET_MANAGER and GL_ANALYST. Those are NOT reproduced here: no migration
+--   and no runtime initializer creates them, and both user_roles and
+--   role_assignments are foreign-keyed to roles(id), so no user could hold one.
+--   To make a persona real, create the role first, then grant it here.
 -- * Grants are additive. Nothing here deletes a row, so permissions an operator
 --   granted through the role-permission admin API survive re-runs.
 --
@@ -41,17 +41,20 @@ SET TIME ZONE 'UTC';
 -- ---------------------------------------------------------------------------
 -- 1. Ensure the roles this baseline grants to exist.
 --
--- RoleInitializer creates GENERAL_MANAGER and MANAGER from Java, but it is an
--- @PostConstruct bean and therefore runs AFTER Flyway. On a fresh database they
--- are absent while this migration executes, so granting to them by name would
--- resolve nothing and trip the assertion in section 4. Creating them here makes
--- the ordering deterministic instead of dependent on bean lifecycle. Descriptions
--- match RoleInitializer so the two agree whichever runs first.
+-- RoleInitializer creates these from Java, but it is an @PostConstruct bean and
+-- therefore runs AFTER Flyway. On a fresh database they are absent while this
+-- migration executes, so granting to them by name would resolve nothing and trip
+-- the assertion in section 4. Creating them here makes the ordering deterministic
+-- instead of dependent on bean lifecycle. Descriptions match RoleInitializer so
+-- the two agree whichever runs first.
 -- ---------------------------------------------------------------------------
 INSERT INTO roles (id, name, description, created_at, created_by)
 SELECT gen_random_uuid(), r.name, r.description, NOW(), 'system'
 FROM (VALUES
     ('GENERAL_MANAGER', 'General manager with broad organizational access'),
+    ('INVENTORY_CONTROLLER', 'Inventory controller with global adjustment approval authority'),
+    ('INVENTORY_LEAD', 'Inventory lead with permission to create adjustment requests'),
+    ('INVENTORY_MANAGER', 'Inventory manager with permission to create and approve adjustments'),
     ('MANAGER', 'Department or location manager')
 ) AS r(name, description)
 ON CONFLICT (name) DO NOTHING;
@@ -249,6 +252,8 @@ FROM (VALUES
     ('mcp:system_prompt:delete', 'mcp', 'system_prompt', 'delete', 102),
     ('mcp:system_prompt:update', 'mcp', 'system_prompt', 'update', 101),
     ('mcp:system_prompt:view', 'mcp', 'system_prompt', 'view', 99),
+    ('mcp:tool:manage', 'mcp', 'tool', 'manage', 347),
+    ('mcp:tool:view', 'mcp', 'tool', 'view', 348),
     ('nlti:audit:read', 'nlti', 'audit', 'read', 223),
     ('nlti:request:read', 'nlti', 'request', 'read', 222),
     ('nlti:request:submit', 'nlti', 'request', 'submit', 221),
@@ -432,6 +437,9 @@ FROM (VALUES
     ('ACCOUNTING_ASSOCIATE', 'accounting:mapping:view'),
     ('ACCOUNTING_ASSOCIATE', 'accounting:posting_rules:view'),
     ('ACCOUNTING_ASSOCIATE', 'mcp:chat:execute'),
+    ('ACCOUNTING_ASSOCIATE', 'mcp:chat:stream'),
+    ('ACCOUNTING_ASSOCIATE', 'nlti:request:read'),
+    ('ACCOUNTING_ASSOCIATE', 'nlti:request:submit'),
     ('ACCOUNT_MANAGER', 'accounting:ap:approve'),
     ('ACCOUNT_MANAGER', 'accounting:ap:pay'),
     ('ACCOUNT_MANAGER', 'accounting:ap:reject'),
@@ -477,6 +485,9 @@ FROM (VALUES
     ('ACCOUNT_MANAGER', 'invoice:billing-rules'),
     ('ACCOUNT_MANAGER', 'invoice:manage'),
     ('ACCOUNT_MANAGER', 'mcp:chat:execute'),
+    ('ACCOUNT_MANAGER', 'mcp:chat:stream'),
+    ('ACCOUNT_MANAGER', 'nlti:request:read'),
+    ('ACCOUNT_MANAGER', 'nlti:request:submit'),
     ('ACCOUNT_MANAGER', 'reporting:view:financial-statements'),
     ('ADMIN', 'accounting:ap:approve'),
     ('ADMIN', 'accounting:ap:pay'),
@@ -651,6 +662,8 @@ FROM (VALUES
     ('ADMIN', 'mcp:system_prompt:delete'),
     ('ADMIN', 'mcp:system_prompt:update'),
     ('ADMIN', 'mcp:system_prompt:view'),
+    ('ADMIN', 'mcp:tool:manage'),
+    ('ADMIN', 'mcp:tool:view'),
     ('ADMIN', 'nlti:audit:read'),
     ('ADMIN', 'nlti:request:read'),
     ('ADMIN', 'nlti:request:submit'),
@@ -813,11 +826,18 @@ FROM (VALUES
     ('ADMIN', 'workorder:workorder:reopen_completed'),
     ('ADMIN', 'workorder:workorder:start'),
     ('ADMIN', 'workorder:workorder:view'),
+    ('CUSTOMER', 'mcp:chat:execute'),
+    ('CUSTOMER', 'mcp:chat:stream'),
+    ('CUSTOMER', 'nlti:request:read'),
+    ('CUSTOMER', 'nlti:request:submit'),
     ('DISPATCHER', 'appointments:cancel'),
     ('DISPATCHER', 'appointments:create'),
     ('DISPATCHER', 'appointments:reschedule'),
     ('DISPATCHER', 'appointments:view'),
     ('DISPATCHER', 'mcp:chat:execute'),
+    ('DISPATCHER', 'mcp:chat:stream'),
+    ('DISPATCHER', 'nlti:request:read'),
+    ('DISPATCHER', 'nlti:request:submit'),
     ('DISPATCHER', 'people:availability:view'),
     ('DISPATCHER', 'shop:bay:assign'),
     ('DISPATCHER', 'shop:bay:view'),
@@ -828,6 +848,9 @@ FROM (VALUES
     ('DISPATCHER', 'workorder:workorder:assign-technician'),
     ('DISPATCHER', 'workorder:workorder:view'),
     ('GENERAL_MANAGER', 'mcp:chat:execute'),
+    ('GENERAL_MANAGER', 'mcp:chat:stream'),
+    ('GENERAL_MANAGER', 'nlti:request:read'),
+    ('GENERAL_MANAGER', 'nlti:request:submit'),
     ('GENERAL_MANAGER', 'people:timekeeping:approve'),
     ('GENERAL_MANAGER', 'people:timekeeping:reject'),
     ('GENERAL_MANAGER', 'people:timekeeping:view'),
@@ -839,6 +862,18 @@ FROM (VALUES
     ('GENERAL_MANAGER', 'security:role:view'),
     ('GENERAL_MANAGER', 'workorder:timeEntry:approve'),
     ('GENERAL_MANAGER', 'workorder:timeEntry:reject'),
+    ('INVENTORY_CONTROLLER', 'mcp:chat:execute'),
+    ('INVENTORY_CONTROLLER', 'mcp:chat:stream'),
+    ('INVENTORY_CONTROLLER', 'nlti:request:read'),
+    ('INVENTORY_CONTROLLER', 'nlti:request:submit'),
+    ('INVENTORY_LEAD', 'mcp:chat:execute'),
+    ('INVENTORY_LEAD', 'mcp:chat:stream'),
+    ('INVENTORY_LEAD', 'nlti:request:read'),
+    ('INVENTORY_LEAD', 'nlti:request:submit'),
+    ('INVENTORY_MANAGER', 'mcp:chat:execute'),
+    ('INVENTORY_MANAGER', 'mcp:chat:stream'),
+    ('INVENTORY_MANAGER', 'nlti:request:read'),
+    ('INVENTORY_MANAGER', 'nlti:request:submit'),
     ('LOCATION_MANAGER', 'appointments:cancel'),
     ('LOCATION_MANAGER', 'appointments:create'),
     ('LOCATION_MANAGER', 'appointments:reschedule'),
@@ -852,6 +887,9 @@ FROM (VALUES
     ('LOCATION_MANAGER', 'invoice:finalize'),
     ('LOCATION_MANAGER', 'invoice:manage'),
     ('LOCATION_MANAGER', 'mcp:chat:execute'),
+    ('LOCATION_MANAGER', 'mcp:chat:stream'),
+    ('LOCATION_MANAGER', 'nlti:request:read'),
+    ('LOCATION_MANAGER', 'nlti:request:submit'),
     ('LOCATION_MANAGER', 'people:availability:view'),
     ('LOCATION_MANAGER', 'people:timeAdjustment:approve'),
     ('LOCATION_MANAGER', 'people:timeAdjustment:create'),
@@ -922,6 +960,9 @@ FROM (VALUES
     ('LOCATION_MANAGER', 'workorder:workorder:reopen_completed'),
     ('LOCATION_MANAGER', 'workorder:workorder:view'),
     ('MANAGER', 'mcp:chat:execute'),
+    ('MANAGER', 'mcp:chat:stream'),
+    ('MANAGER', 'nlti:request:read'),
+    ('MANAGER', 'nlti:request:submit'),
     ('MANAGER', 'people:timekeeping:approve'),
     ('MANAGER', 'people:timekeeping:reject'),
     ('MANAGER', 'people:timekeeping:view'),
@@ -933,6 +974,18 @@ FROM (VALUES
     ('MANAGER', 'security:role:view'),
     ('MANAGER', 'workorder:timeEntry:approve'),
     ('MANAGER', 'workorder:timeEntry:reject'),
+    ('READ_ONLY_SCHEDULER', 'mcp:chat:execute'),
+    ('READ_ONLY_SCHEDULER', 'mcp:chat:stream'),
+    ('READ_ONLY_SCHEDULER', 'nlti:request:read'),
+    ('READ_ONLY_SCHEDULER', 'nlti:request:submit'),
+    ('SECURITY_ADMIN', 'mcp:chat:execute'),
+    ('SECURITY_ADMIN', 'mcp:chat:stream'),
+    ('SECURITY_ADMIN', 'nlti:request:read'),
+    ('SECURITY_ADMIN', 'nlti:request:submit'),
+    ('SELF_SERVICE_CUSTOMER', 'mcp:chat:execute'),
+    ('SELF_SERVICE_CUSTOMER', 'mcp:chat:stream'),
+    ('SELF_SERVICE_CUSTOMER', 'nlti:request:read'),
+    ('SELF_SERVICE_CUSTOMER', 'nlti:request:submit'),
     ('SERVICE_ADVISOR', 'appointments:cancel'),
     ('SERVICE_ADVISOR', 'appointments:create'),
     ('SERVICE_ADVISOR', 'appointments:reschedule'),
@@ -943,6 +996,9 @@ FROM (VALUES
     ('SERVICE_ADVISOR', 'invoice:finalize'),
     ('SERVICE_ADVISOR', 'invoice:manage'),
     ('SERVICE_ADVISOR', 'mcp:chat:execute'),
+    ('SERVICE_ADVISOR', 'mcp:chat:stream'),
+    ('SERVICE_ADVISOR', 'nlti:request:read'),
+    ('SERVICE_ADVISOR', 'nlti:request:submit'),
     ('SERVICE_ADVISOR', 'pricing:promotion:view'),
     ('SERVICE_ADVISOR', 'shop:bay:view'),
     ('SERVICE_ADVISOR', 'shop:location:view'),
@@ -980,7 +1036,24 @@ FROM (VALUES
     ('SERVICE_ADVISOR', 'workorder:workorder:create'),
     ('SERVICE_ADVISOR', 'workorder:workorder:generate_invoice'),
     ('SERVICE_ADVISOR', 'workorder:workorder:view'),
+    ('SHOP_MANAGER', 'mcp:chat:execute'),
+    ('SHOP_MANAGER', 'mcp:chat:stream'),
+    ('SHOP_MANAGER', 'nlti:request:read'),
+    ('SHOP_MANAGER', 'nlti:request:submit'),
     ('SYSTEM_ADMINISTRATOR', 'mcp:chat:execute'),
+    ('SYSTEM_ADMINISTRATOR', 'mcp:chat:stream'),
+    ('SYSTEM_ADMINISTRATOR', 'mcp:document:ingest'),
+    ('SYSTEM_ADMINISTRATOR', 'mcp:llm_api:create'),
+    ('SYSTEM_ADMINISTRATOR', 'mcp:llm_api:delete'),
+    ('SYSTEM_ADMINISTRATOR', 'mcp:llm_api:update'),
+    ('SYSTEM_ADMINISTRATOR', 'mcp:llm_api:view'),
+    ('SYSTEM_ADMINISTRATOR', 'mcp:system_prompt:create'),
+    ('SYSTEM_ADMINISTRATOR', 'mcp:system_prompt:delete'),
+    ('SYSTEM_ADMINISTRATOR', 'mcp:system_prompt:update'),
+    ('SYSTEM_ADMINISTRATOR', 'mcp:system_prompt:view'),
+    ('SYSTEM_ADMINISTRATOR', 'mcp:tool:manage'),
+    ('SYSTEM_ADMINISTRATOR', 'nlti:request:read'),
+    ('SYSTEM_ADMINISTRATOR', 'nlti:request:submit'),
     ('SYSTEM_ADMINISTRATOR', 'security:audit:create'),
     ('SYSTEM_ADMINISTRATOR', 'security:audit:export'),
     ('SYSTEM_ADMINISTRATOR', 'security:audit:view'),
@@ -1003,6 +1076,9 @@ FROM (VALUES
     ('TECHNICIAN', 'inventory:pick_list:execute'),
     ('TECHNICIAN', 'inventory:pick_list:view'),
     ('TECHNICIAN', 'mcp:chat:execute'),
+    ('TECHNICIAN', 'mcp:chat:stream'),
+    ('TECHNICIAN', 'nlti:request:read'),
+    ('TECHNICIAN', 'nlti:request:submit'),
     ('TECHNICIAN', 'people:timeAdjustment:create'),
     ('TECHNICIAN', 'people:timeAdjustment:view'),
     ('TECHNICIAN', 'people:timeException:acknowledge'),
@@ -1047,11 +1123,19 @@ BEGIN
         ('ACCOUNTING_ASSOCIATE'),
         ('ACCOUNT_MANAGER'),
         ('ADMIN'),
+        ('CUSTOMER'),
         ('DISPATCHER'),
         ('GENERAL_MANAGER'),
+        ('INVENTORY_CONTROLLER'),
+        ('INVENTORY_LEAD'),
+        ('INVENTORY_MANAGER'),
         ('LOCATION_MANAGER'),
         ('MANAGER'),
+        ('READ_ONLY_SCHEDULER'),
+        ('SECURITY_ADMIN'),
+        ('SELF_SERVICE_CUSTOMER'),
         ('SERVICE_ADVISOR'),
+        ('SHOP_MANAGER'),
         ('SYSTEM_ADMINISTRATOR'),
         ('TECHNICIAN')
       ) AS g(role_name)
@@ -1233,6 +1317,8 @@ BEGIN
         ('mcp:system_prompt:delete'),
         ('mcp:system_prompt:update'),
         ('mcp:system_prompt:view'),
+        ('mcp:tool:manage'),
+        ('mcp:tool:view'),
         ('nlti:audit:read'),
         ('nlti:request:read'),
         ('nlti:request:submit'),

--- a/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
+++ b/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
@@ -12,12 +12,16 @@
 --   role already exercised through the retired hardcoded expansion, or (for
 --   SYSTEM_ADMINISTRATOR and DISPATCHER, which the hardcoded switch never
 --   covered) the role's documented job function.
--- * Assistant baseline: EVERY role that exists receives mcp:chat:execute,
+-- * Assistant baseline: every role listed in section 3 receives mcp:chat:execute,
 --   mcp:chat:stream, nlti:request:submit and nlti:request:read. These are the
 --   conversational entrypoints; the assistant still enforces domain permissions
 --   per request, so holding them grants reach to the assistant, not to data.
 --   NOTE this includes the customer-facing CUSTOMER and SELF_SERVICE_CUSTOMER
 --   roles, which previously held nothing at all.
+--   These are explicit grants, not a rule the database enforces: a role created
+--   later through the role-permission admin API starts with NO grants, assistant
+--   entrypoints included, until something grants them. To make a new role part of
+--   the baseline, add it to section 3 here.
 -- * SYSTEM_ADMINISTRATOR is deliberately NOT a superuser. It holds the
 --   security/admin surface plus MCP administration (system prompts, LLM API
 --   configuration, tool management, document ingest) and no accounting, catalog,

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/RolePermissionBaselineTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/RolePermissionBaselineTest.java
@@ -76,16 +76,25 @@ class RolePermissionBaselineTest {
     private static final Set<String> UNREACHABLE_LEGACY_ROLES =
             Set.of("ACCOUNTANT", "AP_CLERK", "CONTROLLER", "CSR", "FLEET_MANAGER", "GL_ANALYST");
 
-    /** Roles that are seeded as identity only and intentionally carry no grants. */
-    private static final Set<String> INTENTIONALLY_UNGRANTED = Set.of(
-            "CUSTOMER",
-            "SELF_SERVICE_CUSTOMER",
-            "SHOP_MANAGER",
-            "SECURITY_ADMIN",
-            "READ_ONLY_SCHEDULER",
-            "INVENTORY_LEAD",
-            "INVENTORY_MANAGER",
-            "INVENTORY_CONTROLLER");
+    /**
+     * Conversational entrypoints every role receives. Holding these grants reach to the
+     * assistant, not to data: the assistant still enforces domain permissions per request.
+     */
+    private static final Set<String> ASSISTANT_BASELINE =
+            Set.of("mcp:chat:execute", "mcp:chat:stream", "nlti:request:submit", "nlti:request:read");
+
+    /** MCP administration, reserved for ADMIN and SYSTEM_ADMINISTRATOR. */
+    private static final Set<String> MCP_ADMINISTRATION = Set.of(
+            "mcp:system_prompt:view",
+            "mcp:system_prompt:create",
+            "mcp:system_prompt:update",
+            "mcp:system_prompt:delete",
+            "mcp:llm_api:view",
+            "mcp:llm_api:create",
+            "mcp:llm_api:update",
+            "mcp:llm_api:delete",
+            "mcp:tool:manage",
+            "mcp:document:ingest");
 
     private static Map<String, Set<String>> seededGrants;
     private static Set<String> definedPermissions;
@@ -116,8 +125,8 @@ class RolePermissionBaselineTest {
     }
 
     @Test
-    @DisplayName("reproduces the retired hardcoded expansion exactly for every legacy role")
-    void seed_reproducesLegacyRoleExpansionExactly() throws IOException {
+    @DisplayName("still grants everything the retired hardcoded expansion gave every legacy role")
+    void seed_losesNoLegacyCapability() throws IOException {
         Map<String, Set<String>> legacy = new TreeMap<>();
         for (String line : readResource(LEGACY_BASELINE).lines().toList()) {
             if (line.isBlank()) {
@@ -129,10 +138,13 @@ class RolePermissionBaselineTest {
 
         assertThat(legacy).as("legacy baseline fixture is empty").isNotEmpty();
 
+        // Containment, not equality: the baseline deliberately exceeds the legacy expansion now
+        // (every role gains the assistant entrypoints). The fixture is the no-regression floor —
+        // a capability the switch used to grant must never silently disappear.
         // Per role rather than in bulk, so a failure names the role that drifted.
         legacy.forEach((role, expected) -> assertThat(seededGrants.get(role))
                 .as("grants for legacy role %s", role)
-                .containsExactlyInAnyOrderElementsOf(expected));
+                .containsAll(expected));
     }
 
     @Test
@@ -144,8 +156,12 @@ class RolePermissionBaselineTest {
                 .as("SYSTEM_ADMINISTRATOR must carry the security admin surface")
                 .isNotEmpty();
         assertThat(granted)
-                .as("SYSTEM_ADMINISTRATOR may hold security:* and the chat entrypoint only")
-                .allMatch(permission -> permission.startsWith("security:") || permission.equals("mcp:chat:execute"));
+                .as("SYSTEM_ADMINISTRATOR may hold security:*, MCP administration and the assistant "
+                        + "entrypoints only — never domain authority")
+                .allMatch(permission -> permission.startsWith("security:")
+                        || permission.startsWith("mcp:")
+                        || permission.startsWith("nlti:"));
+        assertThat(granted).containsAll(MCP_ADMINISTRATION);
 
         // ADMIN is the all-domain role; SYSTEM_ADMINISTRATOR must stay strictly narrower.
         assertThat(granted)
@@ -172,7 +188,11 @@ class RolePermissionBaselineTest {
                         "workorder:workorder:view",
                         "workorder:workorder:assign-technician",
                         "people:availability:view",
-                        "mcp:chat:execute");
+                        // the assistant entrypoints every role carries
+                        "mcp:chat:execute",
+                        "mcp:chat:stream",
+                        "nlti:request:submit",
+                        "nlti:request:read");
     }
 
     @Test
@@ -218,9 +238,33 @@ class RolePermissionBaselineTest {
     }
 
     @Test
-    @DisplayName("roles left ungranted on purpose have no rows")
-    void intentionallyUngrantedRoles_haveNoGrants() {
-        assertThat(seededGrants.keySet()).doesNotContainAnyElementsOf(INTENTIONALLY_UNGRANTED);
+    @DisplayName("every role receives the assistant entrypoints")
+    void everyRoleReceivesTheAssistantBaseline() {
+        // Per role, so a failure names the role that is missing them rather than just failing.
+        seededGrants.forEach((role, granted) ->
+                assertThat(granted).as("assistant baseline for %s", role).containsAll(ASSISTANT_BASELINE));
+    }
+
+    @Test
+    @DisplayName("MCP administration is reserved for ADMIN and SYSTEM_ADMINISTRATOR")
+    void mcpAdministrationIsReservedToAdminRoles() {
+        assertThat(seededGrants.get("ADMIN")).containsAll(MCP_ADMINISTRATION);
+        assertThat(seededGrants.get("SYSTEM_ADMINISTRATOR")).containsAll(MCP_ADMINISTRATION);
+
+        Set<String> holders = seededGrants.entrySet().stream()
+                .filter(entry -> entry.getValue().stream().anyMatch(MCP_ADMINISTRATION::contains))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        assertThat(holders)
+                .as("MCP administration must not leak to operational or customer-facing roles")
+                .containsExactly("ADMIN", "SYSTEM_ADMINISTRATOR");
+    }
+
+    @Test
+    @DisplayName("ADMIN holds both tool permissions")
+    void adminHoldsToolViewAndManage() {
+        assertThat(seededGrants.get("ADMIN")).contains("mcp:tool:view", "mcp:tool:manage");
     }
 
     @Test

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/RolePermissionBaselineTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/RolePermissionBaselineTest.java
@@ -19,6 +19,7 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -83,7 +84,7 @@ class RolePermissionBaselineTest {
     private static final Set<String> ASSISTANT_BASELINE =
             Set.of("mcp:chat:execute", "mcp:chat:stream", "nlti:request:submit", "nlti:request:read");
 
-    /** MCP administration, reserved for ADMIN and SYSTEM_ADMINISTRATOR. */
+    /** MCP administration that both ADMIN and SYSTEM_ADMINISTRATOR must hold. */
     private static final Set<String> MCP_ADMINISTRATION = Set.of(
             "mcp:system_prompt:view",
             "mcp:system_prompt:create",
@@ -95,6 +96,16 @@ class RolePermissionBaselineTest {
             "mcp:llm_api:delete",
             "mcp:tool:manage",
             "mcp:document:ingest");
+
+    /**
+     * Everything on the MCP administration surface, which no role outside ADMIN and
+     * SYSTEM_ADMINISTRATOR may hold. Wider than {@link #MCP_ADMINISTRATION} because
+     * {@code mcp:tool:view} is restricted too but is currently held by ADMIN alone, so it is
+     * not something both admin roles are required to have.
+     */
+    private static final Set<String> MCP_ADMINISTRATION_SURFACE = Stream.concat(
+                    MCP_ADMINISTRATION.stream(), Stream.of("mcp:tool:view"))
+            .collect(Collectors.toUnmodifiableSet());
 
     private static Map<String, Set<String>> seededGrants;
     private static Set<String> definedPermissions;
@@ -251,8 +262,11 @@ class RolePermissionBaselineTest {
         assertThat(seededGrants.get("ADMIN")).containsAll(MCP_ADMINISTRATION);
         assertThat(seededGrants.get("SYSTEM_ADMINISTRATOR")).containsAll(MCP_ADMINISTRATION);
 
+        // Scan the whole restricted surface, not just what both admin roles must hold:
+        // mcp:tool:view is equally restricted, and checking only MCP_ADMINISTRATION would let it
+        // leak to any role undetected.
         Set<String> holders = seededGrants.entrySet().stream()
-                .filter(entry -> entry.getValue().stream().anyMatch(MCP_ADMINISTRATION::contains))
+                .filter(entry -> entry.getValue().stream().anyMatch(MCP_ADMINISTRATION_SURFACE::contains))
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toCollection(TreeSet::new));
 

--- a/pos-security-service/src/test/java/com/positivity/securityservice/migration/RolePermissionSeedIT.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/migration/RolePermissionSeedIT.java
@@ -97,8 +97,9 @@ class RolePermissionSeedIT {
                 .doesNotContain("accounting:je:post");
 
         assertThat(grantedTo("CUSTOMER"))
-                .as("roles left ungranted on purpose stay empty")
-                .isEmpty();
+                .as("customer-facing roles receive the assistant entrypoints and nothing else")
+                .containsExactlyInAnyOrder(
+                        "mcp:chat:execute", "mcp:chat:stream", "nlti:request:submit", "nlti:request:read");
     }
 
     @Test
@@ -165,13 +166,17 @@ class RolePermissionSeedIT {
     @Test
     @DisplayName("a user holding only an ungranted role resolves no permissions")
     void userWithOnlyUngrantedRole_failsClosed() {
+        // Every seeded role now carries the assistant entrypoints, so fail-closed has to be
+        // proven against a role with genuinely no grants rather than against a seeded one.
+        jdbc().update("INSERT INTO roles (id, name, description, created_at, created_by) "
+                + "VALUES (gen_random_uuid(), 'IT_UNGRANTED_ROLE', 'no grants', NOW(), 'test')");
         jdbc().update(
                         "INSERT INTO users (id, username, password, enabled) "
                                 + "VALUES (gen_random_uuid(), ?, 'x', true)",
                         "ungranted.user");
         jdbc().update("INSERT INTO user_roles (user_id, role_id) "
                 + "SELECT u.id, r.id FROM users u, roles r "
-                + "WHERE u.username = 'ungranted.user' AND r.name = 'CUSTOMER'");
+                + "WHERE u.username = 'ungranted.user' AND r.name = 'IT_UNGRANTED_ROLE'");
 
         assertThat(effectivePermissionsOf("ungranted.user")).isEmpty();
     }


### PR DESCRIPTION
## Capability & Traceability
- Capability: _n/a — requested directly; no capability/story id supplied_
- Parent STORY (durion): _n/a_
- Child issue: _n/a_
- Domain: `domain:security`

## Contract References
- Contract guide entry (durion): `domains/security/.business-rules/BACKEND_CONTRACT_GUIDE.md` → role/permission resolution

No contract-relevant files changed — the diff is one Flyway migration, two tests and a README. Marker retained so the Contract Sync check has what it looks for.

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations — no controller changed
- [ ] `openapi.yaml` regenerated — n/a
- [ ] Angular SDK regenerated — n/a

## Scope

**Every role** now receives the four conversational entrypoints:

| Permission | Bit | Meaning |
| --- | --- | --- |
| `mcp:chat:execute` | 226 | Synchronous chat via the Spring AI assistant runtime |
| `mcp:chat:stream` | 225 | Streaming SSE chat |
| `nlti:request:submit` | 221 | Submit a natural-language task-interface request |
| `nlti:request:read` | 222 | Read submitted NLTI request status |

**`ADMIN` and `SYSTEM_ADMINISTRATOR`** additionally receive MCP administration. The two wildcards were expanded from the manifest, not guessed:

- `mcp:system_prompt:*` → `view` (99), `create` (100), `update` (101), `delete` (102)
- `mcp:llm_api:*` → `view` (95), `create` (96), `update` (97), `delete` (98)
- `mcp:tool:manage` (347), `mcp:document:ingest` (224)

**`ADMIN`** also gets `mcp:tool:view` (348) and `mcp:tool:manage` — neither was held by any role before.

All sixteen names were verified present in a `permissions.yaml` manifest **and** in `PermissionCode` before use, so every one carries a bit index and can actually travel in a `perm_bits` claim. Grants go 603 → 674; roles 10 → 18.

## Three things worth your explicit attention

**1. `SYSTEM_ADMIN` isn't a role.** No such name exists. The seeded roles are `SYSTEM_ADMINISTRATOR` (the canonical persona this baseline already treats as the security/admin role) and `SECURITY_ADMIN` (a V3 "candidate role" that has never held anything). I applied the MCP administration set to **`SYSTEM_ADMINISTRATOR`**. Say the word if you meant `SECURITY_ADMIN`.

**2. External customers can now reach the assistant.** "Every role" includes `CUSTOMER` and `SELF_SERVICE_CUSTOMER`, which previously held **nothing at all**. They now hold `nlti:request:submit` — submitting natural-language task-interface requests — and both chat entrypoints. This is a real change in external attack surface, so I want it visible rather than buried in a diff.

My read is that it is defensible: these are reach-to-the-assistant permissions, and the assistant still enforces domain permissions per request, so a role that cannot read an invoice cannot read one by asking. But it rests on that enforcement actually holding for NLTI, which is outside what this PR verifies. If you want them excluded it is a two-line change to the seed plus the matching test.

**3. `SYSTEM_ADMINISTRATOR` gets `mcp:tool:manage` without `mcp:tool:view`.** That is exactly what was specified, so I implemented it literally rather than quietly widening it — but manage-without-view looks like an oversight. One line to add if you want it.

## Roles

Eighteen now, up from ten. The eight additions are the previously-empty roles: `CUSTOMER`, `SELF_SERVICE_CUSTOMER`, `SHOP_MANAGER`, `SECURITY_ADMIN`, `READ_ONLY_SCHEDULER`, and the three `INVENTORY_*`.

The `INVENTORY_*` three exist only via `RoleInitializer`, an `@PostConstruct` bean that runs **after** Flyway — the same ordering trap that broke main in #1372. The seed therefore creates them itself, exactly as it already creates `MANAGER` and `GENERAL_MANAGER`. Granting to them without that would abort startup.

The six unreachable legacy personas (`ACCOUNTANT`, `AP_CLERK`, `CONTROLLER`, `CSR`, `FLEET_MANAGER`, `GL_ANALYST`) remain excluded: nothing creates them and both assignment tables are FK'd to `roles(id)`, so "every role" cannot sensibly include roles no user can hold. Creating them is the open question in #1373.

## Tests
- [x] Unit tests added/updated
- [x] Integration tests updated

Three existing assertions became wrong **by design**. I updated them rather than deleting them, and each change narrows what is still guaranteed:

- **Legacy parity moves from equality to containment.** The baseline now deliberately exceeds the retired switch's expansion, so exact match is no longer the right assertion. The fixture stays as the no-regression floor — a capability the switch granted can still never silently disappear.
- **The `SYSTEM_ADMINISTRATOR` scope assertion** now admits `mcp:*` and `nlti:*` while still forbidding domain authority, and still requires a strict subset of `ADMIN`.
- **`DISPATCHER`'s exact-set assertion** gained the three new entrypoints.

New tests pin: the baseline on every role, `ADMIN`'s two tool permissions, and that MCP administration reaches **no** role other than the two admin ones.

`RolePermissionSeedIT` needed two fixes that matter more than they look — it is the test that only runs post-merge, so getting these wrong would have reddened main a second time:

- it asserted `CUSTOMER` held nothing, which is now false;
- it proved fail-closed *through* `CUSTOMER`, which no longer proves anything. Fail-closed is now demonstrated against a role created with no grants, so the property is genuinely tested rather than incidentally true.

**How to run:**

```bash
./mvnw -pl pos-security-service -am -DskipTests=false verify
```

Local result: **BUILD SUCCESS** — 479 unit + 82 IT, 0 failures, all quality gates green.

I also verified the generated SQL directly, independent of the tests: 18 roles, none missing the universal four, `ADMIN` holds both tool permissions, `SYSTEM_ADMINISTRATOR` holds the full MCP administration set, no leakage of MCP administration to any other role, and `SYSTEM_ADMINISTRATOR ⊂ ADMIN` still holds.

> As with every PR here, `RolePermissionSeedIT` will **not** run on this PR's CI — the `pull_request` path passes `-DskipITs` (`ci.yml:255-277`). It runs on the post-merge main build. I'll watch that run and fix forward if it fails.

## Risk & Rollback

**Risk level: Medium** — purely additive to authority, but it widens what customer-facing roles can reach (see point 2).

**Rollback:** revert the commit. Note the seed only inserts, so rows already applied persist after a revert; removing them means a `DELETE` through the admin API or a versioned migration.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — no cap id
- [ ] PR title starts with `[CAP:<cap-id>]` — happy to retitle
- [ ] Links to parent + child issues — none supplied
- [x] Contract guide updated — no contract semantics changed
- [ ] Required CI checks passing — pending

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRTZc5gwTT869MoN8ga4j9)_