### PR TITLE
Grant SYSTEM_ADMINISTRATOR mcp:tool:view and nlti:audit:read

### DIFF
--- a/pos-security-service/README.md
+++ b/pos-security-service/README.md
@@ -74,7 +74,7 @@ therefore creates those two roles itself rather than relying on bean lifecycle.
 | Role | Baseline |
 | --- | --- |
 | `ADMIN` | All domains. The intentional blast-radius role. |
-| `SYSTEM_ADMINISTRATOR` | **Security and MCP administration only** — `security:*`, plus MCP administration (`mcp:system_prompt:*`, `mcp:llm_api:*`, `mcp:tool:manage`, `mcp:document:ingest`) and the assistant entrypoints. Deliberately *not* a superuser: it holds no accounting, catalog, workorder, inventory, or shop authority, and it does **not** auto-acquire newly registered permissions. Widening it is an explicit edit to the seed. |
+| `SYSTEM_ADMINISTRATOR` | **Security and MCP administration only** — `security:*`, plus MCP administration (`mcp:system_prompt:*`, `mcp:llm_api:*`, `mcp:tool:view`, `mcp:tool:manage`, `mcp:document:ingest`), NLTI audit visibility (`nlti:audit:read`) and the assistant entrypoints. Deliberately *not* a superuser: it holds no accounting, catalog, workorder, inventory, or shop authority, and it does **not** auto-acquire newly registered permissions. Widening it is an explicit edit to the seed. |
 | `LOCATION_MANAGER`, `SERVICE_ADVISOR`, `TECHNICIAN`, `DISPATCHER`, `ACCOUNTING_ASSOCIATE`, `ACCOUNT_MANAGER`, `MANAGER`, `GENERAL_MANAGER` | Least privilege, scoped to the role's job function. |
 | `ACCOUNTANT`, `AP_CLERK`, `CONTROLLER`, `CSR`, `FLEET_MANAGER`, `GL_ANALYST` | **Not granted, and not created.** The retired hardcoded switch expanded these, but no migration or initializer creates the role, and `user_roles` / `role_assignments` are foreign-keyed to `roles(id)` — so no user could ever hold one. They were unreachable branches, documentation personas rather than security roles. To make one real, create the role first, then grant it. |
 | `CUSTOMER`, `SELF_SERVICE_CUSTOMER`, `SHOP_MANAGER`, `SECURITY_ADMIN`, `READ_ONLY_SCHEDULER`, `INVENTORY_LEAD`, `INVENTORY_MANAGER`, `INVENTORY_CONTROLLER` | **Assistant entrypoints only.** No domain capability; granting them any is still a product decision. |
@@ -103,9 +103,10 @@ baseline. If that is not wanted, remove those two roles from the universal list 
 the seed; `RolePermissionBaselineTest.everyRoleReceivesTheAssistantBaseline` pins the current
 policy and will need updating alongside.
 
-MCP administration — `mcp:system_prompt:*`, `mcp:llm_api:*`, `mcp:tool:manage`,
-`mcp:document:ingest`, and for `ADMIN` also `mcp:tool:view` — is restricted to `ADMIN` and
-`SYSTEM_ADMINISTRATOR`, and a test asserts no other role holds any of it.
+MCP administration — `mcp:system_prompt:*`, `mcp:llm_api:*`, `mcp:tool:view`, `mcp:tool:manage`
+and `mcp:document:ingest` — is restricted to `ADMIN` and `SYSTEM_ADMINISTRATOR`, and a test asserts
+no other role holds any of it. `nlti:audit:read` (the NLTI audit ledger) is likewise held only by
+those two.
 
 ### Role grants vs. role assignments
 

--- a/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
+++ b/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
@@ -1056,6 +1056,8 @@ FROM (VALUES
     ('SYSTEM_ADMINISTRATOR', 'mcp:system_prompt:update'),
     ('SYSTEM_ADMINISTRATOR', 'mcp:system_prompt:view'),
     ('SYSTEM_ADMINISTRATOR', 'mcp:tool:manage'),
+    ('SYSTEM_ADMINISTRATOR', 'mcp:tool:view'),
+    ('SYSTEM_ADMINISTRATOR', 'nlti:audit:read'),
     ('SYSTEM_ADMINISTRATOR', 'nlti:request:read'),
     ('SYSTEM_ADMINISTRATOR', 'nlti:request:submit'),
     ('SYSTEM_ADMINISTRATOR', 'security:audit:create'),

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/RolePermissionBaselineTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/RolePermissionBaselineTest.java
@@ -276,6 +276,25 @@ class RolePermissionBaselineTest {
     }
 
     @Test
+    @DisplayName("SYSTEM_ADMINISTRATOR holds tool visibility and the NLTI audit ledger")
+    void systemAdministratorHoldsToolViewAndNltiAudit() {
+        assertThat(seededGrants.get("SYSTEM_ADMINISTRATOR")).contains("mcp:tool:view", "nlti:audit:read");
+    }
+
+    @Test
+    @DisplayName("the NLTI audit ledger is reserved for ADMIN and SYSTEM_ADMINISTRATOR")
+    void nltiAuditReadIsReservedToAdminRoles() {
+        Set<String> holders = seededGrants.entrySet().stream()
+                .filter(entry -> entry.getValue().contains("nlti:audit:read"))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        assertThat(holders)
+                .as("the NLTI audit ledger exposes other principals' request history")
+                .containsExactly("ADMIN", "SYSTEM_ADMINISTRATOR");
+    }
+
+    @Test
     @DisplayName("ADMIN holds both tool permissions")
     void adminHoldsToolViewAndManage() {
         assertThat(seededGrants.get("ADMIN")).contains("mcp:tool:view", "mcp:tool:manage");


### PR DESCRIPTION
## Capability & Traceability
- Capability: _n/a — requested directly; no capability/story id supplied_
- Parent STORY (durion): _n/a_
- Child issue: _n/a_
- Domain: `domain:security`

## Contract References
- Contract guide entry (durion): `domains/security/.business-rules/BACKEND_CONTRACT_GUIDE.md` → role/permission resolution

No contract-relevant files changed — one Flyway migration, one test, a README line. Marker retained for the Contract Sync check.

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations — no controller changed
- [ ] `openapi.yaml` regenerated — n/a
- [ ] Angular SDK regenerated — n/a

## Scope

Two grants added to `SYSTEM_ADMINISTRATOR`:

| Permission | Bit | Why |
| --- | --- | --- |
| `mcp:tool:view` | 348 | Closes the manage-without-view asymmetry from #1378 — the role could manage MCP tools but not list them |
| `nlti:audit:read` | 223 | The NLTI audit ledger, consistent with the `security:audit:view/create/export` surface it already holds |

32 → 34 grants for the role; 674 → 676 total. Still a strict subset of `ADMIN`, which already held both.

Only the grant rows changed: both names were already in the seed's permission-definition and assertion blocks, because `ADMIN` holds them.

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests — unchanged

The change needed **no** test edits to pass, which is exactly why it needed new ones. Nothing prevented either grant from silently disappearing again: the `SYSTEM_ADMINISTRATOR` scope assertion only bounds what the role *may* hold, and the MCP leak assertion checks *who* holds a permission, not that this role still does. A grant that no test pins is a grant that can regress unnoticed — the same failure mode as the original empty `role_permissions`.

Two tests added:

- `systemAdministratorHoldsToolViewAndNltiAudit` — the role holds both.
- `nltiAuditReadIsReservedToAdminRoles` — `nlti:audit:read` is held by `ADMIN` and `SYSTEM_ADMINISTRATOR` alone. This one is a genuine restriction, not bookkeeping: the audit ledger exposes *other principals'* NLTI request history, so it belongs on the restricted list beside MCP administration rather than drifting onto an operational role.

Verified by sabotage rather than assumed: removing the `nlti:audit:read` grant fails both.

**How to run:**

```bash
./mvnw -pl pos-security-service -am -DskipTests=false verify
```

Local result: **BUILD SUCCESS** — 481 unit + 82 IT, 0 failures, all gates green.

> `RolePermissionSeedIT` does not run on this PR's CI (`-DskipITs`, `ci.yml:255-277`); it runs post-merge on main. I'll watch that run.

## Risk & Rollback

**Risk level: Low.** Two additive grants to an admin role that is already a subset of `ADMIN`; no operational or customer-facing role is touched.

**Rollback:** revert. The seed only inserts, so applied rows persist after a revert — removal needs the admin API or a versioned migration.

## Note on the deferred customer question

While checking what "limited scope" could mean for customer NLTI access, I found that customer scope is **not** bounded by their grants the way #1378's description assumed: `PermissionCodes.extract` in pos-mcp-server appends a synthetic `AUTHENTICATED` code to every caller regardless of grants, and seven facade tools are gated on exactly that (`OrderFacadeTool`, `PricingFacadeTool`, `CatalogFacadeTool`, `EventsFacadeTool`, and partially `WorkorderFacadeTool` / `TaxFacadeTool` / `AdminFacadeTool`).

Deliberately **not** addressed here — the decision was to leave customer scope as-is for alpha, where there is no real data. Tracked separately so it is not lost before data lands.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — no cap id
- [ ] PR title starts with `[CAP:<cap-id>]` — happy to retitle
- [ ] Links to parent + child issues — none supplied
- [x] Contract guide updated — no contract semantics changed
- [ ] Required CI checks passing — pending

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRTZc5gwTT869MoN8ga4j9)_