### PR TITLE
fix(pos-mcp-server): audit reader persona + config-selectable fail-closed persona (#1218)

### DIFF
--- a/scripts/fixtures/nlti-write-target.example.json
+++ b/scripts/fixtures/nlti-write-target.example.json
@@ -18,7 +18,8 @@
     "prompt and clientContext (tokens {offerId}, {ruleId}). All values below are synthetic \u2014 no",
     "placeholders to fill. Residue: the probe offer remains (no delete-offer endpoint exists) with",
     "zero eligibility rules and a random probe promoCode; see cleanupNote.",
-    "Each seed names its gateway service route ('route': 'price') \u2014 seeds execute in the target service's domain, not pos-mcp-server's."
+    "Each seed names its gateway service route ('route': 'price') \u2014 seeds execute in the target service's domain, not pos-mcp-server's.",
+    "failClosedActor names the persona for the fail-closed probe; it must LACK the target tool's permission (grants move: #1384 made diana a legitimate holder)."
   ],
   "actor": "diana-rowe",
   "prompt": "Remove eligibility rule {ruleId} from promotion {offerId}",
@@ -63,5 +64,6 @@
       "route": "price"
     }
   ],
-  "cleanupNote": "The gated delete removes the rule; the probe offer remains (pos-price exposes no delete-offer endpoint). It is inert: 0.01 fixed discount, usageLimit 1, a one-day far-future window, and a per-run promoCode (NLTI-PROBE-<timestamp>) nobody knows. If desired, deactivate or remove it directly in pos_price_db. An aborted run between seeds leaves the offer with one never-matching CAMPAIGN_CODE rule - equally inert."
+  "cleanupNote": "The gated delete removes the rule; the probe offer remains (pos-price exposes no delete-offer endpoint). It is inert: 0.01 fixed discount, usageLimit 1, a one-day far-future window, and a per-run promoCode (NLTI-PROBE-<timestamp>) nobody knows. If desired, deactivate or remove it directly in pos_price_db. An aborted run between seeds leaves the offer with one never-matching CAMPAIGN_CODE rule - equally inert.",
+  "failClosedActor": "olivia-chen"
 }

--- a/scripts/nlti_live_verify.py
+++ b/scripts/nlti_live_verify.py
@@ -1588,8 +1588,11 @@ def run_workflow(ctx):
                      f"HTTP {audit.status or audit.error}, {len(entries)} entries for "
                      f"correlationId={correlation}")
 
-    if len(ctx.personas) > 1:
-        other = ctx.personas[1]
+    # Ownership probe: any persona other than the session owner works — no permission
+    # requirement, the 403 comes from session ownership.
+    candidates = [p for p in ctx.personas if p.name != persona.name]
+    other = candidates[0] if candidates else None
+    if other is not None:
         try:
             ctx.authenticate(other)
         except (ConfigError, InfraError) as exc:
@@ -1952,13 +1955,20 @@ def run_write_gate(ctx):
                      and replayed.get("status") == confirmed.get("status"),
                      f"first={confirmed.get('status')} replay={replayed.get('status')} "
                      f"HTTP {getattr(replay, 'status', 'refused')}")
-        audit = ctx.runner.send(ctx.plan_audit(persona, correlation))
+        # The audit ledger read requires nlti:audit:read, which the WRITE actor does not
+        # necessarily hold (observed live: diana's 403 rendered as empty eventTypes). Read as an
+        # audit-capable persona — the config's admin persona — falling back to the actor.
+        auditor = next((p for p in ctx.personas if p.admin), persona)
+        if auditor.name != persona.name:
+            ctx.authenticate(auditor)
+        audit = ctx.runner.send(ctx.plan_audit(auditor, correlation))
         entries = ((audit.json_body or {}).get("content") or []) if audit and audit.ok else []
         types = sorted({entry.get("eventType") for entry in entries})
         suite.expect("wg-audit-execution", "CONFIRMATION + EXECUTION audit entries appended",
                      "CONFIRMATION" in types
                      and any(str(t).startswith("EXECUTION") for t in types),
-                     f"audit eventTypes={types} for correlationId={correlation}")
+                     f"HTTP {getattr(audit, 'status', 'refused')} audit eventTypes={types} "
+                     f"reader={auditor.name} correlationId={correlation}")
         if target.get("cleanupNote"):
             suite.notes.append(f"Write target cleanup: {target['cleanupNote']}")
 
@@ -2019,8 +2029,15 @@ def run_write_gate(ctx):
         "(--write-gate-action-prompt) because that is the only phrasing the parser routes to the "
         "write gate today.")
 
-    if len(ctx.personas) > 1:
-        other = ctx.personas[1]
+    # The fail-closed persona must LACK the target tool's permission and differ from the actor.
+    # It is config-selectable ("failClosedActor") because grants move: #1384 gave LOCATION_MANAGER
+    # pricing:promotion:manage, which silently turned the old hardcoded personas[1] (diana) into a
+    # legitimate holder — her plan was CORRECT behavior misread as a fail-closed violation.
+    fail_closed_name = (target or {}).get("failClosedActor")
+    candidates = [p for p in ctx.personas if p.name != persona.name]
+    other = next((p for p in candidates if p.name == fail_closed_name), None) if fail_closed_name \
+        else (candidates[-1] if candidates else None)
+    if other is not None:
         try:
             ctx.authenticate(other)
         except (ConfigError, InfraError) as exc:

--- a/scripts/nlti_live_verify.py
+++ b/scripts/nlti_live_verify.py
@@ -1960,7 +1960,15 @@ def run_write_gate(ctx):
         # audit-capable persona — the config's admin persona — falling back to the actor.
         auditor = next((p for p in ctx.personas if p.admin), persona)
         if auditor.name != persona.name:
-            ctx.authenticate(auditor)
+            try:
+                ctx.authenticate(auditor)
+            except (ConfigError, InfraError) as exc:
+                # The fallback must actually fall back: an unauthenticatable admin persona
+                # degrades the read to the actor (who may 403) instead of aborting the suite.
+                suite.notes.append(
+                    f"audit reader '{auditor.name}' could not authenticate ({exc}); "
+                    "falling back to the write actor")
+                auditor = persona
         audit = ctx.runner.send(ctx.plan_audit(auditor, correlation))
         entries = ((audit.json_body or {}).get("content") or []) if audit and audit.ok else []
         types = sorted({entry.get("eventType") for entry in entries})


### PR DESCRIPTION
## Summary
The first end-to-end write-gate execution **passed its core chain** — seed 201/201, preview `PENDING_CONFIRMATION` with correct targetTool, `wg-risk HIGH`, confirm `COMPLETE`, idempotent replay `COMPLETE` — leaving two evidence defects, both fixed here:

1. **wg-audit-execution** read the audit ledger as the write actor, who need not hold `nlti:audit:read`; diana's 403 rendered as `eventTypes=[]` and a misleading FAIL. The ledger is now read by the config's admin persona (fallback: actor), and evidence carries HTTP status + reader name so a permission failure can't masquerade as missing entries.
2. **wg-fail-closed** hardcoded `personas[1]` (diana) as the lacking-permission persona — stale the moment #1384 granted LOCATION_MANAGER `pricing:promotion:manage`; her plan was correct behavior misread as a violation. Now config-selectable (`failClosedActor: olivia-chen` in the fixture), always distinct from the actor.

The workflow suite's ownership probe (same `personas[1]` pattern) keeps target-free semantics — its 403 is ownership, not permissions.

## Verification
py_compile + flake8 clean; `workflow,write-gate` dry-run exits 0. Real verification is the next live run — expected result: only `wg-intent-gap` red (by design) and `wg-telemetry` SKIP (known submit-path gap).

Serves #1218. Follow-up to #1388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUr5ocMQmymrSa2x2TuNX3