### PR TITLE
Add pricing:promotion:apply and pricing:promotion:manage to LOCATION_MANAGER role

### DIFF
--- a/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
+++ b/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
@@ -907,6 +907,7 @@ FROM (VALUES
     ('LOCATION_MANAGER', 'people:timekeeping:approve'),
     ('LOCATION_MANAGER', 'people:timekeeping:reject'),
     ('LOCATION_MANAGER', 'people:timekeeping:view'),
+    ('LOCATION_MANAGER', 'pricing:promotion:manage'),
     ('LOCATION_MANAGER', 'pricing:promotion:view'),
     ('LOCATION_MANAGER', 'shop:bay:assign'),
     ('LOCATION_MANAGER', 'shop:bay:create'),

--- a/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
+++ b/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
@@ -907,6 +907,7 @@ FROM (VALUES
     ('LOCATION_MANAGER', 'people:timekeeping:approve'),
     ('LOCATION_MANAGER', 'people:timekeeping:reject'),
     ('LOCATION_MANAGER', 'people:timekeeping:view'),
+    ('LOCATION_MANAGER', 'pricing:promotion:apply'),
     ('LOCATION_MANAGER', 'pricing:promotion:manage'),
     ('LOCATION_MANAGER', 'pricing:promotion:view'),
     ('LOCATION_MANAGER', 'shop:bay:assign'),


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A (seed-data permission grant)
- Parent STORY (durion): N/A
- Child issue: N/A
- Domain: `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Not applicable — no controllers, DTOs, events, or API contracts changed; this PR only edits the repeatable Flyway seed migration `R__seed_role_permissions.sql`.

## Contract Chain (when a Controller changed)
- Not applicable — no controller changes.

## Scope
- What changed: Added `pricing:promotion:manage` and `pricing:promotion:apply` to the `LOCATION_MANAGER` role in `pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql`.
- Why: `ADMIN`, `GENERAL_MANAGER`, and `MANAGER` already hold both permissions; `LOCATION_MANAGER` only had `pricing:promotion:view`. This aligns `LOCATION_MANAGER` with the other manager roles so it can apply and manage promotions.

## Tests
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated
- How to run: Seed-data-only change; no test changes. The repeatable migration re-runs on next `pos-security-service` startup (Flyway checksum change) and the inserts are idempotent (`ON CONFLICT`-style seed pattern used by this file).

## Risk & Rollback
- Risk level: Low
- Rollback plan: Revert this commit; the repeatable migration re-runs and note that revoking previously granted rows may require a manual `DELETE` from `role_permissions` for `('LOCATION_MANAGER', 'pricing:promotion:apply')` and `('LOCATION_MANAGER', 'pricing:promotion:manage')` in environments where it already ran.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` (branch is `claude/pricing-promotion-manage-permission-3ornxx`, per session task)
- [ ] PR title starts with `[CAP:<cap-id>]` (no capability id for this change)
- [ ] Links to parent + child issues are present (none)
- [x] Contract guide updated (when contract semantics changed) — no contract semantics changed
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wDq5VNdvfmhRvRTyeqR5C

---
_Generated by [Claude Code](https://claude.ai/code/session_017wDq5VNdvfmhRvRTyeqR5C)_