### PR TITLE
feat(pos-mcp-server): decision C — write-gate target is a seeded probe appointment cancel (#1218)

### DIFF
--- a/pos-mcp-server/docs/gate-closeout-plan-1212-1219.md
+++ b/pos-mcp-server/docs/gate-closeout-plan-1212-1219.md
@@ -133,10 +133,25 @@ list — repeated here as the checklist):
 
 - **A.** Alpha access — session gets it directly, or someone else runs the harness and pastes
   output?
-- **B.** Tier models for #1216 — which models for `mcp.model.simple`/`complex`, pulled on alpha
-  Ollama? (leaning: `simple=qwen3:8b`, `complex` left blank)
-- **C.** #1218 write target — which downstream service/action, and is dirtying alpha data
-  acceptable?
+- **B.** ~~Tier models for #1216~~ **RESOLVED 2026-08-19**: `MCP_MODEL_SIMPLE=gpt-oss:20b`,
+  `MCP_MODEL_COMPLEX` unset (default executor `gpt-oss:120b` is already the complex-class model).
+  Both tiers on the ollama.com cloud backend — chat does NOT run on alpha's local Ollama (that
+  container serves embeddings only), so the plan's "pulled on alpha Ollama" framing was wrong; a
+  local simple model would have measured CPU inference, not tiering. All three models
+  (router `qwen3.5:397b`, both tiers) verified serving HTTP 200 on the rotated key. Set in
+  `/opt/durion/alpha/.env`, live in the container.
+- **C.** ~~#1218 write target~~ **RESOLVED 2026-08-19**: seed-then-delete of a probe MCP system
+  prompt via the discovered tool `prompts_deletesystemprompt` (pos-mcp-server
+  `DELETE /v1/prompts/{id}`). Rationale: the discovered tool arrives already permission-bound
+  (pos-mcp-server emits `x-required-permissions`; pos-security-service cannot, since it does not
+  depend on pos-security-common — its ops would need a manual tool-permission grant, an extra
+  registry mutation); the actor already holds `mcp:system_prompt:create/delete`; a probe-named
+  prompt row is referenced by nothing and lives in no Kafka-enabled domain; and the whole
+  preview→confirm→execute loop stays inside the service under test. Dirtying: acceptable only as
+  self-seeded data — the harness `seed` block creates the probe record and the gated delete
+  removes it (net-zero). Config: `scripts/fixtures/nlti-write-target.example.json`. Runner-up
+  (documented, not chosen): role create/delete on pos-security-service, rejected for the
+  tool-grant side effect.
 - **D.** #1215 — seed `PROCESSING_RETURN` (which tools?) or except it in the sign-off; does
   `routing.workflowState` + the `NLTI_SESSION_WORKFLOW_STATE_SET` audit event satisfy "workflow
   transitions in telemetry," or is a dedicated transition event wanted?

--- a/pos-mcp-server/docs/gate-closeout-plan-1212-1219.md
+++ b/pos-mcp-server/docs/gate-closeout-plan-1212-1219.md
@@ -140,18 +140,30 @@ list — repeated here as the checklist):
   local simple model would have measured CPU inference, not tiering. All three models
   (router `qwen3.5:397b`, both tiers) verified serving HTTP 200 on the rotated key. Set in
   `/opt/durion/alpha/.env`, live in the container.
-- **C.** ~~#1218 write target~~ **RESOLVED 2026-08-19**: seed-then-delete of a probe MCP system
-  prompt via the discovered tool `prompts_deletesystemprompt` (pos-mcp-server
-  `DELETE /v1/prompts/{id}`). Rationale: the discovered tool arrives already permission-bound
-  (pos-mcp-server emits `x-required-permissions`; pos-security-service cannot, since it does not
-  depend on pos-security-common — its ops would need a manual tool-permission grant, an extra
-  registry mutation); the actor already holds `mcp:system_prompt:create/delete`; a probe-named
-  prompt row is referenced by nothing and lives in no Kafka-enabled domain; and the whole
-  preview→confirm→execute loop stays inside the service under test. Dirtying: acceptable only as
-  self-seeded data — the harness `seed` block creates the probe record and the gated delete
-  removes it (net-zero). Config: `scripts/fixtures/nlti-write-target.example.json`. Runner-up
-  (documented, not chosen): role create/delete on pos-security-service, rejected for the
-  tool-grant side effect.
+- **C.** ~~#1218 write target~~ **RESOLVED 2026-08-19 (revised same day)**: seed-then-cancel of a
+  probe appointment via the discovered tool `shop-manager_cancelappointment`
+  (`DELETE /v1/appointments/{appointmentId}/cancel`), actor = the DISPATCHER persona.
+  - **First choice, `prompts_deletesystemprompt`, proved structurally impossible on alpha**: the
+    gateway's api-docs aggregation (swagger-config, 23 services) does not include pos-mcp-server,
+    so its operations are never discovered and no `prompts_*` tool exists for a write plan to bind
+    (observed live: 403 from `requireToolPermission`; 389 discovered tools, none from
+    pos-mcp-server). Whether pos-mcp-server *should* be aggregated is an open product question,
+    deliberately not decided here.
+  - **Why cancelappointment**: discovered live with `appointments:cancel` attached; the DISPATCHER
+    and LOCATION_MANAGER personas hold `appointments:create` + `appointments:cancel` with no grant
+    changes; the write crosses a real service boundary (mcp-server → gateway → shop-manager) under
+    a NON-admin actor; shop-manager is not a Kafka-enabled domain. Residue: one inert CANCELLED
+    probe appointment on a far-future slot (cancel is a status write, not a row delete).
+  - **Rejected alternatives**: `security-service_deleterole` — pos-security-service cannot emit
+    `x-required-permissions` (no pos-security-common dependency), so its discovered ops carry zero
+    grants and would need a manual tool-permission grant, an extra registry mutation;
+    `price_deletepromotioneligibilityrule` — at decision time only the unassigned ADMIN role held
+    `pricing:promotion:manage` (a LOCATION_MANAGER grant is now in flight, making this the
+    documented fallback if appointment seeding fails validation; note its seed is two-step —
+    offer, then rule — and the harness `seed` block currently supports one request).
+  - Dirtying: acceptable only as self-seeded data — the harness `seed` block creates the probe
+    record under `--allow-writes` and the gated write consumes it. Config:
+    `scripts/fixtures/nlti-write-target.example.json` (authoritative).
 - **D.** #1215 — seed `PROCESSING_RETURN` (which tools?) or except it in the sign-off; does
   `routing.workflowState` + the `NLTI_SESSION_WORKFLOW_STATE_SET` audit event satisfy "workflow
   transitions in telemetry," or is a dedicated transition event wanted?

--- a/scripts/fixtures/nlti-write-target.example.json
+++ b/scripts/fixtures/nlti-write-target.example.json
@@ -2,32 +2,50 @@
   "_comment": [
     "Write-target config for scripts/nlti_live_verify.py --write-target (#1218, Gate 6).",
     "",
-    "DECISION C (resolved 2026-08-19): seed-then-delete of a probe MCP system prompt via the",
-    "discovered OpenAPI tool `prompts_deletesystemprompt` (pos-mcp-server DELETE /v1/prompts/{id},",
-    "operationId deleteSystemPrompt). Chosen because: the discovered tool arrives already",
-    "permission-bound (pos-mcp-server emits x-required-permissions, unlike pos-security-service);",
-    "the acting persona already holds mcp:system_prompt:create/delete; a probe-named prompt row is",
-    "referenced by nothing (SystemPromptDefaults never resolves it) and lives in no Kafka-enabled",
-    "domain; and the whole preview->confirm->execute loop stays inside the service under test.",
+    "DECISION C (revised 2026-08-19): seed-then-cancel of a probe appointment via the discovered",
+    "OpenAPI tool `shop-manager_cancelappointment` (DELETE /v1/appointments/{appointmentId}/cancel).",
+    "The original target (deleteSystemPrompt) is structurally impossible today: the gateway's",
+    "api-docs aggregation does not include pos-mcp-server, so its ops are never discovered.",
+    "cancelappointment was chosen because the discovered tool is live on alpha with its permission",
+    "attached (appointments:cancel), the DISPATCHER and LOCATION_MANAGER personas hold both",
+    "appointments:create and appointments:cancel TODAY (no grant changes), the write crosses a real",
+    "service boundary (mcp-server -> gateway -> shop-manager) under a NON-admin actor, and",
+    "shop-manager is not a Kafka-enabled domain on alpha.",
     "",
-    "The `seed` block makes each run own its lifecycle: the harness creates the probe prompt under",
-    "--allow-writes, substitutes its id for {seededId}, and the gated delete removes it (net-zero).",
-    "Re-confirming after deletion hits 404, which is the wg-idempotent evidence.",
+    "actor names the persona that seeds and executes; it must hold the target tool's permission.",
+    "The `seed` block creates the probe appointment under --allow-writes; its id replaces the",
+    "{seededId} token everywhere (deep substitution, including args.pathParams). The executor",
+    "contract for discovered tools is args = {pathParams, queryParams, body}",
+    "(OperationProxyFactory:71-74); targetTool and args ride in clientContext",
+    "(NltiWritePlanService:129, CONTEXT_ARGS).",
     "",
-    "Copy this file outside the repo (e.g. /opt/durion/alpha/nlti-write-target.json) and adjust the",
-    "probe name suffix if runs collide. cleanupNote is copied into the evidence block."
+    "Replace the <PLACEHOLDER> ids with real alpha values before a live run (read them from",
+    "pos-customer / pos-location; the far-future slot avoids conflict checks). Cancellation is a",
+    "status write: the cancelled probe appointment row remains, inert, as the run's residue."
   ],
-  "prompt": "Delete the system prompt {seededId}",
-  "expectedTool": "prompts_deletesystemprompt",
-  "clientContext": { "targetTool": "prompts_deletesystemprompt", "id": "{seededId}" },
+  "actor": "terrence-blake",
+  "prompt": "Remove appointment {seededId} from the schedule",
+  "expectedTool": "shop-manager_cancelappointment",
+  "clientContext": {
+    "targetTool": "shop-manager_cancelappointment",
+    "args": {
+      "pathParams": { "appointmentId": "{seededId}" },
+      "body": { "cancellationReason": "NLTI write-gate verification probe (#1218)" }
+    }
+  },
   "seed": {
     "method": "POST",
-    "path": "prompts",
+    "path": "appointments",
     "body": {
-      "name": "NLTI_PROBE_PROMPT_DECISION_C",
-      "content": "Probe prompt created by nlti_live_verify.py for the #1218 write-gate verification. Safe to delete."
+      "crmCustomerId": "<REAL_ALPHA_CRM_CUSTOMER_UUID>",
+      "crmVehicleId": "<REAL_ALPHA_CRM_VEHICLE_UUID>",
+      "locationId": "<REAL_ALPHA_LOCATION_UUID>",
+      "serviceRequestIds": [],
+      "startAt": "2027-03-01T15:00:00Z",
+      "endAt": "2027-03-01T16:00:00Z",
+      "sourceType": "NLTI_PROBE"
     },
     "idField": "id"
   },
-  "cleanupNote": "Self-cleaning: the gated delete removes the seeded probe prompt. If a run aborts between seed and confirm, DELETE /v1/prompts/{id} as any holder of mcp:system_prompt:delete, or ignore it - a prompt named NLTI_PROBE_PROMPT_DECISION_C is referenced by nothing."
+  "cleanupNote": "Self-limiting: the gated cancel leaves the probe appointment in CANCELLED state (rows are not deleted). It references a real customer/vehicle/location read-only and sits on a far-future slot, so it affects no live scheduling. If a run aborts between seed and confirm, cancel it via DELETE /v1/appointments/{id}/cancel as any appointments:cancel holder."
 }

--- a/scripts/fixtures/nlti-write-target.example.json
+++ b/scripts/fixtures/nlti-write-target.example.json
@@ -1,20 +1,33 @@
 {
   "_comment": [
-    "TEMPLATE for scripts/nlti_live_verify.py --write-target (#1218, Gate 6).",
+    "Write-target config for scripts/nlti_live_verify.py --write-target (#1218, Gate 6).",
     "",
-    "THIS FILE INTENTIONALLY DOES NOT NAME A TARGET. Which downstream service/action the live",
-    "write-gate run executes — and whether dirtying alpha data with it is acceptable — is OPEN",
-    "DECISION C in pos-mcp-server/docs/gate-closeout-plan-1212-1219.md. Copy this file, replace",
-    "every <PLACEHOLDER>, and keep it outside the repo. The harness refuses to run a prompt that",
-    "still contains a <...> placeholder.",
+    "DECISION C (resolved 2026-08-19): seed-then-delete of a probe MCP system prompt via the",
+    "discovered OpenAPI tool `prompts_deletesystemprompt` (pos-mcp-server DELETE /v1/prompts/{id},",
+    "operationId deleteSystemPrompt). Chosen because: the discovered tool arrives already",
+    "permission-bound (pos-mcp-server emits x-required-permissions, unlike pos-security-service);",
+    "the acting persona already holds mcp:system_prompt:create/delete; a probe-named prompt row is",
+    "referenced by nothing (SystemPromptDefaults never resolves it) and lives in no Kafka-enabled",
+    "domain; and the whole preview->confirm->execute loop stays inside the service under test.",
     "",
-    "prompt        : the ACTION-intent natural-language prompt submitted to POST /v1/nlt/requests.",
-    "expectedTool  : the mcp_tool name the previewed plan must target (asserted, optional).",
-    "clientContext : optional key-value map forwarded as NltiRequestDTO.clientContext.",
-    "cleanupNote   : how an operator undoes the write on alpha; copied into the evidence block."
+    "The `seed` block makes each run own its lifecycle: the harness creates the probe prompt under",
+    "--allow-writes, substitutes its id for {seededId}, and the gated delete removes it (net-zero).",
+    "Re-confirming after deletion hits 404, which is the wg-idempotent evidence.",
+    "",
+    "Copy this file outside the repo (e.g. /opt/durion/alpha/nlti-write-target.json) and adjust the",
+    "probe name suffix if runs collide. cleanupNote is copied into the evidence block."
   ],
-  "prompt": "<ACTION prompt naming the agreed write target>",
-  "expectedTool": "<mcp_tool name the plan must target>",
-  "clientContext": {},
-  "cleanupNote": "<how to reverse this write on alpha>"
+  "prompt": "Delete the system prompt {seededId}",
+  "expectedTool": "prompts_deletesystemprompt",
+  "clientContext": { "targetTool": "prompts_deletesystemprompt", "id": "{seededId}" },
+  "seed": {
+    "method": "POST",
+    "path": "prompts",
+    "body": {
+      "name": "NLTI_PROBE_PROMPT_DECISION_C",
+      "content": "Probe prompt created by nlti_live_verify.py for the #1218 write-gate verification. Safe to delete."
+    },
+    "idField": "id"
+  },
+  "cleanupNote": "Self-cleaning: the gated delete removes the seeded probe prompt. If a run aborts between seed and confirm, DELETE /v1/prompts/{id} as any holder of mcp:system_prompt:delete, or ignore it - a prompt named NLTI_PROBE_PROMPT_DECISION_C is referenced by nothing."
 }

--- a/scripts/nlti_live_verify.py
+++ b/scripts/nlti_live_verify.py
@@ -412,18 +412,20 @@ def substitute_seeded_id(value, seeded_id):
 
 
 def load_write_target(path):
-    """The #1218 write target — plan decision C: seed-then-delete of a probe system prompt via the
-    discovered `prompts_deletesystemprompt` tool (see the example fixture for the agreed config).
+    """The #1218 write target — plan decision C. Current agreed target: seed-then-cancel of a probe
+    appointment via the discovered `shop-manager_cancelappointment` tool; the example fixture is
+    the authoritative config, and this loader is target-agnostic.
 
-    Shape: {"prompt": "...", "expectedTool": "...", "clientContext": {...},
-            "cleanupNote": "how to undo this on alpha",
-            "seed": {"method": "POST", "path": "prompts", "body": {...}, "idField": "id"}}
+    Shape: {"prompt": "...", "expectedTool": "...", "actor": "<persona name>",
+            "clientContext": {...}, "cleanupNote": "how to undo this on alpha",
+            "seed": {"method": "POST", "path": "...", "body": {...}, "idField": "id"}}
 
-    The optional "seed" block creates the record the gated delete will target, so each run owns its
-    whole lifecycle (net-zero on alpha). The seeded record's id (read from "idField" in the create
-    response) is substituted for the literal token "{seededId}" wherever it appears in "prompt" and
-    in "clientContext" values. Seeding only happens under --allow-writes, through the same safety
-    gate as every other mutating request.
+    The optional "seed" block creates the record the gated write will target, so each run owns its
+    whole lifecycle. The seeded record's id (read from "idField" in the create response) replaces
+    the literal token "{seededId}" wherever it appears in "prompt" and recursively throughout
+    "clientContext". Seeding only happens under --allow-writes, through the same safety gate as
+    every other mutating request. "actor" selects the persona that seeds and executes; it must
+    hold the target tool's own domain permission.
     """
     file = Path(path)
     if not file.is_file():
@@ -1797,24 +1799,30 @@ def run_write_gate(ctx):
               or ctx.queries["write-gate"][0]["prompt"])
     client_context = (target or {}).get("clientContext")
 
-    # Decision C seed step: create the record the gated delete will target, so the run owns its
-    # whole lifecycle. Only under --allow-writes; without it the substitution token stays in the
-    # prompt and the executing half is skipped below exactly as before.
+    # Decision C seed step: create the record the gated write will target, so the run owns its
+    # whole lifecycle. Only under --allow-writes; without it the substitution token stays in place
+    # and the executing half is skipped below exactly as before. The token may appear in the
+    # prompt, in clientContext (e.g. args.pathParams), or both — check the whole target, not just
+    # the prompt.
     seed = (target or {}).get("seed")
-    if seed and "{seededId}" in prompt and ctx.args.allow_writes:
+    needs_seed = seed and ("{seededId}" in prompt
+                           or "{seededId}" in json.dumps(client_context or {}))
+    if needs_seed and ctx.args.allow_writes:
         seeded = ctx.runner.send(RequestPlan(
             label="wg-seed",
             method=seed["method"],
             url=ctx.mcp_url(seed["path"]),
-            impact=ADMIN_WRITE,
+            # The seed creates a business record in the target domain (an appointment today), so it
+            # is a BUSINESS_WRITE — labelling it ADMIN_WRITE misstated it in skip reasons/output.
+            impact=BUSINESS_WRITE,
             persona=persona.name,
             headers=ctx.headers(persona),
             body=seed["body"],
-            note="decision C seed: creates the probe record the gated delete targets",
+            note="decision C seed: creates the probe record the gated write targets",
         ))
         seeded_id = (seeded.json_body or {}).get(seed["idField"]) \
             if seeded is not None and isinstance(seeded.json_body, dict) else None
-        suite.expect("wg-seed", "Probe record seeded for the gated delete",
+        suite.expect("wg-seed", "Probe record seeded for the gated write",
                      bool(seeded_id),
                      f"{seed['method']} {seed['path']} -> HTTP "
                      f"{getattr(seeded, 'status', 'refused')} {seed['idField']}={seeded_id}")
@@ -1824,8 +1832,8 @@ def run_write_gate(ctx):
         prompt = prompt.replace("{seededId}", str(seeded_id))
         if client_context:
             client_context = substitute_seeded_id(client_context, str(seeded_id))
-    elif seed and "{seededId}" in prompt:
-        suite.skip("wg-seed", "Probe record seeded for the gated delete",
+    elif needs_seed:
+        suite.skip("wg-seed", "Probe record seeded for the gated write",
                    "seed block configured but --allow-writes not passed; executing half will skip")
 
     correlation = uuid7ish()

--- a/scripts/nlti_live_verify.py
+++ b/scripts/nlti_live_verify.py
@@ -398,6 +398,19 @@ def load_queries(path):
     return queries
 
 
+def substitute_seeded_id(value, seeded_id):
+    """Recursively replaces the {seededId} token in a clientContext structure. The executor
+    contract nests args as {"pathParams": {...}, "body": {...}} (OperationProxyFactory:71-74), so
+    top-level-only substitution would leave the token inside pathParams."""
+    if isinstance(value, str):
+        return value.replace("{seededId}", seeded_id)
+    if isinstance(value, dict):
+        return {k: substitute_seeded_id(v, seeded_id) for k, v in value.items()}
+    if isinstance(value, list):
+        return [substitute_seeded_id(v, seeded_id) for v in value]
+    return value
+
+
 def load_write_target(path):
     """The #1218 write target — plan decision C: seed-then-delete of a probe system prompt via the
     discovered `prompts_deletesystemprompt` tool (see the example fixture for the agreed config).
@@ -430,6 +443,11 @@ def load_write_target(path):
         for key in ("method", "path", "body", "idField"):
             if not seed.get(key):
                 raise SystemExit(f"--write-target {file} 'seed' block is missing '{key}'")
+        flat = json.dumps(seed["body"])
+        if "<" in flat and ">" in flat:
+            raise SystemExit(
+                f"--write-target {file} seed body still contains a <PLACEHOLDER>. Replace the "
+                "example ids with real alpha values before a live run.")
     return target
 
 
@@ -1761,10 +1779,16 @@ def plan_write_gate(ctx):
 def run_write_gate(ctx):
     gate, issue, title = SUITES["write-gate"]
     suite = SuiteResult("write-gate", gate, issue, title)
-    persona = ctx.personas[0]
-    ctx.authenticate(persona)
-
     target = load_write_target(ctx.args.write_target) if ctx.args.write_target else None
+    # Decision C: the write-target config may name its acting persona ("actor"), because the actor
+    # must hold the target tool's own permission (e.g. appointments:cancel), which is a domain
+    # grant the admin persona does not necessarily carry. Default stays personas[0].
+    actor_name = (target or {}).get("actor")
+    persona = next((p for p in ctx.personas if p.name == actor_name), None) if actor_name \
+        else ctx.personas[0]
+    if persona is None:
+        raise SystemExit(f"--write-target actor '{actor_name}' is not among the loaded personas")
+    ctx.authenticate(persona)
     if target is None:
         suite.notes.append(
             "OPEN DECISION C: no --write-target supplied, so the executing half of the flow is "
@@ -1799,9 +1823,7 @@ def run_write_gate(ctx):
             return suite
         prompt = prompt.replace("{seededId}", str(seeded_id))
         if client_context:
-            client_context = {k: (v.replace("{seededId}", str(seeded_id))
-                                  if isinstance(v, str) else v)
-                              for k, v in client_context.items()}
+            client_context = substitute_seeded_id(client_context, str(seeded_id))
     elif seed and "{seededId}" in prompt:
         suite.skip("wg-seed", "Probe record seeded for the gated delete",
                    "seed block configured but --allow-writes not passed; executing half will skip")
@@ -2349,8 +2371,11 @@ def build_parser():
                         help="delay between Loki polls (default 2)")
     parser.add_argument("--telemetry-window-pad-seconds", type=float, default=3.0,
                         help="clock-skew padding on the request window join (default 3)")
-    parser.add_argument("--workflow-state", default="CREATING_PO", choices=WORKFLOW_STATES,
-                        help="workflow state the workflow suite activates (default CREATING_PO)")
+    parser.add_argument("--workflow-state", default="PROCESSING_RETURN", choices=WORKFLOW_STATES,
+                        help="workflow state the workflow suite activates (default "
+                             "PROCESSING_RETURN — the state the Gate 2C completeness clause names "
+                             "and the V34 seed populates; a broad-permission actor's IDLE baseline "
+                             "swallowed the CREATING_PO delta on the 2026-08-19 run)")
     parser.add_argument("--admin-tool-name", default="listInventoryItems",
                         help="discovered tool name used by the admin permission read probe")
     parser.add_argument("--tuning-window-hours", type=float, default=48.0,

--- a/scripts/nlti_live_verify.py
+++ b/scripts/nlti_live_verify.py
@@ -399,10 +399,18 @@ def load_queries(path):
 
 
 def load_write_target(path):
-    """The #1218 write target — plan decision C, deliberately not defaulted.
+    """The #1218 write target — plan decision C: seed-then-delete of a probe system prompt via the
+    discovered `prompts_deletesystemprompt` tool (see the example fixture for the agreed config).
 
     Shape: {"prompt": "...", "expectedTool": "...", "clientContext": {...},
-            "cleanupNote": "how to undo this on alpha"}
+            "cleanupNote": "how to undo this on alpha",
+            "seed": {"method": "POST", "path": "prompts", "body": {...}, "idField": "id"}}
+
+    The optional "seed" block creates the record the gated delete will target, so each run owns its
+    whole lifecycle (net-zero on alpha). The seeded record's id (read from "idField" in the create
+    response) is substituted for the literal token "{seededId}" wherever it appears in "prompt" and
+    in "clientContext" values. Seeding only happens under --allow-writes, through the same safety
+    gate as every other mutating request.
     """
     file = Path(path)
     if not file.is_file():
@@ -411,11 +419,17 @@ def load_write_target(path):
     prompt = target.get("prompt")
     if not prompt:
         raise SystemExit(f"--write-target {file} must define a non-empty 'prompt'")
-    if "<" in prompt and ">" in prompt:
+    placeholder = prompt.replace("{seededId}", "")
+    if "<" in placeholder and ">" in placeholder:
         raise SystemExit(
             f"--write-target {file} still contains a template placeholder in 'prompt'. The #1218 "
-            "write target is an open decision (plan decision C): choose a real downstream action, "
-            "agree that dirtying alpha with it is acceptable, and record it in the file.")
+            "write target is decision C in pos-mcp-server/docs/gate-closeout-plan-1212-1219.md: "
+            "copy the example fixture and fill in the agreed target.")
+    seed = target.get("seed")
+    if seed is not None:
+        for key in ("method", "path", "body", "idField"):
+            if not seed.get(key):
+                raise SystemExit(f"--write-target {file} 'seed' block is missing '{key}'")
     return target
 
 
@@ -1758,6 +1772,39 @@ def run_write_gate(ctx):
     prompt = ((target or {}).get("prompt") or ctx.args.write_gate_action_prompt
               or ctx.queries["write-gate"][0]["prompt"])
     client_context = (target or {}).get("clientContext")
+
+    # Decision C seed step: create the record the gated delete will target, so the run owns its
+    # whole lifecycle. Only under --allow-writes; without it the substitution token stays in the
+    # prompt and the executing half is skipped below exactly as before.
+    seed = (target or {}).get("seed")
+    if seed and "{seededId}" in prompt and ctx.args.allow_writes:
+        seeded = ctx.runner.send(RequestPlan(
+            label="wg-seed",
+            method=seed["method"],
+            url=ctx.mcp_url(seed["path"]),
+            impact=ADMIN_WRITE,
+            persona=persona.name,
+            headers=ctx.headers(persona),
+            body=seed["body"],
+            note="decision C seed: creates the probe record the gated delete targets",
+        ))
+        seeded_id = (seeded.json_body or {}).get(seed["idField"]) \
+            if seeded is not None and isinstance(seeded.json_body, dict) else None
+        suite.expect("wg-seed", "Probe record seeded for the gated delete",
+                     bool(seeded_id),
+                     f"{seed['method']} {seed['path']} -> HTTP "
+                     f"{getattr(seeded, 'status', 'refused')} {seed['idField']}={seeded_id}")
+        if not seeded_id:
+            suite.notes.append("Seed failed — the executing half cannot run against a real record.")
+            return suite
+        prompt = prompt.replace("{seededId}", str(seeded_id))
+        if client_context:
+            client_context = {k: (v.replace("{seededId}", str(seeded_id))
+                                  if isinstance(v, str) else v)
+                              for k, v in client_context.items()}
+    elif seed and "{seededId}" in prompt:
+        suite.skip("wg-seed", "Probe record seeded for the gated delete",
+                   "seed block configured but --allow-writes not passed; executing half will skip")
 
     correlation = uuid7ish()
     submit = ctx.runner.send(ctx.plan_nlti_submit(persona, prompt, correlation,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## Capability & Traceability
- Capability: `cap:gate-closeout-1212-1219` (governing plan: `pos-mcp-server/docs/gate-closeout-plan-1212-1219.md`, decision C)
- Parent STORY (durion): N/A — gate-closeout verification work, no durion parent story
- Child issue: louisburroughs/durion-positivity-backend#1218 (Gate 6 write-gate live verification); also serves louisburroughs/durion-positivity-backend#1215 (`--workflow-state` default). Neither issue is closed by this PR.
- Domain: `domain:pos-mcp-server`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): N/A — no controllers, DTOs, events, or `openapi.yaml` change in this PR (Python harness scripts, a fixture, and a plan doc only). Reference retained per template: BACKEND_CONTRACT_GUIDE.md.
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — N/A, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — N/A
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — N/A

## Scope
- What changed:

Two commits, both on `scripts/nlti_live_verify.py`, `scripts/fixtures/nlti-write-target.example.json`, and (first commit only) `pos-mcp-server/docs/gate-closeout-plan-1212-1219.md`:

  1. `601bb0160` — decision-C seed support (seed block in the write-target config: `method`/`path`/`body`/`idField`, seed-then-execute lifecycle under `--allow-writes`, `wg-seed` check, plan-doc updates recording decisions B and C). This commit was originally on the #1382 branch but missed that PR's merge window and is cherry-picked here.
  2. `8580cf0b1` — the retarget of decision C from `prompts_deletesystemprompt` to `shop-manager_cancelappointment`, plus the harness changes below.

- Why:

**Why the previous target died.** The 2026-08-19 live run proved the previous decision-C target structurally impossible: the gateway's api-docs aggregation (swagger-config lists 23 services) does not include pos-mcp-server, so its operations are never discovered and no `prompts_*` tool can exist for the write plan to bind. Observed live: submit with `clientContext.targetTool=prompts_deletesystemprompt` → 403 from `requireToolPermission`, with 389 discovered tools in `mcp_tool` and zero from pos-mcp-server. Whether pos-mcp-server SHOULD be added to the aggregation — which would make MCP admin operations write-gate-executable — is an open product question, deliberately not decided in this PR.

**Why `cancelappointment`.** The new target `shop-manager_cancelappointment` was verified live as a discovered tool with its permission (`appointments:cancel`) attached. Chosen because: the DISPATCHER and LOCATION_MANAGER personas hold both `appointments:create` and `appointments:cancel` today, so no grant changes are needed; a NON-admin actor crossing a real service boundary is stronger Gate 6 evidence; shop-manager is not a Kafka-enabled domain on alpha; and cancellation is a status write, so the run's residue is one inert CANCELLED probe appointment on a far-future slot rather than a deleted row.

**Alternatives rejected.** `price_deletepromotioneligibilityrule`: only the unassigned ADMIN role holds `pricing:promotion:manage`, so it would require a grant change. `security-service_deleterole`: its spec cannot emit `x-required-permissions` because pos-security-service does not depend on pos-security-common (the dependency would be circular) — it is discovered with zero grants and fails closed; making it executable would additionally need a manual tool-permission grant, an extra registry mutation.

**Harness changes** (second commit, on top of the cherry-picked seed support):
  - The write-target config gains an `actor` field selecting the persona that seeds and executes, because the actor must hold the target tool's own domain permission, which the admin persona does not necessarily carry.
  - `{seededId}` substitution is now recursive: the executor contract nests args as `{pathParams, queryParams, body}` (OperationProxyFactory:71-74), and top-level substitution would have left the token inside `args.pathParams`.
  - `load_write_target` rejects a seed body still containing a `<PLACEHOLDER>`, so the unfilled example can never POST garbage at alpha. Proven both ways: the shipped example exits 2; a filled copy dry-runs clean with exit 0.
  - `--workflow-state` now defaults to `PROCESSING_RETURN` (#1215): it is the state the Gate 2C completeness clause names and the V34 seed populates, and the 2026-08-19 run showed a broad-permission actor's IDLE baseline swallowing the CREATING_PO tool delta (wf-tool-delta evidence: tools added vs IDLE = `[]`).

## Tests
- [ ] Unit tests added/updated — N/A (verification harness scripts + docs, no production code)
- [ ] Integration tests added/updated — N/A
- [ ] Provider behavioral contract tests added/updated — N/A
- How to run:
  - `python -m py_compile scripts/nlti_live_verify.py` — clean
  - `flake8 --max-line-length=110 scripts/nlti_live_verify.py` — clean
  - Placeholder-guard proof: dry-run against the shipped example exits 2 (guard rejects `<PLACEHOLDER>` seed body); dry-run against a filled copy exits 0.
  - No Maven run was needed: this PR is scripts + docs plus one cherry-picked commit already verified in its original PR (#1382) context. The second commit changes no Java; the cherry-picked commit's plan-doc edits ride along. No claim of Java test coverage is made.

## Risk & Rollback
- Risk level: Low — no deployed service code changes; live-verification harness, its fixture, and a plan document only. The unfilled example fixture is guarded against accidental execution (exit 2).
- Rollback plan: revert the two commits (`601bb0160`, `8580cf0b1`); no data migration, config, or deployment impact.

## Reviewer attention

Two by-catch findings from the live investigation, recorded here but NOT fixed in this PR — both deserve their own issues:
1. Only 11 of the 23 aggregated services actually produced discovered tools. Absent: accounting, inventory, location, order, people, workorder (plus marketing). Order and marketing are not running on alpha; the others ARE running, so their api-docs fetches failed silently.
2. `security-service_deleterole` and `security-service_deleterole_1` both exist — a discovered-tool name collision caused by the dual `/v1/roles` + `/v1/users/roles` request mapping in pos-security-service.

Standing RBAC follow-up (out of scope here — it is a pos-security-service seed change): `appointments:cancel` should belong to every `*MANAGER` role except the inventory one. Current holders: ADMIN, DISPATCHER, LOCATION_MANAGER, SERVICE_ADVISOR. Currently lacking it: ACCOUNT_MANAGER, GENERAL_MANAGER, MANAGER, SHOP_MANAGER.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is `feat/1218-write-target-cancelappointment` (issue-based naming, consistent with predecessors #1370/#1371/#1382)
- [ ] PR title starts with `[CAP:<cap-id>]` — conventional-commit title used, consistent with predecessor PRs
- [x] Links to parent + child issues are present (#1218, #1215; predecessors #1370, #1371, #1382 all merged)
- [ ] Contract guide updated (when contract semantics changed) — N/A, no contract semantics changed
- [ ] Required CI checks passing — pending at PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUr5ocMQmymrSa2x2TuNX3