### PR TITLE
Per-product whole-quantity invariant from precision_scale; delete the CEILING workaround (#1413, ADR-0055 stage 1)

### DIFF
--- a/pos-workorder/README.md
+++ b/pos-workorder/README.md
@@ -53,6 +53,20 @@ flag per part line (resolved order-spec Q6 — set at settlement time, never inf
 with approval status) on every estimate mutation, feeding pos-order's source-document import
 replicas. Both are gated by `workorder.kafka.enabled`.
 
+## Part quantity divisibility (ADR-0055)
+
+A part quantity must be a whole number unless the product it references declares otherwise. The
+declaration is `product_uom.precision_scale` on the product's `BASE` row, owned by `pos-catalog`
+and replicated here as `ext_product_uom` from `catalog.product.updated` facts (ADR-0044 §6). Scale
+`0` — and equally, a product with no unit-of-measure rows, which is every product until seeding
+lands — means whole units; a non-zero scale permits that many decimal places.
+
+Enforced at estimate-item creation and update, at estimate-to-workorder promotion, and again on the
+issue, consume, return and quantity-correction paths. Parts carrying no `productEntityId` (labour,
+shop supplies, non-stocked consumables) are exempt and stay fractional. A violation returns HTTP
+422 with `code: FRACTIONAL_QUANTITY_NOT_ALLOWED`, a `quantity` field error, and a `nextAction`
+naming the quantity to enter instead.
+
 ## Configuration
 
 | Property                       | Default                    | Description                      |
@@ -65,6 +79,8 @@ replicas. Both are gated by `workorder.kafka.enabled`.
 | `pos.location.base-url`        | `http://pos-location:8080` | Location service URL             |
 | `workorder.kafka.enabled`      | `false`                    | Enable Kafka event emission      |
 | `workorder.kafka.events-topic` | `workorder.events.v1`      | Kafka topic for workorder events |
+| `workorder.kafka.catalog-events-topic` | `catalog.events.v1` | Catalog fact topic feeding the `ext_product_uom` replica |
+| `workorder.kafka.catalog-events-consumer-group` | `pos-workorder-catalog-events` | Consumer group for the catalog fact topic |
 
 ## Dependencies
 

--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -6892,7 +6892,7 @@ components:
           type: number
           description: Corrected authorized quantity
           example: 2
-          minimum: 0
+          minimum: 0.0001
         reason:
           type: string
           description: Audit reason for correction

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/GlobalExceptionHandler.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.positivity.shared.error.ApiError;
 import com.positivity.shared.id.UUIDv7Generator;
 import com.positivity.workorder.internal.exception.BreakSegmentNotFoundException;
 import com.positivity.workorder.internal.exception.DuplicateSubstituteLinkException;
+import com.positivity.workorder.internal.exception.FractionalQuantityNotAllowedException;
 import com.positivity.workorder.internal.exception.InsufficientPartAvailabilityException;
 import com.positivity.workorder.internal.exception.StaleSubstituteLinkVersionException;
 import com.positivity.workorder.internal.exception.SubstituteLinkNotFoundException;
@@ -65,6 +66,36 @@ public class GlobalExceptionHandler {
         HttpHeaders headers = new HttpHeaders();
         headers.add(X_CORRELATION_ID, correlationId);
         return new ResponseEntity<>(body, headers, HttpStatus.CONFLICT);
+    }
+
+    /**
+     * A quantity the referenced product's catalog declaration does not permit (ADR-0055, #1413).
+     *
+     * <p>422 rather than 400: the payload is well-formed and the field is within its declared
+     * bounds. What it violates is a rule about the product it names, which nothing but a product
+     * lookup could have known — the same reason the check cannot live in bean validation.
+     *
+     * <p>Carries both a {@code fieldErrors} entry, so a form can mark the quantity box, and a
+     * {@code nextAction}, so the counter is told what to enter instead of hitting a dead end
+     * (docs/ERROR_ENVELOPE.md).
+     */
+    @ExceptionHandler(FractionalQuantityNotAllowedException.class)
+    public ResponseEntity<ApiError> handleFractionalQuantityNotAllowed(
+            FractionalQuantityNotAllowedException ex, HttpServletRequest request) {
+        String correlationId = resolveCorrelationId(request);
+        ApiError body = new ApiError(
+                "FRACTIONAL_QUANTITY_NOT_ALLOWED",
+                ex.getMessage(),
+                HttpStatus.UNPROCESSABLE_ENTITY.value(),
+                Instant.now(clock).toString(),
+                correlationId,
+                List.of(new ApiError.FieldError(FractionalQuantityNotAllowedException.FIELD, ex.getMessage())),
+                null,
+                ex.getNextAction(),
+                null);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(X_CORRELATION_ID, correlationId);
+        return new ResponseEntity<>(body, headers, HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     @ExceptionHandler(IllegalStateException.class)

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/CorrectPartQuantityRequest.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/CorrectPartQuantityRequest.java
@@ -4,9 +4,9 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIR
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -39,7 +39,7 @@ public class CorrectPartQuantityRequest {
      * New authorized quantity (must be positive).
      */
     @NotNull(message = "New quantity is required")
-    @Positive(message = "New quantity must be positive")
+    @DecimalMin(value = "0.0001", message = "newQuantity must be greater than 0")
     @Schema(description = "Corrected authorized quantity", example = "2", requiredMode = REQUIRED)
     private BigDecimal newQuantity;
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/CorrectPartQuantityRequest.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/dto/CorrectPartQuantityRequest.java
@@ -39,7 +39,7 @@ public class CorrectPartQuantityRequest {
      * New authorized quantity (must be positive).
      */
     @NotNull(message = "New quantity is required")
-    @DecimalMin(value = "0.0001", message = "newQuantity must be greater than 0")
+    @DecimalMin(value = "0.0001", inclusive = true, message = "New quantity must be positive")
     @Schema(description = "Corrected authorized quantity", example = "2", requiredMode = REQUIRED)
     private BigDecimal newQuantity;
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/ExtProductUomReplica.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/ExtProductUomReplica.java
@@ -1,0 +1,87 @@
+package com.positivity.workorder.internal.entity;
+
+import com.positivity.shared.id.UUIDv7Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Read-only per-product unit-of-measure row carried on {@code catalog.product.updated} facts
+ * (ADR-0044 §6, ADR-0055, #1413). pos-catalog owns these rows; nothing in this module may write
+ * the table except {@code CatalogEventsListener}.
+ *
+ * <p>What this module reads is the {@code BASE} row's {@code precisionScale}: the number of decimal
+ * places the product's stock is divisible to. Zero — and equally, no row at all — means the product
+ * is stocked and issued in whole units, which is what {@code PartQuantityDivisibilityService}
+ * enforces on every part quantity.
+ *
+ * <p>{@code factorToBase} converts one unit of {@code uomCode} into the product's base UoM
+ * ({@code 1 CASE = factorToBase × baseUom}); {@code 1} for {@code BASE} rows. It is replicated
+ * because the fact carries it and the row would otherwise misrepresent what catalog published, not
+ * because this module converts anything yet — the work-order line has no UoM column (#1415).
+ *
+ * <p><b>Freshness bound:</b> consistent with catalog's product row at emission time, arriving
+ * within normal Kafka lag. A late arrival can only mean a newly-divisible product is briefly still
+ * judged as integral, which blocks a fractional entry rather than admitting a wrong one.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@IdClass(ExtProductUomReplica.Key.class)
+@Table(name = "ext_product_uom")
+public class ExtProductUomReplica {
+
+    @Id
+    @Column(name = "product_id", nullable = false)
+    private UUID productId;
+
+    @Id
+    @Column(name = "uom_code", nullable = false, length = 32)
+    private String uomCode;
+
+    @Column(name = "uom_type", length = 16)
+    private String uomType;
+
+    @Column(name = "factor_to_base", nullable = false, precision = 20, scale = 6)
+    private BigDecimal factorToBase;
+
+    @Column(name = "precision_scale", nullable = false)
+    private int precisionScale;
+
+    /**
+     * Envelope {@code aggregateVersion} of the fact that wrote this row — catalog's product
+     * {@code updatedAt} as epoch millis. Read only by the listener's stale guard.
+     */
+    @Column(name = "aggregate_version", nullable = false)
+    private long aggregateVersion;
+
+    /**
+     * Explicit dependency hook for the ArchUnit UUIDv7 rule (ADR-0013): the product id IS a UUIDv7
+     * minted by the owning module; this replica stores it verbatim rather than generating one.
+     */
+    @Transient
+    public Class<?> uuidv7Dependency() {
+        return UUIDv7Id.class;
+    }
+
+    /** Composite key: the owner allows exactly one row per (product, uomCode). */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Key implements Serializable {
+        private UUID productId;
+        private String uomCode;
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/exception/FractionalQuantityNotAllowedException.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/exception/FractionalQuantityNotAllowedException.java
@@ -1,0 +1,61 @@
+package com.positivity.workorder.internal.exception;
+
+import java.math.BigDecimal;
+
+/**
+ * A part quantity carries more decimal places than the product's catalog declaration allows
+ * (ADR-0055, #1413).
+ *
+ * <p>Divisibility is a per-product property, not a platform rule: a product whose {@code BASE}
+ * unit-of-measure row declares {@code precision_scale = 0} — and equally, a product with no
+ * unit-of-measure rows at all — is stocked, issued and billed in whole units, while one declaring a
+ * non-zero scale may be quantified to that many decimals.
+ *
+ * <p>Surfaced as 422 UNPROCESSABLE ENTITY rather than 400: the request is well-formed and the field
+ * passes its bean-validation bounds; what it violates is a rule about the referenced product, which
+ * can only be known after looking that product up.
+ *
+ * <p>Carries the remedy rather than only the complaint. A counter told "0.5 is invalid" has nowhere
+ * to go; told "enter 1 to issue and bill the full container" they can finish the job, which is the
+ * partial-container policy ADR-0055 records.
+ */
+public class FractionalQuantityNotAllowedException extends RuntimeException {
+
+    /** The request field the violation belongs to; the same name on every entry point. */
+    public static final String FIELD = "quantity";
+
+    private final transient String nextAction;
+
+    public FractionalQuantityNotAllowedException(String message, String nextAction) {
+        super(message);
+        this.nextAction = nextAction;
+    }
+
+    public String getNextAction() {
+        return nextAction;
+    }
+
+    /**
+     * The product is stocked in whole units. The suggested value rounds up, matching the
+     * "bill the whole container" policy: half a container consumed is a whole container gone.
+     */
+    public static FractionalQuantityNotAllowedException wholeUnitsOnly(
+            String partLabel, BigDecimal quantity, BigDecimal suggestion) {
+        String remedy = "Enter " + suggestion.toPlainString() + " to issue and bill the full container.";
+        return new FractionalQuantityNotAllowedException(
+                "Quantity " + quantity.toPlainString() + " is not valid for '" + partLabel
+                        + "' — this part is issued and billed in whole units. " + remedy,
+                remedy);
+    }
+
+    /** The product is divisible, but not this finely. */
+    public static FractionalQuantityNotAllowedException scaleExceeded(
+            String partLabel, BigDecimal quantity, int declaredScale, BigDecimal suggestion) {
+        String remedy = "Enter a quantity with at most " + declaredScale + " decimal places, such as "
+                + suggestion.toPlainString() + ".";
+        return new FractionalQuantityNotAllowedException(
+                "Quantity " + quantity.toPlainString() + " is not valid for '" + partLabel
+                        + "' — this part is stocked to " + declaredScale + " decimal places. " + remedy,
+                remedy);
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/ExtProductUomReplicaRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/ExtProductUomReplicaRepository.java
@@ -3,6 +3,7 @@ package com.positivity.workorder.internal.repository;
 import com.positivity.workorder.internal.entity.ExtProductUomReplica;
 import java.util.List;
 import java.util.UUID;
+import org.jspecify.annotations.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -21,15 +22,17 @@ public interface ExtProductUomReplicaRepository extends JpaRepository<ExtProduct
      * {@code BASE} rows and a scalar query would fail the whole part-entry path over a data defect
      * the caller can resolve on its own.
      */
+    @NonNull
     @Query("SELECT u.precisionScale FROM ExtProductUomReplica u "
             + "WHERE u.productId = :productId AND u.uomType = 'BASE'")
-    List<Integer> findBasePrecisionScales(@Param("productId") UUID productId);
+    List<Integer> findBasePrecisionScales(@Param("productId") @NonNull UUID productId);
 
     /** Fact versions currently held for the product, empty when it has no rows. */
+    @NonNull
     @Query("SELECT u.aggregateVersion FROM ExtProductUomReplica u WHERE u.productId = :productId")
-    List<Long> findAggregateVersions(@Param("productId") UUID productId);
+    List<Long> findAggregateVersions(@Param("productId") @NonNull UUID productId);
 
     @Modifying
     @Query("DELETE FROM ExtProductUomReplica u WHERE u.productId = :productId")
-    void deleteByProductId(@Param("productId") UUID productId);
+    void deleteByProductId(@Param("productId") @NonNull UUID productId);
 }

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/ExtProductUomReplicaRepository.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/repository/ExtProductUomReplicaRepository.java
@@ -1,0 +1,35 @@
+package com.positivity.workorder.internal.repository;
+
+import com.positivity.workorder.internal.entity.ExtProductUomReplica;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** Read side of the catalog-owned {@code ext_product_uom} replica (ADR-0044 §6, #1413). */
+public interface ExtProductUomReplicaRepository extends JpaRepository<ExtProductUomReplica, ExtProductUomReplica.Key> {
+
+    /**
+     * Declared decimal scales of the product's {@code BASE} rows, empty when the product has no
+     * unit-of-measure rows at all — which is every product today, since nothing seeds
+     * {@code product_uom} platform-wide.
+     *
+     * <p>Returns a list rather than a single value on purpose: the key allows one row per
+     * {@code uomCode}, not one row per {@code uomType}, so a mis-seeded product could carry two
+     * {@code BASE} rows and a scalar query would fail the whole part-entry path over a data defect
+     * the caller can resolve on its own.
+     */
+    @Query("SELECT u.precisionScale FROM ExtProductUomReplica u "
+            + "WHERE u.productId = :productId AND u.uomType = 'BASE'")
+    List<Integer> findBasePrecisionScales(@Param("productId") UUID productId);
+
+    /** Fact versions currently held for the product, empty when it has no rows. */
+    @Query("SELECT u.aggregateVersion FROM ExtProductUomReplica u WHERE u.productId = :productId")
+    List<Long> findAggregateVersions(@Param("productId") UUID productId);
+
+    @Modifying
+    @Query("DELETE FROM ExtProductUomReplica u WHERE u.productId = :productId")
+    void deleteByProductId(@Param("productId") UUID productId);
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CatalogEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/CatalogEventsListener.java
@@ -1,0 +1,130 @@
+package com.positivity.workorder.internal.service;
+
+import com.positivity.domainevents.catalog.ProductUpdatedV1;
+import com.positivity.workorder.internal.entity.ExtProductUomReplica;
+import com.positivity.workorder.internal.entity.ProcessedEvent;
+import com.positivity.workorder.internal.repository.ExtProductUomReplicaRepository;
+import com.positivity.workorder.internal.repository.ProcessedEventRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Consumes {@code catalog.events.v1} into the {@code ext_product_uom} replica (ADR-0044 §6,
+ * ADR-0055, #1413) — the per-product declaration of how divisible a product's stock is, which this
+ * module needs to decide whether a part quantity may carry decimals.
+ *
+ * <p>Only the unit-of-measure set is replicated. pos-inventory and pos-order take more from the
+ * same fact (tracking level, substitution groups, product codes); this module has no use for any
+ * of it, and replicating data nothing reads is how replicas rot.
+ *
+ * <p>Consumer contract: {@code processed_events} idempotency (owner {@code catalog}) in the apply
+ * transaction, transient DB errors rethrown for container retry/DLQ, malformed payloads logged and
+ * dropped rather than poisoning the partition. There is no catalog manifest listener in this
+ * module, so — unlike {@code InventoryEventsListener} — facts of other types are skipped without
+ * recording a dedup row; nothing compares counts against them.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "workorder.kafka", name = "enabled", havingValue = "true")
+public class CatalogEventsListener {
+
+    static final String OWNER = "catalog";
+
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+    private final ProcessedEventRepository processedEventRepository;
+    private final ExtProductUomReplicaRepository productUomReplicaRepository;
+
+    @KafkaListener(
+            topics = "${workorder.kafka.catalog-events-topic:catalog.events.v1}",
+            groupId = "${workorder.kafka.catalog-events-consumer-group:pos-workorder-catalog-events}")
+    @Transactional
+    public void onCatalogEvent(@NonNull String message) {
+        JsonNode envelope;
+        try {
+            envelope = objectMapper.readTree(message);
+        } catch (Exception e) {
+            log.warn("Skipping unparsable catalog event: {}", message, e);
+            return;
+        }
+        if (!ProductUpdatedV1.EVENT_TYPE.equals(envelope.path("eventType").stringValue(null))) {
+            return;
+        }
+        String eventId = envelope.path("eventId").stringValue(null);
+        if (eventId == null || eventId.isBlank()) {
+            log.warn("Skipping catalog event without eventId");
+            return;
+        }
+        if (processedEventRepository.existsById(eventId)) {
+            return;
+        }
+
+        try {
+            applyUomConversions(envelope);
+            processedEventRepository.save(ProcessedEvent.builder()
+                    .eventId(eventId)
+                    .owner(OWNER)
+                    .processedAt(Instant.now(clock))
+                    .build());
+        } catch (TransientDataAccessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("Skipping malformed catalog event eventId={}", eventId, e);
+        }
+    }
+
+    /**
+     * Replaces the product's unit-of-measure set wholesale.
+     *
+     * <p>Wholesale rather than merged, because each fact carries the product's full set. Merging
+     * would leave a UoM catalog has retired still declared here, so a part could go on being judged
+     * divisible against a scale its owner no longer publishes.
+     *
+     * <p>The stale guard compares the fact's {@code aggregateVersion} — catalog stamps the product's
+     * {@code updatedAt} epoch millis there — against the highest version this module already holds
+     * for the product, and applies on equality because catalog fans out several facts for one
+     * product within the same millisecond. It is belt-and-braces: facts are keyed by product id, so
+     * a partition already delivers one product's facts in order, and what this guards is redelivery
+     * after a rebalance. A product that currently holds no rows has nothing to roll backwards, so
+     * the guard does not apply and the fact lands.
+     */
+    private void applyUomConversions(JsonNode envelope) {
+        JsonNode payload = envelope.path("payload");
+        UUID productId = UUID.fromString(payload.path("productId").stringValue(null));
+        long aggregateVersion = envelope.path("aggregateVersion").longValue(0L);
+
+        List<Long> heldVersions = productUomReplicaRepository.findAggregateVersions(productId);
+        if (heldVersions.stream().anyMatch(held -> held > aggregateVersion)) {
+            return;
+        }
+
+        productUomReplicaRepository.deleteByProductId(productId);
+        for (JsonNode conversion : payload.path("uomConversions")) {
+            String uomCode = conversion.path("uomCode").stringValue(null);
+            if (uomCode == null || uomCode.isBlank()) {
+                continue;
+            }
+            productUomReplicaRepository.save(ExtProductUomReplica.builder()
+                    .productId(productId)
+                    .uomCode(uomCode)
+                    .uomType(conversion.path("uomType").stringValue(null))
+                    .factorToBase(conversion.path("factorToBase").decimalValue())
+                    .precisionScale(conversion.path("precisionScale").intValue(0))
+                    .aggregateVersion(aggregateVersion)
+                    .build());
+        }
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
@@ -79,6 +79,7 @@ public class EstimateServiceImpl implements EstimateService {
     private final CustomerReferenceService customerReferenceService;
     private final VehicleReferenceService vehicleReferenceService;
     private final EstimateFactPublisher estimateFactPublisher;
+    private final PartQuantityDivisibilityService partQuantityDivisibilityService;
 
     // Configuration defaults
     private static final String DEFAULT_CURRENCY = "USD";
@@ -884,6 +885,14 @@ public class EstimateServiceImpl implements EstimateService {
                     + ". Estimate must be in DRAFT status.");
         }
 
+        // The quantity column is shared between PART and LABOR rows, and only the PART side names a
+        // catalog product whose divisibility can be read. Labour stays fractional: 1.5 hours is a
+        // real thing to sell (ADR-0055, #1413).
+        if (request.getItemType() == EstimateItemType.PART) {
+            partQuantityDivisibilityService.requirePermittedScale(
+                    request.getProductId(), request.getDescription(), request.getQuantity());
+        }
+
         // Build and validate item
         EstimateItem item = EstimateItem.builder()
                 .estimate(estimate)
@@ -939,6 +948,15 @@ public class EstimateServiceImpl implements EstimateService {
                 .findByIdAndEstimate_IdAndDeletedFalse(itemId, estimateId)
                 .orElseThrow(() ->
                         new EntityNotFoundException("Item not found: " + itemId + " for estimate: " + estimateId));
+
+        // Revising the quantity has to clear the same gate as entering it, or the rule would be
+        // one PATCH away from being bypassed (#1413).
+        if (request.getQuantity() != null && item.getItemType() == EstimateItemType.PART) {
+            partQuantityDivisibilityService.requirePermittedScale(
+                    item.getProductId(),
+                    request.getDescription() != null ? request.getDescription() : item.getDescription(),
+                    request.getQuantity());
+        }
 
         // Update only provided fields
         if (request.getDescription() != null) {

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/PartQuantityDivisibilityService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/PartQuantityDivisibilityService.java
@@ -1,0 +1,112 @@
+package com.positivity.workorder.internal.service;
+
+import com.positivity.workorder.internal.exception.FractionalQuantityNotAllowedException;
+import com.positivity.workorder.internal.repository.ExtProductUomReplicaRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+
+/**
+ * Answers "may this part quantity carry decimals, and how many" from the catalog's own declaration
+ * (ADR-0055, #1413).
+ *
+ * <h2>The rule is per-product, not per-platform</h2>
+ *
+ * A product's stock divisibility is the {@code precision_scale} of its {@code BASE} row in
+ * {@code product_uom}, owned by pos-catalog and replicated here as {@code ext_product_uom}. Scale 0
+ * means whole units; a non-zero scale means the quantity may carry that many decimal places and no
+ * more.
+ *
+ * <p>Deliberately <em>not</em> "an inventory-tracked part is always whole". That statement is true
+ * of every SKU seeded today, and encoding it would make bulk-dispensed stock — fluids by volume,
+ * refrigerant by weight, hose by length, all on the roadmap and one already in the catalog — a
+ * reversal across four modules rather than a data change on one product.
+ *
+ * <h2>Undeclared means whole</h2>
+ *
+ * A product with no unit-of-measure rows resolves to scale 0. That is every product right now:
+ * {@code product_uom} is unpopulated platform-wide, the conversion subsystem is built and empty. So
+ * the absent-row path is the common path, and it must stay the cheap one — a single indexed read
+ * that finds nothing and answers zero. Defaulting to whole units is also what preserves today's
+ * behaviour exactly while the declaration is installed ahead of any seeding.
+ *
+ * <h2>What is exempt</h2>
+ *
+ * A part carrying no {@code productEntityId} is not a catalog product — labour, shop supplies, a
+ * non-stocked consumable. There is no declaration to read and nothing to enforce, so it keeps
+ * accepting fractional quantities exactly as it does today.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PartQuantityDivisibilityService {
+
+    /** Used when a part line has no description to name in the error. */
+    private static final String UNNAMED_PART = "this part";
+
+    private final ExtProductUomReplicaRepository productUomReplicaRepository;
+
+    /**
+     * Rejects a quantity the referenced product's declared scale does not permit.
+     *
+     * @param productEntityId the catalog product the part line references; {@code null} for a
+     *     non-catalog line, which is exempt
+     * @param partLabel the part's description, used to name it in the error
+     * @param quantity the requested quantity
+     * @throws FractionalQuantityNotAllowedException when the quantity carries more decimal places
+     *     than the product declares
+     */
+    public void requirePermittedScale(
+            @Nullable UUID productEntityId, @Nullable String partLabel, @NonNull BigDecimal quantity) {
+        if (productEntityId == null) {
+            return;
+        }
+        int declaredScale = declaredScaleFor(productEntityId);
+        if (fitsScale(quantity, declaredScale)) {
+            return;
+        }
+
+        String label = partLabel == null || partLabel.isBlank() ? UNNAMED_PART : partLabel;
+        // Rounding up, not to nearest: an opened container is spent whether half of it was used or
+        // all of it, so the whole one is what gets issued and billed (ADR-0055).
+        BigDecimal suggestion = quantity.setScale(declaredScale, RoundingMode.CEILING);
+        throw declaredScale == 0
+                ? FractionalQuantityNotAllowedException.wholeUnitsOnly(label, quantity, suggestion)
+                : FractionalQuantityNotAllowedException.scaleExceeded(label, quantity, declaredScale, suggestion);
+    }
+
+    /**
+     * The product's declared base scale, or {@code 0} when it declares none.
+     *
+     * <p>Takes the largest scale on the unlikely chance a product carries more than one
+     * {@code BASE} row: the key permits one row per UoM code, not one per type, so two are possible
+     * as a seeding defect. Blocking every part entry for that product until the data is fixed would
+     * punish the shop for a catalog error, and the widest declared scale is the reading that keeps
+     * work flowing while rejecting anything no declaration supports.
+     */
+    public int declaredScaleFor(@NonNull UUID productEntityId) {
+        List<Integer> scales = productUomReplicaRepository.findBasePrecisionScales(productEntityId);
+        if (scales.size() > 1) {
+            log.warn(
+                    "Product {} declares {} BASE unit-of-measure rows; using the widest scale",
+                    productEntityId,
+                    scales.size());
+        }
+        return scales.stream().max(Integer::compareTo).orElse(0);
+    }
+
+    /**
+     * Whether the value can be written at the given scale without losing anything.
+     * {@code stripTrailingZeros} first, so {@code 1.00} is accepted against scale 0 — the trailing
+     * zeros are how a client serialised the number, not a claim about divisibility.
+     */
+    private static boolean fitsScale(BigDecimal quantity, int scale) {
+        return quantity.stripTrailingZeros().scale() <= scale;
+    }
+}

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImpl.java
@@ -61,18 +61,21 @@ public class WorkorderPartAdjustmentServiceImpl implements WorkorderPartAdjustme
     private final WorkorderPartAdjustmentEventRepository adjustmentEventRepository;
     private final IdempotencyService idempotencyService;
     private final WorkorderFactPublisher workorderFactPublisher;
+    private final PartQuantityDivisibilityService partQuantityDivisibilityService;
 
     public WorkorderPartAdjustmentServiceImpl(
             WorkorderPartRepository workorderPartRepository,
             WorkorderPartAdjustmentEventRepository adjustmentEventRepository,
             IdempotencyService idempotencyService,
             WorkorderFactPublisher workorderFactPublisher,
+            PartQuantityDivisibilityService partQuantityDivisibilityService,
             Clock clock) {
         this.clock = clock;
         this.workorderPartRepository = workorderPartRepository;
         this.adjustmentEventRepository = adjustmentEventRepository;
         this.idempotencyService = idempotencyService;
         this.workorderFactPublisher = workorderFactPublisher;
+        this.partQuantityDivisibilityService = partQuantityDivisibilityService;
     }
 
     /**
@@ -362,6 +365,11 @@ public class WorkorderPartAdjustmentServiceImpl implements WorkorderPartAdjustme
         if (!workorderId.equals(getWorkorderIdForPart(part))) {
             throw new IllegalStateException("Part " + partId + " does not belong to workorder " + workorderId);
         }
+
+        // A correction rewrites the authorized quantity outright, so it is the one path that can
+        // reintroduce a fraction onto a line that was promoted clean (ADR-0055, #1413).
+        partQuantityDivisibilityService.requirePermittedScale(
+                part.getProductEntityId(), part.getDescription(), newQuantity);
 
         // Calculate adjustment
         BigDecimal oldQuantity = part.getQuantity();

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImpl.java
@@ -15,7 +15,6 @@ import com.positivity.workorder.internal.repository.WorkorderRepository;
 import com.positivity.workorder.service.IdempotencyService;
 import com.positivity.workorder.service.WorkorderPartUsageService;
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
@@ -64,6 +63,7 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
     private final IdempotencyService idempotencyService;
     private final WorkorderFactPublisher workorderFactPublisher;
     private final PartAvailabilityService partAvailabilityService;
+    private final PartQuantityDivisibilityService partQuantityDivisibilityService;
     private final WorkorderStateMachine workorderStateMachine;
 
     /**
@@ -80,6 +80,7 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
             IdempotencyService idempotencyService,
             WorkorderFactPublisher workorderFactPublisher,
             PartAvailabilityService partAvailabilityService,
+            PartQuantityDivisibilityService partQuantityDivisibilityService,
             WorkorderStateMachine workorderStateMachine,
             ObjectProvider<InventoryCommandPublisher> inventoryCommandPublisher,
             Clock clock) {
@@ -90,6 +91,7 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
         this.idempotencyService = idempotencyService;
         this.workorderFactPublisher = workorderFactPublisher;
         this.partAvailabilityService = partAvailabilityService;
+        this.partQuantityDivisibilityService = partQuantityDivisibilityService;
         this.workorderStateMachine = workorderStateMachine;
         this.inventoryCommandPublisher = inventoryCommandPublisher;
     }
@@ -147,6 +149,7 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
             throw new IllegalStateException("Part " + partLineId + " does not belong to workorder " + workorderId);
         }
 
+        requirePermittedScale(part, quantity);
         requireOwnedStock(workorder, part, quantity);
 
         // Create usage event
@@ -259,19 +262,44 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
     }
 
     /**
-     * Part quantities are {@code numeric(19,4)} and the API accepts down to {@code 0.0001}, but the
-     * reservation command and its outcome fact are both integer-only (ADR-0044, CAP #1315 Phase 1).
-     * Something has to give at that boundary, and rounding <em>up</em> is the only safe direction.
+     * The reservation command and its outcome fact are integer-only (ADR-0044, CAP #1315 Phase 1),
+     * and the quantity reaching here is already integral: the divisibility gate above rejects a
+     * fractional quantity for a product declaring scale 0, and no product declares anything else —
+     * {@code product_uom} is unpopulated platform-wide, so nothing can be divisible yet.
      *
-     * <p>Truncating instead would be silently wrong twice over: issuing {@code 0.5} would ask
-     * pos-inventory to reserve {@code 0}, which its outcome fact rejects outright as non-positive,
-     * so the part would be issued and then never reconciled; and issuing {@code 2.7} would reserve
-     * {@code 2}, leaving stock we have already handed out unaccounted for. Reserving the whole unit
-     * holds slightly more than was issued, which is visible and self-correcting — the reservation
-     * is released when the part is consumed or returned.
+     * <p>So this converts exactly and throws if it cannot. It replaces a {@code RoundingMode.CEILING}
+     * that turned an issue of {@code 0.5} into a reservation of {@code 1}, holding half a unit
+     * against demand nobody asked for. That rounding was the safe <em>direction</em> at a seam that
+     * should not have been crossed silently at all; with the quantity constrained at entry the seam
+     * is gone, and a fraction arriving here now means the gate was bypassed rather than that a
+     * rounding decision is needed.
+     *
+     * <p>Genuinely divisible stock gets a decimal reservation contract in #1414. Until then this
+     * throw is unreachable, and that is what makes it the right shape: it fails loudly if the
+     * premise stops holding instead of quietly reserving the wrong amount.
      */
     private static int reservableQuantity(BigDecimal quantity) {
-        return quantity.setScale(0, RoundingMode.CEILING).intValueExact();
+        try {
+            return quantity.intValueExact();
+        } catch (ArithmeticException e) {
+            throw new IllegalStateException(
+                    "Cannot reserve a fractional quantity " + quantity.toPlainString()
+                            + ": the reservation contract is integer-only and the divisibility gate should have"
+                            + " rejected this quantity at entry",
+                    e);
+        }
+    }
+
+    /**
+     * The issue, consume and return paths are the backstop, not the gate (ADR-0055, #1413). The
+     * real gate is at estimate-item entry and promotion, because a fractional quantity that reaches
+     * {@code workorder_part.quantity} can never be issued down to zero and would hold the job in
+     * AWAITING_PARTS forever. This catches a quantity keyed directly at the counter, and a line
+     * that predates the product's declaration.
+     */
+    private void requirePermittedScale(WorkorderPart part, BigDecimal quantity) {
+        partQuantityDivisibilityService.requirePermittedScale(
+                part.getProductEntityId(), part.getDescription(), quantity);
     }
 
     /**
@@ -323,6 +351,8 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
         if (!workorderId.equals(getWorkorderIdForPart(part))) {
             throw new IllegalStateException("Part " + partLineId + " does not belong to workorder " + workorderId);
         }
+
+        requirePermittedScale(part, quantity);
 
         // Validate consumption does not exceed issued
         BigDecimal newConsumed = part.getQuantityConsumed().add(quantity);
@@ -410,6 +440,8 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
         if (!workorderId.equals(getWorkorderIdForPart(part))) {
             throw new IllegalStateException("Part " + partLineId + " does not belong to workorder " + workorderId);
         }
+
+        requirePermittedScale(part, quantity);
 
         // Validate return does not exceed available (issued - consumed - already
         // returned)

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderServiceImpl.java
@@ -82,6 +82,7 @@ public class WorkorderServiceImpl implements WorkorderService {
     private final PromotionValidationService promotionValidationService;
     private final PeopleAvailabilityLocalService peopleAvailabilityLocalService;
     private final FleetAuthorizationService fleetAuthorizationService;
+    private final PartQuantityDivisibilityService partQuantityDivisibilityService;
 
     @Override
     public List<Workorder> getAllWorkorders() {
@@ -398,6 +399,15 @@ public class WorkorderServiceImpl implements WorkorderService {
                 laborItems.add(workorderService);
 
             } else if (estimateItem.getItemType() == EstimateItemType.PART) {
+                // Promotion is the second gate, not a formality (ADR-0055, #1413). An approved
+                // estimate item may predate the product's declaration, or have been approved while
+                // the replica was silent, and a quantity that reaches workorder_part is what the
+                // issue path then has to satisfy exactly. A line the technician can never issue to
+                // zero would hold the job in AWAITING_PARTS with nothing anyone can do about it, so
+                // the fractional line is stopped here rather than promoted into a dead end.
+                partQuantityDivisibilityService.requirePermittedScale(
+                        estimateItem.getProductId(), estimateItem.getDescription(), estimateItem.getQuantity());
+
                 // Create WorkorderPart for PART items
                 // CAP:004 Story #27: Parts can be standalone (not tied to a service)
                 WorkorderPart workorderPart = WorkorderPart.builder()

--- a/pos-workorder/src/main/resources/application.yml
+++ b/pos-workorder/src/main/resources/application.yml
@@ -133,6 +133,10 @@ workorder:
     invoice-manifest-topic: ${WORKORDER_INVOICE_MANIFEST_TOPIC:invoice.manifest.v1}
     invoice-manifest-consumer-group: ${WORKORDER_INVOICE_MANIFEST_CONSUMER_GROUP:pos-workorder-invoice-manifests}
     invoice-commands-topic: ${WORKORDER_INVOICE_COMMANDS_TOPIC:invoice.commands.v1}
+    # Catalog product replica feed (ADR-0044 §6, ADR-0055, #1413): the per-product base
+    # unit-of-measure precision scale that decides whether a part quantity may carry decimals.
+    catalog-events-topic: ${WORKORDER_CATALOG_EVENTS_TOPIC:catalog.events.v1}
+    catalog-events-consumer-group: ${WORKORDER_CATALOG_EVENTS_CONSUMER_GROUP:pos-workorder-catalog-events}
     # Order settlement finalize-back feed (odoo-parity E3, #1084): completing a workorder-linked
     # order transitions the workorder to COMPLETED via its own state machine.
     order-events-topic: ${WORKORDER_ORDER_EVENTS_TOPIC:order.events.v1}

--- a/pos-workorder/src/main/resources/db/migration/V17__ext_product_uom.sql
+++ b/pos-workorder/src/main/resources/db/migration/V17__ext_product_uom.sql
@@ -1,0 +1,36 @@
+-- #1413 (ADR-0055): per-product quantity divisibility on the work-order part path.
+--
+-- A part quantity is integral unless the product's BASE unit-of-measure row declares a non-zero
+-- precision_scale. pos-catalog owns that declaration; this module needs it locally to answer the
+-- question at estimate-item entry and part issue, so it is replicated from catalog.product.updated
+-- facts rather than read synchronously across the domain wall (ADR-0044 R1/R3, §6). The same
+-- replica already exists in pos-inventory (V11) and pos-order (V15); this is the third reader,
+-- keyed and typed identically to both.
+--
+-- Additive only: no existing table, column, payload or contract is touched. Widening the ledger
+-- and reservation chain to carry a decimal quantity is a later stage (#1414).
+--
+-- Every fact carries the product's full conversion set, so rows are replaced wholesale per fact
+-- rather than merged — a UoM the owner retired must disappear here too, or a product would keep
+-- being judged against a scale catalog no longer publishes.
+--
+-- The table is expected to be empty for the foreseeable future: nothing seeds product_uom
+-- platform-wide. A product with no row here resolves to scale 0, which is exactly today's
+-- behaviour, and that default is what makes installing the rule safe ahead of any seeding.
+
+CREATE TABLE ext_product_uom (
+    product_id       uuid NOT NULL,
+    uom_code         varchar(32) NOT NULL,
+    uom_type         varchar(16),
+    factor_to_base   numeric(20, 6) NOT NULL,
+    precision_scale  integer NOT NULL,
+    -- Catalog stamps the product's updatedAt epoch millis on the fact envelope; carried per row so
+    -- a redelivered older fact cannot roll a product's declaration backwards. Kept on the row
+    -- rather than in a product-level anchor table because the set is replaced wholesale anyway.
+    aggregate_version bigint NOT NULL,
+    CONSTRAINT ext_product_uom_pkey PRIMARY KEY (product_id, uom_code)
+);
+
+-- The divisibility lookup is by (product, BASE) on every part-quantity check, so it must not be a
+-- primary-key prefix scan that still has to filter every one of the product's package UoMs.
+CREATE INDEX idx_ext_product_uom_product_type ON ext_product_uom (product_id, uom_type);

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateApprovalLifecycleTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateApprovalLifecycleTest.java
@@ -139,7 +139,8 @@ class EstimateApprovalLifecycleTest {
                 new ObjectMapper(),
                 customerReferenceService,
                 vehicleReferenceService,
-                estimateFactPublisher);
+                estimateFactPublisher,
+                org.mockito.Mockito.mock(PartQuantityDivisibilityService.class));
 
         when(estimateRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(estimateItemRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateItemQuantityGateTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/EstimateItemQuantityGateTest.java
@@ -1,0 +1,279 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.client.DocumentClient;
+import com.positivity.workorder.internal.client.TaxClient;
+import com.positivity.workorder.internal.dto.AddEstimateItemRequest;
+import com.positivity.workorder.internal.dto.UpdateEstimateItemRequest;
+import com.positivity.workorder.internal.entity.Estimate;
+import com.positivity.workorder.internal.entity.EstimateItem;
+import com.positivity.workorder.internal.entity.EstimateItemType;
+import com.positivity.workorder.internal.enums.EstimateStatus;
+import com.positivity.workorder.internal.exception.FractionalQuantityNotAllowedException;
+import com.positivity.workorder.internal.repository.ApprovalConfigurationRepository;
+import com.positivity.workorder.internal.repository.EstimateItemRepository;
+import com.positivity.workorder.internal.repository.EstimateRepository;
+import com.positivity.workorder.internal.repository.EstimateSnapshotRepository;
+import com.positivity.workorder.internal.repository.ExtProductUomReplicaRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.service.BillingRulesClientService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * The primary gate for the per-product quantity rule (ADR-0055, #1413): estimate-item entry, where
+ * the quantity is authored.
+ *
+ * <p>{@code estimate_item.quantity} is one column shared by PART and LABOR rows, which is the whole
+ * reason part quantities are fractional at all — labour needs 1.5 hours and parts inherited the
+ * scale by sharing the column. So the rule has to discriminate by row type and by whether the row
+ * names a catalog product, not by the column it lives in.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Estimate item quantity — per-product divisibility gate (#1413)")
+class EstimateItemQuantityGateTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-19T09:00:00Z");
+    private static final UUID ESTIMATE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb01");
+    private static final UUID ITEM_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb02");
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb03");
+    private static final UUID SERVICE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fbb04");
+    private static final String PART_LABEL = "Valvoline MaxLife ATF 1qt";
+
+    @Mock
+    private EstimateRepository estimateRepository;
+
+    @Mock
+    private EstimateItemRepository estimateItemRepository;
+
+    @Mock
+    private EstimateSnapshotRepository estimateSnapshotRepository;
+
+    @Mock
+    private ApprovalConfigurationRepository approvalConfigurationRepository;
+
+    @Mock
+    private WorkorderRepository workOrderRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private BillingRulesClientService billingRulesClientService;
+
+    @Mock
+    private TaxClient taxClient;
+
+    @Mock
+    private LocationReferenceService locationReferenceService;
+
+    @Mock
+    private PeopleAvailabilityLocalService peopleAvailabilityLocalService;
+
+    @Mock
+    private DocumentClient documentClient;
+
+    @Mock
+    private CustomerReferenceService customerReferenceService;
+
+    @Mock
+    private VehicleReferenceService vehicleReferenceService;
+
+    @Mock
+    private EstimateFactPublisher estimateFactPublisher;
+
+    @Mock
+    private ExtProductUomReplicaRepository productUomRepository;
+
+    private EstimateServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        // The platform's actual state: product_uom is unpopulated, so every product resolves to
+        // whole units. Individual cases override this to declare a divisible product.
+        when(productUomRepository.findBasePrecisionScales(any())).thenReturn(List.of());
+
+        service = new EstimateServiceImpl(
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                estimateRepository,
+                estimateItemRepository,
+                estimateSnapshotRepository,
+                approvalConfigurationRepository,
+                workOrderRepository,
+                eventPublisher,
+                billingRulesClientService,
+                taxClient,
+                locationReferenceService,
+                peopleAvailabilityLocalService,
+                documentClient,
+                new ObjectMapper(),
+                customerReferenceService,
+                vehicleReferenceService,
+                estimateFactPublisher,
+                new PartQuantityDivisibilityService(productUomRepository));
+
+        Estimate estimate = new Estimate();
+        estimate.setId(ESTIMATE_ID);
+        estimate.setStatus(EstimateStatus.DRAFT);
+        when(estimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.of(estimate));
+        when(estimateItemRepository.save(any(EstimateItem.class))).thenAnswer(i -> i.getArgument(0));
+    }
+
+    @Nested
+    @DisplayName("Adding an item")
+    class Adding {
+
+        @Test
+        @DisplayName("rejects a fractional quantity for a whole-unit product")
+        void rejectsFractionalPartQuantity() {
+            assertThatThrownBy(() -> service.addEstimateItem(ESTIMATE_ID, partRequest("0.5"), "jane.smith"))
+                    .isInstanceOf(FractionalQuantityNotAllowedException.class)
+                    .hasMessageContaining(PART_LABEL)
+                    .hasMessageContaining("0.5")
+                    .hasMessageContaining("Enter 1 to issue and bill the full container.");
+
+            verify(estimateItemRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("accepts a whole quantity for a whole-unit product")
+        void acceptsWholePartQuantity() {
+            assertThatCode(() -> service.addEstimateItem(ESTIMATE_ID, partRequest("2"), "jane.smith"))
+                    .doesNotThrowAnyException();
+
+            verify(estimateItemRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("accepts a quantity within a divisible product's declared scale and rejects a finer one")
+        void honoursDeclaredScale() {
+            when(productUomRepository.findBasePrecisionScales(PRODUCT_ID)).thenReturn(List.of(2));
+
+            assertThatCode(() -> service.addEstimateItem(ESTIMATE_ID, partRequest("1.01"), "jane.smith"))
+                    .doesNotThrowAnyException();
+
+            assertThatThrownBy(() -> service.addEstimateItem(ESTIMATE_ID, partRequest("1.001"), "jane.smith"))
+                    .isInstanceOf(FractionalQuantityNotAllowedException.class)
+                    .hasMessageContaining("2 decimal places");
+        }
+
+        @Test
+        @DisplayName("leaves a PART line carrying no product alone — shop supplies are not catalog stock")
+        void exemptsPartWithoutProduct() {
+            AddEstimateItemRequest request = partRequest("0.25");
+            request.setProductId(null);
+            request.setDescription("Shop supplies");
+
+            assertThatCode(() -> service.addEstimateItem(ESTIMATE_ID, request, "jane.smith"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("leaves a fractional LABOR line alone")
+        void exemptsLaborLine() {
+            AddEstimateItemRequest request = AddEstimateItemRequest.builder()
+                    .itemType(EstimateItemType.LABOR)
+                    .description("Diagnostic")
+                    .quantity(new BigDecimal("1.5"))
+                    .unitPrice(new BigDecimal("120.00"))
+                    .serviceId(SERVICE_ID)
+                    .build();
+
+            assertThatCode(() -> service.addEstimateItem(ESTIMATE_ID, request, "jane.smith"))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("Updating an item")
+    class Updating {
+
+        @Test
+        @DisplayName("rejects a revision that makes a part quantity fractional")
+        void rejectsFractionalRevision() {
+            givenExistingItem(EstimateItemType.PART, PRODUCT_ID);
+
+            // Without this the rule would be one PATCH away from being bypassed.
+            assertThatThrownBy(() -> service.updateEstimateItem(
+                            ESTIMATE_ID,
+                            ITEM_ID,
+                            new UpdateEstimateItemRequest(null, new BigDecimal("0.5"), null, null)))
+                    .isInstanceOf(FractionalQuantityNotAllowedException.class);
+        }
+
+        @Test
+        @DisplayName("allows a revision that leaves the quantity alone")
+        void allowsDescriptionOnlyRevision() {
+            EstimateItem item = givenExistingItem(EstimateItemType.PART, PRODUCT_ID);
+
+            service.updateEstimateItem(
+                    ESTIMATE_ID, ITEM_ID, new UpdateEstimateItemRequest("Front pads", null, null, null));
+
+            assertThat(item.getDescription()).isEqualTo("Front pads");
+        }
+
+        @Test
+        @DisplayName("leaves a fractional LABOR revision alone")
+        void allowsFractionalLaborRevision() {
+            givenExistingItem(EstimateItemType.LABOR, null);
+
+            assertThatCode(() -> service.updateEstimateItem(
+                            ESTIMATE_ID,
+                            ITEM_ID,
+                            new UpdateEstimateItemRequest(null, new BigDecimal("1.5"), null, null)))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    private AddEstimateItemRequest partRequest(String quantity) {
+        return AddEstimateItemRequest.builder()
+                .itemType(EstimateItemType.PART)
+                .description(PART_LABEL)
+                .quantity(new BigDecimal(quantity))
+                .unitPrice(new BigDecimal("12.00"))
+                .productId(PRODUCT_ID)
+                .build();
+    }
+
+    private EstimateItem givenExistingItem(EstimateItemType type, UUID productId) {
+        Estimate estimate = new Estimate();
+        estimate.setId(ESTIMATE_ID);
+        EstimateItem item = EstimateItem.builder()
+                .id(ITEM_ID)
+                .estimate(estimate)
+                .itemType(type)
+                .description(type == EstimateItemType.PART ? PART_LABEL : "Diagnostic")
+                .quantity(BigDecimal.ONE)
+                .unitPrice(new BigDecimal("12.00"))
+                .productId(productId)
+                .serviceId(type == EstimateItemType.LABOR ? SERVICE_ID : null)
+                .build();
+        when(estimateItemRepository.findByIdAndEstimate_IdAndDeletedFalse(ITEM_ID, ESTIMATE_ID))
+                .thenReturn(Optional.of(item));
+        return item;
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/PartIssueAvailabilityGateTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/PartIssueAvailabilityGateTest.java
@@ -16,8 +16,10 @@ import com.positivity.workorder.internal.entity.Workorder;
 import com.positivity.workorder.internal.entity.WorkorderPart;
 import com.positivity.workorder.internal.entity.WorkorderPartUsageEvent;
 import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.exception.FractionalQuantityNotAllowedException;
 import com.positivity.workorder.internal.exception.InsufficientPartAvailabilityException;
 import com.positivity.workorder.internal.repository.ExtInventoryAvailabilityReplicaRepository;
+import com.positivity.workorder.internal.repository.ExtProductUomReplicaRepository;
 import com.positivity.workorder.internal.repository.WorkorderPartRepository;
 import com.positivity.workorder.internal.repository.WorkorderPartUsageEventRepository;
 import com.positivity.workorder.internal.repository.WorkorderRepository;
@@ -83,6 +85,9 @@ class PartIssueAvailabilityGateTest {
     private ExtInventoryAvailabilityReplicaRepository availabilityRepository;
 
     @Mock
+    private ExtProductUomReplicaRepository productUomRepository;
+
+    @Mock
     private InventoryCommandPublisher inventoryCommandPublisher;
 
     @SuppressWarnings("unchecked")
@@ -93,6 +98,10 @@ class PartIssueAvailabilityGateTest {
     @BeforeEach
     void setUp() {
         PartAvailabilityService availability = new PartAvailabilityService(availabilityRepository);
+        // No product declares a unit-of-measure scale: product_uom is unpopulated platform-wide,
+        // so every product here resolves to whole units, which is the real-world default.
+        when(productUomRepository.findBasePrecisionScales(any())).thenReturn(List.of());
+        PartQuantityDivisibilityService divisibility = new PartQuantityDivisibilityService(productUomRepository);
         when(publisherProvider.getIfAvailable()).thenReturn(inventoryCommandPublisher);
         service = new WorkorderPartUsageServiceImpl(
                 workorderRepository,
@@ -101,6 +110,7 @@ class PartIssueAvailabilityGateTest {
                 idempotencyService,
                 workorderFactPublisher,
                 availability,
+                divisibility,
                 workorderStateMachine,
                 publisherProvider,
                 Clock.fixed(NOW, ZoneOffset.UTC));
@@ -176,31 +186,24 @@ class PartIssueAvailabilityGateTest {
         }
 
         @Test
-        @DisplayName("rounds a fractional issue up when reserving, never down to zero")
-        void reservesWholeUnitsForFractionalIssue() {
+        @DisplayName("rejects a fractional issue of a product declared in whole units")
+        void rejectsFractionalIssueOfWholeUnitProduct() {
             WorkorderPart part = part(PART_ID, PRODUCT_ID, "4", "0");
             givenWorkorderAndPart(workorder(WorkorderStatus.WORK_IN_PROGRESS), part);
             givenAtp(PRODUCT_ID, 10);
 
-            service.issuePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("0.5"), null);
+            // This used to be rounded up into a reservation of 1, holding half a unit against
+            // demand nobody asked for (#1363). The quantity is now refused at the door instead.
+            assertThatThrownBy(() -> service.issuePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("0.5"), null))
+                    .isInstanceOf(FractionalQuantityNotAllowedException.class)
+                    .hasMessageContaining("Brake pad")
+                    .hasMessageContaining("whole units")
+                    .hasMessageContaining("Enter 1");
 
-            // The reservation contract is integer-only. Truncating would ask for 0, which the
-            // outcome fact rejects as non-positive, leaving the issue permanently unreconciled.
-            assertThat(part.getQuantityIssued()).isEqualByComparingTo("0.5");
-            verify(inventoryCommandPublisher).requestReservation(PART_ID, PRODUCT_ID, 1, SHOP_ID);
-        }
-
-        @Test
-        @DisplayName("rounds a fractional issue up rather than under-reserving")
-        void roundsPartialUnitUp() {
-            WorkorderPart part = part(PART_ID, PRODUCT_ID, "4", "0");
-            givenWorkorderAndPart(workorder(WorkorderStatus.WORK_IN_PROGRESS), part);
-            givenAtp(PRODUCT_ID, 10);
-
-            service.issuePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("2.7"), null);
-
-            // 2 would leave 0.7 of a unit handed out and unaccounted for.
-            verify(inventoryCommandPublisher).requestReservation(PART_ID, PRODUCT_ID, 3, SHOP_ID);
+            assertThat(part.getQuantityIssued()).isEqualByComparingTo("0");
+            verify(usageEventRepository, never()).save(any());
+            verify(inventoryCommandPublisher, never())
+                    .requestReservation(any(), any(), org.mockito.ArgumentMatchers.anyInt(), any());
         }
 
         @Test
@@ -241,10 +244,29 @@ class PartIssueAvailabilityGateTest {
             givenWorkorderAndPart(workorder(WorkorderStatus.WORK_IN_PROGRESS), part);
 
             // Labour and shop supplies carry no productEntityId; there is no owned stock to
-            // measure, and blocking them would stop jobs on items inventory never tracked.
-            service.issuePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("1"), null);
+            // measure and no catalog declaration to read, so neither gate applies and a fractional
+            // quantity stays legitimate. Blocking them would stop jobs on items inventory never
+            // tracked.
+            service.issuePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("0.25"), null);
 
-            assertThat(part.getQuantityIssued()).isEqualByComparingTo("1");
+            assertThat(part.getQuantityIssued()).isEqualByComparingTo("0.25");
+            verify(inventoryCommandPublisher, never())
+                    .requestReservation(any(), any(), org.mockito.ArgumentMatchers.anyInt(), any());
+        }
+
+        @Test
+        @DisplayName("passes a divisible product's quantity but cannot reserve it until #1414")
+        void divisibleProductPassesTheGateButCannotReserveYet() {
+            WorkorderPart part = part(PART_ID, PRODUCT_ID, "4", "0");
+            givenWorkorderAndPart(workorder(WorkorderStatus.WORK_IN_PROGRESS), part);
+            givenAtp(PRODUCT_ID, 10);
+            when(productUomRepository.findBasePrecisionScales(PRODUCT_ID)).thenReturn(List.of(2));
+
+            // The divisibility gate passes, but the reservation contract is still integer-only
+            // until #1414 — so the issue fails loudly here rather than reserving a rounded amount.
+            assertThatThrownBy(() -> service.issuePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("1.01"), null))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Cannot reserve a fractional quantity");
         }
     }
 

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/PartQuantityDivisibilityServiceTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/PartQuantityDivisibilityServiceTest.java
@@ -1,0 +1,150 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.exception.FractionalQuantityNotAllowedException;
+import com.positivity.workorder.internal.repository.ExtProductUomReplicaRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * The per-product divisibility rule (ADR-0055, #1413): a part quantity is integral unless the
+ * product's {@code BASE} unit-of-measure row declares a decimal scale.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Part quantity divisibility — per-product scale from the catalog declaration")
+class PartQuantityDivisibilityServiceTest {
+
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fdd01");
+    private static final String PART_LABEL = "Valvoline MaxLife ATF 1qt";
+
+    @Mock
+    private ExtProductUomReplicaRepository productUomRepository;
+
+    @InjectMocks
+    private PartQuantityDivisibilityService service;
+
+    @Nested
+    @DisplayName("Undeclared products are whole-unit")
+    class Undeclared {
+
+        @Test
+        @DisplayName("resolves scale 0 when the product has no unit-of-measure rows")
+        void undeclaredProductResolvesToZero() {
+            // This is every product today: nothing seeds product_uom platform-wide, so the empty
+            // answer is the common path and the one that preserves current behaviour exactly.
+            when(productUomRepository.findBasePrecisionScales(PRODUCT_ID)).thenReturn(List.of());
+
+            assertThat(service.declaredScaleFor(PRODUCT_ID)).isZero();
+        }
+
+        @Test
+        @DisplayName("rejects a fractional quantity, naming the part, the value and the remedy")
+        void rejectsFractionalQuantity() {
+            when(productUomRepository.findBasePrecisionScales(PRODUCT_ID)).thenReturn(List.of());
+
+            assertThatThrownBy(() -> service.requirePermittedScale(PRODUCT_ID, PART_LABEL, new BigDecimal("0.5")))
+                    .isInstanceOf(FractionalQuantityNotAllowedException.class)
+                    .hasMessage("Quantity 0.5 is not valid for 'Valvoline MaxLife ATF 1qt' — this part is issued"
+                            + " and billed in whole units. Enter 1 to issue and bill the full container.");
+        }
+
+        @Test
+        @DisplayName("carries the remedy as the nextAction the caller can act on")
+        void carriesNextAction() {
+            when(productUomRepository.findBasePrecisionScales(PRODUCT_ID)).thenReturn(List.of());
+
+            assertThatThrownBy(() -> service.requirePermittedScale(PRODUCT_ID, PART_LABEL, new BigDecimal("2.25")))
+                    .isInstanceOf(FractionalQuantityNotAllowedException.class)
+                    .extracting(e -> ((FractionalQuantityNotAllowedException) e).getNextAction())
+                    // Rounds up, not to nearest: an opened container is spent either way.
+                    .isEqualTo("Enter 3 to issue and bill the full container.");
+        }
+
+        @Test
+        @DisplayName("accepts a whole quantity, trailing zeros included")
+        void acceptsWholeQuantity() {
+            when(productUomRepository.findBasePrecisionScales(PRODUCT_ID)).thenReturn(List.of());
+
+            // 1.00 is how a client serialised the number, not a claim that the product is divisible.
+            assertThatCode(() -> service.requirePermittedScale(PRODUCT_ID, PART_LABEL, new BigDecimal("1.00")))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("treats an explicit scale-0 declaration the same as no declaration")
+        void explicitZeroScaleBehavesAsUndeclared() {
+            when(productUomRepository.findBasePrecisionScales(PRODUCT_ID)).thenReturn(List.of(0));
+
+            assertThatThrownBy(() -> service.requirePermittedScale(PRODUCT_ID, PART_LABEL, new BigDecimal("0.5")))
+                    .isInstanceOf(FractionalQuantityNotAllowedException.class)
+                    .hasMessageContaining("whole units");
+        }
+    }
+
+    @Nested
+    @DisplayName("Products declaring a decimal scale")
+    class Declared {
+
+        @Test
+        @DisplayName("accepts a quantity within the declared scale")
+        void acceptsWithinDeclaredScale() {
+            when(productUomRepository.findBasePrecisionScales(PRODUCT_ID)).thenReturn(List.of(2));
+
+            assertThatCode(() ->
+                            service.requirePermittedScale(PRODUCT_ID, "Parker Hydraulic Hose", new BigDecimal("1.01")))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("rejects a quantity finer than the declared scale, naming the scale")
+        void rejectsBeyondDeclaredScale() {
+            when(productUomRepository.findBasePrecisionScales(PRODUCT_ID)).thenReturn(List.of(2));
+
+            assertThatThrownBy(() ->
+                            service.requirePermittedScale(PRODUCT_ID, "Parker Hydraulic Hose", new BigDecimal("1.001")))
+                    .isInstanceOf(FractionalQuantityNotAllowedException.class)
+                    .hasMessage("Quantity 1.001 is not valid for 'Parker Hydraulic Hose' — this part is stocked"
+                            + " to 2 decimal places. Enter a quantity with at most 2 decimal places, such as 1.01.");
+        }
+
+        @Test
+        @DisplayName("takes the widest scale when a product mis-declares two BASE rows")
+        void takesWidestScaleOnDuplicateBaseRows() {
+            // A seeding defect, not a domain case. Blocking every part entry for the product would
+            // punish the shop for a catalog error.
+            when(productUomRepository.findBasePrecisionScales(PRODUCT_ID)).thenReturn(List.of(0, 3));
+
+            assertThat(service.declaredScaleFor(PRODUCT_ID)).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("Non-catalog lines")
+    class NonCatalog {
+
+        @Test
+        @DisplayName("exempts a part with no productEntityId and never looks a product up")
+        void exemptsNonCatalogPart() {
+            // Labour, shop supplies, non-stocked consumables: no declaration exists to enforce.
+            assertThatCode(() -> service.requirePermittedScale(null, "Shop supplies", new BigDecimal("0.25")))
+                    .doesNotThrowAnyException();
+
+            verify(productUomRepository, never()).findBasePrecisionScales(any());
+        }
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/PartQuantityStrandingRegressionTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/PartQuantityStrandingRegressionTest.java
@@ -1,0 +1,334 @@
+package com.positivity.workorder.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.security.common.GatewaySecurityConstants;
+import com.positivity.workorder.internal.config.InventoryCommandPublisher;
+import com.positivity.workorder.internal.entity.Estimate;
+import com.positivity.workorder.internal.entity.EstimateItem;
+import com.positivity.workorder.internal.entity.EstimateItemType;
+import com.positivity.workorder.internal.entity.ExtCustomerPartyReplica;
+import com.positivity.workorder.internal.entity.ExtInventoryAvailabilityReplica;
+import com.positivity.workorder.internal.entity.Workorder;
+import com.positivity.workorder.internal.entity.WorkorderPart;
+import com.positivity.workorder.internal.entity.WorkorderPartUsageEvent;
+import com.positivity.workorder.internal.enums.ApprovalStatus;
+import com.positivity.workorder.internal.enums.WorkorderStatus;
+import com.positivity.workorder.internal.exception.FractionalQuantityNotAllowedException;
+import com.positivity.workorder.internal.repository.AuditEventRepository;
+import com.positivity.workorder.internal.repository.EstimateItemRepository;
+import com.positivity.workorder.internal.repository.EstimateRepository;
+import com.positivity.workorder.internal.repository.ExtCustomerPartyReplicaRepository;
+import com.positivity.workorder.internal.repository.ExtInventoryAvailabilityReplicaRepository;
+import com.positivity.workorder.internal.repository.ExtProductUomReplicaRepository;
+import com.positivity.workorder.internal.repository.WorkorderLaborEntryRepository;
+import com.positivity.workorder.internal.repository.WorkorderPartRepository;
+import com.positivity.workorder.internal.repository.WorkorderPartUsageEventRepository;
+import com.positivity.workorder.internal.repository.WorkorderRepository;
+import com.positivity.workorder.internal.repository.WorkorderServiceRepository;
+import com.positivity.workorder.service.IdempotencyService;
+import com.positivity.workorder.service.PromotionValidationService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * The stranding guard behind the gate placement (ADR-0055, #1413).
+ *
+ * <p>{@code outstandingQuantity = quantity - quantityIssued} is what holds a job in
+ * {@code AWAITING_PARTS}. If a fractional quantity could reach {@code workorder_part} while issue
+ * is restricted to whole units, that subtraction would never reach zero: the technician issues the
+ * whole units, is refused the remainder, and the job waits on parts forever with nothing anyone can
+ * do about it. That is why the rule is enforced where the quantity is *authored* — estimate entry
+ * and promotion — and not only where it is spent.
+ *
+ * <p>These two cases are the ends of that argument: nothing fractional gets promoted, and what does
+ * get promoted issues down to zero.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Fractional part quantities cannot strand a workorder (#1413)")
+class PartQuantityStrandingRegressionTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-19T09:00:00Z");
+    private static final UUID ESTIMATE_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee01");
+    private static final UUID WORKORDER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee02");
+    private static final UUID CUSTOMER_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee03");
+    private static final UUID SHOP_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee04");
+    private static final UUID PART_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee05");
+    private static final UUID PRODUCT_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee06");
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @Mock
+    private WorkorderRepository workorderRepository;
+
+    @Mock
+    private EstimateRepository estimateRepository;
+
+    @Mock
+    private EstimateItemRepository estimateItemRepository;
+
+    @Mock
+    private WorkorderServiceRepository workorderServiceRepository;
+
+    @Mock
+    private WorkorderPartRepository workorderPartRepository;
+
+    @Mock
+    private ExtCustomerPartyReplicaRepository extCustomerPartyReplicaRepository;
+
+    @Mock
+    private WorkorderFactPublisher workorderFactPublisher;
+
+    @Mock
+    private WorkorderStateMachine workorderStateMachine;
+
+    @Mock
+    private WorkorderLaborEntryRepository workorderLaborEntryRepository;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Mock
+    private AuditEventRepository auditEventRepository;
+
+    @Mock
+    private IdempotencyService idempotencyService;
+
+    @Mock
+    private PromotionValidationService promotionValidationService;
+
+    @Mock
+    private PeopleAvailabilityLocalService peopleAvailabilityLocalService;
+
+    @Mock
+    private FleetAuthorizationService fleetAuthorizationService;
+
+    @Mock
+    private ExtProductUomReplicaRepository productUomRepository;
+
+    @Mock
+    private ExtInventoryAvailabilityReplicaRepository availabilityRepository;
+
+    @Mock
+    private WorkorderPartUsageEventRepository usageEventRepository;
+
+    @Mock
+    private InventoryCommandPublisher inventoryCommandPublisher;
+
+    @SuppressWarnings("unchecked")
+    private final ObjectProvider<InventoryCommandPublisher> publisherProvider = mock(ObjectProvider.class);
+
+    private PartQuantityDivisibilityService divisibility;
+    private WorkorderServiceImpl workorderService;
+    private WorkorderPartUsageServiceImpl partUsageService;
+
+    @BeforeEach
+    void setUp() {
+        // No product declares a unit-of-measure scale, which is the platform's actual state:
+        // product_uom is unpopulated, so every product is whole-unit.
+        when(productUomRepository.findBasePrecisionScales(any())).thenReturn(List.of());
+        divisibility = new PartQuantityDivisibilityService(productUomRepository);
+
+        workorderService = new WorkorderServiceImpl(
+                clock,
+                workorderRepository,
+                estimateRepository,
+                estimateItemRepository,
+                workorderServiceRepository,
+                workorderPartRepository,
+                extCustomerPartyReplicaRepository,
+                workorderFactPublisher,
+                workorderStateMachine,
+                workorderLaborEntryRepository,
+                applicationEventPublisher,
+                auditEventRepository,
+                idempotencyService,
+                promotionValidationService,
+                peopleAvailabilityLocalService,
+                fleetAuthorizationService,
+                divisibility);
+
+        when(publisherProvider.getIfAvailable()).thenReturn(inventoryCommandPublisher);
+        partUsageService = new WorkorderPartUsageServiceImpl(
+                workorderRepository,
+                workorderPartRepository,
+                usageEventRepository,
+                idempotencyService,
+                workorderFactPublisher,
+                new PartAvailabilityService(availabilityRepository),
+                divisibility,
+                workorderStateMachine,
+                publisherProvider,
+                clock);
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken("jane.smith", "n/a", List.of());
+        token.setDetails(Map.of(GatewaySecurityConstants.DETAIL_USERNAME, "jane.smith"));
+        SecurityContextHolder.getContext().setAuthentication(token);
+
+        when(usageEventRepository.save(any(WorkorderPartUsageEvent.class))).thenAnswer(i -> i.getArgument(0));
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Nested
+    @DisplayName("Promotion")
+    class Promotion {
+
+        @Test
+        @DisplayName("refuses to promote a fractional PART item onto the workorder")
+        void refusesFractionalPartItem() {
+            givenPromotableEstimate(estimateItem(EstimateItemType.PART, PRODUCT_ID, "4.5"));
+
+            assertThatThrownBy(() -> workorderService.createWorkorder(promotedWorkorder()))
+                    .isInstanceOf(FractionalQuantityNotAllowedException.class)
+                    .hasMessageContaining("whole units");
+
+            // Nothing lands on workorder_part: the line that could never be issued to zero does
+            // not come into existence.
+            verify(workorderPartRepository, never()).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("promotes an integral PART item unchanged")
+        void promotesIntegralPartItem() {
+            givenPromotableEstimate(estimateItem(EstimateItemType.PART, PRODUCT_ID, "2"));
+
+            workorderService.createWorkorder(promotedWorkorder());
+
+            verify(workorderPartRepository).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("leaves a fractional LABOR item alone — 1.5 hours is a real thing to sell")
+        void leavesFractionalLaborAlone() {
+            givenPromotableEstimate(estimateItem(EstimateItemType.LABOR, null, "1.5"));
+
+            workorderService.createWorkorder(promotedWorkorder());
+
+            verify(workorderServiceRepository).saveAll(any());
+            verify(workorderPartRepository, never()).saveAll(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Issuing to completion")
+    class IssuingToCompletion {
+
+        @Test
+        @DisplayName("an integral part issues down to zero outstanding without touching AWAITING_PARTS")
+        void issuesDownToZeroOutstanding() {
+            Workorder workorder = new Workorder();
+            workorder.setId(WORKORDER_ID);
+            workorder.setShopId(SHOP_ID);
+            workorder.setStatus(WorkorderStatus.WORK_IN_PROGRESS);
+
+            WorkorderPart part = new WorkorderPart();
+            part.setId(PART_ID);
+            part.setProductEntityId(PRODUCT_ID);
+            part.setDescription("Brake pad");
+            part.setQuantity(new BigDecimal("2"));
+            part.setQuantityIssued(BigDecimal.ZERO);
+            Workorder owner = new Workorder();
+            owner.setId(WORKORDER_ID);
+            part.setWorkorder(owner);
+
+            when(workorderRepository.findById(WORKORDER_ID)).thenReturn(Optional.of(workorder));
+            when(workorderPartRepository.findById(PART_ID)).thenReturn(Optional.of(part));
+            when(availabilityRepository.findByStockItemIdAndLocationId(PRODUCT_ID.toString(), SHOP_ID))
+                    .thenReturn(Optional.of(ExtInventoryAvailabilityReplica.builder()
+                            .aggregateId(UUID.randomUUID())
+                            .stockItemId(PRODUCT_ID.toString())
+                            .locationId(SHOP_ID)
+                            .onHandQuantity(10)
+                            .allocatedQuantity(0)
+                            .availableToPromiseQuantity(10)
+                            .aggregateVersion(1L)
+                            .updatedAt(NOW)
+                            .build()));
+
+            partUsageService.issuePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, null);
+            partUsageService.issuePartQuantity(WORKORDER_ID, PART_ID, BigDecimal.ONE, null);
+
+            // Outstanding reaches exactly zero — the condition that releases the job from
+            // AWAITING_PARTS — rather than the 0.5 remainder a fractional line would leave behind.
+            assertThat(part.getQuantity().subtract(part.getQuantityIssued())).isEqualByComparingTo("0");
+            verify(workorderStateMachine, never()).transitionWorkorder(any(), any(), any(), any());
+        }
+    }
+
+    private EstimateItem estimateItem(EstimateItemType type, UUID productId, String quantity) {
+        return EstimateItem.builder()
+                .id(UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3fee07"))
+                .itemType(type)
+                .description("Valvoline MaxLife ATF 1qt")
+                .quantity(new BigDecimal(quantity))
+                .unitPrice(new BigDecimal("12.00"))
+                .lineTotal(new BigDecimal("54.00"))
+                .productId(productId)
+                .approvalStatus(ApprovalStatus.APPROVED)
+                .build();
+    }
+
+    private void givenPromotableEstimate(EstimateItem approvedItem) {
+        when(extCustomerPartyReplicaRepository.findById(CUSTOMER_ID))
+                .thenReturn(Optional.of(ExtCustomerPartyReplica.builder()
+                        .partyId(CUSTOMER_ID)
+                        .requirementsMet(true)
+                        .aggregateVersion(1L)
+                        .updatedAt(NOW)
+                        .build()));
+        when(workorderRepository.save(any(Workorder.class))).thenAnswer(i -> {
+            Workorder saved = i.getArgument(0);
+            saved.setId(WORKORDER_ID);
+            return saved;
+        });
+        when(estimateItemRepository.findByEstimate_IdAndApprovalStatusAndDeletedFalse(
+                        ESTIMATE_ID, ApprovalStatus.APPROVED))
+                .thenReturn(List.of(approvedItem));
+        when(estimateItemRepository.findByEstimate_IdAndApprovalStatusAndDeletedFalse(
+                        ESTIMATE_ID, ApprovalStatus.DECLINED))
+                .thenReturn(List.of());
+    }
+
+    private Workorder promotedWorkorder() {
+        Estimate estimate = new Estimate();
+        estimate.setId(ESTIMATE_ID);
+        return Workorder.builder()
+                .estimate(estimate)
+                .customerId(CUSTOMER_ID)
+                .shopId(SHOP_ID)
+                .status(WorkorderStatus.DRAFT)
+                .build();
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderPartAdjustmentServiceImplTest.java
@@ -83,6 +83,7 @@ class WorkorderPartAdjustmentServiceImplTest {
                 adjustmentEventRepository,
                 idempotencyService,
                 workorderFactPublisher,
+                org.mockito.Mockito.mock(PartQuantityDivisibilityService.class),
                 Clock.fixed(NOW, ZoneOffset.UTC));
 
         UsernamePasswordAuthenticationToken token =

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImplTest.java
@@ -100,6 +100,7 @@ class WorkorderPartUsageServiceImplTest {
                 idempotencyService,
                 workorderFactPublisher,
                 partAvailabilityService,
+                org.mockito.Mockito.mock(PartQuantityDivisibilityService.class),
                 workorderStateMachine,
                 inventoryCommandPublisher,
                 Clock.fixed(NOW, ZoneOffset.UTC));

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/CatalogEventsListenerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/CatalogEventsListenerTest.java
@@ -1,0 +1,133 @@
+package com.positivity.workorder.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.workorder.internal.entity.ExtProductUomReplica;
+import com.positivity.workorder.internal.repository.ExtProductUomReplicaRepository;
+import com.positivity.workorder.internal.repository.ProcessedEventRepository;
+import com.positivity.workorder.internal.service.CatalogEventsListener;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.QueryTimeoutException;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * The catalog-owned {@code ext_product_uom} replica (ADR-0044 §6, #1413) — the only source this
+ * module has for how divisible a product's stock is.
+ */
+@DisplayName("pos-workorder catalog replica listener")
+class CatalogEventsListenerTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2026-08-19T09:00:00Z"), ZoneOffset.UTC);
+    private static final UUID PRODUCT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b1");
+
+    private final ProcessedEventRepository processedEvents = mock(ProcessedEventRepository.class);
+    private final ExtProductUomReplicaRepository productUoms = mock(ExtProductUomReplicaRepository.class);
+
+    private CatalogEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new CatalogEventsListener(TEST_CLOCK, new ObjectMapper(), processedEvents, productUoms);
+        when(processedEvents.existsById(any())).thenReturn(false);
+        when(productUoms.findAggregateVersions(any())).thenReturn(List.of());
+    }
+
+    private String productEvent(String eventId, long version, String conversions) {
+        return """
+                {"eventId":"%s","eventType":"catalog.product.updated","schemaVersion":2,
+                 "aggregateId":"%s","aggregateVersion":%d,
+                 "payload":{"productId":"%s","sku":"VALV-ATF-ML-QT","baseUom":"QT",
+                            "uomConversions":%s}}
+                """.formatted(eventId, PRODUCT_ID, version, PRODUCT_ID, conversions);
+    }
+
+    @Test
+    @DisplayName("replaces the product's unit-of-measure set wholesale")
+    void replacesUomSetWholesale() {
+        listener.onCatalogEvent(productEvent("e1", 5L, """
+                [{"uomCode":"LB","uomType":"BASE","factorToBase":1,"precisionScale":2},
+                 {"uomCode":"BAG","uomType":"PURCHASE","factorToBase":1.01,"precisionScale":0}]"""));
+
+        // Wholesale, not merged: a UoM catalog retired must disappear here too, or a part would go
+        // on being judged against a scale its owner no longer publishes.
+        verify(productUoms).deleteByProductId(PRODUCT_ID);
+        ArgumentCaptor<ExtProductUomReplica> saved = ArgumentCaptor.forClass(ExtProductUomReplica.class);
+        verify(productUoms, org.mockito.Mockito.times(2)).save(saved.capture());
+        assertThat(saved.getAllValues())
+                .extracting(ExtProductUomReplica::getUomCode, ExtProductUomReplica::getPrecisionScale)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("LB", 2), org.assertj.core.groups.Tuple.tuple("BAG", 0));
+        assertThat(saved.getAllValues().getFirst().getAggregateVersion()).isEqualTo(5L);
+        verify(processedEvents).save(any());
+    }
+
+    @Test
+    @DisplayName("discards a fact older than what the replica already holds")
+    void discardsStaleFact() {
+        when(productUoms.findAggregateVersions(PRODUCT_ID)).thenReturn(List.of(9L));
+
+        listener.onCatalogEvent(productEvent("e2", 5L, """
+                [{"uomCode":"LB","uomType":"BASE","factorToBase":1,"precisionScale":2}]"""));
+
+        verify(productUoms, never()).deleteByProductId(any());
+        verify(productUoms, never()).save(any());
+        // Still recorded as processed: the fact was seen, it simply had nothing newer to say.
+        verify(processedEvents).save(any());
+    }
+
+    @Test
+    @DisplayName("ignores fact types this module does not replicate")
+    void ignoresOtherFactTypes() {
+        listener.onCatalogEvent("""
+                {"eventId":"e3","eventType":"catalog.supplier-article-code.updated","payload":{}}""");
+
+        verify(productUoms, never()).save(any());
+        verify(processedEvents, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("rethrows a transient database error so the container can retry")
+    void rethrowsTransientErrors() {
+        when(productUoms.findAggregateVersions(PRODUCT_ID)).thenThrow(new QueryTimeoutException("db busy"));
+
+        assertThatExceptionOfType(QueryTimeoutException.class)
+                .isThrownBy(() -> listener.onCatalogEvent(productEvent("e4", 1L, """
+                        [{"uomCode":"LB","uomType":"BASE","factorToBase":1,"precisionScale":2}]""")));
+
+        verify(processedEvents, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("drops a malformed payload rather than poisoning the partition")
+    void dropsMalformedPayload() {
+        listener.onCatalogEvent("""
+                {"eventId":"e5","eventType":"catalog.product.updated","payload":{"productId":"not-a-uuid"}}""");
+
+        verify(productUoms, never()).save(any());
+        verify(processedEvents, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("skips a product with no unit-of-measure rows, leaving it at the whole-unit default")
+    void appliesEmptyConversionSet() {
+        listener.onCatalogEvent(productEvent("e6", 3L, "[]"));
+
+        verify(productUoms).deleteByProductId(PRODUCT_ID);
+        verify(productUoms, never()).save(any());
+        verify(processedEvents).save(any());
+    }
+}

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/EstimateServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/EstimateServiceImplTest.java
@@ -89,6 +89,9 @@ class EstimateServiceImplTest {
     @Mock
     private com.positivity.workorder.internal.service.EstimateFactPublisher estimateFactPublisher;
 
+    @Mock
+    private com.positivity.workorder.internal.service.PartQuantityDivisibilityService partQuantityDivisibilityService;
+
     @InjectMocks
     private EstimateServiceImpl estimateService;
 

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderCompletionTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/WorkorderCompletionTest.java
@@ -178,7 +178,9 @@ class WorkorderCompletionTest {
                 idempotencyService,
                 promotionValidationService,
                 peopleAvailabilityLocalService,
-                org.mockito.Mockito.mock(com.positivity.workorder.internal.service.FleetAuthorizationService.class));
+                org.mockito.Mockito.mock(com.positivity.workorder.internal.service.FleetAuthorizationService.class),
+                org.mockito.Mockito.mock(
+                        com.positivity.workorder.internal.service.PartQuantityDivisibilityService.class));
     }
 
     @AfterEach


### PR DESCRIPTION
> **Stacked PR 1 of 4** for the ADR-0055 staged path (louisburroughs/durion#400). Merge order: this → #1414's PR → #1415's PR → #1416's PR.

## Capability & Traceability
- Capability: n/a — decision-driven task chain from durion-positivity-backend#1365 (ADR-0055, PROPOSED: louisburroughs/durion#400)
- Parent STORY (durion): n/a (ADR PR: louisburroughs/durion#400)
- Child issue: louisburroughs/durion-positivity-backend#1413
- Domain: `domain:workexec`, `domain:inventory`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` — checked; no entry documents the workorder part-quantity validation surface, so no guide change was required at this stage (stage 2 updates the availability/stock-movement entries)
- Durion contract PR (if applicable): louisburroughs/durion#400 (ADR-0055 only)

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller — `CorrectPartQuantityRequest` gained `@DecimalMin("0.0001")`; the one resulting schema line synced in `pos-workorder/openapi.yaml`
- [x] `openapi.yaml` regenerated — semantic sync of the single changed line, verified against generator output
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — **not reachable from this session; required follow-up**

## Scope
- What changed:
  - `PartQuantityDivisibilityService` (new, pos-workorder): a part quantity for a product is integral unless the product's `product_uom` BASE row declares `precision_scale > 0`, in which case it may carry up to that many decimals. No `product_uom` rows → scale 0. Parts without `productEntityId` (labour, shop supplies) stay exempt.
  - Gates at estimate-item add/update, estimate→workorder promotion, and issue/consume/return/correct as backstop. Violations return 422 `FRACTIONAL_QUANTITY_NOT_ALLOWED` (`ApiError` with `fieldErrors[quantity]` and `nextAction`).
  - New `ext_product_uom` replica in pos-workorder (`V17__ext_product_uom.sql`, entity, repository, `CatalogEventsListener` consuming `catalog.events.v1` with idempotency + stale-version guard), mirroring the pos-order/pos-inventory replica pattern per ADR-0044. This is the one deviation from the issue's "no migration" AC: pos-workorder cannot read `precision_scale` without it, and a synchronous read to pos-catalog would violate ADR-0044. Additive only — no existing table, column, event payload, or contract modified.
  - `RoundingMode.CEILING` workaround from #1363 deleted from `WorkorderPartUsageServiceImpl.reservableQuantity`, along with the tests pinning `0.5→1` / `2.7→3`. A non-integral quantity now throws `IllegalStateException` — unreachable while `product_uom` is unseeded, pinned by a test, removed in stage 2 when the reservation command goes decimal.
- Why: records/enforces the ADR-0055 stage-1 invariant. Issuing 0.5 no longer silently reserves 1; the coercion becomes a visible, actionable error at the point of entry. Critically, the rule reads the declared scale (defaulting to 0) rather than hardcoding "inventory-tracked = whole", so stage 2 is a widening, not a reversal.

## Tests
- [x] Unit tests added/updated — `PartQuantityDivisibilityServiceTest`, `EstimateItemQuantityGateTest`, `CatalogEventsListenerTest` (scale-0 rejection; scale-2 accepts 1.01, rejects 1.001; non-tracked part accepts 0.25; `1.00` passes at scale 0)
- [x] Integration tests added/updated — `PartQuantityStrandingRegressionTest`: fractional refused at promotion; integral part issues to zero outstanding without stranding in AWAITING_PARTS
- [x] Provider behavioral contract tests added/updated — n/a, no event contract changed at this stage
- How to run: `./mvnw -pl pos-workorder -am test`

## Risk & Rollback
- Risk level: Low — additive replica table + validation that matches current data reality (every seeded SKU is integral; `product_uom` is unseeded, so the default-scale-0 path is the only live path)
- Rollback plan: revert the single commit; the replica table is additive and unused elsewhere

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — branch is session-mandated (`claude/fractional-quantities-usecases-u2xkqv`)
- [ ] PR title starts with `[CAP:<cap-id>]` — no capability id; issue-numbered title
- [x] Links to parent + child issues are present
- [x] Contract guide reference present (see above)
- [ ] Required CI checks passing — pending

**Verification run:** `./mvnw -pl pos-workorder -am test` → 889 tests, 0 failures (Checkstyle/Spotless/SpotBugs active; module `ArchitectureTest` 11/11); `scripts/check-flyway-hygiene.sh` → 25 modules pass; `pos-openapi-validation` → pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJPZ9szyzL6C5KQdNyeF48

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJPZ9szyzL6C5KQdNyeF48)_