### PR TITLE
fix(pos-mcp-server): per-run-unique seed values via {runId} token (#1218)

### DIFF
--- a/scripts/fixtures/nlti-write-target.example.json
+++ b/scripts/fixtures/nlti-write-target.example.json
@@ -37,7 +37,7 @@
       "method": "POST",
       "path": "promotions/offers",
       "body": {
-        "promoCode": "NLTI-PROBE-1218",
+        "promoCode": "NLTI-PROBE-{runId}",
         "name": "NLTI write-gate verification probe (#1218)",
         "description": "Synthetic promotion created by nlti_live_verify.py; safe to ignore or delete.",
         "discountType": "FIXED_INVOICE",
@@ -63,5 +63,5 @@
       "route": "price"
     }
   ],
-  "cleanupNote": "The gated delete removes the rule; the probe offer remains (pos-price exposes no delete-offer endpoint). It is inert: 0.01 fixed discount, usageLimit 1, a one-day far-future window, and a promoCode nobody knows. If desired, deactivate or remove it directly in pos_price_db. An aborted run between seeds leaves the offer with one never-matching CAMPAIGN_CODE rule - equally inert."
+  "cleanupNote": "The gated delete removes the rule; the probe offer remains (pos-price exposes no delete-offer endpoint). It is inert: 0.01 fixed discount, usageLimit 1, a one-day far-future window, and a per-run promoCode (NLTI-PROBE-<timestamp>) nobody knows. If desired, deactivate or remove it directly in pos_price_db. An aborted run between seeds leaves the offer with one never-matching CAMPAIGN_CODE rule - equally inert."
 }

--- a/scripts/nlti_live_verify.py
+++ b/scripts/nlti_live_verify.py
@@ -81,6 +81,7 @@ import re
 import sys
 import time
 import urllib.error
+import uuid
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
@@ -1833,8 +1834,10 @@ def run_write_gate(ctx):
         # {runId} is pre-populated so seed bodies can carry per-run-unique values (e.g. promoCode
         # "NLTI-PROBE-{runId}"): pos-price enforces promoCode uniqueness, and a static fixture
         # collided with its own previous run's orphan (observed live: HTTP 409 after a 201 run
-        # whose id capture failed). A time-based suffix keeps every run self-contained.
-        tokens = {"{runId}": now_utc().strftime("%Y%m%d%H%M%S")}
+        # whose id capture failed). A microsecond timestamp plus a random suffix makes collisions practically
+        # impossible even for runs started in the same second (parallel jobs, rapid retries).
+        tokens = {"{runId}": now_utc().strftime("%Y%m%d%H%M%S%f")
+                  + "-" + uuid.uuid4().hex[:6]}
         for index, seed in enumerate(seeds):
             check_id = "wg-seed" if index == 0 else f"wg-seed-{index + 1}"
             path = substitute_tokens(seed["path"], tokens)

--- a/scripts/nlti_live_verify.py
+++ b/scripts/nlti_live_verify.py
@@ -1830,7 +1830,11 @@ def run_write_gate(ctx):
     # offer seeded one step earlier) and finally into the prompt and clientContext.
     seeds = (target or {}).get("seeds") or []
     if seeds and ctx.args.allow_writes:
-        tokens = {}
+        # {runId} is pre-populated so seed bodies can carry per-run-unique values (e.g. promoCode
+        # "NLTI-PROBE-{runId}"): pos-price enforces promoCode uniqueness, and a static fixture
+        # collided with its own previous run's orphan (observed live: HTTP 409 after a 201 run
+        # whose id capture failed). A time-based suffix keeps every run self-contained.
+        tokens = {"{runId}": now_utc().strftime("%Y%m%d%H%M%S")}
         for index, seed in enumerate(seeds):
             check_id = "wg-seed" if index == 0 else f"wg-seed-{index + 1}"
             path = substitute_tokens(seed["path"], tokens)


### PR DESCRIPTION
## Summary
pos-price enforces promoCode uniqueness; the static fixture collided with the orphan its own previous run left behind (live: HTTP 409, following the earlier 201 whose id capture failed on the wrong `idField`). The seed token map is now pre-populated with `{runId}` (UTC timestamp) and the fixture's promoCode becomes `NLTI-PROBE-{runId}`, so every run is self-contained and repeatable with no manual cleanup between runs.

## Residue
The orphaned `NLTI-PROBE-1218` offer stays on alpha — inert by construction; deletable from `pos_price_db.promotion_offer` whenever convenient (an SQL delete was deliberately not performed by the harness session).

## Verification
py_compile + flake8 + JSON valid. Real verification is the next live run. Serves #1218; follow-up to #1387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUr5ocMQmymrSa2x2TuNX3