### PR TITLE
[BACKEND] Grant invoice:finalize:override to ADMIN and the manager roles (#1374)

### DIFF
--- a/pos-invoice/README.md
+++ b/pos-invoice/README.md
@@ -71,15 +71,17 @@ capability. There are two ways to obtain it:
 - **Service advisor naming a manager (employee-number approval).** The named manager
   must hold the `invoice:finalize:override` **authority**. The permission is registered
   at startup from `permissions.yaml`, and role grants live in pos-security's
-  `role_permissions` table. **No role holds it by default** — pos-security's baseline seed
-  (`R__seed_role_permissions.sql`) deliberately does not grant it to any role, including
-  `ADMIN`. For this path, an admin must, after deploy:
-  1. Grant `invoice:finalize:override` to the manager/admin roles via the pos-security
-     role-permission admin API
-     (`PUT /v1/roles/{roleId}/permissions/invoice:finalize:override`).
-  2. Ensure managers are assigned those roles via the **user-role** admin API (the
-     `person-decision` check resolves authorities through `User.roles`, not
-     `role_assignments`).
+  `role_permissions` table. Since #1374, pos-security's baseline seed
+  (`R__seed_role_permissions.sql`) grants it to the manager roles —
+  `ACCOUNT_MANAGER`, `GENERAL_MANAGER`, `LOCATION_MANAGER`, `MANAGER`, and
+  `SHOP_MANAGER` — so no manual grant is needed after deploy. The only remaining
+  setup is ensuring managers are assigned one of those roles via the **user-role**
+  admin API (the `person-decision` check resolves authorities through `User.roles`,
+  not `role_assignments`). Additional roles can still be granted the permission via
+  the role-permission admin API
+  (`PUT /v1/roles/{roleId}/permissions/invoice:finalize:override`), but keep the
+  holder set small: this permission is the control that caps what a service advisor
+  can finalize by naming an absent manager.
 
 ## Dependencies
 

--- a/pos-invoice/README.md
+++ b/pos-invoice/README.md
@@ -72,7 +72,7 @@ capability. There are two ways to obtain it:
   must hold the `invoice:finalize:override` **authority**. The permission is registered
   at startup from `permissions.yaml`, and role grants live in pos-security's
   `role_permissions` table. Since #1374, pos-security's baseline seed
-  (`R__seed_role_permissions.sql`) grants it to the manager roles —
+  (`R__seed_role_permissions.sql`) grants it to `ADMIN` and the manager roles —
   `ACCOUNT_MANAGER`, `GENERAL_MANAGER`, `LOCATION_MANAGER`, `MANAGER`, and
   `SHOP_MANAGER` — so no manual grant is needed after deploy. The only remaining
   setup is ensuring managers are assigned one of those roles via the **user-role**

--- a/pos-invoice/src/test/java/com/positivity/invoice/internal/service/ElevationServiceTest.java
+++ b/pos-invoice/src/test/java/com/positivity/invoice/internal/service/ElevationServiceTest.java
@@ -1,0 +1,118 @@
+package com.positivity.invoice.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.positivity.invoice.internal.client.ManagerApprovalClient;
+import com.positivity.invoice.internal.dto.ElevateResponse;
+import com.positivity.invoice.internal.entity.ExtEmployeeReplica;
+import com.positivity.invoice.internal.exception.ElevationDeniedException;
+import com.positivity.invoice.internal.repository.ExtEmployeeReplicaRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ElevationService} — the employee-number manager-approval flow:
+ * a service advisor names an absent manager by employee number, the manager is resolved
+ * through the {@code ext_people_employee} replica, their {@code invoice:finalize:override}
+ * authority is verified against pos-security, and a token scoped to the invoice is minted.
+ *
+ * <p>The authority half only works because pos-security's baseline seed grants
+ * {@code invoice:finalize:override} to the manager roles (#1374);
+ * {@code RolePermissionSeedIT} in pos-security-service pins that end to end against the
+ * real resolution path. Here the client is mocked to cover this module's orchestration
+ * and its deny paths.
+ */
+class ElevationServiceTest {
+
+    private static final String EMPLOYEE_NUMBER = "EMP-042";
+    private static final UUID MANAGER_PERSON_ID = UUID.fromString("01990010-0000-7000-8000-00000000cafe");
+    private static final UUID INVOICE_ID = UUID.fromString("01990010-0000-7000-8000-00000000beef");
+    private static final String TOKEN_SECRET = "test-elevation-secret-please-rotate";
+
+    private ManagerApprovalClient managerApprovalClient;
+    private ExtEmployeeReplicaRepository extEmployeeReplicaRepository;
+    private ElevationTokenService tokenService;
+    private ElevationService elevationService;
+
+    @BeforeEach
+    void setUp() {
+        managerApprovalClient = mock(ManagerApprovalClient.class);
+        extEmployeeReplicaRepository = mock(ExtEmployeeReplicaRepository.class);
+        tokenService = new ElevationTokenService(
+                Clock.fixed(Instant.parse("2026-08-19T12:00:00Z"), ZoneOffset.UTC), TOKEN_SECRET, 300);
+        elevationService = new ElevationService(managerApprovalClient, extEmployeeReplicaRepository, tokenService);
+    }
+
+    @Test
+    void elevate_mintsInvoiceScopedToken_whenManagerActiveAndHoldsFinalizeOverride() {
+        when(extEmployeeReplicaRepository.findFirstByEmployeeNumberIgnoreCase(EMPLOYEE_NUMBER))
+                .thenReturn(Optional.of(activeManager()));
+        when(managerApprovalClient.personHoldsFinalizeOverride(MANAGER_PERSON_ID))
+                .thenReturn(true);
+
+        ElevateResponse response = elevationService.elevate(EMPLOYEE_NUMBER, INVOICE_ID);
+
+        // The minted token must verify against the invoice it was requested for and
+        // carry the approving manager, i.e. it is accepted by the finalize call.
+        assertThat(tokenService.verify(response.getElevationToken(), INVOICE_ID))
+                .contains(MANAGER_PERSON_ID);
+        assertThat(response.getExpiresAt()).isAfter(Instant.parse("2026-08-19T12:00:00Z"));
+        verify(managerApprovalClient).personHoldsFinalizeOverride(MANAGER_PERSON_ID);
+    }
+
+    @Test
+    void elevate_denies_whenNamedManagerLacksFinalizeOverride() {
+        // The pre-#1374 production state: the manager exists and is active, but no role
+        // grants invoice:finalize:override, so the person-decision comes back DENY.
+        when(extEmployeeReplicaRepository.findFirstByEmployeeNumberIgnoreCase(EMPLOYEE_NUMBER))
+                .thenReturn(Optional.of(activeManager()));
+        when(managerApprovalClient.personHoldsFinalizeOverride(MANAGER_PERSON_ID))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> elevationService.elevate(EMPLOYEE_NUMBER, INVOICE_ID))
+                .isInstanceOf(ElevationDeniedException.class)
+                .hasMessage("Manager approval denied");
+    }
+
+    @Test
+    void elevate_denies_whenEmployeeNumberUnknown() {
+        when(extEmployeeReplicaRepository.findFirstByEmployeeNumberIgnoreCase(EMPLOYEE_NUMBER))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> elevationService.elevate(EMPLOYEE_NUMBER, INVOICE_ID))
+                .isInstanceOf(ElevationDeniedException.class);
+        verifyNoInteractions(managerApprovalClient);
+    }
+
+    @Test
+    void elevate_denies_whenEmployeeInactive_withoutConsultingSecurity() {
+        ExtEmployeeReplica inactive = activeManager();
+        inactive.setStatus("TERMINATED");
+        when(extEmployeeReplicaRepository.findFirstByEmployeeNumberIgnoreCase(EMPLOYEE_NUMBER))
+                .thenReturn(Optional.of(inactive));
+
+        assertThatThrownBy(() -> elevationService.elevate(EMPLOYEE_NUMBER, INVOICE_ID))
+                .isInstanceOf(ElevationDeniedException.class);
+        verifyNoInteractions(managerApprovalClient);
+    }
+
+    private static ExtEmployeeReplica activeManager() {
+        return ExtEmployeeReplica.builder()
+                .employeeId(UUID.fromString("01990010-0000-7000-8000-00000000f00d"))
+                .personId(MANAGER_PERSON_ID)
+                .employeeNumber(EMPLOYEE_NUMBER)
+                .status("ACTIVE")
+                .aggregateVersion(1L)
+                .build();
+    }
+}

--- a/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
+++ b/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
@@ -34,6 +34,12 @@
 --   and no runtime initializer creates them, and both user_roles and
 --   role_assignments are foreign-keyed to roles(id), so no user could hold one.
 --   To make a persona real, create the role first, then grant it here.
+-- * invoice:finalize:override (#1374) gates manager-approval elevation for
+--   invoice finalization above the service-advisor cap. It is held by the
+--   manager roles only — ACCOUNT_MANAGER, GENERAL_MANAGER, LOCATION_MANAGER,
+--   MANAGER and SHOP_MANAGER — per the product decision on that issue. Do not
+--   widen it: the permission exists specifically to cap what a service advisor
+--   can finalize by naming an absent manager.
 -- * Grants are additive. Nothing here deletes a row, so permissions an operator
 --   granted through the role-permission admin API survive re-runs.
 --
@@ -236,6 +242,7 @@ FROM (VALUES
     ('inventory:stock_movement:create', 'inventory', 'stock_movement', 'create', 260),
     ('invoice:billing-rules', 'invoice', '', 'billing-rules', 83),
     ('invoice:finalize', 'invoice', '', 'finalize', 84),
+    ('invoice:finalize:override', 'invoice', 'finalize', 'override', 346),
     ('invoice:manage', 'invoice', '', 'manage', 82),
     ('location:bay:manage', 'location', 'bay', 'manage', 88),
     ('location:bay:read', 'location', 'bay', 'read', 87),
@@ -489,6 +496,7 @@ FROM (VALUES
     ('ACCOUNT_MANAGER', 'accounting:posting_rules:publish'),
     ('ACCOUNT_MANAGER', 'accounting:posting_rules:view'),
     ('ACCOUNT_MANAGER', 'invoice:billing-rules'),
+    ('ACCOUNT_MANAGER', 'invoice:finalize:override'),
     ('ACCOUNT_MANAGER', 'invoice:manage'),
     ('ACCOUNT_MANAGER', 'mcp:chat:execute'),
     ('ACCOUNT_MANAGER', 'mcp:chat:stream'),
@@ -855,6 +863,7 @@ FROM (VALUES
     ('DISPATCHER', 'workorder:workorder:view'),
     ('GENERAL_MANAGER', 'catalog:category:view'),
     ('GENERAL_MANAGER', 'catalog:product:view'),
+    ('GENERAL_MANAGER', 'invoice:finalize:override'),
     ('GENERAL_MANAGER', 'mcp:chat:execute'),
     ('GENERAL_MANAGER', 'mcp:chat:stream'),
     ('GENERAL_MANAGER', 'nlti:request:read'),
@@ -913,6 +922,7 @@ FROM (VALUES
     ('LOCATION_MANAGER', 'inventory:pick_list:execute'),
     ('LOCATION_MANAGER', 'inventory:pick_list:view'),
     ('LOCATION_MANAGER', 'invoice:finalize'),
+    ('LOCATION_MANAGER', 'invoice:finalize:override'),
     ('LOCATION_MANAGER', 'invoice:manage'),
     ('LOCATION_MANAGER', 'mcp:chat:execute'),
     ('LOCATION_MANAGER', 'mcp:chat:stream'),
@@ -992,6 +1002,7 @@ FROM (VALUES
     ('LOCATION_MANAGER', 'workorder:workorder:generate_invoice'),
     ('LOCATION_MANAGER', 'workorder:workorder:reopen_completed'),
     ('LOCATION_MANAGER', 'workorder:workorder:view'),
+    ('MANAGER', 'invoice:finalize:override'),
     ('MANAGER', 'mcp:chat:execute'),
     ('MANAGER', 'mcp:chat:stream'),
     ('MANAGER', 'nlti:request:read'),
@@ -1069,6 +1080,7 @@ FROM (VALUES
     ('SERVICE_ADVISOR', 'workorder:workorder:create'),
     ('SERVICE_ADVISOR', 'workorder:workorder:generate_invoice'),
     ('SERVICE_ADVISOR', 'workorder:workorder:view'),
+    ('SHOP_MANAGER', 'invoice:finalize:override'),
     ('SHOP_MANAGER', 'mcp:chat:execute'),
     ('SHOP_MANAGER', 'mcp:chat:stream'),
     ('SHOP_MANAGER', 'nlti:request:read'),
@@ -1330,6 +1342,7 @@ BEGIN
         ('inventory:stock_movement:create'),
         ('invoice:billing-rules'),
         ('invoice:finalize'),
+        ('invoice:finalize:override'),
         ('invoice:manage'),
         ('location:bay:manage'),
         ('location:bay:read'),

--- a/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
+++ b/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
@@ -35,11 +35,11 @@
 --   role_assignments are foreign-keyed to roles(id), so no user could hold one.
 --   To make a persona real, create the role first, then grant it here.
 -- * invoice:finalize:override (#1374) gates manager-approval elevation for
---   invoice finalization above the service-advisor cap. It is held by the
---   manager roles only — ACCOUNT_MANAGER, GENERAL_MANAGER, LOCATION_MANAGER,
---   MANAGER and SHOP_MANAGER — per the product decision on that issue. Do not
---   widen it: the permission exists specifically to cap what a service advisor
---   can finalize by naming an absent manager.
+--   invoice finalization above the service-advisor cap. It is held by ADMIN
+--   and the manager roles only — ACCOUNT_MANAGER, GENERAL_MANAGER,
+--   LOCATION_MANAGER, MANAGER and SHOP_MANAGER — per the product decision on
+--   that issue. Do not widen it: the permission exists specifically to cap
+--   what a service advisor can finalize by naming an absent manager.
 -- * Grants are additive. Nothing here deletes a row, so permissions an operator
 --   granted through the role-permission admin API survive re-runs.
 --
@@ -654,6 +654,7 @@ FROM (VALUES
     ('ADMIN', 'inventory:stock_movement:create'),
     ('ADMIN', 'invoice:billing-rules'),
     ('ADMIN', 'invoice:finalize'),
+    ('ADMIN', 'invoice:finalize:override'),
     ('ADMIN', 'invoice:manage'),
     ('ADMIN', 'location:bay:manage'),
     ('ADMIN', 'location:bay:read'),

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/RolePermissionBaselineTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/RolePermissionBaselineTest.java
@@ -295,7 +295,7 @@ class RolePermissionBaselineTest {
     }
 
     @Test
-    @DisplayName("invoice:finalize:override is held by exactly the manager roles agreed on #1374")
+    @DisplayName("invoice:finalize:override is held by exactly ADMIN and the manager roles agreed on #1374")
     void finalizeOverrideIsHeldByExactlyTheAgreedManagerRoles() {
         Set<String> holders = seededGrants.entrySet().stream()
                 .filter(entry -> entry.getValue().contains("invoice:finalize:override"))
@@ -309,7 +309,8 @@ class RolePermissionBaselineTest {
         // as much a regression as losing it.
         assertThat(holders)
                 .as("roles holding invoice:finalize:override")
-                .containsExactly("ACCOUNT_MANAGER", "GENERAL_MANAGER", "LOCATION_MANAGER", "MANAGER", "SHOP_MANAGER");
+                .containsExactly(
+                        "ACCOUNT_MANAGER", "ADMIN", "GENERAL_MANAGER", "LOCATION_MANAGER", "MANAGER", "SHOP_MANAGER");
     }
 
     @Test

--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/RolePermissionBaselineTest.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/config/RolePermissionBaselineTest.java
@@ -295,6 +295,24 @@ class RolePermissionBaselineTest {
     }
 
     @Test
+    @DisplayName("invoice:finalize:override is held by exactly the manager roles agreed on #1374")
+    void finalizeOverrideIsHeldByExactlyTheAgreedManagerRoles() {
+        Set<String> holders = seededGrants.entrySet().stream()
+                .filter(entry -> entry.getValue().contains("invoice:finalize:override"))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        // pos-invoice's employee-number approval flow resolves the named manager's
+        // authority through role_permissions, so an empty holder set silently breaks
+        // manager-approval elevation (#1374). Equality rather than containment: the
+        // permission caps what a service advisor can finalize, so widening the set is
+        // as much a regression as losing it.
+        assertThat(holders)
+                .as("roles holding invoice:finalize:override")
+                .containsExactly("ACCOUNT_MANAGER", "GENERAL_MANAGER", "LOCATION_MANAGER", "MANAGER", "SHOP_MANAGER");
+    }
+
+    @Test
     @DisplayName("ADMIN holds both tool permissions")
     void adminHoldsToolViewAndManage() {
         assertThat(seededGrants.get("ADMIN")).contains("mcp:tool:view", "mcp:tool:manage");

--- a/pos-security-service/src/test/java/com/positivity/securityservice/migration/RolePermissionSeedIT.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/migration/RolePermissionSeedIT.java
@@ -3,10 +3,12 @@ package com.positivity.securityservice.migration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.positivity.securityservice.service.AuthorizationService;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.UUID;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -51,6 +53,9 @@ class RolePermissionSeedIT {
 
     @Autowired
     private DataSource dataSource;
+
+    @Autowired
+    private AuthorizationService authorizationService;
 
     /**
      * The seed migration for {@code admin.alpha} interpolates this placeholder. It is a
@@ -164,6 +169,41 @@ class RolePermissionSeedIT {
     }
 
     @Test
+    @DisplayName("manager-approval elevation: a manager person resolves invoice:finalize:override, "
+            + "a service advisor does not")
+    void managerApprovalElevation_resolvesFinalizeOverrideThroughPersonDecision() {
+        // The grant half: exactly the manager roles agreed on #1374 hold the permission.
+        for (String role :
+                List.of("ACCOUNT_MANAGER", "GENERAL_MANAGER", "LOCATION_MANAGER", "MANAGER", "SHOP_MANAGER")) {
+            assertThat(grantedTo(role)).as("grants for %s", role).contains("invoice:finalize:override");
+        }
+        assertThat(grantedTo("SERVICE_ADVISOR"))
+                .as("the permission caps what a service advisor can finalize; the advisor must not hold it")
+                .doesNotContain("invoice:finalize:override");
+
+        // The resolution half, end to end: pos-invoice's employee-number approval flow calls
+        // GET /v1/users/authorization/person-decision, which lands on
+        // AuthorizationService.authorizePerson and resolves
+        // users.person_id -> user_roles -> roles -> role_permissions -> permissions.
+        // Run that real code path against the seeded baseline for a manager and a
+        // non-manager, so the flow cannot silently regress to "no role holds it" (#1374).
+        UUID managerPersonId = UUID.fromString("01990010-0000-7000-8000-000000000001");
+        UUID advisorPersonId = UUID.fromString("01990010-0000-7000-8000-000000000002");
+        insertUserWithRole("it.elevation.manager", managerPersonId, "LOCATION_MANAGER");
+        insertUserWithRole("it.elevation.advisor", advisorPersonId, "SERVICE_ADVISOR");
+        try {
+            assertThat(authorizationService.authorizePerson(managerPersonId, "invoice:finalize:override"))
+                    .isEqualTo(AuthorizationService.Decision.ALLOW);
+            assertThat(authorizationService.authorizePerson(advisorPersonId, "invoice:finalize:override"))
+                    .isEqualTo(AuthorizationService.Decision.DENY);
+        } finally {
+            jdbc().update("DELETE FROM user_roles WHERE user_id IN "
+                    + "(SELECT id FROM users WHERE username IN ('it.elevation.manager', 'it.elevation.advisor'))");
+            jdbc().update("DELETE FROM users WHERE username IN ('it.elevation.manager', 'it.elevation.advisor')");
+        }
+    }
+
+    @Test
     @DisplayName("a user holding only an ungranted role resolves no permissions")
     void userWithOnlyUngrantedRole_failsClosed() {
         // Every seeded role now carries the assistant entrypoints, so fail-closed has to be
@@ -179,6 +219,19 @@ class RolePermissionSeedIT {
                 + "WHERE u.username = 'ungranted.user' AND r.name = 'IT_UNGRANTED_ROLE'");
 
         assertThat(effectivePermissionsOf("ungranted.user")).isEmpty();
+    }
+
+    private void insertUserWithRole(String username, UUID personId, String roleName) {
+        jdbc().update(
+                        "INSERT INTO users (id, username, password, enabled, person_id) "
+                                + "VALUES (gen_random_uuid(), ?, 'x', true, ?)",
+                        username,
+                        personId);
+        jdbc().update(
+                        "INSERT INTO user_roles (user_id, role_id) "
+                                + "SELECT u.id, r.id FROM users u, roles r WHERE u.username = ? AND r.name = ?",
+                        username,
+                        roleName);
     }
 
     private JdbcTemplate jdbc() {

--- a/pos-security-service/src/test/java/com/positivity/securityservice/migration/RolePermissionSeedIT.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/migration/RolePermissionSeedIT.java
@@ -174,7 +174,7 @@ class RolePermissionSeedIT {
     void managerApprovalElevation_resolvesFinalizeOverrideThroughPersonDecision() {
         // The grant half: exactly the manager roles agreed on #1374 hold the permission.
         for (String role :
-                List.of("ACCOUNT_MANAGER", "GENERAL_MANAGER", "LOCATION_MANAGER", "MANAGER", "SHOP_MANAGER")) {
+                List.of("ACCOUNT_MANAGER", "ADMIN", "GENERAL_MANAGER", "LOCATION_MANAGER", "MANAGER", "SHOP_MANAGER")) {
             assertThat(grantedTo(role)).as("grants for %s", role).contains("invoice:finalize:override");
         }
         assertThat(grantedTo("SERVICE_ADVISOR"))


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (RBAC baseline fix, no new capability)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1374
- Domain: `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Not applicable — no controllers, DTOs, events, or `openapi.yaml` change. The diff is a repeatable seed migration, tests, and a README update; no API or event contract semantics changed.

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — n/a, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope
- What changed:
  - `R__seed_role_permissions.sql` now grants `invoice:finalize:override` (bit index 346) to `ADMIN`, `ACCOUNT_MANAGER`, `GENERAL_MANAGER`, `LOCATION_MANAGER`, `MANAGER`, and `SHOP_MANAGER`, with the permission definition and section-4 assertion entry added, plus a policy note documenting the decision.
  - `RolePermissionBaselineTest` pins the exact holder set — losing the grant silently breaks the flow again; widening it defeats the service-advisor finalization cap.
  - `RolePermissionSeedIT` exercises the real person-decision path (`users.person_id → user_roles → roles → role_permissions → permissions` via `AuthorizationService.authorizePerson`): ALLOW for a `LOCATION_MANAGER` person, DENY for a `SERVICE_ADVISOR`.
  - New `ElevationServiceTest` in pos-invoice covers the employee-number approval flow orchestration: invoice-scoped token minted on allow; denied for unknown/inactive employees and for managers lacking the authority.
  - `pos-invoice/README.md` operational-setup section no longer instructs admins to grant the permission manually after every deploy.
- Why: no role held `invoice:finalize:override`, so the service-advisor-names-a-manager elevation path in pos-invoice always ended in `ElevationDeniedException` on a freshly provisioned environment (#1374). Role list per the product decision on the issue: ADMIN plus the manager roles. The requested `ACCOUNTING_MANAGER` and `STORE_MANAGER` map to the canonical `ACCOUNT_MANAGER` and `SHOP_MANAGER` roles — those personas exist under those names, and granting to an unknown name aborts the seed's section-4 assertion.

## Tests
- [x] Unit tests added/updated (`RolePermissionBaselineTest`, `ElevationServiceTest`)
- [x] Integration tests added/updated (`RolePermissionSeedIT`, Postgres/Testcontainers)
- [ ] Provider behavioral contract tests added/updated — n/a, no contract change
- How to run:
  - `./mvnw -pl pos-security-service -am -Dtest=RolePermissionBaselineTest test`
  - `./mvnw -pl pos-invoice -am -Dtest=ElevationServiceTest,ElevationTokenServiceTest test`
  - `./mvnw -pl pos-security-service -am verify` (runs `RolePermissionSeedIT`; requires Docker)

## Risk & Rollback
- Risk level: Low
- Rollback plan: revert the PR. The repeatable seed is additive (`ON CONFLICT DO NOTHING`); reverting stops future environments from receiving the grants, and rows already applied can be removed via the role-permission admin API (`DELETE /v1/roles/{roleId}/permissions/invoice:finalize:override`) if the grant must be withdrawn from a live environment.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, task branch `claude/manager-roles-permission-ma4wgl` per session instructions
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability id for this fix
- [x] Links to parent + child issues are present (#1374)
- [x] Contract guide updated (when contract semantics changed) — n/a, none changed
- [ ] Required CI checks passing (pending)

Closes #1374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111uivk1VJoQJWLGkFQoQEX

---
_Generated by [Claude Code](https://claude.ai/code/session_0111uivk1VJoQJWLGkFQoQEX)_