### PR TITLE
fix(pos-mcp-server): tag security.guide with security-administration permissions (#1396)

### DIFF
--- a/pos-mcp-server/src/main/resources/application-alpha.yml
+++ b/pos-mcp-server/src/main/resources/application-alpha.yml
@@ -104,6 +104,7 @@ mcp:
         - id: "security.guide"
           source-path: "classpath:rag/security-service-guide.md"
           rag-scope: "master"
+          required-permissions: ["security:permission:view", "security:role:view"]
         # Gate 5 documents. `required-permissions` is bound by StaticDocEntry (G5.2) and enforced by
         # the permission-aware RAG filter (G5.1). Permission codes verified against the service
         # permissions.yaml files. Kept in parity with application.yml so alpha's corpus matches the

--- a/pos-mcp-server/src/main/resources/application.yml
+++ b/pos-mcp-server/src/main/resources/application.yml
@@ -123,6 +123,7 @@ mcp:
         - id: "security.guide"
           source-path: "classpath:rag/security-service-guide.md"
           rag-scope: "master"
+          required-permissions: ["security:permission:view", "security:role:view"]
         # Gate 5 documents. `required-permissions` is the G5.2 metadata field (not yet bound by
         # StaticDocEntry — ignored until G5.2 adds the field + permission-aware filter G5.1);
         # carried here so it is ready and records intent. Permission codes verified against the

--- a/pos-mcp-server/src/main/resources/rag/security-service-guide.md
+++ b/pos-mcp-server/src/main/resources/rag/security-service-guide.md
@@ -1,5 +1,7 @@
 # Security Service — Administrator Guide
 
+> Access to this guide requires security-administration permissions (`security:permission:view`, `security:role:view`).
+
 This guide is for platform administrators and security operators who manage user accounts, roles, permissions, and access policies in the Durion Positivity platform. It describes what each capability does and who is authorised to use it.
 
 ---

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/eval/RetrievalLockTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/eval/RetrievalLockTest.java
@@ -72,14 +72,11 @@ import org.springframework.core.io.ClassPathResource;
  * the assertion is an equality both ways. A new doc that forgets the key fails; a doc that silently
  * loses its permission tags fails; and removing a doc from the public set without adding tags fails.
  *
- * <p><strong>Recorded exception (#1217, plan decision F):</strong> {@code security.guide}
- * ({@code rag/security-service-guide.md}) is in {@link #PUBLIC_DOC_IDS}. Its own opening line reads
- * "This guide is for platform administrators and security operators", which sits badly with the
- * Gate 5 completeness clause "admin/security docs require admin/security permissions". It is
- * carried as an explicit, reviewable exception rather than silently — the fix (tagging it
- * {@code security:permission:view} / {@code security:role:view}, or at minimum
- * {@code AUTHENTICATED}) is a content decision for #1217, not a test decision. The other five
- * public docs are pre-Gate-5 operational guides with no restricted content.
+ * <p><strong>#1396 resolved (2026-08-19):</strong> {@code security.guide} was the recorded
+ * exception here — an admin-and-security-operator guide shipped world-readable. The owner decision
+ * was to tag it ({@code security:permission:view} + {@code security:role:view} in both
+ * {@code application.yml} and {@code application-alpha.yml}), so it left this set. The remaining
+ * five public docs are pre-Gate-5 operational guides with no restricted content.
  */
 class RetrievalLockTest {
 
@@ -117,10 +114,7 @@ class RetrievalLockTest {
             "inventory.inv-cntrl",
             "people.human-resources",
             "shop.management",
-            "shop.management.guidelines",
-            // FINDING / recorded exception (#1217, plan decision F): admin-and-security-operator
-            // facing guide shipped without permission tags. Tracked, not silently blessed.
-            "security.guide");
+            "shop.management.guidelines");
 
     /**
      * {@code domain:resource:action}, snake_case, plus the synthetic {@code AUTHENTICATED} code that


### PR DESCRIPTION
## Summary
Executes the #1396 owner decision (option 1: **tag it**). `security.guide` was world-readable despite being an admin/security-operator guide, contradicting the Gate 5 admin-docs clause — the last blocker on Gate 5's Pass besides sign-off.

- `required-permissions: ["security:permission:view", "security:role:view"]` in **both** `application.yml` and `application-alpha.yml` (the overlay is the live corpus; `RetrievalLockTest.alphaOverlayCorpusMatchesBaseCorpus` keeps them identical).
- Removed from `RetrievalLockTest.PUBLIC_DOC_IDS`; the bidirectional pin now guards exactly the five operational guides.
- **Deliberate content touch** (access note added to the doc): `StaticRagPreloadServiceImpl` skips re-ingestion when the content hash is unchanged, so a YAML-only change would never rewrite the embedded chunks' permission metadata — the doc would have stayed world-readable live. The hash flip forces a re-embed carrying the new metadata on next startup.

## Verification
`RetrievalLockTest` 9/9 green. Post-deploy live verification: `rag_lock_sweep.py` (doc re-embedded, LOADED with new hash) + persona lacks-probe (non-security personas no longer retrieve it).

Closes #1396. Unblocks the Gate 5 Pass flip (approver decision G resolved: Louis Burroughs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUr5ocMQmymrSa2x2TuNX3