### PR TITLE
fix(pos-mcp-server): fallback-visibility check scopes to model-backed tiers (#1216)

### DIFF
--- a/scripts/nlti_live_verify.py
+++ b/scripts/nlti_live_verify.py
@@ -1741,13 +1741,19 @@ def run_router(ctx):
     model_rows = [row for row in observed if row["tier"] != TIER_RULE]
     reported = sum(1 for row in model_rows if row["fallbackUsed"] is not None)
     fell_back = sorted(row["id"] for row in model_rows if row["fallbackUsed"])
-    suite.expect_joined("router-fallback-visible",
-                        "Fallback usage visible in telemetry (model-backed tiers)",
-                        all(row["fallbackUsed"] is not None for row in model_rows),
-                        f"model.fallbackUsed reported for {reported}/{len(model_rows)} "
-                        f"model-backed probes ({len(observed) - len(model_rows)} T0_RULE rows "
-                        f"correctly carry none); used on {fell_back}; NOTE fallbackUsed=false is "
-                        "the factory's hardcoded value — no failover path exists in code", joined)
+    if not model_rows:
+        suite.skip("router-fallback-visible",
+                   "Fallback usage visible in telemetry (model-backed tiers)",
+                   f"all {len(observed)} probes routed to T0_RULE — no model-backed request to "
+                   "assert visibility on (all() over an empty set would pass vacuously)")
+    else:
+        suite.expect_joined("router-fallback-visible",
+                            "Fallback usage visible in telemetry (model-backed tiers)",
+                            all(row["fallbackUsed"] is not None for row in model_rows),
+                            f"model.fallbackUsed reported for {reported}/{len(model_rows)} "
+                            f"model-backed probes ({len(observed) - len(model_rows)} T0_RULE rows "
+                            f"correctly carry none); used on {fell_back}; NOTE fallbackUsed=false is "
+                            "the factory's hardcoded value — no failover path exists in code", joined)
 
     p95 = percentile(latencies, 95)
     suite.expect("router-p95", "p95 latency within the soft SLO",

--- a/scripts/nlti_live_verify.py
+++ b/scripts/nlti_live_verify.py
@@ -1733,12 +1733,21 @@ def run_router(ctx):
     suite.expect_joined("router-no-break", "Router output never breaks processing",
                         all(row["outcome"] in (None, "SUCCESS") for row in observed),
                         f"outcomes={outcomes}", joined)
-    reported = sum(1 for row in observed if row["fallbackUsed"] is not None)
-    fell_back = sorted(row["id"] for row in observed if row["fallbackUsed"])
-    suite.expect_joined("router-fallback-visible", "Fallback usage visible in telemetry",
-                        all(row["fallbackUsed"] is not None for row in observed),
-                        f"model.fallbackUsed reported for {reported}/{len(observed)} probes; "
-                        f"used on {fell_back}", joined)
+    # Only model-backed tiers can fall back: T0_RULE answers without a model, so fallbackUsed=None
+    # there is correct, not missing telemetry (2026-08-19 run: 2/8 probes were T0_RULE and the
+    # all-rows form misread them as a visibility failure). Caveat the check can't escape: the
+    # factory currently hardcodes fallbackUsed=false and no fallback path exists in code (Wave 0
+    # finding), so a PASS here proves the FIELD is visible, not that failover works.
+    model_rows = [row for row in observed if row["tier"] != TIER_RULE]
+    reported = sum(1 for row in model_rows if row["fallbackUsed"] is not None)
+    fell_back = sorted(row["id"] for row in model_rows if row["fallbackUsed"])
+    suite.expect_joined("router-fallback-visible",
+                        "Fallback usage visible in telemetry (model-backed tiers)",
+                        all(row["fallbackUsed"] is not None for row in model_rows),
+                        f"model.fallbackUsed reported for {reported}/{len(model_rows)} "
+                        f"model-backed probes ({len(observed) - len(model_rows)} T0_RULE rows "
+                        f"correctly carry none); used on {fell_back}; NOTE fallbackUsed=false is "
+                        "the factory's hardcoded value — no failover path exists in code", joined)
 
     p95 = percentile(latencies, 95)
     suite.expect("router-p95", "p95 latency within the soft SLO",


### PR DESCRIPTION
## Summary
The Wave 2 router run's only FAIL was `router-fallback-visible`: 2/8 probes routed to **T0_RULE**, which answers without a model — `fallbackUsed=None` there is correct, not missing telemetry. The check now scopes to model-backed tiers, reports the T0_RULE count in evidence, and carries the standing caveat that `fallbackUsed=false` is the factory's hardcoded value (no failover path exists in code — Wave 0 finding), so PASS proves field visibility, not working failover.

## The run this unblocks (already captured, 6/7 PASS)
- T0_RULE for greetings (~0.7-0.8s, no model) · T2_SIMPLE → `gpt-oss:20b` · T2_COMPLEX → `gpt-oss:120b` for writes + accounting/tax
- simple-mix 100% (floor 80) · all outcomes SUCCESS · p95 11.3s < 15s soft SLO

## Verification
py_compile + flake8 clean. Real verification is the rerun. Scripts only. Serves #1216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUr5ocMQmymrSa2x2TuNX3