### PR TITLE
fix: restore V18 migration to applied checksum (alpha deploy failure)

### DIFF
--- a/pos-mcp-server/README.md
+++ b/pos-mcp-server/README.md
@@ -101,7 +101,22 @@ sentinel marks operations available to any authenticated caller.
 17 curated facade tools live in `internal/orchestration/tools/`: Accounting, Admin, Catalog, Customer, Events,
 Hr, Inventory, Invoice, Location, Order, Pricing, Reporting, ShopManager, Tax, Vehicle, Workorder, and the always-on
 Exa web search. Each maps to backend endpoints via a `@LoadBalanced` RestClient. Permission mappings for these tools
-are seeded by migration `V18`.
+are seeded by migration `V18` (retargeted by `V35`).
+
+The seed mirrors each downstream controller's *declared* authorization, not the product intent of the facade: for
+every backend endpoint a `@Tool` method calls, the merged class + method `@PreAuthorize` is read and
+`hasAuthority('X')` / `hasAnyAuthority('X','Y')` contribute codes `X`, `Y`, unioned across every `@Tool` method in
+the tool class. Some facade reads therefore fall back to the `AUTHENTICATED` sentinel instead of a "normal" business
+permission code:
+
+- **`isAuthenticated()` or no `@PreAuthorize` at all** (e.g. Order and Pricing reads, EventSummaryController) — there
+  is no permission-coded guard for MCP to copy, only the authenticated floor.
+- **Role-only guards** (`hasRole(...)`, e.g. Catalog reads) — `mcp_tool_permission` stores permission codes, not role
+  names, so role-only controller guards cannot be mirrored here; the role gates are still enforced in the downstream
+  service via Spring Security.
+
+> **Do not edit `V18` (or any applied migration) in place** — even comment-only changes alter the Flyway checksum and
+> fail validation on deployed environments. Document rationale here or add a new migration instead.
 
 ### OpenAPI-discovered tools
 

--- a/pos-mcp-server/README.md
+++ b/pos-mcp-server/README.md
@@ -110,13 +110,18 @@ the tool class. Some facade reads therefore fall back to the `AUTHENTICATED` sen
 permission code:
 
 - **`isAuthenticated()` or no `@PreAuthorize` at all** (e.g. Order and Pricing reads, EventSummaryController) — there
-  is no permission-coded guard for MCP to copy, only the authenticated floor.
+  is no permission-coded guard for MCP to copy, so the seed uses the `AUTHENTICATED` sentinel by design. Note this
+  reflects MCP's own selection gate, not a claim about the downstream endpoint: an endpoint with no `@PreAuthorize`
+  (like EventSummaryController) declares no gate of its own.
 - **Role-only guards** (`hasRole(...)`, e.g. Catalog reads) — `mcp_tool_permission` stores permission codes, not role
   names, so role-only controller guards cannot be mirrored here; the role gates are still enforced in the downstream
   service via Spring Security.
 
 > **Do not edit `V18` (or any applied migration) in place** — even comment-only changes alter the Flyway checksum and
-> fail validation on deployed environments. Document rationale here or add a new migration instead.
+> fail validation on deployed environments. Document rationale here or add a new migration instead. (This is also why
+> V18's in-file comment saying role gates are "enforced separately at the gateway" is left as-is despite being
+> imprecise — the corrected statement is the one above: role authorization happens in the downstream service's
+> Spring Security, the gateway only authenticates and forwards identity headers.)
 
 ### OpenAPI-discovered tools
 

--- a/pos-mcp-server/src/main/resources/db/migration/V18__seed_facade_tool_permissions.sql
+++ b/pos-mcp-server/src/main/resources/db/migration/V18__seed_facade_tool_permissions.sql
@@ -9,17 +9,7 @@
 --     and read the merged @PreAuthorize on class + method.
 --   * hasAuthority('X') / hasAnyAuthority('X','Y') → codes X, Y.
 --   * isAuthenticated() or no @PreAuthorize → 'AUTHENTICATED'.
---   * hasRole(...) only → also 'AUTHENTICATED': this table stores permission codes,
---     not role names, so role-only controller guards do not provide a normal
---     permission code the MCP selection layer can mirror here.
 --   * Union all codes across every @Tool method in the tool class.
---
--- Why some facade reads are not gated here with their "normal" business permission:
--- this seed mirrors the downstream controller's declared authorization, not the
--- product intent of the facade. If the downstream endpoint is only
--- isAuthenticated(), is ungated, or is role-gated without a permission code, the
--- tool-selection layer has no normal permission code to seed and must fall back to
--- AUTHENTICATED.
 --
 -- ─────────────────────────────────────────────────────────────────────────────
 -- 1. InventoryFacadeTool
@@ -47,8 +37,6 @@ WHERE mcp_tool.name = 'InventoryFacadeTool';
 --                    → SalesOrderController (/v1/orders) class-level: @PreAuthorize("isAuthenticated()")
 --    searchOrders  → /order/v1/orders/search?q={query}
 --                    → SalesOrderController (same, isAuthenticated())
---    Why not order:* here? These GETs inherit only the controller's
---    isAuthenticated() floor, so there is no order permission code for MCP to seed.
 --    Union: AUTHENTICATED
 -- ─────────────────────────────────────────────────────────────────────────────
 INSERT INTO mcp_tool_permission (tool_id, permission_code)
@@ -86,8 +74,6 @@ WHERE mcp_tool.name = 'CustomerFacadeTool';
 --                     → PricingSnapshotController (/v1/price/snapshots): @PreAuthorize("isAuthenticated()")
 --    getPriceList   → /price/v1/pricing/lists/{priceListId}
 --                     → PricingSnapshotController or PriceNormalizationController: isAuthenticated()
---    Why not pricing:* here? The mapped read endpoints are all
---    isAuthenticated()-only, so MCP sees no permission-coded guard to copy.
 --    Union: AUTHENTICATED
 -- ─────────────────────────────────────────────────────────────────────────────
 INSERT INTO mcp_tool_permission (tool_id, permission_code)
@@ -128,9 +114,7 @@ WHERE mcp_tool.name = 'WorkorderFacadeTool';
 --                         → ProductController (/v1/products/search) — same role gate
 --    getCatalogByCategory → /catalog/v1/catalog/categories/{category}
 --                         → CatalogController (/v1/catalogs) — same role gate
---    Why not catalog:* here? The catalog reads are guarded with roles, not
---    permission codes, and this table can only store permission-code gates.
---    Union: AUTHENTICATED  (role gates are enforced in the downstream service via Spring Security)
+--    Union: AUTHENTICATED  (role gates are enforced separately at the gateway)
 -- ─────────────────────────────────────────────────────────────────────────────
 INSERT INTO mcp_tool_permission (tool_id, permission_code)
 SELECT id, code
@@ -324,8 +308,6 @@ WHERE mcp_tool.name = 'AdminFacadeTool';
 --                     → EventSummaryController (/v1/events/summary): no @PreAuthorize → AUTHENTICATED
 --    getEventHistory→ /event-receiver/v1/events/events/summary?entityId={entityId}
 --                     → EventSummaryController: no @PreAuthorize → AUTHENTICATED
---    Why not events:* here? These endpoints declare no permission gate at all, so
---    MCP can only model the authenticated floor.
 --    Union: AUTHENTICATED
 -- ─────────────────────────────────────────────────────────────────────────────
 INSERT INTO mcp_tool_permission (tool_id, permission_code)


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (deploy hotfix)
- Parent STORY (durion): n/a
- Child issue: n/a
- Domain: `domain:mcp`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Not applicable — no controllers, DTOs, events, or `openapi.yaml` changed; this PR only reverts comments in a Flyway migration and updates a README.

## Contract Chain (when a Controller changed)
- Not applicable — no controller changed.

## Scope
- What changed:
  - Reverted `pos-mcp-server/src/main/resources/db/migration/V18__seed_facade_tool_permissions.sql` byte-for-byte to the version already applied to the alpha `pos_mcp` database (Flyway checksum `1660278854`).
  - Moved the AUTHENTICATED-fallback gating rationale (added by b87946a and c0e5ae4 as V18 comments) into `pos-mcp-server/README.md` (Facade tools section), plus a warning that applied migrations must never be edited in place.
- Why: Alpha deploy run [32299749618](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/32299749618) failed — `pos-mcp-server` crash-looped at startup with `Migration checksum mismatch for migration version 18` (applied `1660278854` vs resolved `685615842`). Two comment-only edits to the already-applied V18 changed its Flyway checksum. Restoring the original file content makes validation pass with no DB repair needed; the documentation moves to the README where it can evolve freely.

## Tests
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated
- How to run: No code changed (SQL comments + README only). Verified the reverted file's Flyway CRC32 checksum equals the applied value `1660278854` and the pre-revert file equals the failing resolved value `685615842`.

## Risk & Rollback
- Risk level: Low — comment-only revert of a migration plus README docs; no schema or code changes.
- Rollback plan: Revert this PR. (Note: rolling back reintroduces the checksum mismatch on alpha unless `flyway repair` is run against `pos_mcp`.)

## Checklist
- [ ] Branch name matches `cap/<cap-id>` (hotfix branch `claude/pos-mcp-server-deploy-error-869sdt`)
- [ ] PR title starts with `[CAP:<cap-id>]` (n/a — deploy hotfix)
- [ ] Links to parent + child issues are present (n/a)
- [ ] Contract guide updated (no contract semantics changed)
- [ ] Required CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyBeavQk5AUSxjqLSitwoA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyBeavQk5AUSxjqLSitwoA)_