### PR TITLE
fix(pos-mcp-server): seed requests route to the target service (#1218)

### DIFF
--- a/scripts/fixtures/nlti-write-target.example.json
+++ b/scripts/fixtures/nlti-write-target.example.json
@@ -6,18 +6,19 @@
     "rule in pos-price, then gate-delete the RULE via the discovered tool",
     "`price_deletepromotioneligibilityrule` (DELETE /v1/promotions/offers/{promotionId}/rules/{ruleId}).",
     "",
-    "History: target #1 (prompts_deletesystemprompt) is impossible — the gateway api-docs",
+    "History: target #1 (prompts_deletesystemprompt) is impossible \u2014 the gateway api-docs",
     "aggregation excludes pos-mcp-server, so its ops are never discovered. Target #2",
-    "(shop-manager_cancelappointment) is dead on alpha — createAppointment validates against",
+    "(shop-manager_cancelappointment) is dead on alpha \u2014 createAppointment validates against",
     "shop-manager's ADR-0044 local replica and ext_vehicle has ZERO rows, so appointment creation",
     "404s for every vehicle id. This target has no cross-service references at all: offer and rule",
     "are synthetic, self-contained in pos-price, pricing is not a Kafka-enabled domain, and the",
     "LOCATION_MANAGER persona holds pricing:promotion:manage (PR #1384) for create and delete alike.",
     "",
     "Seeds run in order; each captured id substitutes into later seed paths and finally into the",
-    "prompt and clientContext (tokens {offerId}, {ruleId}). All values below are synthetic — no",
+    "prompt and clientContext (tokens {offerId}, {ruleId}). All values below are synthetic \u2014 no",
     "placeholders to fill. Residue: the probe offer remains (no delete-offer endpoint exists) with",
-    "zero eligibility rules and a random probe promoCode; see cleanupNote."
+    "zero eligibility rules and a random probe promoCode; see cleanupNote.",
+    "Each seed names its gateway service route ('route': 'price') \u2014 seeds execute in the target service's domain, not pos-mcp-server's."
   ],
   "actor": "diana-rowe",
   "prompt": "Remove eligibility rule {ruleId} from promotion {offerId}",
@@ -25,7 +26,10 @@
   "clientContext": {
     "targetTool": "price_deletepromotioneligibilityrule",
     "args": {
-      "pathParams": { "promotionId": "{offerId}", "ruleId": "{ruleId}" }
+      "pathParams": {
+        "promotionId": "{offerId}",
+        "ruleId": "{ruleId}"
+      }
     }
   },
   "seeds": [
@@ -43,7 +47,8 @@
         "usageLimit": 1
       },
       "idField": "id",
-      "token": "{offerId}"
+      "token": "{offerId}",
+      "route": "price"
     },
     {
       "method": "POST",
@@ -54,7 +59,8 @@
         "value": "NLTI-PROBE-NEVER-MATCHES"
       },
       "idField": "id",
-      "token": "{ruleId}"
+      "token": "{ruleId}",
+      "route": "price"
     }
   ],
   "cleanupNote": "The gated delete removes the rule; the probe offer remains (pos-price exposes no delete-offer endpoint). It is inert: 0.01 fixed discount, usageLimit 1, a one-day far-future window, and a promoCode nobody knows. If desired, deactivate or remove it directly in pos_price_db. An aborted run between seeds leaves the offer with one never-matching CAMPAIGN_CODE rule - equally inert."

--- a/scripts/nlti_live_verify.py
+++ b/scripts/nlti_live_verify.py
@@ -450,7 +450,7 @@ def load_write_target(path):
         seeds = [dict(target["seed"], token=target["seed"].get("token", "{seededId}"))]
     if seeds is not None:
         for index, seed in enumerate(seeds):
-            for key in ("method", "path", "body", "idField", "token"):
+            for key in ("method", "path", "body", "idField", "token", "route"):
                 if not seed.get(key):
                     raise SystemExit(
                         f"--write-target {file} seed #{index + 1} is missing '{key}'")
@@ -912,11 +912,16 @@ class Context:
 
     # -- URL building: gateway contract is X-API-Version + path rewrite /{domain}/vN/... ----------
     def mcp_url(self, path):
+        return self.route_url(self.args.service_route, path)
+
+    def route_url(self, route, path):
+        """Gateway URL for any service route (mcp-server, price, shop-manager, ...) under the
+        same X-API-Version rewrite contract mcp_url uses."""
         path = path.lstrip("/")
         base = self.args.gateway_url.rstrip("/")
         if self.args.already_versioned:
-            return f"{base}/{self.args.service_route}/v{self.args.api_version}/{path}"
-        return f"{base}/{self.args.service_route}/{path}"
+            return f"{base}/{route}/v{self.args.api_version}/{path}"
+        return f"{base}/{route}/{path}"
 
     def auth_url(self):
         # /security-service/v1/auth/** bypasses the gateway's version rewrite
@@ -1830,10 +1835,13 @@ def run_write_gate(ctx):
             check_id = "wg-seed" if index == 0 else f"wg-seed-{index + 1}"
             path = substitute_tokens(seed["path"], tokens)
             body = substitute_tokens(seed["body"], tokens)
+            # Seeds live in the TARGET service's domain, so they route to that service through the
+            # gateway ("route"), not to pos-mcp-server — the 2026-08-19 run 404'd on
+            # POST /mcp-server/promotions/offers because mcp_url() hardcoded the mcp-server route.
             seeded = ctx.runner.send(RequestPlan(
                 label=check_id,
                 method=seed["method"],
-                url=ctx.mcp_url(path),
+                url=ctx.route_url(seed.get("route", ctx.args.service_route), path),
                 # Seeds create business records in the target domain, so BUSINESS_WRITE.
                 impact=BUSINESS_WRITE,
                 persona=persona.name,


### PR DESCRIPTION
## Summary
First live write-gate execution attempt (post-#1385) failed at the first seed: `POST promotions/offers -> HTTP 404`. The seed step built its URL with `mcp_url()`, which hardcodes the `mcp-server` gateway route — correct for the original same-service target (`prompts_deletesystemprompt`), silently wrong for every cross-service target since.

## Change
- New `Context.route_url(route, path)` builds a gateway URL for any service route under the same `X-API-Version` rewrite contract; `mcp_url()` delegates to it.
- Each seed block now names its gateway route (`"route": "price"`); `load_write_target` requires the field, so a routeless seed fails at load time instead of 404ing live.
- Fixture updated accordingly (both seeds route to `price`).

## Verification
`py_compile` + `flake8` clean; two-seed dry-run exits 0. Real verification is the next live run. Scripts only — no maven.

## Context
Same-day follow-up to #1385; serves #1218. The rest of that run: **workflow suite 8/8 PASS** (#1215 live evidence complete), admin suite green except the two expected Wave-3 tuning checks and the admin-mutation SKIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUr5ocMQmymrSa2x2TuNX3