### PR TITLE
fix(pos-mcp-server): correct seed idFields to the pos-price response schema (#1218)

### DIFF
--- a/scripts/fixtures/nlti-write-target.example.json
+++ b/scripts/fixtures/nlti-write-target.example.json
@@ -46,7 +46,7 @@
         "endDate": "2027-03-02",
         "usageLimit": 1
       },
-      "idField": "id",
+      "idField": "promotionOfferId",
       "token": "{offerId}",
       "route": "price"
     },
@@ -58,7 +58,7 @@
         "operator": "EQUALS",
         "value": "NLTI-PROBE-NEVER-MATCHES"
       },
-      "idField": "id",
+      "idField": "ruleId",
       "token": "{ruleId}",
       "route": "price"
     }


### PR DESCRIPTION
## Summary
The routed seed run reached pos-price (`POST promotions/offers` → **HTTP 201**) but captured no id: the fixture assumed `id`, while `PromotionOfferResponse` exposes `promotionOfferId` and `EligibilityRuleResponse` exposes `ruleId`. Both `idField`s corrected from the OpenAPI schemas.

## Residue note
That 201 created one uncaptured probe offer on alpha (`promoCode NLTI-PROBE-1218`) — inert by construction (0.01 fixed discount, usageLimit 1, one-day far-future window). A duplicate-promoCode 409 on the next run would be self-evident in wg-seed evidence; if pos-price enforces promoCode uniqueness the earlier orphan may need a manual delete from pos_price_db first.

## Verification
JSON valid; fixture-only change, no code. Real verification is the next live run.

Serves #1218. Follow-up to #1386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUr5ocMQmymrSa2x2TuNX3