### PR TITLE
Decimal inventory ledger and reservation chain, gated by declared precision_scale (#1414, ADR-0055 stage 2)

### DIFF
--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -5585,13 +5585,11 @@ components:
       description: Availability information with status indicator
       properties:
         onHandQuantity:
-          type: integer
-          format: int32
+          type: number
           description: On-hand quantity at location
           example: 15
         availableToPromiseQuantity:
-          type: integer
-          format: int32
+          type: number
           description: Available to promise quantity
           example: 12
         leadTime:

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/client/InventoryClient.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/client/InventoryClient.java
@@ -1,5 +1,6 @@
 package com.positivity.catalog.internal.client;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -38,7 +39,10 @@ public interface InventoryClient {
      * fields.
      */
     record AvailabilityClientResponse(
-            int onHandQuantity, int allocatedQuantity, int availableToPromiseQuantity, String unitOfMeasure) {}
+            BigDecimal onHandQuantity,
+            BigDecimal allocatedQuantity,
+            BigDecimal availableToPromiseQuantity,
+            String unitOfMeasure) {}
 
     /**
      * Local response record mirroring the lead-time fields returned by

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductDetailView.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/dto/ProductDetailView.java
@@ -4,6 +4,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIR
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
@@ -108,10 +109,10 @@ public class ProductDetailView {
     @Schema(description = "Availability information with status indicator")
     public static class AvailabilityInfo {
         @Schema(description = "On-hand quantity at location", example = "15", requiredMode = NOT_REQUIRED)
-        private Integer onHandQuantity;
+        private BigDecimal onHandQuantity;
 
         @Schema(description = "Available to promise quantity", example = "12", requiredMode = NOT_REQUIRED)
-        private Integer availableToPromiseQuantity;
+        private BigDecimal availableToPromiseQuantity;
 
         @Schema(description = "Lead time information", requiredMode = NOT_REQUIRED)
         private LeadTimeInfo leadTime;

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ExtInventoryAvailabilityReplica.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ExtInventoryAvailabilityReplica.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -44,14 +45,14 @@ public class ExtInventoryAvailabilityReplica {
     @Column(name = "location_id")
     private UUID locationId;
 
-    @Column(name = "on_hand_quantity", nullable = false)
-    private int onHandQuantity;
+    @Column(name = "on_hand_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal onHandQuantity;
 
-    @Column(name = "allocated_quantity", nullable = false)
-    private int allocatedQuantity;
+    @Column(name = "allocated_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal allocatedQuantity;
 
-    @Column(name = "available_to_promise_quantity", nullable = false)
-    private int availableToPromiseQuantity;
+    @Column(name = "available_to_promise_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal availableToPromiseQuantity;
 
     @Column(name = "unit_of_measure")
     private String unitOfMeasure;

--- a/pos-catalog/src/main/resources/db/migration/V13__decimal_inventory_availability_replica.sql
+++ b/pos-catalog/src/main/resources/db/migration/V13__decimal_inventory_availability_replica.sql
@@ -1,0 +1,13 @@
+-- ADR-0055 stage 2 (#1414): the availability facts this replica mirrors are now decimal.
+--
+-- InventoryAvailabilityUpdatedV1 carries BigDecimal quantities so that a product whose catalog
+-- declaration (product_uom.precision_scale) permits decimals can be reported at its real
+-- quantity. Every product declares scale 0 today, so no value stored here changes; what changes
+-- is that a divisible one is no longer truncated on arrival.
+--
+-- Pre-production widening: numeric(19,4) holds every value the integer columns could, so the
+-- implicit cast preserves existing rows exactly.
+ALTER TABLE ext_inventory_availability
+    ALTER COLUMN on_hand_quantity TYPE numeric(19,4),
+    ALTER COLUMN allocated_quantity TYPE numeric(19,4),
+    ALTER COLUMN available_to_promise_quantity TYPE numeric(19,4);

--- a/pos-catalog/src/test/java/com/positivity/catalog/contract/ProductDetailContractBehaviorIT.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/contract/ProductDetailContractBehaviorIT.java
@@ -60,7 +60,8 @@ class ProductDetailContractBehaviorIT extends BaseContractIntegrationTest {
                         new BigDecimal("199.99"), "TIER_A")));
 
         Mockito.when(inventoryClient.fetchAvailability(Mockito.any(), Mockito.any()))
-                .thenReturn(Optional.of(new AvailabilityClientResponse(25, 5, 20, "EA")));
+                .thenReturn(Optional.of(new AvailabilityClientResponse(
+                        BigDecimal.valueOf(25), BigDecimal.valueOf(5), BigDecimal.valueOf(20), "EA")));
 
         UUID productId = createProductAndGetId(
                 "SKU-PD-001-" + UUID.fromString("00000000-0000-0000-0000-000000000001"), "MPN-PD-001");
@@ -92,7 +93,8 @@ class ProductDetailContractBehaviorIT extends BaseContractIntegrationTest {
                 .thenThrow(new RuntimeException("price service down"));
 
         Mockito.when(inventoryClient.fetchAvailability(Mockito.any(), Mockito.any()))
-                .thenReturn(Optional.of(new AvailabilityClientResponse(10, 2, 8, "EA")));
+                .thenReturn(Optional.of(new AvailabilityClientResponse(
+                        BigDecimal.valueOf(10), BigDecimal.valueOf(2), BigDecimal.valueOf(8), "EA")));
 
         UUID productId = createProductAndGetId(
                 "SKU-PD-002-" + UUID.fromString("00000000-0000-0000-0000-000000000001"), "MPN-PD-002");

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/InventoryListenersTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/InventoryListenersTest.java
@@ -21,6 +21,7 @@ import com.positivity.domainevents.inventory.InventoryAvailabilityUpdatedV1;
 import com.positivity.domainevents.inventory.LeadTimeUpdatedV1;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -146,11 +147,55 @@ class InventoryListenersTest {
             assertThat(saved.getAggregateId()).isEqualTo(AGGREGATE_ID);
             assertThat(saved.getStockItemId()).isEqualTo("BRK-100");
             assertThat(saved.getLocationId()).isEqualTo(LOCATION_ID);
-            assertThat(saved.getOnHandQuantity()).isEqualTo(10);
-            assertThat(saved.getAvailableToPromiseQuantity()).isEqualTo(8);
+            assertThat(saved.getOnHandQuantity()).isEqualByComparingTo("10");
+            assertThat(saved.getAvailableToPromiseQuantity()).isEqualByComparingTo("8");
             assertThat(saved.getUnitOfMeasure()).isEqualTo("EA");
             assertThat(saved.getAggregateVersion()).isEqualTo(3);
             assertThat(saved.getUpdatedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("lands a divisible product's fractional quantities from the real contract type")
+        void carriesDecimalQuantitiesFromTheContract() {
+            // ADR-0055 stage 2 (#1414) AC: pos-catalog consumes InventoryAvailabilityUpdatedV1 and
+            // is the module easiest to forget when that contract changes — it sits outside the
+            // #1315 gate work and its other test here hand-writes the payload JSON, which would
+            // keep passing through a type change on the record. This one serialises the actual
+            // contract type, so a narrowing of these fields breaks here rather than silently
+            // truncating a bulk product's on-hand on a product-detail page.
+            InventoryAvailabilityUpdatedV1 payload = new InventoryAvailabilityUpdatedV1(
+                    "BULK-OIL-DRUM",
+                    LOCATION_ID,
+                    new BigDecimal("120.5000"),
+                    new BigDecimal("0.2500"),
+                    new BigDecimal("120.2500"),
+                    "LB",
+                    new BigDecimal("2.5000"),
+                    new BigDecimal("1.2500"),
+                    new BigDecimal("121.7500"));
+
+            listener.onInventoryEvent(objectMapper.writeValueAsString(java.util.Map.of(
+                    "eventId",
+                    "evt-decimal",
+                    "eventType",
+                    InventoryAvailabilityUpdatedV1.EVENT_TYPE,
+                    "aggregateVersion",
+                    7L,
+                    "aggregateId",
+                    AGGREGATE_ID.toString(),
+                    "payload",
+                    payload)));
+
+            ArgumentCaptor<ExtInventoryAvailabilityReplica> captor =
+                    ArgumentCaptor.forClass(ExtInventoryAvailabilityReplica.class);
+            verify(availabilityRepository).save(captor.capture());
+            ExtInventoryAvailabilityReplica saved = captor.getValue();
+            assertThat(saved.getStockItemId()).isEqualTo("BULK-OIL-DRUM");
+            // compareTo, not equals: scale is how the number was spelled, not what it means.
+            assertThat(saved.getOnHandQuantity()).isEqualByComparingTo("120.5");
+            assertThat(saved.getAllocatedQuantity()).isEqualByComparingTo("0.25");
+            assertThat(saved.getAvailableToPromiseQuantity()).isEqualByComparingTo("120.25");
+            assertThat(saved.getUnitOfMeasure()).isEqualTo("LB");
         }
 
         @Test

--- a/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductDetailDegradationTest.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/internal/service/ProductDetailDegradationTest.java
@@ -111,7 +111,8 @@ class ProductDetailDegradationTest {
 
     private void availabilityWorks() {
         when(inventoryClient.fetchAvailability(any(), any()))
-                .thenReturn(Optional.of(new InventoryClient.AvailabilityClientResponse(12, 2, 10, "EA")));
+                .thenReturn(Optional.of(new InventoryClient.AvailabilityClientResponse(
+                        BigDecimal.valueOf(12), BigDecimal.valueOf(2), BigDecimal.valueOf(10), "EA")));
     }
 
     private void leadTimeAbsent() {
@@ -134,7 +135,7 @@ class ProductDetailDegradationTest {
         assertThat(view.getAvailability().getStatus()).isEqualTo(DataStatus.OK);
         assertThat(view.getPricing().getMsrp()).isEqualTo(129.99);
         assertThat(view.getPricing().getStorePrice()).isEqualTo(99.99);
-        assertThat(view.getAvailability().getOnHandQuantity()).isEqualTo(12);
+        assertThat(view.getAvailability().getOnHandQuantity()).isEqualByComparingTo("12");
     }
 
     @ParameterizedTest(name = "pricing up={0}, availability up={1} -> {2}")

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/BackorderCreatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/BackorderCreatedV1.java
@@ -1,5 +1,6 @@
 package com.positivity.domainevents.inventory;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -26,7 +27,8 @@ import org.jspecify.annotations.Nullable;
  * @param salesOrderLineId sales-order line whose demand was short, when demand was from a sales
  *     order (additive, schema v2)
  * @param sku stock-item identifier that was short (ledger stock-item string)
- * @param quantityShort quantity that could not be fulfilled (positive)
+ * @param quantityShort quantity that could not be fulfilled (positive); decimal-capable per the
+ *     product's catalog divisibility declaration (ADR-0055, #1414)
  * @param occurredAt when the backorder was opened
  */
 public record BackorderCreatedV1(
@@ -34,7 +36,7 @@ public record BackorderCreatedV1(
         @Nullable UUID workorderLineId,
         @Nullable UUID salesOrderLineId,
         @NonNull String sku,
-        int quantityShort,
+        @NonNull BigDecimal quantityShort,
         @Nullable UUID locationId,
         @NonNull Instant occurredAt) {
 
@@ -51,7 +53,7 @@ public record BackorderCreatedV1(
         if (sku == null || sku.isBlank()) {
             throw new IllegalArgumentException("sku must not be blank");
         }
-        if (quantityShort <= 0) {
+        if (quantityShort == null || quantityShort.signum() <= 0) {
             throw new IllegalArgumentException("quantityShort must be positive");
         }
         if (occurredAt == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/BackorderResolvedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/BackorderResolvedV1.java
@@ -1,5 +1,6 @@
 package com.positivity.domainevents.inventory;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -23,7 +24,8 @@ import org.jspecify.annotations.Nullable;
  * @param salesOrderLineId sales-order line whose demand was short, when demand was from a sales
  *     order (additive, schema v2)
  * @param sku stock-item identifier that was short (ledger stock-item string)
- * @param quantityShort quantity that was resolved (positive; the whole backorder)
+ * @param quantityShort quantity that was resolved (positive; the whole backorder); decimal-capable
+ *     per the product's catalog divisibility declaration (ADR-0055, #1414)
  * @param resolutionSource what drove the resolution: {@code AVAILABILITY},
  *     {@code REPLENISHMENT_RECEIPT}, or {@code MANUAL}
  * @param occurredAt when the backorder was resolved
@@ -33,7 +35,7 @@ public record BackorderResolvedV1(
         @Nullable UUID workorderLineId,
         @Nullable UUID salesOrderLineId,
         @NonNull String sku,
-        int quantityShort,
+        @NonNull BigDecimal quantityShort,
         @NonNull String resolutionSource,
         @Nullable UUID locationId,
         @NonNull Instant occurredAt) {
@@ -51,7 +53,7 @@ public record BackorderResolvedV1(
         if (sku == null || sku.isBlank()) {
             throw new IllegalArgumentException("sku must not be blank");
         }
-        if (quantityShort <= 0) {
+        if (quantityShort == null || quantityShort.signum() <= 0) {
             throw new IllegalArgumentException("quantityShort must be positive");
         }
         if (resolutionSource == null || resolutionSource.isBlank()) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/InventoryAvailabilityUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/InventoryAvailabilityUpdatedV1.java
@@ -1,5 +1,6 @@
 package com.positivity.domainevents.inventory;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -18,11 +19,19 @@ import org.jspecify.annotations.Nullable;
  * emission time and arrive within normal Kafka lag (seconds). They are display/planning inputs —
  * authoritative allocation decisions stay inside pos-inventory, which reads its own ledger.
  *
+ * <p><b>Quantities are decimal (ADR-0055, issue #1414).</b> A product's stock divisibility is
+ * declared per product by the catalog ({@code product_uom.precision_scale}); a product declaring
+ * scale 0 — which is every product until one is seeded otherwise — still only ever produces
+ * integral values here. The type carries what a divisible product needs; the declaration is what
+ * decides whether any given product may use it. Compare these with {@code compareTo}, never
+ * {@code equals}: {@code 1} and {@code 1.0} are the same quantity and are not equal.
+ *
  * <p><b>Schema v2 (odoo-parity A2, issue #1028):</b> adds the additive forecast fields
  * {@code incomingQuantity}, {@code outgoingQuantity}, and {@code projectedAvailableQuantity}
  * (unbounded variant — no horizon cutoff). Events emitted under schema v1 deserialize with these
  * fields defaulting to {@code 0}; consumers must not treat a zero forecast on a v1 event as a
- * computed value.
+ * computed value. They are marked {@code @Nullable} because a v1 payload legitimately omits them;
+ * the canonical constructor substitutes {@code ZERO}, so the accessors never return null.
  *
  * @param stockItemId owner stock-item identifier (the product SKU string)
  * @param locationId location the availability is scoped to (site or storage location, as
@@ -40,13 +49,13 @@ import org.jspecify.annotations.Nullable;
 public record InventoryAvailabilityUpdatedV1(
         @NonNull String stockItemId,
         @Nullable UUID locationId,
-        int onHandQuantity,
-        int allocatedQuantity,
-        int availableToPromiseQuantity,
+        @NonNull BigDecimal onHandQuantity,
+        @NonNull BigDecimal allocatedQuantity,
+        @NonNull BigDecimal availableToPromiseQuantity,
         @Nullable String unitOfMeasure,
-        long incomingQuantity,
-        long outgoingQuantity,
-        long projectedAvailableQuantity) {
+        @Nullable BigDecimal incomingQuantity,
+        @Nullable BigDecimal outgoingQuantity,
+        @Nullable BigDecimal projectedAvailableQuantity) {
 
     public static final String EVENT_TYPE = "inventory.availability.updated";
     public static final int SCHEMA_VERSION = 2;
@@ -55,5 +64,27 @@ public record InventoryAvailabilityUpdatedV1(
         if (stockItemId == null || stockItemId.isBlank()) {
             throw new IllegalArgumentException("stockItemId must not be blank");
         }
+        onHandQuantity = required(onHandQuantity, "onHandQuantity");
+        allocatedQuantity = required(allocatedQuantity, "allocatedQuantity");
+        availableToPromiseQuantity = required(availableToPromiseQuantity, "availableToPromiseQuantity");
+        // The forecast triple arrived in schema v2 and is absent from a v1 payload, so it
+        // defaults rather than throwing — the same "absent means zero" the primitive `long`
+        // fields gave it before the widening.
+        incomingQuantity = incomingQuantity == null ? BigDecimal.ZERO : incomingQuantity;
+        outgoingQuantity = outgoingQuantity == null ? BigDecimal.ZERO : outgoingQuantity;
+        projectedAvailableQuantity = projectedAvailableQuantity == null ? BigDecimal.ZERO : projectedAvailableQuantity;
+    }
+
+    /**
+     * The three core quantities are required. They were primitives before the widening, and an
+     * omitted primitive is a databind failure the consumers already count and reject — keeping
+     * them mandatory keeps a truncated payload loud rather than letting it land as a silent zero
+     * that would read as "nothing on hand".
+     */
+    private static BigDecimal required(@Nullable BigDecimal value, String field) {
+        if (value == null) {
+            throw new IllegalArgumentException(field + " must not be null");
+        }
+        return value;
     }
 }

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/ProductValueChangedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/ProductValueChangedV1.java
@@ -29,7 +29,8 @@ import org.jspecify.annotations.Nullable;
  *     {@code "AVERAGE"})
  * @param previousUnitCost unit cost before the revaluation, {@code null} when the SKU was uncosted
  * @param newUnitCost corrected unit cost after the revaluation
- * @param onHandQuantity on-hand quantity the engine had costed at revaluation time (delta basis)
+ * @param onHandQuantity on-hand quantity the engine had costed at revaluation time (delta basis);
+ *     decimal since ADR-0055 (#1414) — it is the ledger quantity the value delta multiplies
  * @param totalValueDelta signed inventory value change {@code (newUnitCost − previousUnitCost) ×
  *     onHandQuantity}
  * @param reason operator-supplied justification for the correction
@@ -42,7 +43,7 @@ public record ProductValueChangedV1(
         @NonNull String costingMethod,
         @Nullable BigDecimal previousUnitCost,
         @NonNull BigDecimal newUnitCost,
-        long onHandQuantity,
+        @NonNull BigDecimal onHandQuantity,
         @NonNull BigDecimal totalValueDelta,
         @NonNull String reason,
         @NonNull String actor,

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/ReservationOutcomeV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/ReservationOutcomeV1.java
@@ -1,5 +1,6 @@
 package com.positivity.domainevents.inventory;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -27,7 +28,10 @@ import org.jspecify.annotations.Nullable;
  * @param workorderLineId workorder line the demand is for, when demand is from a workorder
  * @param salesOrderLineId sales-order line the demand is for, when demand is from a sales order
  * @param stockItemId stock-item identifier that was requested
- * @param requiredQuantity quantity requested
+ * @param requiredQuantity quantity requested; decimal-capable, and permitted to carry decimals
+ *     only to the scale the product's catalog declaration allows (ADR-0055, #1414). Zero and
+ *     negative remain rejected — a reservation for nothing is not an outcome. Compare with
+ *     {@code compareTo}, never {@code equals}.
  * @param covered whether owned ATP at the requested location currently covers the full quantity
  * @param backorderId the backorder opened for the shortfall, when {@code covered} is false
  * @param occurredAt when the outcome was determined
@@ -37,7 +41,7 @@ public record ReservationOutcomeV1(
         @Nullable UUID workorderLineId,
         @Nullable UUID salesOrderLineId,
         @NonNull String stockItemId,
-        int requiredQuantity,
+        @NonNull BigDecimal requiredQuantity,
         boolean covered,
         @Nullable UUID backorderId,
         @NonNull Instant occurredAt) {
@@ -55,7 +59,7 @@ public record ReservationOutcomeV1(
         if (stockItemId == null || stockItemId.isBlank()) {
             throw new IllegalArgumentException("stockItemId must not be blank");
         }
-        if (requiredQuantity <= 0) {
+        if (requiredQuantity == null || requiredQuantity.signum() <= 0) {
             throw new IllegalArgumentException("requiredQuantity must be positive");
         }
         if (!covered && backorderId == null) {

--- a/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/StorageLocationOnHandUpdatedV1.java
+++ b/pos-domain-events/src/main/java/com/positivity/domainevents/inventory/StorageLocationOnHandUpdatedV1.java
@@ -1,5 +1,6 @@
 package com.positivity.domainevents.inventory;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 
@@ -13,9 +14,13 @@ import org.jspecify.annotations.NonNull;
  * {@code ext_storage_location_on_hand} replica for the "no decommission while stocked" guard.
  *
  * @param storageLocationId storage location identifier
- * @param onHandQuantity total ledger on-hand across all stock items at this location
+ * @param onHandQuantity total ledger on-hand across all stock items at this location. Decimal
+ *     since ADR-0055 (#1414): it is a sum over the same ledger the quantity chain widened, so an
+ *     integral field here would have narrowed the one place the guard exists to protect —
+ *     "is anything still stocked here" must see half a drum as stock, not as zero.
  */
-public record StorageLocationOnHandUpdatedV1(@NonNull UUID storageLocationId, int onHandQuantity) {
+public record StorageLocationOnHandUpdatedV1(
+        @NonNull UUID storageLocationId, @NonNull BigDecimal onHandQuantity) {
 
     public static final String EVENT_TYPE = "inventory.storage-location-on-hand.updated";
     public static final int SCHEMA_VERSION = 1;
@@ -23,6 +28,9 @@ public record StorageLocationOnHandUpdatedV1(@NonNull UUID storageLocationId, in
     public StorageLocationOnHandUpdatedV1 {
         if (storageLocationId == null) {
             throw new IllegalArgumentException("storageLocationId must not be null");
+        }
+        if (onHandQuantity == null) {
+            throw new IllegalArgumentException("onHandQuantity must not be null");
         }
     }
 }

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/BackorderCreatedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/BackorderCreatedV1Test.java
@@ -3,6 +3,7 @@ package com.positivity.domainevents.inventory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -21,8 +22,8 @@ class BackorderCreatedV1Test {
 
     @Test
     void roundTripsForAWorkorderLine() {
-        BackorderCreatedV1 evt =
-                new BackorderCreatedV1(BACKORDER_ID, WORKORDER_LINE_ID, null, "SKU-1", 3, null, OCCURRED_AT);
+        BackorderCreatedV1 evt = new BackorderCreatedV1(
+                BACKORDER_ID, WORKORDER_LINE_ID, null, "SKU-1", new BigDecimal("3"), null, OCCURRED_AT);
 
         String json = MAPPER.writeValueAsString(evt);
         BackorderCreatedV1 back = MAPPER.readValue(json, BackorderCreatedV1.class);
@@ -34,8 +35,8 @@ class BackorderCreatedV1Test {
 
     @Test
     void roundTripsForASalesOrderLine() {
-        BackorderCreatedV1 evt =
-                new BackorderCreatedV1(BACKORDER_ID, null, SALES_ORDER_LINE_ID, "SKU-1", 3, null, OCCURRED_AT);
+        BackorderCreatedV1 evt = new BackorderCreatedV1(
+                BACKORDER_ID, null, SALES_ORDER_LINE_ID, "SKU-1", new BigDecimal("3"), null, OCCURRED_AT);
 
         String json = MAPPER.writeValueAsString(evt);
         BackorderCreatedV1 back = MAPPER.readValue(json, BackorderCreatedV1.class);
@@ -47,7 +48,8 @@ class BackorderCreatedV1Test {
 
     @Test
     void rejectsNeitherDemandLine() {
-        assertThatThrownBy(() -> new BackorderCreatedV1(BACKORDER_ID, null, null, "SKU-1", 3, null, OCCURRED_AT))
+        assertThatThrownBy(() -> new BackorderCreatedV1(
+                        BACKORDER_ID, null, null, "SKU-1", new BigDecimal("3"), null, OCCURRED_AT))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("exactly one");
     }
@@ -55,7 +57,13 @@ class BackorderCreatedV1Test {
     @Test
     void rejectsBothDemandLines() {
         assertThatThrownBy(() -> new BackorderCreatedV1(
-                        BACKORDER_ID, WORKORDER_LINE_ID, SALES_ORDER_LINE_ID, "SKU-1", 3, null, OCCURRED_AT))
+                        BACKORDER_ID,
+                        WORKORDER_LINE_ID,
+                        SALES_ORDER_LINE_ID,
+                        "SKU-1",
+                        new BigDecimal("3"),
+                        null,
+                        OCCURRED_AT))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("exactly one");
     }

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/BackorderResolvedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/BackorderResolvedV1Test.java
@@ -3,6 +3,7 @@ package com.positivity.domainevents.inventory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,14 @@ class BackorderResolvedV1Test {
     @Test
     void roundTripsForAWorkorderLine() {
         BackorderResolvedV1 evt = new BackorderResolvedV1(
-                BACKORDER_ID, WORKORDER_LINE_ID, null, "SKU-1", 3, "AVAILABILITY", LOCATION_ID, OCCURRED_AT);
+                BACKORDER_ID,
+                WORKORDER_LINE_ID,
+                null,
+                "SKU-1",
+                new BigDecimal("3"),
+                "AVAILABILITY",
+                LOCATION_ID,
+                OCCURRED_AT);
 
         String json = MAPPER.writeValueAsString(evt);
         BackorderResolvedV1 back = MAPPER.readValue(json, BackorderResolvedV1.class);
@@ -36,7 +44,14 @@ class BackorderResolvedV1Test {
     @Test
     void roundTripsForASalesOrderLine() {
         BackorderResolvedV1 evt = new BackorderResolvedV1(
-                BACKORDER_ID, null, SALES_ORDER_LINE_ID, "SKU-1", 3, "REPLENISHMENT_RECEIPT", LOCATION_ID, OCCURRED_AT);
+                BACKORDER_ID,
+                null,
+                SALES_ORDER_LINE_ID,
+                "SKU-1",
+                new BigDecimal("3"),
+                "REPLENISHMENT_RECEIPT",
+                LOCATION_ID,
+                OCCURRED_AT);
 
         String json = MAPPER.writeValueAsString(evt);
         BackorderResolvedV1 back = MAPPER.readValue(json, BackorderResolvedV1.class);
@@ -49,7 +64,7 @@ class BackorderResolvedV1Test {
     @Test
     void rejectsNeitherDemandLine() {
         assertThatThrownBy(() -> new BackorderResolvedV1(
-                        BACKORDER_ID, null, null, "SKU-1", 3, "MANUAL", LOCATION_ID, OCCURRED_AT))
+                        BACKORDER_ID, null, null, "SKU-1", new BigDecimal("3"), "MANUAL", LOCATION_ID, OCCURRED_AT))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("exactly one");
     }
@@ -61,7 +76,7 @@ class BackorderResolvedV1Test {
                         WORKORDER_LINE_ID,
                         SALES_ORDER_LINE_ID,
                         "SKU-1",
-                        3,
+                        new BigDecimal("3"),
                         "MANUAL",
                         LOCATION_ID,
                         OCCURRED_AT))

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/ProductValueChangedV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/ProductValueChangedV1Test.java
@@ -28,7 +28,7 @@ class ProductValueChangedV1Test {
                 "AVERAGE",
                 new BigDecimal("4.0000"),
                 new BigDecimal("5.0000"),
-                10L,
+                new BigDecimal("10"),
                 new BigDecimal("10.0000"),
                 "Q3 physical recount correction",
                 "cost-admin",
@@ -36,7 +36,7 @@ class ProductValueChangedV1Test {
 
         assertThat(fact.previousUnitCost()).isEqualByComparingTo("4.00");
         assertThat(fact.newUnitCost()).isEqualByComparingTo("5.00");
-        assertThat(fact.onHandQuantity()).isEqualTo(10L);
+        assertThat(fact.onHandQuantity()).isEqualByComparingTo("10");
         assertThat(fact.totalValueDelta()).isEqualByComparingTo("10.00");
         assertThat(fact.costingMethod()).isEqualTo("AVERAGE");
     }
@@ -49,7 +49,7 @@ class ProductValueChangedV1Test {
                 "STANDARD",
                 null,
                 new BigDecimal("6.0000"),
-                0L,
+                BigDecimal.ZERO,
                 BigDecimal.ZERO,
                 "Initial standard price",
                 "cost-admin",
@@ -67,7 +67,7 @@ class ProductValueChangedV1Test {
                         "AVERAGE",
                         null,
                         BigDecimal.ONE,
-                        0L,
+                        BigDecimal.ZERO,
                         BigDecimal.ZERO,
                         "r",
                         "a",
@@ -75,7 +75,16 @@ class ProductValueChangedV1Test {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("sku");
         assertThatThrownBy(() -> new ProductValueChangedV1(
-                        REVALUATION_ID, "SKU-1", " ", null, BigDecimal.ONE, 0L, BigDecimal.ZERO, "r", "a", OCCURRED_AT))
+                        REVALUATION_ID,
+                        "SKU-1",
+                        " ",
+                        null,
+                        BigDecimal.ONE,
+                        BigDecimal.ZERO,
+                        BigDecimal.ZERO,
+                        "r",
+                        "a",
+                        OCCURRED_AT))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("costingMethod");
         assertThatThrownBy(() -> new ProductValueChangedV1(
@@ -84,7 +93,7 @@ class ProductValueChangedV1Test {
                         "AVERAGE",
                         null,
                         BigDecimal.ONE,
-                        0L,
+                        BigDecimal.ZERO,
                         BigDecimal.ZERO,
                         " ",
                         "a",
@@ -97,7 +106,7 @@ class ProductValueChangedV1Test {
                         "AVERAGE",
                         null,
                         BigDecimal.ONE,
-                        0L,
+                        BigDecimal.ZERO,
                         BigDecimal.ZERO,
                         "r",
                         " ",
@@ -109,11 +118,29 @@ class ProductValueChangedV1Test {
     @Test
     void rejectsNullNewCostAndDelta() {
         assertThatThrownBy(() -> new ProductValueChangedV1(
-                        REVALUATION_ID, "SKU-1", "AVERAGE", null, null, 0L, BigDecimal.ZERO, "r", "a", OCCURRED_AT))
+                        REVALUATION_ID,
+                        "SKU-1",
+                        "AVERAGE",
+                        null,
+                        null,
+                        BigDecimal.ZERO,
+                        BigDecimal.ZERO,
+                        "r",
+                        "a",
+                        OCCURRED_AT))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("newUnitCost");
         assertThatThrownBy(() -> new ProductValueChangedV1(
-                        REVALUATION_ID, "SKU-1", "AVERAGE", null, BigDecimal.ONE, 0L, null, "r", "a", OCCURRED_AT))
+                        REVALUATION_ID,
+                        "SKU-1",
+                        "AVERAGE",
+                        null,
+                        BigDecimal.ONE,
+                        BigDecimal.ZERO,
+                        null,
+                        "r",
+                        "a",
+                        OCCURRED_AT))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("totalValueDelta");
     }

--- a/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/ReservationOutcomeV1Test.java
+++ b/pos-domain-events/src/test/java/com/positivity/domainevents/inventory/ReservationOutcomeV1Test.java
@@ -3,6 +3,7 @@ package com.positivity.domainevents.inventory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -18,12 +19,13 @@ class ReservationOutcomeV1Test {
     private static final UUID WORKORDER_LINE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000062");
     private static final UUID SALES_ORDER_LINE_ID = UUID.fromString("01980a58-0000-7000-8000-000000000063");
     private static final UUID BACKORDER_ID = UUID.fromString("01980a58-0000-7000-8000-000000000064");
+    private static final BigDecimal THREE = new BigDecimal("3");
     private static final Instant OCCURRED_AT = Instant.parse("2026-08-18T10:00:00Z");
 
     @Test
     void roundTripsCoveredForAWorkorderLine() {
-        ReservationOutcomeV1 evt =
-                new ReservationOutcomeV1(RESERVATION_ID, WORKORDER_LINE_ID, null, "SKU-1", 3, true, null, OCCURRED_AT);
+        ReservationOutcomeV1 evt = new ReservationOutcomeV1(
+                RESERVATION_ID, WORKORDER_LINE_ID, null, "SKU-1", THREE, true, null, OCCURRED_AT);
 
         String json = MAPPER.writeValueAsString(evt);
         ReservationOutcomeV1 back = MAPPER.readValue(json, ReservationOutcomeV1.class);
@@ -36,7 +38,7 @@ class ReservationOutcomeV1Test {
     @Test
     void roundTripsUncoveredForASalesOrderLine() {
         ReservationOutcomeV1 evt = new ReservationOutcomeV1(
-                RESERVATION_ID, null, SALES_ORDER_LINE_ID, "SKU-1", 3, false, BACKORDER_ID, OCCURRED_AT);
+                RESERVATION_ID, null, SALES_ORDER_LINE_ID, "SKU-1", THREE, false, BACKORDER_ID, OCCURRED_AT);
 
         String json = MAPPER.writeValueAsString(evt);
         ReservationOutcomeV1 back = MAPPER.readValue(json, ReservationOutcomeV1.class);
@@ -49,8 +51,8 @@ class ReservationOutcomeV1Test {
 
     @Test
     void rejectsNeitherDemandLine() {
-        assertThatThrownBy(
-                        () -> new ReservationOutcomeV1(RESERVATION_ID, null, null, "SKU-1", 3, true, null, OCCURRED_AT))
+        assertThatThrownBy(() ->
+                        new ReservationOutcomeV1(RESERVATION_ID, null, null, "SKU-1", THREE, true, null, OCCURRED_AT))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("exactly one");
     }
@@ -58,7 +60,14 @@ class ReservationOutcomeV1Test {
     @Test
     void rejectsBothDemandLines() {
         assertThatThrownBy(() -> new ReservationOutcomeV1(
-                        RESERVATION_ID, WORKORDER_LINE_ID, SALES_ORDER_LINE_ID, "SKU-1", 3, true, null, OCCURRED_AT))
+                        RESERVATION_ID,
+                        WORKORDER_LINE_ID,
+                        SALES_ORDER_LINE_ID,
+                        "SKU-1",
+                        THREE,
+                        true,
+                        null,
+                        OCCURRED_AT))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("exactly one");
     }
@@ -66,15 +75,67 @@ class ReservationOutcomeV1Test {
     @Test
     void rejectsUncoveredWithoutBackorderId() {
         assertThatThrownBy(() -> new ReservationOutcomeV1(
-                        RESERVATION_ID, WORKORDER_LINE_ID, null, "SKU-1", 3, false, null, OCCURRED_AT))
+                        RESERVATION_ID, WORKORDER_LINE_ID, null, "SKU-1", THREE, false, null, OCCURRED_AT))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("backorderId");
     }
 
     @Test
+    void carriesAFractionalQuantityForADivisibleProduct() {
+        // ADR-0055 #1414: the widening exists so a product whose catalog declaration permits
+        // decimals can be reserved at its real quantity instead of a rounded one.
+        ReservationOutcomeV1 evt = new ReservationOutcomeV1(
+                RESERVATION_ID, WORKORDER_LINE_ID, null, "SKU-1", new BigDecimal("1.01"), true, null, OCCURRED_AT);
+
+        ReservationOutcomeV1 back = MAPPER.readValue(MAPPER.writeValueAsString(evt), ReservationOutcomeV1.class);
+
+        assertThat(back.requiredQuantity()).isEqualByComparingTo("1.01");
+    }
+
+    @Test
+    void rejectsZeroQuantityAtAnyScale() {
+        // Zero must stay rejected after the widening, including the scaled spellings a decimal
+        // type makes possible: a reservation for nothing is not an outcome.
+        assertThatThrownBy(() -> new ReservationOutcomeV1(
+                        RESERVATION_ID,
+                        WORKORDER_LINE_ID,
+                        null,
+                        "SKU-1",
+                        new BigDecimal("0.0000"),
+                        true,
+                        null,
+                        OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("requiredQuantity must be positive");
+    }
+
+    @Test
+    void rejectsNegativeQuantity() {
+        assertThatThrownBy(() -> new ReservationOutcomeV1(
+                        RESERVATION_ID,
+                        WORKORDER_LINE_ID,
+                        null,
+                        "SKU-1",
+                        new BigDecimal("-1"),
+                        true,
+                        null,
+                        OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("requiredQuantity must be positive");
+    }
+
+    @Test
+    void rejectsNullQuantity() {
+        assertThatThrownBy(() -> new ReservationOutcomeV1(
+                        RESERVATION_ID, WORKORDER_LINE_ID, null, "SKU-1", null, true, null, OCCURRED_AT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("requiredQuantity must be positive");
+    }
+
+    @Test
     void rejectsCoveredWithBackorderId() {
         assertThatThrownBy(() -> new ReservationOutcomeV1(
-                        RESERVATION_ID, WORKORDER_LINE_ID, null, "SKU-1", 3, true, BACKORDER_ID, OCCURRED_AT))
+                        RESERVATION_ID, WORKORDER_LINE_ID, null, "SKU-1", THREE, true, BACKORDER_ID, OCCURRED_AT))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("backorderId");
     }

--- a/pos-inventory/README.md
+++ b/pos-inventory/README.md
@@ -150,6 +150,74 @@ per vendor and never aggregated.
 Not in this module: publishing hints onward as an `inventory.supplier-availability.updated` fact
 for estimates. That waits on resolution being settled — see #1312.
 
+## Decimal quantities, gated by the product's declaration (ADR-0055, #1414)
+
+The ledger and everything derived from it carry `numeric(19,4)` / `BigDecimal` quantities:
+`inventory_ledger_entry.change_in_quantity` and `quantity_after`, the reservation / allocation /
+backorder chain, the `inventory_stock_summary` read model, the costing state, cycle-count
+variances, returns, manual adjustments and shortage records.
+
+**Widening the columns did not make stock divisible.** A product's divisibility is declared by the
+catalog as the `precision_scale` of its `BASE` row in `product_uom`, replicated here as
+`ext_product_uom`. Scale `0` — and equally a product with no unit-of-measure rows, which is every
+product until seeding lands — means whole units and is still refused a fraction. A non-zero scale
+permits that many decimal places and no more. `UomConversionService.declaredBaseScale` answers the
+question; `QuantityScaleGuard` enforces it.
+
+Enforcement is symmetric. pos-workorder gates the demand side at estimate-item entry and part issue
+(#1413); this module gates the supply side and both raise HTTP 422
+`FRACTIONAL_QUANTITY_NOT_ALLOWED` from the same declaration. The guard took over the three
+`intValueExact()` calls in receiving, ASN and returns — keeping their fail-closed character,
+losing their hardcoding — and manual stock movements, which post to the ledger just as directly,
+gained the same gate.
+
+On the read side, the `Math.toIntExact` calls that used to narrow the availability math are
+replaced by the same scale check (`QuantityScaleGuard.requireReportable`). Those calls threw rather
+than wrapping, and that fail-loud property is preserved: a stored quantity carrying more precision
+than the product declared stops the computation instead of being reported as though it were fine.
+The check only runs when the ledger's `stockItemId` names a catalog product. The ledger's posting
+paths disagree about whether that column holds a product UUID or a human SKU, and a reference that
+names no product declares nothing — which cannot be evidence that a value already in the ledger is
+wrong. Such a row is reported as stored rather than refused; refusing would turn an availability
+read into a 500 and stall the replicas behind it.
+
+**Still integral, deliberately:** pick-task quantities, putaway and transfer-order line quantities,
+and the cycle-count capture DTOs (`SubmitCountRequest.actualQuantity`, `CountEntryResponse`). These
+widen with the unit-of-measure work in ADR-0055 stages 3 and 4. Where they meet the ledger they
+widen at the boundary (`BigDecimal.valueOf`), never narrow it. Sales-order line quantities stay
+`int` by decision — see ADR-0055.
+
+Compare these quantities with `compareTo`, never `equals`: PostgreSQL returns `numeric(19,4)` at
+scale 4, so a stored `4.0000` and a computed `4` are the same quantity and are not equal.
+
+### Rollout: breaking on the wire, deployed in lockstep
+
+`InventoryAvailabilityUpdatedV1`, `ReservationOutcomeV1`, `BackorderCreatedV1`,
+`BackorderResolvedV1`, `ProductValueChangedV1` and `StorageLocationOnHandUpdatedV1` changed their
+quantity fields from `int`/`long` to `BigDecimal`. That is a **breaking payload change** for every
+consumer: the `ext_inventory_availability` replicas in pos-order, pos-workorder and pos-catalog, and
+the `ext_storage_location_on_hand` replica in pos-location.
+
+**No dual-read shim was added, deliberately.** The platform is pre-production with no live data, and
+every producer and consumer of these topics ships from this one Maven reactor, so there is no
+version skew to bridge — only a deployment ordering to respect. The repository's pre-production
+policy is explicit that clean code beats compatibility scaffolding, and a versioned-claim or
+dual-read path here would be scaffolding for a skew that cannot occur.
+
+What that costs is a constraint on the rollout, and it is stated rather than mitigated:
+
+- **Deploy the fleet together.** pos-inventory, pos-order, pos-workorder, pos-catalog and
+  pos-location must go out in the same release. A consumer running the old code against a new
+  payload rejects it as a databind failure (counted on `replica.payload.rejected`) rather than
+  landing a wrong number — loud, not silent — but the replica stops advancing until it is upgraded.
+- **Run the migrations first.** Each module's widening migration (`V39` here; `V21`, `V18`, `V13`,
+  `V5` in pos-order, pos-workorder, pos-catalog and pos-location) is a pure `ALTER … TYPE`
+  widening. `numeric(19,4)` holds every value the integer columns could, so the implicit cast
+  preserves existing rows exactly and needs no data-preservation logic.
+- **Drain or accept a stalled topic.** In-flight events published under the old shape deserialize
+  with the three core availability quantities missing, which the record constructor rejects. The
+  forecast triple defaults to zero as it always did for schema-v1 payloads.
+
 ## Configuration
 
 | Property                                             | Default  | Description                                            |

--- a/pos-inventory/openapi.yaml
+++ b/pos-inventory/openapi.yaml
@@ -5227,7 +5227,7 @@ paths:
 
         Preconditions: none beyond a positive shortQuantity; SUBSTITUTE and TRANSFER_IN options appear only when locationId is provided, and SUBSTITUTE additionally requires sku to parse as a product UUID.
 
-        Required inputs: allocationId (UUID), sku (non-blank) and shortQuantity (positive integer); workorderLineId and locationId are optional but drive which options appear.
+        Required inputs: allocationId (UUID), sku (non-blank) and shortQuantity (positive, decimal-capable per the product''s catalog precision_scale declaration); workorderLineId and locationId are optional but drive which options appear.
 
         No events are emitted and no state changes; this is a read-only computation.
 
@@ -5255,8 +5255,7 @@ paths:
         description: Quantity that is short
         required: true
         schema:
-          type: integer
-          format: int32
+          type: number
           exclusiveMinimum: 0
       - name: workorderLineId
         in: query
@@ -8326,8 +8325,7 @@ components:
           type: number
           description: Corrected unit cost
         onHandQuantity:
-          type: integer
-          format: int64
+          type: number
           description: On-hand quantity the engine had costed at revaluation time (delta basis)
         valueDelta:
           type: number
@@ -8663,8 +8661,7 @@ components:
           - TRANSFER
           example: RECEIVE
         quantity:
-          type: integer
-          format: int32
+          type: number
           description: Quantity of units being moved
           example: 12
           minimum: 0
@@ -8711,8 +8708,7 @@ components:
           example: 01960003-0000-7000-8000-000000000002
           minLength: 1
         shortQuantity:
-          type: integer
-          format: int32
+          type: number
           description: Quantity that is short and to be resolved
           example: 3
           minimum: 0
@@ -9110,9 +9106,8 @@ components:
           description: Identifier of the stock item being reserved
           example: 01960003-0000-7000-8000-000000000002
         requiredQuantity:
-          type: integer
-          format: int32
-          description: Quantity of the stock item required by the reservation
+          type: number
+          description: Quantity of the stock item required by the reservation. Decimal-capable, and permitted decimals only to the precision_scale the product's catalog declaration allows (ADR-0055)
           example: 4
           minimum: 0
       required:
@@ -9143,13 +9138,11 @@ components:
           description: Identifier of the stock item being reserved
           example: 01960003-0000-7000-8000-000000000003
         requiredQuantity:
-          type: integer
-          format: int32
+          type: number
           description: Quantity of the stock item required by the reservation
           example: 4
         allocatedQuantity:
-          type: integer
-          format: int32
+          type: number
           description: Quantity currently allocated against the reservation
           example: 4
         status:
@@ -10236,7 +10229,6 @@ components:
           example: SKU-10042
         quantity:
           type: number
-          format: double
           description: Quantity of the item moved
           example: 4.5
       required:
@@ -10581,14 +10573,12 @@ components:
           example: CYCLE_COUNT_VARIANCE
           minLength: 1
         countedQuantity:
-          type: integer
-          format: int32
+          type: number
           description: Quantity physically counted by the auditor
           example: 12
           minimum: 0
         quantityOnHandBefore:
-          type: integer
-          format: int32
+          type: number
           description: Quantity on hand recorded before the count was applied
           example: 15
         costAtTimeOfAdjustment:
@@ -10632,8 +10622,7 @@ components:
           description: Reason code explaining why the adjustment was made
           example: CYCLE_COUNT_VARIANCE
         quantityChange:
-          type: integer
-          format: int32
+          type: number
           description: Net change in quantity on hand resulting from the adjustment (may be negative)
           example: -3
         costAtTimeOfAdjustment:
@@ -10641,13 +10630,11 @@ components:
           description: Unit cost captured at the moment the adjustment was created
           example: 12.5
         quantityOnHandBefore:
-          type: integer
-          format: int32
+          type: number
           description: Quantity on hand recorded before the count was applied
           example: 15
         countedQuantity:
-          type: integer
-          format: int32
+          type: number
           description: Quantity physically counted by the auditor
           example: 12
         status:
@@ -11022,8 +11009,7 @@ components:
           description: Identifier of the location the quantity applies to
           example: 01960003-0000-7000-8000-000000000001
         quantity:
-          type: integer
-          format: int32
+          type: number
           description: Quantity to ingest for the product (non-negative)
           example: 120
           minimum: 0
@@ -11386,8 +11372,7 @@ components:
           description: Number of audit records created during the reallocation
           example: 3
         atpAfterReallocation:
-          type: integer
-          format: int32
+          type: number
           description: Available-to-promise quantity for the stock item after reallocation
           example: 20
       required:
@@ -11410,8 +11395,7 @@ components:
           description: Identifier of the location where the adjustment applies
           example: 01960003-0000-7000-8000-000000000001
         quantity:
-          type: integer
-          format: int32
+          type: number
           description: Adjustment quantity (positive to add stock, negative to remove)
           example: 12
         reasonCode:
@@ -11447,8 +11431,7 @@ components:
           description: Identifier of the location where the adjustment applies
           example: 01960003-0000-7000-8000-000000000002
         quantity:
-          type: integer
-          format: int32
+          type: number
           description: Requested adjustment quantity (positive to add, negative to remove)
           example: 12
         reasonCode:
@@ -11514,8 +11497,7 @@ components:
           type: string
           description: SKU / stock-item identifier
         onHand:
-          type: integer
-          format: int64
+          type: number
           description: On-hand quantity contributing to the value (site-scoped when a location filter is applied)
           example: 20
         costingMethod:
@@ -11725,18 +11707,15 @@ components:
       description: On-hand, allocated and available quantity triple used at every rollup node
       properties:
         onHand:
-          type: integer
-          format: int64
+          type: number
           description: On-hand quantity
           example: 120
         allocated:
-          type: integer
-          format: int64
+          type: number
           description: Outstanding allocated quantity
           example: 30
         available:
-          type: integer
-          format: int64
+          type: number
           description: 'Available to promise: onHand - allocated (may be negative)'
           example: 90
         empty:
@@ -11832,8 +11811,7 @@ components:
           description: Source site surplus can be pulled from, when the option is TRANSFER_IN
           example: 01960004-0001-7000-8000-00000000000a
         availableQuantity:
-          type: integer
-          format: int64
+          type: number
           description: Quantity available toward the shortage for SUBSTITUTE / TRANSFER_IN options
           example: 12
         expectedResolutionDate:
@@ -12025,12 +12003,10 @@ components:
           format: date-time
           description: When the movement was posted
         changeInQuantity:
-          type: integer
-          format: int32
+          type: number
           description: Signed quantity change (positive inbound, negative outbound)
         quantityAfter:
-          type: integer
-          format: int32
+          type: number
           description: On-hand quantity after this movement at its location
         locationId:
           type: string
@@ -12239,13 +12215,11 @@ components:
           description: Identifier of the location the policy applies to
           example: 01960003-0000-7000-8000-000000000002
         onHand:
-          type: integer
-          format: int64
+          type: number
           description: Current on-hand quantity at the policy's location
           example: 3
         projectedAvailable:
-          type: integer
-          format: int64
+          type: number
           description: Projected available quantity at the lead-time horizon (on-hand + expected supply - open demand)
           example: 3
         leadHorizonDate:
@@ -12323,13 +12297,11 @@ components:
           description: Location holding the lot; null for postings recorded without a location
           example: 01980003-0000-7000-8000-000000000004
         onHand:
-          type: integer
-          format: int64
+          type: number
           description: On-hand quantity of the lot at the location
           example: 12
         inTransitQty:
-          type: integer
-          format: int64
+          type: number
           description: Quantity of the lot in transit toward the location
           example: 0
       required:
@@ -12428,8 +12400,7 @@ components:
           description: Stock item identifier (product SKU)
           example: MICH-XC2-0001
         onHandQuantity:
-          type: integer
-          format: int64
+          type: number
           description: On-hand quantity of this stock item at the location
           example: 24
       required:
@@ -12460,13 +12431,11 @@ components:
           format: uuid
           description: Storage location identifier
         onHandQuantity:
-          type: integer
-          format: int64
+          type: number
           description: Current on-hand quantity across all stock items at the location
           example: 12
         availableToPromiseQuantity:
-          type: integer
-          format: int64
+          type: number
           description: 'Quantity available to promise after pending allocations. Note: reservation events are not yet factored in. Null for as-of (historical) requests: historical allocation state is not reliably reconstructable from ATP-neutral ledger events, so as-of responses carry on-hand only.'
           example: 8
       required:
@@ -12530,13 +12499,11 @@ components:
           - PICK_TASK_COMPLETED
           example: GOODS_RECEIPT
         changeInQuantity:
-          type: integer
-          format: int32
+          type: number
           description: Signed change in quantity applied by this entry (positive inbound, negative outbound)
           example: 12
         quantityAfter:
-          type: integer
-          format: int32
+          type: number
           description: Running quantity after this entry was applied
           example: 120
         unitCost:
@@ -12706,13 +12673,11 @@ components:
           - PICK_TASK_COMPLETED
           example: GOODS_ISSUE
         changeInQuantity:
-          type: integer
-          format: int32
+          type: number
           description: Signed change in quantity applied by this entry (positive inbound, negative outbound)
           example: -3
         quantityAfter:
-          type: integer
-          format: int32
+          type: number
           description: Running quantity after this entry was applied
           example: 7
         locationId:
@@ -12823,8 +12788,7 @@ components:
           format: uuid
           description: Site the demand is short at
         quantityShort:
-          type: integer
-          format: int32
+          type: number
           description: Quantity that could not be fulfilled (positive)
         status:
           type: string
@@ -12874,18 +12838,15 @@ components:
           description: Optional storage sub-location identifier; null when scoped to the full location
           example: 01960003-0000-7000-8000-000000000002
         onHandQuantity:
-          type: integer
-          format: int32
+          type: number
           description: Net on-hand quantity (sum of affectsOnHand ledger entries)
           example: 120
         allocatedQuantity:
-          type: integer
-          format: int32
+          type: number
           description: Net allocated quantity (ALLOCATION_CREATED minus ALLOCATION_RELEASED)
           example: 30
         availableToPromiseQuantity:
-          type: integer
-          format: int32
+          type: number
           description: Available-to-promise quantity, equal to onHandQuantity minus allocatedQuantity
           example: 90
         unitOfMeasure:
@@ -12893,18 +12854,15 @@ components:
           description: Unit of measure code for the quantities (e.g. EACH, KG)
           example: EACH
         incomingQty:
-          type: integer
-          format: int64
+          type: number
           description: 'Open expected supply: approved purchase-order open line quantity plus un-received ASN remainder. Site-level when a location scope is given. Bounded by the ''horizon'' query parameter when present (documents without an expected date are excluded from horizon-bounded results). Omitted for as-of (historical) requests.'
           example: 25
         outgoingQty:
-          type: integer
-          format: int64
+          type: number
           description: 'Open expected demand not yet decremented from on-hand: unallocated reservation remainders plus released-not-picked pick-task remainders. Reservation demand carries no site and is included in every scope. Omitted for as-of (historical) requests.'
           example: 10
         projectedAvailable:
-          type: integer
-          format: int64
+          type: number
           description: 'Projected availability: onHandQuantity + incomingQty - outgoingQty. Omitted for as-of (historical) requests.'
           example: 135
       required:
@@ -12928,28 +12886,23 @@ components:
           description: Human-readable name of the location
           example: Main Warehouse
         onHandQuantity:
-          type: integer
-          format: int32
+          type: number
           description: On-hand quantity at the location
           example: 120
         availableToPromiseQuantity:
-          type: integer
-          format: int32
+          type: number
           description: 'Available-to-promise quantity at the location. Null for as-of (historical) requests: historical allocation state is not reliably reconstructable from ATP-neutral ledger events, so as-of responses carry on-hand only.'
           example: 90
         incomingQty:
-          type: integer
-          format: int64
+          type: number
           description: 'Open expected supply at the site: approved purchase-order open line quantity plus un-received ASN remainder. Bounded by the ''horizon'' query parameter when present (documents without an expected date are excluded from horizon-bounded results). Omitted for as-of requests.'
           example: 25
         outgoingQty:
-          type: integer
-          format: int64
+          type: number
           description: 'Open expected demand not yet decremented from on-hand: unallocated reservation remainders plus released-not-picked pick-task remainders. Reservation demand carries no site and is included in every site row. Omitted for as-of requests.'
           example: 10
         projectedAvailable:
-          type: integer
-          format: int64
+          type: number
           description: 'Projected availability: onHandQuantity + incomingQty - outgoingQty (Odoo virtual_available). Omitted for as-of requests.'
           example: 135
       required:

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/config/InventoryCommandListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/config/InventoryCommandListener.java
@@ -8,6 +8,7 @@ import com.positivity.inventory.service.ConsumptionService;
 import com.positivity.inventory.service.OutboxReplayService;
 import com.positivity.inventory.service.PickListService;
 import com.positivity.inventory.service.ReservationRequestService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -263,7 +264,10 @@ public class InventoryCommandListener {
         UUID salesOrderLineId = parseUuid(payload, "salesOrderLineId");
         UUID stockItemId = parseUuid(payload, "stockItemId");
         UUID locationId = parseUuid(payload, "locationId");
-        int requiredQuantity = payload.path("requiredQuantity").intValue(0);
+        // decimalValue() rather than intValue(): the reservation command carries a decimal
+        // quantity since ADR-0055 (#1414), and reading it as an int would truncate a divisible
+        // product's demand at the very edge the widening exists to open.
+        BigDecimal requiredQuantity = payload.path("requiredQuantity").decimalValue(BigDecimal.ZERO);
         if ((workorderLineId == null) == (salesOrderLineId == null)) {
             log.warn(
                     "Ignoring reservation-request command: exactly one of workorderLineId/salesOrderLineId must be"
@@ -271,7 +275,7 @@ public class InventoryCommandListener {
                     payload);
             return;
         }
-        if (stockItemId == null || locationId == null || requiredQuantity <= 0) {
+        if (stockItemId == null || locationId == null || requiredQuantity.signum() <= 0) {
             log.warn("Ignoring reservation-request command with missing/invalid fields: {}", payload);
             return;
         }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/InventoryGlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.positivity.inventory.internal.exception.CrossSiteTransferRequiresOrde
 import com.positivity.inventory.internal.exception.CycleCountConflictException;
 import com.positivity.inventory.internal.exception.CycleCountPlanNotFoundException;
 import com.positivity.inventory.internal.exception.DuplicateAsnException;
+import com.positivity.inventory.internal.exception.FractionalQuantityNotAllowedException;
 import com.positivity.inventory.internal.exception.InsufficientAtpException;
 import com.positivity.inventory.internal.exception.InsufficientPermissionException;
 import com.positivity.inventory.internal.exception.InsufficientStockException;
@@ -305,6 +306,15 @@ public class InventoryGlobalExceptionHandler {
     @ExceptionHandler(PartMatchPermissionException.class)
     public ResponseEntity<ApiError> handlePartMatchPermission(PartMatchPermissionException ex) {
         return build(HttpStatus.FORBIDDEN, "PART_MATCH_PERMISSION_REQUIRED", ex.getMessage());
+    }
+
+    @ExceptionHandler(FractionalQuantityNotAllowedException.class)
+    public ResponseEntity<ApiError> handleFractionalQuantityNotAllowed(FractionalQuantityNotAllowedException ex) {
+        // ADR-0055 (#1414): the posted quantity carries more decimals than the product's catalog
+        // declaration allows. 422, not 400 — the request is well-formed and passes its bounds;
+        // what it violates can only be known after looking the product up. Same code as
+        // pos-workorder's demand-side gate (#1413), because it is the same invariant.
+        return build(HttpStatus.valueOf(422), FractionalQuantityNotAllowedException.ERROR_CODE, ex.getMessage());
     }
 
     @ExceptionHandler(UomConversionUndefinedException.class)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ShortageController.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/controller/ShortageController.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -61,7 +62,8 @@ public class ShortageController {
                     Preconditions: none beyond a positive shortQuantity; SUBSTITUTE and TRANSFER_IN options appear \
                     only when locationId is provided, and SUBSTITUTE additionally requires sku to parse as a \
                     product UUID.
-                    Required inputs: allocationId (UUID), sku (non-blank) and shortQuantity (positive integer); \
+                    Required inputs: allocationId (UUID), sku (non-blank) and shortQuantity (positive, decimal-capable \
+                    per the product's catalog precision_scale declaration); \
                     workorderLineId and locationId are optional but drive which options appear.
                     No events are emitted and no state changes; this is a read-only computation.
                     Returns 400 when shortQuantity is not positive or sku is blank.
@@ -85,7 +87,7 @@ public class ShortageController {
     public ResponseEntity<List<ShortageOptionDto>> listShortageOptions(
             @Parameter(description = "Allocation experiencing the shortage") @RequestParam UUID allocationId,
             @Parameter(description = "SKU / stock-item identifier that is short") @RequestParam @NotBlank String sku,
-            @Parameter(description = "Quantity that is short") @RequestParam @Positive int shortQuantity,
+            @Parameter(description = "Quantity that is short") @RequestParam @Positive BigDecimal shortQuantity,
             @Parameter(description = "Workorder line whose demand is short") @RequestParam(required = false)
                     UUID workorderLineId,
             @Parameter(description = "Site the demand is short at") @RequestParam(required = false) UUID locationId) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/AdjustmentRequestResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/AdjustmentRequestResponse.java
@@ -4,6 +4,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Value;
@@ -44,7 +45,7 @@ public class AdjustmentRequestResponse {
             example = "12",
             requiredMode = REQUIRED)
     @NotNull
-    Integer quantity;
+    BigDecimal quantity;
 
     @Schema(
             description = "Reason code explaining why the adjustment was requested",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/AvailabilityView.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/AvailabilityView.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Value;
@@ -53,21 +54,21 @@ public class AvailabilityView {
             description = "Net on-hand quantity (sum of affectsOnHand ledger entries)",
             example = "120",
             requiredMode = REQUIRED)
-    int onHandQuantity;
+    BigDecimal onHandQuantity;
 
     /** Net allocated quantity (ALLOCATION_CREATED minus ALLOCATION_RELEASED). */
     @Schema(
             description = "Net allocated quantity (ALLOCATION_CREATED minus ALLOCATION_RELEASED)",
             example = "30",
             requiredMode = REQUIRED)
-    int allocatedQuantity;
+    BigDecimal allocatedQuantity;
 
     /** ATP = onHandQuantity - allocatedQuantity. */
     @Schema(
             description = "Available-to-promise quantity, equal to onHandQuantity minus allocatedQuantity",
             example = "90",
             requiredMode = REQUIRED)
-    int availableToPromiseQuantity;
+    BigDecimal availableToPromiseQuantity;
 
     /** Unit of measure code (e.g. EACH, KG). */
     @Schema(
@@ -89,7 +90,7 @@ public class AvailabilityView {
                             + "Omitted for as-of (historical) requests.",
             example = "25",
             requiredMode = NOT_REQUIRED)
-    Long incomingQty;
+    BigDecimal incomingQty;
 
     /**
      * Open expected demand not yet decremented from on-hand (unallocated reservation remainders +
@@ -102,7 +103,7 @@ public class AvailabilityView {
                             + "in every scope. Omitted for as-of (historical) requests.",
             example = "10",
             requiredMode = NOT_REQUIRED)
-    Long outgoingQty;
+    BigDecimal outgoingQty;
 
     /** Projected availability: onHandQuantity + incomingQty - outgoingQty (Odoo virtual_available). */
     @Schema(
@@ -110,5 +111,5 @@ public class AvailabilityView {
                     + "Omitted for as-of (historical) requests.",
             example = "135",
             requiredMode = NOT_REQUIRED)
-    Long projectedAvailable;
+    BigDecimal projectedAvailable;
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/CreateAdjustmentRequestDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/CreateAdjustmentRequestDto.java
@@ -6,6 +6,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -40,7 +41,7 @@ public class CreateAdjustmentRequestDto {
             example = "12",
             requiredMode = REQUIRED)
     @NotNull
-    Integer quantity;
+    BigDecimal quantity;
 
     /** Mandatory reason code explaining the adjustment. */
     @Schema(

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/DeactivateLocationResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/DeactivateLocationResponse.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -74,7 +75,7 @@ public class DeactivateLocationResponse {
         private String itemId;
 
         @Schema(description = "Quantity of the item moved", example = "4.5", requiredMode = REQUIRED)
-        private double quantity;
+        private BigDecimal quantity;
 
         public String getItemId() {
             return itemId;
@@ -84,11 +85,11 @@ public class DeactivateLocationResponse {
             this.itemId = itemId;
         }
 
-        public double getQuantity() {
+        public BigDecimal getQuantity() {
             return quantity;
         }
 
-        public void setQuantity(double quantity) {
+        public void setQuantity(BigDecimal quantity) {
             this.quantity = quantity;
         }
     }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/InventoryBulkIngestRecord.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/InventoryBulkIngestRecord.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.Data;
 
@@ -30,7 +31,7 @@ public class InventoryBulkIngestRecord {
     @Schema(description = "Quantity to ingest for the product (non-negative)", example = "120", requiredMode = REQUIRED)
     @NotNull
     @Min(0)
-    private Integer quantity;
+    private BigDecimal quantity;
 
     @Schema(
             description = "Optional reason code explaining the ingest",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/InventoryLedgerEntryDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/InventoryLedgerEntryDto.java
@@ -50,11 +50,11 @@ public class InventoryLedgerEntryDto {
             example = "12",
             requiredMode = REQUIRED)
     @NotNull
-    private Integer changeInQuantity;
+    private BigDecimal changeInQuantity;
 
     @Schema(description = "Running quantity after this entry was applied", example = "120", requiredMode = REQUIRED)
     @NotNull
-    private Integer quantityAfter;
+    private BigDecimal quantityAfter;
 
     @Schema(
             description = "Unit cost associated with this movement, if recorded",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/InventoryLedgerEntryResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/InventoryLedgerEntryResponse.java
@@ -49,11 +49,11 @@ public class InventoryLedgerEntryResponse {
             example = "12",
             requiredMode = REQUIRED)
     @NotNull
-    Integer changeInQuantity;
+    BigDecimal changeInQuantity;
 
     @Schema(description = "Running quantity after this entry was applied", example = "120", requiredMode = REQUIRED)
     @NotNull
-    Integer quantityAfter;
+    BigDecimal quantityAfter;
 
     @Schema(
             description = "Unit cost associated with this movement, if recorded",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationAvailabilityDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationAvailabilityDto.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,7 +36,7 @@ public class LocationAvailabilityDto {
     private String locationName;
 
     @Schema(description = "On-hand quantity at the location", example = "120", requiredMode = REQUIRED)
-    private int onHandQuantity;
+    private BigDecimal onHandQuantity;
 
     @Schema(
             description = "Available-to-promise quantity at the location. Null for as-of (historical) requests: "
@@ -43,7 +44,7 @@ public class LocationAvailabilityDto {
                     + "so as-of responses carry on-hand only.",
             example = "90",
             requiredMode = NOT_REQUIRED)
-    private Integer availableToPromiseQuantity;
+    private BigDecimal availableToPromiseQuantity;
 
     @Schema(
             description =
@@ -52,7 +53,7 @@ public class LocationAvailabilityDto {
                             + "an expected date are excluded from horizon-bounded results). Omitted for as-of requests.",
             example = "25",
             requiredMode = NOT_REQUIRED)
-    private Long incomingQty;
+    private BigDecimal incomingQty;
 
     @Schema(
             description =
@@ -61,12 +62,12 @@ public class LocationAvailabilityDto {
                             + "included in every site row. Omitted for as-of requests.",
             example = "10",
             requiredMode = NOT_REQUIRED)
-    private Long outgoingQty;
+    private BigDecimal outgoingQty;
 
     @Schema(
             description = "Projected availability: onHandQuantity + incomingQty - outgoingQty "
                     + "(Odoo virtual_available). Omitted for as-of requests.",
             example = "135",
             requiredMode = NOT_REQUIRED)
-    private Long projectedAvailable;
+    private BigDecimal projectedAvailable;
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryInquiryResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryInquiryResponse.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.internal.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,7 +25,7 @@ public class LocationInventoryInquiryResponse {
             description = "Current on-hand quantity across all stock items at the location",
             example = "12",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private long onHandQuantity;
+    private BigDecimal onHandQuantity;
 
     @Schema(
             description =
@@ -33,5 +34,5 @@ public class LocationInventoryInquiryResponse {
                             + "reconstructable from ATP-neutral ledger events, so as-of responses carry on-hand only.",
             example = "8",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private Long availableToPromiseQuantity;
+    private BigDecimal availableToPromiseQuantity;
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryItemsResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/LocationInventoryItemsResponse.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.internal.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -41,6 +42,6 @@ public class LocationInventoryItemsResponse {
                 description = "On-hand quantity of this stock item at the location",
                 example = "24",
                 requiredMode = Schema.RequiredMode.REQUIRED)
-        private long onHandQuantity;
+        private BigDecimal onHandQuantity;
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/RecordMovementRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/RecordMovementRequest.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -67,7 +68,7 @@ public class RecordMovementRequest {
     @Schema(description = "Quantity of units being moved", example = "12", requiredMode = REQUIRED)
     @NotNull
     @Positive
-    Integer quantity;
+    BigDecimal quantity;
 
     @Schema(description = "Unit of measure for the quantity", example = "EACH", requiredMode = NOT_REQUIRED)
     String unitOfMeasure;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/ShortageOptionDto.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/ShortageOptionDto.java
@@ -63,7 +63,7 @@ public class ShortageOptionDto {
             example = "12",
             requiredMode = NOT_REQUIRED)
     @Nullable
-    private Long availableQuantity;
+    private BigDecimal availableQuantity;
 
     @Schema(
             description = "Estimated date the shortage would be resolved via this option",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/ShortageResolveRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/ShortageResolveRequest.java
@@ -54,6 +54,7 @@ public class ShortageResolveRequest {
     private String sku;
 
     @Schema(description = "Quantity that is short and to be resolved", example = "3", requiredMode = REQUIRED)
+    @NotNull
     @Positive
     private BigDecimal shortQuantity;
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/ShortageResolveRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/ShortageResolveRequest.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -54,7 +55,7 @@ public class ShortageResolveRequest {
 
     @Schema(description = "Quantity that is short and to be resolved", example = "3", requiredMode = REQUIRED)
     @Positive
-    private int shortQuantity;
+    private BigDecimal shortQuantity;
 
     @Schema(
             description = "Site the demand is short at (required for BACKORDER / TRANSFER_IN)",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/backorder/BackorderResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/backorder/BackorderResponse.java
@@ -3,6 +3,7 @@ package com.positivity.inventory.internal.dto.backorder;
 import com.positivity.inventory.internal.enums.BackorderResolutionSource;
 import com.positivity.inventory.internal.enums.BackorderStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
@@ -36,7 +37,7 @@ public class BackorderResponse {
     private UUID locationId;
 
     @Schema(description = "Quantity that could not be fulfilled (positive)")
-    private Integer quantityShort;
+    private BigDecimal quantityShort;
 
     @Schema(description = "Lifecycle status: OPEN, RESOLVED, or CANCELLED")
     private BackorderStatus status;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/AdjustmentResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/AdjustmentResponse.java
@@ -57,7 +57,7 @@ public class AdjustmentResponse {
             example = "-3",
             requiredMode = REQUIRED)
     @NotNull
-    private Integer quantityChange;
+    private BigDecimal quantityChange;
 
     @Schema(
             description = "Unit cost captured at the moment the adjustment was created",
@@ -71,11 +71,11 @@ public class AdjustmentResponse {
             example = "15",
             requiredMode = REQUIRED)
     @NotNull
-    private Integer quantityOnHandBefore;
+    private BigDecimal quantityOnHandBefore;
 
     @Schema(description = "Quantity physically counted by the auditor", example = "12", requiredMode = REQUIRED)
     @NotNull
-    private Integer countedQuantity;
+    private BigDecimal countedQuantity;
 
     @Schema(
             description = "Current lifecycle status of the adjustment",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/CreateAdjustmentRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/CreateAdjustmentRequest.java
@@ -45,14 +45,14 @@ public class CreateAdjustmentRequest {
     @Schema(description = "Quantity physically counted by the auditor", example = "12", requiredMode = REQUIRED)
     @NotNull(message = "Counted quantity is required")
     @Min(value = 0, message = "Counted quantity cannot be negative")
-    private Integer countedQuantity;
+    private BigDecimal countedQuantity;
 
     @Schema(
             description = "Quantity on hand recorded before the count was applied",
             example = "15",
             requiredMode = REQUIRED)
     @NotNull(message = "Quantity on-hand before count is required")
-    private Integer quantityOnHandBefore;
+    private BigDecimal quantityOnHandBefore;
 
     @Schema(
             description = "Unit cost to capture at the time of the adjustment",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/InterferingMovementResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/cyclecount/InterferingMovementResponse.java
@@ -6,6 +6,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
@@ -37,10 +38,10 @@ public class InterferingMovementResponse {
             example = "-3",
             requiredMode = REQUIRED)
     @NotNull
-    Integer changeInQuantity;
+    BigDecimal changeInQuantity;
 
     @Schema(description = "Running quantity after this entry was applied", example = "7", requiredMode = NOT_REQUIRED)
-    Integer quantityAfter;
+    BigDecimal quantityAfter;
 
     @Schema(
             description = "Location the entry applies to",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/lot/LotDetailResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/lot/LotDetailResponse.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -44,12 +45,12 @@ public class LotDetailResponse {
         private UUID locationId;
 
         @Schema(description = "On-hand quantity of the lot at the location", example = "12", requiredMode = REQUIRED)
-        private long onHand;
+        private BigDecimal onHand;
 
         @Schema(
                 description = "Quantity of the lot in transit toward the location",
                 example = "0",
                 requiredMode = REQUIRED)
-        private long inTransitQty;
+        private BigDecimal inTransitQty;
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/reallocation/ReallocateResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/reallocation/ReallocateResponse.java
@@ -4,6 +4,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -40,5 +41,5 @@ public class ReallocateResponse {
             description = "Available-to-promise quantity for the stock item after reallocation",
             example = "20",
             requiredMode = REQUIRED)
-    private int atpAfterReallocation;
+    private BigDecimal atpAfterReallocation;
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/ReplenishmentNeedResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/replenishment/ReplenishmentNeedResponse.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -44,14 +45,14 @@ public class ReplenishmentNeedResponse {
     private UUID locationId;
 
     @Schema(description = "Current on-hand quantity at the policy's location", example = "3", requiredMode = REQUIRED)
-    private long onHand;
+    private BigDecimal onHand;
 
     @Schema(
             description = "Projected available quantity at the lead-time horizon"
                     + " (on-hand + expected supply - open demand)",
             example = "3",
             requiredMode = REQUIRED)
-    private long projectedAvailable;
+    private BigDecimal projectedAvailable;
 
     @Schema(
             description = "UTC date of the lead-time horizon the projection was evaluated at",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/reservation/CreateReservationRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/reservation/CreateReservationRequest.java
@@ -6,6 +6,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -42,17 +43,20 @@ public class CreateReservationRequest {
     private UUID stockItemId;
 
     @Schema(
-            description = "Quantity of the stock item required by the reservation",
+            description = "Quantity of the stock item required by the reservation. Decimal-capable, and"
+                    + " permitted decimals only to the precision_scale the product's catalog declaration allows"
+                    + " (ADR-0055)",
             example = "4",
             requiredMode = REQUIRED)
+    @NotNull
     @Positive
-    private int requiredQuantity;
+    private BigDecimal requiredQuantity;
 
     /**
      * Workorder-line convenience constructor, predating the CAP #1315 sales-order-line addition.
      * Equivalent to the all-args constructor with {@code salesOrderLineId = null}.
      */
-    public CreateReservationRequest(UUID workorderLineId, UUID stockItemId, int requiredQuantity) {
+    public CreateReservationRequest(UUID workorderLineId, UUID stockItemId, BigDecimal requiredQuantity) {
         this(workorderLineId, null, stockItemId, requiredQuantity);
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/reservation/ReservationResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/reservation/ReservationResponse.java
@@ -4,6 +4,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Data;
@@ -43,13 +44,13 @@ public class ReservationResponse {
             description = "Quantity of the stock item required by the reservation",
             example = "4",
             requiredMode = REQUIRED)
-    private int requiredQuantity;
+    private BigDecimal requiredQuantity;
 
     @Schema(
             description = "Quantity currently allocated against the reservation",
             example = "4",
             requiredMode = REQUIRED)
-    private int allocatedQuantity;
+    private BigDecimal allocatedQuantity;
 
     @Schema(
             description = "Status of the reservation, such as PENDING, ALLOCATED, or HARDENED",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnItemLine.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnItemLine.java
@@ -31,10 +31,11 @@ public class ReturnItemLine {
     @Schema(
             description = "Quantity of the SKU being returned, in the product's base UoM. Required unless"
                     + " documentUom/documentQuantity are supplied, in which case the base quantity is derived and"
-                    + " this field is ignored",
+                    + " this field is ignored. May carry decimals only to the precision_scale the product's"
+                    + " catalog declaration allows (422 FRACTIONAL_QUANTITY_NOT_ALLOWED otherwise)",
             example = "2",
             requiredMode = NOT_REQUIRED)
-    private int quantityReturned;
+    private BigDecimal quantityReturned;
 
     @Schema(
             description = "Optional UoM the return line is keyed in (e.g. CASE). When present, documentQuantity"
@@ -61,14 +62,16 @@ public class ReturnItemLine {
     private String lotNumber;
 
     /** Pre-E2 arity kept for existing callers/tests: no lot number keyed. */
-    public ReturnItemLine(UUID skuId, int quantityReturned, String documentUom, BigDecimal documentQuantity) {
+    public ReturnItemLine(UUID skuId, BigDecimal quantityReturned, String documentUom, BigDecimal documentQuantity) {
         this(skuId, quantityReturned, documentUom, documentQuantity, null);
     }
 
     @JsonIgnore
     @AssertTrue(message = "quantityReturned must be positive when documentUom/documentQuantity are absent")
     public boolean isQuantitySourcePresent() {
-        return quantityReturned > 0 || documentUom != null || documentQuantity != null;
+        return (quantityReturned != null && quantityReturned.signum() > 0)
+                || documentUom != null
+                || documentQuantity != null;
     }
 
     @JsonIgnore

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/returns/ReturnResponse.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -39,7 +40,7 @@ public class ReturnResponse {
     private String returnReason;
 
     @Schema(description = "Total number of items returned across all lines", example = "5", requiredMode = REQUIRED)
-    private int totalItemsReturned;
+    private BigDecimal totalItemsReturned;
 
     @Schema(
             description = "Timestamp when the return was created",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/revaluation/RevaluationResponse.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/revaluation/RevaluationResponse.java
@@ -38,7 +38,7 @@ public class RevaluationResponse {
     private BigDecimal newUnitCost;
 
     @Schema(description = "On-hand quantity the engine had costed at revaluation time (delta basis)")
-    private long onHandQuantity;
+    private BigDecimal onHandQuantity;
 
     @Schema(description = "Signed inventory value change: (newUnitCost - previousUnitCost) x onHandQuantity")
     private BigDecimal valueDelta;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/rollup/RollupQuantities.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/rollup/RollupQuantities.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.internal.dto.rollup;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
 
 /**
  * Quantity triple used at every rollup node. {@code available} is
@@ -10,31 +11,32 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "On-hand, allocated and available quantity triple used at every rollup node")
 public record RollupQuantities(
         @Schema(description = "On-hand quantity", example = "120", requiredMode = Schema.RequiredMode.REQUIRED)
-        long onHand,
+        BigDecimal onHand,
 
         @Schema(
                 description = "Outstanding allocated quantity",
                 example = "30",
                 requiredMode = Schema.RequiredMode.REQUIRED)
-        long allocated,
+        BigDecimal allocated,
 
         @Schema(
                 description = "Available to promise: onHand - allocated (may be negative)",
                 example = "90",
                 requiredMode = Schema.RequiredMode.REQUIRED)
-        long available) {
+        BigDecimal available) {
 
-    public static final RollupQuantities ZERO = new RollupQuantities(0, 0, 0);
+    public static final RollupQuantities ZERO = new RollupQuantities(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO);
 
-    public static RollupQuantities of(long onHand, long allocated) {
-        return new RollupQuantities(onHand, allocated, onHand - allocated);
+    public static RollupQuantities of(BigDecimal onHand, BigDecimal allocated) {
+        return new RollupQuantities(onHand, allocated, onHand.subtract(allocated));
     }
 
     public RollupQuantities plus(RollupQuantities other) {
-        return of(onHand + other.onHand, allocated + other.allocated);
+        return of(onHand.add(other.onHand), allocated.add(other.allocated));
     }
 
+    /** {@code signum}, not {@code equals}: {@code 0.0000} from numeric(19,4) is still empty. */
     public boolean isEmpty() {
-        return onHand == 0 && allocated == 0;
+        return onHand.signum() == 0 && allocated.signum() == 0;
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/traceability/TraceabilityMovement.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/traceability/TraceabilityMovement.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -34,10 +35,10 @@ public class TraceabilityMovement {
     private Instant timestamp;
 
     @Schema(description = "Signed quantity change (positive inbound, negative outbound)", requiredMode = REQUIRED)
-    private Integer changeInQuantity;
+    private BigDecimal changeInQuantity;
 
     @Schema(description = "On-hand quantity after this movement at its location", requiredMode = NOT_REQUIRED)
-    private Integer quantityAfter;
+    private BigDecimal quantityAfter;
 
     @Schema(description = "Location the movement affected", requiredMode = NOT_REQUIRED)
     private UUID locationId;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/valuation/ValuationRow.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/dto/valuation/ValuationRow.java
@@ -31,7 +31,7 @@ public class ValuationRow {
             description = "On-hand quantity contributing to the value (site-scoped when a location filter is applied)",
             example = "20",
             requiredMode = Schema.RequiredMode.REQUIRED)
-    private long onHand;
+    private BigDecimal onHand;
 
     @Schema(
             description = "Resolved costing method for the SKU (AVERAGE or STANDARD)",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/AllocationEntity.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/AllocationEntity.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -45,8 +46,12 @@ public class AllocationEntity {
     @Column(nullable = true)
     private UUID locationId;
 
-    @Column(nullable = false)
-    private int allocatedQuantity;
+    /**
+     * Quantity hard-allocated by this allocation. Decimal-capable (ADR-0055, #1414); the
+     * product's declared {@code precision_scale} is what constrains it, not the type.
+     */
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal allocatedQuantity;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/BackorderRecord.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/BackorderRecord.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -83,9 +84,13 @@ public class BackorderRecord {
     @Column(name = "location_id")
     private UUID locationId;
 
-    /** Quantity that could not be fulfilled; always positive. */
-    @Column(name = "quantity_short", nullable = false)
-    private Integer quantityShort;
+    /**
+     * Quantity that could not be fulfilled; always positive (DB CHECK). Decimal-capable
+     * (ADR-0055, #1414): a shortfall on a divisible product is itself divisible, and rounding it
+     * to a whole unit would either invent demand or lose it. Compare with {@code compareTo}.
+     */
+    @Column(name = "quantity_short", nullable = false, precision = 19, scale = 4)
+    private BigDecimal quantityShort;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/CycleCountAdjustment.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/CycleCountAdjustment.java
@@ -62,9 +62,16 @@ public class CycleCountAdjustment {
     /**
      * The variance quantity to be applied. Can be positive (overage) or negative
      * (shrinkage).
+     *
+     * <p>Decimal since ADR-0055 (#1414). The variance posts straight into the ledger, so it has to
+     * be able to hold what the ledger can — a bulk SKU's shrinkage is a fraction of a unit by
+     * nature, and an integral variance column would have rounded it away at the one place the
+     * platform gets to notice it. The count-capture DTOs are still {@code Integer}; making the
+     * counter able to key a decimal is stage 4 (#1416), and so is the tolerance policy that
+     * decides which small variances are worth surfacing.
      */
-    @Column(nullable = false)
-    private Integer quantityChange;
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal quantityChange;
 
     /**
      * The item's cost price at the time the adjustment was proposed.
@@ -76,14 +83,14 @@ public class CycleCountAdjustment {
     /**
      * Quantity on-hand in system before the adjustment.
      */
-    @Column(nullable = false)
-    private Integer quantityOnHandBefore;
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal quantityOnHandBefore;
 
     /**
      * Actual counted quantity that triggered this adjustment.
      */
-    @Column(nullable = false)
-    private Integer countedQuantity;
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal countedQuantity;
 
     /**
      * Current status of the adjustment in its lifecycle.
@@ -171,7 +178,7 @@ public class CycleCountAdjustment {
      * @return absolute value of (quantityChange * costAtTimeOfAdjustment)
      */
     public BigDecimal getVarianceValue() {
-        return costAtTimeOfAdjustment.multiply(BigDecimal.valueOf(Math.abs(quantityChange)));
+        return costAtTimeOfAdjustment.multiply(quantityChange.abs());
     }
 
     /**
@@ -180,11 +187,12 @@ public class CycleCountAdjustment {
      * @return percentage variance, or 100% if quantityOnHandBefore is 0
      */
     public BigDecimal getVariancePercentage() {
-        if (quantityOnHandBefore == 0) {
+        if (quantityOnHandBefore.signum() == 0) {
             return BigDecimal.valueOf(100);
         }
-        return BigDecimal.valueOf(Math.abs(quantityChange))
-                .divide(BigDecimal.valueOf(Math.abs(quantityOnHandBefore)), 4, java.math.RoundingMode.HALF_UP)
+        return quantityChange
+                .abs()
+                .divide(quantityOnHandBefore.abs(), 4, java.math.RoundingMode.HALF_UP)
                 .multiply(BigDecimal.valueOf(100));
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryAdjustmentRequest.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryAdjustmentRequest.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -55,8 +56,8 @@ public class InventoryAdjustmentRequest {
     @Column(nullable = false)
     private UUID locationId;
 
-    @Column(nullable = false)
-    private Integer quantity;
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal quantity;
 
     @NonNull
     @Column(nullable = false, length = 100)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryLedgerEntry.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryLedgerEntry.java
@@ -54,11 +54,22 @@ public class InventoryLedgerEntry {
     @Column(nullable = false)
     private InventoryLedgerEventType eventType;
 
-    @Column(nullable = false)
-    private Integer changeInQuantity;
+    /**
+     * Signed quantity delta this entry posts. Decimal-capable (ADR-0055, #1414): a product whose
+     * catalog {@code product_uom} BASE row declares {@code precision_scale > 0} posts fractions
+     * to that scale, while a product declaring 0 — every product until one is seeded otherwise —
+     * is still refused a fraction on both the demand and the supply side. The column width is
+     * what a divisible product needs; the declaration is what decides who may use it.
+     *
+     * <p>Compare with {@code compareTo}, never {@code equals}: {@code 1} and {@code 1.0} are the
+     * same quantity and are not equal.
+     */
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal changeInQuantity;
 
-    @Column(nullable = false)
-    private Integer quantityAfter;
+    /** Running on-hand after this entry, on the same decimal basis as {@link #changeInQuantity}. */
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal quantityAfter;
 
     @Column(precision = 19, scale = 4)
     private BigDecimal unitCost;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryReturnEntity.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryReturnEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,8 +43,9 @@ public class InventoryReturnEntity {
     @Column(nullable = false)
     private String returnReason;
 
-    @Column(nullable = false)
-    private int totalItemsReturned;
+    /** Sum of the lines' base-UoM quantities; decimal-capable (ADR-0055). */
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal totalItemsReturned;
 
     /**
      * Timestamp when the task was created.

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryReturnLineEntity.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryReturnLineEntity.java
@@ -42,8 +42,9 @@ public class InventoryReturnLineEntity {
     @Column(nullable = false)
     private UUID skuId;
 
-    @Column(nullable = false)
-    private int quantityReturned;
+    /** Base-UoM quantity returned; decimal-capable per the product's declaration (ADR-0055). */
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal quantityReturned;
 
     /** UoM the line was keyed in, when it differed from base (odoo-parity B2, #1034). */
     @Column(name = "document_uom", length = 32)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryStockSummary.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/InventoryStockSummary.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -73,20 +74,24 @@ public class InventoryStockSummary {
     private UUID lotId;
 
     /** Net physical stock: sum of on-hand-affecting ledger deltas. */
-    @Column(name = "on_hand", nullable = false)
-    private long onHand;
+    @Column(name = "on_hand", nullable = false, precision = 19, scale = 4)
+    @Builder.Default
+    private BigDecimal onHand = BigDecimal.ZERO;
 
     /** Outstanding hard allocations: ALLOCATION_CREATED - ALLOCATION_RELEASED. */
-    @Column(name = "allocated", nullable = false)
-    private long allocated;
+    @Column(name = "allocated", nullable = false, precision = 19, scale = 4)
+    @Builder.Default
+    private BigDecimal allocated = BigDecimal.ZERO;
 
     /** Outstanding soft reservations: RESERVATION_CREATED - RESERVATION_RELEASED. */
-    @Column(name = "reserved", nullable = false)
-    private long reserved;
+    @Column(name = "reserved", nullable = false, precision = 19, scale = 4)
+    @Builder.Default
+    private BigDecimal reserved = BigDecimal.ZERO;
 
     /** Available to promise: onHand - allocated (ADR-0001). */
-    @Column(name = "atp", nullable = false)
-    private long atp;
+    @Column(name = "atp", nullable = false, precision = 19, scale = 4)
+    @Builder.Default
+    private BigDecimal atp = BigDecimal.ZERO;
 
     /**
      * Stock in transit TOWARD this key (odoo-parity C2, issue #1036): dispatched transfer
@@ -96,8 +101,9 @@ public class InventoryStockSummary {
      * adds to {@code onHand}). Conserved invariant: source on-hand + destination in-transit +
      * destination on-hand is constant across dispatch → partial receive → final receive.
      */
-    @Column(name = "in_transit_qty", nullable = false)
-    private long inTransitQty;
+    @Column(name = "in_transit_qty", nullable = false, precision = 19, scale = 4)
+    @Builder.Default
+    private BigDecimal inTransitQty = BigDecimal.ZERO;
 
     /** Ledger entry that last touched this row. */
     @Column(name = "last_ledger_entry_id")

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ReservationEntity.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ReservationEntity.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,12 +60,17 @@ public class ReservationEntity {
     @Column(name = "stock_item_id", nullable = false)
     private UUID stockItemId;
 
-    @Column(nullable = false)
-    private int requiredQuantity;
+    /**
+     * Quantity demanded. Decimal-capable (ADR-0055, #1414) and gated by the referenced product's
+     * declared {@code precision_scale}, not by this type. Compare with {@code compareTo}.
+     */
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal requiredQuantity;
 
-    @Column(nullable = false)
+    /** Quantity hard-allocated against {@link #requiredQuantity}, on the same decimal basis. */
+    @Column(nullable = false, precision = 19, scale = 4)
     @Builder.Default
-    private int allocatedQuantity = 0;
+    private BigDecimal allocatedQuantity = BigDecimal.ZERO;
 
     @Column(nullable = false)
     @Builder.Default

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/RevaluationRecord.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/RevaluationRecord.java
@@ -76,8 +76,8 @@ public class RevaluationRecord {
     private BigDecimal newUnitCost;
 
     /** On-hand quantity the engine had costed at revaluation time (delta basis). */
-    @Column(name = "on_hand_quantity", nullable = false)
-    private long onHandQuantity;
+    @Column(name = "on_hand_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal onHandQuantity;
 
     /** Signed inventory value change: (newUnitCost − previousUnitCost) × onHandQuantity. */
     @Column(name = "value_delta", nullable = false, precision = 19, scale = 4)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ShortageResolutionRecord.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/ShortageResolutionRecord.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -76,8 +77,8 @@ public class ShortageResolutionRecord {
     private String sku;
 
     /** Quantity that was short. */
-    @Column(name = "short_quantity", nullable = false)
-    private Integer shortQuantity;
+    @Column(name = "short_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal shortQuantity;
 
     /** Site the demand was short at; null when the caller did not supply one. */
     @Column(name = "location_id")

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/SkuCostState.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/entity/SkuCostState.java
@@ -71,8 +71,8 @@ public class SkuCostState {
     private BigDecimal avgCost;
 
     /** Quantity the engine has costed so far (AVCO denominator + negative-branch input). */
-    @Column(name = "on_hand_qty", nullable = false)
-    private long onHandQty;
+    @Column(name = "on_hand_qty", nullable = false, precision = 19, scale = 4)
+    private BigDecimal onHandQty;
 
     /** Configured standard price (STANDARD method); null until set via revaluation (J4). */
     @Column(name = "standard_cost", precision = 19, scale = 6)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/CycleCountConflictException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/CycleCountConflictException.java
@@ -1,5 +1,6 @@
 package com.positivity.inventory.internal.exception;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 /**
@@ -12,8 +13,9 @@ import java.util.UUID;
  */
 public class CycleCountConflictException extends RuntimeException {
 
-    public CycleCountConflictException(UUID taskId, int movementDelta) {
-        super("Cycle count task " + taskId + " has interfering stock movements (net on-hand delta " + movementDelta
+    public CycleCountConflictException(UUID taskId, BigDecimal movementDelta) {
+        super("Cycle count task " + taskId + " has interfering stock movements (net on-hand delta "
+                + movementDelta.toPlainString()
                 + ") since the count snapshot; task flagged CONFLICT. Request a recount, or approve again to accept"
                 + " the variance recomputed against current on-hand.");
     }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/FractionalQuantityNotAllowedException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/FractionalQuantityNotAllowedException.java
@@ -1,0 +1,59 @@
+package com.positivity.inventory.internal.exception;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A posted quantity carries more decimal places than the product's catalog declaration allows
+ * (ADR-0055, #1414).
+ *
+ * <p>This is the supply side of the invariant pos-workorder's part gate enforces on the demand
+ * side (#1413), and it deliberately raises the same error code so a counter receiving stock and an
+ * advisor issuing it are told the same thing about the same product. It replaces the
+ * {@code intValueExact()} guards in receiving, ASN and returns: those refused every fraction for
+ * every product, which was right for the whole catalog as seeded and wrong the moment one product
+ * declares itself divisible. What changed is that the rule is read from the declaration rather
+ * than hardcoded — the guards keep their fail-closed character, and a product declaring nothing
+ * still resolves to whole units.
+ *
+ * <p>Maps to a deterministic 422 with code {@code FRACTIONAL_QUANTITY_NOT_ALLOWED}, matching the
+ * other catalog-declaration violations in this module ({@code UOM_CONVERSION_UNDEFINED} and the
+ * lot codes): the request is well-formed and passes its bean-validation bounds; what it violates
+ * can only be known after looking the product up.
+ */
+public class FractionalQuantityNotAllowedException extends RuntimeException {
+
+    public static final String ERROR_CODE = "FRACTIONAL_QUANTITY_NOT_ALLOWED";
+
+    private final transient @Nullable UUID productId;
+
+    public FractionalQuantityNotAllowedException(String message, @Nullable UUID productId) {
+        super(message);
+        this.productId = productId;
+    }
+
+    /** The product declares no divisibility (scale 0, or no {@code product_uom} rows at all). */
+    public static FractionalQuantityNotAllowedException wholeUnitsOnly(
+            @Nullable UUID productId, String stockReference, String fieldName, BigDecimal quantity) {
+        return new FractionalQuantityNotAllowedException(
+                ERROR_CODE + ": " + fieldName + " " + quantity.toPlainString() + " is not valid for '" + stockReference
+                        + "' — this product is stocked in whole units. Post a whole quantity, or declare a"
+                        + " precision_scale for the product in the catalog if it is genuinely divisible.",
+                productId);
+    }
+
+    /** The product is divisible, but not this finely. */
+    public static FractionalQuantityNotAllowedException scaleExceeded(
+            @Nullable UUID productId, String stockReference, String fieldName, BigDecimal quantity, int declaredScale) {
+        return new FractionalQuantityNotAllowedException(
+                ERROR_CODE + ": " + fieldName + " " + quantity.toPlainString() + " is not valid for '" + stockReference
+                        + "' — this product is stocked to " + declaredScale
+                        + " decimal places. Post a quantity with at most " + declaredScale + " decimal places.",
+                productId);
+    }
+
+    public @Nullable UUID getProductId() {
+        return productId;
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/InsufficientAtpException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/InsufficientAtpException.java
@@ -1,5 +1,6 @@
 package com.positivity.inventory.internal.exception;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 /**
@@ -22,13 +23,13 @@ public class InsufficientAtpException extends RuntimeException {
 
     private final String errorCode = "INSUFFICIENT_ATP";
     private final UUID allocationId;
-    private final int requiredQuantity;
-    private final int availableAtp;
+    private final transient BigDecimal requiredQuantity;
+    private final transient BigDecimal availableAtp;
 
-    public InsufficientAtpException(UUID allocationId, int requiredQuantity, int availableAtp) {
+    public InsufficientAtpException(UUID allocationId, BigDecimal requiredQuantity, BigDecimal availableAtp) {
         super(String.format(
-                "INSUFFICIENT_ATP: allocationId=%s requiredQuantity=%d availableAtp=%d",
-                allocationId, requiredQuantity, availableAtp));
+                "INSUFFICIENT_ATP: allocationId=%s requiredQuantity=%s availableAtp=%s",
+                allocationId, requiredQuantity.toPlainString(), availableAtp.toPlainString()));
         this.allocationId = allocationId;
         this.requiredQuantity = requiredQuantity;
         this.availableAtp = availableAtp;
@@ -42,11 +43,11 @@ public class InsufficientAtpException extends RuntimeException {
         return allocationId;
     }
 
-    public int getRequiredQuantity() {
+    public BigDecimal getRequiredQuantity() {
         return requiredQuantity;
     }
 
-    public int getAvailableAtp() {
+    public BigDecimal getAvailableAtp() {
         return availableAtp;
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LocationAtCapacityException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LocationAtCapacityException.java
@@ -1,5 +1,6 @@
 package com.positivity.inventory.internal.exception;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 /**
@@ -14,14 +15,15 @@ public class LocationAtCapacityException extends PutawayValidationException {
     public static final String ERROR_CODE = "LOCATION_AT_CAPACITY";
 
     private final UUID locationId;
-    private final int currentCapacity;
-    private final int maxCapacity;
+    private final transient BigDecimal currentCapacity;
+    private final transient BigDecimal maxCapacity;
 
-    public LocationAtCapacityException(UUID locationId, int currentCapacity, int maxCapacity) {
+    public LocationAtCapacityException(UUID locationId, BigDecimal currentCapacity, BigDecimal maxCapacity) {
         super(
                 ERROR_CODE,
                 String.format(
-                        "Location %s is at full capacity (%d/%d units)", locationId, currentCapacity, maxCapacity));
+                        "Location %s is at full capacity (%s/%s units)",
+                        locationId, currentCapacity.toPlainString(), maxCapacity.toPlainString()));
         this.locationId = locationId;
         this.currentCapacity = currentCapacity;
         this.maxCapacity = maxCapacity;
@@ -31,11 +33,11 @@ public class LocationAtCapacityException extends PutawayValidationException {
         return locationId;
     }
 
-    public int getCurrentCapacity() {
+    public BigDecimal getCurrentCapacity() {
         return currentCapacity;
     }
 
-    public int getMaxCapacity() {
+    public BigDecimal getMaxCapacity() {
         return maxCapacity;
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LotInsufficientStockException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LotInsufficientStockException.java
@@ -1,5 +1,6 @@
 package com.positivity.inventory.internal.exception;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 import org.jspecify.annotations.Nullable;
 
@@ -20,9 +21,9 @@ public class LotInsufficientStockException extends RuntimeException {
     private final UUID lotId;
 
     public LotInsufficientStockException(
-            String stockItemId, UUID lotId, @Nullable UUID locationId, long projectedOnHand) {
+            String stockItemId, UUID lotId, @Nullable UUID locationId, BigDecimal projectedOnHand) {
         super("LOT_INSUFFICIENT_STOCK: posting would take lot " + lotId + " of stock item " + stockItemId
-                + " at location " + locationId + " to " + projectedOnHand
+                + " at location " + locationId + " to " + projectedOnHand.toPlainString()
                 + "; a lot cannot be drawn below its per-lot on-hand");
         this.stockItemId = stockItemId;
         this.lotId = lotId;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/ReturnQuantityExceededException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/ReturnQuantityExceededException.java
@@ -1,10 +1,11 @@
 package com.positivity.inventory.internal.exception;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 public class ReturnQuantityExceededException extends RuntimeException {
 
-    public ReturnQuantityExceededException(UUID skuId, int requested, int available) {
+    public ReturnQuantityExceededException(UUID skuId, BigDecimal requested, BigDecimal available) {
         super("Return quantity exceeds available consumed quantity for skuId "
                 + skuId
                 + ": requested="

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/AllocationRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/AllocationRepository.java
@@ -3,6 +3,7 @@ package com.positivity.inventory.internal.repository;
 import com.positivity.inventory.internal.entity.AllocationEntity;
 import com.positivity.inventory.internal.entity.ReservationEntity;
 import com.positivity.inventory.internal.enums.AllocationState;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -89,10 +90,10 @@ public interface AllocationRepository extends JpaRepository<AllocationEntity, UU
         /** {@code ALLOCATED}/{@code PICKED}/{@code RELEASED}, or {@code ORPHAN}. */
         String getStatus();
 
-        int getAllocatedQuantity();
+        BigDecimal getAllocatedQuantity();
 
-        long getLedgerCreated();
+        BigDecimal getLedgerCreated();
 
-        long getLedgerReleased();
+        BigDecimal getLedgerReleased();
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepository.java
@@ -82,7 +82,7 @@ public interface InventoryLedgerEntryRepository
                           AND e.eventType IN :eventTypes
                           AND e.timestamp > :after
                         """)
-    Integer sumChangeForStockItemSince(
+    BigDecimal sumChangeForStockItemSince(
             @Param("stockItemId") String stockItemId,
             @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes,
             @Param("after") java.time.Instant after);
@@ -96,13 +96,13 @@ public interface InventoryLedgerEntryRepository
                           AND e.eventType IN :eventTypes
                           AND e.timestamp > :after
                         """)
-    Integer sumChangeForStockItemAtLocationSince(
+    BigDecimal sumChangeForStockItemAtLocationSince(
             @Param("stockItemId") String stockItemId,
             @Param("locationId") UUID locationId,
             @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes,
             @Param("after") java.time.Instant after);
 
-    default Integer calculateOnHandQuantity(UUID stockItemId) {
+    default BigDecimal calculateOnHandQuantity(UUID stockItemId) {
         return calculateOnHandQuantityForEventTypes(
                 stockItemId.toString(), InventoryLedgerEventType.onHandAffectingTypes());
     }
@@ -113,26 +113,26 @@ public interface InventoryLedgerEntryRepository
                         WHERE e.stockItemId = :stockItemId
                           AND e.eventType IN :eventTypes
                         """)
-    Integer calculateOnHandQuantityForEventTypes(
+    BigDecimal calculateOnHandQuantityForEventTypes(
             @Param("stockItemId") String stockItemId,
             @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
 
-    default Integer calculateOnHandQuantityAtLocation(UUID stockItemId, UUID locationId) {
+    default BigDecimal calculateOnHandQuantityAtLocation(UUID stockItemId, UUID locationId) {
         return calculateOnHandQuantityAtLocationForEventTypes(
                 stockItemId.toString(), locationId, InventoryLedgerEventType.onHandAffectingTypes());
     }
 
-    default Integer calculateOnHandQuantityAtLocation(
+    default BigDecimal calculateOnHandQuantityAtLocation(
             UUID stockItemId, UUID locationId, Collection<InventoryLedgerEventType> eventTypes) {
         return calculateOnHandQuantityAtLocationForEventTypes(stockItemId.toString(), locationId, eventTypes);
     }
 
-    default Integer calculateOnHandQuantityAtLocation(String stockItemId, UUID locationId) {
+    default BigDecimal calculateOnHandQuantityAtLocation(String stockItemId, UUID locationId) {
         return calculateOnHandQuantityAtLocationForEventTypes(
                 stockItemId, locationId, InventoryLedgerEventType.onHandAffectingTypes());
     }
 
-    default Integer calculateOnHandQuantityAtLocation(
+    default BigDecimal calculateOnHandQuantityAtLocation(
             String stockItemId, UUID locationId, Collection<InventoryLedgerEventType> eventTypes) {
         return calculateOnHandQuantityAtLocationForEventTypes(stockItemId, locationId, eventTypes);
     }
@@ -144,7 +144,7 @@ public interface InventoryLedgerEntryRepository
                           AND e.locationId = :locationId
                           AND e.eventType IN :eventTypes
                         """)
-    Integer calculateOnHandQuantityAtLocationForEventTypes(
+    BigDecimal calculateOnHandQuantityAtLocationForEventTypes(
             @Param("stockItemId") String stockItemId,
             @Param("locationId") UUID locationId,
             @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
@@ -155,7 +155,7 @@ public interface InventoryLedgerEntryRepository
                         WHERE e.locationId = :locationId
                           AND e.eventType IN :eventTypes
                         """)
-    Integer calculateOnHandQuantityAtLocation(
+    BigDecimal calculateOnHandQuantityAtLocation(
             @Param("locationId") UUID locationId, @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes);
 
     @Query("""
@@ -172,7 +172,7 @@ public interface InventoryLedgerEntryRepository
     interface LocationOnHand {
         String getStockItemId();
 
-        Long getOnHandQuantity();
+        BigDecimal getOnHandQuantity();
     }
 
     // ─── Point-in-time (as-of) aggregations (odoo-parity A3, issue #1029) ─────
@@ -202,7 +202,7 @@ public interface InventoryLedgerEntryRepository
                           AND e.eventType IN :eventTypes
                           AND e.timestamp <= :asOf
                         """)
-    Integer calculateOnHandAtLocationAsOf(
+    BigDecimal calculateOnHandAtLocationAsOf(
             @Param("locationId") UUID locationId,
             @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes,
             @Param("asOf") java.time.Instant asOf);
@@ -216,7 +216,7 @@ public interface InventoryLedgerEntryRepository
                           AND e.eventType IN :eventTypes
                           AND e.timestamp <= :asOf
                         """)
-    Integer calculateOnHandForStockItemAtLocationAsOf(
+    BigDecimal calculateOnHandForStockItemAtLocationAsOf(
             @Param("stockItemId") String stockItemId,
             @Param("locationId") UUID locationId,
             @Param("eventTypes") Collection<InventoryLedgerEventType> eventTypes,
@@ -287,7 +287,7 @@ public interface InventoryLedgerEntryRepository
                         WHERE e.sourceTransactionId = :sourceTransactionId
                           AND e.eventType = :eventType
                         """)
-    int sumChangeBySourceTransactionIdAndEventType(
+    BigDecimal sumChangeBySourceTransactionIdAndEventType(
             @Param("sourceTransactionId") String sourceTransactionId,
             @Param("eventType") InventoryLedgerEventType eventType);
 
@@ -353,7 +353,7 @@ public interface InventoryLedgerEntryRepository
      * <p>Locations without matching ledger entries are absent from the result (treat as 0).
      * An empty {@code locationIds} collection short-circuits to an empty map without executing SQL.
      */
-    default Map<UUID, Long> sumQuantityByLocationChunked(
+    default Map<UUID, BigDecimal> sumQuantityByLocationChunked(
             Collection<UUID> locationIds, Collection<InventoryLedgerEventType> eventTypes) {
         if (eventTypes == null || eventTypes.isEmpty()) {
             return Map.of();
@@ -366,7 +366,7 @@ public interface InventoryLedgerEntryRepository
      *
      * <p>Same semantics as {@link #sumQuantityByLocationChunked(Collection, Collection)}.
      */
-    default Map<UUID, Long> sumQuantityByLocationForSkuChunked(
+    default Map<UUID, BigDecimal> sumQuantityByLocationForSkuChunked(
             String stockItemId, Collection<UUID> locationIds, Collection<InventoryLedgerEventType> eventTypes) {
         if (eventTypes == null || eventTypes.isEmpty()) {
             return Map.of();
@@ -381,29 +381,29 @@ public interface InventoryLedgerEntryRepository
      * {@code LocationInventoryInquiryServiceImpl#calculateOutstandingAllocations}. Locations without
      * allocation entries are absent from the result (treat as 0).
      */
-    default Map<UUID, Long> calculateOutstandingAllocationsByLocation(Collection<UUID> locationIds) {
-        Map<UUID, Long> created =
+    default Map<UUID, BigDecimal> calculateOutstandingAllocationsByLocation(Collection<UUID> locationIds) {
+        Map<UUID, BigDecimal> created =
                 sumQuantityByLocationChunked(locationIds, List.of(InventoryLedgerEventType.ALLOCATION_CREATED));
-        Map<UUID, Long> released =
+        Map<UUID, BigDecimal> released =
                 sumQuantityByLocationChunked(locationIds, List.of(InventoryLedgerEventType.ALLOCATION_RELEASED));
 
-        Map<UUID, Long> outstanding = new HashMap<>(created);
-        released.forEach((locationId, quantity) -> outstanding.merge(locationId, -quantity, Long::sum));
+        Map<UUID, BigDecimal> outstanding = new HashMap<>(created);
+        released.forEach((locationId, quantity) -> outstanding.merge(locationId, quantity.negate(), BigDecimal::add));
         return Map.copyOf(outstanding);
     }
 
-    private Map<UUID, Long> sumChunked(
+    private Map<UUID, BigDecimal> sumChunked(
             Collection<UUID> locationIds, Function<List<UUID>, List<LocationQuantity>> query) {
         if (locationIds == null || locationIds.isEmpty()) {
             return Map.of();
         }
 
         List<UUID> distinctIds = locationIds.stream().distinct().toList();
-        Map<UUID, Long> totals = new HashMap<>();
+        Map<UUID, BigDecimal> totals = new HashMap<>();
         for (int start = 0; start < distinctIds.size(); start += LOCATION_ID_CHUNK_SIZE) {
             List<UUID> chunk = distinctIds.subList(start, Math.min(start + LOCATION_ID_CHUNK_SIZE, distinctIds.size()));
             for (LocationQuantity row : query.apply(chunk)) {
-                totals.merge(row.getLocationId(), row.getQuantity(), Long::sum);
+                totals.merge(row.getLocationId(), row.getQuantity(), BigDecimal::add);
             }
         }
         return Map.copyOf(totals);
@@ -412,7 +412,7 @@ public interface InventoryLedgerEntryRepository
     interface LocationQuantity {
         UUID getLocationId();
 
-        long getQuantity();
+        BigDecimal getQuantity();
     }
 
     /**
@@ -449,11 +449,11 @@ public interface InventoryLedgerEntryRepository
 
         UUID getLocationId();
 
-        long getOnHand();
+        BigDecimal getOnHand();
 
-        long getAllocated();
+        BigDecimal getAllocated();
 
-        long getReserved();
+        BigDecimal getReserved();
 
         /**
          * In-transit contribution of arrivals grouped at this key: {@code Σ -change} of
@@ -461,7 +461,7 @@ public interface InventoryLedgerEntryRepository
          * (positive) side keys on {@code toLocationId} and comes from
          * {@link #aggregateOutboundInTransit} (odoo-parity C2, #1036).
          */
-        long getInTransitArrived();
+        BigDecimal getInTransitArrived();
     }
 
     /**
@@ -486,7 +486,7 @@ public interface InventoryLedgerEntryRepository
 
         UUID getLocationId();
 
-        long getInTransit();
+        BigDecimal getInTransit();
     }
 
     /**

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryStockSummaryRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/InventoryStockSummaryRepository.java
@@ -2,6 +2,7 @@ package com.positivity.inventory.internal.repository;
 
 import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import jakarta.persistence.LockModeType;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
@@ -106,7 +107,7 @@ public interface InventoryStockSummaryRepository extends JpaRepository<Inventory
                         FROM InventoryStockSummary s
                         WHERE s.lotId = :lotId
                         """)
-    long sumLotStockAcrossLocations(@Param("lotId") UUID lotId);
+    BigDecimal sumLotStockAcrossLocations(@Param("lotId") UUID lotId);
 
     /**
      * Σ per-lot on-hand of the SKU's EXPIRED, ACTIVE lots at the given scope (odoo-parity E3,
@@ -128,7 +129,7 @@ public interface InventoryStockSummaryRepository extends JpaRepository<Inventory
                       AND l.expiration_date IS NOT NULL
                       AND l.expiration_date < :today
                     """, nativeQuery = true)
-    long sumExpiredActiveLotOnHand(
+    BigDecimal sumExpiredActiveLotOnHand(
             @Param("stockItemId") String stockItemId,
             @Param("locationId") UUID locationId,
             @Param("today") LocalDate today);
@@ -183,21 +184,21 @@ public interface InventoryStockSummaryRepository extends JpaRepository<Inventory
                         WHERE s.locationId = :locationId AND s.onHand > :onHand AND s.lotId IS NULL
                         """)
     List<InventoryStockSummary> findByLocationIdAndOnHandGreaterThan(
-            @Param("locationId") UUID locationId, @Param("onHand") long onHand);
+            @Param("locationId") UUID locationId, @Param("onHand") BigDecimal onHand);
 
     @Query("""
                         SELECT COALESCE(SUM(s.onHand), 0)
                         FROM InventoryStockSummary s
                         WHERE s.locationId = :locationId AND s.lotId IS NULL
                         """)
-    long sumOnHandAtLocation(@Param("locationId") UUID locationId);
+    BigDecimal sumOnHandAtLocation(@Param("locationId") UUID locationId);
 
     @Query("""
                         SELECT COALESCE(SUM(s.allocated), 0)
                         FROM InventoryStockSummary s
                         WHERE s.locationId = :locationId AND s.lotId IS NULL
                         """)
-    long sumAllocatedAtLocation(@Param("locationId") UUID locationId);
+    BigDecimal sumAllocatedAtLocation(@Param("locationId") UUID locationId);
 
     @Query("""
                         SELECT s.locationId AS locationId, COALESCE(SUM(s.onHand), 0) AS onHand,
@@ -223,9 +224,9 @@ public interface InventoryStockSummaryRepository extends JpaRepository<Inventory
     interface LocationSummary {
         UUID getLocationId();
 
-        long getOnHand();
+        BigDecimal getOnHand();
 
-        long getAllocated();
+        BigDecimal getAllocated();
     }
 
     // ─── Valuation read model on-hand aggregation (odoo-parity J2, issue #1052) ──
@@ -260,12 +261,12 @@ public interface InventoryStockSummaryRepository extends JpaRepository<Inventory
                         FROM InventoryStockSummary s
                         WHERE s.stockItemId = :stockItemId AND s.lotId IS NULL
                         """)
-    long sumOnHandForSku(@Param("stockItemId") String stockItemId);
+    BigDecimal sumOnHandForSku(@Param("stockItemId") String stockItemId);
 
     interface SkuOnHand {
         String getStockItemId();
 
-        long getOnHand();
+        BigDecimal getOnHand();
     }
 
     /**
@@ -407,21 +408,21 @@ public interface InventoryStockSummaryRepository extends JpaRepository<Inventory
         /** Rendered as text in SQL; null on lot-agnostic keys (log-only field). */
         String getLotId();
 
-        long getLedgerOnHand();
+        BigDecimal getLedgerOnHand();
 
-        long getLedgerAllocated();
+        BigDecimal getLedgerAllocated();
 
-        long getLedgerReserved();
+        BigDecimal getLedgerReserved();
 
-        long getLedgerInTransit();
+        BigDecimal getLedgerInTransit();
 
-        Long getSummaryOnHand();
+        BigDecimal getSummaryOnHand();
 
-        Long getSummaryAllocated();
+        BigDecimal getSummaryAllocated();
 
-        Long getSummaryReserved();
+        BigDecimal getSummaryReserved();
 
-        Long getSummaryInTransit();
+        BigDecimal getSummaryInTransit();
     }
 
     /**
@@ -473,9 +474,9 @@ public interface InventoryStockSummaryRepository extends JpaRepository<Inventory
         /** Rendered as text in SQL; null for the null-location (site-level) key. */
         String getLocationId();
 
-        long getLedgerOutstanding();
+        BigDecimal getLedgerOutstanding();
 
-        long getSummaryAllocated();
+        BigDecimal getSummaryAllocated();
     }
 
     /**
@@ -484,8 +485,8 @@ public interface InventoryStockSummaryRepository extends JpaRepository<Inventory
      * summary rows are absent from the maps (treat as 0).
      */
     default LocationQuantityMaps sumByLocationChunked(Collection<UUID> locationIds, String stockItemIdOrNull) {
-        Map<UUID, Long> onHand = new HashMap<>();
-        Map<UUID, Long> allocated = new HashMap<>();
+        Map<UUID, BigDecimal> onHand = new HashMap<>();
+        Map<UUID, BigDecimal> allocated = new HashMap<>();
         if (locationIds != null && !locationIds.isEmpty()) {
             List<UUID> distinctIds = locationIds.stream().distinct().toList();
             for (int start = 0; start < distinctIds.size(); start += LOCATION_ID_CHUNK_SIZE) {
@@ -495,13 +496,13 @@ public interface InventoryStockSummaryRepository extends JpaRepository<Inventory
                         ? sumByLocation(chunk)
                         : sumByLocationForSku(stockItemIdOrNull, chunk);
                 for (LocationSummary row : rows) {
-                    onHand.merge(row.getLocationId(), row.getOnHand(), Long::sum);
-                    allocated.merge(row.getLocationId(), row.getAllocated(), Long::sum);
+                    onHand.merge(row.getLocationId(), row.getOnHand(), BigDecimal::add);
+                    allocated.merge(row.getLocationId(), row.getAllocated(), BigDecimal::add);
                 }
             }
         }
         return new LocationQuantityMaps(Map.copyOf(onHand), Map.copyOf(allocated));
     }
 
-    record LocationQuantityMaps(Map<UUID, Long> onHand, Map<UUID, Long> allocated) {}
+    record LocationQuantityMaps(Map<UUID, BigDecimal> onHand, Map<UUID, BigDecimal> allocated) {}
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ReservationRepository.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/repository/ReservationRepository.java
@@ -2,6 +2,7 @@ package com.positivity.inventory.internal.repository;
 
 import com.positivity.inventory.internal.entity.ReservationEntity;
 import com.positivity.inventory.internal.enums.ReservationStatus;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -49,7 +50,7 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
                           AND (:boundByDueDate = FALSE
                                OR (r.dueDateTime IS NOT NULL AND r.dueDateTime <= :horizon))
                         """)
-    Long sumOpenRemainderForSku(
+    BigDecimal sumOpenRemainderForSku(
             @Param("stockItemId") UUID stockItemId,
             @Param("statuses") Collection<ReservationStatus> statuses,
             @Param("boundByDueDate") boolean boundByDueDate,

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AllocationConsistencyVerifier.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AllocationConsistencyVerifier.java
@@ -150,7 +150,7 @@ public class AllocationConsistencyVerifier {
                     row.getAllocatedQuantity(),
                     row.getLedgerCreated(),
                     row.getLedgerReleased(),
-                    row.getLedgerCreated() - row.getLedgerReleased());
+                    row.getLedgerCreated().subtract(row.getLedgerReleased()));
         }
         for (InventoryStockSummaryRepository.AllocatedDriftRow row : perLocation) {
             if (logged++ >= MAX_DETAILED_VIOLATION_LOGS) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AllocationReallocationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AllocationReallocationServiceImpl.java
@@ -10,6 +10,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.ReservationRepository;
 import com.positivity.inventory.service.AllocationReallocationService;
 import com.positivity.security.common.SecurityContextHelper;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -45,8 +46,7 @@ public class AllocationReallocationServiceImpl implements AllocationReallocation
         }
         Instant now = Instant.now(clock);
 
-        int onHand = Optional.ofNullable(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
-                .orElse(0);
+        BigDecimal onHand = Quantities.nz(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId));
 
         List<ReservationEntity> reservations = reservationRepository.findByStockItemId(stockItemId);
 
@@ -64,19 +64,20 @@ public class AllocationReallocationServiceImpl implements AllocationReallocation
                         .thenComparing(ReservationEntity::getCreatedAt))
                 .toList();
 
-        int previousTotalAllocated = reservations.stream()
-                .mapToInt(ReservationEntity::getAllocatedQuantity)
-                .sum();
-        int remainingStock = previousTotalAllocated;
+        BigDecimal previousTotalAllocated = reservations.stream()
+                .map(ReservationEntity::getAllocatedQuantity)
+                .map(Quantities::nz)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal remainingStock = previousTotalAllocated;
         int totalReallocated = 0;
         List<AllocationAuditEntity> audits = new ArrayList<>();
 
         for (ReservationEntity reservation : sorted) {
-            int required = reservation.getRequiredQuantity();
-            int prevAlloc = reservation.getAllocatedQuantity();
-            if (remainingStock >= required) {
+            BigDecimal required = Quantities.nz(reservation.getRequiredQuantity());
+            BigDecimal prevAlloc = Quantities.nz(reservation.getAllocatedQuantity());
+            if (Quantities.gte(remainingStock, required)) {
                 reservation.setAllocatedQuantity(required);
-                remainingStock -= required;
+                remainingStock = remainingStock.subtract(required);
                 totalReallocated++;
                 AllocationAuditReasonCode reasonCode = parseReasonCode(request.getTriggerType());
                 int effective = computeEffectivePriority(reservation, now);
@@ -84,18 +85,20 @@ public class AllocationReallocationServiceImpl implements AllocationReallocation
                         (effective < reservation.getPriority()) ? AllocationAuditReasonCode.PRIORITY_AGED : reasonCode;
                 audits.add(buildAudit(request, auditReason, now, prevAlloc, required));
             } else {
-                reservation.setAllocatedQuantity(0);
-                audits.add(buildAudit(request, AllocationAuditReasonCode.STOCK_SHORTAGE, now, prevAlloc, 0));
+                reservation.setAllocatedQuantity(BigDecimal.ZERO);
+                audits.add(
+                        buildAudit(request, AllocationAuditReasonCode.STOCK_SHORTAGE, now, prevAlloc, BigDecimal.ZERO));
             }
         }
 
         reservationRepository.saveAll(sorted);
         allocationAuditRepository.saveAll(audits);
 
-        int totalAllocated = sorted.stream()
-                .mapToInt(ReservationEntity::getAllocatedQuantity)
-                .sum();
-        int atpAfterReallocation = onHand - totalAllocated;
+        BigDecimal totalAllocated = sorted.stream()
+                .map(ReservationEntity::getAllocatedQuantity)
+                .map(Quantities::nz)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal atpAfterReallocation = onHand.subtract(totalAllocated);
 
         return ReallocateResponse.builder()
                 .stockItemId(request.getStockItemId())
@@ -122,15 +125,15 @@ public class AllocationReallocationServiceImpl implements AllocationReallocation
             ReallocateRequest request,
             AllocationAuditReasonCode reasonCode,
             Instant now,
-            int previousAllocatedQty,
-            int newAllocatedQty) {
+            BigDecimal previousAllocatedQty,
+            BigDecimal newAllocatedQty) {
         return AllocationAuditEntity.builder()
                 .stockItemId(request.getStockItemId())
                 .reasonCode(reasonCode)
                 .triggeredBy(resolveTriggeredBy())
                 .triggerReferenceId(request.getTriggerReferenceId())
-                .previousState("allocatedQuantity=" + previousAllocatedQty)
-                .newState("allocatedQuantity=" + newAllocatedQty)
+                .previousState("allocatedQuantity=" + previousAllocatedQty.toPlainString())
+                .newState("allocatedQuantity=" + newAllocatedQty.toPlainString())
                 .occurredAt(now)
                 .build();
     }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ApprovalThresholdEvaluatorImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ApprovalThresholdEvaluatorImpl.java
@@ -46,7 +46,7 @@ public class ApprovalThresholdEvaluatorImpl implements ApprovalThresholdEvaluato
         }
 
         // Calculate variance metrics
-        int absUnitVariance = Math.abs(adjustment.getQuantityChange());
+        BigDecimal absUnitVariance = adjustment.getQuantityChange().abs();
         BigDecimal absValueVariance = adjustment.getVarianceValue();
         BigDecimal percentVariance = adjustment.getVariancePercentage();
 
@@ -134,11 +134,11 @@ public class ApprovalThresholdEvaluatorImpl implements ApprovalThresholdEvaluato
      * Checks if variance exceeds ANY threshold in the configuration (OR logic).
      */
     private boolean exceedsThreshold(
-            int absUnitVariance,
+            BigDecimal absUnitVariance,
             BigDecimal absValueVariance,
             BigDecimal percentVariance,
             ApprovalThresholdConfig config) {
-        boolean exceedsUnit = absUnitVariance >= config.getUnitVarianceThreshold();
+        boolean exceedsUnit = absUnitVariance.compareTo(BigDecimal.valueOf(config.getUnitVarianceThreshold())) >= 0;
         boolean exceedsValue = absValueVariance.compareTo(config.getValueVarianceThreshold()) >= 0;
         boolean exceedsPercent = percentVariance.compareTo(config.getPercentageVarianceThreshold()) >= 0;
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AsnServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AsnServiceImpl.java
@@ -61,6 +61,7 @@ public class AsnServiceImpl implements AsnService {
     private final ApplicationEventPublisher eventPublisher;
     private final DocumentQuantityConverter documentQuantityConverter;
     private final InventoryLotCaptureService lotCaptureService;
+    private final QuantityScaleGuard quantityScaleGuard;
 
     @Override
     @Transactional
@@ -272,7 +273,7 @@ public class AsnServiceImpl implements AsnService {
                     .locationId(request.getLocationId())
                     .toLocationId(request.getLocationId())
                     .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
-                    .changeInQuantity(toWholeQuantity(computed.baseQuantity()))
+                    .changeInQuantity(computed.baseQuantity())
                     .quantityAfter(calculateQuantityAfter(
                             computed.request().getSku(), request.getLocationId(), computed.baseQuantity()))
                     .lotId(computed.lotId())
@@ -397,6 +398,12 @@ public class AsnServiceImpl implements AsnService {
                 throw new IllegalArgumentException(
                         "quantityReceived is required when documentUom/documentQuantity are absent");
             }
+            // ADR-0055 (#1414): the base quantity may carry decimals only to the scale the
+            // product declares. Checked here, where the product id is already resolved, rather
+            // than at the ledger builder — a receipt that cannot post must be refused before any
+            // accrual or lot is computed against it.
+            baseQuantity = quantityScaleGuard.requirePostable(
+                    resolveProductId(poLine, line.getSku()), line.getSku(), "quantityReceived", baseQuantity);
             // unitCostMinor refers to one document-UoM unit when a document UoM is keyed, so the
             // money math is documentQuantity × unitCostMinor either way.
             BigDecimal costedQuantity = conversion != null ? conversion.documentQuantity() : baseQuantity;
@@ -431,19 +438,10 @@ public class AsnServiceImpl implements AsnService {
         }
     }
 
-    private int toWholeQuantity(@NonNull BigDecimal quantity) {
-        try {
-            return quantity.intValueExact();
-        } catch (ArithmeticException ex) {
-            throw new IllegalArgumentException("quantity must be a whole number", ex);
-        }
-    }
-
-    private int calculateQuantityAfter(
+    private BigDecimal calculateQuantityAfter(
             @NonNull String stockItemId, @NonNull UUID locationId, @NonNull BigDecimal quantityDelta) {
-        Integer onHand = inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(stockItemId, locationId);
-        int current = onHand == null ? 0 : onHand;
-        return current + toWholeQuantity(quantityDelta);
+        BigDecimal onHand = inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(stockItemId, locationId);
+        return Quantities.nz(onHand).add(quantityDelta);
     }
 
     private long safeLong(Long value) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AverageCostingStrategy.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/AverageCostingStrategy.java
@@ -49,36 +49,36 @@ public class AverageCostingStrategy implements CostingStrategy {
     @Override
     public @NonNull CostingResult cost(@NonNull CostingInput input) {
         BigDecimal oldAvg = input.state().avgCost();
-        long oldQty = input.state().onHandQty();
-        int change = input.changeInQuantity();
+        BigDecimal oldQty = Quantities.nz(input.state().onHandQty());
+        BigDecimal change = Quantities.nz(input.changeInQuantity());
         BigDecimal docCost = input.documentUnitCost();
         BigDecimal standardCost = input.state().standardCost();
 
-        if (change > 0 && docCost != null) {
+        if (Quantities.isPositive(change) && docCost != null) {
             // Receipt: recompute weighted average, stamp the received cost.
             BigDecimal newAvg;
-            if (oldQty <= 0 || oldAvg == null) {
+            if (!Quantities.isPositive(oldQty) || oldAvg == null) {
                 // Seed (first receipt) or reset from a non-positive on-hand: no meaningful
                 // prior value to blend — the receipt cost becomes the average.
                 newAvg = docCost;
             } else {
-                BigDecimal oldValue = oldAvg.multiply(BigDecimal.valueOf(oldQty));
-                BigDecimal rcvValue = docCost.multiply(BigDecimal.valueOf(change));
-                long newQty = oldQty + change;
-                newAvg = oldValue.add(rcvValue).divide(BigDecimal.valueOf(newQty), AVG_SCALE, RoundingMode.HALF_UP);
+                BigDecimal oldValue = oldAvg.multiply(oldQty);
+                BigDecimal rcvValue = docCost.multiply(change);
+                BigDecimal newQty = oldQty.add(change);
+                newAvg = oldValue.add(rcvValue).divide(newQty, AVG_SCALE, RoundingMode.HALF_UP);
             }
-            return new CostingResult(stamp(docCost), new CostState(newAvg, oldQty + change, standardCost));
+            return new CostingResult(stamp(docCost), new CostState(newAvg, oldQty.add(change), standardCost));
         }
 
-        if (change > 0) {
+        if (Quantities.isPositive(change)) {
             // Cost-less inbound: enters at the current average; quantity rises, average unchanged.
-            return new CostingResult(stamp(oldAvg), new CostState(oldAvg, oldQty + change, standardCost));
+            return new CostingResult(stamp(oldAvg), new CostState(oldAvg, oldQty.add(change), standardCost));
         }
 
         // Issue / consumption / scrap / transfer-out (and no-op zero change): stamp the current
         // average, decrement quantity, average unchanged. Negative branch (oldQty <= 0) keeps the
         // last known average by construction.
-        return new CostingResult(stamp(oldAvg), new CostState(oldAvg, oldQty + change, standardCost));
+        return new CostingResult(stamp(oldAvg), new CostState(oldAvg, oldQty.add(change), standardCost));
     }
 
     private static @Nullable BigDecimal stamp(@Nullable BigDecimal value) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/BackorderServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/BackorderServiceImpl.java
@@ -5,6 +5,7 @@ import com.positivity.domainevents.inventory.BackorderResolvedV1;
 import com.positivity.inventory.internal.dto.backorder.BackorderResponse;
 import com.positivity.inventory.internal.entity.BackorderRecord;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.entity.ReservationEntity;
 import com.positivity.inventory.internal.enums.BackorderResolutionSource;
 import com.positivity.inventory.internal.enums.BackorderStatus;
@@ -17,6 +18,7 @@ import com.positivity.inventory.internal.repository.InventoryStockSummaryReposit
 import com.positivity.inventory.internal.repository.ReservationRepository;
 import com.positivity.inventory.service.BackorderService;
 import com.positivity.security.common.SecurityContextHelper;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -87,7 +89,10 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
 
     @Override
     public @NonNull BackorderResponse createBackorder(
-            @NonNull UUID workorderLineId, @NonNull String sku, int quantityShort, @Nullable UUID locationId) {
+            @NonNull UUID workorderLineId,
+            @NonNull String sku,
+            @NonNull BigDecimal quantityShort,
+            @Nullable UUID locationId) {
         return createBackorder(
                 workorderLineId,
                 null,
@@ -102,7 +107,10 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
 
     @Override
     public @NonNull BackorderResponse createBackorderForSalesOrderLine(
-            @NonNull UUID salesOrderLineId, @NonNull String sku, int quantityShort, @Nullable UUID locationId) {
+            @NonNull UUID salesOrderLineId,
+            @NonNull String sku,
+            @NonNull BigDecimal quantityShort,
+            @Nullable UUID locationId) {
         return createBackorder(
                 null,
                 salesOrderLineId,
@@ -124,7 +132,7 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
             @Nullable UUID workorderLineId,
             @Nullable UUID salesOrderLineId,
             @NonNull String sku,
-            int quantityShort,
+            @NonNull BigDecimal quantityShort,
             @Nullable UUID locationId,
             Supplier<Optional<BackorderRecord>> findExistingOpen,
             String demandLineLabel,
@@ -132,7 +140,9 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
         if (sku.isBlank()) {
             throw new IllegalArgumentException("sku must not be blank");
         }
-        if (quantityShort <= 0) {
+        // Positivity survives the widening at every scale a decimal type makes expressible:
+        // 0.0000 is as much "no shortfall" as 0 was, and the DB CHECK says the same thing.
+        if (quantityShort == null || quantityShort.signum() <= 0) {
             throw new IllegalArgumentException("quantityShort must be positive");
         }
 
@@ -195,16 +205,16 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
                 .sorted(oldestPriorityFirst(reservations, now))
                 .toList();
 
-        long budget = availableToPromise(sku, locationId);
+        BigDecimal budget = availableToPromise(sku, locationId);
         for (BackorderRecord backorder : ordered) {
-            int shortage = backorder.getQuantityShort();
-            if (shortage > budget) {
+            BigDecimal shortage = Quantities.nz(backorder.getQuantityShort());
+            if (Quantities.gt(shortage, budget)) {
                 // Partial availability: whole-backorder resolution only — leave larger shortages OPEN.
                 continue;
             }
             try {
                 resolve(backorder, reservations.get(backorder.getDemandLineId()), now);
-                budget -= shortage;
+                budget = budget.subtract(shortage);
             } catch (RuntimeException e) {
                 // Best-effort per candidate: one bad backorder must not roll back the inbound posting.
                 log.warn("Failed to auto-resolve backorder {}: {}", backorder.getBackorderId(), e.getMessage());
@@ -299,14 +309,12 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
     private InventoryLedgerEntry postNeutralEntry(
             InventoryLedgerEventType eventType,
             BackorderRecord backorder,
-            int quantityShort,
+            BigDecimal quantityShort,
             @Nullable UUID locationId,
             String actor) {
-        int onHand = locationId == null
-                ? 0
-                : Optional.ofNullable(
-                                ledgerRepository.calculateOnHandQuantityAtLocation(backorder.getSku(), locationId))
-                        .orElse(0);
+        BigDecimal onHand = locationId == null
+                ? BigDecimal.ZERO
+                : Quantities.nz(ledgerRepository.calculateOnHandQuantityAtLocation(backorder.getSku(), locationId));
         InventoryLedgerEntry entry = InventoryLedgerEntry.builder()
                 .stockItemId(backorder.getSku())
                 .eventType(eventType)
@@ -319,11 +327,12 @@ public class BackorderServiceImpl implements BackorderService, BackorderResoluti
         return ledgerPostingService.post(entry);
     }
 
-    private long availableToPromise(String sku, UUID locationId) {
+    private BigDecimal availableToPromise(String sku, UUID locationId) {
         return summaryRepository
                 .findByStockItemIdAndLocationId(sku, locationId)
-                .map(row -> row.getAtp())
-                .orElse(0L);
+                .map(InventoryStockSummary::getAtp)
+                .map(Quantities::nz)
+                .orElse(BigDecimal.ZERO);
     }
 
     private Map<UUID, ReservationEntity> loadBackingReservations(List<BackorderRecord> backorders) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ConsumptionServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ConsumptionServiceImpl.java
@@ -169,7 +169,7 @@ public class ConsumptionServiceImpl implements ConsumptionService {
         // Releases accumulated in this request are not yet visible to the
         // ledger-derived "already released" lookup; track them per allocation
         // so multi-item requests cannot over-release (PR #661 re-review finding 1).
-        Map<UUID, Integer> releasedInBatch = new HashMap<>();
+        Map<UUID, BigDecimal> releasedInBatch = new HashMap<>();
         for (ConsumeItemLine item : items) {
             PickTaskEntity task = pickTaskRepository
                     .findById(item.getPickTaskId())
@@ -251,7 +251,7 @@ public class ConsumptionServiceImpl implements ConsumptionService {
             ConsumeItemsRequest request,
             ConsumeItemLine item,
             PickTaskEntity task,
-            Map<UUID, Integer> releasedInBatch) {
+            Map<UUID, BigDecimal> releasedInBatch) {
         if (task.getWorkorderLineId() == null) {
             return List.of();
         }
@@ -273,25 +273,31 @@ public class ConsumptionServiceImpl implements ConsumptionService {
                 orderAllocationsForClose(unordered, reservation.get().getStockItemId(), task);
 
         UUID stockItemId = reservation.get().getStockItemId();
-        int netOnHand = Optional.ofNullable(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
-                .orElse(0);
+        BigDecimal netOnHand = Quantities.nz(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId));
 
         List<InventoryLedgerEntry> releases = new ArrayList<>();
-        int remainingToClose = item.getQuantity();
-        int totalReleasedForReservation = 0;
+        // The pick chain is still integral (pick-task quantities widen with the UOM work in
+        // ADR-0055 stage 3/4), so this widens at the boundary rather than narrowing: an int
+        // consumed quantity is exactly representable as a BigDecimal, and the allocation math it
+        // feeds is decimal because allocations are.
+        BigDecimal remainingToClose = BigDecimal.valueOf(item.getQuantity());
+        BigDecimal totalReleasedForReservation = BigDecimal.ZERO;
         for (AllocationEntity allocation : locatedHard) {
-            if (remainingToClose <= 0) {
+            if (!Quantities.isPositive(remainingToClose)) {
                 break;
             }
-            int alreadyReleased = inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
-                            allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED)
-                    + releasedInBatch.getOrDefault(allocation.getAllocationId(), 0);
-            int allocationRemaining = allocation.getAllocatedQuantity() - alreadyReleased;
-            if (allocationRemaining <= 0) {
+            BigDecimal alreadyReleased = Quantities.nz(
+                            inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
+                                    allocation.getAllocationId().toString(),
+                                    InventoryLedgerEventType.ALLOCATION_RELEASED))
+                    .add(releasedInBatch.getOrDefault(allocation.getAllocationId(), BigDecimal.ZERO));
+            BigDecimal allocationRemaining =
+                    Quantities.nz(allocation.getAllocatedQuantity()).subtract(alreadyReleased);
+            if (!Quantities.isPositive(allocationRemaining)) {
                 continue;
             }
 
-            int release = Math.min(remainingToClose, allocationRemaining);
+            BigDecimal release = Quantities.min(remainingToClose, allocationRemaining);
             releases.add(InventoryLedgerEntry.builder()
                     .stockItemId(stockItemId.toString())
                     .eventType(InventoryLedgerEventType.ALLOCATION_RELEASED)
@@ -305,20 +311,21 @@ public class ConsumptionServiceImpl implements ConsumptionService {
                     .timestamp(Instant.now(clock))
                     .build());
 
-            releasedInBatch.merge(allocation.getAllocationId(), release, Integer::sum);
+            releasedInBatch.merge(allocation.getAllocationId(), release, BigDecimal::add);
             if (release == allocationRemaining) {
                 allocation.setStatus(AllocationStatus.RELEASED);
                 allocationRepository.save(allocation);
             }
-            remainingToClose -= release;
-            totalReleasedForReservation += release;
+            remainingToClose = remainingToClose.subtract(release);
+            totalReleasedForReservation = totalReleasedForReservation.add(release);
         }
-        if (totalReleasedForReservation > 0) {
+        if (Quantities.isPositive(totalReleasedForReservation)) {
             // PR #661 re-review finding 2: AllocationReallocationServiceImpl pools
             // reservation.allocatedQuantity as reallocatable stock; consumed stock
             // is physically gone and must leave that pool.
             ReservationEntity owning = reservation.get();
-            owning.setAllocatedQuantity(Math.max(0, owning.getAllocatedQuantity() - totalReleasedForReservation));
+            owning.setAllocatedQuantity(Quantities.atLeastZero(
+                    Quantities.nz(owning.getAllocatedQuantity()).subtract(totalReleasedForReservation)));
             reservationRepository.save(owning);
         }
         return releases;
@@ -402,8 +409,8 @@ public class ConsumptionServiceImpl implements ConsumptionService {
         return InventoryLedgerEntry.builder()
                 .stockItemId(item.getSkuId() == null ? "" : item.getSkuId().toString())
                 .eventType(InventoryLedgerEventType.WORKORDER_CONSUMPTION)
-                .changeInQuantity(-Math.abs(item.getQuantity()))
-                .quantityAfter(0)
+                .changeInQuantity(BigDecimal.valueOf(item.getQuantity()).abs().negate())
+                .quantityAfter(BigDecimal.ZERO)
                 .lotId(lotId)
                 .transactionUserId(SecurityContextHelper.getCurrentUsernameOrDefault("system"))
                 .notes("Consumed from pick task " + item.getPickTaskId() + " for workorder " + request.getWorkorderId())

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CostingStrategy.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CostingStrategy.java
@@ -47,7 +47,7 @@ public interface CostingStrategy {
     record CostingInput(
             @NonNull String stockItemId,
             @NonNull InventoryLedgerEventType eventType,
-            int changeInQuantity,
+            @NonNull BigDecimal changeInQuantity,
             @Nullable BigDecimal documentUnitCost,
             @NonNull CostState state) {}
 
@@ -71,6 +71,6 @@ public interface CostingStrategy {
      */
     record CostState(
             @Nullable BigDecimal avgCost,
-            long onHandQty,
+            @NonNull BigDecimal onHandQty,
             @Nullable BigDecimal standardCost) {}
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImpl.java
@@ -70,8 +70,8 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
                 request.getStockItemId(),
                 request.getCreatedByUserId());
 
-        int quantityChange = request.getCountedQuantity() - request.getQuantityOnHandBefore();
-        if (quantityChange == 0) {
+        BigDecimal quantityChange = request.getCountedQuantity().subtract(request.getQuantityOnHandBefore());
+        if (quantityChange.signum() == 0) {
             log.info("No variance detected for SKU {}. Count matches system quantity.", request.getStockItemId());
             throw new IllegalArgumentException("No adjustment needed - counted quantity matches system quantity");
         }
@@ -237,8 +237,8 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
             return;
         }
 
-        int movementDelta = conflictDetector.movementDeltaSinceSnapshot(task);
-        if (movementDelta != 0) {
+        BigDecimal movementDelta = conflictDetector.movementDeltaSinceSnapshot(task);
+        if (!Quantities.isZero(movementDelta)) {
             conflictDetector.flagConflict(task.getTaskId());
             throw new CycleCountConflictException(task.getTaskId(), movementDelta);
         }
@@ -251,8 +251,8 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
      * floor-at-zero matrix still applies when the recomputed variance posts.
      */
     private void recomputeVarianceAgainstCurrentOnHand(CycleCountAdjustment adjustment) {
-        Integer currentOnHand = ledgerRepository.calculateOnHandQuantity(adjustment.getStockItemId());
-        int recomputedChange = adjustment.getCountedQuantity() - currentOnHand;
+        BigDecimal currentOnHand = Quantities.nz(ledgerRepository.calculateOnHandQuantity(adjustment.getStockItemId()));
+        BigDecimal recomputedChange = adjustment.getCountedQuantity().subtract(currentOnHand);
         log.info(
                 "Adjustment {} approved on CONFLICT task {}: variance recomputed against current on-hand"
                         + " {} (stale snapshot {}): quantityChange {} -> {}",
@@ -273,7 +273,7 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
      * without a ledger entry.
      */
     private void postApprovedAdjustment(CycleCountAdjustment adjustment) {
-        if (adjustment.getQuantityChange() != 0) {
+        if (!Quantities.isZero(adjustment.getQuantityChange())) {
             postAdjustmentToLedger(adjustment);
         } else {
             log.info(
@@ -297,10 +297,11 @@ public class CycleCountAdjustmentServiceImpl implements CycleCountAdjustmentServ
         log.info("Posting adjustment {} to inventory ledger", adjustment.getAdjustmentId());
 
         try {
-            Integer currentOnHand = ledgerRepository.calculateOnHandQuantity(adjustment.getStockItemId());
-            Integer quantityAfter = currentOnHand + adjustment.getQuantityChange();
+            BigDecimal currentOnHand =
+                    Quantities.nz(ledgerRepository.calculateOnHandQuantity(adjustment.getStockItemId()));
+            BigDecimal quantityAfter = currentOnHand.add(adjustment.getQuantityChange());
 
-            InventoryLedgerEventType eventType = adjustment.getQuantityChange() > 0
+            InventoryLedgerEventType eventType = Quantities.isPositive(adjustment.getQuantityChange())
                     ? InventoryLedgerEventType.COUNT_VARIANCE_IN
                     : InventoryLedgerEventType.COUNT_VARIANCE_OUT;
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountConflictDetector.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountConflictDetector.java
@@ -6,6 +6,7 @@ import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.enums.TaskStatus;
 import com.positivity.inventory.internal.repository.CycleCountTaskRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -44,9 +45,9 @@ public class CycleCountConflictDetector {
      * was taken. Non-zero ⇒ the count window was interfered with.
      */
     @Transactional(readOnly = true)
-    public int movementDeltaSinceSnapshot(@NonNull CycleCountTask task) {
+    public BigDecimal movementDeltaSinceSnapshot(@NonNull CycleCountTask task) {
         Optional<UUID> locationId = locationIdOf(task);
-        Integer delta = locationId
+        BigDecimal delta = locationId
                 .map(location -> ledgerRepository.sumChangeForStockItemAtLocationSince(
                         task.getItemSku(),
                         location,
@@ -54,7 +55,7 @@ public class CycleCountConflictDetector {
                         task.getCreatedAt()))
                 .orElseGet(() -> ledgerRepository.sumChangeForStockItemSince(
                         task.getItemSku(), InventoryLedgerEventType.onHandAffectingTypes(), task.getCreatedAt()));
-        return delta == null ? 0 : delta;
+        return Quantities.nz(delta);
     }
 
     /**

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountServiceImpl.java
@@ -17,6 +17,7 @@ import com.positivity.inventory.internal.exception.TaskNotFoundException;
 import com.positivity.inventory.internal.repository.CountEntryRepository;
 import com.positivity.inventory.internal.repository.CycleCountTaskRepository;
 import com.positivity.inventory.service.CycleCountService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -257,8 +258,8 @@ public class CycleCountServiceImpl implements CycleCountService {
      * COUNTED_PENDING_REVIEW otherwise. Returns whether a conflict was found.
      */
     private boolean applyConflictStatus(CycleCountTask task) {
-        int movementDelta = conflictDetector.movementDeltaSinceSnapshot(task);
-        if (movementDelta != 0) {
+        BigDecimal movementDelta = conflictDetector.movementDeltaSinceSnapshot(task);
+        if (!Quantities.isZero(movementDelta)) {
             if (log.isWarnEnabled()) {
                 log.warn(
                         "Cycle count conflict detected at submission for task {}: in-window movement delta {}",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ForecastQuantityService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ForecastQuantityService.java
@@ -1,5 +1,6 @@
 package com.positivity.inventory.internal.service;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -47,8 +48,17 @@ public interface ForecastQuantityService {
      */
     @NonNull
     ForecastQuantities forecast(
-            @NonNull String stockItemId, @Nullable UUID siteId, @Nullable Instant horizon, long onHand);
+            @NonNull String stockItemId, @Nullable UUID siteId, @Nullable Instant horizon, @NonNull BigDecimal onHand);
 
-    /** Computed forecast triple; quantities floor fractional supply DOWN (never over-promise). */
-    record ForecastQuantities(long incomingQty, long outgoingQty, long projectedAvailable) {}
+    /**
+     * Computed forecast triple.
+     *
+     * <p>Decimal since ADR-0055 (#1414). These derive from the same arithmetic as
+     * {@code onHand} — {@code projectedAvailable = onHand + incoming - outgoing} — so leaving them
+     * integral once on-hand is decimal would only relocate the truncation into the projection,
+     * where it would be harder to see. The former {@code DOWN} floor on incoming supply went with
+     * the widening: it existed to squeeze a fractional expected quantity into an integer field
+     * without over-promising, and there is no longer a field to squeeze it into.
+     */
+    record ForecastQuantities(BigDecimal incomingQty, BigDecimal outgoingQty, BigDecimal projectedAvailable) {}
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ForecastQuantityServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ForecastQuantityServiceImpl.java
@@ -6,7 +6,6 @@ import com.positivity.inventory.internal.enums.ReservationStatus;
 import com.positivity.inventory.internal.repository.PickTaskRepository;
 import com.positivity.inventory.internal.repository.ReservationRepository;
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -39,30 +38,32 @@ public class ForecastQuantityServiceImpl implements ForecastQuantityService {
     @Override
     @Transactional(readOnly = true)
     public @NonNull ForecastQuantities forecast(
-            @NonNull String stockItemId, @Nullable UUID siteId, @Nullable Instant horizon, long onHand) {
-        BigDecimal incoming = expectedSupplyService.expectedIncomingQuantity(stockItemId, siteId, horizon);
-        // Floor fractional supply DOWN: never project more than is certain to arrive.
-        long incomingQty = incoming.setScale(0, RoundingMode.DOWN).longValueExact();
+            @NonNull String stockItemId, @Nullable UUID siteId, @Nullable Instant horizon, @NonNull BigDecimal onHand) {
+        // No rounding here since ADR-0055 (#1414): the forecast fields are decimal, so expected
+        // supply is carried at the precision the supplying documents state it in rather than
+        // floored to squeeze it into an integer.
+        BigDecimal incomingQty = expectedSupplyService.expectedIncomingQuantity(stockItemId, siteId, horizon);
 
-        long outgoingQty = reservationRemainder(stockItemId, horizon) + pickTaskRemainder(stockItemId, siteId);
+        BigDecimal outgoingQty = reservationRemainder(stockItemId, horizon).add(pickTaskRemainder(stockItemId, siteId));
 
-        return new ForecastQuantities(incomingQty, outgoingQty, onHand + incomingQty - outgoingQty);
+        return new ForecastQuantities(
+                incomingQty, outgoingQty, onHand.add(incomingQty).subtract(outgoingQty));
     }
 
-    private long reservationRemainder(String stockItemId, @Nullable Instant horizon) {
+    private BigDecimal reservationRemainder(String stockItemId, @Nullable Instant horizon) {
         UUID skuUuid = parseUuid(stockItemId);
         if (skuUuid == null) {
-            return 0L;
+            return BigDecimal.ZERO;
         }
-        Long remainder = reservationRepository.sumOpenRemainderForSku(
+        BigDecimal remainder = reservationRepository.sumOpenRemainderForSku(
                 skuUuid, OPEN_RESERVATION_STATUSES, horizon != null, horizon);
-        return remainder == null ? 0L : remainder;
+        return remainder == null ? BigDecimal.ZERO : remainder;
     }
 
-    private long pickTaskRemainder(String stockItemId, @Nullable UUID siteId) {
+    private BigDecimal pickTaskRemainder(String stockItemId, @Nullable UUID siteId) {
         Long remainder = pickTaskRepository.sumReleasedUnpickedRemainderForSku(
                 stockItemId, parseUuid(stockItemId), PickTaskStatus.PENDING, RELEASED_PICK_LIST_STATUSES, siteId);
-        return remainder == null ? 0L : remainder;
+        return remainder == null ? BigDecimal.ZERO : BigDecimal.valueOf(remainder);
     }
 
     private static @Nullable UUID parseUuid(String value) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/HighestStockSourcingStrategy.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/HighestStockSourcingStrategy.java
@@ -4,6 +4,7 @@ import com.positivity.inventory.internal.enums.SourcingStrategy;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingCandidate;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingSelection;
+import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -38,19 +39,20 @@ public class HighestStockSourcingStrategy implements SourcingOrderingStrategy {
             return List.copyOf(selection.candidates());
         }
         return selection.candidates().stream()
-                .sorted(Comparator.comparingLong(
-                                (SourcingCandidate candidate) -> -availableOf(selection.stockItemId(), candidate))
+                .sorted(Comparator.comparing(
+                                (SourcingCandidate candidate) -> availableOf(selection.stockItemId(), candidate),
+                                Comparator.reverseOrder())
                         .thenComparing(SourcingCandidate::locationId))
                 .toList();
     }
 
-    private long availableOf(String stockItemId, SourcingCandidate candidate) {
+    private BigDecimal availableOf(String stockItemId, SourcingCandidate candidate) {
         if (candidate.availableQuantity() != null) {
             return candidate.availableQuantity();
         }
         return stockSummaryRepository
                 .findByStockItemIdAndLocationId(stockItemId, candidate.locationId())
-                .map(summary -> summary.getOnHand() - summary.getAllocated())
-                .orElse(0L);
+                .map(summary -> Quantities.nz(summary.getOnHand()).subtract(Quantities.nz(summary.getAllocated())))
+                .orElse(BigDecimal.ZERO);
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryAvailabilityServiceImpl.java
@@ -10,6 +10,7 @@ import com.positivity.inventory.internal.exception.ProductNotFoundException;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.service.InventoryAvailabilityService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -45,6 +46,7 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
     private final ForecastQuantityService forecastQuantityService;
     private final AsOfQueryGuard asOfQueryGuard;
     private final ForecastSiteResolver forecastSiteResolver;
+    private final QuantityScaleGuard quantityScaleGuard;
     private final Clock clock;
 
     public InventoryAvailabilityServiceImpl(
@@ -53,12 +55,14 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
             ForecastQuantityService forecastQuantityService,
             AsOfQueryGuard asOfQueryGuard,
             ForecastSiteResolver forecastSiteResolver,
+            QuantityScaleGuard quantityScaleGuard,
             Clock clock) {
         this.stockSummaryRepository = stockSummaryRepository;
         this.inventoryLedgerEntryRepository = inventoryLedgerEntryRepository;
         this.forecastQuantityService = forecastQuantityService;
         this.asOfQueryGuard = asOfQueryGuard;
         this.forecastSiteResolver = forecastSiteResolver;
+        this.quantityScaleGuard = quantityScaleGuard;
         this.clock = clock;
     }
 
@@ -67,8 +71,24 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
      * (odoo-parity E3, issue #1047; decision D-7 on-read guard). Expired lots stay counted in
      * on-hand but drop out of what can be promised. A null scope sums across every location.
      */
-    private long expiredLotDeduction(@NonNull String stockItemId, @Nullable UUID scopeLocationId) {
-        return stockSummaryRepository.sumExpiredActiveLotOnHand(stockItemId, scopeLocationId, LocalDate.now(clock));
+    private BigDecimal expiredLotDeduction(@NonNull String stockItemId, @Nullable UUID scopeLocationId) {
+        return Quantities.nz(
+                stockSummaryRepository.sumExpiredActiveLotOnHand(stockItemId, scopeLocationId, LocalDate.now(clock)));
+    }
+
+    /**
+     * Fail-loud narrowing replacement (ADR-0055, #1414).
+     *
+     * <p>Every quantity leaving this service used to pass through {@code Math.toIntExact}, which
+     * threw rather than wrapping. That throw is the property worth keeping; the bound it checked
+     * is not, because a decimal read model has no 32-bit edge. So each of those calls became this:
+     * the value is checked against the scale the product's catalog declaration permits, and a
+     * quantity carrying more precision than any declaration supports still stops the computation
+     * loudly instead of being reported as though it were fine.
+     */
+    private BigDecimal reportable(@NonNull String stockItemId, @NonNull String fieldName, BigDecimal quantity) {
+        return quantityScaleGuard.requireReportable(
+                QuantityScaleGuard.productIdOf(stockItemId), stockItemId, fieldName, Quantities.nz(quantity));
     }
 
     /** Bin → parent-site resolution shared with the replenishment orderpoint math (F2). */
@@ -124,7 +144,7 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
                 .map(row -> LocationAvailabilityDto.builder()
                         .locationId(row.getLocationId())
                         .locationName(row.getLocationId().toString())
-                        .onHandQuantity(Math.toIntExact(row.getQuantity()))
+                        .onHandQuantity(reportable(productId.toString(), "onHandQuantity", row.getQuantity()))
                         .build())
                 .toList();
     }
@@ -153,22 +173,24 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
         }
 
         UUID scopeLocationId = storageLocationId != null ? storageLocationId : locationId;
-        long onHand;
-        long allocated;
+        BigDecimal onHand;
+        BigDecimal allocated;
         if (scopeLocationId == null) {
             onHand = productRows.stream()
-                    .mapToLong(InventoryStockSummary::getOnHand)
-                    .sum();
+                    .map(InventoryStockSummary::getOnHand)
+                    .map(Quantities::nz)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
             allocated = productRows.stream()
-                    .mapToLong(InventoryStockSummary::getAllocated)
-                    .sum();
+                    .map(InventoryStockSummary::getAllocated)
+                    .map(Quantities::nz)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
         } else {
             InventoryStockSummary scoped = productRows.stream()
                     .filter(row -> scopeLocationId.equals(row.getLocationId()))
                     .findFirst()
                     .orElse(null);
-            onHand = scoped == null ? 0L : scoped.getOnHand();
-            allocated = scoped == null ? 0L : scoped.getAllocated();
+            onHand = scoped == null ? BigDecimal.ZERO : Quantities.nz(scoped.getOnHand());
+            allocated = scoped == null ? BigDecimal.ZERO : Quantities.nz(scoped.getAllocated());
         }
 
         // Forecast site scope (odoo-parity A2, #1028): the site parameter when present,
@@ -180,15 +202,18 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
 
         // odoo-parity E3 (#1047, decision D-7): expired lots stay in on-hand but drop from ATP.
         // ATP = lot-agnostic (onHand − allocated) − Σ(expired ACTIVE lots' per-lot on-hand at scope).
-        long expiredDeduction = expiredLotDeduction(productSku, scopeLocationId);
+        BigDecimal expiredDeduction = expiredLotDeduction(productSku, scopeLocationId);
 
         return AvailabilityView.builder()
                 .productSku(productSku)
                 .locationId(locationId)
                 .storageLocationId(storageLocationId)
-                .onHandQuantity(Math.toIntExact(onHand))
-                .allocatedQuantity(Math.toIntExact(allocated))
-                .availableToPromiseQuantity(Math.toIntExact(onHand - allocated - expiredDeduction))
+                .onHandQuantity(reportable(productSku, "onHandQuantity", onHand))
+                .allocatedQuantity(reportable(productSku, "allocatedQuantity", allocated))
+                .availableToPromiseQuantity(reportable(
+                        productSku,
+                        "availableToPromiseQuantity",
+                        onHand.subtract(allocated).subtract(expiredDeduction)))
                 .unitOfMeasure(deriveUnitOfMeasure(productSku, scopeLocationId))
                 .incomingQty(forecast.incomingQty())
                 .outgoingQty(forecast.outgoingQty())
@@ -209,15 +234,22 @@ public class InventoryAvailabilityServiceImpl implements InventoryAvailabilitySe
         // allocations and soft reservations from ATP (unlike queryAvailability,
         // which per ADR-0001 subtracts allocations only). odoo-parity E3 (#1047,
         // decision D-7): also subtract the location's expired ACTIVE lot on-hand.
-        long expiredDeduction = expiredLotDeduction(row.getStockItemId(), row.getLocationId());
-        long atpWithReservations = row.getOnHand() - row.getAllocated() - row.getReserved() - expiredDeduction;
+        BigDecimal expiredDeduction = expiredLotDeduction(row.getStockItemId(), row.getLocationId());
+        BigDecimal atpWithReservations = Quantities.nz(row.getOnHand())
+                .subtract(Quantities.nz(row.getAllocated()))
+                .subtract(Quantities.nz(row.getReserved()))
+                .subtract(expiredDeduction);
         ForecastQuantityService.ForecastQuantities forecast = forecastQuantityService.forecast(
-                row.getStockItemId(), resolveForecastSite(row.getLocationId()), horizon, row.getOnHand());
+                row.getStockItemId(),
+                resolveForecastSite(row.getLocationId()),
+                horizon,
+                Quantities.nz(row.getOnHand()));
         return LocationAvailabilityDto.builder()
                 .locationId(row.getLocationId())
                 .locationName(row.getLocationId().toString())
-                .onHandQuantity(Math.toIntExact(row.getOnHand()))
-                .availableToPromiseQuantity(Math.toIntExact(atpWithReservations))
+                .onHandQuantity(reportable(row.getStockItemId(), "onHandQuantity", row.getOnHand()))
+                .availableToPromiseQuantity(
+                        reportable(row.getStockItemId(), "availableToPromiseQuantity", atpWithReservations))
                 .incomingQty(forecast.incomingQty())
                 .outgoingQty(forecast.outgoingQty())
                 .projectedAvailable(forecast.projectedAvailable())

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryFactPublisher.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryFactPublisher.java
@@ -301,9 +301,9 @@ public class InventoryFactPublisher {
                                 view.getAllocatedQuantity(),
                                 view.getAvailableToPromiseQuantity(),
                                 view.getUnitOfMeasure(),
-                                zeroIfNull(view.getIncomingQty()),
-                                zeroIfNull(view.getOutgoingQty()),
-                                zeroIfNull(view.getProjectedAvailable())));
+                                Quantities.nz(view.getIncomingQty()),
+                                Quantities.nz(view.getOutgoingQty()),
+                                Quantities.nz(view.getProjectedAvailable())));
             } catch (Exception e) {
                 // A snapshot that cannot be computed must not roll back the business write;
                 // the next mutation or a manifest replay repairs the replica.
@@ -320,7 +320,7 @@ public class InventoryFactPublisher {
                         StorageLocationOnHandUpdatedV1.SCHEMA_VERSION,
                         storageLocationId,
                         new StorageLocationOnHandUpdatedV1(
-                                storageLocationId, Math.toIntExact(inquiry.getOnHandQuantity())));
+                                storageLocationId, Quantities.nz(inquiry.getOnHandQuantity())));
             } catch (Exception e) {
                 log.warn("Skipping storage-location on-hand fact for {}: {}", storageLocationId, e.getMessage());
             }
@@ -520,10 +520,6 @@ public class InventoryFactPublisher {
                 payload,
                 clock);
         writer.publish(eventsTopic, envelope);
-    }
-
-    private static long zeroIfNull(@Nullable Long value) {
-        return value == null ? 0L : value;
     }
 
     /** Deterministic aggregate identity for a (stockItemId, locationId) availability key. */

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLocationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLocationServiceImpl.java
@@ -8,6 +8,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.service.InventoryLocationService;
 import com.positivity.security.common.SecurityContextHelper;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -144,14 +145,15 @@ public class InventoryLocationServiceImpl implements InventoryLocationService {
         List<DeactivateLocationResponse.MovedItem> movedItems = new ArrayList<>(onHandRows.size());
 
         for (InventoryLedgerEntryRepository.LocationOnHand row : onHandRows) {
-            int quantityToMove = Math.toIntExact(row.getOnHandQuantity());
-            if (quantityToMove <= 0) {
+            BigDecimal quantityToMove = Quantities.nz(row.getOnHandQuantity());
+            if (!Quantities.isPositive(quantityToMove)) {
                 continue;
             }
 
             String stockItemId = row.getStockItemId();
-            int destinationOnHand = safeQuantity(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
-                    stockItemId, destinationLocationId));
+            BigDecimal destinationOnHand =
+                    Quantities.nz(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
+                            stockItemId, destinationLocationId));
 
             transferEntries.add(InventoryLedgerEntry.builder()
                     .stockItemId(stockItemId)
@@ -159,8 +161,8 @@ public class InventoryLocationServiceImpl implements InventoryLocationService {
                     .fromLocationId(sourceLocationId)
                     .toLocationId(destinationLocationId)
                     .eventType(InventoryLedgerEventType.TRANSFER_OUT)
-                    .changeInQuantity(-quantityToMove)
-                    .quantityAfter(0)
+                    .changeInQuantity(quantityToMove.negate())
+                    .quantityAfter(BigDecimal.ZERO)
                     .transactionUserId(actorUserId)
                     .timestamp(timestamp)
                     .reasonCode(LOCATION_TRANSFER_REASON)
@@ -174,7 +176,7 @@ public class InventoryLocationServiceImpl implements InventoryLocationService {
                     .toLocationId(destinationLocationId)
                     .eventType(InventoryLedgerEventType.TRANSFER_IN)
                     .changeInQuantity(quantityToMove)
-                    .quantityAfter(destinationOnHand + quantityToMove)
+                    .quantityAfter(destinationOnHand.add(quantityToMove))
                     .transactionUserId(actorUserId)
                     .timestamp(timestamp)
                     .reasonCode(LOCATION_TRANSFER_REASON)
@@ -217,9 +219,5 @@ public class InventoryLocationServiceImpl implements InventoryLocationService {
                     .counter("inventory.location.deactivate.items_moved.total")
                     .increment(movedItemCount);
         }
-    }
-
-    private int safeQuantity(Integer value) {
-        return value == null ? 0 : value;
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLotStatusReconciler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/InventoryLotStatusReconciler.java
@@ -4,6 +4,7 @@ import com.positivity.inventory.internal.entity.InventoryLot;
 import com.positivity.inventory.internal.enums.InventoryLotStatus;
 import com.positivity.inventory.internal.repository.InventoryLotRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -46,12 +47,12 @@ public class InventoryLotStatusReconciler {
             if (lot == null) {
                 continue;
             }
-            long totalStock = summaryRepository.sumLotStockAcrossLocations(lotId);
-            if (totalStock == 0 && lot.getStatus() == InventoryLotStatus.ACTIVE) {
+            BigDecimal totalStock = Quantities.nz(summaryRepository.sumLotStockAcrossLocations(lotId));
+            if (Quantities.isZero(totalStock) && lot.getStatus() == InventoryLotStatus.ACTIVE) {
                 lot.setStatus(InventoryLotStatus.CONSUMED);
                 lotRepository.save(lot);
                 log.info("Lot {} ({}) fully consumed; status ACTIVE -> CONSUMED", lotId, lot.getLotNumber());
-            } else if (totalStock > 0 && lot.getStatus() == InventoryLotStatus.CONSUMED) {
+            } else if (Quantities.isPositive(totalStock) && lot.getStatus() == InventoryLotStatus.CONSUMED) {
                 lot.setStatus(InventoryLotStatus.ACTIVE);
                 lotRepository.save(lot);
                 log.info(

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerCostingService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerCostingService.java
@@ -79,7 +79,7 @@ public class LedgerCostingService {
             }
             SkuCostState state = stateCache.computeIfAbsent(stockItemId, this::loadOrSeedState);
 
-            int change = entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity();
+            BigDecimal change = Quantities.nz(entry.getChangeInQuantity());
             CostingStrategy.CostState currentState =
                     new CostingStrategy.CostState(state.getAvgCost(), state.getOnHandQty(), state.getStandardCost());
             CostingStrategy.CostingInput input =

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerPostingServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LedgerPostingServiceImpl.java
@@ -11,6 +11,7 @@ import com.positivity.inventory.internal.exception.UomConversionUndefinedExcepti
 import com.positivity.inventory.internal.repository.ExtProductReplicaRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -220,10 +221,10 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
         Set<SummaryKey> inboundKeys = new LinkedHashSet<>();
         for (InventoryLedgerEntry entry : entries) {
             InventoryLedgerEventType eventType = entry.getEventType();
-            int change = entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity();
+            BigDecimal change = Quantities.nz(entry.getChangeInQuantity());
             if (eventType != null
                     && eventType.affectsOnHand()
-                    && change > 0
+                    && Quantities.isPositive(change)
                     && entry.getStockItemId() != null
                     && entry.getLocationId() != null) {
                 inboundKeys.add(new SummaryKey(entry.getStockItemId(), entry.getLocationId(), null));
@@ -299,7 +300,7 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
             List<InventoryLedgerEntry> entries,
             Map<SummaryKey, InventoryStockSummary> lockedRows,
             boolean negativeStockOverride) {
-        Map<SummaryKey, Long> projectedOnHand = new HashMap<>();
+        Map<SummaryKey, BigDecimal> projectedOnHand = new HashMap<>();
         for (InventoryLedgerEntry entry : entries) {
             InventoryLedgerEventType eventType = entry.getEventType();
             if (eventType == null || !eventType.affectsOnHand()) {
@@ -308,14 +309,14 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
             // The matrix evaluates the lot-agnostic key only; the per-lot floor is a separate,
             // absolute check (enforcePerLotFloor — odoo-parity E2, #1042).
             SummaryKey key = new SummaryKey(entry.getStockItemId(), entry.getLocationId(), null);
-            long projected = projectedOnHand.computeIfAbsent(
+            BigDecimal projected = projectedOnHand.computeIfAbsent(
                     key,
-                    missing -> Objects.requireNonNull(
+                    missing -> Quantities.nz(Objects.requireNonNull(
                                     lockedRows.get(missing), "summary row must be locked for on-hand entry " + missing)
-                            .getOnHand());
-            projected += entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity();
+                            .getOnHand()));
+            projected = projected.add(Quantities.nz(entry.getChangeInQuantity()));
             projectedOnHand.put(key, projected);
-            if (projected < 0) {
+            if (Quantities.isNegative(projected)) {
                 rejectNegativeProjection(eventType, entry, projected, negativeStockOverride);
             }
         }
@@ -336,21 +337,21 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
      */
     private void enforcePerLotFloor(
             List<InventoryLedgerEntry> entries, Map<SummaryKey, InventoryStockSummary> lockedRows) {
-        Map<SummaryKey, Long> projectedOnHand = new HashMap<>();
+        Map<SummaryKey, BigDecimal> projectedOnHand = new HashMap<>();
         for (InventoryLedgerEntry entry : entries) {
             InventoryLedgerEventType eventType = entry.getEventType();
             if (entry.getLotId() == null || eventType == null || !eventType.affectsOnHand()) {
                 continue;
             }
             SummaryKey key = new SummaryKey(entry.getStockItemId(), entry.getLocationId(), entry.getLotId());
-            long projected = projectedOnHand.computeIfAbsent(
+            BigDecimal projected = projectedOnHand.computeIfAbsent(
                     key,
-                    missing -> Objects.requireNonNull(
+                    missing -> Quantities.nz(Objects.requireNonNull(
                                     lockedRows.get(missing), "per-lot summary row must be locked for entry " + missing)
-                            .getOnHand());
-            projected += entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity();
+                            .getOnHand()));
+            projected = projected.add(Quantities.nz(entry.getChangeInQuantity()));
             projectedOnHand.put(key, projected);
-            if (projected < 0) {
+            if (Quantities.isNegative(projected)) {
                 throw new LotInsufficientStockException(
                         entry.getStockItemId(), entry.getLotId(), entry.getLocationId(), projected);
             }
@@ -360,7 +361,7 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
     private void rejectNegativeProjection(
             InventoryLedgerEventType eventType,
             InventoryLedgerEntry entry,
-            long projectedOnHand,
+            BigDecimal projectedOnHand,
             boolean negativeStockOverride) {
         switch (NegativeStockPolicy.forEventType(eventType)) {
             case BLOCKED ->
@@ -395,26 +396,26 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
 
     private @Nullable SummaryDelta deltaFor(InventoryLedgerEntry entry) {
         InventoryLedgerEventType eventType = entry.getEventType();
-        int change = entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity();
-        long onHand = 0;
-        long allocated = 0;
-        long reserved = 0;
-        long inTransit = 0;
+        BigDecimal change = Quantities.nz(entry.getChangeInQuantity());
+        BigDecimal onHand = BigDecimal.ZERO;
+        BigDecimal allocated = BigDecimal.ZERO;
+        BigDecimal reserved = BigDecimal.ZERO;
+        BigDecimal inTransit = BigDecimal.ZERO;
         if (eventType != null && eventType.affectsOnHand()) {
             onHand = change;
             if (eventType == InventoryLedgerEventType.TRANSFER_IN) {
                 // Arrival at the destination key: goods leave transit as they land on-hand
                 // (odoo-parity C2, #1036). -change because arrivals carry a positive change.
-                inTransit = -change;
+                inTransit = change.negate();
             }
         } else if (eventType == InventoryLedgerEventType.ALLOCATION_CREATED) {
             allocated = change;
         } else if (eventType == InventoryLedgerEventType.ALLOCATION_RELEASED) {
-            allocated = -change;
+            allocated = change.negate();
         } else if (eventType == InventoryLedgerEventType.RESERVATION_CREATED) {
             reserved = change;
         } else if (eventType == InventoryLedgerEventType.RESERVATION_RELEASED) {
-            reserved = -change;
+            reserved = change.negate();
         } else {
             return null;
         }
@@ -433,16 +434,22 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
         if (entry.getEventType() != InventoryLedgerEventType.TRANSFER_OUT || entry.getToLocationId() == null) {
             return null;
         }
-        int change = entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity();
-        return new SummaryDelta(0, 0, 0, -change, entry.getLedgerEntryId(), entry.getTimestamp());
+        BigDecimal change = Quantities.nz(entry.getChangeInQuantity());
+        return new SummaryDelta(
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                change.negate(),
+                entry.getLedgerEntryId(),
+                entry.getTimestamp());
     }
 
     private void applyDelta(InventoryStockSummary row, SummaryDelta delta) {
-        row.setOnHand(row.getOnHand() + delta.onHand());
-        row.setAllocated(row.getAllocated() + delta.allocated());
-        row.setReserved(row.getReserved() + delta.reserved());
-        row.setAtp(row.getOnHand() - row.getAllocated());
-        row.setInTransitQty(row.getInTransitQty() + delta.inTransit());
+        row.setOnHand(Quantities.nz(row.getOnHand()).add(delta.onHand()));
+        row.setAllocated(Quantities.nz(row.getAllocated()).add(delta.allocated()));
+        row.setReserved(Quantities.nz(row.getReserved()).add(delta.reserved()));
+        row.setAtp(row.getOnHand().subtract(row.getAllocated()));
+        row.setInTransitQty(Quantities.nz(row.getInTransitQty()).add(delta.inTransit()));
         row.setLastLedgerEntryId(delta.lastLedgerEntryId());
         row.setLastEventAt(delta.lastEventAt());
         summaryRepository.save(row);
@@ -494,19 +501,19 @@ public class LedgerPostingServiceImpl implements LedgerPostingService {
     }
 
     private record SummaryDelta(
-            long onHand,
-            long allocated,
-            long reserved,
-            long inTransit,
+            BigDecimal onHand,
+            BigDecimal allocated,
+            BigDecimal reserved,
+            BigDecimal inTransit,
             @Nullable UUID lastLedgerEntryId,
             @Nullable Instant lastEventAt) {
 
         private SummaryDelta plus(SummaryDelta other) {
             return new SummaryDelta(
-                    onHand + other.onHand,
-                    allocated + other.allocated,
-                    reserved + other.reserved,
-                    inTransit + other.inTransit,
+                    onHand.add(other.onHand),
+                    allocated.add(other.allocated),
+                    reserved.add(other.reserved),
+                    inTransit.add(other.inTransit),
                     other.lastLedgerEntryId() != null ? other.lastLedgerEntryId() : lastLedgerEntryId,
                     other.lastEventAt() != null ? other.lastEventAt() : lastEventAt);
         }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryInquiryServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/LocationInventoryInquiryServiceImpl.java
@@ -7,6 +7,7 @@ import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.service.LocationInventoryInquiryService;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -42,23 +43,23 @@ public class LocationInventoryInquiryServiceImpl implements LocationInventoryInq
     @Transactional(readOnly = true)
     @NonNull
     public LocationInventoryInquiryResponse getLocationInventory(@NonNull UUID locationId, @Nullable String sku) {
-        long onHandQuantity;
-        long outstandingAllocations;
+        BigDecimal onHandQuantity;
+        BigDecimal outstandingAllocations;
         if (sku == null || sku.isBlank()) {
-            onHandQuantity = stockSummaryRepository.sumOnHandAtLocation(locationId);
-            outstandingAllocations = stockSummaryRepository.sumAllocatedAtLocation(locationId);
+            onHandQuantity = Quantities.nz(stockSummaryRepository.sumOnHandAtLocation(locationId));
+            outstandingAllocations = Quantities.nz(stockSummaryRepository.sumAllocatedAtLocation(locationId));
         } else {
             InventoryStockSummary row = stockSummaryRepository
                     .findByStockItemIdAndLocationId(sku, locationId)
                     .orElse(null);
-            onHandQuantity = row == null ? 0L : row.getOnHand();
-            outstandingAllocations = row == null ? 0L : row.getAllocated();
+            onHandQuantity = row == null ? BigDecimal.ZERO : Quantities.nz(row.getOnHand());
+            outstandingAllocations = row == null ? BigDecimal.ZERO : Quantities.nz(row.getAllocated());
         }
 
         return LocationInventoryInquiryResponse.builder()
                 .locationId(locationId)
                 .onHandQuantity(onHandQuantity)
-                .availableToPromiseQuantity(onHandQuantity - outstandingAllocations)
+                .availableToPromiseQuantity(onHandQuantity.subtract(outstandingAllocations))
                 .build();
     }
 
@@ -67,7 +68,7 @@ public class LocationInventoryInquiryServiceImpl implements LocationInventoryInq
     @NonNull
     public LocationInventoryItemsResponse listLocationInventoryItems(@NonNull UUID locationId) {
         List<LocationInventoryItemsResponse.Item> items =
-                stockSummaryRepository.findByLocationIdAndOnHandGreaterThan(locationId, 0L).stream()
+                stockSummaryRepository.findByLocationIdAndOnHandGreaterThan(locationId, BigDecimal.ZERO).stream()
                         .map(row -> LocationInventoryItemsResponse.Item.builder()
                                 .stockItemId(row.getStockItemId())
                                 .onHandQuantity(row.getOnHand())
@@ -87,7 +88,7 @@ public class LocationInventoryInquiryServiceImpl implements LocationInventoryInq
             @NonNull UUID locationId, @Nullable String sku, @NonNull Instant asOf) {
         asOfQueryGuard.check(asOf);
 
-        Integer onHand = (sku == null || sku.isBlank())
+        BigDecimal onHand = (sku == null || sku.isBlank())
                 ? inventoryLedgerEntryRepository.calculateOnHandAtLocationAsOf(
                         locationId, InventoryLedgerEventType.onHandAffectingTypes(), asOf)
                 : inventoryLedgerEntryRepository.calculateOnHandForStockItemAtLocationAsOf(
@@ -97,7 +98,7 @@ public class LocationInventoryInquiryServiceImpl implements LocationInventoryInq
         // is not reliably reconstructable from ATP-neutral ledger events (A3, #1029).
         return LocationInventoryInquiryResponse.builder()
                 .locationId(locationId)
-                .onHandQuantity(onHand == null ? 0L : onHand.longValue())
+                .onHandQuantity(Quantities.nz(onHand))
                 .build();
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/OrderEventsListener.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/OrderEventsListener.java
@@ -9,6 +9,7 @@ import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.entity.ProcessedEvent;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.ProcessedEventRepository;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.UUID;
@@ -128,8 +129,11 @@ public class OrderEventsListener {
                 counterSaleIssuePoster.post(InventoryLedgerEntry.builder()
                         .stockItemId(sku)
                         .eventType(InventoryLedgerEventType.GOODS_ISSUE)
-                        .changeInQuantity(-quantity)
-                        .quantityAfter(0)
+                        // Sales-order demand stays integral by decision (ADR-0055 leaves
+                        // SalesOrderLine.quantity an int), so this widens at the boundary rather
+                        // than narrowing anything.
+                        .changeInQuantity(BigDecimal.valueOf(quantity).negate())
+                        .quantityAfter(BigDecimal.ZERO)
                         .locationId(locationId)
                         .reasonCode(COUNTER_SALE_REASON)
                         .sourceTransactionId(orderLineId.toString())
@@ -171,8 +175,8 @@ public class OrderEventsListener {
                 counterSaleIssuePoster.post(InventoryLedgerEntry.builder()
                         .stockItemId(sku)
                         .eventType(InventoryLedgerEventType.RETURN_TO_STOCK)
-                        .changeInQuantity(quantity)
-                        .quantityAfter(0)
+                        .changeInQuantity(BigDecimal.valueOf(quantity))
+                        .quantityAfter(BigDecimal.ZERO)
                         .locationId(locationId)
                         .reasonCode(COUNTER_RETURN_REASON)
                         .sourceTransactionId(sourceTransactionId)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PickListGenerationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PickListGenerationServiceImpl.java
@@ -174,9 +174,11 @@ public class PickListGenerationServiceImpl implements PickListGenerationService 
     private SourcingDecision suggestLocation(String sku) {
         List<SourcingCandidate> candidates = stockSummaryRepository.findByStockItemId(sku).stream()
                 .filter(summary -> summary.getLocationId() != null)
-                .filter(summary -> summary.getOnHand() - summary.getAllocated() > 0)
-                .map(summary ->
-                        new SourcingCandidate(summary.getLocationId(), summary.getOnHand() - summary.getAllocated()))
+                .filter(summary -> Quantities.isPositive(
+                        Quantities.nz(summary.getOnHand()).subtract(Quantities.nz(summary.getAllocated()))))
+                .map(summary -> new SourcingCandidate(
+                        summary.getLocationId(),
+                        Quantities.nz(summary.getOnHand()).subtract(Quantities.nz(summary.getAllocated()))))
                 .toList();
         return sourcingStrategyService.orderCandidates(new SourcingSelection(sku, null, null, candidates));
     }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayExecuteServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayExecuteServiceImpl.java
@@ -14,6 +14,7 @@ import com.positivity.inventory.internal.repository.PutawayTaskRepository;
 import com.positivity.inventory.service.PutawayExecuteService;
 import com.positivity.inventory.service.PutawayValidationService;
 import com.positivity.security.common.SecurityContextHelper;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.UUID;
@@ -49,19 +50,24 @@ public class PutawayExecuteServiceImpl implements PutawayExecuteService {
         ensureValidationPassed(validationResult);
 
         Instant now = Instant.now(clock);
-        int sourceOnHandBefore = onHandQuantityAtLocation(request.getSkuId(), request.getSourceLocationId());
-        int sourceOnHandAfter = sourceOnHandBefore - request.getQuantity();
+        // The putaway request quantity is still an int (a bin move of discrete units; the UOM
+        // work in ADR-0055 stage 3 revisits it), so this widens at the boundary — the ledger
+        // running totals it is added to are decimal.
+        BigDecimal movedQuantity = BigDecimal.valueOf(request.getQuantity());
+        BigDecimal sourceOnHandBefore = onHandQuantityAtLocation(request.getSkuId(), request.getSourceLocationId());
+        BigDecimal sourceOnHandAfter = sourceOnHandBefore.subtract(movedQuantity);
 
-        int destinationOnHandBefore = onHandQuantityAtLocation(request.getSkuId(), request.getDestinationLocationId());
-        int destinationBaseOnHand = request.getSourceLocationId().equals(request.getDestinationLocationId())
+        BigDecimal destinationOnHandBefore =
+                onHandQuantityAtLocation(request.getSkuId(), request.getDestinationLocationId());
+        BigDecimal destinationBaseOnHand = request.getSourceLocationId().equals(request.getDestinationLocationId())
                 ? sourceOnHandAfter
                 : destinationOnHandBefore;
-        int destinationOnHandAfter = destinationBaseOnHand + request.getQuantity();
+        BigDecimal destinationOnHandAfter = destinationBaseOnHand.add(movedQuantity);
 
         InventoryLedgerEntry sourceLedgerEntry = InventoryLedgerEntry.builder()
                 .stockItemId(request.getSkuId())
                 .eventType(InventoryLedgerEventType.PUTAWAY)
-                .changeInQuantity(-request.getQuantity())
+                .changeInQuantity(movedQuantity.negate())
                 .quantityAfter(sourceOnHandAfter)
                 .transactionUserId(actorId)
                 .locationId(request.getSourceLocationId())
@@ -75,7 +81,7 @@ public class PutawayExecuteServiceImpl implements PutawayExecuteService {
         InventoryLedgerEntry destinationLedgerEntry = InventoryLedgerEntry.builder()
                 .stockItemId(request.getSkuId())
                 .eventType(InventoryLedgerEventType.PUTAWAY)
-                .changeInQuantity(request.getQuantity())
+                .changeInQuantity(movedQuantity)
                 .quantityAfter(destinationOnHandAfter)
                 .transactionUserId(actorId)
                 .locationId(request.getDestinationLocationId())
@@ -135,8 +141,7 @@ public class PutawayExecuteServiceImpl implements PutawayExecuteService {
         throw new PutawayValidationException(errorCode, message);
     }
 
-    private int onHandQuantityAtLocation(String skuId, UUID locationId) {
-        Integer currentOnHand = inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(skuId, locationId);
-        return currentOnHand != null ? currentOnHand : 0;
+    private BigDecimal onHandQuantityAtLocation(String skuId, UUID locationId) {
+        return Quantities.nz(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(skuId, locationId));
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayValidationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayValidationServiceImpl.java
@@ -14,6 +14,8 @@ import com.positivity.inventory.internal.security.PutawayPermissions;
 import com.positivity.inventory.internal.service.StorageLocationValidationService.StorageLocationValidation;
 import com.positivity.inventory.service.PutawayValidationService;
 import com.positivity.security.common.SecurityContextHelper;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -30,6 +32,9 @@ public class PutawayValidationServiceImpl implements PutawayValidationService {
 
     private static final Logger log = LoggerFactory.getLogger(PutawayValidationServiceImpl.class);
     private static final double CAPACITY_TOLERANCE_PERCENT = 0.10; // 10% tolerance
+    /** Scale for the capacity utilisation ratio; BigDecimal division needs an explicit one. */
+    private static final int CAPACITY_RATIO_SCALE = 6;
+
     private static final List<InventoryLedgerEventType> ON_HAND_EVENT_TYPES = Arrays.stream(
                     InventoryLedgerEventType.values())
             .filter(InventoryLedgerEventType::affectsOnHand)
@@ -138,26 +143,32 @@ public class PutawayValidationServiceImpl implements PutawayValidationService {
         StorageLocationValidation locationValidation = getStorageLocationValidation(destinationLocationId);
         validateStorageLocation(locationValidation);
 
-        int currentCapacity = safeInt(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
+        // Capacity is a bin's declared unit limit and stays an int; the on-hand it is compared
+        // against comes from the ledger and is decimal (ADR-0055, #1414). Comparing them widens
+        // the limit rather than narrowing the measurement, so a bin holding 10.5 units is not
+        // reported as holding 10.
+        BigDecimal currentCapacity = Quantities.nz(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
                 destinationLocationId, ON_HAND_EVENT_TYPES));
-        int maxCapacity = getMaxCapacity(destinationLocationId, locationValidation);
+        BigDecimal maxCapacity = BigDecimal.valueOf(getMaxCapacity(destinationLocationId, locationValidation));
 
-        if (maxCapacity <= 0) {
+        if (!Quantities.isPositive(maxCapacity)) {
             throw new LocationAtCapacityException(destinationLocationId, currentCapacity, maxCapacity);
         }
 
-        int projectedCapacity = currentCapacity + quantity;
-        if (projectedCapacity < maxCapacity) {
+        BigDecimal projectedCapacity = currentCapacity.add(BigDecimal.valueOf(quantity));
+        if (Quantities.lt(projectedCapacity, maxCapacity)) {
             addCapacityNearLimitWarning(result, projectedCapacity, maxCapacity);
             return result;
         }
 
-        if (projectedCapacity == maxCapacity) {
+        if (projectedCapacity.compareTo(maxCapacity) == 0) {
             throw new LocationAtCapacityException(destinationLocationId, currentCapacity, maxCapacity);
         }
 
-        int overfillUnits = projectedCapacity - maxCapacity;
-        double overfillPercent = (double) overfillUnits / maxCapacity;
+        BigDecimal overfillUnits = projectedCapacity.subtract(maxCapacity);
+        double overfillPercent = overfillUnits
+                .divide(maxCapacity, CAPACITY_RATIO_SCALE, RoundingMode.HALF_UP)
+                .doubleValue();
         if (overfillPercent > CAPACITY_TOLERANCE_PERCENT) {
             throw new LocationAtCapacityException(destinationLocationId, currentCapacity, maxCapacity);
         }
@@ -165,13 +176,16 @@ public class PutawayValidationServiceImpl implements PutawayValidationService {
         result.addWarning(
                 "CAPACITY_NEAR_LIMIT",
                 String.format(
-                        "Projected capacity exceeds configured limit by %d units (%.2f%%). Override may be required.",
-                        overfillUnits, overfillPercent * 100.0));
+                        "Projected capacity exceeds configured limit by %s units (%.2f%%). Override may be required.",
+                        overfillUnits.toPlainString(), overfillPercent * 100.0));
         return result;
     }
 
-    private void addCapacityNearLimitWarning(ValidationResult result, int projectedCapacity, int maxCapacity) {
-        double utilizationPercent = (double) projectedCapacity / maxCapacity;
+    private void addCapacityNearLimitWarning(
+            ValidationResult result, BigDecimal projectedCapacity, BigDecimal maxCapacity) {
+        double utilizationPercent = projectedCapacity
+                .divide(maxCapacity, CAPACITY_RATIO_SCALE, RoundingMode.HALF_UP)
+                .doubleValue();
         if (utilizationPercent >= 1.0 - CAPACITY_TOLERANCE_PERCENT) {
             result.addWarning(
                     "CAPACITY_NEAR_LIMIT",
@@ -188,18 +202,19 @@ public class PutawayValidationServiceImpl implements PutawayValidationService {
             return result;
         }
 
-        int onHandQuantity = inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
-                skuId, sourceLocationId, ON_HAND_EVENT_TYPES);
+        BigDecimal onHandQuantity = Quantities.nz(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
+                skuId, sourceLocationId, ON_HAND_EVENT_TYPES));
 
-        if (onHandQuantity <= 0) {
+        if (!Quantities.isPositive(onHandQuantity)) {
             throw new NoOnHandAtSourceLocationException(sourceLocationId, skuId);
         }
 
-        if (onHandQuantity < quantity) {
+        if (Quantities.lt(onHandQuantity, BigDecimal.valueOf(quantity))) {
             result.addError(
                     "INSUFFICIENT_QUANTITY",
                     String.format(
-                            "Insufficient on-hand quantity. Available: %d, Required: %d", onHandQuantity, quantity));
+                            "Insufficient on-hand quantity. Available: %s, Required: %d",
+                            onHandQuantity.toPlainString(), quantity));
         }
 
         return result;
@@ -347,14 +362,18 @@ public class PutawayValidationServiceImpl implements PutawayValidationService {
                 toleranceValidation.getErrors().forEach(err -> result.addError(err.getErrorCode(), err.getMessage()));
             }
         } catch (LocationAtCapacityException e) {
-            if (e.getMaxCapacity() <= 0) {
+            if (!Quantities.isPositive(e.getMaxCapacity())) {
                 result.addError(
                         "CAPACITY_OVERRIDE_TOLERANCE_UNCHECKABLE",
                         "Cannot evaluate capacity override tolerance because max capacity is not configured");
             } else {
-                int projectedCapacity = e.getCurrentCapacity() + request.getQuantity();
-                int overfillUnits = projectedCapacity - e.getMaxCapacity();
-                double overfillPercent = overfillUnits <= 0 ? 0.0 : (double) overfillUnits / e.getMaxCapacity();
+                BigDecimal projectedCapacity = e.getCurrentCapacity().add(BigDecimal.valueOf(request.getQuantity()));
+                BigDecimal overfillUnits = projectedCapacity.subtract(e.getMaxCapacity());
+                double overfillPercent = !Quantities.isPositive(overfillUnits)
+                        ? 0.0
+                        : overfillUnits
+                                .divide(e.getMaxCapacity(), CAPACITY_RATIO_SCALE, RoundingMode.HALF_UP)
+                                .doubleValue();
                 if (overfillPercent > CAPACITY_TOLERANCE_PERCENT) {
                     result.addError(
                             "CAPACITY_OVERRIDE_EXCEEDS_TOLERANCE",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/Quantities.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/Quantities.java
@@ -1,0 +1,66 @@
+package com.positivity.inventory.internal.service;
+
+import java.math.BigDecimal;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Arithmetic helpers for the decimal inventory quantities the ledger and its read model carry
+ * (ADR-0055, #1414).
+ *
+ * <p>Exists for two reasons the widening from {@code int}/{@code long} made necessary. First,
+ * every quantity that used to be a primitive is now a reference and can be null, and a null
+ * quantity on a ledger entry has always meant zero — {@link #nz} keeps that reading in one place
+ * instead of scattering ternaries. Second, {@code BigDecimal.equals} compares scale as well as
+ * value, so {@code 1} and {@code 1.0} are unequal to it while being the same quantity; every
+ * comparison here goes through {@code compareTo} so no caller has to remember that.
+ */
+final class Quantities {
+
+    private Quantities() {}
+
+    /** The value, or {@code ZERO} when absent. An absent quantity has always meant none. */
+    static @NonNull BigDecimal nz(@Nullable BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
+    }
+
+    /** {@code a > b} by value, ignoring scale. */
+    static boolean gt(@Nullable BigDecimal a, @Nullable BigDecimal b) {
+        return nz(a).compareTo(nz(b)) > 0;
+    }
+
+    /** {@code a >= b} by value, ignoring scale. */
+    static boolean gte(@Nullable BigDecimal a, @Nullable BigDecimal b) {
+        return nz(a).compareTo(nz(b)) >= 0;
+    }
+
+    /** {@code a < b} by value, ignoring scale. */
+    static boolean lt(@Nullable BigDecimal a, @Nullable BigDecimal b) {
+        return nz(a).compareTo(nz(b)) < 0;
+    }
+
+    /** Whether the value is strictly positive. */
+    static boolean isPositive(@Nullable BigDecimal value) {
+        return nz(value).signum() > 0;
+    }
+
+    /** Whether the value is strictly negative. */
+    static boolean isNegative(@Nullable BigDecimal value) {
+        return nz(value).signum() < 0;
+    }
+
+    /** Whether the value is zero, at any scale. */
+    static boolean isZero(@Nullable BigDecimal value) {
+        return nz(value).signum() == 0;
+    }
+
+    /** The lesser of two quantities by value. */
+    static @NonNull BigDecimal min(@Nullable BigDecimal a, @Nullable BigDecimal b) {
+        return nz(a).compareTo(nz(b)) <= 0 ? nz(a) : nz(b);
+    }
+
+    /** The value floored at zero — negatives collapse to {@code ZERO}. */
+    static @NonNull BigDecimal atLeastZero(@Nullable BigDecimal value) {
+        return isNegative(value) ? BigDecimal.ZERO : nz(value);
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/QuantityScaleGuard.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/QuantityScaleGuard.java
@@ -1,0 +1,144 @@
+package com.positivity.inventory.internal.service;
+
+import com.positivity.inventory.internal.exception.FractionalQuantityNotAllowedException;
+import java.math.BigDecimal;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+
+/**
+ * The supply side of the per-product divisibility invariant (ADR-0055, #1414).
+ *
+ * <h2>What this replaces, and what it keeps</h2>
+ *
+ * Receiving, ASN and returns used to call {@code intValueExact()} on the base quantity and throw
+ * on any fraction. That was correct for the entire catalog as seeded — every SKU is integral — and
+ * it was the right instinct: a ledger that silently rounds is worse than one that refuses. What
+ * was wrong is that the rule was a constant rather than a reading of the catalog's own
+ * declaration, so the first product to declare {@code precision_scale > 0} would have been refused
+ * by the ledger while the conversion subsystem happily produced its fractional base quantity.
+ *
+ * <p>So the guards keep their fail-closed character and lose their hardcoding: the quantity is
+ * checked against the scale the product declares, and a product declaring nothing — which is every
+ * product until one is seeded otherwise — is refused a fraction exactly as before.
+ *
+ * <h2>Symmetry with the demand side</h2>
+ *
+ * pos-workorder enforces the same rule at estimate-item entry and part issue (#1413) and raises
+ * {@code FRACTIONAL_QUANTITY_NOT_ALLOWED}. This raises the same code from the same declaration, so
+ * both sides of the ledger enforce one invariant rather than two that happen to agree.
+ */
+@Service
+@RequiredArgsConstructor
+public class QuantityScaleGuard {
+
+    private final UomConversionService uomConversionService;
+
+    /**
+     * Returns the quantity when the product's declaration permits it; throws otherwise.
+     *
+     * @param productId the catalog product the posting is for; {@code null} when the stock
+     *     reference resolves to no catalog product, which declares nothing and so is integral
+     * @param stockReference the SKU or stock-item id, used to name the product in the error
+     * @param fieldName the request field the quantity came from
+     * @param quantity the base-UoM quantity about to be posted
+     * @throws FractionalQuantityNotAllowedException when the quantity carries more decimal places
+     *     than the product declares
+     */
+    public @NonNull BigDecimal requirePostable(
+            @Nullable UUID productId,
+            @NonNull String stockReference,
+            @NonNull String fieldName,
+            @NonNull BigDecimal quantity) {
+        if (quantity == null) {
+            throw new IllegalArgumentException(fieldName + " is required");
+        }
+        int declaredScale = uomConversionService.declaredBaseScale(productId);
+        if (fitsScale(quantity, declaredScale)) {
+            return quantity;
+        }
+        throw declaredScale == 0
+                ? FractionalQuantityNotAllowedException.wholeUnitsOnly(productId, stockReference, fieldName, quantity)
+                : FractionalQuantityNotAllowedException.scaleExceeded(
+                        productId, stockReference, fieldName, quantity, declaredScale);
+    }
+
+    /**
+     * The read-path counterpart: a stored quantity whose scale the product does not declare is a
+     * ledger-integrity failure, and it is reported as one.
+     *
+     * <p>This replaces the {@code Math.toIntExact} calls the availability computation used to
+     * narrow its {@code long} math with. Those threw rather than wrapping, and that fail-loud
+     * property is the one thing about them worth preserving: an availability figure that silently
+     * lost information is worse than no figure at all. What they can no longer do is bound the
+     * value, because a decimal column has no 32-bit edge to fall off — so the check they are
+     * replaced by is the one that still means something after the widening: does this quantity
+     * carry more precision than the product ever declared it could?
+     *
+     * <p>The check only runs when the stock reference names a catalog product: a reference that
+     * names none declares nothing, and "declares nothing" cannot be evidence that a value already
+     * in the ledger is wrong.
+     *
+     * <p>An {@link IllegalStateException} rather than the 422: nothing the caller sent is wrong.
+     * A quantity in the ledger that no declaration supports means the posting path was bypassed or
+     * a declaration was narrowed after the fact, and both are the platform's problem to fix. The
+     * fact publisher already isolates a failed availability snapshot per key, so this surfaces as
+     * a skipped fact and a log line rather than a rolled-back business write.
+     */
+    public @NonNull BigDecimal requireReportable(
+            @Nullable UUID productId,
+            @NonNull String stockReference,
+            @NonNull String fieldName,
+            @NonNull BigDecimal quantity) {
+        if (productId == null) {
+            // Nothing to check against. Unlike the posting side, where "no declaration" is a
+            // decision the platform makes about what may be written and defaults to whole units,
+            // here the quantity is already written — the ledger is the record. Refusing to report
+            // a value we have no declaration to contradict would turn a read into a 500 and stall
+            // the availability replicas behind it, and it would do so precisely for the stock
+            // items the ledger keys by human SKU rather than product id (its two posting paths
+            // disagree about which goes in `stockItemId`). Report what is there.
+            return quantity;
+        }
+        int declaredScale = uomConversionService.declaredBaseScale(productId);
+        if (fitsScale(quantity, declaredScale)) {
+            return quantity;
+        }
+        throw new IllegalStateException("Ledger quantity " + quantity.toPlainString() + " for '" + stockReference
+                + "' (" + fieldName + ") carries more decimal places than the product declares (precision_scale="
+                + declaredScale + "); the posting path should have rejected it");
+    }
+
+    /**
+     * The catalog product a ledger stock-item id refers to, or {@code null} when it names none.
+     *
+     * <p>pos-inventory's ledger stores {@code stockItemId} as a plain string and its own posting
+     * paths disagree about what goes in it — the allocation path writes a product UUID, receiving
+     * paths write the human SKU. A stock item that does not resolve to a catalog product declares
+     * nothing, and undeclared means whole units.
+     */
+    public static @Nullable UUID productIdOf(@Nullable String stockItemId) {
+        if (stockItemId == null || stockItemId.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(stockItemId.trim());
+        } catch (IllegalArgumentException _) {
+            return null;
+        }
+    }
+
+    /**
+     * Whether a value can be written at the given scale without losing anything.
+     *
+     * <p>{@code stripTrailingZeros} first, so {@code 1.00} is accepted against scale 0: the
+     * trailing zeros are how a client or a JDBC driver spelled the number, not a claim about
+     * divisibility. Postgres returns {@code numeric(19,4)} at scale 4, so without this every value
+     * read back out of the ledger would fail its own guard.
+     */
+    public static boolean fitsScale(@NonNull BigDecimal quantity, int scale) {
+        return quantity.stripTrailingZeros().scale() <= scale;
+    }
+}

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReceivingServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReceivingServiceImpl.java
@@ -68,6 +68,7 @@ public class ReceivingServiceImpl implements ReceivingService {
     private final WorkorderValidationService workorderValidationService;
     private final DocumentQuantityConverter documentQuantityConverter;
     private final InventoryLotCaptureService lotCaptureService;
+    private final QuantityScaleGuard quantityScaleGuard;
 
     @Value("${pos.inventory.receiving.source-document-service:}")
     private String configuredSourceDocumentService;
@@ -251,7 +252,7 @@ public class ReceivingServiceImpl implements ReceivingService {
         validatePartMatchOrOverride(
                 line, actorUserId, request.getWorkorderLineId(), workorderValidation.demandedProductId());
 
-        int quantityDelta = toWholeLedgerQuantity(request.getQuantity(), "quantity");
+        BigDecimal quantityDelta = toLedgerQuantity(line.getProductId(), request.getQuantity(), "quantity");
         BigDecimal existingReceivedQuantity =
                 line.getReceivedQuantity() != null ? line.getReceivedQuantity() : BigDecimal.ZERO;
         BigDecimal expectedQuantity = line.getExpectedQuantity() != null ? line.getExpectedQuantity() : BigDecimal.ZERO;
@@ -269,7 +270,8 @@ public class ReceivingServiceImpl implements ReceivingService {
         }
 
         UUID crossDockLocationId = resolveCrossDockLocationId();
-        int receiptQuantityAfter = calculateQuantityAfter(line.getProductId(), crossDockLocationId, quantityDelta);
+        BigDecimal receiptQuantityAfter =
+                calculateQuantityAfter(line.getProductId(), crossDockLocationId, quantityDelta);
 
         // odoo-parity E2 (#1042): cross-dock is lot-gated like any other receipt of a
         // LOT-tracked product (E1 deferred this because only the receipt half could have been
@@ -301,14 +303,15 @@ public class ReceivingServiceImpl implements ReceivingService {
 
         InventoryLedgerEntry savedReceiptEntry = ledgerPostingService.post(receiptEntry);
         inventoryFactPublisher.markEntry(savedReceiptEntry);
-        int issueQuantityAfter = calculateQuantityAfter(line.getProductId(), crossDockLocationId, -quantityDelta);
+        BigDecimal issueQuantityAfter =
+                calculateQuantityAfter(line.getProductId(), crossDockLocationId, quantityDelta.negate());
 
         InventoryLedgerEntry issueEntry = InventoryLedgerEntry.builder()
                 .stockItemId(line.getProductId())
                 .locationId(crossDockLocationId)
                 .fromLocationId(crossDockLocationId)
                 .eventType(InventoryLedgerEventType.GOODS_ISSUE)
-                .changeInQuantity(-quantityDelta)
+                .changeInQuantity(quantityDelta.negate())
                 .quantityAfter(issueQuantityAfter)
                 .lotId(lotId)
                 .transactionUserId(actorUserId)
@@ -384,7 +387,7 @@ public class ReceivingServiceImpl implements ReceivingService {
             UUID lotId,
             java.util.List<String> serialNumbers,
             String actorUserId) {
-        int quantityDelta = toWholeLedgerQuantity(quantity, "receivedQuantity");
+        BigDecimal quantityDelta = toLedgerQuantity(productId, quantity, "receivedQuantity");
         UUID stagingLocationId = resolveStagingLocationId();
         InventoryLedgerEntry entry = InventoryLedgerEntry.builder()
                 .stockItemId(productId)
@@ -421,15 +424,25 @@ public class ReceivingServiceImpl implements ReceivingService {
         }
     }
 
-    private int toWholeLedgerQuantity(BigDecimal quantity, String fieldName) {
+    /**
+     * The base quantity a receipt may post, checked against the product's declared divisibility
+     * (ADR-0055, #1414).
+     *
+     * <p>This replaces an {@code intValueExact()} that refused every fraction for every product.
+     * That refusal was right for the whole catalog as seeded and would have been wrong for the
+     * first product to declare {@code precision_scale > 0} — the conversion subsystem already
+     * produces fractional base quantities for such a product (its scale-2 fixture asserts
+     * {@code 1 BAG -> 1.01 LB}), and the ledger would have refused to hold what the conversion
+     * computed. The guard is still fail-closed; what changed is that the rule is read from the
+     * catalog rather than hardcoded, so a product declaring nothing is refused a fraction exactly
+     * as before.
+     */
+    private BigDecimal toLedgerQuantity(String stockItemId, BigDecimal quantity, String fieldName) {
         if (quantity == null) {
             throw new IllegalArgumentException(fieldName + " is required");
         }
-        try {
-            return quantity.intValueExact();
-        } catch (ArithmeticException ex) {
-            throw new IllegalArgumentException(fieldName + " must be a whole number within 32-bit integer range", ex);
-        }
+        return quantityScaleGuard.requirePostable(
+                parseProductId(stockItemId), String.valueOf(stockItemId), fieldName, quantity);
     }
 
     /**
@@ -448,11 +461,10 @@ public class ReceivingServiceImpl implements ReceivingService {
         }
     }
 
-    private int calculateQuantityAfter(String stockItemId, UUID locationId, int quantityDelta) {
-        Integer currentOnHand =
+    private BigDecimal calculateQuantityAfter(String stockItemId, UUID locationId, BigDecimal quantityDelta) {
+        BigDecimal currentOnHand =
                 inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(stockItemId, locationId);
-        int onHand = currentOnHand != null ? currentOnHand : 0;
-        return onHand + quantityDelta;
+        return Quantities.nz(currentOnHand).add(quantityDelta);
     }
 
     private UUID resolveStagingLocationId() {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentServiceImpl.java
@@ -6,6 +6,7 @@ import com.positivity.inventory.internal.dto.replenishment.ReplenishmentPolicyRe
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentScanResultResponse;
 import com.positivity.inventory.internal.dto.replenishment.ReplenishmentTaskResponse;
 import com.positivity.inventory.internal.dto.replenishment.UpdateReplenishmentPolicyRequest;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.entity.PurchaseSuggestion;
 import com.positivity.inventory.internal.entity.ReplenishmentPolicy;
 import com.positivity.inventory.internal.entity.ReplenishmentTask;
@@ -20,6 +21,8 @@ import com.positivity.inventory.internal.repository.NormalizedAvailabilityReposi
 import com.positivity.inventory.internal.repository.ReplenishmentPolicyRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentTaskRepository;
 import com.positivity.inventory.service.ReplenishmentService;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -563,12 +566,15 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
         LeadTimeResolver.ResolvedLeadTime leadTime = leadTimeResolver.resolve(policy);
         Instant evaluatedAt = Instant.now(clock);
         Instant leadHorizon = evaluatedAt.plus(Duration.ofDays(leadTime.days()));
-        long onHand = currentOnHand(policy.getItemSKU(), policy.getLocationId());
+        BigDecimal onHand = currentOnHand(policy.getItemSKU(), policy.getLocationId());
         UUID forecastSiteId = forecastSiteResolver.resolveForecastSite(policy.getLocationId());
-        long projectedAvailable = forecastQuantityService
+        BigDecimal projectedAvailable = forecastQuantityService
                 .forecast(policy.getItemSKU(), forecastSiteId, leadHorizon, onHand)
                 .projectedAvailable();
-        boolean triggered = projectedAvailable < policy.getMinimumQuantity();
+        // Replenishment policy min/max stay integral (they are order-planning parameters, not
+        // stock measurements), so the comparison widens the parameter rather than narrowing the
+        // measurement — a projected 0.5 correctly reads as below a minimum of 1.
+        boolean triggered = Quantities.lt(projectedAvailable, BigDecimal.valueOf(policy.getMinimumQuantity()));
         return new Projection(
                 policy.getItemSKU(),
                 forecastSiteId,
@@ -614,7 +620,14 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
             @Nullable UUID excludeSuggestionId) {
         long inProgress =
                 inProgressQuantity(policy.getItemSKU(), policy.getLocationId(), excludeTaskId, excludeSuggestionId);
-        return Math.max(0L, policy.getMaximumQuantity() - projection.projectedAvailable() - inProgress);
+        // The replenishment need is a whole number of units to order — a purchase order for
+        // 3.5 units of a divisible product still buys 4 containers unless the supplier sells it
+        // by measure, which the F4 MOQ/pack rounding decides. Rounding the need UP is the safe
+        // direction: it never orders less than the shortfall.
+        BigDecimal need = BigDecimal.valueOf(policy.getMaximumQuantity())
+                .subtract(projection.projectedAvailable())
+                .subtract(BigDecimal.valueOf(inProgress));
+        return Math.max(0L, need.setScale(0, RoundingMode.CEILING).longValue());
     }
 
     /** Rounds a positive quantity UP to the nearest multiple; zero and no-multiple pass through. */
@@ -756,8 +769,8 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
     private record Projection(
             String stockItemId,
             @Nullable UUID forecastSiteId,
-            long onHand,
-            long projectedAvailable,
+            BigDecimal onHand,
+            BigDecimal projectedAvailable,
             Instant evaluatedAt,
             Instant leadHorizon,
             LeadTimeResolver.ResolvedLeadTime leadTime,
@@ -774,11 +787,12 @@ public class ReplenishmentServiceImpl implements ReplenishmentService {
      * (single sanctioned read path since issue #1024); absent row means no
      * postings yet, i.e. zero on-hand.
      */
-    private long currentOnHand(String itemSKU, UUID locationId) {
+    private BigDecimal currentOnHand(String itemSKU, UUID locationId) {
         return stockSummaryRepository
                 .findByStockItemIdAndLocationId(itemSKU, locationId)
-                .map(summary -> summary.getOnHand())
-                .orElse(0L);
+                .map(InventoryStockSummary::getOnHand)
+                .map(Quantities::nz)
+                .orElse(BigDecimal.ZERO);
     }
 
     /** Refreshes a still-open PENDING task's quantity (and stock-out deadline) to the currently computed need. */

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentSourcingService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReplenishmentSourcingService.java
@@ -16,6 +16,7 @@ import com.positivity.inventory.internal.repository.TransferOrderRepository;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourceSelection;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingCandidate;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingSelection;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -161,8 +162,10 @@ public class ReplenishmentSourcingService {
             if (loc == null) {
                 continue;
             }
-            long surplus = row.getOnHand() - row.getAllocated() - ownMinimum(sku, loc);
-            if (surplus <= 0) {
+            BigDecimal surplus = Quantities.nz(row.getOnHand())
+                    .subtract(Quantities.nz(row.getAllocated()))
+                    .subtract(BigDecimal.valueOf(ownMinimum(sku, loc)));
+            if (!Quantities.isPositive(surplus)) {
                 continue;
             }
             UUID rowSite = forecastSiteResolver.resolveForecastSite(loc);
@@ -181,7 +184,8 @@ public class ReplenishmentSourcingService {
         Optional<SourceSelection> sameSitePick = sameSite.isEmpty()
                 ? Optional.empty()
                 : sourcingStrategyService.selectSource(
-                        new SourcingSelection(sku, destinationSite, policy.getLocationId(), sameSite), neededQuantity);
+                        new SourcingSelection(sku, destinationSite, policy.getLocationId(), sameSite),
+                        BigDecimal.valueOf(neededQuantity));
         if (sameSitePick.isPresent()) {
             SourceSelection selection = sameSitePick.get();
             log.info(
@@ -203,7 +207,7 @@ public class ReplenishmentSourcingService {
         Optional<SourceSelection> crossSitePick = crossSite.isEmpty()
                 ? Optional.empty()
                 : sourcingStrategyService.selectSource(
-                        new SourcingSelection(sku, null, null, crossSite), neededQuantity);
+                        new SourcingSelection(sku, null, null, crossSite), BigDecimal.valueOf(neededQuantity));
         if (crossSitePick.isPresent()) {
             SourceSelection selection = crossSitePick.get();
             UUID sourceLocation = selection.candidate().locationId();

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationRequestHandler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationRequestHandler.java
@@ -4,6 +4,7 @@ import com.positivity.domainevents.inventory.ReservationOutcomeV1;
 import com.positivity.inventory.internal.dto.backorder.BackorderResponse;
 import com.positivity.inventory.internal.dto.reservation.CreateReservationRequest;
 import com.positivity.inventory.internal.dto.reservation.ReservationResponse;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.entity.ReservationEntity;
 import com.positivity.inventory.internal.enums.ReservationStatus;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
@@ -11,6 +12,7 @@ import com.positivity.inventory.internal.repository.ReservationRepository;
 import com.positivity.inventory.service.BackorderService;
 import com.positivity.inventory.service.ReservationRequestService;
 import com.positivity.inventory.service.ReservationService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.UUID;
@@ -71,7 +73,7 @@ public class ReservationRequestHandler implements ReservationRequestService {
             @Nullable UUID workorderLineId,
             @Nullable UUID salesOrderLineId,
             @NonNull UUID stockItemId,
-            int requiredQuantity,
+            @NonNull BigDecimal requiredQuantity,
             @NonNull UUID locationId) {
         if ((workorderLineId == null) == (salesOrderLineId == null)) {
             throw new IllegalArgumentException(
@@ -81,10 +83,10 @@ public class ReservationRequestHandler implements ReservationRequestService {
         ReservationResponse reservation = reservationService.createOrUpdateReservation(
                 new CreateReservationRequest(workorderLineId, salesOrderLineId, stockItemId, requiredQuantity));
 
-        long atp = availableToPromise(stockItemId, locationId);
+        BigDecimal atp = availableToPromise(stockItemId, locationId);
         Instant now = Instant.now(clock);
 
-        if (atp >= requiredQuantity) {
+        if (Quantities.gte(atp, requiredQuantity)) {
             log.info(
                     "Reservation {} covered: demandLine={} sku={} qty={} atp={}",
                     reservation.getReservationId(),
@@ -104,7 +106,12 @@ public class ReservationRequestHandler implements ReservationRequestService {
             return;
         }
 
-        int quantityShort = (int) Math.min(requiredQuantity, requiredQuantity - atp);
+        // The shortfall, never more than the whole demand: a negative ATP means the site is
+        // already oversold, and backordering more than this line asked for would charge it with
+        // someone else's deficit. Decimal since ADR-0055 (#1414) — a shortfall on a divisible
+        // product is itself divisible, and the old (int) cast would have floored it toward zero,
+        // quietly backordering less than is actually missing.
+        BigDecimal quantityShort = Quantities.min(requiredQuantity, requiredQuantity.subtract(atp));
         markBackordered(reservation.getReservationId());
         BackorderResponse backorder = workorderLineId != null
                 ? backorderService.createBackorder(workorderLineId, stockItemId.toString(), quantityShort, locationId)
@@ -146,10 +153,11 @@ public class ReservationRequestHandler implements ReservationRequestService {
         }
     }
 
-    private long availableToPromise(UUID stockItemId, UUID locationId) {
+    private BigDecimal availableToPromise(UUID stockItemId, UUID locationId) {
         return summaryRepository
                 .findByStockItemIdAndLocationId(stockItemId.toString(), locationId)
-                .map(row -> row.getAtp())
-                .orElse(0L);
+                .map(InventoryStockSummary::getAtp)
+                .map(Quantities::nz)
+                .orElse(BigDecimal.ZERO);
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationServiceImpl.java
@@ -18,6 +18,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.ReservationRepository;
 import com.positivity.inventory.service.ReservationService;
 import com.positivity.security.common.SecurityContextHelper;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
@@ -70,19 +71,20 @@ public class ReservationServiceImpl implements ReservationService {
 
         ReservationEntity reservation = allocation.getReservation();
         UUID stockItemId = reservation.getStockItemId();
-        int netOnHand = calculateNetOnHand(stockItemId);
+        BigDecimal netOnHand = calculateNetOnHand(stockItemId);
 
-        int existingHard =
+        BigDecimal existingHard =
                 allocationRepository.findByReservationAndAllocationState(reservation, AllocationState.HARD).stream()
-                        .mapToInt(AllocationEntity::getAllocatedQuantity)
-                        .sum();
+                        .map(AllocationEntity::getAllocatedQuantity)
+                        .map(Quantities::nz)
+                        .reduce(BigDecimal.ZERO, BigDecimal::add);
 
         if (allocation.getAllocationState() == AllocationState.HARD) {
-            existingHard -= allocation.getAllocatedQuantity();
+            existingHard = existingHard.subtract(Quantities.nz(allocation.getAllocatedQuantity()));
         }
 
-        int availableAtp = netOnHand - existingHard;
-        if (availableAtp < allocation.getAllocatedQuantity()) {
+        BigDecimal availableAtp = netOnHand.subtract(existingHard);
+        if (Quantities.lt(availableAtp, allocation.getAllocatedQuantity())) {
             reservation.setStatus(ReservationStatus.BACKORDERED);
             reservationRepository.save(reservation);
             throw new InsufficientAtpException(allocationId, allocation.getAllocatedQuantity(), availableAtp);
@@ -120,12 +122,13 @@ public class ReservationServiceImpl implements ReservationService {
         }
 
         List<AllocationEntity> allocations = allocationRepository.findByReservation(reservation);
-        int totalAllocated = allocations.stream()
-                .mapToInt(AllocationEntity::getAllocatedQuantity)
-                .sum();
+        BigDecimal totalAllocated = allocations.stream()
+                .map(AllocationEntity::getAllocatedQuantity)
+                .map(Quantities::nz)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
         reservation.setAllocatedQuantity(totalAllocated);
         reservation.setStatus(
-                totalAllocated >= reservation.getRequiredQuantity()
+                Quantities.gte(totalAllocated, reservation.getRequiredQuantity())
                         ? ReservationStatus.FULFILLED
                         : ReservationStatus.PARTIALLY_FULFILLED);
         reservationRepository.save(reservation);
@@ -165,15 +168,17 @@ public class ReservationServiceImpl implements ReservationService {
         allocationRepository.saveAll(allocations);
 
         if (!ledgerReleasable.isEmpty()) {
-            int netOnHand = calculateNetOnHand(reservation.getStockItemId());
+            BigDecimal netOnHand = calculateNetOnHand(reservation.getStockItemId());
             for (AllocationEntity allocation : ledgerReleasable) {
                 // CAP-218 #662: partial consumption may already have released
                 // part of this allocation; release only the remainder so the
                 // per-allocation CREATED - RELEASED invariant holds.
-                int alreadyReleased = inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
-                        allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED);
-                int remaining = allocation.getAllocatedQuantity() - alreadyReleased;
-                if (remaining > 0) {
+                BigDecimal alreadyReleased =
+                        Quantities.nz(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
+                                allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED));
+                BigDecimal remaining =
+                        Quantities.nz(allocation.getAllocatedQuantity()).subtract(alreadyReleased);
+                if (Quantities.isPositive(remaining)) {
                     writeAllocationLedgerEntry(
                             InventoryLedgerEventType.ALLOCATION_RELEASED,
                             allocation,
@@ -184,7 +189,7 @@ public class ReservationServiceImpl implements ReservationService {
             }
         }
 
-        reservation.setAllocatedQuantity(0);
+        reservation.setAllocatedQuantity(BigDecimal.ZERO);
         reservation.setStatus(ReservationStatus.CANCELLED);
         reservationRepository.save(reservation);
     }
@@ -210,8 +215,8 @@ public class ReservationServiceImpl implements ReservationService {
             InventoryLedgerEventType eventType,
             AllocationEntity allocation,
             UUID stockItemId,
-            int netOnHand,
-            int quantity) {
+            BigDecimal netOnHand,
+            BigDecimal quantity) {
         InventoryLedgerEntry entry = InventoryLedgerEntry.builder()
                 .stockItemId(stockItemId.toString())
                 .eventType(eventType)
@@ -272,9 +277,8 @@ public class ReservationServiceImpl implements ReservationService {
         return reservationRepository.save(reservation);
     }
 
-    private int calculateNetOnHand(UUID stockItemId) {
-        Integer onHand = inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId);
-        return onHand == null ? 0 : onHand;
+    private BigDecimal calculateNetOnHand(UUID stockItemId) {
+        return Quantities.nz(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId));
     }
 
     private ReservationResponse toResponse(ReservationEntity reservation) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReturnServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReturnServiceImpl.java
@@ -18,6 +18,7 @@ import com.positivity.inventory.internal.repository.InventoryReturnRepository;
 import com.positivity.inventory.service.ReturnService;
 import com.positivity.security.common.SecurityContextHelper;
 import com.positivity.shared.id.UUIDv7Generator;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -41,6 +42,7 @@ public class ReturnServiceImpl implements ReturnService {
     private final DocumentQuantityConverter documentQuantityConverter;
     private final Clock clock;
     private final @Nullable InventoryLotOutboundService lotOutboundService;
+    private final QuantityScaleGuard quantityScaleGuard;
 
     @Autowired
     public ReturnServiceImpl(
@@ -50,7 +52,8 @@ public class ReturnServiceImpl implements ReturnService {
             InventoryFactPublisher inventoryFactPublisher,
             DocumentQuantityConverter documentQuantityConverter,
             Clock clock,
-            InventoryLotOutboundService lotOutboundService) {
+            InventoryLotOutboundService lotOutboundService,
+            QuantityScaleGuard quantityScaleGuard) {
         this.inventoryReturnRepository = inventoryReturnRepository;
         this.inventoryLedgerEntryRepository = inventoryLedgerEntryRepository;
         this.ledgerPostingService = ledgerPostingService;
@@ -58,6 +61,7 @@ public class ReturnServiceImpl implements ReturnService {
         this.documentQuantityConverter = documentQuantityConverter;
         this.clock = clock;
         this.lotOutboundService = lotOutboundService;
+        this.quantityScaleGuard = quantityScaleGuard;
     }
 
     /**
@@ -72,7 +76,8 @@ public class ReturnServiceImpl implements ReturnService {
             LedgerPostingService ledgerPostingService,
             InventoryFactPublisher inventoryFactPublisher,
             DocumentQuantityConverter documentQuantityConverter,
-            Clock clock) {
+            Clock clock,
+            QuantityScaleGuard quantityScaleGuard) {
         this(
                 inventoryReturnRepository,
                 inventoryLedgerEntryRepository,
@@ -80,7 +85,8 @@ public class ReturnServiceImpl implements ReturnService {
                 inventoryFactPublisher,
                 documentQuantityConverter,
                 clock,
-                null);
+                null,
+                quantityScaleGuard);
     }
 
     @Override
@@ -194,7 +200,7 @@ public class ReturnServiceImpl implements ReturnService {
     private record ReturnLineComputation(
             ReturnItemLine item,
             DocumentQuantityConverter.DocumentConversion conversion,
-            int baseQuantity,
+            BigDecimal baseQuantity,
             @Nullable UUID lotId) {}
 
     private ReturnLineComputation computeReturnLine(ReturnItemLine item) {
@@ -205,28 +211,25 @@ public class ReturnServiceImpl implements ReturnService {
                         item.getDocumentUom(),
                         item.getDocumentQuantity())
                 .orElse(null);
-        int baseQuantity;
-        if (conversion == null) {
-            baseQuantity = item.getQuantityReturned();
-        } else {
-            try {
-                baseQuantity = conversion.baseQuantity().intValueExact();
-            } catch (ArithmeticException ex) {
-                throw new IllegalArgumentException(
-                        "converted base quantity must be a whole number within 32-bit integer range", ex);
-            }
-        }
-        if (baseQuantity <= 0) {
+        // ADR-0055 (#1414): the base quantity may carry decimals only to the scale the product
+        // declares. This replaces an intValueExact() that refused every fraction for every
+        // product — still fail-closed, but reading the catalog's declaration instead of assuming
+        // one, so a product declaring precision_scale > 0 can be returned at its real quantity
+        // and one declaring nothing is refused a fraction exactly as before.
+        BigDecimal rawBaseQuantity = conversion == null ? item.getQuantityReturned() : conversion.baseQuantity();
+        if (rawBaseQuantity == null || rawBaseQuantity.signum() <= 0) {
             throw new IllegalArgumentException("quantityReturned must be positive");
         }
+        BigDecimal baseQuantity = quantityScaleGuard.requirePostable(
+                item.getSkuId(), String.valueOf(item.getSkuId()), "quantityReturned", rawBaseQuantity);
         UUID lotId = lotOutboundService == null
                 ? null
                 : lotOutboundService.resolveReturnLot(item.getSkuId().toString(), item.getLotNumber());
         return new ReturnLineComputation(item, conversion, baseQuantity, lotId);
     }
 
-    private int calculateTotalItemsReturned(List<ReturnLineComputation> items) {
-        return items.stream().mapToInt(ReturnLineComputation::baseQuantity).sum();
+    private BigDecimal calculateTotalItemsReturned(List<ReturnLineComputation> items) {
+        return items.stream().map(ReturnLineComputation::baseQuantity).reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
     private InventoryReturnEntity buildReturnEntity(ReturnItemsRequest request, List<ReturnLineComputation> items) {
@@ -257,8 +260,8 @@ public class ReturnServiceImpl implements ReturnService {
         return InventoryLedgerEntry.builder()
                 .stockItemId(computed.item().getSkuId().toString())
                 .eventType(InventoryLedgerEventType.RETURN_TO_STOCK)
-                .changeInQuantity(Math.abs(computed.baseQuantity()))
-                .quantityAfter(0)
+                .changeInQuantity(computed.baseQuantity().abs())
+                .quantityAfter(BigDecimal.ZERO)
                 .lotId(computed.lotId())
                 .transactionUserId(SecurityContextHelper.getCurrentUsernameOrDefault("system"))
                 .notes("Returned to stock from workorder "
@@ -275,13 +278,13 @@ public class ReturnServiceImpl implements ReturnService {
                         InventoryLedgerEventType.WORKORDER_CONSUMPTION,
                         workorderId.toString());
 
-        int totalConsumed = consumptionEntries.stream()
+        BigDecimal totalConsumed = consumptionEntries.stream()
                 .map(InventoryLedgerEntry::getChangeInQuantity)
                 .filter(Objects::nonNull)
-                .mapToInt(value -> Math.abs(value.intValue()))
-                .sum();
+                .map(BigDecimal::abs)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
 
-        if (totalConsumed < computed.baseQuantity()) {
+        if (Quantities.lt(totalConsumed, computed.baseQuantity())) {
             throw new ReturnQuantityExceededException(
                     computed.item().getSkuId(), computed.baseQuantity(), totalConsumed);
         }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/RevaluationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/RevaluationServiceImpl.java
@@ -75,13 +75,10 @@ public class RevaluationServiceImpl implements RevaluationService {
 
         BigDecimal previousUnitCost = currentCost(state, method);
         BigDecimal newUnitCost = resolveNewUnitCost(request, previousUnitCost);
-        long onHand = state.getOnHandQty();
+        BigDecimal onHand = Quantities.nz(state.getOnHandQty());
 
         BigDecimal base = previousUnitCost != null ? previousUnitCost : BigDecimal.ZERO;
-        BigDecimal valueDelta = newUnitCost
-                .subtract(base)
-                .multiply(BigDecimal.valueOf(onHand))
-                .setScale(VALUE_SCALE, RoundingMode.HALF_UP);
+        BigDecimal valueDelta = newUnitCost.subtract(base).multiply(onHand).setScale(VALUE_SCALE, RoundingMode.HALF_UP);
 
         RevaluationRecord record = RevaluationRecord.builder()
                 .stockItemId(stockItemId)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ScrapServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ScrapServiceImpl.java
@@ -295,13 +295,16 @@ public class ScrapServiceImpl implements ScrapService {
         UUID postingLocationId =
                 scrap.getStorageLocationId() != null ? scrap.getStorageLocationId() : scrap.getLocationId();
 
-        Integer currentOnHand =
-                ledgerRepository.calculateOnHandQuantityAtLocation(scrap.getStockItemId(), postingLocationId);
+        BigDecimal currentOnHand = Quantities.nz(
+                ledgerRepository.calculateOnHandQuantityAtLocation(scrap.getStockItemId(), postingLocationId));
+        // A scrap request quantity is still an Integer (the scrap DTOs widen with the UOM work in
+        // ADR-0055 stage 4); this widens at the boundary rather than narrowing the ledger total.
+        BigDecimal scrappedQuantity = BigDecimal.valueOf(scrap.getQuantity());
         InventoryLedgerEntry entry = InventoryLedgerEntry.builder()
                 .stockItemId(scrap.getStockItemId())
                 .eventType(InventoryLedgerEventType.SCRAP_OUT)
-                .changeInQuantity(-scrap.getQuantity())
-                .quantityAfter(currentOnHand - scrap.getQuantity())
+                .changeInQuantity(scrappedQuantity.negate())
+                .quantityAfter(currentOnHand.subtract(scrappedQuantity))
                 .unitCost(scrap.getUnitCostSnapshot())
                 .locationId(postingLocationId)
                 .lotId(scrap.getLotId())

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SerialUnitOnHandVerifier.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SerialUnitOnHandVerifier.java
@@ -1,10 +1,12 @@
 package com.positivity.inventory.internal.service;
 
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.enums.InventorySerialStatus;
 import com.positivity.inventory.internal.repository.InventorySerialUnitRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.math.BigDecimal;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -82,11 +84,14 @@ public class SerialUnitOnHandVerifier {
             if (row.getLocationId() == null) {
                 continue;
             }
-            long summaryOnHand = summaryRepository
+            BigDecimal summaryOnHand = summaryRepository
                     .findByStockItemIdAndLocationId(row.getStockItemId(), row.getLocationId())
-                    .map(summary -> summary.getOnHand())
-                    .orElse(0L);
-            if (summaryOnHand != row.getInStockCount()) {
+                    .map(InventoryStockSummary::getOnHand)
+                    .map(Quantities::nz)
+                    .orElse(BigDecimal.ZERO);
+            // compareTo, not equals: a summary of 4.0000 read back from numeric(19,4) is the same
+            // quantity as a serial count of 4, and equals would call that drift.
+            if (summaryOnHand.compareTo(BigDecimal.valueOf(row.getInStockCount())) != 0) {
                 if (driftedKeys < MAX_DETAILED_DRIFT_LOGS) {
                     log.warn(
                             "Serial on-hand drift: stockItemId={} locationId={} serialInStock={} summaryOnHand={}",

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SerialUnitPostingService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SerialUnitPostingService.java
@@ -9,6 +9,7 @@ import com.positivity.inventory.internal.exception.SerialAlreadyInStockException
 import com.positivity.inventory.internal.exception.SerialCountMismatchException;
 import com.positivity.inventory.internal.exception.SerialNotAvailableException;
 import com.positivity.inventory.internal.repository.InventorySerialUnitRepository;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -80,16 +81,20 @@ public class SerialUnitPostingService {
     }
 
     private void apply(InventoryLedgerEntry entry) {
-        int change = entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity();
+        // A serialised unit is discrete by definition — you cannot receive half a serial number
+        // — so this is one place the whole-quantity rule is a property of the tracking mode
+        // rather than of the type, and it survives the ADR-0055 widening unchanged. A fractional
+        // change on a SERIAL-tracked item is a contradiction, and intValueExact says so loudly.
+        BigDecimal change = Quantities.nz(entry.getChangeInQuantity());
         List<String> serials = normalize(entry.getSerialNumbers());
-        int required = Math.abs(change);
+        int required = change.abs().intValueExact();
         if (serials.size() != required) {
             throw new SerialCountMismatchException(entry.getStockItemId(), required, serials.size());
         }
         if (required == 0) {
             return;
         }
-        if (change > 0) {
+        if (Quantities.isPositive(change)) {
             enumerateInbound(entry, serials);
         } else {
             consumeOutbound(entry, serials);

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ShortageResolutionServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ShortageResolutionServiceImpl.java
@@ -27,6 +27,7 @@ import com.positivity.inventory.service.ShortageResolutionService;
 import com.positivity.inventory.service.TransferOrderService;
 import com.positivity.shared.id.UUIDv7Generator;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -114,9 +115,9 @@ public class ShortageResolutionServiceImpl implements ShortageResolutionService 
             @NonNull UUID allocationId,
             @Nullable UUID workorderLineId,
             @NonNull String sku,
-            int shortQuantity,
+            BigDecimal shortQuantity,
             @Nullable UUID locationId) {
-        if (shortQuantity <= 0) {
+        if (shortQuantity == null || shortQuantity.signum() <= 0) {
             throw new IllegalArgumentException("shortQuantity must be positive");
         }
         LocalDate today = LocalDate.ofInstant(Instant.now(clock), ZoneOffset.UTC);
@@ -146,7 +147,7 @@ public class ShortageResolutionServiceImpl implements ShortageResolutionService 
     private List<ShortageOptionDto> substituteOptions(
             UUID allocationId,
             String sku,
-            int shortQuantity,
+            BigDecimal shortQuantity,
             @Nullable UUID locationId,
             @Nullable BigDecimal originalCost,
             LocalDate today) {
@@ -161,8 +162,8 @@ public class ShortageResolutionServiceImpl implements ShortageResolutionService 
                 continue; // the group carries the product itself; skip self
             }
             String memberSku = memberId.toString();
-            long atp = atpOf(memberSku, locationId);
-            if (atp <= 0) {
+            BigDecimal atp = atpOf(memberSku, locationId);
+            if (!Quantities.isPositive(atp)) {
                 continue; // only offer substitutes with live availability
             }
             options.add(ShortageOptionDto.builder()
@@ -179,12 +180,12 @@ public class ShortageResolutionServiceImpl implements ShortageResolutionService 
     }
 
     private List<ShortageOptionDto> transferInOptions(
-            UUID allocationId, String sku, int shortQuantity, @Nullable UUID locationId, LocalDate today) {
+            UUID allocationId, String sku, BigDecimal shortQuantity, @Nullable UUID locationId, LocalDate today) {
         if (locationId == null) {
             return List.of();
         }
         UUID shortageSite = forecastSiteResolver.resolveForecastSite(locationId);
-        Map<UUID, Long> surplusBySite = new LinkedHashMap<>();
+        Map<UUID, BigDecimal> surplusBySite = new LinkedHashMap<>();
         for (InventoryStockSummary row : stockSummaryRepository.findByStockItemId(sku)) {
             UUID loc = row.getLocationId();
             if (loc == null) {
@@ -194,19 +195,21 @@ public class ShortageResolutionServiceImpl implements ShortageResolutionService 
             if (rowSite == null || Objects.equals(rowSite, shortageSite)) {
                 continue; // same-site surplus is not a cross-site transfer
             }
-            long surplus = row.getOnHand() - row.getAllocated();
-            if (surplus > 0) {
-                surplusBySite.merge(rowSite, surplus, Long::sum);
+            BigDecimal surplus = Quantities.nz(row.getOnHand()).subtract(Quantities.nz(row.getAllocated()));
+            if (Quantities.isPositive(surplus)) {
+                surplusBySite.merge(rowSite, surplus, BigDecimal::add);
             }
         }
         List<ShortageOptionDto> options = new ArrayList<>();
         surplusBySite.forEach((site, surplus) -> {
-            if (surplus >= shortQuantity) {
+            if (Quantities.gte(surplus, shortQuantity)) {
                 options.add(ShortageOptionDto.builder()
                         .allocationId(allocationId)
                         .optionType(ShortageResolutionOption.TRANSFER_IN)
-                        .description("Transfer " + shortQuantity + " in from sibling site " + site + " (" + surplus
-                                + " surplus available)")
+                        .description(
+                                "Transfer " + shortQuantity.toPlainString() + " in from sibling site " + site + " ("
+                                        + surplus.toPlainString()
+                                        + " surplus available)")
                         .sourceLocationId(site)
                         .availableQuantity(surplus)
                         .expectedResolutionDate(today.plusDays(TRANSFER_LEAD_DAYS))
@@ -217,9 +220,13 @@ public class ShortageResolutionServiceImpl implements ShortageResolutionService 
     }
 
     private ShortageOptionDto emergencyPurchaseOption(
-            UUID allocationId, String sku, int shortQuantity, @Nullable BigDecimal originalCost, LocalDate today) {
+            UUID allocationId,
+            String sku,
+            BigDecimal shortQuantity,
+            @Nullable BigDecimal originalCost,
+            LocalDate today) {
         VendorSelectionService.VendorCandidate vendor = vendorSelectionService
-                .selectVendor(parseUuid(sku), shortQuantity)
+                .selectVendor(parseUuid(sku), orderableUnits(shortQuantity))
                 .chosen();
         int leadDays =
                 vendor != null && vendor.leadTimeDays() != null ? vendor.leadTimeDays() : DEFAULT_PURCHASE_LEAD_DAYS;
@@ -310,7 +317,8 @@ public class ShortageResolutionServiceImpl implements ShortageResolutionService 
         if (substituteId == null) {
             throw ShortageResolutionException.invalidIdentifier("substituteSku", request.getSubstituteSku());
         }
-        if (request.getLocationId() != null && atpOf(request.getSubstituteSku(), request.getLocationId()) <= 0) {
+        if (request.getLocationId() != null
+                && !Quantities.isPositive(atpOf(request.getSubstituteSku(), request.getLocationId()))) {
             throw ShortageResolutionException.substituteUnavailable(request.getSubstituteSku());
         }
         ReservationResponse reservation = reservationService.createOrUpdateReservation(
@@ -334,7 +342,7 @@ public class ShortageResolutionServiceImpl implements ShortageResolutionService 
                 .destinationLocationId(destinationSite)
                 .lines(List.of(TransferOrderLineRequest.builder()
                         .sku(request.getSku())
-                        .requestedQty(request.getShortQuantity())
+                        .requestedQty(Math.toIntExact(orderableUnits(request.getShortQuantity())))
                         .build()))
                 .notes("Auto-sourced by shortage resolution (odoo-parity G2) for allocation "
                         + request.getAllocationId())
@@ -346,7 +354,7 @@ public class ShortageResolutionServiceImpl implements ShortageResolutionService 
     private ArtifactRef executeEmergencyPurchase(ShortageResolveRequest request) {
         UUID productId = parseUuid(request.getSku());
         VendorSelectionService.VendorSelection selection =
-                vendorSelectionService.selectVendor(productId, request.getShortQuantity());
+                vendorSelectionService.selectVendor(productId, orderableUnits(request.getShortQuantity()));
         VendorSelectionService.VendorCandidate vendor = selection.chosen();
         int leadDays =
                 vendor != null && vendor.leadTimeDays() != null ? vendor.leadTimeDays() : DEFAULT_PURCHASE_LEAD_DAYS;
@@ -360,7 +368,7 @@ public class ShortageResolutionServiceImpl implements ShortageResolutionService 
                 .policyId(policyId)
                 .itemSKU(request.getSku())
                 .locationId(request.getLocationId() != null ? request.getLocationId() : policyId)
-                .suggestedQuantity(request.getShortQuantity())
+                .suggestedQuantity(Math.toIntExact(orderableUnits(request.getShortQuantity())))
                 .suggestedVendorType(vendor != null ? vendor.sourceType() : null)
                 .vendorRefId(vendor != null ? vendor.vendorRefId() : null)
                 .unitCostMinor(vendor != null ? vendor.unitCostMinor() : null)
@@ -403,11 +411,27 @@ public class ShortageResolutionServiceImpl implements ShortageResolutionService 
                 .orElse(DEFAULT_BACKORDER_LEAD_DAYS);
     }
 
-    private long atpOf(String sku, UUID locationId) {
+    /**
+     * A shortfall expressed as a whole number of units to buy or move.
+     *
+     * <p>The shortfall itself is decimal since ADR-0055 (#1414) — half a drum missing is half a
+     * drum missing — but a purchase suggestion and a transfer-order line are documents about
+     * containers, and neither a vendor nor a shipping label understands 3.5 of something. Rounding
+     * UP is the only safe direction here: ordering less than the shortfall leaves the shortage
+     * unresolved, which is the failure this whole path exists to prevent. The over-order is
+     * exactly the same one a whole-units catalog produces today. Purchase and transfer documents
+     * gain their own UoM handling in ADR-0055 stage 3.
+     */
+    private static long orderableUnits(BigDecimal shortQuantity) {
+        return shortQuantity.setScale(0, RoundingMode.CEILING).longValueExact();
+    }
+
+    private BigDecimal atpOf(String sku, UUID locationId) {
         return stockSummaryRepository
                 .findByStockItemIdAndLocationId(sku, locationId)
                 .map(InventoryStockSummary::getAtp)
-                .orElse(0L);
+                .map(Quantities::nz)
+                .orElse(BigDecimal.ZERO);
     }
 
     private @Nullable BigDecimal costOf(String sku) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryQuantityLoader.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryQuantityLoader.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.internal.service;
 
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
@@ -40,5 +41,5 @@ public class SiteInventoryQuantityLoader {
         return new QuantitySnapshot(maps.onHand(), maps.allocated());
     }
 
-    public record QuantitySnapshot(Map<UUID, Long> onHand, Map<UUID, Long> allocated) {}
+    public record QuantitySnapshot(Map<UUID, BigDecimal> onHand, Map<UUID, BigDecimal> allocated) {}
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryRollupServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SiteInventoryRollupServiceImpl.java
@@ -5,6 +5,7 @@ import com.positivity.inventory.internal.dto.rollup.SiteInventoryRollupResponse;
 import com.positivity.inventory.internal.dto.rollup.StorageLocationRollupNode;
 import com.positivity.inventory.internal.service.StorageLocationTopologyService.StorageLocationNode;
 import com.positivity.inventory.service.SiteInventoryRollupService;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -60,8 +61,8 @@ public class SiteInventoryRollupServiceImpl implements SiteInventoryRollupServic
                     new MutableNode(
                             node,
                             RollupQuantities.of(
-                                    quantities.onHand().getOrDefault(node.id(), 0L),
-                                    quantities.allocated().getOrDefault(node.id(), 0L))));
+                                    quantities.onHand().getOrDefault(node.id(), BigDecimal.ZERO),
+                                    quantities.allocated().getOrDefault(node.id(), BigDecimal.ZERO))));
         }
         List<MutableNode> roots = new ArrayList<>();
         for (MutableNode node : byId.values()) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SkuCostStateInitializer.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SkuCostStateInitializer.java
@@ -2,6 +2,7 @@ package com.positivity.inventory.internal.service;
 
 import com.positivity.inventory.internal.entity.SkuCostState;
 import com.positivity.inventory.internal.repository.SkuCostStateRepository;
+import java.math.BigDecimal;
 import org.jspecify.annotations.NonNull;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
@@ -44,7 +45,7 @@ public class SkuCostStateInitializer {
             costStateRepository.saveAndFlush(SkuCostState.builder()
                     .stockItemId(stockItemId)
                     .avgCost(null)
-                    .onHandQty(0L)
+                    .onHandQty(BigDecimal.ZERO)
                     .standardCost(null)
                     .build());
         } catch (DataIntegrityViolationException raced) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SourcingStrategyService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SourcingStrategyService.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.internal.service;
 
 import com.positivity.inventory.internal.enums.SourcingStrategy;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -40,7 +41,7 @@ public interface SourcingStrategyService {
      * when no candidate has enough available stock.
      */
     @NonNull
-    Optional<SourceSelection> selectSource(@NonNull SourcingSelection selection, long neededQuantity);
+    Optional<SourceSelection> selectSource(@NonNull SourcingSelection selection, @NonNull BigDecimal neededQuantity);
 
     /**
      * One sourcing question: order these candidate locations for this SKU.
@@ -62,7 +63,7 @@ public interface SourcingStrategyService {
 
     /** One candidate location, with its available quantity when the caller already knows it. */
     record SourcingCandidate(
-            @NonNull UUID locationId, @Nullable Long availableQuantity) {}
+            @NonNull UUID locationId, @Nullable BigDecimal availableQuantity) {}
 
     /**
      * Ordering decision: the configured strategy, the effective strategy that

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SourcingStrategyServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/SourcingStrategyServiceImpl.java
@@ -10,6 +10,7 @@ import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRep
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.repository.SourcingStrategyConfigRepository;
 import com.positivity.inventory.service.SourcingStrategyConfigService;
+import java.math.BigDecimal;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -83,10 +84,11 @@ public class SourcingStrategyServiceImpl implements SourcingStrategyService, Sou
 
     @Override
     @Transactional(readOnly = true)
-    public @NonNull Optional<SourceSelection> selectSource(@NonNull SourcingSelection selection, long neededQuantity) {
+    public @NonNull Optional<SourceSelection> selectSource(
+            @NonNull SourcingSelection selection, @NonNull BigDecimal neededQuantity) {
         SourcingDecision decision = orderCandidates(selection);
         return decision.orderedCandidates().stream()
-                .filter(candidate -> availableOf(selection.stockItemId(), candidate) >= neededQuantity)
+                .filter(candidate -> Quantities.gte(availableOf(selection.stockItemId(), candidate), neededQuantity))
                 .findFirst()
                 .map(candidate -> new SourceSelection(candidate, decision));
     }
@@ -147,14 +149,14 @@ public class SourcingStrategyServiceImpl implements SourcingStrategyService, Sou
         return null;
     }
 
-    private long availableOf(String stockItemId, SourcingCandidate candidate) {
+    private BigDecimal availableOf(String stockItemId, SourcingCandidate candidate) {
         if (candidate.availableQuantity() != null) {
             return candidate.availableQuantity();
         }
         return stockSummaryRepository
                 .findByStockItemIdAndLocationId(stockItemId, candidate.locationId())
-                .map(summary -> summary.getOnHand() - summary.getAllocated())
-                .orElse(0L);
+                .map(summary -> Quantities.nz(summary.getOnHand()).subtract(Quantities.nz(summary.getAllocated())))
+                .orElse(BigDecimal.ZERO);
     }
 
     // ─── Admin (SourcingStrategyConfigService) ───────────────────────────────

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StandardCostingStrategy.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StandardCostingStrategy.java
@@ -35,13 +35,13 @@ public class StandardCostingStrategy implements CostingStrategy {
     @Override
     public @NonNull CostingResult cost(@NonNull CostingInput input) {
         BigDecimal standardCost = input.state().standardCost();
-        int change = input.changeInQuantity();
+        BigDecimal change = Quantities.nz(input.changeInQuantity());
         BigDecimal docCost = input.documentUnitCost();
-        long newQty = input.state().onHandQty() + change;
+        BigDecimal newQty = Quantities.nz(input.state().onHandQty()).add(change);
 
         // avgCost doubles as the latest-receipt-cost memo under STANDARD.
         BigDecimal latestReceiptCost = input.state().avgCost();
-        if (change > 0 && docCost != null) {
+        if (Quantities.isPositive(change) && docCost != null) {
             latestReceiptCost = docCost; // remember most recent receipt cost; standard price untouched
         }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockMovementServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockMovementServiceImpl.java
@@ -16,6 +16,7 @@ import com.positivity.inventory.internal.repository.InventoryAdjustmentRequestRe
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.LocationRefRepository;
 import com.positivity.inventory.service.StockMovementService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.UUID;
@@ -40,6 +41,7 @@ public class StockMovementServiceImpl implements StockMovementService {
     private final LocationRefRepository locationRefRepository;
     private final ExtStorageLocationReplicaRepository storageLocationRepository;
     private final Clock clock;
+    private final QuantityScaleGuard quantityScaleGuard;
 
     public StockMovementServiceImpl(
             InventoryLedgerEntryRepository ledgerRepository,
@@ -47,12 +49,14 @@ public class StockMovementServiceImpl implements StockMovementService {
             LedgerPostingService ledgerPostingService,
             LocationRefRepository locationRefRepository,
             ExtStorageLocationReplicaRepository storageLocationRepository,
+            QuantityScaleGuard quantityScaleGuard,
             Clock clock) {
         this.ledgerRepository = ledgerRepository;
         this.adjustmentRepository = adjustmentRepository;
         this.ledgerPostingService = ledgerPostingService;
         this.locationRefRepository = locationRefRepository;
         this.storageLocationRepository = storageLocationRepository;
+        this.quantityScaleGuard = quantityScaleGuard;
         this.clock = clock;
     }
 
@@ -62,11 +66,18 @@ public class StockMovementServiceImpl implements StockMovementService {
             @NonNull RecordMovementRequest request, @NonNull String actorUserId) {
         MovementType movementType = request.getMovementType();
 
+        // ADR-0055 (#1414): a movement posts straight into the ledger, so it is gated by the
+        // product's declared divisibility exactly as receiving, ASN and returns are.
+        BigDecimal movementQuantity = quantityScaleGuard.requirePostable(
+                QuantityScaleGuard.productIdOf(request.getProductSku()),
+                request.getProductSku(),
+                "quantity",
+                request.getQuantity());
+
         if (movementType == MovementType.PICK || movementType == MovementType.ISSUE) {
-            Integer currentOnHand = ledgerRepository.calculateOnHandQuantityAtLocation(
-                    request.getProductSku(), request.getFromLocationId());
-            int onHand = currentOnHand != null ? currentOnHand : 0;
-            if (onHand < request.getQuantity()) {
+            BigDecimal onHand = Quantities.nz(ledgerRepository.calculateOnHandQuantityAtLocation(
+                    request.getProductSku(), request.getFromLocationId()));
+            if (Quantities.lt(onHand, request.getQuantity())) {
                 throw new InsufficientStockException(request.getProductSku(), request.getFromLocationId());
             }
         }
@@ -83,9 +94,9 @@ public class StockMovementServiceImpl implements StockMovementService {
                     .fromLocationId(request.getFromLocationId())
                     .toLocationId(request.getToLocationId())
                     .eventType(InventoryLedgerEventType.TRANSFER_IN)
-                    .changeInQuantity(request.getQuantity())
+                    .changeInQuantity(movementQuantity)
                     .quantityAfter(calculateQuantityAfter(
-                            request.getProductSku(), request.getToLocationId(), request.getQuantity()))
+                            request.getProductSku(), request.getToLocationId(), movementQuantity))
                     .unitOfMeasure(request.getUnitOfMeasure())
                     .sourceTransactionId(request.getSourceTransactionId())
                     .transactionUserId(actorUserId)
@@ -95,7 +106,7 @@ public class StockMovementServiceImpl implements StockMovementService {
         }
 
         InventoryLedgerEventType eventType = mapMovementTypeToEventType(movementType);
-        int quantityDelta = isOutbound(movementType) ? -request.getQuantity() : request.getQuantity();
+        BigDecimal quantityDelta = isOutbound(movementType) ? movementQuantity.negate() : movementQuantity;
 
         InventoryLedgerEntry entry = InventoryLedgerEntry.builder()
                 .stockItemId(request.getProductSku())
@@ -162,9 +173,10 @@ public class StockMovementServiceImpl implements StockMovementService {
             throw new IllegalStateException("Adjustment request is not pending approval: " + adjustmentRequestId);
         }
 
-        int quantityDelta = adjustmentRequest.getQuantity();
-        InventoryLedgerEventType eventType =
-                quantityDelta >= 0 ? InventoryLedgerEventType.ADJUSTMENT_IN : InventoryLedgerEventType.ADJUSTMENT_OUT;
+        BigDecimal quantityDelta = Quantities.nz(adjustmentRequest.getQuantity());
+        InventoryLedgerEventType eventType = quantityDelta.signum() >= 0
+                ? InventoryLedgerEventType.ADJUSTMENT_IN
+                : InventoryLedgerEventType.ADJUSTMENT_OUT;
 
         InventoryLedgerEntry entry = InventoryLedgerEntry.builder()
                 .stockItemId(adjustmentRequest.getProductSku())
@@ -246,10 +258,9 @@ public class StockMovementServiceImpl implements StockMovementService {
                 || movementType == MovementType.TRANSFER;
     }
 
-    private int calculateQuantityAfter(String stockItemId, UUID locationId, int quantityDelta) {
-        Integer currentOnHand = ledgerRepository.calculateOnHandQuantityAtLocation(stockItemId, locationId);
-        int onHand = currentOnHand != null ? currentOnHand : 0;
-        return onHand + quantityDelta;
+    private BigDecimal calculateQuantityAfter(String stockItemId, UUID locationId, BigDecimal quantityDelta) {
+        return Quantities.nz(ledgerRepository.calculateOnHandQuantityAtLocation(stockItemId, locationId))
+                .add(quantityDelta);
     }
 
     private @NonNull InventoryLedgerEntryResponse toResponse(@NonNull InventoryLedgerEntry entry) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryRebuildServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryRebuildServiceImpl.java
@@ -116,7 +116,7 @@ public class StockSummaryRebuildServiceImpl implements StockSummaryRebuildServic
                         .locationId(missing.locationId())
                         .lotId(missing.lotId())
                         .build());
-        row.setInTransitQty(row.getInTransitQty() + outbound.getInTransit());
+        row.setInTransitQty(Quantities.nz(row.getInTransitQty()).add(Quantities.nz(outbound.getInTransit())));
     }
 
     private InventoryStockSummary toSummaryRow(
@@ -139,7 +139,7 @@ public class StockSummaryRebuildServiceImpl implements StockSummaryRebuildServic
                 .onHand(aggregate.getOnHand())
                 .allocated(aggregate.getAllocated())
                 .reserved(aggregate.getReserved())
-                .atp(aggregate.getOnHand() - aggregate.getAllocated())
+                .atp(Quantities.nz(aggregate.getOnHand()).subtract(Quantities.nz(aggregate.getAllocated())))
                 .inTransitQty(aggregate.getInTransitArrived())
                 .lastLedgerEntryId(latest == null ? null : latest.getLedgerEntryId())
                 .lastEventAt(latest == null ? null : latest.getTimestamp())

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryRowInitializer.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockSummaryRowInitializer.java
@@ -2,6 +2,7 @@ package com.positivity.inventory.internal.service;
 
 import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.math.BigDecimal;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -48,11 +49,11 @@ public class StockSummaryRowInitializer {
                 .stockItemId(stockItemId)
                 .locationId(locationId)
                 .lotId(lotId)
-                .onHand(0L)
-                .allocated(0L)
-                .reserved(0L)
-                .atp(0L)
-                .inTransitQty(0L)
+                .onHand(BigDecimal.ZERO)
+                .allocated(BigDecimal.ZERO)
+                .reserved(BigDecimal.ZERO)
+                .atp(BigDecimal.ZERO)
+                .inTransitQty(BigDecimal.ZERO)
                 .build());
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockoutDeadlineCalculator.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/StockoutDeadlineCalculator.java
@@ -6,6 +6,7 @@ import com.positivity.inventory.internal.enums.ReservationStatus;
 import com.positivity.inventory.internal.repository.AsnLineRepository;
 import com.positivity.inventory.internal.repository.ExtPurchaseOrderLineRepository;
 import com.positivity.inventory.internal.repository.ReservationRepository;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -68,21 +69,22 @@ public class StockoutDeadlineCalculator {
     public @Nullable LocalDate stockoutDeadline(
             @NonNull String stockItemId,
             @Nullable UUID forecastSiteId,
-            long onHand,
+            @NonNull BigDecimal onHand,
             @NonNull Instant now,
             @NonNull Instant leadHorizon) {
-        if (projectedAt(stockItemId, forecastSiteId, onHand, now) < 0) {
+        if (Quantities.isNegative(projectedAt(stockItemId, forecastSiteId, onHand, now))) {
             return LocalDate.ofInstant(now, ZoneOffset.UTC);
         }
         for (Instant cutoff : candidateCutoffs(stockItemId, forecastSiteId, now, leadHorizon)) {
-            if (projectedAt(stockItemId, forecastSiteId, onHand, cutoff) < 0) {
+            if (Quantities.isNegative(projectedAt(stockItemId, forecastSiteId, onHand, cutoff))) {
                 return LocalDate.ofInstant(cutoff, ZoneOffset.UTC);
             }
         }
         return null;
     }
 
-    private long projectedAt(String stockItemId, @Nullable UUID forecastSiteId, long onHand, Instant horizon) {
+    private BigDecimal projectedAt(
+            String stockItemId, @Nullable UUID forecastSiteId, BigDecimal onHand, Instant horizon) {
         return forecastQuantityService
                 .forecast(stockItemId, forecastSiteId, horizon, onHand)
                 .projectedAvailable();

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/TransferOrderServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/TransferOrderServiceImpl.java
@@ -258,7 +258,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
         String actor = currentActor();
 
         List<InventoryLedgerEntry> entries = new ArrayList<>();
-        Map<String, Integer> runningDelta = new HashMap<>();
+        Map<String, BigDecimal> runningDelta = new HashMap<>();
         for (TransferOrderLine line : order.getLines()) {
             TransferQuantityLineRequest explicitLine = explicit.get(line.getLineId());
             int quantity = explicitLine != null ? explicitLine.getQuantity() : line.getRequestedQty();
@@ -326,7 +326,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
         String actor = currentActor();
 
         List<InventoryLedgerEntry> entries = new ArrayList<>();
-        Map<String, Integer> runningDelta = new HashMap<>();
+        Map<String, BigDecimal> runningDelta = new HashMap<>();
         for (TransferOrderLine line : order.getLines()) {
             int remaining = line.getDispatchedQty() - line.getReceivedQty();
             TransferQuantityLineRequest explicitLine = explicit.get(line.getLineId());
@@ -401,7 +401,7 @@ public class TransferOrderServiceImpl implements TransferOrderService {
         String actor = currentActor();
 
         List<InventoryLedgerEntry> entries = new ArrayList<>();
-        Map<String, Integer> runningDelta = new HashMap<>();
+        Map<String, BigDecimal> runningDelta = new HashMap<>();
         for (TransferOrderLine line : order.getLines()) {
             int remainder = line.getDispatchedQty() - line.getReceivedQty();
             if (remainder == 0) {
@@ -490,19 +490,23 @@ public class TransferOrderServiceImpl implements TransferOrderService {
             int remainder,
             UUID destinationPosting,
             ShortCloseTransferOrderRequest request,
-            Map<String, Integer> runningDelta,
+            Map<String, BigDecimal> runningDelta,
             String actor) {
         String sku = line.getSku();
-        Integer currentOnHand = ledgerRepository.calculateOnHandQuantityAtLocation(sku, destinationPosting);
+        // Transfer-order line quantities are still ints (the transfer document widens with the
+        // UOM work); the running ledger totals they are added to are decimal.
+        BigDecimal lostQuantity = BigDecimal.valueOf(remainder);
+        BigDecimal currentOnHand =
+                Quantities.nz(ledgerRepository.calculateOnHandQuantityAtLocation(sku, destinationPosting));
         String deltaKey = runningDeltaKey(sku, destinationPosting);
-        int before = (currentOnHand != null ? currentOnHand : 0) + runningDelta.getOrDefault(deltaKey, 0);
-        runningDelta.merge(deltaKey, -remainder, Integer::sum);
+        BigDecimal before = currentOnHand.add(runningDelta.getOrDefault(deltaKey, BigDecimal.ZERO));
+        runningDelta.merge(deltaKey, lostQuantity.negate(), BigDecimal::add);
         return InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(destinationPosting)
                 .eventType(InventoryLedgerEventType.SCRAP_OUT)
-                .changeInQuantity(-remainder)
-                .quantityAfter(before - remainder)
+                .changeInQuantity(lostQuantity.negate())
+                .quantityAfter(before.subtract(lostQuantity))
                 .unitCost(latestUnitCost(sku))
                 .reasonCode(ScrapReasonCode.LOST.name())
                 .lotId(line.getLotId())
@@ -578,20 +582,22 @@ public class TransferOrderServiceImpl implements TransferOrderService {
             UUID fromLocationId,
             UUID toLocationId,
             @Nullable UUID lotId,
-            Map<String, Integer> runningDelta,
+            Map<String, BigDecimal> runningDelta,
             String actor) {
-        Integer currentOnHand = ledgerRepository.calculateOnHandQuantityAtLocation(sku, postingLocationId);
+        BigDecimal change = BigDecimal.valueOf(changeInQuantity);
+        BigDecimal currentOnHand =
+                Quantities.nz(ledgerRepository.calculateOnHandQuantityAtLocation(sku, postingLocationId));
         String deltaKey = runningDeltaKey(sku, postingLocationId);
-        int before = (currentOnHand != null ? currentOnHand : 0) + runningDelta.getOrDefault(deltaKey, 0);
-        runningDelta.merge(deltaKey, changeInQuantity, Integer::sum);
+        BigDecimal before = currentOnHand.add(runningDelta.getOrDefault(deltaKey, BigDecimal.ZERO));
+        runningDelta.merge(deltaKey, change, BigDecimal::add);
         return InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(postingLocationId)
                 .fromLocationId(fromLocationId)
                 .toLocationId(toLocationId)
                 .eventType(eventType)
-                .changeInQuantity(changeInQuantity)
-                .quantityAfter(before + changeInQuantity)
+                .changeInQuantity(change)
+                .quantityAfter(before.add(change))
                 .lotId(lotId)
                 .sourceTransactionId(order.getTransferOrderId().toString())
                 .transactionUserId(actor)

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/UomConversionService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/UomConversionService.java
@@ -4,6 +4,7 @@ import com.positivity.inventory.internal.exception.UomConversionUndefinedExcepti
 import java.math.BigDecimal;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Converts document-UoM quantities into a product's base (stocking) UoM using the catalog-fed
@@ -51,4 +52,19 @@ public interface UomConversionService {
      *     row for the UoM
      */
     int precisionScale(@NonNull UUID productId, @NonNull String uomCode);
+
+    /**
+     * The product's declared stock divisibility (ADR-0055, #1414): the {@code precision_scale} of
+     * its base UoM's own conversion row, or {@code 0} when the product declares none.
+     *
+     * <p>Unlike {@link #precisionScale}, this never throws. Undeclared means integral, and that
+     * default is load-bearing rather than a fallback: {@code product_uom} is unpopulated
+     * platform-wide, so the absent-row path is the common path and it must answer "whole units"
+     * rather than refuse to answer. It is also what preserves today's behaviour exactly for every
+     * product while the declaration is installed ahead of any seeding.
+     *
+     * @param productId the catalog product; {@code null} for a stock reference that resolves to no
+     *     catalog product, which likewise declares nothing and so is integral
+     */
+    int declaredBaseScale(@Nullable UUID productId);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/UomConversionServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/UomConversionServiceImpl.java
@@ -10,6 +10,7 @@ import java.math.RoundingMode;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +27,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class UomConversionServiceImpl implements UomConversionService {
+
+    /** What a product that declares nothing resolves to: whole units (ADR-0055, #1414). */
+    private static final int UNDECLARED_SCALE = 0;
 
     private final ExtProductReplicaRepository extProductReplicaRepository;
     private final ExtProductUomReplicaRepository extProductUomReplicaRepository;
@@ -55,6 +59,28 @@ public class UomConversionServiceImpl implements UomConversionService {
                 .findByProductIdAndUomCode(productId, uomCode)
                 .map(ExtProductUomReplica::getPrecisionScale)
                 .orElseThrow(() -> UomConversionUndefinedException.unknownUom(productId, uomCode));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public int declaredBaseScale(@Nullable UUID productId) {
+        if (productId == null) {
+            return UNDECLARED_SCALE;
+        }
+        String baseUom = extProductReplicaRepository
+                .findById(productId)
+                .map(ExtProductReplica::getBaseUom)
+                .orElse(null);
+        if (baseUom == null || baseUom.isBlank()) {
+            return UNDECLARED_SCALE;
+        }
+        try {
+            return precisionScale(productId, baseUom);
+        } catch (UomConversionUndefinedException _) {
+            // The product exists but declares no BASE conversion row, which is every product
+            // today. Undeclared means whole units — see the interface contract.
+            return UNDECLARED_SCALE;
+        }
     }
 
     private BigDecimal convert(UUID productId, String uomCode, BigDecimal quantity, RoundingMode roundingMode) {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ValuationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ValuationServiceImpl.java
@@ -3,6 +3,7 @@ package com.positivity.inventory.internal.service;
 import com.positivity.inventory.internal.dto.valuation.ValuationReportResponse;
 import com.positivity.inventory.internal.dto.valuation.ValuationRow;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
+import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.entity.SkuCostState;
 import com.positivity.inventory.internal.enums.CostingMethod;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
@@ -132,47 +133,48 @@ public class ValuationServiceImpl implements ValuationService {
 
     private List<SkuQty> currentOnHands(@Nullable UUID locationId, @Nullable String sku) {
         if (sku != null && !sku.isBlank()) {
-            long onHand = locationId == null
-                    ? stockSummaryRepository.sumOnHandForSku(sku)
+            BigDecimal onHand = locationId == null
+                    ? Quantities.nz(stockSummaryRepository.sumOnHandForSku(sku))
                     : stockSummaryRepository
                             .findByStockItemIdAndLocationId(sku, locationId)
-                            .map(s -> s.getOnHand())
-                            .orElse(0L);
-            return onHand == 0L ? List.of() : List.of(new SkuQty(sku, onHand));
+                            .map(InventoryStockSummary::getOnHand)
+                            .map(Quantities::nz)
+                            .orElse(BigDecimal.ZERO);
+            return Quantities.isZero(onHand) ? List.of() : List.of(new SkuQty(sku, onHand));
         }
         List<InventoryStockSummaryRepository.SkuOnHand> rows = locationId == null
                 ? stockSummaryRepository.sumOnHandBySku()
                 : stockSummaryRepository.sumOnHandBySkuAtLocation(locationId);
         return rows.stream()
-                .map(r -> new SkuQty(r.getStockItemId(), r.getOnHand()))
+                .map(r -> new SkuQty(r.getStockItemId(), Quantities.nz(r.getOnHand())))
                 .toList();
     }
 
     private List<SkuQty> asOfOnHands(
             @Nullable UUID locationId, @Nullable String sku, Set<InventoryLedgerEventType> onHandTypes, Instant asOf) {
         if (sku != null && !sku.isBlank()) {
-            Integer onHand = locationId == null
+            BigDecimal onHand = locationId == null
                     ? sumChangeForSkuAsOf(sku, onHandTypes, asOf)
                     : ledgerRepository.calculateOnHandForStockItemAtLocationAsOf(sku, locationId, onHandTypes, asOf);
-            long value = onHand == null ? 0L : onHand.longValue();
-            return value == 0L ? List.of() : List.of(new SkuQty(sku, value));
+            BigDecimal value = Quantities.nz(onHand);
+            return Quantities.isZero(value) ? List.of() : List.of(new SkuQty(sku, value));
         }
         List<InventoryLedgerEntryRepository.LocationOnHand> rows = locationId == null
                 ? ledgerRepository.sumOnHandBySkuAsOf(onHandTypes, asOf)
                 : ledgerRepository.findPositiveOnHandByLocationAsOf(locationId, onHandTypes, asOf);
         return rows.stream()
-                .map(r -> new SkuQty(r.getStockItemId(), r.getOnHandQuantity()))
+                .map(r -> new SkuQty(r.getStockItemId(), Quantities.nz(r.getOnHandQuantity())))
                 .toList();
     }
 
-    private @Nullable Integer sumChangeForSkuAsOf(String sku, Set<InventoryLedgerEventType> onHandTypes, Instant asOf) {
+    private BigDecimal sumChangeForSkuAsOf(String sku, Set<InventoryLedgerEventType> onHandTypes, Instant asOf) {
         // Reuse the ordered replay stream to derive on-hand for a single SKU across all sites.
-        int total = 0;
+        BigDecimal total = BigDecimal.ZERO;
         for (InventoryLedgerEntry entry :
                 ledgerRepository
                         .findByStockItemIdAndEventTypeInAndTimestampLessThanEqualOrderByTimestampAscLedgerEntryIdAsc(
                                 sku, onHandTypes, asOf)) {
-            total += entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity();
+            total = total.add(Quantities.nz(entry.getChangeInQuantity()));
         }
         return total;
     }
@@ -189,9 +191,9 @@ public class ValuationServiceImpl implements ValuationService {
     private @Nullable BigDecimal unitCostAsOf(
             String sku, CostingMethod method, @Nullable BigDecimal standardCost, List<InventoryLedgerEntry> entries) {
         CostingStrategy strategy = strategy(method);
-        CostingStrategy.CostState state = new CostingStrategy.CostState(null, 0L, standardCost);
+        CostingStrategy.CostState state = new CostingStrategy.CostState(null, BigDecimal.ZERO, standardCost);
         for (InventoryLedgerEntry entry : entries) {
-            int change = entry.getChangeInQuantity() == null ? 0 : entry.getChangeInQuantity();
+            BigDecimal change = Quantities.nz(entry.getChangeInQuantity());
             CostingStrategy.CostingInput input =
                     new CostingStrategy.CostingInput(sku, entry.getEventType(), change, entry.getUnitCost(), state);
             state = strategy.cost(input).state();
@@ -265,11 +267,12 @@ public class ValuationServiceImpl implements ValuationService {
 
     // ─── Assembly ────────────────────────────────────────────────────────────
 
-    private static ValuationRow buildRow(String sku, long onHand, CostingMethod method, @Nullable BigDecimal unitCost) {
+    private static ValuationRow buildRow(
+            String sku, BigDecimal onHand, CostingMethod method, @Nullable BigDecimal unitCost) {
         boolean uncosted = unitCost == null;
         BigDecimal value = uncosted
                 ? BigDecimal.ZERO.setScale(VALUE_SCALE, RoundingMode.HALF_UP)
-                : unitCost.multiply(BigDecimal.valueOf(onHand)).setScale(VALUE_SCALE, RoundingMode.HALF_UP);
+                : unitCost.multiply(onHand).setScale(VALUE_SCALE, RoundingMode.HALF_UP);
         return ValuationRow.builder()
                 .stockItemId(sku)
                 .onHand(onHand)
@@ -294,5 +297,5 @@ public class ValuationServiceImpl implements ValuationService {
                 .build();
     }
 
-    private record SkuQty(String stockItemId, long onHand) {}
+    private record SkuQty(String stockItemId, BigDecimal onHand) {}
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/BackorderService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/BackorderService.java
@@ -2,6 +2,7 @@ package com.positivity.inventory.service;
 
 import com.positivity.inventory.internal.dto.backorder.BackorderResponse;
 import com.positivity.inventory.internal.enums.BackorderStatus;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -32,7 +33,10 @@ public interface BackorderService {
      */
     @NonNull
     BackorderResponse createBackorder(
-            @NonNull UUID workorderLineId, @NonNull String sku, int quantityShort, @Nullable UUID locationId);
+            @NonNull UUID workorderLineId,
+            @NonNull String sku,
+            @NonNull BigDecimal quantityShort,
+            @Nullable UUID locationId);
 
     /**
      * Opens a backorder for a sales-order line whose demand was short (CAP #1315), the sales-order
@@ -47,7 +51,10 @@ public interface BackorderService {
      */
     @NonNull
     BackorderResponse createBackorderForSalesOrderLine(
-            @NonNull UUID salesOrderLineId, @NonNull String sku, int quantityShort, @Nullable UUID locationId);
+            @NonNull UUID salesOrderLineId,
+            @NonNull String sku,
+            @NonNull BigDecimal quantityShort,
+            @Nullable UUID locationId);
 
     /**
      * Retrieves one backorder.

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/ReservationRequestService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/ReservationRequestService.java
@@ -1,5 +1,6 @@
 package com.positivity.inventory.service;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -17,13 +18,14 @@ public interface ReservationRequestService {
      * @param workorderLineId workorder line the demand is for, when demand is from a workorder
      * @param salesOrderLineId sales-order line the demand is for, when demand is from a sales order
      * @param stockItemId stock item requested
-     * @param requiredQuantity quantity requested
+     * @param requiredQuantity quantity requested; decimal-capable per the product's catalog
+     *     divisibility declaration (ADR-0055, #1414)
      * @param locationId site the demand must be covered at
      */
     void handle(
             @Nullable UUID workorderLineId,
             @Nullable UUID salesOrderLineId,
             @NonNull UUID stockItemId,
-            int requiredQuantity,
+            @NonNull BigDecimal requiredQuantity,
             @NonNull UUID locationId);
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/service/ShortageResolutionService.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/service/ShortageResolutionService.java
@@ -3,6 +3,7 @@ package com.positivity.inventory.service;
 import com.positivity.inventory.internal.dto.ShortageOptionDto;
 import com.positivity.inventory.internal.dto.ShortageResolutionResultDto;
 import com.positivity.inventory.internal.dto.ShortageResolveRequest;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -24,7 +25,8 @@ public interface ShortageResolutionService {
      * @param allocationId the allocation experiencing the shortage
      * @param workorderLineId the workorder line whose demand is short (optional)
      * @param sku the SKU / stock-item identifier that is short
-     * @param shortQuantity the quantity that is short (positive)
+     * @param shortQuantity the quantity that is short (positive); decimal-capable per the product's
+     *     catalog divisibility declaration (ADR-0055, #1414)
      * @param locationId the site the demand is short at (optional)
      * @return the computed options
      */
@@ -33,7 +35,7 @@ public interface ShortageResolutionService {
             @NonNull UUID allocationId,
             @Nullable UUID workorderLineId,
             @NonNull String sku,
-            int shortQuantity,
+            @NonNull BigDecimal shortQuantity,
             @Nullable UUID locationId);
 
     /**

--- a/pos-inventory/src/main/resources/db/migration/V39__decimal_inventory_quantities.sql
+++ b/pos-inventory/src/main/resources/db/migration/V39__decimal_inventory_quantities.sql
@@ -1,0 +1,92 @@
+-- ADR-0055 stage 2 (#1414): widen the inventory quantity chain to numeric(19,4).
+--
+-- Divisibility is a per-product property declared by the catalog
+-- (product_uom.precision_scale, replicated here as ext_product_uom). Widening these columns
+-- does NOT make stock divisible: a product declaring scale 0 — which is every product until
+-- one is seeded otherwise — is still refused a fractional quantity on both the demand side
+-- (pos-workorder's part gate, #1413) and the supply side (receiving, ASN, returns). The width
+-- exists so that a product declaring scale > 0 has somewhere truthful to land.
+--
+-- numeric(19,4) matches workorder_part.quantity, which has always been decimal. The scale of 4
+-- is the ceiling the platform will store; the per-product declaration is what decides how much
+-- of it any given product may use.
+--
+-- Pre-production widening: numeric(19,4) is a strict superset of integer and bigint for every
+-- value those columns can hold, so the implicit cast preserves existing rows exactly. There is
+-- no data-preservation logic here because there is nothing to preserve beyond the cast.
+
+-- 1. The ledger. change_in_quantity and quantity_after are the two columns #1365's Option A
+--    description omitted, and they are the reason the widening cannot stop at the read model.
+ALTER TABLE inventory_ledger_entry
+    ALTER COLUMN change_in_quantity TYPE numeric(19,4),
+    ALTER COLUMN quantity_after TYPE numeric(19,4);
+
+-- 2. The reservation chain.
+ALTER TABLE inventory_reservation
+    ALTER COLUMN required_quantity TYPE numeric(19,4),
+    ALTER COLUMN allocated_quantity TYPE numeric(19,4);
+
+ALTER TABLE inventory_allocation
+    ALTER COLUMN allocated_quantity TYPE numeric(19,4);
+
+-- backorder_record.quantity_short keeps its positivity CHECK. The constraint is dropped and
+-- re-added rather than left alone because "> 0" on numeric is a different comparison than on
+-- integer: 0.0000 must be rejected the same way 0 was, and a fractional shortfall of 0.5 must
+-- be accepted. Re-stating it makes that explicit rather than relying on the implicit re-check.
+ALTER TABLE backorder_record DROP CONSTRAINT backorder_record_quantity_check;
+ALTER TABLE backorder_record
+    ALTER COLUMN quantity_short TYPE numeric(19,4);
+ALTER TABLE backorder_record
+    ADD CONSTRAINT backorder_record_quantity_check CHECK (quantity_short > 0);
+
+-- 3. The derived read model. Already 64-bit (bigint), so this is a scale change rather than a
+--    range change: the ledger it derives from can now carry decimals, and a summary that could
+--    not would silently truncate every rebuild.
+ALTER TABLE inventory_stock_summary
+    ALTER COLUMN on_hand TYPE numeric(19,4),
+    ALTER COLUMN allocated TYPE numeric(19,4),
+    ALTER COLUMN reserved TYPE numeric(19,4),
+    ALTER COLUMN atp TYPE numeric(19,4),
+    ALTER COLUMN in_transit_qty TYPE numeric(19,4);
+
+-- 4. Returns. The return document's own quantities post straight into the ledger, so leaving
+--    them integral would reinstate the whole-units rule one layer up from the column that just
+--    lost it — a divisible product could be received and issued fractionally but not returned.
+ALTER TABLE inventory_return
+    ALTER COLUMN total_items_returned TYPE numeric(19,4);
+
+ALTER TABLE inventory_return_line
+    ALTER COLUMN quantity_returned TYPE numeric(19,4);
+
+-- 5. Cycle-count adjustments. The variance posts straight into the ledger, so an integral
+--    variance column would have rounded away exactly the small fractional shrinkage a bulk SKU
+--    produces — the one thing the platform gets to notice about a drum that is quietly draining.
+--    The count-capture DTOs stay integral; letting a counter key a decimal, and the tolerance
+--    policy that decides which small variances are worth surfacing, are stage 4 (#1416).
+ALTER TABLE cycle_count_adjustment
+    ALTER COLUMN counted_quantity TYPE numeric(19,4),
+    ALTER COLUMN quantity_change TYPE numeric(19,4),
+    ALTER COLUMN quantity_on_hand_before TYPE numeric(19,4);
+
+-- 6. Costing state and revaluation. The costing engine multiplies a movement quantity into a
+--    unit cost, so an integral running quantity would have made the AVCO denominator disagree
+--    with the ledger it is derived from the moment a fractional receipt posted.
+ALTER TABLE sku_cost_state
+    ALTER COLUMN on_hand_qty TYPE numeric(19,4);
+
+ALTER TABLE revaluation_record
+    ALTER COLUMN on_hand_quantity TYPE numeric(19,4);
+
+-- 7. Shortage resolution. A shortage is measured against the same ledger and resolves into a
+--    backorder or a reservation, both of which are now decimal; an integral short quantity here
+--    would have been the one remaining place that rounded the shortfall before recording it.
+ALTER TABLE shortage_resolution_record DROP CONSTRAINT shortage_resolution_short_quantity_check;
+ALTER TABLE shortage_resolution_record
+    ALTER COLUMN short_quantity TYPE numeric(19,4);
+ALTER TABLE shortage_resolution_record
+    ADD CONSTRAINT shortage_resolution_short_quantity_check CHECK (short_quantity > 0);
+
+-- 8. Manual adjustments. An adjustment request posts to the ledger on approval, so it carries
+--    the same divisibility rule as every other posting path.
+ALTER TABLE inventory_adjustment_request
+    ALTER COLUMN quantity TYPE numeric(19,4);

--- a/pos-inventory/src/test/java/com/positivity/inventory/config/InventoryCommandListenerTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/config/InventoryCommandListenerTest.java
@@ -25,6 +25,7 @@ import com.positivity.inventory.service.ConsumptionService;
 import com.positivity.inventory.service.OutboxReplayService;
 import com.positivity.inventory.service.PickListService;
 import com.positivity.inventory.service.ReservationRequestService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -191,6 +192,37 @@ class InventoryCommandListenerTest {
         verify(pickListService, never()).confirmPickTask(any(), any(), any(), any(), anyInt());
         verify(replayService, never()).replaySince(any());
         verify(consumptionService, never()).consumePickedItems(any());
+    }
+
+    @Test
+    @DisplayName("a reservation-request command carries its quantity's decimals through to the handler")
+    void reservationRequestCarriesDecimalQuantity() {
+        // ADR-0055 stage 2 (#1414): the seam between the demand modules and the ledger. The
+        // command payload is JSON, so a listener that read this field as an int would truncate a
+        // divisible product's demand here — after the demand-side gate has already approved it and
+        // before the ledger that can now hold it. Neither side would report anything wrong.
+        listener.onCommand("""
+                {"commandType":"inventory.reservation.request-requested","commandId":"%s",
+                 "payload":{"workorderLineId":"%s","stockItemId":"%s","locationId":"%s",
+                            "requiredQuantity":1.01}}
+                """.formatted(UUID.randomUUID(), WORKORDER_ID, SKU_ID, LOCATION_ID));
+
+        ArgumentCaptor<BigDecimal> quantity = ArgumentCaptor.forClass(BigDecimal.class);
+        verify(reservationRequestHandler)
+                .handle(eq(WORKORDER_ID), eq(null), eq(SKU_ID), quantity.capture(), eq(LOCATION_ID));
+        assertThat(quantity.getValue()).isEqualByComparingTo("1.01");
+    }
+
+    @Test
+    @DisplayName("a reservation-request command for no quantity is ignored, at any scale")
+    void reservationRequestWithZeroQuantityIsIgnored() {
+        listener.onCommand("""
+                {"commandType":"inventory.reservation.request-requested","commandId":"%s",
+                 "payload":{"workorderLineId":"%s","stockItemId":"%s","locationId":"%s",
+                            "requiredQuantity":0.0000}}
+                """.formatted(UUID.randomUUID(), WORKORDER_ID, SKU_ID, LOCATION_ID));
+
+        verify(reservationRequestHandler, never()).handle(any(), any(), any(), any(), any());
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/AsOfOnHandContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/AsOfOnHandContractBehaviorIT.java
@@ -11,6 +11,7 @@ import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.service.LedgerPostingService;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -60,11 +61,11 @@ class AsOfOnHandContractBehaviorIT extends BaseContractIntegrationTest {
         UUID productId = UUID.randomUUID();
         UUID location = UUID.randomUUID();
 
-        post(productId, location, InventoryLedgerEventType.GOODS_RECEIPT, 10);
+        post(productId, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("10"));
         Thread.sleep(50);
-        post(productId, location, InventoryLedgerEventType.GOODS_ISSUE, -4);
+        post(productId, location, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-4"));
         Thread.sleep(50);
-        post(productId, location, InventoryLedgerEventType.GOODS_RECEIPT, 7);
+        post(productId, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("7"));
 
         List<InventoryLedgerEntry> entries =
                 inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString());
@@ -116,9 +117,9 @@ class AsOfOnHandContractBehaviorIT extends BaseContractIntegrationTest {
         UUID productId = UUID.randomUUID();
         UUID location = UUID.randomUUID();
 
-        post(productId, location, InventoryLedgerEventType.GOODS_RECEIPT, 9);
+        post(productId, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("9"));
         Thread.sleep(50);
-        post(productId, location, InventoryLedgerEventType.GOODS_ISSUE, -9);
+        post(productId, location, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-9"));
 
         List<InventoryLedgerEntry> entries =
                 inventoryLedgerEntryRepository.findByStockItemIdOrderByTimestampAsc(productId.toString());
@@ -148,7 +149,7 @@ class AsOfOnHandContractBehaviorIT extends BaseContractIntegrationTest {
     void asOfRequiresLedgerViewAuthority() throws Exception {
         UUID productId = UUID.randomUUID();
         UUID location = UUID.randomUUID();
-        post(productId, location, InventoryLedgerEventType.GOODS_RECEIPT, 5);
+        post(productId, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("5"));
 
         String pastInstant = Instant.now().minusSeconds(1).toString();
 
@@ -197,13 +198,13 @@ class AsOfOnHandContractBehaviorIT extends BaseContractIntegrationTest {
                 .andExpect(jsonPath("$.code").value("AS_OF_IN_FUTURE"));
     }
 
-    private void post(UUID productId, UUID locationId, InventoryLedgerEventType eventType, int change) {
+    private void post(UUID productId, UUID locationId, InventoryLedgerEventType eventType, BigDecimal change) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productId.toString())
                 .locationId(locationId)
                 .eventType(eventType)
                 .changeInQuantity(change)
-                .quantityAfter(0)
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("asof-contract-seed")
                 .build());
     }

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/CrossSiteTransferGuardIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/CrossSiteTransferGuardIT.java
@@ -14,6 +14,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.repository.LocationRefRepository;
 import com.positivity.inventory.internal.service.LedgerPostingService;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,7 +72,7 @@ class CrossSiteTransferGuardIT extends BaseContractIntegrationTest {
     @DisplayName("TRANSFER between bins of different sites returns 422 CROSS_SITE_TRANSFER_REQUIRES_ORDER")
     void transfer_binsAcrossSites_returns422() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, BIN_A1, 10);
+        seedOnHand(sku, BIN_A1, new BigDecimal("10"));
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/stock-movements"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -90,7 +91,7 @@ class CrossSiteTransferGuardIT extends BaseContractIntegrationTest {
     @DisplayName("TRANSFER between site keys of different sites returns 422")
     void transfer_siteToSite_returns422() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SITE_A, 10);
+        seedOnHand(sku, SITE_A, new BigDecimal("10"));
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/stock-movements"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -103,7 +104,7 @@ class CrossSiteTransferGuardIT extends BaseContractIntegrationTest {
     @DisplayName("TRANSFER between bins of the same site still posts the paired OUT/IN with zero net in-transit")
     void transfer_binsSameSite_allowed() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, BIN_A1, 10);
+        seedOnHand(sku, BIN_A1, new BigDecimal("10"));
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/stock-movements"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -113,7 +114,8 @@ class CrossSiteTransferGuardIT extends BaseContractIntegrationTest {
         assertThat(onHand(sku, BIN_A1)).isEqualTo(6);
         assertThat(onHand(sku, BIN_A2)).isEqualTo(4);
         // The paired OUT/IN posts in one transaction: in-transit cancels to zero everywhere.
-        assertThat(summaryRepository.findByStockItemId(sku)).allMatch(row -> row.getInTransitQty() == 0);
+        assertThat(summaryRepository.findByStockItemId(sku))
+                .allMatch(row -> row.getInTransitQty().signum() == 0);
     }
 
     @Test
@@ -122,7 +124,7 @@ class CrossSiteTransferGuardIT extends BaseContractIntegrationTest {
         String sku = uniqueSku();
         UUID freeFrom = UUID.randomUUID();
         UUID freeTo = UUID.randomUUID();
-        seedOnHand(sku, freeFrom, 10);
+        seedOnHand(sku, freeFrom, new BigDecimal("10"));
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/stock-movements"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -164,7 +166,7 @@ class CrossSiteTransferGuardIT extends BaseContractIntegrationTest {
                 .build());
     }
 
-    private void seedOnHand(String sku, UUID locationId, int quantity) {
+    private void seedOnHand(String sku, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(locationId)
@@ -176,10 +178,10 @@ class CrossSiteTransferGuardIT extends BaseContractIntegrationTest {
                 .build());
     }
 
-    private long onHand(String sku, UUID locationId) {
+    private BigDecimal onHand(String sku, UUID locationId) {
         return summaryRepository
                 .findByStockItemIdAndLocationId(sku, locationId)
                 .map(row -> row.getOnHand())
-                .orElse(0L);
+                .orElse(BigDecimal.ZERO);
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ForecastAvailabilityContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ForecastAvailabilityContractBehaviorIT.java
@@ -61,7 +61,7 @@ class ForecastAvailabilityContractBehaviorIT extends BaseContractIntegrationTest
     @DisplayName("AC-1: per-location availability rows expose forecast fields; existing fields unchanged")
     void perLocationRowsExposeForecastFields() throws Exception {
         UUID productId = UUID.randomUUID();
-        seedOnHand(productId, SITE, 100);
+        seedOnHand(productId, SITE, new BigDecimal("100"));
         seedApprovedPo(productId, SITE, "25", LocalDate.parse("2026-07-30"));
         seedPendingReservation(productId, 10, 0, null); // remainder 10, site-agnostic
 
@@ -82,7 +82,7 @@ class ForecastAvailabilityContractBehaviorIT extends BaseContractIntegrationTest
     @DisplayName("AC-2: horizon bounds the forecast; undated documents drop out of bounded results")
     void horizonBoundsForecast() throws Exception {
         UUID productId = UUID.randomUUID();
-        seedOnHand(productId, SITE, 50);
+        seedOnHand(productId, SITE, new BigDecimal("50"));
         seedApprovedPo(productId, SITE, "20", LocalDate.parse("2026-07-25")); // inside horizon
         seedApprovedPo(productId, SITE, "40", LocalDate.parse("2026-12-01")); // beyond horizon
         seedApprovedPo(productId, SITE, "5", null); // undated
@@ -109,7 +109,7 @@ class ForecastAvailabilityContractBehaviorIT extends BaseContractIntegrationTest
     @DisplayName("AC-3: by-sku availability views expose forecast fields with unchanged ATP semantics")
     void bySkuViewExposesForecastFields() throws Exception {
         UUID productId = UUID.randomUUID();
-        seedOnHand(productId, SITE, 30);
+        seedOnHand(productId, SITE, new BigDecimal("30"));
         seedApprovedPo(productId, SITE, "12", null);
 
         mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/by-sku")
@@ -132,7 +132,7 @@ class ForecastAvailabilityContractBehaviorIT extends BaseContractIntegrationTest
                 .andExpect(jsonPath("$[0].projectedAvailable").value(42));
     }
 
-    private void seedOnHand(UUID productId, UUID locationId, int quantity) {
+    private void seedOnHand(UUID productId, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productId.toString())
                 .locationId(locationId)
@@ -164,8 +164,8 @@ class ForecastAvailabilityContractBehaviorIT extends BaseContractIntegrationTest
         reservationRepository.save(ReservationEntity.builder()
                 .workorderLineId(UUID.randomUUID())
                 .stockItemId(stockItemId)
-                .requiredQuantity(required)
-                .allocatedQuantity(allocated)
+                .requiredQuantity(BigDecimal.valueOf(required))
+                .allocatedQuantity(BigDecimal.valueOf(allocated))
                 .status(ReservationStatus.PENDING)
                 .dueDateTime(dueDateTime)
                 .build());

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryAvailabilityContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryAvailabilityContractBehaviorIT.java
@@ -11,6 +11,7 @@ import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.service.LedgerPostingService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -55,8 +56,8 @@ class InventoryAvailabilityContractBehaviorIT extends BaseContractIntegrationTes
     void getAvailability_returnsPerLocationList_whenProductHasStock() throws Exception {
         UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-        seedOnHand(productId, LOC_1, 40);
-        seedOnHand(productId, LOC_2, 60);
+        seedOnHand(productId, LOC_1, new BigDecimal("40"));
+        seedOnHand(productId, LOC_2, new BigDecimal("60"));
 
         mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/{productId}", productId)))
                 .andExpect(status().isOk())
@@ -106,12 +107,12 @@ class InventoryAvailabilityContractBehaviorIT extends BaseContractIntegrationTes
     void getAvailability_calculatesAtp_excludingInactiveReservations() throws Exception {
         UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-        seedOnHand(productId, LOC_ATP, 100);
+        seedOnHand(productId, LOC_ATP, new BigDecimal("100"));
 
-        seedReservationCreated(productId, LOC_ATP, 30);
+        seedReservationCreated(productId, LOC_ATP, new BigDecimal("30"));
 
-        seedReservationCreated(productId, LOC_ATP, 20);
-        seedReservationReleased(productId, LOC_ATP, 20);
+        seedReservationCreated(productId, LOC_ATP, new BigDecimal("20"));
+        seedReservationReleased(productId, LOC_ATP, new BigDecimal("20"));
 
         mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/{productId}", productId)))
                 .andExpect(status().isOk())
@@ -121,7 +122,7 @@ class InventoryAvailabilityContractBehaviorIT extends BaseContractIntegrationTes
                 .andExpect(jsonPath("$[0].availableToPromiseQuantity").value(70));
     }
 
-    private void seedOnHand(UUID productId, UUID locationId, int quantity) {
+    private void seedOnHand(UUID productId, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productId.toString())
                 .locationId(locationId)
@@ -134,26 +135,26 @@ class InventoryAvailabilityContractBehaviorIT extends BaseContractIntegrationTes
                 .build());
     }
 
-    private void seedReservationCreated(UUID productId, UUID locationId, int quantity) {
+    private void seedReservationCreated(UUID productId, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productId.toString())
                 .locationId(locationId)
                 .eventType(InventoryLedgerEventType.RESERVATION_CREATED)
                 .changeInQuantity(quantity)
-                .quantityAfter(0)
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("contract-seed")
                 .timestamp(Instant.now(TEST_CLOCK))
                 .notes("seed active reservation")
                 .build());
     }
 
-    private void seedReservationReleased(UUID productId, UUID locationId, int quantity) {
+    private void seedReservationReleased(UUID productId, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productId.toString())
                 .locationId(locationId)
                 .eventType(InventoryLedgerEventType.RESERVATION_RELEASED)
                 .changeInQuantity(quantity)
-                .quantityAfter(0)
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("contract-seed")
                 .timestamp(Instant.now(TEST_CLOCK))
                 .notes("seed released reservation")

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryAvailabilityQueryContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryAvailabilityQueryContractBehaviorIT.java
@@ -10,6 +10,7 @@ import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.service.LedgerPostingService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -67,8 +68,8 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
     @Test
     @DisplayName("AC-1: queryAvailability_returns200_withCorrectOnHandAndAtp")
     void queryAvailability_returns200_withCorrectOnHandAndAtp() throws Exception {
-        seedGoodsReceipt("SKU-TEST-1", LOC_ALPHA, 100);
-        seedAllocationCreated("SKU-TEST-1", LOC_ALPHA, 20);
+        seedGoodsReceipt("SKU-TEST-1", LOC_ALPHA, new BigDecimal("100"));
+        seedAllocationCreated("SKU-TEST-1", LOC_ALPHA, new BigDecimal("20"));
 
         mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/by-sku")
                         .param("productSku", "SKU-TEST-1")
@@ -90,7 +91,7 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
     void queryAvailability_returnsZeroQuantities_whenProductKnownButNoStockAtLocation() throws Exception {
         // Seed an entry for SKU-ZERO at a DIFFERENT location so the product is
         // "known" in the system; the queried location has no stock.
-        seedGoodsReceipt("SKU-ZERO", LOC_OTHER, 50);
+        seedGoodsReceipt("SKU-ZERO", LOC_OTHER, new BigDecimal("50"));
 
         mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/by-sku")
                         .param("productSku", "SKU-ZERO")
@@ -122,8 +123,8 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
     @Test
     @DisplayName("AC-4: queryAvailability_aggregatesAllStorageLocations_whenNoStorageLocationId")
     void queryAvailability_aggregatesAllStorageLocations_whenNoStorageLocationId() throws Exception {
-        seedGoodsReceipt("SKU-BETA", LOC_BETA, 40);
-        seedGoodsReceipt("SKU-BETA", LOC_BETA, 60);
+        seedGoodsReceipt("SKU-BETA", LOC_BETA, new BigDecimal("40"));
+        seedGoodsReceipt("SKU-BETA", LOC_BETA, new BigDecimal("60"));
 
         mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability/by-sku")
                         .param("productSku", "SKU-BETA")
@@ -142,11 +143,11 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
     @Test
     @DisplayName("AC-5: queryAvailability_atpReflectsAllocations_notReservations")
     void queryAvailability_atpReflectsAllocations_notReservations() throws Exception {
-        seedGoodsReceipt("SKU-ATP", LOC_GAMMA, 200);
-        seedAllocationCreated("SKU-ATP", LOC_GAMMA, 50);
-        seedAllocationReleased("SKU-ATP", LOC_GAMMA, 10);
+        seedGoodsReceipt("SKU-ATP", LOC_GAMMA, new BigDecimal("200"));
+        seedAllocationCreated("SKU-ATP", LOC_GAMMA, new BigDecimal("50"));
+        seedAllocationReleased("SKU-ATP", LOC_GAMMA, new BigDecimal("10"));
         // RESERVATION_CREATED must NOT count toward allocatedQuantity or ATP
-        seedReservationCreated("SKU-ATP", LOC_GAMMA, 30);
+        seedReservationCreated("SKU-ATP", LOC_GAMMA, new BigDecimal("30"));
 
         // allocatedQuantity = 50 (ALLOCATION_CREATED) - 10 (ALLOCATION_RELEASED) = 40
         // ATP = 200 (onHand) - 40 (allocated) = 160
@@ -164,8 +165,8 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
     @Test
     @DisplayName("CP-665-001: GET /v1/inventory/availability?sku=... returns list with one element")
     void queryAvailabilityBySkuList_returns200_withListWrappingResult() throws Exception {
-        seedGoodsReceipt("SKU-LIST-1", LOC_ALPHA, 50);
-        seedAllocationCreated("SKU-LIST-1", LOC_ALPHA, 10);
+        seedGoodsReceipt("SKU-LIST-1", LOC_ALPHA, new BigDecimal("50"));
+        seedAllocationCreated("SKU-LIST-1", LOC_ALPHA, new BigDecimal("10"));
 
         mockMvc.perform(withGatewayAuth(get("/v1/inventory/availability")
                         .param("sku", "SKU-LIST-1")
@@ -195,7 +196,7 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
     // Seed helpers
     // -------------------------------------------------------------------------
 
-    private void seedGoodsReceipt(String productSku, UUID locationId, int quantity) {
+    private void seedGoodsReceipt(String productSku, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productSku)
                 .locationId(locationId)
@@ -208,39 +209,39 @@ class InventoryAvailabilityQueryContractBehaviorIT extends BaseContractIntegrati
                 .build());
     }
 
-    private void seedAllocationCreated(String productSku, UUID locationId, int quantity) {
+    private void seedAllocationCreated(String productSku, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productSku)
                 .locationId(locationId)
                 .eventType(InventoryLedgerEventType.ALLOCATION_CREATED)
                 .changeInQuantity(quantity)
-                .quantityAfter(0)
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("contract-seed")
                 .timestamp(Instant.now(TEST_CLOCK))
                 .notes("seed allocation created")
                 .build());
     }
 
-    private void seedAllocationReleased(String productSku, UUID locationId, int quantity) {
+    private void seedAllocationReleased(String productSku, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productSku)
                 .locationId(locationId)
                 .eventType(InventoryLedgerEventType.ALLOCATION_RELEASED)
                 .changeInQuantity(quantity)
-                .quantityAfter(0)
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("contract-seed")
                 .timestamp(Instant.now(TEST_CLOCK))
                 .notes("seed allocation released")
                 .build());
     }
 
-    private void seedReservationCreated(String productSku, UUID locationId, int quantity) {
+    private void seedReservationCreated(String productSku, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productSku)
                 .locationId(locationId)
                 .eventType(InventoryLedgerEventType.RESERVATION_CREATED)
                 .changeInQuantity(quantity)
-                .quantityAfter(0)
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("contract-seed")
                 .timestamp(Instant.now(TEST_CLOCK))
                 .notes("seed reservation (must not affect allocated qty per ADR-0001)")

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryLedgerContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/InventoryLedgerContractBehaviorIT.java
@@ -10,6 +10,7 @@ import com.positivity.inventory.internal.dto.LedgerPage;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.service.InventoryLedgerService;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -35,8 +36,8 @@ class InventoryLedgerContractBehaviorIT extends BaseContractIntegrationTest {
                 .ledgerEntryId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .stockItemId("SKU-1")
                 .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
-                .changeInQuantity(5)
-                .quantityAfter(5)
+                .changeInQuantity(new BigDecimal("5"))
+                .quantityAfter(new BigDecimal("5"))
                 .timestamp(Instant.parse("2024-01-01T00:00:00Z"))
                 .build();
 
@@ -64,8 +65,8 @@ class InventoryLedgerContractBehaviorIT extends BaseContractIntegrationTest {
                         .ledgerEntryId(entryId)
                         .stockItemId("SKU-1")
                         .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
-                        .changeInQuantity(2)
-                        .quantityAfter(2)
+                        .changeInQuantity(new BigDecimal("2"))
+                        .quantityAfter(new BigDecimal("2"))
                         .timestamp(Instant.parse("2024-01-01T00:00:00Z"))
                         .build());
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/LocationInventoryRollupContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/LocationInventoryRollupContractBehaviorIT.java
@@ -16,6 +16,7 @@ import com.positivity.inventory.internal.dto.rollup.StorageLocationRollupNode;
 import com.positivity.inventory.internal.exception.LocationNotFoundException;
 import com.positivity.inventory.internal.exception.RollupExpansionTooLargeException;
 import com.positivity.inventory.service.LocationInventoryRollupService;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -49,8 +50,12 @@ class LocationInventoryRollupContractBehaviorIT extends BaseContractIntegrationT
         LocationInventoryRollupResponse response = new LocationInventoryRollupResponse(
                 BUILDING_ID,
                 "PHYSICAL",
-                RollupQuantities.of(150, 15),
-                List.of(new SiteRollupSummary(SITE_A, "Main Workshop", RollupQuantities.of(150, 15), null)));
+                RollupQuantities.of(new BigDecimal("150"), new BigDecimal("15")),
+                List.of(new SiteRollupSummary(
+                        SITE_A,
+                        "Main Workshop",
+                        RollupQuantities.of(new BigDecimal("150"), new BigDecimal("15")),
+                        null)));
         when(locationInventoryRollupService.getLocationInventoryRollup(
                         eq(BUILDING_ID), isNull(), isNull(), eq(false), isNull(), eq(false)))
                 .thenReturn(response);
@@ -74,14 +79,18 @@ class LocationInventoryRollupContractBehaviorIT extends BaseContractIntegrationT
                 "Floor A",
                 "FLOOR",
                 "ACTIVE",
-                RollupQuantities.of(150, 15),
-                RollupQuantities.of(150, 15),
+                RollupQuantities.of(new BigDecimal("150"), new BigDecimal("15")),
+                RollupQuantities.of(new BigDecimal("150"), new BigDecimal("15")),
                 List.of());
         LocationInventoryRollupResponse response = new LocationInventoryRollupResponse(
                 BUILDING_ID,
                 "PHYSICAL",
-                RollupQuantities.of(150, 15),
-                List.of(new SiteRollupSummary(SITE_A, "Main Workshop", RollupQuantities.of(150, 15), List.of(node))));
+                RollupQuantities.of(new BigDecimal("150"), new BigDecimal("15")),
+                List.of(new SiteRollupSummary(
+                        SITE_A,
+                        "Main Workshop",
+                        RollupQuantities.of(new BigDecimal("150"), new BigDecimal("15")),
+                        List.of(node))));
         when(locationInventoryRollupService.getLocationInventoryRollup(
                         eq(BUILDING_ID), isNull(), isNull(), eq(true), isNull(), eq(false)))
                 .thenReturn(response);

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/LotInboundCaptureIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/LotInboundCaptureIT.java
@@ -173,11 +173,11 @@ class LotInboundCaptureIT extends BaseContractIntegrationTest {
         InventoryStockSummary agnostic = summaryRepository
                 .findByStockItemIdAndLocationId(productId.toString(), locationId)
                 .orElseThrow();
-        assertThat(agnostic.getOnHand()).isEqualTo(7);
+        assertThat(agnostic.getOnHand()).isEqualByComparingTo("7");
         InventoryStockSummary perLot = summaryRepository
                 .findByKey(productId.toString(), locationId, lot.getLotId())
                 .orElseThrow();
-        assertThat(perLot.getOnHand()).isEqualTo(7);
+        assertThat(perLot.getOnHand()).isEqualByComparingTo("7");
 
         // Second receipt of the same lot number reuses the lot (find-or-create).
         CreateGoodsReceiptRequest second = receiptRequest(po, locationId);

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/LotOutboundFlowsIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/LotOutboundFlowsIT.java
@@ -227,8 +227,8 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
         InventoryLot lotB = seedLot(productId, "LOT-CONS-B", Instant.parse("2026-02-02T00:00:00Z"));
         // Consumption posts at the NULL-location key (pre-E2 shape, unchanged) — seed the lot
         // stock there so the walk exercises the exact rows consumption touches.
-        seedLotStock(productId, null, lotA.getLotId(), 5);
-        seedLotStock(productId, null, lotB.getLotId(), 5);
+        seedLotStock(productId, null, lotA.getLotId(), new BigDecimal("5"));
+        seedLotStock(productId, null, lotB.getLotId(), new BigDecimal("5"));
 
         UUID workorderId = UUID.randomUUID();
         PickTaskEntity task = seedPickedTask(productId, 5, lotA.getLotId());
@@ -277,8 +277,8 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
         UUID productId = seedProduct("LOT");
         InventoryLot lotA = seedLot(productId, "LOT-SRC-A", Instant.parse("2026-02-01T00:00:00Z"));
         InventoryLot lotB = seedLot(productId, "LOT-SRC-B", Instant.parse("2026-02-02T00:00:00Z"));
-        seedLotStock(productId, null, lotA.getLotId(), 4);
-        seedLotStock(productId, null, lotB.getLotId(), 4);
+        seedLotStock(productId, null, lotA.getLotId(), new BigDecimal("4"));
+        seedLotStock(productId, null, lotB.getLotId(), new BigDecimal("4"));
 
         UUID workorderId = UUID.randomUUID();
         // Pre-E2 task shape: PICKED but no pickedLotId (e.g. confirmed before E2).
@@ -305,7 +305,7 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
     void returns_reincrementAndReactivate() {
         UUID productId = seedProduct("LOT");
         InventoryLot lot = seedLot(productId, "LOT-RET-A", Instant.parse("2026-03-01T00:00:00Z"));
-        seedLotStock(productId, null, lot.getLotId(), 3);
+        seedLotStock(productId, null, lot.getLotId(), new BigDecimal("3"));
 
         UUID workorderId = UUID.randomUUID();
         PickTaskEntity task = seedPickedTask(productId, 3, lot.getLotId());
@@ -315,19 +315,23 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
                 .isEqualTo(InventoryLotStatus.CONSUMED);
 
         // Tracked return without a lot number → 422 LOT_NUMBER_REQUIRED.
-        ReturnItemsRequest noLot =
-                new ReturnItemsRequest(workorderId, "DAMAGED", List.of(new ReturnItemLine(productId, 2, null, null)));
+        ReturnItemsRequest noLot = new ReturnItemsRequest(
+                workorderId, "DAMAGED", List.of(new ReturnItemLine(productId, new BigDecimal("2"), null, null)));
         assertThatThrownBy(() -> returnService.returnItemsToStock(noLot))
                 .isInstanceOf(LotNumberRequiredException.class);
 
         // Unknown lot → 422 LOT_UNKNOWN (returns never create lots).
         ReturnItemsRequest unknownLot = new ReturnItemsRequest(
-                workorderId, "DAMAGED", List.of(new ReturnItemLine(productId, 2, null, null, "LOT-NOPE")));
+                workorderId,
+                "DAMAGED",
+                List.of(new ReturnItemLine(productId, new BigDecimal("2"), null, null, "LOT-NOPE")));
         assertThatThrownBy(() -> returnService.returnItemsToStock(unknownLot)).isInstanceOf(LotUnknownException.class);
 
         // Valid return against the CONSUMED lot: per-lot row re-increments, lot reactivates.
         returnService.returnItemsToStock(new ReturnItemsRequest(
-                workorderId, "DAMAGED", List.of(new ReturnItemLine(productId, 2, null, null, "LOT-RET-A"))));
+                workorderId,
+                "DAMAGED",
+                List.of(new ReturnItemLine(productId, new BigDecimal("2"), null, null, "LOT-RET-A"))));
         assertThat(perLotOnHand(productId, null, lot.getLotId())).isEqualTo(2);
         assertThat(lotRepository.findById(lot.getLotId()).orElseThrow().getStatus())
                 .isEqualTo(InventoryLotStatus.ACTIVE);
@@ -345,7 +349,7 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
         UUID productId = seedProduct("LOT");
         UUID locationId = UUID.randomUUID();
         InventoryLot lot = seedLot(productId, "LOT-SCRAP-A", Instant.parse("2026-04-01T00:00:00Z"));
-        seedLotStock(productId, locationId, lot.getLotId(), 6);
+        seedLotStock(productId, locationId, lot.getLotId(), new BigDecimal("6"));
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/scraps"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -407,7 +411,8 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
         // No phantom per-lot on-hand: the paired entries net the per-lot row to zero, and the
         // reconciler marks the lot CONSUMED (its stock went straight to the workorder).
         assertThat(summaryRepository.findByLotId(lot.getLotId()))
-                .allMatch(row -> row.getOnHand() == 0 && row.getInTransitQty() == 0);
+                .allMatch(row ->
+                        row.getOnHand().signum() == 0 && row.getInTransitQty().signum() == 0);
         assertThat(lotRepository.findById(lot.getLotId()).orElseThrow().getStatus())
                 .isEqualTo(InventoryLotStatus.CONSUMED);
     }
@@ -423,9 +428,9 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
         InventoryLot oldest = seedLot(productId, "LOT-FIFO-1", Instant.parse("2026-01-01T00:00:00Z"));
         InventoryLot middle = seedLot(productId, "LOT-FIFO-2", Instant.parse("2026-02-01T00:00:00Z"));
         InventoryLot newest = seedLot(productId, "LOT-FIFO-3", Instant.parse("2026-03-01T00:00:00Z"));
-        seedLotStock(productId, locationId, oldest.getLotId(), 4);
-        seedLotStock(productId, locationId, middle.getLotId(), 4);
-        seedLotStock(productId, locationId, newest.getLotId(), 4);
+        seedLotStock(productId, locationId, oldest.getLotId(), new BigDecimal("4"));
+        seedLotStock(productId, locationId, middle.getLotId(), new BigDecimal("4"));
+        seedLotStock(productId, locationId, newest.getLotId(), new BigDecimal("4"));
 
         assertThat(taskFor(generate(productId)).getSuggestedLotNumber()).isEqualTo("LOT-FIFO-1");
 
@@ -436,7 +441,7 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
 
         // Untracked SKUs get no suggestion.
         UUID untracked = seedProduct("NONE");
-        seedLotStock(untracked, locationId, null, 4);
+        seedLotStock(untracked, locationId, null, new BigDecimal("4"));
         assertThat(taskFor(generate(untracked)).getSuggestedLotNumber()).isNull();
     }
 
@@ -465,7 +470,7 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
     }
 
     /** Posts a lot-tagged GOODS_RECEIPT through the funnel so both summary rows exist. */
-    private void seedLotStock(UUID productId, UUID locationId, UUID lotId, int quantity) {
+    private void seedLotStock(UUID productId, UUID locationId, UUID lotId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(productId.toString())
                 .locationId(locationId)
@@ -569,11 +574,11 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
                 + "\",\"reasonCode\":\"" + ScrapReasonCode.DAMAGED.name() + "\"" + lotPart + "}";
     }
 
-    private long perLotOnHand(UUID productId, UUID locationId, UUID lotId) {
+    private BigDecimal perLotOnHand(UUID productId, UUID locationId, UUID lotId) {
         return summaryRepository
                 .findByKey(productId.toString(), locationId, lotId)
                 .map(row -> row.getOnHand())
-                .orElse(0L);
+                .orElse(BigDecimal.ZERO);
     }
 
     private List<InventoryLedgerEntry> entriesOf(UUID productId, InventoryLedgerEventType eventType) {

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/PutawayExecutionContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/PutawayExecutionContractBehaviorIT.java
@@ -13,6 +13,7 @@ import com.positivity.inventory.internal.exception.LocationAtCapacityException;
 import com.positivity.inventory.internal.exception.LocationNotValidForSkuException;
 import com.positivity.inventory.internal.exception.NoOnHandAtSourceLocationException;
 import com.positivity.inventory.service.PutawayExecuteService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -161,7 +162,8 @@ class PutawayExecutionContractBehaviorIT extends BaseContractIntegrationTest {
         UUID destinationLocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
         when(putawayExecuteService.executePutaway(eq(taskId), any(PutawayExecutionRequest.class)))
-                .thenThrow(new LocationAtCapacityException(destinationLocationId, 100, 100));
+                .thenThrow(new LocationAtCapacityException(
+                        destinationLocationId, new BigDecimal("100"), new BigDecimal("100")));
 
         String requestBody =
                 buildExecutionRequestBody(skuId, sourceLocationId.toString(), destinationLocationId.toString(), 4);

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ReallocationContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ReallocationContractBehaviorIT.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.positivity.inventory.internal.dto.reallocation.ReallocateRequest;
 import com.positivity.inventory.internal.dto.reallocation.ReallocateResponse;
 import com.positivity.inventory.service.AllocationReallocationService;
+import java.math.BigDecimal;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -97,7 +98,7 @@ class ReallocationContractBehaviorIT extends BaseContractIntegrationTest {
                 .stockItemId(stockItemId)
                 .totalReallocated(3)
                 .auditRecordsCreated(2)
-                .atpAfterReallocation(7)
+                .atpAfterReallocation(new BigDecimal("7"))
                 .build();
 
         when(allocationReallocationService.reallocate(any(ReallocateRequest.class)))
@@ -141,7 +142,7 @@ class ReallocationContractBehaviorIT extends BaseContractIntegrationTest {
                 .stockItemId(stockItemId)
                 .totalReallocated(5)
                 .auditRecordsCreated(2)
-                .atpAfterReallocation(0)
+                .atpAfterReallocation(new BigDecimal("0"))
                 .build();
 
         when(allocationReallocationService.reallocate(any(ReallocateRequest.class)))
@@ -186,7 +187,7 @@ class ReallocationContractBehaviorIT extends BaseContractIntegrationTest {
                 .stockItemId(stockItemId)
                 .totalReallocated(10)
                 .auditRecordsCreated(1)
-                .atpAfterReallocation(0)
+                .atpAfterReallocation(new BigDecimal("0"))
                 .build();
 
         when(allocationReallocationService.reallocate(any(ReallocateRequest.class)))

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ReplenishmentContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ReplenishmentContractBehaviorIT.java
@@ -16,6 +16,7 @@ import com.positivity.inventory.internal.dto.replenishment.ReplenishmentTaskResp
 import com.positivity.inventory.internal.dto.replenishment.UpdateReplenishmentPolicyRequest;
 import com.positivity.inventory.internal.exception.SnoozeUntilNotInFutureException;
 import com.positivity.inventory.service.ReplenishmentService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -401,8 +402,8 @@ class ReplenishmentContractBehaviorIT extends BaseContractIntegrationTest {
                         .policyId("00000000-0000-0000-0000-000000000001")
                         .itemSKU("SKU-BOLT-M5")
                         .locationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
-                        .onHand(3)
-                        .projectedAvailable(3)
+                        .onHand(new BigDecimal("3"))
+                        .projectedAvailable(new BigDecimal("3"))
                         .leadHorizonDate("2024-01-06")
                         .leadTimeSource("POLICY_OVERRIDE")
                         .minimumQuantity(5)

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ReservationContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ReservationContractBehaviorIT.java
@@ -15,6 +15,7 @@ import com.positivity.inventory.internal.dto.reservation.ReservationResponse;
 import com.positivity.inventory.internal.enums.ReservationStatus;
 import com.positivity.inventory.internal.exception.InsufficientAtpException;
 import com.positivity.inventory.service.ReservationService;
+import java.math.BigDecimal;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -81,16 +82,16 @@ class ReservationContractBehaviorIT extends BaseContractIntegrationTest {
                 .reservationId(reservationId)
                 .workorderLineId(workorderLineId)
                 .stockItemId(stockItemId)
-                .requiredQuantity(5)
-                .allocatedQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("5"))
                 .status(ReservationStatus.PENDING.name())
                 .build();
 
         when(reservationService.createOrUpdateReservation(any(CreateReservationRequest.class)))
                 .thenReturn(mockResponse);
 
-        String requestBody =
-                objectMapper.writeValueAsString(new CreateReservationRequest(workorderLineId, stockItemId, 5));
+        String requestBody = objectMapper.writeValueAsString(
+                new CreateReservationRequest(workorderLineId, stockItemId, new BigDecimal("5")));
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/reservations"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -125,8 +126,8 @@ class ReservationContractBehaviorIT extends BaseContractIntegrationTest {
                 .reservationId(reservationId)
                 .workorderLineId(workorderLineId)
                 .stockItemId(stockItemId)
-                .requiredQuantity(5)
-                .allocatedQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("5"))
                 .status(ReservationStatus.FULFILLED.name())
                 .build();
 
@@ -215,7 +216,7 @@ class ReservationContractBehaviorIT extends BaseContractIntegrationTest {
         UUID allocationId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
         when(reservationService.promoteToHard(eq(allocationId), any(PromoteAllocationRequest.class)))
-                .thenThrow(new InsufficientAtpException(allocationId, 10, 3));
+                .thenThrow(new InsufficientAtpException(allocationId, new BigDecimal("10"), new BigDecimal("3")));
 
         String requestBody = objectMapper.writeValueAsString(new PromoteAllocationRequest(
                 UUID.fromString("00000000-0000-0000-0000-0000000000aa"), "urgent hardening"));
@@ -242,8 +243,8 @@ class ReservationContractBehaviorIT extends BaseContractIntegrationTest {
         // Issue #29: authenticated user + unrelated authority must yield 403
         UUID workorderLineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID stockItemId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        String requestBody =
-                objectMapper.writeValueAsString(new CreateReservationRequest(workorderLineId, stockItemId, 5));
+        String requestBody = objectMapper.writeValueAsString(
+                new CreateReservationRequest(workorderLineId, stockItemId, new BigDecimal("5")));
 
         mockMvc.perform(post("/v1/inventory/reservations")
                         .header("X-User", "test-user")

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ReturnContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ReturnContractBehaviorIT.java
@@ -11,6 +11,7 @@ import com.positivity.inventory.internal.dto.returns.ReturnSubmissionResultDto;
 import com.positivity.inventory.internal.dto.returns.ReturnSubmitRequest;
 import com.positivity.inventory.internal.exception.ReturnQuantityExceededException;
 import com.positivity.inventory.service.ReturnService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -119,7 +120,7 @@ class ReturnContractBehaviorIT extends BaseContractIntegrationTest {
     void RC4_submitToStock_quantityExceeded_returns422() throws Exception {
         UUID skuId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         when(returnService.submitToStock(any(ReturnSubmitRequest.class)))
-                .thenThrow(new ReturnQuantityExceededException(skuId, 99, 2));
+                .thenThrow(new ReturnQuantityExceededException(skuId, new BigDecimal("99"), new BigDecimal("2")));
 
         ReturnSubmitRequest requestBody = ReturnSubmitRequest.builder()
                 .workorderId(UUID.fromString("00000000-0000-0000-0000-000000000001"))

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ScrapContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ScrapContractBehaviorIT.java
@@ -101,7 +101,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
     @DisplayName("below-threshold scrap auto-posts SCRAP_OUT, decrements the summary, and queues the fact")
     void belowThresholdScrap_autoPostsAndDecrements() throws Exception {
         String sku = uniqueSku();
-        seedReceipt(sku, 10, new BigDecimal("2.0000"));
+        seedReceipt(sku, new BigDecimal("10"), new BigDecimal("2.0000"));
 
         MvcResult result = mockMvc.perform(withGatewayAuth(post("/v1/inventory/scraps"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -121,7 +121,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
                         .filter(entry -> entry.getEventType() == InventoryLedgerEventType.SCRAP_OUT)
                         .toList();
         assertThat(scrapEntries).hasSize(1);
-        assertThat(scrapEntries.getFirst().getChangeInQuantity()).isEqualTo(-3);
+        assertThat(scrapEntries.getFirst().getChangeInQuantity()).isEqualByComparingTo("-3");
         assertThat(scrapEntries.getFirst().getReasonCode()).isEqualTo("DAMAGED");
         assertThat(scrapEntries.getFirst().getSourceTransactionId()).isEqualTo(scrapId);
 
@@ -141,7 +141,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
     @DisplayName("above-threshold scrap requires approval, then approve posts SCRAP_OUT")
     void aboveThresholdScrap_requiresApprovalThenPosts() throws Exception {
         String sku = uniqueSku();
-        seedReceipt(sku, 10, new BigDecimal("200.0000"));
+        seedReceipt(sku, new BigDecimal("10"), new BigDecimal("200.0000"));
 
         MvcResult created = mockMvc.perform(withGatewayAuth(post("/v1/inventory/scraps"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -176,7 +176,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
     @DisplayName("reject leaves stock untouched")
     void rejectScrap_leavesStockUntouched() throws Exception {
         String sku = uniqueSku();
-        seedReceipt(sku, 10, new BigDecimal("200.0000"));
+        seedReceipt(sku, new BigDecimal("10"), new BigDecimal("200.0000"));
 
         MvcResult created = mockMvc.perform(withGatewayAuth(post("/v1/inventory/scraps"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -209,7 +209,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
     @DisplayName("insufficient on-hand yields the deterministic SCRAP_INSUFFICIENT_STOCK 422 and rolls back")
     void insufficientStock_yieldsGuided422() throws Exception {
         String sku = uniqueSku();
-        seedReceipt(sku, 2, new BigDecimal("2.0000"));
+        seedReceipt(sku, new BigDecimal("2"), new BigDecimal("2.0000"));
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/scraps"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -229,7 +229,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
     @DisplayName("authorized negative-stock override posts and drives on-hand below zero")
     void authorizedOverride_postsNegative() throws Exception {
         String sku = uniqueSku();
-        seedReceipt(sku, 2, new BigDecimal("2.0000"));
+        seedReceipt(sku, new BigDecimal("2"), new BigDecimal("2.0000"));
 
         mockMvc.perform(withScrapOverrideAuth(post("/v1/inventory/scraps"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -246,7 +246,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
     @DisplayName("override flag without inventory:adjustment:override is rejected with 403")
     void overrideWithoutPermission_returns403() throws Exception {
         String sku = uniqueSku();
-        seedReceipt(sku, 2, new BigDecimal("2.0000"));
+        seedReceipt(sku, new BigDecimal("2"), new BigDecimal("2.0000"));
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/scraps"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -262,7 +262,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
     @DisplayName("OTHER reason without notes returns 400")
     void otherWithoutNotes_returns400() throws Exception {
         String sku = uniqueSku();
-        seedReceipt(sku, 10, new BigDecimal("2.0000"));
+        seedReceipt(sku, new BigDecimal("10"), new BigDecimal("2.0000"));
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/scraps"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -284,7 +284,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
     @DisplayName("list filters by status and returns the scrap document")
     void listScraps_filtersByStatus() throws Exception {
         String sku = uniqueSku();
-        seedReceipt(sku, 10, new BigDecimal("200.0000"));
+        seedReceipt(sku, new BigDecimal("10"), new BigDecimal("200.0000"));
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/scraps"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(createBody(sku, 3, "CONTAMINATED", null, false)))
@@ -334,7 +334,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
                 .build());
     }
 
-    private void seedReceipt(String sku, int quantity, BigDecimal unitCost) {
+    private void seedReceipt(String sku, BigDecimal quantity, BigDecimal unitCost) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
@@ -346,11 +346,11 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
                 .build());
     }
 
-    private long onHand(String sku) {
+    private BigDecimal onHand(String sku) {
         return stockSummaryRepository.findAll().stream()
                 .filter(row -> sku.equals(row.getStockItemId()))
-                .mapToLong(InventoryStockSummary::getOnHand)
-                .sum();
+                .map(InventoryStockSummary::getOnHand)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
     private String createBody(String sku, int quantity, String reasonCode, String notes, boolean override)

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ShortageResolutionContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ShortageResolutionContractBehaviorIT.java
@@ -10,6 +10,7 @@ import com.positivity.inventory.internal.dto.ShortageResolutionResultDto;
 import com.positivity.inventory.internal.dto.ShortageResolveRequest;
 import com.positivity.inventory.internal.enums.ShortageResolutionOption;
 import com.positivity.inventory.service.ShortageResolutionService;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -62,7 +63,7 @@ class ShortageResolutionContractBehaviorIT extends BaseContractIntegrationTest {
                 .allocationId(allocationId)
                 .optionType(ShortageResolutionOption.BACKORDER)
                 .sku("00000000-0000-0000-0000-0000000000c1")
-                .shortQuantity(3)
+                .shortQuantity(new BigDecimal("3"))
                 .workorderLineId(UUID.fromString("00000000-0000-0000-0000-0000000000b1"))
                 .build();
 
@@ -112,7 +113,7 @@ class ShortageResolutionContractBehaviorIT extends BaseContractIntegrationTest {
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .optionType(ShortageResolutionOption.BACKORDER)
                 .sku("00000000-0000-0000-0000-0000000000c1")
-                .shortQuantity(3)
+                .shortQuantity(new BigDecimal("3"))
                 .build();
 
         mockMvc.perform(post("/v1/inventory/shortage/resolve")

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/SiteInventoryRollupContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/SiteInventoryRollupContractBehaviorIT.java
@@ -14,6 +14,7 @@ import com.positivity.inventory.internal.dto.rollup.StorageLocationRollupNode;
 import com.positivity.inventory.internal.exception.LocationNotFoundException;
 import com.positivity.inventory.internal.exception.LocationServiceUnavailableException;
 import com.positivity.inventory.service.SiteInventoryRollupService;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -51,8 +52,8 @@ class SiteInventoryRollupContractBehaviorIT extends BaseContractIntegrationTest 
     @DisplayName("GET /v1/inventory/sites/{siteId}/inventory-rollup → 200 with totals and tree")
     void contract_rollup_returns200WithTree() throws Exception {
         // Issue #658: happy path returns siteId, totals, nodes with own/rolledUp
-        RollupQuantities own = RollupQuantities.of(0, 0);
-        RollupQuantities rolledUp = RollupQuantities.of(480, 30);
+        RollupQuantities own = RollupQuantities.of(new BigDecimal("0"), new BigDecimal("0"));
+        RollupQuantities rolledUp = RollupQuantities.of(new BigDecimal("480"), new BigDecimal("30"));
         SiteInventoryRollupResponse response = new SiteInventoryRollupResponse(
                 SITE_ID,
                 rolledUp,

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/TransferOrderDispatchReceiveIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/TransferOrderDispatchReceiveIT.java
@@ -123,7 +123,7 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
             + " across dispatch, partial receive, and final receive")
     void conservationInvariant_holdsAcrossDispatchPartialAndFinalReceive() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
         UUID lineId = singleLineId(orderId);
 
@@ -195,7 +195,7 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
                 .receivedAt(Instant.parse("2026-01-01T00:00:00Z"))
                 .status(InventoryLotStatus.ACTIVE)
                 .build());
-        seedLotOnHand(sku, SOURCE_SITE, lot.getLotId(), 10);
+        seedLotOnHand(sku, SOURCE_SITE, lot.getLotId(), new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
         UUID lineId = singleLineId(orderId);
 
@@ -257,7 +257,7 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
     @DisplayName("dispatch that would drive source on-hand below zero is blocked with 422 and rolls back")
     void dispatch_belowZero_blocked() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 3);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("3"));
         String orderId = createOrder(sku, 6);
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/dispatch", orderId)))
@@ -280,7 +280,7 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
     @DisplayName("dispatch quantity above requested returns 422 TRANSFER_DISPATCH_EXCEEDS_REQUESTED")
     void dispatch_overRequested_returns422() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 20);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("20"));
         String orderId = createOrder(sku, 6);
         UUID lineId = singleLineId(orderId);
 
@@ -295,7 +295,7 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
     @DisplayName("receive quantity above the dispatched remainder returns 422 TRANSFER_RECEIVE_EXCEEDS_DISPATCHED")
     void receive_overDispatched_returns422() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
         UUID lineId = singleLineId(orderId);
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/dispatch", orderId))
@@ -317,7 +317,7 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
     @DisplayName("partial dispatch keeps in-transit at the dispatched (not requested) quantity")
     void partialDispatch_transitsOnlyDispatched() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
         UUID lineId = singleLineId(orderId);
 
@@ -336,7 +336,7 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
     @DisplayName("receive on a cancelled order returns 409")
     void receive_onCancelled_returns409() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/cancel", orderId)))
                 .andExpect(status().isOk());
@@ -350,7 +350,7 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
     @DisplayName("dispatch on an already dispatched order returns 409")
     void dispatch_twice_returns409() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 4);
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/dispatch", orderId)))
                 .andExpect(status().isOk());
@@ -366,7 +366,7 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
     @DisplayName("dispatch without inventory:transfer:dispatch is rejected with 403")
     void dispatchWithoutPermission_returns403() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 4);
 
         mockMvc.perform(withViewOnly(post("/v1/inventory/transfer-orders/{id}/dispatch", orderId)))
@@ -394,7 +394,7 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
                 .build());
     }
 
-    private void seedOnHand(String sku, UUID locationId, int quantity) {
+    private void seedOnHand(String sku, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(locationId)
@@ -441,7 +441,7 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
     }
 
     /** Lot-tagged variant of {@link #seedOnHand} (odoo-parity E2, #1042). */
-    private void seedLotOnHand(String sku, UUID locationId, UUID lotId, int quantity) {
+    private void seedLotOnHand(String sku, UUID locationId, UUID lotId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(locationId)
@@ -464,15 +464,15 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
             String sku, UUID lotId, long sourceOnHand, long destinationInTransit, long destinationOnHand) {
         assertThat(perLotRow(sku, SOURCE_SITE, lotId)
                         .map(row -> row.getOnHand())
-                        .orElse(0L))
+                        .orElse(BigDecimal.ZERO))
                 .isEqualTo(sourceOnHand);
         assertThat(perLotRow(sku, DESTINATION_SITE, lotId)
                         .map(row -> row.getInTransitQty())
-                        .orElse(0L))
+                        .orElse(BigDecimal.ZERO))
                 .isEqualTo(destinationInTransit);
         assertThat(perLotRow(sku, DESTINATION_SITE, lotId)
                         .map(row -> row.getOnHand())
-                        .orElse(0L))
+                        .orElse(BigDecimal.ZERO))
                 .isEqualTo(destinationOnHand);
     }
 
@@ -496,24 +496,24 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
                 .isEqualTo(sourceOnHand + destinationInTransit + destinationOnHand);
     }
 
-    private long totalAcrossAllKeys(String sku) {
+    private BigDecimal totalAcrossAllKeys(String sku) {
         return summaryRepository.findByStockItemId(sku).stream()
-                .mapToLong(row -> row.getOnHand() + row.getInTransitQty())
-                .sum();
+                .map(row -> row.getOnHand().add(row.getInTransitQty()))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
-    private long onHand(String sku, UUID locationId) {
+    private BigDecimal onHand(String sku, UUID locationId) {
         return summaryRepository
                 .findByStockItemIdAndLocationId(sku, locationId)
                 .map(row -> row.getOnHand())
-                .orElse(0L);
+                .orElse(BigDecimal.ZERO);
     }
 
-    private long inTransit(String sku, UUID locationId) {
+    private BigDecimal inTransit(String sku, UUID locationId) {
         return summaryRepository
                 .findByStockItemIdAndLocationId(sku, locationId)
                 .map(row -> row.getInTransitQty())
-                .orElse(0L);
+                .orElse(BigDecimal.ZERO);
     }
 
     private long expectedIncoming(String sku) {

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/TransferOrderShortCloseIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/TransferOrderShortCloseIT.java
@@ -119,11 +119,11 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
             + " and ledger truth reproduces the balances (drift clean, rebuild identical)")
     void shortClose_lost_zeroesTransitAndDropsGlobalOnHand() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
         UUID lineId = singleLineId(orderId);
         dispatch(orderId);
-        receive(orderId, lineId, 2); // remainder 4 stays in transit
+        receive(orderId, lineId, new BigDecimal("2")); // remainder 4 stays in transit
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -146,7 +146,7 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
         List<InventoryLedgerEntry> scrapEntries = entriesOf(sku, InventoryLedgerEventType.SCRAP_OUT);
         assertThat(scrapEntries).hasSize(1);
         InventoryLedgerEntry scrap = scrapEntries.getFirst();
-        assertThat(scrap.getChangeInQuantity()).isEqualTo(-4);
+        assertThat(scrap.getChangeInQuantity()).isEqualByComparingTo("-4");
         assertThat(scrap.getReasonCode()).isEqualTo("LOST");
         assertThat(scrap.getSourceTransactionId()).isEqualTo(orderId);
         assertThat(scrap.getLocationId()).isEqualTo(DESTINATION_SITE);
@@ -176,11 +176,11 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
             + " with drift clean and rebuild identical")
     void shortClose_returned_zeroesTransitAndRestoresSource() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
         UUID lineId = singleLineId(orderId);
         dispatch(orderId);
-        receive(orderId, lineId, 2); // remainder 4 stays in transit
+        receive(orderId, lineId, new BigDecimal("2")); // remainder 4 stays in transit
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -205,7 +205,7 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
                         .filter(entry -> SOURCE_SITE.equals(entry.getLocationId()))
                         .map(InventoryLedgerEntry::getQuantityAfter)
                         .toList())
-                .containsExactly(8);
+                .containsExactly(new BigDecimal("8.0000"));
         assertThat(entriesOf(sku, InventoryLedgerEventType.SCRAP_OUT)).isEmpty();
 
         assertThat(driftVerifier.verify()).isZero();
@@ -223,7 +223,7 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
     @DisplayName("short-close straight from DISPATCHED (no receipt at all) resolves the full dispatched quantity")
     void shortClose_fromDispatched_resolvesFullQuantity() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
         dispatch(orderId);
 
@@ -246,7 +246,7 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
     @DisplayName("receive and dispatch on a SHORT_CLOSED order return 409")
     void receiveAndDispatch_onShortClosed_return409() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
         dispatch(orderId);
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
@@ -269,7 +269,7 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
     @DisplayName("short-close before dispatch returns 409")
     void shortClose_beforeDispatch_returns409() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/short-close", orderId))
@@ -283,7 +283,7 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
     @DisplayName("short-close on a fully RECEIVED order returns 409 (terminal, no remainder)")
     void shortClose_onFullyReceived_returns409() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
         dispatch(orderId);
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/receive", orderId)))
@@ -300,7 +300,7 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
     @DisplayName("missing disposition, reason, or notes each return 400")
     void shortClose_missingMandatoryFields_returns400() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
         dispatch(orderId);
 
@@ -325,7 +325,7 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
     @DisplayName("RETURNED_TO_SOURCE against a no-longer-eligible source returns 422 and rolls back")
     void shortClose_returnedToIneligibleSource_returns422() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
         dispatch(orderId);
         LocationRefEntity source =
@@ -352,7 +352,7 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
     @DisplayName("short-close without inventory:transfer:short_close is rejected with 403")
     void shortCloseWithoutPermission_returns403() throws Exception {
         String sku = uniqueSku();
-        seedOnHand(sku, SOURCE_SITE, 10);
+        seedOnHand(sku, SOURCE_SITE, new BigDecimal("10"));
         String orderId = createOrder(sku, 6);
         dispatch(orderId);
 
@@ -383,7 +383,7 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
                 .build());
     }
 
-    private void seedOnHand(String sku, UUID locationId, int quantity) {
+    private void seedOnHand(String sku, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(locationId)
@@ -415,7 +415,7 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
                 .andExpect(status().isOk());
     }
 
-    private void receive(String orderId, UUID lineId, int quantity) throws Exception {
+    private void receive(String orderId, UUID lineId, BigDecimal quantity) throws Exception {
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/transfer-orders/{id}/receive", orderId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"lines\":[{\"lineId\":\"" + lineId + "\",\"quantity\":" + quantity + "}]}"))
@@ -455,24 +455,24 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
                 .isEqualTo(sourceOnHand + destinationInTransit + destinationOnHand);
     }
 
-    private long totalAcrossAllKeys(String sku) {
+    private BigDecimal totalAcrossAllKeys(String sku) {
         return summaryRepository.findByStockItemId(sku).stream()
-                .mapToLong(row -> row.getOnHand() + row.getInTransitQty())
-                .sum();
+                .map(row -> row.getOnHand().add(row.getInTransitQty()))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
-    private long onHand(String sku, UUID locationId) {
+    private BigDecimal onHand(String sku, UUID locationId) {
         return summaryRepository
                 .findByStockItemIdAndLocationId(sku, locationId)
                 .map(row -> row.getOnHand())
-                .orElse(0L);
+                .orElse(BigDecimal.ZERO);
     }
 
-    private long inTransit(String sku, UUID locationId) {
+    private BigDecimal inTransit(String sku, UUID locationId) {
         return summaryRepository
                 .findByStockItemIdAndLocationId(sku, locationId)
                 .map(row -> row.getInTransitQty())
-                .orElse(0L);
+                .orElse(BigDecimal.ZERO);
     }
 
     private long expectedIncoming(String sku) {

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/UomDocumentBoundaryIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/UomDocumentBoundaryIT.java
@@ -193,7 +193,7 @@ class UomDocumentBoundaryIT {
         BigDecimal totalPosted = ledgerEntriesFor(productId).stream()
                 .map(InventoryLedgerEntry::getChangeInQuantity)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
-        assertThat(totalPosted).isEqualTo(24);
+        assertThat(totalPosted).isEqualByComparingTo("24");
 
         // What the order becomes after this receipt is pos-order's decision, made from the
         // goods-receipt fact and asserted in GoodsReceiptListenerTest (CAP-320 #1334).

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/UomDocumentBoundaryIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/UomDocumentBoundaryIT.java
@@ -131,7 +131,7 @@ class UomDocumentBoundaryIT {
         List<InventoryLedgerEntry> entries = ledgerEntriesFor(productId);
         assertThat(entries).hasSize(1);
         assertThat(entries.getFirst().getEventType()).isEqualTo(InventoryLedgerEventType.GOODS_RECEIPT);
-        assertThat(entries.getFirst().getChangeInQuantity()).isEqualTo(12);
+        assertThat(entries.getFirst().getChangeInQuantity()).isEqualByComparingTo("12");
 
         // What the order becomes after this receipt is pos-order's decision, made from the
         // goods-receipt fact and asserted in GoodsReceiptListenerTest (CAP-320 #1334).
@@ -190,9 +190,9 @@ class UomDocumentBoundaryIT {
         GoodsReceiptResponse response = asnService.createGoodsReceipt(exactReceipt, ACTOR);
         assertThat(response.getTotalAccruedAmountMinor()).isEqualTo(24_000L);
 
-        int totalPosted = ledgerEntriesFor(productId).stream()
-                .mapToInt(InventoryLedgerEntry::getChangeInQuantity)
-                .sum();
+        BigDecimal totalPosted = ledgerEntriesFor(productId).stream()
+                .map(InventoryLedgerEntry::getChangeInQuantity)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
         assertThat(totalPosted).isEqualTo(24);
 
         // What the order becomes after this receipt is pos-order's decision, made from the
@@ -219,7 +219,7 @@ class UomDocumentBoundaryIT {
         assertThat(response.getLines().getFirst().getConversionFactor()).isNull();
         List<InventoryLedgerEntry> entries = ledgerEntriesFor(productId);
         assertThat(entries).hasSize(1);
-        assertThat(entries.getFirst().getChangeInQuantity()).isEqualTo(5);
+        assertThat(entries.getFirst().getChangeInQuantity()).isEqualByComparingTo("5");
     }
 
     // ─── B3: HALF_UP rounding at base precision scale ────────────────────────────
@@ -251,7 +251,7 @@ class UomDocumentBoundaryIT {
 
         List<InventoryLedgerEntry> entries = ledgerEntriesFor(productId);
         assertThat(entries).hasSize(1);
-        assertThat(entries.getFirst().getChangeInQuantity()).isEqualTo(101);
+        assertThat(entries.getFirst().getChangeInQuantity()).isEqualByComparingTo("101");
     }
 
     // ─── ledger funnel unitOfMeasure validation + documented tolerance ───────────
@@ -356,8 +356,8 @@ class UomDocumentBoundaryIT {
                 .stockItemId(stockItemId)
                 .locationId(UUID.randomUUID())
                 .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
-                .changeInQuantity(5)
-                .quantityAfter(5)
+                .changeInQuantity(new BigDecimal("5"))
+                .quantityAfter(new BigDecimal("5"))
                 .transactionUserId(ACTOR)
                 .unitOfMeasure(unitOfMeasure)
                 .notes("B2 funnel validation IT")

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/controller/BackorderControllerTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/controller/BackorderControllerTest.java
@@ -10,6 +10,7 @@ import com.positivity.inventory.config.TestSecurityConfig;
 import com.positivity.inventory.internal.dto.backorder.BackorderResponse;
 import com.positivity.inventory.internal.enums.BackorderStatus;
 import com.positivity.inventory.service.BackorderService;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -54,7 +55,7 @@ class BackorderControllerTest {
                 .workorderLineId(UUID.fromString("00000000-0000-0000-0000-0000000000b1"))
                 .sku("PART-BRAKE-PAD-01")
                 .locationId(UUID.fromString("00000000-0000-0000-0000-0000000000c1"))
-                .quantityShort(5)
+                .quantityShort(new BigDecimal("5"))
                 .status(BackorderStatus.OPEN)
                 .build();
     }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/controller/InventoryBulkIngestControllerTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/controller/InventoryBulkIngestControllerTest.java
@@ -11,6 +11,7 @@ import com.positivity.inventory.config.TestSecurityConfig;
 import com.positivity.inventory.internal.dto.AdjustmentRequestResponse;
 import com.positivity.inventory.internal.dto.InventoryBulkIngestRecord;
 import com.positivity.inventory.service.StockMovementService;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -51,7 +52,7 @@ class InventoryBulkIngestControllerTest {
     void bulkIngest_validRequest_returns200WithResults() throws Exception {
         InventoryBulkIngestRecord invRecord = new InventoryBulkIngestRecord();
         invRecord.setSku("PART-001");
-        invRecord.setQuantity(10);
+        invRecord.setQuantity(new BigDecimal("10"));
         invRecord.setLocationId(LOCATION_ID);
 
         BulkIngestRequest<InventoryBulkIngestRecord> request = new BulkIngestRequest<>();
@@ -78,7 +79,7 @@ class InventoryBulkIngestControllerTest {
     void bulkIngest_whenServiceThrows_recordsAsFailure() throws Exception {
         InventoryBulkIngestRecord invRecord = new InventoryBulkIngestRecord();
         invRecord.setSku("BAD-001");
-        invRecord.setQuantity(5);
+        invRecord.setQuantity(new BigDecimal("5"));
 
         BulkIngestRequest<InventoryBulkIngestRecord> request = new BulkIngestRequest<>();
         request.setJobId(JOB_ID);

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/controller/ValuationControllerTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/controller/ValuationControllerTest.java
@@ -50,7 +50,7 @@ class ValuationControllerTest {
         return ValuationReportResponse.builder()
                 .rows(List.of(ValuationRow.builder()
                         .stockItemId("PART-A")
-                        .onHand(20L)
+                        .onHand(new BigDecimal("20"))
                         .costingMethod("AVERAGE")
                         .unitCostCurrent(new BigDecimal("6.0000"))
                         .onHandValue(new BigDecimal("120.0000"))

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepositoryTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/repository/InventoryLedgerEntryRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,8 +39,8 @@ class InventoryLedgerEntryRepositoryTest {
                 .stockItemId(stockItemId)
                 .locationId(locationId)
                 .eventType(eventType)
-                .changeInQuantity(changeInQuantity)
-                .quantityAfter(0)
+                .changeInQuantity(BigDecimal.valueOf(changeInQuantity))
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("test-user")
                 .timestamp(now)
                 .createdAt(now)
@@ -61,17 +62,19 @@ class InventoryLedgerEntryRepositoryTest {
         seed(SKU_B, locationB, InventoryLedgerEventType.ADJUSTMENT_OUT, -2);
 
         Set<InventoryLedgerEventType> onHandTypes = InventoryLedgerEventType.onHandAffectingTypes();
-        Map<UUID, Long> result =
+        Map<UUID, BigDecimal> result =
                 repository.sumQuantityByLocationChunked(List.of(locationA, locationB, locationC), onHandTypes);
 
-        assertThat(result).containsOnly(Map.entry(locationA, 6L), Map.entry(locationB, 5L));
+        assertThat(result).hasSize(2);
+        assertThat(result.get(locationA)).isEqualByComparingTo("6");
+        assertThat(result.get(locationB)).isEqualByComparingTo("5");
         assertThat(result).doesNotContainKey(locationC);
 
         // grouped result matches the existing single-location aggregate for the same data
-        assertThat(result.get(locationA).intValue())
-                .isEqualTo(repository.calculateOnHandQuantityAtLocation(locationA, onHandTypes));
-        assertThat(result.get(locationB).intValue())
-                .isEqualTo(repository.calculateOnHandQuantityAtLocation(locationB, onHandTypes));
+        assertThat(result.get(locationA))
+                .isEqualByComparingTo(repository.calculateOnHandQuantityAtLocation(locationA, onHandTypes));
+        assertThat(result.get(locationB))
+                .isEqualByComparingTo(repository.calculateOnHandQuantityAtLocation(locationB, onHandTypes));
     }
 
     @Test
@@ -85,10 +88,12 @@ class InventoryLedgerEntryRepositoryTest {
         seed(SKU_B, locationA, InventoryLedgerEventType.GOODS_RECEIPT, 50);
         seed(SKU_A, locationB, InventoryLedgerEventType.GOODS_RECEIPT, 2);
 
-        Map<UUID, Long> result = repository.sumQuantityByLocationForSkuChunked(
+        Map<UUID, BigDecimal> result = repository.sumQuantityByLocationForSkuChunked(
                 SKU_A, List.of(locationA, locationB), InventoryLedgerEventType.onHandAffectingTypes());
 
-        assertThat(result).containsOnly(Map.entry(locationA, 7L), Map.entry(locationB, 2L));
+        assertThat(result).hasSize(2);
+        assertThat(result.get(locationA)).isEqualByComparingTo("7");
+        assertThat(result.get(locationB)).isEqualByComparingTo("2");
     }
 
     @Test
@@ -127,10 +132,12 @@ class InventoryLedgerEntryRepositoryTest {
         locationIds.add(lastLocation); // id #1001, lands in the second chunk
         assertThat(locationIds).hasSize(1001);
 
-        Map<UUID, Long> result =
+        Map<UUID, BigDecimal> result =
                 repository.sumQuantityByLocationChunked(locationIds, InventoryLedgerEventType.onHandAffectingTypes());
 
-        assertThat(result).containsOnly(Map.entry(firstLocation, 11L), Map.entry(lastLocation, 20L));
+        assertThat(result).hasSize(2);
+        assertThat(result.get(firstLocation)).isEqualByComparingTo("11");
+        assertThat(result.get(lastLocation)).isEqualByComparingTo("20");
     }
 
     @Test
@@ -146,25 +153,27 @@ class InventoryLedgerEntryRepositoryTest {
         seed(SKU_A, locationB, InventoryLedgerEventType.ALLOCATION_CREATED, 4);
         seed(SKU_A, locationC, InventoryLedgerEventType.GOODS_RECEIPT, 9); // no allocations
 
-        Map<UUID, Long> result =
+        Map<UUID, BigDecimal> result =
                 repository.calculateOutstandingAllocationsByLocation(List.of(locationA, locationB, locationC));
 
         // single-location semantics: sum(ALLOCATION_CREATED) - sum(ALLOCATION_RELEASED)
-        assertThat(result).containsOnly(Map.entry(locationA, 6L), Map.entry(locationB, 4L));
+        assertThat(result).hasSize(2);
+        assertThat(result.get(locationA)).isEqualByComparingTo("6");
+        assertThat(result.get(locationB)).isEqualByComparingTo("4");
         assertThat(result).doesNotContainKey(locationC);
 
         // cross-check against the same ledger entries the single-location path reads
         List<InventoryLedgerEntry> locationAEntries = repository.findByLocationIdAndEventTypeIn(
                 locationA,
                 List.of(InventoryLedgerEventType.ALLOCATION_CREATED, InventoryLedgerEventType.ALLOCATION_RELEASED));
-        long created = locationAEntries.stream()
+        BigDecimal created = locationAEntries.stream()
                 .filter(entry -> entry.getEventType() == InventoryLedgerEventType.ALLOCATION_CREATED)
-                .mapToLong(InventoryLedgerEntry::getChangeInQuantity)
-                .sum();
-        long released = locationAEntries.stream()
+                .map(InventoryLedgerEntry::getChangeInQuantity)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal released = locationAEntries.stream()
                 .filter(entry -> entry.getEventType() == InventoryLedgerEventType.ALLOCATION_RELEASED)
-                .mapToLong(InventoryLedgerEntry::getChangeInQuantity)
-                .sum();
-        assertThat(result.get(locationA)).isEqualTo(created - released);
+                .map(InventoryLedgerEntry::getChangeInQuantity)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(result.get(locationA)).isEqualByComparingTo(created.subtract(released));
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/AllocationConsistencyVerifierTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/AllocationConsistencyVerifierTest.java
@@ -15,6 +15,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.repository.ReservationRepository;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.math.BigDecimal;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -77,27 +78,31 @@ class AllocationConsistencyVerifierTest {
         ReservationEntity reservation = reservationRepository.save(ReservationEntity.builder()
                 .workorderLineId(UUID.randomUUID())
                 .stockItemId(stockItemId)
-                .requiredQuantity(quantity)
-                .allocatedQuantity(quantity)
+                .requiredQuantity(BigDecimal.valueOf(quantity))
+                .allocatedQuantity(BigDecimal.valueOf(quantity))
                 .status(ReservationStatus.PENDING)
                 .build());
         return allocationRepository.save(AllocationEntity.builder()
                 .reservation(reservation)
                 .locationId(locationId)
-                .allocatedQuantity(quantity)
+                .allocatedQuantity(BigDecimal.valueOf(quantity))
                 .allocationState(state)
                 .status(status)
                 .build());
     }
 
     private void postAllocationEvent(
-            InventoryLedgerEventType type, UUID stockItemId, UUID locationId, String sourceTransactionId, int qty) {
+            InventoryLedgerEventType type,
+            UUID stockItemId,
+            UUID locationId,
+            String sourceTransactionId,
+            BigDecimal qty) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(stockItemId.toString())
                 .locationId(locationId)
                 .eventType(type)
                 .changeInQuantity(qty)
-                .quantityAfter(0)
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("consistency-test")
                 .sourceTransactionId(sourceTransactionId)
                 .build());
@@ -121,7 +126,7 @@ class AllocationConsistencyVerifierTest {
                 sku,
                 location,
                 outstanding.getAllocationId().toString(),
-                5);
+                new BigDecimal("5"));
 
         // Partially consumed located HARD allocation: 0 < released < created.
         AllocationEntity partial =
@@ -131,13 +136,13 @@ class AllocationConsistencyVerifierTest {
                 sku,
                 location,
                 partial.getAllocationId().toString(),
-                6);
+                new BigDecimal("6"));
         postAllocationEvent(
                 InventoryLedgerEventType.ALLOCATION_RELEASED,
                 sku,
                 location,
                 partial.getAllocationId().toString(),
-                2);
+                new BigDecimal("2"));
 
         // Fully released located HARD allocation: released == created.
         AllocationEntity released =
@@ -147,13 +152,13 @@ class AllocationConsistencyVerifierTest {
                 sku,
                 location,
                 released.getAllocationId().toString(),
-                3);
+                new BigDecimal("3"));
         postAllocationEvent(
                 InventoryLedgerEventType.ALLOCATION_RELEASED,
                 sku,
                 location,
                 released.getAllocationId().toString(),
-                3);
+                new BigDecimal("3"));
 
         double before = violationCount();
 
@@ -180,7 +185,7 @@ class AllocationConsistencyVerifierTest {
                 allocationRepository.findById(broken.getAllocationId()).orElseThrow();
         assertThat(untouched.getAllocationState()).isEqualTo(AllocationState.HARD);
         assertThat(untouched.getStatus()).isEqualTo(AllocationStatus.ALLOCATED);
-        assertThat(untouched.getAllocatedQuantity()).isEqualTo(5);
+        assertThat(untouched.getAllocatedQuantity()).isEqualByComparingTo("5");
         assertThat(ledgerRepository.count()).isEqualTo(ledgerRowsBefore);
         assertThat(summaryRepository.findAll()).isEmpty();
 
@@ -198,13 +203,13 @@ class AllocationConsistencyVerifierTest {
                 sku,
                 location,
                 stale.getAllocationId().toString(),
-                5);
+                new BigDecimal("5"));
         postAllocationEvent(
                 InventoryLedgerEventType.ALLOCATION_RELEASED,
                 sku,
                 location,
                 stale.getAllocationId().toString(),
-                5);
+                new BigDecimal("5"));
 
         // Ledger outstanding is 0 and summary agrees, so this is purely an
         // invariant-A (status lag) finding.
@@ -223,7 +228,7 @@ class AllocationConsistencyVerifierTest {
                 sku,
                 location,
                 UUID.randomUUID().toString(),
-                3);
+                new BigDecimal("3"));
 
         assertThat(verifier.verify()).isEqualTo(1);
     }
@@ -241,7 +246,7 @@ class AllocationConsistencyVerifierTest {
                 sku,
                 location,
                 allocation.getAllocationId().toString(),
-                5);
+                new BigDecimal("5"));
 
         assertThat(verifier.verify()).isZero();
 
@@ -249,7 +254,7 @@ class AllocationConsistencyVerifierTest {
         InventoryStockSummary row = summaryRepository
                 .findByStockItemIdAndLocationId(sku.toString(), location)
                 .orElseThrow();
-        row.setAllocated(999);
+        row.setAllocated(new BigDecimal("999"));
         summaryRepository.save(row);
 
         double before = violationCount();
@@ -261,6 +266,6 @@ class AllocationConsistencyVerifierTest {
                         .findByStockItemIdAndLocationId(sku.toString(), location)
                         .orElseThrow()
                         .getAllocated())
-                .isEqualTo(999);
+                .isEqualByComparingTo("999");
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/AverageCostingStrategyTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/AverageCostingStrategyTest.java
@@ -24,12 +24,13 @@ class AverageCostingStrategyTest {
     private static final String SKU = "SKU-AVCO";
 
     private CostingResult receipt(CostState state, int qty, String unitCost) {
-        return strategy.cost(
-                new CostingInput(SKU, InventoryLedgerEventType.GOODS_RECEIPT, qty, new BigDecimal(unitCost), state));
+        return strategy.cost(new CostingInput(
+                SKU, InventoryLedgerEventType.GOODS_RECEIPT, BigDecimal.valueOf(qty), new BigDecimal(unitCost), state));
     }
 
     private CostingResult issue(CostState state, int qty) {
-        return strategy.cost(new CostingInput(SKU, InventoryLedgerEventType.GOODS_ISSUE, -qty, null, state));
+        return strategy.cost(
+                new CostingInput(SKU, InventoryLedgerEventType.GOODS_ISSUE, BigDecimal.valueOf(-qty), null, state));
     }
 
     @Test
@@ -42,22 +43,22 @@ class AverageCostingStrategyTest {
     @DisplayName("ported Odoo AVCO vector: recv 10@5, recv 10@7 => avg 6; issue 5 => cost 6; recv 10@9 => avg 7.20")
     void avcoVector() {
         // recv 10 @ $5 -> avg seeds to 5, on-hand 10
-        CostingResult r1 = receipt(new CostState(null, 0, null), 10, "5");
+        CostingResult r1 = receipt(new CostState(null, new BigDecimal("0"), null), 10, "5");
         assertThat(r1.unitCost()).isEqualByComparingTo("5");
         assertThat(r1.state().avgCost()).isEqualByComparingTo("5");
-        assertThat(r1.state().onHandQty()).isEqualTo(10);
+        assertThat(r1.state().onHandQty()).isEqualByComparingTo("10");
 
         // recv 10 @ $7 -> avg (10*5 + 10*7)/20 = 6, on-hand 20
         CostingResult r2 = receipt(r1.state(), 10, "7");
         assertThat(r2.unitCost()).isEqualByComparingTo("7");
         assertThat(r2.state().avgCost()).isEqualByComparingTo("6");
-        assertThat(r2.state().onHandQty()).isEqualTo(20);
+        assertThat(r2.state().onHandQty()).isEqualByComparingTo("20");
 
         // issue 5 -> stamped at current avg 6, avg unchanged, on-hand 15
         CostingResult r3 = issue(r2.state(), 5);
         assertThat(r3.unitCost()).isEqualByComparingTo("6");
         assertThat(r3.state().avgCost()).isEqualByComparingTo("6");
-        assertThat(r3.state().onHandQty()).isEqualTo(15);
+        assertThat(r3.state().onHandQty()).isEqualByComparingTo("15");
 
         // recv 10 @ $9 (15 on hand) -> avg (15*6 + 10*9)/25 = 180/25 = 7.20, on-hand 25.
         // NOTE: the story text wrote "$6.60" for this step, but (15*6 + 10*9)/25 = 7.20
@@ -65,53 +66,54 @@ class AverageCostingStrategyTest {
         CostingResult r4 = receipt(r3.state(), 10, "9");
         assertThat(r4.unitCost()).isEqualByComparingTo("9");
         assertThat(r4.state().avgCost()).isEqualByComparingTo("7.20");
-        assertThat(r4.state().onHandQty()).isEqualTo(25);
+        assertThat(r4.state().onHandQty()).isEqualByComparingTo("25");
     }
 
     @Test
     @DisplayName("first issue with no prior cost stamps null (visibly uncosted)")
     void firstIssueNoPriorCost_stampsNull() {
-        CostingResult r = issue(new CostState(null, 0, null), 3);
+        CostingResult r = issue(new CostState(null, new BigDecimal("0"), null), 3);
         assertThat(r.unitCost()).isNull();
         assertThat(r.state().avgCost()).isNull();
-        assertThat(r.state().onHandQty()).isEqualTo(-3);
+        assertThat(r.state().onHandQty()).isEqualByComparingTo("-3");
     }
 
     @Test
     @DisplayName("negative branch: issue when on-hand already <= 0 keeps the last average")
     void negativeBranch_issueBelowZero_keepsLastAverage() {
         // Seed an average, then drive on-hand negative via successive issues.
-        CostState seeded = new CostState(new BigDecimal("4.50"), 2, null);
+        CostState seeded = new CostState(new BigDecimal("4.50"), new BigDecimal("2"), null);
         CostingResult afterFirst = issue(seeded, 5); // on-hand 2 -> -3
         assertThat(afterFirst.unitCost()).isEqualByComparingTo("4.50");
         assertThat(afterFirst.state().avgCost()).isEqualByComparingTo("4.50");
-        assertThat(afterFirst.state().onHandQty()).isEqualTo(-3);
+        assertThat(afterFirst.state().onHandQty()).isEqualByComparingTo("-3");
 
         // Another issue while already negative still stamps and keeps the last average.
         CostingResult afterSecond = issue(afterFirst.state(), 2);
         assertThat(afterSecond.unitCost()).isEqualByComparingTo("4.50");
         assertThat(afterSecond.state().avgCost()).isEqualByComparingTo("4.50");
-        assertThat(afterSecond.state().onHandQty()).isEqualTo(-5);
+        assertThat(afterSecond.state().onHandQty()).isEqualByComparingTo("-5");
     }
 
     @Test
     @DisplayName("receipt onto non-positive on-hand reseeds the average from the receipt cost")
     void receiptOntoNonPositiveOnHand_reseedsAverage() {
-        CostState negative = new CostState(new BigDecimal("4.50"), -5, null);
+        CostState negative = new CostState(new BigDecimal("4.50"), new BigDecimal("-5"), null);
         CostingResult r = receipt(negative, 10, "8");
         assertThat(r.unitCost()).isEqualByComparingTo("8");
         assertThat(r.state().avgCost()).isEqualByComparingTo("8");
-        assertThat(r.state().onHandQty()).isEqualTo(5);
+        assertThat(r.state().onHandQty()).isEqualByComparingTo("5");
     }
 
     @Test
     @DisplayName("cost-less inbound enters at the current average, quantity rises, average unchanged")
     void costlessInbound_entersAtCurrentAverage() {
-        CostState state = new CostState(new BigDecimal("6"), 10, null);
-        CostingResult r = strategy.cost(new CostingInput(SKU, InventoryLedgerEventType.ADJUSTMENT_IN, 5, null, state));
+        CostState state = new CostState(new BigDecimal("6"), new BigDecimal("10"), null);
+        CostingResult r = strategy.cost(
+                new CostingInput(SKU, InventoryLedgerEventType.ADJUSTMENT_IN, new BigDecimal("5"), null, state));
         assertThat(r.unitCost()).isEqualByComparingTo("6");
         assertThat(r.state().avgCost()).isEqualByComparingTo("6");
-        assertThat(r.state().onHandQty()).isEqualTo(15);
+        assertThat(r.state().onHandQty()).isEqualByComparingTo("15");
     }
 
     @Test
@@ -119,7 +121,7 @@ class AverageCostingStrategyTest {
     void stampRoundedToScaleFour() {
         // Force a repeating-decimal average: recv 3 @ 10 then recv 0-less inbound won't help;
         // use recv 1@10 then recv 2@11 -> (10 + 22)/3 = 10.666666...
-        CostingResult r1 = receipt(new CostState(null, 0, null), 1, "10");
+        CostingResult r1 = receipt(new CostState(null, new BigDecimal("0"), null), 1, "10");
         CostingResult r2 = receipt(r1.state(), 2, "11");
         // avg = 32/3 = 10.666667 (scale 6). An issue stamps that rounded to scale 4 = 10.6667.
         CostingResult issue = issue(r2.state(), 1);

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/BackorderServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/BackorderServiceImplTest.java
@@ -24,6 +24,7 @@ import com.positivity.inventory.internal.repository.BackorderRecordRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.repository.ReservationRepository;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -102,7 +103,7 @@ class BackorderServiceImplTest {
                 });
         lenient()
                 .when(ledgerRepository.calculateOnHandQuantityAtLocation(SKU, LOCATION_ID))
-                .thenReturn(0);
+                .thenReturn(new BigDecimal("0"));
     }
 
     @Test
@@ -111,10 +112,10 @@ class BackorderServiceImplTest {
         when(backorderRepository.findByWorkorderLineIdAndSkuAndStatus(WORKORDER_LINE_A, SKU, BackorderStatus.OPEN))
                 .thenReturn(Optional.empty());
 
-        BackorderResponse response = service.createBackorder(WORKORDER_LINE_A, SKU, 5, LOCATION_ID);
+        BackorderResponse response = service.createBackorder(WORKORDER_LINE_A, SKU, new BigDecimal("5"), LOCATION_ID);
 
         assertThat(response.getStatus()).isEqualTo(BackorderStatus.OPEN);
-        assertThat(response.getQuantityShort()).isEqualTo(5);
+        assertThat(response.getQuantityShort()).isEqualByComparingTo("5");
         assertThat(response.getSku()).isEqualTo(SKU);
         assertThat(response.getLocationId()).isEqualTo(LOCATION_ID);
 
@@ -123,7 +124,7 @@ class BackorderServiceImplTest {
         InventoryLedgerEntry entry = entryCaptor.getValue();
         assertThat(entry.getEventType()).isEqualTo(InventoryLedgerEventType.BACKORDER_CREATED);
         assertThat(entry.getEventType().affectsOnHand()).isFalse();
-        assertThat(entry.getChangeInQuantity()).isEqualTo(5);
+        assertThat(entry.getChangeInQuantity()).isEqualByComparingTo("5");
         assertThat(entry.getStockItemId()).isEqualTo(SKU);
         assertThat(entry.getSourceTransactionId())
                 .isEqualTo(response.getBackorderId().toString());
@@ -131,7 +132,7 @@ class BackorderServiceImplTest {
         ArgumentCaptor<BackorderCreatedV1> factCaptor = ArgumentCaptor.forClass(BackorderCreatedV1.class);
         verify(inventoryFactPublisher).recordBackorderCreated(factCaptor.capture());
         assertThat(factCaptor.getValue().backorderId()).isEqualTo(response.getBackorderId());
-        assertThat(factCaptor.getValue().quantityShort()).isEqualTo(5);
+        assertThat(factCaptor.getValue().quantityShort()).isEqualByComparingTo("5");
     }
 
     @Test
@@ -141,7 +142,7 @@ class BackorderServiceImplTest {
         when(backorderRepository.findByWorkorderLineIdAndSkuAndStatus(WORKORDER_LINE_A, SKU, BackorderStatus.OPEN))
                 .thenReturn(Optional.of(existing));
 
-        BackorderResponse response = service.createBackorder(WORKORDER_LINE_A, SKU, 5, LOCATION_ID);
+        BackorderResponse response = service.createBackorder(WORKORDER_LINE_A, SKU, new BigDecimal("5"), LOCATION_ID);
 
         assertThat(response.getBackorderId()).isEqualTo(existing.getBackorderId());
         verify(backorderRepository, never()).save(any());
@@ -156,12 +157,13 @@ class BackorderServiceImplTest {
         when(backorderRepository.findBySalesOrderLineIdAndSkuAndStatus(salesOrderLineId, SKU, BackorderStatus.OPEN))
                 .thenReturn(Optional.empty());
 
-        BackorderResponse response = service.createBackorderForSalesOrderLine(salesOrderLineId, SKU, 4, LOCATION_ID);
+        BackorderResponse response =
+                service.createBackorderForSalesOrderLine(salesOrderLineId, SKU, new BigDecimal("4"), LOCATION_ID);
 
         assertThat(response.getStatus()).isEqualTo(BackorderStatus.OPEN);
         assertThat(response.getSalesOrderLineId()).isEqualTo(salesOrderLineId);
         assertThat(response.getWorkorderLineId()).isNull();
-        assertThat(response.getQuantityShort()).isEqualTo(4);
+        assertThat(response.getQuantityShort()).isEqualByComparingTo("4");
 
         ArgumentCaptor<BackorderCreatedV1> factCaptor = ArgumentCaptor.forClass(BackorderCreatedV1.class);
         verify(inventoryFactPublisher).recordBackorderCreated(factCaptor.capture());
@@ -211,7 +213,7 @@ class BackorderServiceImplTest {
         ReservationEntity reservation = ReservationEntity.builder()
                 .workorderLineId(WORKORDER_LINE_A)
                 .stockItemId(UUID.randomUUID())
-                .requiredQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
                 .priority(5)
                 .status(ReservationStatus.BACKORDERED)
                 .build();
@@ -289,7 +291,7 @@ class BackorderServiceImplTest {
                 .workorderLineId(workorderLineId)
                 .sku(SKU)
                 .locationId(LOCATION_ID)
-                .quantityShort(quantityShort)
+                .quantityShort(BigDecimal.valueOf(quantityShort))
                 .status(BackorderStatus.OPEN)
                 .createdBy("SYSTEM")
                 .createdAt(createdAt)
@@ -301,9 +303,9 @@ class BackorderServiceImplTest {
         return InventoryStockSummary.builder()
                 .stockItemId(SKU)
                 .locationId(LOCATION_ID)
-                .onHand(atp)
-                .allocated(0)
-                .atp(atp)
+                .onHand(BigDecimal.valueOf(atp))
+                .allocated(new BigDecimal("0"))
+                .atp(BigDecimal.valueOf(atp))
                 .build();
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/BatchReplenishmentScanTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/BatchReplenishmentScanTest.java
@@ -61,7 +61,7 @@ class BatchReplenishmentScanTest {
         return "SKU-F1-" + UUID.randomUUID();
     }
 
-    private void receive(String sku, UUID locationId, int quantity) {
+    private void receive(String sku, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(locationId)
@@ -95,7 +95,7 @@ class BatchReplenishmentScanTest {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
         seedPolicy(sku, location, 5, 20);
-        receive(sku, location, 3); // on-hand 3 < min 5
+        receive(sku, location, new BigDecimal("3")); // on-hand 3 < min 5
 
         replenishmentService.runBatchReplenishmentScan();
         replenishmentService.runBatchReplenishmentScan();
@@ -116,7 +116,7 @@ class BatchReplenishmentScanTest {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
         seedPolicy(sku, location, 5, 20);
-        receive(sku, location, 5); // exactly at minimum
+        receive(sku, location, new BigDecimal("5")); // exactly at minimum
 
         ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
 
@@ -130,7 +130,7 @@ class BatchReplenishmentScanTest {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
         seedPolicy(sku, location, 5, 20);
-        receive(sku, location, 4); // on-hand 4 < min 5 → need 16
+        receive(sku, location, new BigDecimal("4")); // on-hand 4 < min 5 → need 16
 
         replenishmentService.runBatchReplenishmentScan();
         assertThat(openTasksFor(sku).getFirst().getQuantity()).isEqualTo(16);
@@ -140,8 +140,8 @@ class BatchReplenishmentScanTest {
                 .stockItemId(sku)
                 .locationId(location)
                 .eventType(InventoryLedgerEventType.GOODS_ISSUE)
-                .changeInQuantity(-2)
-                .quantityAfter(2)
+                .changeInQuantity(new BigDecimal("-2"))
+                .quantityAfter(new BigDecimal("2"))
                 .transactionUserId("f1-test")
                 .build());
 
@@ -183,7 +183,7 @@ class BatchReplenishmentScanTest {
         String sku = skuId.toString();
         UUID location = UUID.randomUUID(); // not in the replica → treated as a site id
         seedPolicy(sku, location, 5, 20);
-        receive(sku, location, 3); // on-hand 3 < min 5 — pre-F2 math would trigger
+        receive(sku, location, new BigDecimal("3")); // on-hand 3 < min 5 — pre-F2 math would trigger
         // Open APPROVED PO for 7 units expected TODAY (== horizon date, boundary inclusive):
         // projected 3 + 7 = 10 >= min 5.
         savePo("APPROVED", location, LocalDate.now(ZoneOffset.UTC), skuId, "7");
@@ -200,7 +200,7 @@ class BatchReplenishmentScanTest {
         String sku = skuId.toString();
         UUID location = UUID.randomUUID();
         seedPolicy(sku, location, 5, 20);
-        receive(sku, location, 3);
+        receive(sku, location, new BigDecimal("3"));
         // Same PO but expected TOMORROW — outside the 0-day horizon, excluded from the
         // projection: projected stays 3 < min 5.
         savePo("APPROVED", location, LocalDate.now(ZoneOffset.UTC).plusDays(1), skuId, "7");
@@ -225,7 +225,7 @@ class BatchReplenishmentScanTest {
                 .name("F2 pick face")
                 .build());
         seedPolicy(sku, bin, 5, 20);
-        receive(sku, bin, 3); // on-hand at the BIN the policy governs
+        receive(sku, bin, new BigDecimal("3")); // on-hand at the BIN the policy governs
         // PO ships to the SITE (POs are never keyed by bin) — bin→site resolution must
         // credit it to the policy's projection: 3 + 7 = 10 >= 5 → no trigger.
         savePo("APPROVED", site, LocalDate.now(ZoneOffset.UTC), skuId, "7");
@@ -242,7 +242,7 @@ class BatchReplenishmentScanTest {
         String sku = skuId.toString();
         UUID location = UUID.randomUUID();
         seedPolicy(sku, location, 5, 20);
-        receive(sku, location, 3);
+        receive(sku, location, new BigDecimal("3"));
 
         replenishmentService.runBatchReplenishmentScan();
         var eventResponse = replenishmentService.evaluatePickFaceForReplenishment(sku, location);

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ConsumptionSourcingOrderingTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ConsumptionSourcingOrderingTest.java
@@ -25,6 +25,7 @@ import com.positivity.inventory.internal.repository.ReservationRepository;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingCandidate;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingDecision;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingSelection;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -110,8 +111,8 @@ class ConsumptionSourcingOrderingTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000009"))
                 .workorderLineId(WO_LINE_ID)
                 .stockItemId(STOCK_ITEM_ID)
-                .requiredQuantity(5)
-                .allocatedQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("5"))
                 .status(ReservationStatus.FULFILLED)
                 .build();
 
@@ -131,10 +132,10 @@ class ConsumptionSourcingOrderingTest {
                         allocation(ALLOC_NEW, LOC_NEW, Instant.parse("2026-06-02T00:00:00Z")),
                         allocation(ALLOC_OLD, LOC_OLD, Instant.parse("2026-06-01T00:00:00Z"))));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(STOCK_ITEM_ID))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
                         any(), any(InventoryLedgerEventType.class)))
-                .thenReturn(0);
+                .thenReturn(new BigDecimal("0"));
         when(ledgerPostingService.postAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
     }
 
@@ -143,7 +144,7 @@ class ConsumptionSourcingOrderingTest {
                 .allocationId(allocationId)
                 .reservation(reservation)
                 .locationId(locationId)
-                .allocatedQuantity(3)
+                .allocatedQuantity(new BigDecimal("3"))
                 .allocationState(AllocationState.HARD)
                 .status(AllocationStatus.ALLOCATED)
                 .createdAt(createdAt)

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CounterSaleIssuePosterTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CounterSaleIssuePosterTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import java.math.BigDecimal;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,8 +38,8 @@ class CounterSaleIssuePosterTest {
         return InventoryLedgerEntry.builder()
                 .stockItemId("SKU-1")
                 .eventType(InventoryLedgerEventType.GOODS_ISSUE)
-                .changeInQuantity(-1)
-                .quantityAfter(0)
+                .changeInQuantity(new BigDecimal("-1"))
+                .quantityAfter(new BigDecimal("0"))
                 .sourceTransactionId(sourceTransactionId)
                 .build();
     }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountAdjustmentServiceImplTest.java
@@ -102,8 +102,8 @@ class CycleCountAdjustmentServiceImplTest {
         @DisplayName("should throw IllegalArgumentException if quantity change is zero")
         void shouldThrowExceptionWhenQuantityIsUnchanged() {
             CreateAdjustmentRequest request = CreateAdjustmentRequest.builder()
-                    .countedQuantity(10)
-                    .quantityOnHandBefore(10)
+                    .countedQuantity(new BigDecimal("10"))
+                    .quantityOnHandBefore(new BigDecimal("10"))
                     .build();
 
             assertThatThrownBy(() -> service.createAdjustment(request))
@@ -116,8 +116,8 @@ class CycleCountAdjustmentServiceImplTest {
         void shouldCreatePendingAdjustmentWhenApprovalRequired() {
             CreateAdjustmentRequest request = CreateAdjustmentRequest.builder()
                     .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                    .countedQuantity(15)
-                    .quantityOnHandBefore(10)
+                    .countedQuantity(new BigDecimal("15"))
+                    .quantityOnHandBefore(new BigDecimal("10"))
                     .costAtTimeOfAdjustment(BigDecimal.TEN)
                     .build();
 
@@ -146,8 +146,8 @@ class CycleCountAdjustmentServiceImplTest {
             UUID stockItemId = UUID.fromString("00000000-0000-0000-0000-000000000009");
             CreateAdjustmentRequest request = CreateAdjustmentRequest.builder()
                     .stockItemId(stockItemId)
-                    .countedQuantity(15)
-                    .quantityOnHandBefore(10)
+                    .countedQuantity(new BigDecimal("15"))
+                    .quantityOnHandBefore(new BigDecimal("10"))
                     .costAtTimeOfAdjustment(new BigDecimal("99.0000")) // stale interim client value
                     .build();
 
@@ -175,8 +175,8 @@ class CycleCountAdjustmentServiceImplTest {
             UUID stockItemId = UUID.fromString("00000000-0000-0000-0000-00000000000a");
             CreateAdjustmentRequest request = CreateAdjustmentRequest.builder()
                     .stockItemId(stockItemId)
-                    .countedQuantity(8)
-                    .quantityOnHandBefore(10)
+                    .countedQuantity(new BigDecimal("8"))
+                    .quantityOnHandBefore(new BigDecimal("10"))
                     .costAtTimeOfAdjustment(new BigDecimal("99.0000"))
                     .build();
 
@@ -205,8 +205,8 @@ class CycleCountAdjustmentServiceImplTest {
             UUID stockItemId = UUID.fromString("00000000-0000-0000-0000-000000000001");
             CreateAdjustmentRequest request = CreateAdjustmentRequest.builder()
                     .stockItemId(stockItemId)
-                    .countedQuantity(11)
-                    .quantityOnHandBefore(10)
+                    .countedQuantity(new BigDecimal("11"))
+                    .quantityOnHandBefore(new BigDecimal("10"))
                     .costAtTimeOfAdjustment(BigDecimal.ONE)
                     .build();
 
@@ -221,7 +221,7 @@ class CycleCountAdjustmentServiceImplTest {
                 return saved;
             });
 
-            when(ledgerRepository.calculateOnHandQuantity(stockItemId)).thenReturn(10);
+            when(ledgerRepository.calculateOnHandQuantity(stockItemId)).thenReturn(new BigDecimal("10"));
             when(ledgerPostingService.post(any(InventoryLedgerEntry.class))).thenAnswer(invocation -> {
                 InventoryLedgerEntry entry = invocation.getArgument(0);
                 entry.setLedgerEntryId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
@@ -322,10 +322,10 @@ class CycleCountAdjustmentServiceImplTest {
                     .adjustmentId(adjustmentId)
                     .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                     .reasonCode("CYCLE_COUNT_SHRINK")
-                    .quantityChange(-2)
+                    .quantityChange(new BigDecimal("-2"))
                     .costAtTimeOfAdjustment(BigDecimal.ONE)
-                    .quantityOnHandBefore(10)
-                    .countedQuantity(8)
+                    .quantityOnHandBefore(new BigDecimal("10"))
+                    .countedQuantity(new BigDecimal("8"))
                     .createdByUserId("counter-user")
                     .status(AdjustmentStatus.PENDING_APPROVAL)
                     .build();

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountConflictDetectionTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/CycleCountConflictDetectionTest.java
@@ -84,13 +84,13 @@ class CycleCountConflictDetectionTest {
         SecurityContextHolder.clearContext();
     }
 
-    private void post(String sku, UUID locationId, InventoryLedgerEventType type, int change, int after) {
+    private void post(String sku, UUID locationId, InventoryLedgerEventType type, BigDecimal change, int after) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(locationId)
                 .eventType(type)
                 .changeInQuantity(change)
-                .quantityAfter(after)
+                .quantityAfter(BigDecimal.valueOf(after))
                 .transactionUserId("i2-test")
                 .build());
     }
@@ -136,10 +136,10 @@ class CycleCountConflictDetectionTest {
     void movementMidCount_flagsConflictAtSubmission() {
         String sku = "SKU-I2-" + UUID.randomUUID();
         UUID location = UUID.randomUUID();
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 10, 10);
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("10"), 10);
         CycleCountTask task = task(location.toString(), sku, 10);
         tick();
-        post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -3, 7);
+        post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-3"), 7);
 
         CountResponse response = cycleCountService.submitCount(SubmitCountRequest.builder()
                 .taskId(task.getTaskId())
@@ -157,7 +157,7 @@ class CycleCountConflictDetectionTest {
     void noMovement_staysPendingReview() {
         String sku = "SKU-I2-" + UUID.randomUUID();
         UUID location = UUID.randomUUID();
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 10, 10);
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("10"), 10);
         CycleCountTask task = task(location.toString(), sku, 10);
 
         CountResponse response = cycleCountService.submitCount(SubmitCountRequest.builder()
@@ -175,10 +175,10 @@ class CycleCountConflictDetectionTest {
     void recountFromConflict_works() {
         String sku = "SKU-I2-" + UUID.randomUUID();
         UUID location = UUID.randomUUID();
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 10, 10);
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("10"), 10);
         CycleCountTask task = task(location.toString(), sku, 10);
         tick();
-        post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -3, 7);
+        post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-3"), 7);
 
         cycleCountService.submitCount(SubmitCountRequest.builder()
                 .taskId(task.getTaskId())
@@ -209,10 +209,10 @@ class CycleCountConflictDetectionTest {
         String sku = stockItemId.toString();
         // Non-UUID bin ⇒ detection and recomputation both use the global
         // (SKU-wide) on-hand math, like the adjustment posting path itself.
-        post(sku, null, InventoryLedgerEventType.GOODS_RECEIPT, 10, 10);
+        post(sku, null, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("10"), 10);
         CycleCountTask task = task("BIN-I2-APPROVE", sku, 10);
         tick();
-        post(sku, null, InventoryLedgerEventType.GOODS_ISSUE, -3, 7);
+        post(sku, null, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-3"), 7);
 
         CountResponse count = cycleCountService.submitCount(SubmitCountRequest.builder()
                 .taskId(task.getTaskId())
@@ -225,8 +225,8 @@ class CycleCountConflictDetectionTest {
                 .stockItemId(stockItemId)
                 .taskId(task.getTaskId())
                 .reasonCode("CYCLE_COUNT_VARIANCE")
-                .countedQuantity(5)
-                .quantityOnHandBefore(10) // stale snapshot: would imply -5
+                .countedQuantity(new BigDecimal("5"))
+                .quantityOnHandBefore(new BigDecimal("10")) // stale snapshot: would imply -5
                 .costAtTimeOfAdjustment(new BigDecimal("10.00"))
                 .createdByUserId(AUDITOR)
                 .build());
@@ -238,13 +238,13 @@ class CycleCountConflictDetectionTest {
         // Recomputed against CURRENT on-hand (7), never the stale snapshot (10):
         // counted 5 - current 7 = -2, not -5.
         assertThat(approved.getStatus()).isEqualTo(AdjustmentStatus.POSTED);
-        assertThat(approved.getQuantityChange()).isEqualTo(-2);
-        assertThat(approved.getQuantityOnHandBefore()).isEqualTo(7);
+        assertThat(approved.getQuantityChange()).isEqualByComparingTo("-2");
+        assertThat(approved.getQuantityOnHandBefore()).isEqualByComparingTo("7");
 
         InventoryLedgerEntry posted =
                 ledgerRepository.findByAdjustmentId(created.getAdjustmentId()).orElseThrow();
         assertThat(posted.getEventType()).isEqualTo(InventoryLedgerEventType.COUNT_VARIANCE_OUT);
-        assertThat(posted.getChangeInQuantity()).isEqualTo(-2);
+        assertThat(posted.getChangeInQuantity()).isEqualByComparingTo("-2");
 
         assertThat(taskRepository.findById(task.getTaskId()).orElseThrow().getStatus())
                 .isEqualTo(TaskStatus.APPROVED);
@@ -257,7 +257,7 @@ class CycleCountConflictDetectionTest {
 
         UUID stockItemId = UUID.randomUUID();
         String sku = stockItemId.toString();
-        post(sku, null, InventoryLedgerEventType.GOODS_RECEIPT, 10, 10);
+        post(sku, null, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("10"), 10);
         CycleCountTask task = task("BIN-I2-LATE", sku, 10);
 
         CountResponse count = cycleCountService.submitCount(SubmitCountRequest.builder()
@@ -271,8 +271,8 @@ class CycleCountConflictDetectionTest {
                 .stockItemId(stockItemId)
                 .taskId(task.getTaskId())
                 .reasonCode("CYCLE_COUNT_VARIANCE")
-                .countedQuantity(8)
-                .quantityOnHandBefore(10)
+                .countedQuantity(new BigDecimal("8"))
+                .quantityOnHandBefore(new BigDecimal("10"))
                 .costAtTimeOfAdjustment(new BigDecimal("10.00"))
                 .createdByUserId(AUDITOR)
                 .build());
@@ -280,7 +280,7 @@ class CycleCountConflictDetectionTest {
 
         // Movement lands between count and approval.
         tick();
-        post(sku, null, InventoryLedgerEventType.GOODS_ISSUE, -4, 6);
+        post(sku, null, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-4"), 6);
 
         assertThatExceptionOfType(CycleCountConflictException.class)
                 .isThrownBy(() -> adjustmentService.approveAdjustment(
@@ -299,11 +299,11 @@ class CycleCountConflictDetectionTest {
                 created.getAdjustmentId(), ApproveAdjustmentRequest.builder().build(), null);
 
         // counted 8 - current 6 = +2 → COUNT_VARIANCE_IN.
-        assertThat(approved.getQuantityChange()).isEqualTo(2);
+        assertThat(approved.getQuantityChange()).isEqualByComparingTo("2");
         InventoryLedgerEntry posted =
                 ledgerRepository.findByAdjustmentId(created.getAdjustmentId()).orElseThrow();
         assertThat(posted.getEventType()).isEqualTo(InventoryLedgerEventType.COUNT_VARIANCE_IN);
-        assertThat(posted.getChangeInQuantity()).isEqualTo(2);
+        assertThat(posted.getChangeInQuantity()).isEqualByComparingTo("2");
     }
 
     @Test
@@ -313,22 +313,22 @@ class CycleCountConflictDetectionTest {
         UUID location = UUID.randomUUID();
         UUID otherLocation = UUID.randomUUID();
         // Before the task snapshot — must NOT be listed.
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 5, 5);
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("5"), 5);
         CycleCountTask task = task(location.toString(), sku, 5);
         tick();
         // In-window entries at the task's location — must be listed, in order.
-        post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -2, 3);
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 3, 6);
+        post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-2"), 3);
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("3"), 6);
         // In-window but other location — must NOT be listed.
-        post(sku, otherLocation, InventoryLedgerEventType.GOODS_RECEIPT, 7, 7);
+        post(sku, otherLocation, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("7"), 7);
 
         List<InterferingMovementResponse> movements = cycleCountService.getInterferingMovements(task.getTaskId());
 
         assertThat(movements).hasSize(2);
         assertThat(movements.get(0).getEventType()).isEqualTo(InventoryLedgerEventType.GOODS_ISSUE);
-        assertThat(movements.get(0).getChangeInQuantity()).isEqualTo(-2);
+        assertThat(movements.get(0).getChangeInQuantity()).isEqualByComparingTo("-2");
         assertThat(movements.get(1).getEventType()).isEqualTo(InventoryLedgerEventType.GOODS_RECEIPT);
-        assertThat(movements.get(1).getChangeInQuantity()).isEqualTo(3);
+        assertThat(movements.get(1).getChangeInQuantity()).isEqualByComparingTo("3");
         assertThat(movements)
                 .allSatisfy(movement -> assertThat(movement.getLocationId()).isEqualTo(location));
     }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ForecastQuantityServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ForecastQuantityServiceImplTest.java
@@ -176,10 +176,10 @@ class ForecastQuantityServiceImplTest {
         saveReservation(sku, ReservationStatus.PENDING, 5, 5, null);
 
         ForecastQuantityService.ForecastQuantities forecast =
-                forecastQuantityService.forecast(sku.toString(), null, null, 0L);
+                forecastQuantityService.forecast(sku.toString(), null, null, new BigDecimal("0"));
 
-        assertThat(forecast.outgoingQty()).isEqualTo(9L);
-        assertThat(forecast.projectedAvailable()).isEqualTo(-9L);
+        assertThat(forecast.outgoingQty()).isEqualByComparingTo("9");
+        assertThat(forecast.projectedAvailable()).isEqualByComparingTo("-9");
     }
 
     @Test
@@ -193,13 +193,13 @@ class ForecastQuantityServiceImplTest {
         Instant horizon = Instant.parse("2026-08-01T12:00:00Z");
 
         assertThat(forecastQuantityService
-                        .forecast(sku.toString(), null, null, 0L)
+                        .forecast(sku.toString(), null, null, new BigDecimal("0"))
                         .outgoingQty())
-                .isEqualTo(33L);
+                .isEqualByComparingTo("33");
         assertThat(forecastQuantityService
-                        .forecast(sku.toString(), null, horizon, 0L)
+                        .forecast(sku.toString(), null, horizon, new BigDecimal("0"))
                         .outgoingQty())
-                .isEqualTo(10L);
+                .isEqualByComparingTo("10");
     }
 
     // ─── outgoing: released pick tasks ───────────────────────────────────────
@@ -216,10 +216,10 @@ class ForecastQuantityServiceImplTest {
         savePickTask(sku, PickListStatus.READY_TO_PICK, PickTaskStatus.CANCELLED, 9, 0, null);
 
         ForecastQuantityService.ForecastQuantities forecast =
-                forecastQuantityService.forecast(sku.toString(), null, null, 10L);
+                forecastQuantityService.forecast(sku.toString(), null, null, new BigDecimal("10"));
 
-        assertThat(forecast.outgoingQty()).isEqualTo(8L);
-        assertThat(forecast.projectedAvailable()).isEqualTo(2L);
+        assertThat(forecast.outgoingQty()).isEqualByComparingTo("8");
+        assertThat(forecast.projectedAvailable()).isEqualByComparingTo("2");
     }
 
     @Test
@@ -241,23 +241,23 @@ class ForecastQuantityServiceImplTest {
         saveReservation(sku, ReservationStatus.PARTIALLY_FULFILLED, 4, 1, null); // remainder 3, site-agnostic
 
         assertThat(forecastQuantityService
-                        .forecast(sku.toString(), siteA, null, 0L)
+                        .forecast(sku.toString(), siteA, null, new BigDecimal("0"))
                         .outgoingQty())
-                .isEqualTo(8L); // 5 (bin under site A) + 3 (global reservation demand)
+                .isEqualByComparingTo("8"); // 5 (bin under site A) + 3 (global reservation demand)
         assertThat(forecastQuantityService
-                        .forecast(sku.toString(), siteB, null, 0L)
+                        .forecast(sku.toString(), siteB, null, new BigDecimal("0"))
                         .outgoingQty())
-                .isEqualTo(5L); // 2 (task suggested at site B itself) + 3
+                .isEqualByComparingTo("5"); // 2 (task suggested at site B itself) + 3
         assertThat(forecastQuantityService
-                        .forecast(sku.toString(), null, null, 0L)
+                        .forecast(sku.toString(), null, null, new BigDecimal("0"))
                         .outgoingQty())
-                .isEqualTo(10L); // everything
+                .isEqualByComparingTo("10"); // everything
     }
 
     // ─── projection ──────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("projectedAvailable = onHand + incoming - outgoing; fractional supply floors DOWN")
+    @DisplayName("projectedAvailable = onHand + incoming - outgoing, at the precision the documents state")
     void projectedAvailableFormula() {
         UUID sku = UUID.randomUUID();
         UUID site = UUID.randomUUID();
@@ -265,22 +265,27 @@ class ForecastQuantityServiceImplTest {
         saveReservation(sku, ReservationStatus.PENDING, 3, 0, null);
 
         ForecastQuantityService.ForecastQuantities forecast =
-                forecastQuantityService.forecast(sku.toString(), site, null, 100L);
+                forecastQuantityService.forecast(sku.toString(), site, null, new BigDecimal("100"));
 
-        assertThat(forecast.incomingQty()).isEqualTo(7L); // 7.9 floored DOWN
-        assertThat(forecast.outgoingQty()).isEqualTo(3L);
-        assertThat(forecast.projectedAvailable()).isEqualTo(104L);
+        // ADR-0055 stage 2 (#1414): the forecast fields are decimal, so expected supply is no
+        // longer floored DOWN to fit an integer. The floor existed to squeeze a fractional
+        // expected quantity into a `long` without over-promising; with a decimal field there is
+        // nothing to squeeze it into, and losing 0.9 of a divisible product's inbound supply
+        // would understate the projection for exactly the stock this stage exists to serve.
+        assertThat(forecast.incomingQty()).isEqualByComparingTo("7.900000");
+        assertThat(forecast.outgoingQty()).isEqualByComparingTo("3");
+        assertThat(forecast.projectedAvailable()).isEqualByComparingTo("104.900000");
     }
 
     @Test
     @DisplayName("non-UUID stock item ids skip PO/reservation matching without failing")
     void nonUuidStockItemIdIsSafe() {
         ForecastQuantityService.ForecastQuantities forecast =
-                forecastQuantityService.forecast("SKU-FREE-TEXT", null, null, 5L);
+                forecastQuantityService.forecast("SKU-FREE-TEXT", null, null, new BigDecimal("5"));
 
         assertThat(forecast.incomingQty()).isZero();
         assertThat(forecast.outgoingQty()).isZero();
-        assertThat(forecast.projectedAvailable()).isEqualTo(5L);
+        assertThat(forecast.projectedAvailable()).isEqualByComparingTo("5");
     }
 
     // ─── seeding helpers ─────────────────────────────────────────────────────
@@ -335,8 +340,8 @@ class ForecastQuantityServiceImplTest {
         reservationRepository.save(ReservationEntity.builder()
                 .workorderLineId(UUID.randomUUID())
                 .stockItemId(stockItemId)
-                .requiredQuantity(required)
-                .allocatedQuantity(allocated)
+                .requiredQuantity(BigDecimal.valueOf(required))
+                .allocatedQuantity(BigDecimal.valueOf(allocated))
                 .status(status)
                 .dueDateTime(dueDateTime)
                 .build());

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/InventoryLedgerServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/InventoryLedgerServiceImplTest.java
@@ -12,6 +12,7 @@ import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.exception.ResourceNotFoundException;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -51,8 +52,8 @@ class InventoryLedgerServiceImplTest {
                 .ledgerEntryId(id)
                 .stockItemId("SKU-TEST")
                 .eventType(InventoryLedgerEventType.ADJUSTMENT_IN)
-                .changeInQuantity(1)
-                .quantityAfter(10)
+                .changeInQuantity(new BigDecimal("1"))
+                .quantityAfter(new BigDecimal("10"))
                 .transactionUserId("user-1")
                 .build();
     }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/InventoryLotOutboundSuggestionTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/InventoryLotOutboundSuggestionTest.java
@@ -11,6 +11,7 @@ import com.positivity.inventory.internal.enums.InventoryLotStatus;
 import com.positivity.inventory.internal.enums.ProductTrackingLevel;
 import com.positivity.inventory.internal.repository.InventoryLotRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -63,7 +64,7 @@ class InventoryLotOutboundSuggestionTest {
         row.setStockItemId(SKU);
         row.setLocationId(LOCATION);
         row.setLotId(lotId);
-        row.setOnHand(5);
+        row.setOnHand(new BigDecimal("5"));
         return row;
     }
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/InventorySerialTrackingTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/InventorySerialTrackingTest.java
@@ -16,6 +16,7 @@ import com.positivity.inventory.internal.repository.ExtProductReplicaRepository;
 import com.positivity.inventory.internal.repository.InventorySerialUnitRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.repository.WarrantyPartReturnHoldRepository;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -71,8 +72,8 @@ class InventorySerialTrackingTest {
                 .locationId(location)
                 .toLocationId(location)
                 .eventType(InventoryLedgerEventType.GOODS_RECEIPT)
-                .changeInQuantity(qty)
-                .quantityAfter(0)
+                .changeInQuantity(BigDecimal.valueOf(qty))
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("serial-test")
                 .serialNumbers(serials)
                 .build();
@@ -90,8 +91,8 @@ class InventorySerialTrackingTest {
                 .locationId(location)
                 .fromLocationId(location)
                 .eventType(type)
-                .changeInQuantity(-qty)
-                .quantityAfter(0)
+                .changeInQuantity(BigDecimal.valueOf(-qty))
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("serial-test")
                 .serialNumbers(serials)
                 .serialWorkorderId(workorderId)
@@ -146,7 +147,7 @@ class InventorySerialTrackingTest {
         assertThat(summaryRepository
                         .findByStockItemIdAndLocationId(product.toString(), location)
                         .map(s -> s.getOnHand())
-                        .orElse(0L))
+                        .orElse(BigDecimal.ZERO))
                 .isZero();
     }
 
@@ -191,7 +192,7 @@ class InventorySerialTrackingTest {
                         .findByStockItemIdAndLocationId(product.toString(), location)
                         .orElseThrow()
                         .getOnHand())
-                .isEqualTo(1);
+                .isEqualByComparingTo("1");
     }
 
     @Test
@@ -265,8 +266,8 @@ class InventorySerialTrackingTest {
                 .locationId(location)
                 .toLocationId(location)
                 .eventType(InventoryLedgerEventType.RETURN_TO_STOCK)
-                .changeInQuantity(1)
-                .quantityAfter(0)
+                .changeInQuantity(new BigDecimal("1"))
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("serial-test")
                 .serialNumbers(List.of("SN-2"))
                 .build();
@@ -342,11 +343,11 @@ class InventorySerialTrackingTest {
     private long countDriftFor(UUID product, UUID location) {
         long serialInStock =
                 serialRepository.countByStockItemIdAndStatus(product.toString(), InventorySerialStatus.IN_STOCK);
-        long summaryOnHand = summaryRepository
+        BigDecimal summaryOnHand = summaryRepository
                 .findByStockItemIdAndLocationId(product.toString(), location)
                 .map(s -> s.getOnHand())
-                .orElse(0L);
-        return serialInStock == summaryOnHand ? 0 : 1;
+                .orElse(BigDecimal.ZERO);
+        return summaryOnHand.compareTo(BigDecimal.valueOf(serialInStock)) == 0 ? 0 : 1;
     }
 
     // ─── LOT / NONE unaffected: zero behavior change ────────────────────────────
@@ -373,11 +374,11 @@ class InventorySerialTrackingTest {
                         .findByStockItemIdAndLocationId(lotProduct.toString(), location)
                         .orElseThrow()
                         .getOnHand())
-                .isEqualTo(5);
+                .isEqualByComparingTo("5");
         assertThat(summaryRepository
                         .findByStockItemIdAndLocationId(noneProduct.toString(), location)
                         .orElseThrow()
                         .getOnHand())
-                .isEqualTo(5);
+                .isEqualByComparingTo("5");
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/InventoryTraceabilityTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/InventoryTraceabilityTest.java
@@ -74,8 +74,8 @@ class InventoryTraceabilityTest {
         return ledgerRepository.save(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .eventType(type)
-                .changeInQuantity(change)
-                .quantityAfter(0)
+                .changeInQuantity(BigDecimal.valueOf(change))
+                .quantityAfter(new BigDecimal("0"))
                 .lotId(lotId)
                 .locationId(to != null ? to : from)
                 .fromLocationId(from)
@@ -171,7 +171,7 @@ class InventoryTraceabilityTest {
                         InventoryLedgerEventType.RETURN_TO_STOCK,
                         InventoryLedgerEventType.SCRAP_OUT);
         assertThat(trace.getDownstream().get(0).getSourceTransactionId()).isEqualTo("GR");
-        assertThat(trace.getDownstream().get(0).getChangeInQuantity()).isEqualTo(10);
+        assertThat(trace.getDownstream().get(0).getChangeInQuantity()).isEqualByComparingTo("10");
     }
 
     // ─── lot: partial history (receipt only, no documents) ───────────────────────

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LedgerCostingIntegrationTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LedgerCostingIntegrationTest.java
@@ -42,8 +42,8 @@ class LedgerCostingIntegrationTest {
                 .stockItemId(sku)
                 .locationId(location)
                 .eventType(type)
-                .changeInQuantity(change)
-                .quantityAfter(0)
+                .changeInQuantity(BigDecimal.valueOf(change))
+                .quantityAfter(new BigDecimal("0"))
                 .unitCost(unitCost)
                 .transactionUserId("costing-test")
                 .build();
@@ -67,7 +67,7 @@ class LedgerCostingIntegrationTest {
 
         SkuCostState state = costStateRepository.findByStockItemId(sku).orElseThrow();
         assertThat(state.getAvgCost()).isEqualByComparingTo("6");
-        assertThat(state.getOnHandQty()).isEqualTo(15);
+        assertThat(state.getOnHandQty()).isEqualByComparingTo("15");
     }
 
     @Test
@@ -99,7 +99,7 @@ class LedgerCostingIntegrationTest {
         assertThat(allocation.getUnitCost()).isNull();
         // the running cost state reflects only the receipt
         SkuCostState state = costStateRepository.findByStockItemId(sku).orElseThrow();
-        assertThat(state.getOnHandQty()).isEqualTo(100);
+        assertThat(state.getOnHandQty()).isEqualByComparingTo("100");
         assertThat(state.getAvgCost()).isEqualByComparingTo("3");
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LedgerPostingConcurrencyTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LedgerPostingConcurrencyTest.java
@@ -7,6 +7,7 @@ import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -68,8 +69,8 @@ class LedgerPostingConcurrencyTest {
                                 .stockItemId(sku)
                                 .locationId(location)
                                 .eventType(type)
-                                .changeInQuantity(change)
-                                .quantityAfter(0)
+                                .changeInQuantity(BigDecimal.valueOf(change))
+                                .quantityAfter(new BigDecimal("0"))
                                 .transactionUserId("concurrency-test")
                                 .build());
                     }
@@ -94,7 +95,7 @@ class LedgerPostingConcurrencyTest {
 
         assertThat(summary.getOnHand())
                 .as("summary on-hand must equal SUM(ledger) — no lost updates")
-                .isEqualTo(ledgerSum);
+                .isEqualByComparingTo(BigDecimal.valueOf(ledgerSum));
         // Exactly one summary row despite the first-post creation race.
         assertThat(summaryRepository.findByStockItemId(sku)).hasSize(1);
     }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LedgerPostingServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/LedgerPostingServiceImplTest.java
@@ -6,6 +6,7 @@ import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -38,8 +39,8 @@ class LedgerPostingServiceImplTest {
                 .stockItemId(sku)
                 .locationId(locationId)
                 .eventType(type)
-                .changeInQuantity(change)
-                .quantityAfter(0)
+                .changeInQuantity(BigDecimal.valueOf(change))
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("posting-test")
                 .build();
     }
@@ -55,9 +56,9 @@ class LedgerPostingServiceImplTest {
 
         InventoryStockSummary summary =
                 summaryRepository.findByStockItemIdAndLocationId(sku, location).orElseThrow();
-        assertThat(summary.getOnHand()).isEqualTo(6);
+        assertThat(summary.getOnHand()).isEqualByComparingTo("6");
         assertThat(summary.getAllocated()).isZero();
-        assertThat(summary.getAtp()).isEqualTo(6);
+        assertThat(summary.getAtp()).isEqualByComparingTo("6");
         assertThat(summary.getLastLedgerEntryId()).isNotNull();
         assertThat(summary.getLastLedgerEntryId()).isNotEqualTo(first.getLedgerEntryId());
         assertThat(summary.getLastEventAt()).isNotNull();
@@ -74,9 +75,9 @@ class LedgerPostingServiceImplTest {
 
         InventoryStockSummary summary =
                 summaryRepository.findByStockItemIdAndLocationId(sku, location).orElseThrow();
-        assertThat(summary.getOnHand()).isEqualTo(100);
-        assertThat(summary.getAllocated()).isEqualTo(20);
-        assertThat(summary.getAtp()).isEqualTo(80);
+        assertThat(summary.getOnHand()).isEqualByComparingTo("100");
+        assertThat(summary.getAllocated()).isEqualByComparingTo("20");
+        assertThat(summary.getAtp()).isEqualByComparingTo("80");
     }
 
     @Test
@@ -90,11 +91,11 @@ class LedgerPostingServiceImplTest {
 
         InventoryStockSummary summary =
                 summaryRepository.findByStockItemIdAndLocationId(sku, location).orElseThrow();
-        assertThat(summary.getOnHand()).isEqualTo(50);
+        assertThat(summary.getOnHand()).isEqualByComparingTo("50");
         assertThat(summary.getAllocated()).isZero();
-        assertThat(summary.getReserved()).isEqualTo(15);
+        assertThat(summary.getReserved()).isEqualByComparingTo("15");
         // ATP per ADR-0001 subtracts allocations only.
-        assertThat(summary.getAtp()).isEqualTo(50);
+        assertThat(summary.getAtp()).isEqualByComparingTo("50");
     }
 
     @Test
@@ -121,7 +122,7 @@ class LedgerPostingServiceImplTest {
 
         InventoryStockSummary summary =
                 summaryRepository.findByStockItemIdAndLocationIdIsNull(sku).orElseThrow();
-        assertThat(summary.getOnHand()).isEqualTo(3);
+        assertThat(summary.getOnHand()).isEqualByComparingTo("3");
     }
 
     @Test
@@ -149,6 +150,6 @@ class LedgerPostingServiceImplTest {
                         .findByStockItemIdAndLocationId(sku, locationB)
                         .orElseThrow()
                         .getOnHand())
-                .isEqualTo(7);
+                .isEqualByComparingTo("7");
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/NegativeStockPolicyEnforcementTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/NegativeStockPolicyEnforcementTest.java
@@ -10,6 +10,7 @@ import com.positivity.inventory.internal.exception.InsufficientStockException;
 import com.positivity.inventory.internal.exception.NegativeStockPolicyViolationException;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -53,22 +54,22 @@ class NegativeStockPolicyEnforcementTest {
         return "SKU-K1-" + UUID.randomUUID();
     }
 
-    private InventoryLedgerEntry entry(String sku, UUID locationId, InventoryLedgerEventType type, int change) {
+    private InventoryLedgerEntry entry(String sku, UUID locationId, InventoryLedgerEventType type, BigDecimal change) {
         return InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(locationId)
                 .eventType(type)
                 .changeInQuantity(change)
-                .quantityAfter(0)
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("k1-policy-test")
                 .build();
     }
 
-    private void seed(String sku, UUID location, int quantity) {
+    private void seed(String sku, UUID location, BigDecimal quantity) {
         ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, quantity));
     }
 
-    private long onHand(String sku, UUID location) {
+    private BigDecimal onHand(String sku, UUID location) {
         return summaryRepository
                 .findByStockItemIdAndLocationId(sku, location)
                 .orElseThrow()
@@ -81,13 +82,13 @@ class NegativeStockPolicyEnforcementTest {
     void goodsIssue_belowZero_isBlockedWithInsufficientStock() {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
-        seed(sku, location, 5);
+        seed(sku, location, new BigDecimal("5"));
 
         assertThatExceptionOfType(InsufficientStockException.class)
-                .isThrownBy(() ->
-                        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -8)));
+                .isThrownBy(() -> ledgerPostingService.post(
+                        entry(sku, location, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-8"))));
 
-        assertThat(onHand(sku, location)).isEqualTo(5);
+        assertThat(onHand(sku, location)).isEqualByComparingTo("5");
         assertThat(ledgerRepository.findByStockItemIdOrderByTimestampAsc(sku)).hasSize(1);
     }
 
@@ -95,35 +96,35 @@ class NegativeStockPolicyEnforcementTest {
     void workorderConsumption_belowZero_isBlockedWithInsufficientStock() {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
-        seed(sku, location, 2);
+        seed(sku, location, new BigDecimal("2"));
 
         assertThatExceptionOfType(InsufficientStockException.class)
                 .isThrownBy(() -> ledgerPostingService.post(
-                        entry(sku, location, InventoryLedgerEventType.WORKORDER_CONSUMPTION, -3)));
+                        entry(sku, location, InventoryLedgerEventType.WORKORDER_CONSUMPTION, new BigDecimal("-3"))));
 
-        assertThat(onHand(sku, location)).isEqualTo(2);
+        assertThat(onHand(sku, location)).isEqualByComparingTo("2");
     }
 
     @Test
     void transferOut_belowZero_isBlockedWithInsufficientStock() {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
-        seed(sku, location, 1);
+        seed(sku, location, new BigDecimal("1"));
 
         assertThatExceptionOfType(InsufficientStockException.class)
-                .isThrownBy(() ->
-                        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.TRANSFER_OUT, -2)));
+                .isThrownBy(() -> ledgerPostingService.post(
+                        entry(sku, location, InventoryLedgerEventType.TRANSFER_OUT, new BigDecimal("-2"))));
 
-        assertThat(onHand(sku, location)).isEqualTo(1);
+        assertThat(onHand(sku, location)).isEqualByComparingTo("1");
     }
 
     @Test
     void goodsIssue_exactlyToZero_isAllowed() {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
-        seed(sku, location, 5);
+        seed(sku, location, new BigDecimal("5"));
 
-        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -5));
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-5")));
 
         assertThat(onHand(sku, location)).isZero();
     }
@@ -134,37 +135,38 @@ class NegativeStockPolicyEnforcementTest {
     void scrapOut_belowZero_withoutOverride_isRejectedWithOverrideRequiredCode() {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
-        seed(sku, location, 3);
+        seed(sku, location, new BigDecimal("3"));
 
         assertThatExceptionOfType(NegativeStockPolicyViolationException.class)
-                .isThrownBy(
-                        () -> ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.SCRAP_OUT, -4)))
+                .isThrownBy(() -> ledgerPostingService.post(
+                        entry(sku, location, InventoryLedgerEventType.SCRAP_OUT, new BigDecimal("-4"))))
                 .satisfies(ex -> assertThat(ex.getErrorCode())
                         .isEqualTo(NegativeStockPolicyViolationException.OVERRIDE_REQUIRED));
 
-        assertThat(onHand(sku, location)).isEqualTo(3);
+        assertThat(onHand(sku, location)).isEqualByComparingTo("3");
     }
 
     @Test
     void scrapOut_belowZero_withOverride_isAllowed() {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
-        seed(sku, location, 3);
+        seed(sku, location, new BigDecimal("3"));
 
         // Caller has already verified inventory:adjustment:override and passes
         // the explicit flag — the funnel never reads the security context.
-        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.SCRAP_OUT, -5), true);
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.SCRAP_OUT, new BigDecimal("-5")), true);
 
-        assertThat(onHand(sku, location)).isEqualTo(-2);
+        assertThat(onHand(sku, location)).isEqualByComparingTo("-2");
     }
 
     @Test
     void scrapOut_exactlyToZero_withoutOverride_isAllowed() {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
-        seed(sku, location, 3);
+        seed(sku, location, new BigDecimal("3"));
 
-        assertThatCode(() -> ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.SCRAP_OUT, -3)))
+        assertThatCode(() -> ledgerPostingService.post(
+                        entry(sku, location, InventoryLedgerEventType.SCRAP_OUT, new BigDecimal("-3"))))
                 .doesNotThrowAnyException();
 
         assertThat(onHand(sku, location)).isZero();
@@ -176,24 +178,24 @@ class NegativeStockPolicyEnforcementTest {
     void adjustmentOut_belowZero_isRejectedEvenWithOverride() {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
-        seed(sku, location, 2);
+        seed(sku, location, new BigDecimal("2"));
 
         assertThatExceptionOfType(NegativeStockPolicyViolationException.class)
                 .isThrownBy(() -> ledgerPostingService.post(
-                        entry(sku, location, InventoryLedgerEventType.ADJUSTMENT_OUT, -3), true))
+                        entry(sku, location, InventoryLedgerEventType.ADJUSTMENT_OUT, new BigDecimal("-3")), true))
                 .satisfies(ex ->
                         assertThat(ex.getErrorCode()).isEqualTo(NegativeStockPolicyViolationException.FLOOR_VIOLATION));
 
-        assertThat(onHand(sku, location)).isEqualTo(2);
+        assertThat(onHand(sku, location)).isEqualByComparingTo("2");
     }
 
     @Test
     void adjustmentOut_exactlyToZero_isAllowed() {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
-        seed(sku, location, 2);
+        seed(sku, location, new BigDecimal("2"));
 
-        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.ADJUSTMENT_OUT, -2));
+        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.ADJUSTMENT_OUT, new BigDecimal("-2")));
 
         assertThat(onHand(sku, location)).isZero();
     }
@@ -202,16 +204,17 @@ class NegativeStockPolicyEnforcementTest {
     void countVarianceOut_belowZero_isRejected_andExactlyToZeroAllowed() {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
-        seed(sku, location, 4);
+        seed(sku, location, new BigDecimal("4"));
 
         assertThatExceptionOfType(NegativeStockPolicyViolationException.class)
                 .isThrownBy(() -> ledgerPostingService.post(
-                        entry(sku, location, InventoryLedgerEventType.COUNT_VARIANCE_OUT, -5)))
+                        entry(sku, location, InventoryLedgerEventType.COUNT_VARIANCE_OUT, new BigDecimal("-5"))))
                 .satisfies(ex ->
                         assertThat(ex.getErrorCode()).isEqualTo(NegativeStockPolicyViolationException.FLOOR_VIOLATION));
 
         // Counts set reality: zeroing the balance is legitimate.
-        ledgerPostingService.post(entry(sku, location, InventoryLedgerEventType.COUNT_VARIANCE_OUT, -4));
+        ledgerPostingService.post(
+                entry(sku, location, InventoryLedgerEventType.COUNT_VARIANCE_OUT, new BigDecimal("-4")));
 
         assertThat(onHand(sku, location)).isZero();
     }
@@ -226,9 +229,9 @@ class NegativeStockPolicyEnforcementTest {
         // Paired putaway moves decrement the source location with the same
         // PUTAWAY event type; the matrix leaves them unconstrained (the putaway
         // services validate source on-hand themselves).
-        ledgerPostingService.post(entry(sku, stagingLocation, InventoryLedgerEventType.PUTAWAY, -4));
+        ledgerPostingService.post(entry(sku, stagingLocation, InventoryLedgerEventType.PUTAWAY, new BigDecimal("-4")));
 
-        assertThat(onHand(sku, stagingLocation)).isEqualTo(-4);
+        assertThat(onHand(sku, stagingLocation)).isEqualByComparingTo("-4");
     }
 
     @Test
@@ -237,14 +240,14 @@ class NegativeStockPolicyEnforcementTest {
         UUID location = UUID.randomUUID();
 
         assertThatCode(() -> ledgerPostingService.postAll(List.of(
-                        entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 1),
-                        entry(sku, location, InventoryLedgerEventType.TRANSFER_IN, 1),
-                        entry(sku, location, InventoryLedgerEventType.RETURN_TO_STOCK, 1),
-                        entry(sku, location, InventoryLedgerEventType.ADJUSTMENT_IN, 1),
-                        entry(sku, location, InventoryLedgerEventType.COUNT_VARIANCE_IN, 1))))
+                        entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("1")),
+                        entry(sku, location, InventoryLedgerEventType.TRANSFER_IN, new BigDecimal("1")),
+                        entry(sku, location, InventoryLedgerEventType.RETURN_TO_STOCK, new BigDecimal("1")),
+                        entry(sku, location, InventoryLedgerEventType.ADJUSTMENT_IN, new BigDecimal("1")),
+                        entry(sku, location, InventoryLedgerEventType.COUNT_VARIANCE_IN, new BigDecimal("1")))))
                 .doesNotThrowAnyException();
 
-        assertThat(onHand(sku, location)).isEqualTo(5);
+        assertThat(onHand(sku, location)).isEqualByComparingTo("5");
     }
 
     // ─── Neutral/ATP-only types: untouched by the matrix ─────────────────────
@@ -253,18 +256,18 @@ class NegativeStockPolicyEnforcementTest {
     void neutralAtpOnlyTypes_areUntouchedByTheMatrix() {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
-        seed(sku, location, 1);
+        seed(sku, location, new BigDecimal("1"));
 
         // Reservations/allocations far beyond on-hand are an ATP concern
         // (InsufficientAtpException at the caller), never a negative-stock one.
         assertThatCode(() -> ledgerPostingService.postAll(List.of(
-                        entry(sku, location, InventoryLedgerEventType.RESERVATION_CREATED, 100),
-                        entry(sku, location, InventoryLedgerEventType.ALLOCATION_CREATED, 100),
-                        entry(sku, location, InventoryLedgerEventType.BACKORDER_CREATED, 100),
-                        entry(sku, location, InventoryLedgerEventType.PICK_TASK_CREATED, 100))))
+                        entry(sku, location, InventoryLedgerEventType.RESERVATION_CREATED, new BigDecimal("100")),
+                        entry(sku, location, InventoryLedgerEventType.ALLOCATION_CREATED, new BigDecimal("100")),
+                        entry(sku, location, InventoryLedgerEventType.BACKORDER_CREATED, new BigDecimal("100")),
+                        entry(sku, location, InventoryLedgerEventType.PICK_TASK_CREATED, new BigDecimal("100")))))
                 .doesNotThrowAnyException();
 
-        assertThat(onHand(sku, location)).isEqualTo(1);
+        assertThat(onHand(sku, location)).isEqualByComparingTo("1");
     }
 
     // ─── Batch semantics ─────────────────────────────────────────────────────
@@ -276,8 +279,8 @@ class NegativeStockPolicyEnforcementTest {
 
         assertThatExceptionOfType(InsufficientStockException.class)
                 .isThrownBy(() -> ledgerPostingService.postAll(List.of(
-                        entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 5),
-                        entry(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -8))));
+                        entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("5")),
+                        entry(sku, location, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-8")))));
 
         // Single enforcement point inside the posting transaction: the valid
         // receipt rolls back together with the rejected issue. (The summary row
@@ -287,7 +290,7 @@ class NegativeStockPolicyEnforcementTest {
         assertThat(summaryRepository
                         .findByStockItemIdAndLocationId(sku, location)
                         .map(row -> row.getOnHand())
-                        .orElse(0L))
+                        .orElse(BigDecimal.ZERO))
                 .isZero();
     }
 
@@ -297,8 +300,8 @@ class NegativeStockPolicyEnforcementTest {
         UUID location = UUID.randomUUID();
 
         ledgerPostingService.postAll(List.of(
-                entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 5),
-                entry(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -5)));
+                entry(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("5")),
+                entry(sku, location, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-5"))));
 
         assertThat(onHand(sku, location)).isZero();
     }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/OrderEventsListenerTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/OrderEventsListenerTest.java
@@ -103,7 +103,7 @@ class OrderEventsListenerTest {
         InventoryLedgerEntry entry = posted.getFirst();
         assertThat(entry.getStockItemId()).isEqualTo("SKU-1");
         assertThat(entry.getEventType()).isEqualTo(InventoryLedgerEventType.GOODS_ISSUE);
-        assertThat(entry.getChangeInQuantity()).isEqualTo(-2);
+        assertThat(entry.getChangeInQuantity()).isEqualByComparingTo("-2");
         assertThat(entry.getLocationId()).isEqualTo(LOCATION_ID);
         verify(processedEventRepository).save(any());
     }
@@ -189,7 +189,7 @@ class OrderEventsListenerTest {
         InventoryLedgerEntry entry = posted.getFirst();
         assertThat(entry.getEventType()).isEqualTo(InventoryLedgerEventType.RETURN_TO_STOCK);
         assertThat(entry.getStockItemId()).isEqualTo("SKU-1");
-        assertThat(entry.getChangeInQuantity()).isEqualTo(2);
+        assertThat(entry.getChangeInQuantity()).isEqualByComparingTo("2");
         assertThat(entry.getLocationId()).isEqualTo(LOCATION_ID);
         verify(processedEventRepository).save(any());
     }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PickListGenerationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PickListGenerationServiceImplTest.java
@@ -24,6 +24,7 @@ import com.positivity.inventory.internal.repository.ReservationRepository;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingCandidate;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingDecision;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingSelection;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -121,7 +122,9 @@ class PickListGenerationServiceImplTest {
                 .thenReturn(new SourcingDecision(
                         SourcingStrategy.PROXIMITY,
                         SourcingStrategy.PROXIMITY,
-                        List.of(new SourcingCandidate(LOC_BEST, 5L), new SourcingCandidate(LOC_OTHER, 7L))));
+                        List.of(
+                                new SourcingCandidate(LOC_BEST, new BigDecimal("5")),
+                                new SourcingCandidate(LOC_OTHER, new BigDecimal("7")))));
 
         PickListResponse response = service.generatePickList(requestWithOneLine(PRODUCT_ID.toString()));
 
@@ -206,8 +209,8 @@ class PickListGenerationServiceImplTest {
         return InventoryStockSummary.builder()
                 .stockItemId(PRODUCT_ID.toString())
                 .locationId(locationId)
-                .onHand(onHand)
-                .allocated(allocated)
+                .onHand(BigDecimal.valueOf(onHand))
+                .allocated(BigDecimal.valueOf(allocated))
                 .build();
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseSuggestionScanTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PurchaseSuggestionScanTest.java
@@ -77,13 +77,13 @@ class PurchaseSuggestionScanTest {
         jdbcTemplate.execute("CREATE SEQUENCE IF NOT EXISTS purchase_order_number_seq START WITH 1 INCREMENT BY 1");
     }
 
-    private void post(String sku, UUID locationId, InventoryLedgerEventType eventType, int change, int after) {
+    private void post(String sku, UUID locationId, InventoryLedgerEventType eventType, BigDecimal change, int after) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(locationId)
                 .eventType(eventType)
                 .changeInQuantity(change)
-                .quantityAfter(after)
+                .quantityAfter(BigDecimal.valueOf(after))
                 .transactionUserId(ACTOR)
                 .build());
     }
@@ -150,7 +150,7 @@ class PurchaseSuggestionScanTest {
         UUID location = UUID.randomUUID();
         seedPurchasePolicy(sku, location, 5, 20, null, 0);
         seedManufacturerFeed(productId, manufacturerId, 100, 5, new BigDecimal("4.99"), null, 1);
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 3, 3); // on-hand 3 < min 5
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("3"), 3); // on-hand 3 < min 5
 
         ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
 
@@ -178,7 +178,7 @@ class PurchaseSuggestionScanTest {
         UUID location = UUID.randomUUID();
         seedPurchasePolicy(sku, location, 5, 20, null, 0);
         seedManufacturerFeed(productId, UUID.randomUUID(), 100, 5, new BigDecimal("4.99"), null, 1);
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 4, 4); // need 16
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("4"), 4); // need 16
 
         replenishmentService.runBatchReplenishmentScan();
         replenishmentService.runBatchReplenishmentScan();
@@ -189,7 +189,7 @@ class PurchaseSuggestionScanTest {
         assertThat(suggestions.getFirst().getSuggestedQuantity()).isEqualTo(16);
 
         // Stock drops between scans → the open suggestion's quantity is refreshed, not duplicated.
-        post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -2, 2);
+        post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-2"), 2);
         ReplenishmentScanResultResponse second = replenishmentService.runBatchReplenishmentScan();
 
         suggestions = suggestionsFor(sku);
@@ -207,7 +207,7 @@ class PurchaseSuggestionScanTest {
         UUID location = UUID.randomUUID();
         seedPurchasePolicy(sku, location, 5, 20, 4, 0); // orderMultiple 4
         seedManufacturerFeed(productId, UUID.randomUUID(), 100, 5, new BigDecimal("4.99"), 24, 6); // MOQ 24, pack 6
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 3, 3); // raw need 17
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("3"), 3); // raw need 17
 
         replenishmentService.runBatchReplenishmentScan();
 
@@ -226,7 +226,7 @@ class PurchaseSuggestionScanTest {
         UUID location = UUID.randomUUID();
         seedPurchasePolicy(sku, location, 5, 20, null, 0);
         seedManufacturerFeed(productId, UUID.randomUUID(), 100, 5, new BigDecimal("4.99"), null, 1);
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 3, 3);
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("3"), 3);
 
         replenishmentService.runBatchReplenishmentScan();
         var eventResponse = replenishmentService.evaluatePickFaceForReplenishment(sku, location);
@@ -298,8 +298,8 @@ class PurchaseSuggestionScanTest {
         // state. What lands here is that state.
         projection.restate(converted.getPurchaseOrderId(), "PARTIALLY_RECEIVED");
         projection.setOpenQuantity(converted.getPurchaseOrderId(), "5");
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 15, 15);
-        post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, -12, 3);
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("15"), 15);
+        post(sku, location, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-12"), 3);
 
         var eventResponse = replenishmentService.evaluatePickFaceForReplenishment(sku, location);
 
@@ -323,7 +323,7 @@ class PurchaseSuggestionScanTest {
         UUID location = UUID.randomUUID();
         seedPurchasePolicy(sku, location, 5, 20, null, 0);
         seedManufacturerFeed(productId, manufacturerId, 100, 5, new BigDecimal("4.99"), null, 1);
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 3, 3);
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("3"), 3);
 
         replenishmentService.runBatchReplenishmentScan();
         PurchaseSuggestion suggestion = suggestionsFor(sku).getFirst();

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PutawayDestinationResolverTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PutawayDestinationResolverTest.java
@@ -19,6 +19,7 @@ import com.positivity.inventory.internal.repository.ExtStorageLocationReplicaRep
 import com.positivity.inventory.internal.repository.PutawayTaskRepository;
 import com.positivity.inventory.internal.service.PutawayDestinationResolver.ResolvedDestination;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingCandidate;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -163,7 +164,7 @@ class PutawayDestinationResolverTest {
         when(proximitySourcingStrategy.order(any()))
                 .thenReturn(List.of(candidate(NEAR), candidate(FAR), candidate(ANCHOR)));
         when(putawayValidationService.validateLocationCapacity(NEAR, QTY))
-                .thenThrow(new LocationAtCapacityException(NEAR, 10, 10));
+                .thenThrow(new LocationAtCapacityException(NEAR, new BigDecimal("10"), new BigDecimal("10")));
         when(putawayValidationService.validateLocationCapacity(FAR, QTY)).thenReturn(ValidationResult.success());
 
         ResolvedDestination result =
@@ -181,7 +182,7 @@ class PutawayDestinationResolverTest {
         when(proximitySourcingStrategy.order(any()))
                 .thenReturn(List.of(candidate(NEAR), candidate(FAR), candidate(ANCHOR)));
         when(putawayValidationService.validateLocationCapacity(any(UUID.class), eq(QTY)))
-                .thenThrow(new LocationAtCapacityException(NEAR, 10, 10));
+                .thenThrow(new LocationAtCapacityException(NEAR, new BigDecimal("10"), new BigDecimal("10")));
 
         ResolvedDestination result =
                 resolver().resolve(rule(PutawayDestinationStrategy.CLOSEST_AVAILABLE), PRODUCT, QTY);

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PutawayValidationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/PutawayValidationServiceImplTest.java
@@ -19,6 +19,7 @@ import com.positivity.inventory.internal.repository.PutawayRuleRepository;
 import com.positivity.inventory.internal.repository.ReplenishmentPolicyRepository;
 import com.positivity.inventory.internal.security.PutawayPermissions;
 import com.positivity.security.common.GatewaySecurityConstants;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -80,10 +81,10 @@ class PutawayValidationServiceImplTest {
                 .thenReturn(locationValidation(true, true, 100));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
                         eq(DESTINATION_LOCATION_ID), any(List.class)))
-                .thenReturn(0);
+                .thenReturn(new BigDecimal("0"));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
                         eq(SKU), eq(SOURCE_LOCATION_ID), any(List.class)))
-                .thenReturn(50);
+                .thenReturn(new BigDecimal("50"));
     }
 
     @AfterEach
@@ -257,7 +258,7 @@ class PutawayValidationServiceImplTest {
         void countsExistingStockTowardTheLimit() {
             when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
                             eq(DESTINATION_LOCATION_ID), any(List.class)))
-                    .thenReturn(95);
+                    .thenReturn(new BigDecimal("95"));
 
             assertThatThrownBy(() -> service.validateLocationCapacity(DESTINATION_LOCATION_ID, 20))
                     .isInstanceOf(LocationAtCapacityException.class);
@@ -278,7 +279,7 @@ class PutawayValidationServiceImplTest {
         void refusesASourceWithNothingOnHand() {
             when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
                             eq(SKU), eq(SOURCE_LOCATION_ID), any(List.class)))
-                    .thenReturn(0);
+                    .thenReturn(new BigDecimal("0"));
 
             assertThatThrownBy(() -> service.validateSourceOnHand(SOURCE_LOCATION_ID, SKU, 10))
                     .isInstanceOf(NoOnHandAtSourceLocationException.class);
@@ -288,7 +289,7 @@ class PutawayValidationServiceImplTest {
         void reportsAShortfallRatherThanThrowing() {
             when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
                             eq(SKU), eq(SOURCE_LOCATION_ID), any(List.class)))
-                    .thenReturn(4);
+                    .thenReturn(new BigDecimal("4"));
 
             ValidationResult result = service.validateSourceOnHand(SOURCE_LOCATION_ID, SKU, 10);
 
@@ -313,7 +314,7 @@ class PutawayValidationServiceImplTest {
         void collectsASourceShortfallAsAnError() {
             when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
                             eq(SKU), eq(SOURCE_LOCATION_ID), any(List.class)))
-                    .thenReturn(4);
+                    .thenReturn(new BigDecimal("4"));
 
             ValidationResult result = service.validatePutawayExecution(request(10));
 
@@ -361,7 +362,7 @@ class PutawayValidationServiceImplTest {
         void turnsAMissingSourceIntoAReconciliationWarningWhenCompatibilityIsOverridden() {
             when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
                             eq(SKU), eq(SOURCE_LOCATION_ID), any(List.class)))
-                    .thenReturn(0);
+                    .thenReturn(new BigDecimal("0"));
             PutawayExecutionRequest request = request(10);
             request.setOverrideLocationCompatibility(true);
             request.setOverrideReasonCode(OverrideReasonCode.CAPACITY_OVERRIDE);
@@ -377,7 +378,7 @@ class PutawayValidationServiceImplTest {
         void stillRefusesAMissingSourceWhenNothingIsOverridden() {
             when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation(
                             eq(SKU), eq(SOURCE_LOCATION_ID), any(List.class)))
-                    .thenReturn(0);
+                    .thenReturn(new BigDecimal("0"));
             PutawayExecutionRequest request = request(10);
 
             assertThatThrownBy(() -> service.validatePutawayExecution(request))

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/QuantityScaleGuardTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/QuantityScaleGuardTest.java
@@ -1,0 +1,147 @@
+package com.positivity.inventory.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.positivity.inventory.internal.exception.FractionalQuantityNotAllowedException;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The per-product divisibility rule as the supply side and the read side each apply it
+ * (ADR-0055, #1414).
+ *
+ * <p>The two entry points deliberately answer differently when the product declares nothing.
+ * {@code requirePostable} decides what may be written and defaults to whole units, which is the
+ * ADR's "undeclared means integral". {@code requireReportable} describes what is already written,
+ * where an absent declaration is not evidence that the stored value is wrong.
+ */
+class QuantityScaleGuardTest {
+
+    private static final UUID WHOLE_UNITS_PRODUCT = UUID.fromString("018f0000-0000-7000-8000-000000000e01");
+    private static final UUID SCALE_TWO_PRODUCT = UUID.fromString("018f0000-0000-7000-8000-000000000e02");
+
+    private final UomConversionService uomConversionService = mock(UomConversionService.class);
+    private final QuantityScaleGuard guard = new QuantityScaleGuard(uomConversionService);
+
+    @Nested
+    @DisplayName("requirePostable — the supply-side gate")
+    class RequirePostable {
+
+        @Test
+        @DisplayName("refuses a fraction for a product that declares nothing")
+        void refusesFractionForUndeclaredProduct() {
+            when(uomConversionService.declaredBaseScale(WHOLE_UNITS_PRODUCT)).thenReturn(0);
+
+            assertThatExceptionOfType(FractionalQuantityNotAllowedException.class)
+                    .isThrownBy(() ->
+                            guard.requirePostable(WHOLE_UNITS_PRODUCT, "PROD-1", "quantity", new BigDecimal("1.5")))
+                    .satisfies(ex -> assertThat(ex.getMessage())
+                            .contains(FractionalQuantityNotAllowedException.ERROR_CODE)
+                            .contains("whole units"));
+        }
+
+        @Test
+        @DisplayName("accepts a fraction within the declared scale")
+        void acceptsFractionWithinDeclaredScale() {
+            when(uomConversionService.declaredBaseScale(SCALE_TWO_PRODUCT)).thenReturn(2);
+
+            assertThat(guard.requirePostable(SCALE_TWO_PRODUCT, "BULK-LB", "quantity", new BigDecimal("1.01")))
+                    .isEqualByComparingTo("1.01");
+        }
+
+        @Test
+        @DisplayName("refuses a fraction finer than the declared scale, and says how fine is allowed")
+        void refusesFractionFinerThanDeclaredScale() {
+            when(uomConversionService.declaredBaseScale(SCALE_TWO_PRODUCT)).thenReturn(2);
+
+            assertThatExceptionOfType(FractionalQuantityNotAllowedException.class)
+                    .isThrownBy(() ->
+                            guard.requirePostable(SCALE_TWO_PRODUCT, "BULK-LB", "quantity", new BigDecimal("1.005")))
+                    .satisfies(ex -> assertThat(ex.getMessage()).contains("2 decimal places"));
+        }
+
+        @Test
+        @DisplayName("trailing zeros are spelling, not divisibility: 1.00 is a whole unit")
+        void trailingZerosAreNotAFraction() {
+            when(uomConversionService.declaredBaseScale(WHOLE_UNITS_PRODUCT)).thenReturn(0);
+
+            // numeric(19,4) hands values back at scale 4, so without this every quantity read out
+            // of the ledger would fail its own guard on the way back in.
+            assertThat(guard.requirePostable(WHOLE_UNITS_PRODUCT, "PROD-1", "quantity", new BigDecimal("1.0000")))
+                    .isEqualByComparingTo("1");
+        }
+
+        @Test
+        @DisplayName("a stock reference naming no catalog product is integral, like an undeclared one")
+        void unresolvableReferenceIsIntegralOnTheWayIn() {
+            when(uomConversionService.declaredBaseScale(null)).thenReturn(0);
+
+            assertThatExceptionOfType(FractionalQuantityNotAllowedException.class)
+                    .isThrownBy(() -> guard.requirePostable(null, "FREE-TEXT-SKU", "quantity", new BigDecimal("0.5")));
+        }
+    }
+
+    @Nested
+    @DisplayName("requireReportable — the fail-loud replacement for Math.toIntExact")
+    class RequireReportable {
+
+        @Test
+        @DisplayName("stops the computation when the ledger holds precision no declaration supports")
+        void refusesPrecisionNoDeclarationSupports() {
+            when(uomConversionService.declaredBaseScale(WHOLE_UNITS_PRODUCT)).thenReturn(0);
+
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> guard.requireReportable(
+                            WHOLE_UNITS_PRODUCT, "PROD-1", "onHandQuantity", new BigDecimal("1.5")))
+                    .withMessageContaining("precision_scale=0");
+        }
+
+        @Test
+        @DisplayName("reports a divisible product's real quantity")
+        void reportsDeclaredPrecision() {
+            when(uomConversionService.declaredBaseScale(SCALE_TWO_PRODUCT)).thenReturn(2);
+
+            assertThat(guard.requireReportable(
+                            SCALE_TWO_PRODUCT, "BULK-LB", "onHandQuantity", new BigDecimal("120.5000")))
+                    .isEqualByComparingTo("120.5");
+        }
+
+        @Test
+        @DisplayName("reports what is stored when the stock reference names no catalog product")
+        void unresolvableReferenceIsReportedNotRefused() {
+            // The ledger's two posting paths disagree about whether stockItemId holds a product
+            // UUID or a human SKU. A SKU-keyed row has no declaration to consult, and refusing to
+            // report it would turn an availability read into a 500 and stall the replicas behind
+            // it — for a value the ledger already accepted.
+            assertThat(guard.requireReportable(null, "FREE-TEXT-SKU", "onHandQuantity", new BigDecimal("1.5")))
+                    .isEqualByComparingTo("1.5");
+        }
+    }
+
+    @Nested
+    @DisplayName("productIdOf")
+    class ProductIdOf {
+
+        @Test
+        @DisplayName("a UUID stock-item id names its catalog product")
+        void uuidResolves() {
+            assertThat(QuantityScaleGuard.productIdOf(SCALE_TWO_PRODUCT.toString()))
+                    .isEqualTo(SCALE_TWO_PRODUCT);
+        }
+
+        @Test
+        @DisplayName("a human SKU, a blank and a null name none")
+        void nonUuidResolvesToNull() {
+            assertThat(QuantityScaleGuard.productIdOf("PARK-387TC-4-FT")).isNull();
+            assertThat(QuantityScaleGuard.productIdOf("  ")).isNull();
+            assertThat(QuantityScaleGuard.productIdOf(null)).isNull();
+        }
+    }
+}

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ReplenishmentPolicyEnrichmentTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ReplenishmentPolicyEnrichmentTest.java
@@ -78,7 +78,7 @@ class ReplenishmentPolicyEnrichmentTest {
         return "SKU-F3-" + UUID.randomUUID();
     }
 
-    private void receive(String sku, UUID locationId, int quantity) {
+    private void receive(String sku, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(locationId)
@@ -116,7 +116,7 @@ class ReplenishmentPolicyEnrichmentTest {
         ReplenishmentPolicy policy = seedPolicy(sku, location, 5, 10);
         policy.setOrderMultiple(6);
         policyRepository.save(policy);
-        receive(sku, location, 3); // need = 10 - 3 = 7 → rounded to 12
+        receive(sku, location, new BigDecimal("3")); // need = 10 - 3 = 7 → rounded to 12
 
         replenishmentService.runBatchReplenishmentScan();
 
@@ -133,7 +133,7 @@ class ReplenishmentPolicyEnrichmentTest {
         ReplenishmentPolicy policy = seedPolicy(sku, location, 10, 20);
         policy.setOrderMultiple(6);
         policyRepository.save(policy);
-        receive(sku, location, 8); // need = 20 - 8 = 12, exact multiple of 6
+        receive(sku, location, new BigDecimal("8")); // need = 20 - 8 = 12, exact multiple of 6
 
         replenishmentService.runBatchReplenishmentScan();
 
@@ -150,7 +150,7 @@ class ReplenishmentPolicyEnrichmentTest {
         ReplenishmentPolicy policy = seedPolicy(sku, location, 5, 20);
         policy.setOrderMultiple(6);
         policyRepository.save(policy);
-        receive(sku, location, 3);
+        receive(sku, location, new BigDecimal("3"));
 
         // Scan creates the open task (need 17 → rounded to 18); its quantity is now the
         // in-progress supply covering the breach.
@@ -182,7 +182,7 @@ class ReplenishmentPolicyEnrichmentTest {
         // which is exercised separately in ReplenishmentSourcingScanTest.
         policy.setPreferredSourceType(ReplenishmentSourceType.INTERNAL_TRANSFER);
         policyRepository.save(policy);
-        receive(sku, location, 3);
+        receive(sku, location, new BigDecimal("3"));
         savePo("APPROVED", location, LocalDate.now(ZoneOffset.UTC).plusDays(1), skuId, "7");
 
         assertThat(leadTimeResolver.resolve(policy).source())
@@ -208,7 +208,7 @@ class ReplenishmentPolicyEnrichmentTest {
         ReplenishmentPolicy policy = seedPolicy(sku, location, 5, 20);
         policy.setSnoozedUntil(Instant.now().plus(Duration.ofHours(1)));
         policyRepository.save(policy);
-        receive(sku, location, 3); // below min — would trigger if not snoozed
+        receive(sku, location, new BigDecimal("3")); // below min — would trigger if not snoozed
 
         ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
 
@@ -229,7 +229,7 @@ class ReplenishmentPolicyEnrichmentTest {
         ReplenishmentPolicy policy = seedPolicy(sku, location, 5, 20);
         policy.setSnoozedUntil(Instant.now().minus(Duration.ofSeconds(1)));
         policyRepository.save(policy);
-        receive(sku, location, 3);
+        receive(sku, location, new BigDecimal("3"));
 
         replenishmentService.runBatchReplenishmentScan();
 
@@ -244,7 +244,7 @@ class ReplenishmentPolicyEnrichmentTest {
         ReplenishmentPolicy policy = seedPolicy(sku, location, 5, 20);
         policy.setActive(Boolean.FALSE);
         policyRepository.save(policy);
-        receive(sku, location, 3);
+        receive(sku, location, new BigDecimal("3"));
 
         ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
 
@@ -346,15 +346,15 @@ class ReplenishmentPolicyEnrichmentTest {
         ReplenishmentPolicy policy = seedPolicy(sku, location, 5, 10);
         policy.setOrderMultiple(6);
         policyRepository.save(policy);
-        receive(sku, location, 3); // need 7 → rounded 12
+        receive(sku, location, new BigDecimal("3")); // need 7 → rounded 12
 
         long tasksBefore = taskRepository.count();
         ReplenishmentNeedResponse need = needFor(sku);
         assertThat(taskRepository.count()).isEqualTo(tasksBefore); // side-effect free
 
         assertThat(need.isWouldTrigger()).isTrue();
-        assertThat(need.getOnHand()).isEqualTo(3);
-        assertThat(need.getProjectedAvailable()).isEqualTo(3);
+        assertThat(need.getOnHand()).isEqualByComparingTo("3");
+        assertThat(need.getProjectedAvailable()).isEqualByComparingTo("3");
         assertThat(need.getSuggestedQuantity()).isEqualTo(12);
         assertThat(need.getMinimumQuantity()).isEqualTo(5);
         assertThat(need.getMaximumQuantity()).isEqualTo(10);
@@ -379,15 +379,15 @@ class ReplenishmentPolicyEnrichmentTest {
         ReplenishmentPolicy policy = seedPolicy(sku, location, 10, 20);
         policy.setLeadTimeDaysOverride(5);
         policyRepository.save(policy);
-        receive(sku, location, 5);
+        receive(sku, location, new BigDecimal("5"));
         // Open reservation remainder of 8 due in 2 days: projected(now) = 5 >= 0, but at
         // the due-date cutoff the projection drops to 5 - 8 = -3 < 0 → deadline = due date.
         Instant due = Instant.now().plus(Duration.ofDays(2));
         reservationRepository.save(ReservationEntity.builder()
                 .workorderLineId(UUID.randomUUID())
                 .stockItemId(skuId)
-                .requiredQuantity(13)
-                .allocatedQuantity(5)
+                .requiredQuantity(new BigDecimal("13"))
+                .allocatedQuantity(new BigDecimal("5"))
                 .status(ReservationStatus.PENDING)
                 .dueDateTime(due)
                 .build());
@@ -411,13 +411,13 @@ class ReplenishmentPolicyEnrichmentTest {
         String sku = skuId.toString();
         UUID location = UUID.randomUUID();
         seedPolicy(sku, location, 5, 20);
-        receive(sku, location, 2);
+        receive(sku, location, new BigDecimal("2"));
         // Overdue reservation remainder of 5: projected(now) = 2 - 5 = -3 < 0 → deadline today.
         reservationRepository.save(ReservationEntity.builder()
                 .workorderLineId(UUID.randomUUID())
                 .stockItemId(skuId)
-                .requiredQuantity(5)
-                .allocatedQuantity(0)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("0"))
                 .status(ReservationStatus.PENDING)
                 .dueDateTime(Instant.now().minus(Duration.ofHours(1)))
                 .build());
@@ -435,7 +435,7 @@ class ReplenishmentPolicyEnrichmentTest {
         String sku = uniqueSku();
         UUID location = UUID.randomUUID();
         seedPolicy(sku, location, 5, 20);
-        receive(sku, location, 3); // below min but never below zero
+        receive(sku, location, new BigDecimal("3")); // below min but never below zero
 
         replenishmentService.runBatchReplenishmentScan();
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ReplenishmentSourcingScanTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ReplenishmentSourcingScanTest.java
@@ -78,7 +78,7 @@ class ReplenishmentSourcingScanTest {
         return "SKU-F5-" + UUID.randomUUID();
     }
 
-    private void receive(String sku, UUID locationId, int quantity) {
+    private void receive(String sku, UUID locationId, BigDecimal quantity) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(locationId)
@@ -144,8 +144,8 @@ class ReplenishmentSourcingScanTest {
         UUID destSite = seedActiveSite();
         UUID srcSite = seedActiveSite();
         seedPolicy(sku, destSite, 5, 20, ReplenishmentSourceType.INTERNAL_TRANSFER);
-        receive(sku, destSite, 3); // pick-face on-hand 3 < min 5 → need 17
-        receive(sku, srcSite, 30); // sibling surplus 30 covers 17
+        receive(sku, destSite, new BigDecimal("3")); // pick-face on-hand 3 < min 5 → need 17
+        receive(sku, srcSite, new BigDecimal("30")); // sibling surplus 30 covers 17
 
         replenishmentService.runBatchReplenishmentScan();
 
@@ -179,8 +179,8 @@ class ReplenishmentSourcingScanTest {
         UUID destSite = seedActiveSite();
         UUID srcSite = seedActiveSite();
         seedPolicy(sku, destSite, 5, 20, ReplenishmentSourceType.INTERNAL_TRANSFER);
-        receive(sku, destSite, 3);
-        receive(sku, srcSite, 20); // 20 on-hand, but the source keeps all 20 as its own floor
+        receive(sku, destSite, new BigDecimal("3"));
+        receive(sku, srcSite, new BigDecimal("20")); // 20 on-hand, but the source keeps all 20 as its own floor
         // Source's own policy min = 20 → offerable surplus = 20 - 0 - 20 = 0 → not a candidate.
         // (min == on-hand so the source policy itself does not trigger: projected 20 !< 20.)
         seedPolicy(sku, srcSite, 20, 40, ReplenishmentSourceType.INTERNAL_TRANSFER);
@@ -201,7 +201,7 @@ class ReplenishmentSourcingScanTest {
         String sku = productId.toString();
         UUID destSite = seedActiveSite();
         ReplenishmentPolicy policy = seedPolicy(sku, destSite, 5, 20, ReplenishmentSourceType.EITHER);
-        receive(sku, destSite, 3); // below min, no sibling surplus anywhere
+        receive(sku, destSite, new BigDecimal("3")); // below min, no sibling surplus anywhere
         seedManufacturerFeed(productId, 50);
 
         replenishmentService.runBatchReplenishmentScan();
@@ -224,8 +224,8 @@ class ReplenishmentSourcingScanTest {
         UUID destSite = seedActiveSite();
         UUID srcSite = seedActiveSite();
         ReplenishmentPolicy policy = seedPolicy(sku, destSite, 5, 20, ReplenishmentSourceType.EITHER);
-        receive(sku, destSite, 3);
-        receive(sku, srcSite, 30);
+        receive(sku, destSite, new BigDecimal("3"));
+        receive(sku, srcSite, new BigDecimal("30"));
         seedManufacturerFeed(productId, 50); // a vendor exists, but internal surplus wins
 
         replenishmentService.runBatchReplenishmentScan();
@@ -247,8 +247,8 @@ class ReplenishmentSourcingScanTest {
         UUID pickFace = seedBin(destSite);
         UUID backstock = seedBin(destSite);
         seedPolicy(sku, pickFace, 5, 20, ReplenishmentSourceType.INTERNAL_TRANSFER);
-        receive(sku, pickFace, 3); // pick face below min → need 17
-        receive(sku, backstock, 30); // same-site backstock surplus
+        receive(sku, pickFace, new BigDecimal("3")); // pick face below min → need 17
+        receive(sku, backstock, new BigDecimal("30")); // same-site backstock surplus
 
         replenishmentService.runBatchReplenishmentScan();
 
@@ -270,8 +270,8 @@ class ReplenishmentSourcingScanTest {
         UUID destSite = seedActiveSite();
         UUID srcSite = seedActiveSite();
         seedPolicy(sku, destSite, 5, 20, ReplenishmentSourceType.INTERNAL_TRANSFER);
-        receive(sku, destSite, 3);
-        receive(sku, srcSite, 30);
+        receive(sku, destSite, new BigDecimal("3"));
+        receive(sku, srcSite, new BigDecimal("30"));
 
         replenishmentService.runBatchReplenishmentScan();
         assertThat(transfersFor(sku)).hasSize(1);
@@ -297,7 +297,7 @@ class ReplenishmentSourcingScanTest {
         String sku = uniqueSku();
         UUID destSite = seedActiveSite();
         seedPolicy(sku, destSite, 5, 20, ReplenishmentSourceType.INTERNAL_TRANSFER);
-        receive(sku, destSite, 3); // below min, no surplus anywhere
+        receive(sku, destSite, new BigDecimal("3")); // below min, no surplus anywhere
 
         replenishmentService.runBatchReplenishmentScan();
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ReservationRequestHandlerTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ReservationRequestHandlerTest.java
@@ -3,7 +3,6 @@ package com.positivity.inventory.internal.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -20,6 +19,7 @@ import com.positivity.inventory.internal.repository.InventoryStockSummaryReposit
 import com.positivity.inventory.internal.repository.ReservationRepository;
 import com.positivity.inventory.service.BackorderService;
 import com.positivity.inventory.service.ReservationService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -75,7 +75,7 @@ class ReservationRequestHandlerTest {
 
     private static InventoryStockSummary summaryWithAtp(long atp) {
         InventoryStockSummary summary = mock(InventoryStockSummary.class);
-        when(summary.getAtp()).thenReturn(atp);
+        when(summary.getAtp()).thenReturn(BigDecimal.valueOf(atp));
         return summary;
     }
 
@@ -89,7 +89,7 @@ class ReservationRequestHandlerTest {
     @Test
     @DisplayName("rejects when neither demand line is set")
     void handle_neitherDemandLine_throws() {
-        assertThatThrownBy(() -> handler.handle(null, null, STOCK_ITEM_ID, 5, LOCATION_ID))
+        assertThatThrownBy(() -> handler.handle(null, null, STOCK_ITEM_ID, new BigDecimal("5"), LOCATION_ID))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("exactly one");
     }
@@ -97,7 +97,8 @@ class ReservationRequestHandlerTest {
     @Test
     @DisplayName("rejects when both demand lines are set")
     void handle_bothDemandLines_throws() {
-        assertThatThrownBy(() -> handler.handle(WORKORDER_LINE_ID, SALES_ORDER_LINE_ID, STOCK_ITEM_ID, 5, LOCATION_ID))
+        assertThatThrownBy(() -> handler.handle(
+                        WORKORDER_LINE_ID, SALES_ORDER_LINE_ID, STOCK_ITEM_ID, new BigDecimal("5"), LOCATION_ID))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("exactly one");
     }
@@ -110,9 +111,9 @@ class ReservationRequestHandlerTest {
         when(summaryRepository.findByStockItemIdAndLocationId(STOCK_ITEM_ID.toString(), LOCATION_ID))
                 .thenReturn(Optional.of(summary));
 
-        handler.handle(WORKORDER_LINE_ID, null, STOCK_ITEM_ID, 5, LOCATION_ID);
+        handler.handle(WORKORDER_LINE_ID, null, STOCK_ITEM_ID, new BigDecimal("5"), LOCATION_ID);
 
-        verify(backorderService, never()).createBackorder(any(), any(), anyInt(), any());
+        verify(backorderService, never()).createBackorder(any(), any(), any(), any());
         ArgumentCaptor<ReservationOutcomeV1> factCaptor = ArgumentCaptor.forClass(ReservationOutcomeV1.class);
         verify(inventoryFactPublisher).recordReservationOutcome(factCaptor.capture());
         ReservationOutcomeV1 fact = factCaptor.getValue();
@@ -133,23 +134,23 @@ class ReservationRequestHandlerTest {
                 .reservationId(RESERVATION_ID)
                 .salesOrderLineId(SALES_ORDER_LINE_ID)
                 .stockItemId(STOCK_ITEM_ID)
-                .requiredQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
                 .status(ReservationStatus.PENDING)
                 .build();
         when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
         when(backorderService.createBackorderForSalesOrderLine(
-                        SALES_ORDER_LINE_ID, STOCK_ITEM_ID.toString(), 3, LOCATION_ID))
+                        SALES_ORDER_LINE_ID, STOCK_ITEM_ID.toString(), new BigDecimal("3"), LOCATION_ID))
                 .thenReturn(BackorderResponse.builder()
                         .backorderId(BACKORDER_ID)
                         .salesOrderLineId(SALES_ORDER_LINE_ID)
                         .status(BackorderStatus.OPEN)
                         .build());
 
-        handler.handle(null, SALES_ORDER_LINE_ID, STOCK_ITEM_ID, 5, LOCATION_ID);
+        handler.handle(null, SALES_ORDER_LINE_ID, STOCK_ITEM_ID, new BigDecimal("5"), LOCATION_ID);
 
         assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.BACKORDERED);
         verify(reservationRepository).save(reservation);
-        verify(backorderService, never()).createBackorder(any(), any(), anyInt(), any());
+        verify(backorderService, never()).createBackorder(any(), any(), any(), any());
 
         ArgumentCaptor<ReservationOutcomeV1> factCaptor = ArgumentCaptor.forClass(ReservationOutcomeV1.class);
         verify(inventoryFactPublisher).recordReservationOutcome(factCaptor.capture());

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/RevaluationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/RevaluationServiceImplTest.java
@@ -130,7 +130,7 @@ class RevaluationServiceImplTest {
         assertThat(fact.costingMethod()).isEqualTo("AVERAGE");
         assertThat(fact.previousUnitCost()).isEqualByComparingTo("4.00");
         assertThat(fact.newUnitCost()).isEqualByComparingTo("5.00");
-        assertThat(fact.onHandQuantity()).isEqualTo(10L);
+        assertThat(fact.onHandQuantity()).isEqualByComparingTo("10");
         assertThat(fact.totalValueDelta()).isEqualByComparingTo("10.00");
         assertThat(fact.actor()).isEqualTo(ACTOR);
     }
@@ -163,7 +163,7 @@ class RevaluationServiceImplTest {
                 .costingMethod(CostingMethod.STANDARD)
                 .previousUnitCost(new BigDecimal("6.000000"))
                 .newUnitCost(new BigDecimal("8.000000"))
-                .onHandQuantity(150L)
+                .onHandQuantity(new BigDecimal("150"))
                 .valueDelta(new BigDecimal("300.0000"))
                 .reason("Standard price correction")
                 .status(RevaluationStatus.PENDING_APPROVAL)
@@ -199,7 +199,7 @@ class RevaluationServiceImplTest {
                 .stockItemId(SKU)
                 .costingMethod(CostingMethod.AVERAGE)
                 .newUnitCost(new BigDecimal("9.000000"))
-                .onHandQuantity(200L)
+                .onHandQuantity(new BigDecimal("200"))
                 .valueDelta(new BigDecimal("1000.0000"))
                 .reason("r")
                 .status(RevaluationStatus.PENDING_APPROVAL)
@@ -282,7 +282,7 @@ class RevaluationServiceImplTest {
                 .stockItemId(SKU)
                 .avgCost(avgCost)
                 .standardCost(standardCost)
-                .onHandQty(onHand)
+                .onHandQty(BigDecimal.valueOf(onHand))
                 .build();
     }
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ScrapServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ScrapServiceImplTest.java
@@ -112,7 +112,7 @@ class ScrapServiceImplTest {
         });
         lenient()
                 .when(ledgerRepository.calculateOnHandQuantityAtLocation(SKU, LOCATION_ID))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
     }
 
     @AfterEach
@@ -181,7 +181,7 @@ class ScrapServiceImplTest {
         stubBelowThreshold();
         UUID ledgerEntryId = stubPostingSuccess();
         when(ledgerRepository.calculateOnHandQuantityAtLocation(SKU, LOCATION_ID))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
 
         ScrapResponse response = service.createScrap(createRequest(ScrapReasonCode.DAMAGED, null));
 
@@ -193,8 +193,8 @@ class ScrapServiceImplTest {
         verify(ledgerPostingService).post(entryCaptor.capture(), eq(false));
         InventoryLedgerEntry entry = entryCaptor.getValue();
         assertThat(entry.getEventType()).isEqualTo(InventoryLedgerEventType.SCRAP_OUT);
-        assertThat(entry.getChangeInQuantity()).isEqualTo(-3);
-        assertThat(entry.getQuantityAfter()).isEqualTo(7);
+        assertThat(entry.getChangeInQuantity()).isEqualByComparingTo("-3");
+        assertThat(entry.getQuantityAfter()).isEqualByComparingTo("7");
         assertThat(entry.getReasonCode()).isEqualTo("DAMAGED");
         assertThat(entry.getSourceTransactionId())
                 .isEqualTo(response.getScrapId().toString());
@@ -217,7 +217,7 @@ class ScrapServiceImplTest {
         stubBelowThreshold();
         stubPostingWithEngineCost(new BigDecimal("2.5000"));
         when(ledgerRepository.calculateOnHandQuantityAtLocation(SKU, LOCATION_ID))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
 
         service.createScrap(createRequest(ScrapReasonCode.DAMAGED, null));
 
@@ -235,7 +235,7 @@ class ScrapServiceImplTest {
         stubPostingWithEngineCost(new BigDecimal("6.0000"));
         when(methodResolver.resolve(SKU)).thenReturn(CostingMethod.STANDARD);
         when(ledgerRepository.calculateOnHandQuantityAtLocation(SKU, LOCATION_ID))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
 
         service.createScrap(createRequest(ScrapReasonCode.DAMAGED, null));
 
@@ -254,7 +254,7 @@ class ScrapServiceImplTest {
         stubBelowThreshold();
         stubPostingWithEngineCost(null);
         when(ledgerRepository.calculateOnHandQuantityAtLocation(SKU, LOCATION_ID))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
 
         service.createScrap(createRequest(ScrapReasonCode.DAMAGED, null));
 
@@ -284,7 +284,7 @@ class ScrapServiceImplTest {
         ScrapRecord pending = pendingScrap();
         when(scrapRepository.findById(pending.getScrapId())).thenReturn(Optional.of(pending));
         when(ledgerRepository.calculateOnHandQuantityAtLocation(SKU, LOCATION_ID))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         stubPostingSuccess();
 
         ScrapResponse response = service.approveScrap(pending.getScrapId(), new ApproveScrapRequest());
@@ -328,7 +328,7 @@ class ScrapServiceImplTest {
         ScrapRecord pending = pendingScrap();
         when(scrapRepository.findById(pending.getScrapId())).thenReturn(Optional.of(pending));
         when(ledgerRepository.calculateOnHandQuantityAtLocation(SKU, LOCATION_ID))
-                .thenReturn(1);
+                .thenReturn(new BigDecimal("1"));
         when(ledgerPostingService.post(any(InventoryLedgerEntry.class), anyBoolean()))
                 .thenThrow(new NegativeStockPolicyViolationException(
                         NegativeStockPolicyViolationException.OVERRIDE_REQUIRED, "below zero"));
@@ -361,7 +361,7 @@ class ScrapServiceImplTest {
         ScrapRecord pending = pendingScrap();
         when(scrapRepository.findById(pending.getScrapId())).thenReturn(Optional.of(pending));
         when(ledgerRepository.calculateOnHandQuantityAtLocation(SKU, LOCATION_ID))
-                .thenReturn(1);
+                .thenReturn(new BigDecimal("1"));
         stubPostingSuccess();
 
         ApproveScrapRequest request =

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/SourcingOrderingStrategiesTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/SourcingOrderingStrategiesTest.java
@@ -15,6 +15,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingCandidate;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingSelection;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -152,15 +153,15 @@ class SourcingOrderingStrategiesTest {
                 .thenReturn(Optional.of(InventoryStockSummary.builder()
                         .stockItemId(SKU)
                         .locationId(LOC_A)
-                        .onHand(9)
-                        .allocated(2)
+                        .onHand(new BigDecimal("9"))
+                        .allocated(new BigDecimal("2"))
                         .build()));
 
         List<SourcingCandidate> ordered = highestStock.order(selectionOf(
                 null,
                 new SourcingCandidate(LOC_A, null), // 9 - 2 = 7 available
-                new SourcingCandidate(LOC_B, 3L),
-                new SourcingCandidate(LOC_C, 7L))); // ties with LOC_A → id tie-break
+                new SourcingCandidate(LOC_B, new BigDecimal("3")),
+                new SourcingCandidate(LOC_C, new BigDecimal("7")))); // ties with LOC_A → id tie-break
 
         assertThat(locations(ordered)).containsExactly(LOC_A, LOC_C, LOC_B);
     }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/SourcingStrategyServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/SourcingStrategyServiceImplTest.java
@@ -19,6 +19,7 @@ import com.positivity.inventory.internal.service.SourcingStrategyService.SourceS
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingCandidate;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingDecision;
 import com.positivity.inventory.internal.service.SourcingStrategyService.SourcingSelection;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -294,9 +295,14 @@ class SourcingStrategyServiceImplTest {
     void selectSource_picksFirstCandidateWithSurplus() {
         // Default FIFO order is [LOC_A, LOC_B]; LOC_A has too little.
         SourcingSelection selection = new SourcingSelection(
-                SKU, SITE_ID, null, List.of(new SourcingCandidate(LOC_A, 3L), new SourcingCandidate(LOC_B, 10L)));
+                SKU,
+                SITE_ID,
+                null,
+                List.of(
+                        new SourcingCandidate(LOC_A, new BigDecimal("3")),
+                        new SourcingCandidate(LOC_B, new BigDecimal("10"))));
 
-        Optional<SourceSelection> picked = service.selectSource(selection, 5);
+        Optional<SourceSelection> picked = service.selectSource(selection, new BigDecimal("5"));
 
         assertThat(picked).isPresent();
         assertThat(picked.orElseThrow().candidate().locationId()).isEqualTo(LOC_B);
@@ -307,9 +313,14 @@ class SourcingStrategyServiceImplTest {
     @DisplayName("selectSource is empty when no candidate covers the needed quantity")
     void selectSource_emptyWithoutSurplus() {
         SourcingSelection selection = new SourcingSelection(
-                SKU, SITE_ID, null, List.of(new SourcingCandidate(LOC_A, 3L), new SourcingCandidate(LOC_B, 4L)));
+                SKU,
+                SITE_ID,
+                null,
+                List.of(
+                        new SourcingCandidate(LOC_A, new BigDecimal("3")),
+                        new SourcingCandidate(LOC_B, new BigDecimal("4"))));
 
-        assertThat(service.selectSource(selection, 5)).isEmpty();
+        assertThat(service.selectSource(selection, new BigDecimal("5"))).isEmpty();
     }
 
     // ─── Admin operations ────────────────────────────────────────────────────

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/StandardCostingStrategyTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/StandardCostingStrategyTest.java
@@ -28,16 +28,16 @@ class StandardCostingStrategyTest {
     @Test
     @DisplayName("stamps the configured standard price; receipts do not change it")
     void stampsStandardPrice_receiptDoesNotChangeIt() {
-        CostState state = new CostState(null, 0, new BigDecimal("12.5"));
-        CostingResult receipt = strategy.cost(
-                new CostingInput(SKU, InventoryLedgerEventType.GOODS_RECEIPT, 10, new BigDecimal("9"), state));
+        CostState state = new CostState(null, new BigDecimal("0"), new BigDecimal("12.5"));
+        CostingResult receipt = strategy.cost(new CostingInput(
+                SKU, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("10"), new BigDecimal("9"), state));
         assertThat(receipt.unitCost()).isEqualByComparingTo("12.5");
         assertThat(receipt.state().standardCost()).isEqualByComparingTo("12.5");
         // latest-receipt-cost memo is remembered but never overrides the standard price
         assertThat(receipt.state().avgCost()).isEqualByComparingTo("9");
 
-        CostingResult issue =
-                strategy.cost(new CostingInput(SKU, InventoryLedgerEventType.GOODS_ISSUE, -4, null, receipt.state()));
+        CostingResult issue = strategy.cost(new CostingInput(
+                SKU, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-4"), null, receipt.state()));
         assertThat(issue.unitCost()).isEqualByComparingTo("12.5");
     }
 
@@ -45,18 +45,26 @@ class StandardCostingStrategyTest {
     @DisplayName("no standard price: falls back to latest receipt cost, then to null")
     void noStandardPrice_fallsBackToLatestReceiptCostThenNull() {
         // First issue with no prior receipt and no standard -> uncosted (null).
-        CostingResult firstIssue = strategy.cost(
-                new CostingInput(SKU, InventoryLedgerEventType.GOODS_ISSUE, -2, null, new CostState(null, 0, null)));
+        CostingResult firstIssue = strategy.cost(new CostingInput(
+                SKU,
+                InventoryLedgerEventType.GOODS_ISSUE,
+                new BigDecimal("-2"),
+                null,
+                new CostState(null, new BigDecimal("0"), null)));
         assertThat(firstIssue.unitCost()).isNull();
 
         // A receipt records the latest receipt cost memo.
         CostingResult receipt = strategy.cost(new CostingInput(
-                SKU, InventoryLedgerEventType.GOODS_RECEIPT, 10, new BigDecimal("7.25"), firstIssue.state()));
+                SKU,
+                InventoryLedgerEventType.GOODS_RECEIPT,
+                new BigDecimal("10"),
+                new BigDecimal("7.25"),
+                firstIssue.state()));
         assertThat(receipt.unitCost()).isEqualByComparingTo("7.25");
 
         // Subsequent issue with still no standard price falls back to that latest receipt cost.
-        CostingResult issue =
-                strategy.cost(new CostingInput(SKU, InventoryLedgerEventType.GOODS_ISSUE, -3, null, receipt.state()));
+        CostingResult issue = strategy.cost(new CostingInput(
+                SKU, InventoryLedgerEventType.GOODS_ISSUE, new BigDecimal("-3"), null, receipt.state()));
         assertThat(issue.unitCost()).isEqualByComparingTo("7.25");
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/StockSummaryReadBenchmarkTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/StockSummaryReadBenchmarkTest.java
@@ -7,6 +7,7 @@ import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.service.InventoryAvailabilityService;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -80,8 +81,8 @@ class StockSummaryReadBenchmarkTest {
                     .stockItemId(skus.get(random.nextInt(skuCount)).toString())
                     .locationId(locations.get(random.nextInt(locationCount)))
                     .eventType(issue ? InventoryLedgerEventType.GOODS_ISSUE : InventoryLedgerEventType.GOODS_RECEIPT)
-                    .changeInQuantity(issue ? -random.nextInt(3) : 1 + random.nextInt(10))
-                    .quantityAfter(0)
+                    .changeInQuantity(BigDecimal.valueOf(issue ? -random.nextInt(3) : 1 + random.nextInt(10)))
+                    .quantityAfter(new BigDecimal("0"))
                     .transactionUserId("benchmark")
                     .build());
             if (batch.size() == 1000) {

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/StockSummaryRebuildAndDriftTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/StockSummaryRebuildAndDriftTest.java
@@ -7,6 +7,7 @@ import com.positivity.inventory.internal.entity.InventoryStockSummary;
 import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
+import java.math.BigDecimal;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -47,13 +48,13 @@ class StockSummaryRebuildAndDriftTest {
         ledgerRepository.deleteAll();
     }
 
-    private void post(String sku, UUID location, InventoryLedgerEventType type, int change) {
+    private void post(String sku, UUID location, InventoryLedgerEventType type, BigDecimal change) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(location)
                 .eventType(type)
                 .changeInQuantity(change)
-                .quantityAfter(0)
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("rebuild-test")
                 .build());
     }
@@ -65,15 +66,15 @@ class StockSummaryRebuildAndDriftTest {
         UUID loc1 = UUID.randomUUID();
         UUID loc2 = UUID.randomUUID();
 
-        post(skuA, loc1, InventoryLedgerEventType.GOODS_RECEIPT, 40);
-        post(skuA, loc1, InventoryLedgerEventType.ALLOCATION_CREATED, 15);
-        post(skuA, loc2, InventoryLedgerEventType.TRANSFER_IN, 7);
-        post(skuB, loc1, InventoryLedgerEventType.GOODS_RECEIPT, 3);
+        post(skuA, loc1, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("40"));
+        post(skuA, loc1, InventoryLedgerEventType.ALLOCATION_CREATED, new BigDecimal("15"));
+        post(skuA, loc2, InventoryLedgerEventType.TRANSFER_IN, new BigDecimal("7"));
+        post(skuB, loc1, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("3"));
         // K1 (#1027): consumption may not drive on-hand negative — seed the
         // null-location key before consuming from it.
-        post(skuB, null, InventoryLedgerEventType.GOODS_RECEIPT, 6);
-        post(skuB, null, InventoryLedgerEventType.WORKORDER_CONSUMPTION, -2);
-        post(skuB, loc1, InventoryLedgerEventType.RESERVATION_CREATED, 1);
+        post(skuB, null, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("6"));
+        post(skuB, null, InventoryLedgerEventType.WORKORDER_CONSUMPTION, new BigDecimal("-2"));
+        post(skuB, loc1, InventoryLedgerEventType.RESERVATION_CREATED, new BigDecimal("1"));
 
         var liveRows = summaryRepository.findAll();
 
@@ -100,14 +101,14 @@ class StockSummaryRebuildAndDriftTest {
     void verifier_reportsDriftWithoutMutating() {
         String sku = "SKU-DRIFT-" + UUID.randomUUID();
         UUID location = UUID.randomUUID();
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 25);
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("25"));
 
         assertThat(driftVerifier.verify()).isZero();
 
         // Corrupt the summary out-of-band (simulating a bypassing write).
         InventoryStockSummary row =
                 summaryRepository.findByStockItemIdAndLocationId(sku, location).orElseThrow();
-        row.setOnHand(999);
+        row.setOnHand(new BigDecimal("999"));
         summaryRepository.save(row);
 
         int drifted = driftVerifier.verify();
@@ -118,7 +119,7 @@ class StockSummaryRebuildAndDriftTest {
                         .findByStockItemIdAndLocationId(sku, location)
                         .orElseThrow()
                         .getOnHand())
-                .isEqualTo(999);
+                .isEqualByComparingTo("999");
 
         // Repair path is the rebuild.
         rebuildService.rebuildFromLedger();
@@ -126,7 +127,7 @@ class StockSummaryRebuildAndDriftTest {
                         .findByStockItemIdAndLocationId(sku, location)
                         .orElseThrow()
                         .getOnHand())
-                .isEqualTo(25);
+                .isEqualByComparingTo("25");
         assertThat(driftVerifier.verify()).isZero();
     }
 
@@ -138,15 +139,15 @@ class StockSummaryRebuildAndDriftTest {
         UUID source = UUID.randomUUID();
         UUID destination = UUID.randomUUID();
 
-        post(sku, source, InventoryLedgerEventType.GOODS_RECEIPT, 10);
+        post(sku, source, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("10"));
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(source)
                 .fromLocationId(source)
                 .toLocationId(destination)
                 .eventType(InventoryLedgerEventType.TRANSFER_OUT)
-                .changeInQuantity(-6)
-                .quantityAfter(4)
+                .changeInQuantity(new BigDecimal("-6"))
+                .quantityAfter(new BigDecimal("4"))
                 .transactionUserId("rebuild-test")
                 .build());
         ledgerPostingService.post(InventoryLedgerEntry.builder()
@@ -155,16 +156,16 @@ class StockSummaryRebuildAndDriftTest {
                 .fromLocationId(source)
                 .toLocationId(destination)
                 .eventType(InventoryLedgerEventType.TRANSFER_IN)
-                .changeInQuantity(2)
-                .quantityAfter(2)
+                .changeInQuantity(new BigDecimal("2"))
+                .quantityAfter(new BigDecimal("2"))
                 .transactionUserId("rebuild-test")
                 .build());
 
         InventoryStockSummary liveDestination = summaryRepository
                 .findByStockItemIdAndLocationId(sku, destination)
                 .orElseThrow();
-        assertThat(liveDestination.getOnHand()).isEqualTo(2);
-        assertThat(liveDestination.getInTransitQty()).isEqualTo(4);
+        assertThat(liveDestination.getOnHand()).isEqualByComparingTo("2");
+        assertThat(liveDestination.getInTransitQty()).isEqualByComparingTo("4");
         assertThat(driftVerifier.verify()).isZero();
 
         rebuildService.rebuildFromLedger();
@@ -172,16 +173,16 @@ class StockSummaryRebuildAndDriftTest {
         InventoryStockSummary rebuiltDestination = summaryRepository
                 .findByStockItemIdAndLocationId(sku, destination)
                 .orElseThrow();
-        assertThat(rebuiltDestination.getOnHand()).isEqualTo(2);
-        assertThat(rebuiltDestination.getInTransitQty()).isEqualTo(4);
+        assertThat(rebuiltDestination.getOnHand()).isEqualByComparingTo("2");
+        assertThat(rebuiltDestination.getInTransitQty()).isEqualByComparingTo("4");
         InventoryStockSummary rebuiltSource =
                 summaryRepository.findByStockItemIdAndLocationId(sku, source).orElseThrow();
-        assertThat(rebuiltSource.getOnHand()).isEqualTo(4);
+        assertThat(rebuiltSource.getOnHand()).isEqualByComparingTo("4");
         assertThat(rebuiltSource.getInTransitQty()).isZero();
         assertThat(driftVerifier.verify()).isZero();
 
         // Out-of-band in-transit corruption is drift like any other column.
-        rebuiltDestination.setInTransitQty(999);
+        rebuiltDestination.setInTransitQty(new BigDecimal("999"));
         summaryRepository.save(rebuiltDestination);
         assertThat(driftVerifier.verify()).isEqualTo(1);
     }
@@ -190,7 +191,7 @@ class StockSummaryRebuildAndDriftTest {
     void verifier_reportsMissingSummaryRowForLedgerBalance() {
         String sku = "SKU-MISSING-" + UUID.randomUUID();
         UUID location = UUID.randomUUID();
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 5);
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("5"));
 
         summaryRepository.deleteAll();
 
@@ -199,14 +200,14 @@ class StockSummaryRebuildAndDriftTest {
 
     // ─── odoo-parity E1 (#1038): per-lot rows follow the same funnel/rebuild/drift math ───
 
-    private void postWithLot(String sku, UUID location, UUID lotId, InventoryLedgerEventType type, int change) {
+    private void postWithLot(String sku, UUID location, UUID lotId, InventoryLedgerEventType type, BigDecimal change) {
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(location)
                 .lotId(lotId)
                 .eventType(type)
                 .changeInQuantity(change)
-                .quantityAfter(0)
+                .quantityAfter(new BigDecimal("0"))
                 .transactionUserId("rebuild-test")
                 .build());
     }
@@ -219,23 +220,23 @@ class StockSummaryRebuildAndDriftTest {
         UUID lotB = UUID.randomUUID();
 
         // Mixed stream: two lot-tagged receipts and one untracked receipt at the same key.
-        postWithLot(sku, location, lotA, InventoryLedgerEventType.GOODS_RECEIPT, 10);
-        postWithLot(sku, location, lotB, InventoryLedgerEventType.GOODS_RECEIPT, 4);
-        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, 3);
+        postWithLot(sku, location, lotA, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("10"));
+        postWithLot(sku, location, lotB, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("4"));
+        post(sku, location, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("3"));
 
         // Lot-agnostic row aggregates EVERYTHING (conservation: equal to pre-lot behavior).
         InventoryStockSummary agnostic =
                 summaryRepository.findByStockItemIdAndLocationId(sku, location).orElseThrow();
-        assertThat(agnostic.getOnHand()).isEqualTo(17);
+        assertThat(agnostic.getOnHand()).isEqualByComparingTo("17");
         assertThat(agnostic.getLotId()).isNull();
 
         // Per-lot rows carry only their lot's deltas.
         InventoryStockSummary lotARow =
                 summaryRepository.findByKey(sku, location, lotA).orElseThrow();
-        assertThat(lotARow.getOnHand()).isEqualTo(10);
+        assertThat(lotARow.getOnHand()).isEqualByComparingTo("10");
         InventoryStockSummary lotBRow =
                 summaryRepository.findByKey(sku, location, lotB).orElseThrow();
-        assertThat(lotBRow.getOnHand()).isEqualTo(4);
+        assertThat(lotBRow.getOnHand()).isEqualByComparingTo("4");
 
         // The three rows are consistent with the funnel's dual-row math → verifier clean.
         assertThat(driftVerifier.verify()).isZero();
@@ -248,16 +249,16 @@ class StockSummaryRebuildAndDriftTest {
                         .findByStockItemIdAndLocationId(sku, location)
                         .orElseThrow()
                         .getOnHand())
-                .isEqualTo(17);
+                .isEqualByComparingTo("17");
         InventoryStockSummary rebuiltLotA =
                 summaryRepository.findByKey(sku, location, lotA).orElseThrow();
-        assertThat(rebuiltLotA.getOnHand()).isEqualTo(10);
+        assertThat(rebuiltLotA.getOnHand()).isEqualByComparingTo("10");
         assertThat(rebuiltLotA.getLastLedgerEntryId()).isEqualTo(lotARow.getLastLedgerEntryId());
         assertThat(summaryRepository
                         .findByKey(sku, location, lotB)
                         .orElseThrow()
                         .getOnHand())
-                .isEqualTo(4);
+                .isEqualByComparingTo("4");
         assertThat(driftVerifier.verify()).isZero();
     }
 
@@ -266,13 +267,13 @@ class StockSummaryRebuildAndDriftTest {
         String sku = "SKU-LOT-DRIFT-" + UUID.randomUUID();
         UUID location = UUID.randomUUID();
         UUID lot = UUID.randomUUID();
-        postWithLot(sku, location, lot, InventoryLedgerEventType.GOODS_RECEIPT, 7);
+        postWithLot(sku, location, lot, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("7"));
 
         assertThat(driftVerifier.verify()).isZero();
 
         InventoryStockSummary lotRow =
                 summaryRepository.findByKey(sku, location, lot).orElseThrow();
-        lotRow.setOnHand(999);
+        lotRow.setOnHand(new BigDecimal("999"));
         summaryRepository.save(lotRow);
 
         // Exactly one drifted key: the per-lot row; the agnostic row is still consistent.
@@ -280,7 +281,7 @@ class StockSummaryRebuildAndDriftTest {
 
         rebuildService.rebuildFromLedger();
         assertThat(summaryRepository.findByKey(sku, location, lot).orElseThrow().getOnHand())
-                .isEqualTo(7);
+                .isEqualByComparingTo("7");
         assertThat(driftVerifier.verify()).isZero();
     }
 
@@ -293,7 +294,7 @@ class StockSummaryRebuildAndDriftTest {
         UUID destination = UUID.randomUUID();
         UUID lot = UUID.randomUUID();
 
-        postWithLot(sku, source, lot, InventoryLedgerEventType.GOODS_RECEIPT, 10);
+        postWithLot(sku, source, lot, InventoryLedgerEventType.GOODS_RECEIPT, new BigDecimal("10"));
         ledgerPostingService.post(InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .locationId(source)
@@ -301,17 +302,17 @@ class StockSummaryRebuildAndDriftTest {
                 .toLocationId(destination)
                 .lotId(lot)
                 .eventType(InventoryLedgerEventType.TRANSFER_OUT)
-                .changeInQuantity(-6)
-                .quantityAfter(4)
+                .changeInQuantity(new BigDecimal("-6"))
+                .quantityAfter(new BigDecimal("4"))
                 .transactionUserId("rebuild-test")
                 .build());
 
         InventoryStockSummary agnosticDestination =
                 summaryRepository.findByKey(sku, destination, null).orElseThrow();
-        assertThat(agnosticDestination.getInTransitQty()).isEqualTo(6);
+        assertThat(agnosticDestination.getInTransitQty()).isEqualByComparingTo("6");
         InventoryStockSummary lotDestination =
                 summaryRepository.findByKey(sku, destination, lot).orElseThrow();
-        assertThat(lotDestination.getInTransitQty()).isEqualTo(6);
+        assertThat(lotDestination.getInTransitQty()).isEqualByComparingTo("6");
         assertThat(driftVerifier.verify()).isZero();
 
         rebuildService.rebuildFromLedger();
@@ -319,7 +320,7 @@ class StockSummaryRebuildAndDriftTest {
                         .findByKey(sku, destination, lot)
                         .orElseThrow()
                         .getInTransitQty())
-                .isEqualTo(6);
+                .isEqualByComparingTo("6");
         assertThat(driftVerifier.verify()).isZero();
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/TransferOrderServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/TransferOrderServiceImplTest.java
@@ -109,7 +109,7 @@ class TransferOrderServiceImplTest {
         });
         when(ledgerPostingService.postAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(ledgerRepository.calculateOnHandQuantityAtLocation(anyString(), any(UUID.class)))
-                .thenReturn(50);
+                .thenReturn(new BigDecimal("50"));
         when(storageLocationRepository.findById(any())).thenReturn(Optional.empty());
         when(lotOutboundService.resolveOutboundLot(anyString(), any())).thenReturn(null);
     }
@@ -376,8 +376,8 @@ class TransferOrderServiceImplTest {
             List<InventoryLedgerEntry> entries = postedEntries();
             assertThat(entries).hasSize(1);
             assertThat(entries.get(0).getEventType()).isEqualTo(InventoryLedgerEventType.TRANSFER_OUT);
-            assertThat(entries.get(0).getChangeInQuantity()).isEqualTo(-10);
-            assertThat(entries.get(0).getQuantityAfter()).isEqualTo(40);
+            assertThat(entries.get(0).getChangeInQuantity()).isEqualByComparingTo("-10");
+            assertThat(entries.get(0).getQuantityAfter()).isEqualByComparingTo("40");
             assertThat(entries.get(0).getLocationId()).isEqualTo(SOURCE_SITE);
             assertThat(entries.get(0).getToLocationId()).isEqualTo(DESTINATION_SITE);
             assertThat(entries.get(0).getSourceTransactionId()).isEqualTo(ORDER_ID.toString());
@@ -399,7 +399,7 @@ class TransferOrderServiceImplTest {
                                     .build()))
                             .build());
 
-            assertThat(postedEntries().get(0).getChangeInQuantity()).isEqualTo(-4);
+            assertThat(postedEntries().get(0).getChangeInQuantity()).isEqualByComparingTo("-4");
         }
 
         @Test
@@ -517,7 +517,7 @@ class TransferOrderServiceImplTest {
             List<InventoryLedgerEntry> entries = postedEntries();
             assertThat(entries).hasSize(1);
             assertThat(entries.get(0).getEventType()).isEqualTo(InventoryLedgerEventType.TRANSFER_IN);
-            assertThat(entries.get(0).getChangeInQuantity()).isEqualTo(10);
+            assertThat(entries.get(0).getChangeInQuantity()).isEqualByComparingTo("10");
             assertThat(entries.get(0).getLocationId()).isEqualTo(DESTINATION_SITE);
             assertThat(dispatched.getLines().get(0).getReceivedQty()).isEqualTo(10);
             assertThat(response.getStatus()).isEqualTo(TransferOrderStatus.RECEIVED);
@@ -600,9 +600,9 @@ class TransferOrderServiceImplTest {
             List<InventoryLedgerEntry> entries = postedEntries();
             assertThat(entries).hasSize(2);
             assertThat(entries.get(0).getEventType()).isEqualTo(InventoryLedgerEventType.TRANSFER_IN);
-            assertThat(entries.get(0).getChangeInQuantity()).isEqualTo(6);
+            assertThat(entries.get(0).getChangeInQuantity()).isEqualByComparingTo("6");
             assertThat(entries.get(1).getEventType()).isEqualTo(InventoryLedgerEventType.SCRAP_OUT);
-            assertThat(entries.get(1).getChangeInQuantity()).isEqualTo(-6);
+            assertThat(entries.get(1).getChangeInQuantity()).isEqualByComparingTo("-6");
             assertThat(entries.get(1).getReasonCode()).isEqualTo(ScrapReasonCode.LOST.name());
             assertThat(entries.get(1).getUnitCost()).isEqualByComparingTo("12.50");
             assertThat(entries.get(1).getNotes()).isEqualTo("claim filed");
@@ -651,7 +651,7 @@ class TransferOrderServiceImplTest {
             assertThat(entries.get(1).getToLocationId()).isEqualTo(SOURCE_SITE);
             assertThat(entries.get(2).getEventType()).isEqualTo(InventoryLedgerEventType.TRANSFER_IN);
             assertThat(entries.get(2).getLocationId()).isEqualTo(SOURCE_SITE);
-            assertThat(entries.get(2).getChangeInQuantity()).isEqualTo(3);
+            assertThat(entries.get(2).getChangeInQuantity()).isEqualByComparingTo("3");
         }
 
         @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ValuationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/internal/service/ValuationServiceImplTest.java
@@ -88,7 +88,7 @@ class ValuationServiceImplTest {
                 .stockItemId(sku)
                 .avgCost(avg)
                 .standardCost(std)
-                .onHandQty(qty)
+                .onHandQty(BigDecimal.valueOf(qty))
                 .build();
     }
 
@@ -100,8 +100,8 @@ class ValuationServiceImplTest {
             }
 
             @Override
-            public long getOnHand() {
-                return qty;
+            public BigDecimal getOnHand() {
+                return BigDecimal.valueOf(qty);
             }
         };
     }
@@ -114,8 +114,8 @@ class ValuationServiceImplTest {
             }
 
             @Override
-            public Long getOnHandQuantity() {
-                return qty;
+            public BigDecimal getOnHandQuantity() {
+                return BigDecimal.valueOf(qty);
             }
         };
     }
@@ -125,7 +125,7 @@ class ValuationServiceImplTest {
         return InventoryLedgerEntry.builder()
                 .stockItemId(sku)
                 .eventType(type)
-                .changeInQuantity(change)
+                .changeInQuantity(BigDecimal.valueOf(change))
                 .unitCost(unitCost)
                 .build();
     }
@@ -144,7 +144,7 @@ class ValuationServiceImplTest {
         assertThat(report.getRows()).hasSize(1);
         ValuationRow row = report.getRows().get(0);
         assertThat(row.getStockItemId()).isEqualTo(SKU_A);
-        assertThat(row.getOnHand()).isEqualTo(20L);
+        assertThat(row.getOnHand()).isEqualByComparingTo("20");
         assertThat(row.getCostingMethod()).isEqualTo("AVERAGE");
         assertThat(row.getUnitCostCurrent()).isEqualByComparingTo("6.0000");
         assertThat(row.getOnHandValue()).isEqualByComparingTo("120.0000");
@@ -239,7 +239,7 @@ class ValuationServiceImplTest {
         InventoryStockSummary row = InventoryStockSummary.builder()
                 .stockItemId(SKU_A)
                 .locationId(LOC_1)
-                .onHand(4L)
+                .onHand(new BigDecimal("4"))
                 .build();
         when(stockSummaryRepository.findByStockItemIdAndLocationId(SKU_A, LOC_1))
                 .thenReturn(Optional.of(row));

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/AllocationReallocationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/AllocationReallocationServiceImplTest.java
@@ -17,6 +17,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.ReservationRepository;
 import com.positivity.inventory.internal.service.AllocationReallocationServiceImpl;
 import com.positivity.security.common.GatewaySecurityConstants;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -117,8 +118,8 @@ class AllocationReallocationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(workorderId)
                 .stockItemId(stockItemId)
-                .requiredQuantity(required)
-                .allocatedQuantity(0)
+                .requiredQuantity(BigDecimal.valueOf(required))
+                .allocatedQuantity(new BigDecimal("0"))
                 .priority(priority)
                 .waitingSince(waitingSince)
                 .status(ReservationStatus.PENDING)
@@ -150,11 +151,11 @@ class AllocationReallocationServiceImplTest {
         ReservationEntity lowPrio = buildReservation(WORKORDER_LOW_PRIO, stockItemId, 8, 5, null);
         // AC5: previousTotalAllocated must be non-zero so the redistribution pool
         // exists
-        highPrio.setAllocatedQuantity(5);
-        lowPrio.setAllocatedQuantity(5);
+        highPrio.setAllocatedQuantity(new BigDecimal("5"));
+        lowPrio.setAllocatedQuantity(new BigDecimal("5"));
         when(reservationRepository.findByStockItemId(stockItemId)).thenReturn(java.util.List.of(highPrio, lowPrio));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(reservationRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationAuditRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -197,11 +198,11 @@ class AllocationReallocationServiceImplTest {
         ReservationEntity lowPrio = buildReservation(WORKORDER_LOW_PRIO, stockItemId, 8, 5, null);
         // AC5: previousTotalAllocated must be non-zero so the redistribution pool
         // exists
-        highPrio.setAllocatedQuantity(5);
-        lowPrio.setAllocatedQuantity(5);
+        highPrio.setAllocatedQuantity(new BigDecimal("5"));
+        lowPrio.setAllocatedQuantity(new BigDecimal("5"));
         when(reservationRepository.findByStockItemId(stockItemId)).thenReturn(java.util.List.of(highPrio, lowPrio));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(reservationRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationAuditRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -255,7 +256,7 @@ class AllocationReallocationServiceImplTest {
         ReservationEntity reservation = buildReservation(WORKORDER_LOW_PRIO, stockItemId, 5, 5, null);
         when(reservationRepository.findByStockItemId(stockItemId)).thenReturn(java.util.List.of(reservation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
-                .thenReturn(3);
+                .thenReturn(new BigDecimal("3"));
         when(reservationRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationAuditRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -294,18 +295,18 @@ class AllocationReallocationServiceImplTest {
     void AC3_atpConsistency_atpUnchangedAfterReallocation() {
         // Issue #24: AC3 — reallocation redistributes among existing allocations; ATP
         // must not change
-        int onHand = 10;
-        int totalAllocatedBefore = 7;
-        int expectedAtp = onHand - totalAllocatedBefore; // 3
+        BigDecimal onHand = new BigDecimal("10");
+        BigDecimal totalAllocatedBefore = new BigDecimal("7");
+        BigDecimal expectedAtp = onHand.subtract(totalAllocatedBefore); // 3
 
         UUID stockItemId = STOCK_ITEM_ID;
         ReservationEntity reservation = buildReservation(WORKORDER_HIGH_PRIO, stockItemId, 3, 7, null);
         // PRCR-C02: pre-existing allocation of 7 units must be set so that
         // previousTotalAllocated = 7, and ATP after reallocation = 10 - 7 = 3.
-        reservation.setAllocatedQuantity(7);
+        reservation.setAllocatedQuantity(new BigDecimal("7"));
         when(reservationRepository.findByStockItemId(stockItemId)).thenReturn(java.util.List.of(reservation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(reservationRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationAuditRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -379,13 +380,13 @@ class AllocationReallocationServiceImplTest {
         // (previousTotalAllocated)
         // is non-zero; both reservations had 4 units allocated before this
         // reallocation.
-        agedWaiter.setAllocatedQuantity(4);
-        freshHigher.setAllocatedQuantity(4);
+        agedWaiter.setAllocatedQuantity(new BigDecimal("4"));
+        freshHigher.setAllocatedQuantity(new BigDecimal("4"));
 
         when(reservationRepository.findByStockItemId(stockItemId))
                 .thenReturn(java.util.List.of(freshHigher, agedWaiter));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
-                .thenReturn(5);
+                .thenReturn(new BigDecimal("5"));
         when(reservationRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationAuditRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -408,7 +409,7 @@ class AllocationReallocationServiceImplTest {
                 .isGreaterThanOrEqualTo(1);
         assertThat(agedWaiter.getAllocatedQuantity())
                 .as("Long-waiting workorder must be allocated 4 units after aging improves priority")
-                .isEqualTo(4);
+                .isEqualByComparingTo("4");
         assertThat(savedAudits)
                 .as("At least one audit record must have PRIORITY_AGED reason code when aging changes allocation")
                 .anyMatch(a -> a.getReasonCode() == AllocationAuditReasonCode.PRIORITY_AGED);
@@ -424,8 +425,8 @@ class AllocationReallocationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(WORKORDER_HIGH_PRIO)
                 .stockItemId(stockItemId)
-                .requiredQuantity(5)
-                .allocatedQuantity(0)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("0"))
                 .priority(5)
                 .waitingSince(null)
                 .dueDateTime(FIXED_NOW.plus(Duration.ofDays(1)))
@@ -438,8 +439,8 @@ class AllocationReallocationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(WORKORDER_LOW_PRIO)
                 .stockItemId(stockItemId)
-                .requiredQuantity(5)
-                .allocatedQuantity(0)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("0"))
                 .priority(5)
                 .waitingSince(null)
                 .dueDateTime(FIXED_NOW.plus(Duration.ofDays(7)))
@@ -450,12 +451,12 @@ class AllocationReallocationServiceImplTest {
                 .build();
         // AC5: lateDueDate previously held the 5-unit allocation; after reallocation
         // earlyDueDate wins the tie-break by dueDateTime.
-        lateDueDate.setAllocatedQuantity(5);
+        lateDueDate.setAllocatedQuantity(new BigDecimal("5"));
 
         when(reservationRepository.findByStockItemId(stockItemId))
                 .thenReturn(java.util.List.of(lateDueDate, earlyDueDate));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
-                .thenReturn(5);
+                .thenReturn(new BigDecimal("5"));
         when(reservationRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationAuditRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -469,7 +470,7 @@ class AllocationReallocationServiceImplTest {
 
         assertThat(earlyDueDate.getAllocatedQuantity())
                 .as("Workorder with earlier dueDateTime must receive stock first when priorities are equal")
-                .isEqualTo(5);
+                .isEqualByComparingTo("5");
         assertThat(lateDueDate.getAllocatedQuantity())
                 .as("Workorder with later dueDateTime must receive 0 when stock is insufficient")
                 .isZero();
@@ -483,7 +484,7 @@ class AllocationReallocationServiceImplTest {
         ReservationEntity reservation = buildReservation(WORKORDER_HIGH_PRIO, stockItemId, 1, 5, null);
         when(reservationRepository.findByStockItemId(stockItemId)).thenReturn(List.of(reservation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(reservationRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationAuditRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -519,10 +520,10 @@ class AllocationReallocationServiceImplTest {
         // AC5: seed allocation so the pool is non-zero and the reservation reaches the
         // if-branch, producing an audit record with the parsed (not STOCK_SHORTAGE)
         // reason.
-        reservation.setAllocatedQuantity(5);
+        reservation.setAllocatedQuantity(new BigDecimal("5"));
         when(reservationRepository.findByStockItemId(stockItemId)).thenReturn(List.of(reservation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(reservationRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationAuditRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -556,10 +557,10 @@ class AllocationReallocationServiceImplTest {
         ReservationEntity reservation = buildReservation(WORKORDER_HIGH_PRIO, stockItemId, 1, 5, null);
         // AC5: seed allocation so the pool is non-zero and the reservation reaches the
         // if-branch, producing an audit record with the parsed SCHEDULE_CHANGE reason.
-        reservation.setAllocatedQuantity(5);
+        reservation.setAllocatedQuantity(new BigDecimal("5"));
         when(reservationRepository.findByStockItemId(stockItemId)).thenReturn(List.of(reservation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(reservationRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationAuditRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -597,12 +598,12 @@ class AllocationReallocationServiceImplTest {
         ReservationEntity higherPrioReservation = buildReservation(WORKORDER_HIGH_PRIO, stockItemId, 7, 5, null);
         // AC5: seed prior allocation on the lower-priority reservation so that
         // previousTotalAllocated = 5 and the pool is available for redistribution.
-        noAgingReservation.setAllocatedQuantity(5);
+        noAgingReservation.setAllocatedQuantity(new BigDecimal("5"));
 
         when(reservationRepository.findByStockItemId(stockItemId))
                 .thenReturn(List.of(noAgingReservation, higherPrioReservation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
-                .thenReturn(5);
+                .thenReturn(new BigDecimal("5"));
         when(reservationRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationAuditRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -617,7 +618,7 @@ class AllocationReallocationServiceImplTest {
 
         // Assert
         // higherPrioReservation (prio 7) should get the stock
-        assertThat(higherPrioReservation.getAllocatedQuantity()).isEqualTo(5);
+        assertThat(higherPrioReservation.getAllocatedQuantity()).isEqualByComparingTo("5");
         // noAgingReservation (prio 8) should not get stock, because no aging occurred
         assertThat(noAgingReservation.getAllocatedQuantity()).isZero();
     }
@@ -631,10 +632,10 @@ class AllocationReallocationServiceImplTest {
         // AC5: seed allocation so the pool is non-zero and the reservation reaches the
         // if-branch, producing an audit record with MANUAL_OVERRIDE (fallback for
         // invalid).
-        reservation.setAllocatedQuantity(5);
+        reservation.setAllocatedQuantity(new BigDecimal("5"));
         when(reservationRepository.findByStockItemId(stockItemId)).thenReturn(List.of(reservation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(stockItemId))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(reservationRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationAuditRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/AsnServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/AsnServiceImplTest.java
@@ -112,7 +112,11 @@ class AsnServiceImplTest {
                         org.mockito.Mockito.mock(com.positivity.inventory.internal.service.UomConversionService.class)),
                 // Lot gate answers "untracked" for every SKU in these unit tests (E1 #1038):
                 // a mock resolveReceiptLot returns null by default.
-                org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryLotCaptureService.class));
+                org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryLotCaptureService.class),
+                // The guard reads the product's declared precision_scale; a mocked conversion
+                // service declares none, which is the whole-units default every SKU has today.
+                new com.positivity.inventory.internal.service.QuantityScaleGuard(org.mockito.Mockito.mock(
+                        com.positivity.inventory.internal.service.UomConversionService.class)));
         authenticateAs("asn-test-user");
     }
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ConsumptionServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ConsumptionServiceImplTest.java
@@ -19,6 +19,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.PickTaskRepository;
 import com.positivity.inventory.internal.service.ConsumptionServiceImpl;
 import com.positivity.inventory.internal.service.LedgerPostingService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
@@ -237,11 +238,11 @@ class ConsumptionServiceImplTest {
         InventoryLedgerEntry secondEntry = entriesCaptor.getValue().get(1);
         assertThat(firstEntry.getStockItemId()).isEqualTo("");
         assertThat(firstEntry.getEventType()).isEqualTo(InventoryLedgerEventType.WORKORDER_CONSUMPTION);
-        assertThat(firstEntry.getChangeInQuantity()).isEqualTo(-2);
+        assertThat(firstEntry.getChangeInQuantity()).isEqualByComparingTo("-2");
         assertThat(firstEntry.getQuantityAfter()).isZero();
         assertThat(firstEntry.getNotes()).contains(workorderId.toString());
         assertThat(secondEntry.getStockItemId()).isEqualTo(skuId2.toString());
-        assertThat(secondEntry.getChangeInQuantity()).isEqualTo(-3);
+        assertThat(secondEntry.getChangeInQuantity()).isEqualByComparingTo("-3");
 
         assertThat(response.getWorkorderId()).isEqualTo(workorderId);
         assertThat(response.getTotalItemsConsumed()).isEqualTo(5);
@@ -326,8 +327,8 @@ class ConsumptionServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(WO_LINE_ID)
                 .stockItemId(STOCK_ITEM_ID)
-                .requiredQuantity(5)
-                .allocatedQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("5"))
                 .status(com.positivity.inventory.internal.enums.ReservationStatus.FULFILLED)
                 .build();
     }
@@ -338,7 +339,7 @@ class ConsumptionServiceImplTest {
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
                 .reservation(reservation)
                 .locationId(LOCATION_ID)
-                .allocatedQuantity(quantity)
+                .allocatedQuantity(BigDecimal.valueOf(quantity))
                 .allocationState(com.positivity.inventory.internal.enums.AllocationState.HARD)
                 .status(com.positivity.inventory.internal.enums.AllocationStatus.ALLOCATED)
                 .build();
@@ -365,10 +366,10 @@ class ConsumptionServiceImplTest {
         when(reservationRepository.findByWorkorderLineId(WO_LINE_ID)).thenReturn(Optional.of(reservation));
         when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(allocation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(STOCK_ITEM_ID))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
                         allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
-                .thenReturn(0);
+                .thenReturn(new BigDecimal("0"));
         when(ledgerPostingService.postAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -384,7 +385,7 @@ class ConsumptionServiceImplTest {
         assertThat(entries).hasSize(2);
         InventoryLedgerEntry released = entries.get(1);
         assertThat(released.getEventType()).isEqualTo(InventoryLedgerEventType.ALLOCATION_RELEASED);
-        assertThat(released.getChangeInQuantity()).isEqualTo(5);
+        assertThat(released.getChangeInQuantity()).isEqualByComparingTo("5");
         assertThat(released.getLocationId()).isEqualTo(LOCATION_ID);
         assertThat(released.getStockItemId()).isEqualTo(STOCK_ITEM_ID.toString());
         assertThat(released.getSourceTransactionId())
@@ -404,10 +405,10 @@ class ConsumptionServiceImplTest {
         when(reservationRepository.findByWorkorderLineId(WO_LINE_ID)).thenReturn(Optional.of(reservation));
         when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(allocation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(STOCK_ITEM_ID))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
                         allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
-                .thenReturn(0);
+                .thenReturn(new BigDecimal("0"));
         when(ledgerPostingService.postAll(any())).thenAnswer(i -> i.getArgument(0));
 
         ConsumeItemsRequest request = new ConsumeItemsRequest(
@@ -419,7 +420,7 @@ class ConsumptionServiceImplTest {
 
         verify(ledgerPostingService).postAll(entriesCaptor.capture());
         InventoryLedgerEntry released = entriesCaptor.getValue().get(1);
-        assertThat(released.getChangeInQuantity()).isEqualTo(2);
+        assertThat(released.getChangeInQuantity()).isEqualByComparingTo("2");
         assertThat(allocation.getStatus())
                 .isEqualTo(com.positivity.inventory.internal.enums.AllocationStatus.ALLOCATED);
         verify(allocationRepository, org.mockito.Mockito.never()).save(any());
@@ -460,10 +461,10 @@ class ConsumptionServiceImplTest {
         when(reservationRepository.findByWorkorderLineId(WO_LINE_ID)).thenReturn(Optional.of(reservation));
         when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(allocation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(STOCK_ITEM_ID))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
                         allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
-                .thenReturn(3);
+                .thenReturn(new BigDecimal("3"));
         when(ledgerPostingService.postAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -477,7 +478,7 @@ class ConsumptionServiceImplTest {
         verify(ledgerPostingService).postAll(entriesCaptor.capture());
         InventoryLedgerEntry released = entriesCaptor.getValue().get(1);
         // invariant: total RELEASED never exceeds allocatedQuantity (3 + 2 = 5)
-        assertThat(released.getChangeInQuantity()).isEqualTo(2);
+        assertThat(released.getChangeInQuantity()).isEqualByComparingTo("2");
         assertThat(allocation.getStatus()).isEqualTo(com.positivity.inventory.internal.enums.AllocationStatus.RELEASED);
     }
 
@@ -491,7 +492,7 @@ class ConsumptionServiceImplTest {
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
                 .reservation(reservation)
                 .locationId(LOCATION_ID)
-                .allocatedQuantity(3)
+                .allocatedQuantity(new BigDecimal("3"))
                 .allocationState(com.positivity.inventory.internal.enums.AllocationState.HARD)
                 .status(com.positivity.inventory.internal.enums.AllocationStatus.ALLOCATED)
                 .createdAt(java.time.Instant.parse("2024-01-01T00:00:00Z"))
@@ -501,7 +502,7 @@ class ConsumptionServiceImplTest {
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000004"))
                 .reservation(reservation)
                 .locationId(otherLocation)
-                .allocatedQuantity(3)
+                .allocatedQuantity(new BigDecimal("3"))
                 .allocationState(com.positivity.inventory.internal.enums.AllocationState.HARD)
                 .status(com.positivity.inventory.internal.enums.AllocationStatus.ALLOCATED)
                 .createdAt(java.time.Instant.parse("2024-02-01T00:00:00Z"))
@@ -512,11 +513,11 @@ class ConsumptionServiceImplTest {
         // returned newest-first to prove the service sorts oldest-first itself
         when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(newer, older));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(STOCK_ITEM_ID))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
                         any(String.class),
                         org.mockito.ArgumentMatchers.eq(InventoryLedgerEventType.ALLOCATION_RELEASED)))
-                .thenReturn(0);
+                .thenReturn(new BigDecimal("0"));
         when(ledgerPostingService.postAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
         when(reservationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
@@ -535,16 +536,16 @@ class ConsumptionServiceImplTest {
         InventoryLedgerEntry second = entries.get(2);
         assertThat(first.getSourceTransactionId())
                 .isEqualTo(older.getAllocationId().toString());
-        assertThat(first.getChangeInQuantity()).isEqualTo(3); // older exhausted
+        assertThat(first.getChangeInQuantity()).isEqualByComparingTo("3"); // older exhausted
         assertThat(first.getLocationId()).isEqualTo(LOCATION_ID);
         assertThat(second.getSourceTransactionId())
                 .isEqualTo(newer.getAllocationId().toString());
-        assertThat(second.getChangeInQuantity()).isEqualTo(1); // spill
+        assertThat(second.getChangeInQuantity()).isEqualByComparingTo("1"); // spill
         assertThat(second.getLocationId()).isEqualTo(otherLocation);
         assertThat(older.getStatus()).isEqualTo(com.positivity.inventory.internal.enums.AllocationStatus.RELEASED);
         assertThat(newer.getStatus()).isEqualTo(com.positivity.inventory.internal.enums.AllocationStatus.ALLOCATED);
         // reservation pool shrinks by total released (PR #661 re-review finding 2)
-        assertThat(reservation.getAllocatedQuantity()).isEqualTo(1);
+        assertThat(reservation.getAllocatedQuantity()).isEqualByComparingTo("1");
     }
 
     @Test
@@ -561,10 +562,10 @@ class ConsumptionServiceImplTest {
         when(reservationRepository.findByWorkorderLineId(WO_LINE_ID)).thenReturn(Optional.of(reservation));
         when(allocationRepository.findByReservation(reservation)).thenReturn(List.of(allocation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(STOCK_ITEM_ID))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
                         allocation.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
-                .thenReturn(0);
+                .thenReturn(new BigDecimal("0"));
         when(ledgerPostingService.postAll(any())).thenAnswer(i -> i.getArgument(0));
         when(allocationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
         when(reservationRepository.save(any())).thenAnswer(i -> i.getArgument(0));
@@ -579,11 +580,11 @@ class ConsumptionServiceImplTest {
         service.consumePickedItems(request);
 
         verify(ledgerPostingService).postAll(entriesCaptor.capture());
-        int totalReleased = entriesCaptor.getValue().stream()
+        BigDecimal totalReleased = entriesCaptor.getValue().stream()
                 .filter(e -> e.getEventType() == InventoryLedgerEventType.ALLOCATION_RELEASED)
-                .mapToInt(InventoryLedgerEntry::getChangeInQuantity)
-                .sum();
-        assertThat(totalReleased).isEqualTo(5); // capped at allocatedQuantity, not 8
+                .map(InventoryLedgerEntry::getChangeInQuantity)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(totalReleased).isEqualByComparingTo("5"); // capped at allocatedQuantity, not 8
         // second item exhausts the remainder and closes the allocation
         assertThat(allocation.getStatus()).isEqualTo(com.positivity.inventory.internal.enums.AllocationStatus.RELEASED);
     }
@@ -620,7 +621,7 @@ class ConsumptionServiceImplTest {
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
                 .reservation(reservation)
                 .locationId(null)
-                .allocatedQuantity(5)
+                .allocatedQuantity(new BigDecimal("5"))
                 .allocationState(com.positivity.inventory.internal.enums.AllocationState.SOFT)
                 .status(com.positivity.inventory.internal.enums.AllocationStatus.ALLOCATED)
                 .build();

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/CycleCountAdjustmentServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/CycleCountAdjustmentServiceImplTest.java
@@ -135,7 +135,7 @@ class CycleCountAdjustmentServiceImplTest {
             }
             return adj;
         });
-        when(ledgerRepository.calculateOnHandQuantity(STOCK_ITEM_ID)).thenReturn(10);
+        when(ledgerRepository.calculateOnHandQuantity(STOCK_ITEM_ID)).thenReturn(new BigDecimal("10"));
         when(ledgerPostingService.post(any(InventoryLedgerEntry.class))).thenAnswer(inv -> {
             InventoryLedgerEntry entry = inv.getArgument(0);
             entry.setLedgerEntryId(ledgerId);
@@ -186,7 +186,7 @@ class CycleCountAdjustmentServiceImplTest {
 
         when(adjustmentRepository.findById(adjustmentId)).thenReturn(Optional.of(adjustment));
         when(adjustmentRepository.save(any(CycleCountAdjustment.class))).thenAnswer(inv -> inv.getArgument(0));
-        when(ledgerRepository.calculateOnHandQuantity(STOCK_ITEM_ID)).thenReturn(10);
+        when(ledgerRepository.calculateOnHandQuantity(STOCK_ITEM_ID)).thenReturn(new BigDecimal("10"));
         when(ledgerPostingService.post(any(InventoryLedgerEntry.class))).thenAnswer(inv -> {
             InventoryLedgerEntry entry = inv.getArgument(0);
             entry.setLedgerEntryId(ledgerId);
@@ -303,8 +303,8 @@ class CycleCountAdjustmentServiceImplTest {
         return CreateAdjustmentRequest.builder()
                 .stockItemId(STOCK_ITEM_ID)
                 .reasonCode("CYCLE_COUNT_SHRINK")
-                .countedQuantity(counted)
-                .quantityOnHandBefore(onHand)
+                .countedQuantity(BigDecimal.valueOf(counted))
+                .quantityOnHandBefore(BigDecimal.valueOf(onHand))
                 .costAtTimeOfAdjustment(BigDecimal.valueOf(50.00))
                 .createdByUserId("counter-user-1")
                 .build();
@@ -319,10 +319,10 @@ class CycleCountAdjustmentServiceImplTest {
                 .adjustmentId(id)
                 .stockItemId(STOCK_ITEM_ID)
                 .reasonCode("CYCLE_COUNT_SHRINK")
-                .quantityChange(-2)
+                .quantityChange(new BigDecimal("-2"))
                 .costAtTimeOfAdjustment(BigDecimal.valueOf(50.00))
-                .quantityOnHandBefore(10)
-                .countedQuantity(8)
+                .quantityOnHandBefore(new BigDecimal("10"))
+                .countedQuantity(new BigDecimal("8"))
                 .createdByUserId("counter-user-1")
                 .status(AdjustmentStatus.PENDING_APPROVAL)
                 .build();

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryAvailabilityServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryAvailabilityServiceImplTest.java
@@ -17,6 +17,7 @@ import com.positivity.inventory.internal.repository.InventoryStockSummaryReposit
 import com.positivity.inventory.internal.service.AsOfQueryGuard;
 import com.positivity.inventory.internal.service.ForecastQuantityService;
 import com.positivity.inventory.internal.service.InventoryAvailabilityServiceImpl;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,9 +58,9 @@ class InventoryAvailabilityServiceImplTest {
         // Default forecast: projected = onHand (no open supply/demand). Individual tests
         // override where forecast behavior is asserted.
         Mockito.lenient()
-                .when(forecastQuantityService.forecast(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyLong()))
-                .thenAnswer(invocation ->
-                        new ForecastQuantityService.ForecastQuantities(0L, 0L, invocation.getArgument(3, Long.class)));
+                .when(forecastQuantityService.forecast(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenAnswer(invocation -> new ForecastQuantityService.ForecastQuantities(
+                        BigDecimal.ZERO, BigDecimal.ZERO, invocation.getArgument(3, BigDecimal.class)));
         Mockito.lenient()
                 .when(storageLocationReplicaRepository.findById(Mockito.any()))
                 .thenReturn(java.util.Optional.empty());
@@ -69,6 +70,8 @@ class InventoryAvailabilityServiceImplTest {
                 forecastQuantityService,
                 asOfQueryGuard,
                 new com.positivity.inventory.internal.service.ForecastSiteResolver(storageLocationReplicaRepository),
+                new com.positivity.inventory.internal.service.QuantityScaleGuard(
+                        org.mockito.Mockito.mock(com.positivity.inventory.internal.service.UomConversionService.class)),
                 java.time.Clock.systemUTC());
     }
 
@@ -104,8 +107,8 @@ class InventoryAvailabilityServiceImplTest {
 
         assertThat(result).hasSize(1);
         assertThat(result.getFirst().getLocationId()).isEqualTo(LOC_1);
-        assertThat(result.getFirst().getOnHandQuantity()).isEqualTo(2);
-        assertThat(result.getFirst().getAvailableToPromiseQuantity()).isEqualTo(-3);
+        assertThat(result.getFirst().getOnHandQuantity()).isEqualByComparingTo("2");
+        assertThat(result.getFirst().getAvailableToPromiseQuantity()).isEqualByComparingTo("-3");
     }
 
     @Test
@@ -120,9 +123,9 @@ class InventoryAvailabilityServiceImplTest {
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getLocationId()).isEqualTo(LOC_1);
-        assertThat(result.get(0).getOnHandQuantity()).isEqualTo(40);
+        assertThat(result.get(0).getOnHandQuantity()).isEqualByComparingTo("40");
         assertThat(result.get(1).getLocationId()).isEqualTo(LOC_2);
-        assertThat(result.get(1).getOnHandQuantity()).isEqualTo(60);
+        assertThat(result.get(1).getOnHandQuantity()).isEqualByComparingTo("60");
     }
 
     @Test
@@ -151,8 +154,8 @@ class InventoryAvailabilityServiceImplTest {
         List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
 
         assertThat(result).hasSize(1);
-        assertThat(result.getFirst().getOnHandQuantity()).isEqualTo(100);
-        assertThat(result.getFirst().getAvailableToPromiseQuantity()).isEqualTo(50);
+        assertThat(result.getFirst().getOnHandQuantity()).isEqualByComparingTo("100");
+        assertThat(result.getFirst().getAvailableToPromiseQuantity()).isEqualByComparingTo("50");
     }
 
     @Test
@@ -175,9 +178,9 @@ class InventoryAvailabilityServiceImplTest {
 
         AvailabilityView result = service.queryAvailability(productSku, LOC_1, SLOC_A, null);
 
-        assertThat(result.getOnHandQuantity()).isEqualTo(5);
-        assertThat(result.getAllocatedQuantity()).isEqualTo(2);
-        assertThat(result.getAvailableToPromiseQuantity()).isEqualTo(3);
+        assertThat(result.getOnHandQuantity()).isEqualByComparingTo("5");
+        assertThat(result.getAllocatedQuantity()).isEqualByComparingTo("2");
+        assertThat(result.getAvailableToPromiseQuantity()).isEqualByComparingTo("3");
         assertThat(result.getStorageLocationId()).isEqualTo(SLOC_A);
         assertThat(result.getUnitOfMeasure()).isEqualTo("EACH");
     }
@@ -193,10 +196,10 @@ class InventoryAvailabilityServiceImplTest {
 
         AvailabilityView result = service.queryAvailability(productSku, LOC_1, null, null);
 
-        assertThat(result.getOnHandQuantity()).isEqualTo(10);
+        assertThat(result.getOnHandQuantity()).isEqualByComparingTo("10");
         // Per ADR-0001, allocatedQuantity counts hard allocations only, never reservations.
-        assertThat(result.getAllocatedQuantity()).isEqualTo(2);
-        assertThat(result.getAvailableToPromiseQuantity()).isEqualTo(8);
+        assertThat(result.getAllocatedQuantity()).isEqualByComparingTo("2");
+        assertThat(result.getAvailableToPromiseQuantity()).isEqualByComparingTo("8");
         assertThat(result.getStorageLocationId()).isNull();
         assertThat(result.getUnitOfMeasure()).isEqualTo("EA");
     }
@@ -210,17 +213,17 @@ class InventoryAvailabilityServiceImplTest {
                 .thenReturn(List.of(summary(productSku, LOC_1, 10, 2, 0)));
         when(stockSummaryRepository.sumExpiredActiveLotOnHand(
                         eq(productSku), eq(LOC_1), any(java.time.LocalDate.class)))
-                .thenReturn(4L);
+                .thenReturn(new BigDecimal("4"));
         when(inventoryLedgerEntryRepository.findUnitsOfMeasureByStockItemAtLocation(
                         eq(productSku), eq(LOC_1), any(Pageable.class)))
                 .thenReturn(List.of("EA"));
 
         AvailabilityView result = service.queryAvailability(productSku, LOC_1, null, null);
 
-        assertThat(result.getOnHandQuantity()).isEqualTo(10);
-        assertThat(result.getAllocatedQuantity()).isEqualTo(2);
+        assertThat(result.getOnHandQuantity()).isEqualByComparingTo("10");
+        assertThat(result.getAllocatedQuantity()).isEqualByComparingTo("2");
         // 10 onHand − 2 allocated − 4 expired = 4
-        assertThat(result.getAvailableToPromiseQuantity()).isEqualTo(4);
+        assertThat(result.getAvailableToPromiseQuantity()).isEqualByComparingTo("4");
     }
 
     @Test
@@ -236,9 +239,9 @@ class InventoryAvailabilityServiceImplTest {
 
         AvailabilityView result = service.queryAvailability(productSku, null, null, null);
 
-        assertThat(result.getOnHandQuantity()).isEqualTo(12);
-        assertThat(result.getAllocatedQuantity()).isEqualTo(3);
-        assertThat(result.getAvailableToPromiseQuantity()).isEqualTo(9);
+        assertThat(result.getOnHandQuantity()).isEqualByComparingTo("12");
+        assertThat(result.getAllocatedQuantity()).isEqualByComparingTo("3");
+        assertThat(result.getAvailableToPromiseQuantity()).isEqualByComparingTo("9");
     }
 
     @Test
@@ -262,18 +265,19 @@ class InventoryAvailabilityServiceImplTest {
         UUID productId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         when(stockSummaryRepository.findByStockItemId(productId.toString()))
                 .thenReturn(List.of(summary(productId.toString(), LOC_1, 100, 20, 0)));
-        when(forecastQuantityService.forecast(productId.toString(), LOC_1, null, 100L))
-                .thenReturn(new ForecastQuantityService.ForecastQuantities(25L, 10L, 115L));
+        when(forecastQuantityService.forecast(productId.toString(), LOC_1, null, new BigDecimal("100")))
+                .thenReturn(new ForecastQuantityService.ForecastQuantities(
+                        new BigDecimal("25"), new BigDecimal("10"), new BigDecimal("115")));
 
         List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId);
 
         assertThat(result).hasSize(1);
-        assertThat(result.getFirst().getIncomingQty()).isEqualTo(25L);
-        assertThat(result.getFirst().getOutgoingQty()).isEqualTo(10L);
-        assertThat(result.getFirst().getProjectedAvailable()).isEqualTo(115L);
+        assertThat(result.getFirst().getIncomingQty()).isEqualByComparingTo("25");
+        assertThat(result.getFirst().getOutgoingQty()).isEqualByComparingTo("10");
+        assertThat(result.getFirst().getProjectedAvailable()).isEqualByComparingTo("115");
         // Existing field semantics unchanged.
-        assertThat(result.getFirst().getOnHandQuantity()).isEqualTo(100);
-        assertThat(result.getFirst().getAvailableToPromiseQuantity()).isEqualTo(80);
+        assertThat(result.getFirst().getOnHandQuantity()).isEqualByComparingTo("100");
+        assertThat(result.getFirst().getAvailableToPromiseQuantity()).isEqualByComparingTo("80");
     }
 
     @Test
@@ -282,14 +286,15 @@ class InventoryAvailabilityServiceImplTest {
         java.time.Instant horizon = java.time.Instant.parse("2026-08-01T00:00:00Z");
         when(stockSummaryRepository.findByStockItemId(productId.toString()))
                 .thenReturn(List.of(summary(productId.toString(), LOC_1, 40, 0, 0)));
-        when(forecastQuantityService.forecast(productId.toString(), LOC_1, horizon, 40L))
-                .thenReturn(new ForecastQuantityService.ForecastQuantities(5L, 0L, 45L));
+        when(forecastQuantityService.forecast(productId.toString(), LOC_1, horizon, new BigDecimal("40")))
+                .thenReturn(new ForecastQuantityService.ForecastQuantities(
+                        new BigDecimal("5"), new BigDecimal("0"), new BigDecimal("45")));
 
         List<LocationAvailabilityDto> result = service.getAvailabilityByProduct(productId, horizon);
 
-        assertThat(result.getFirst().getIncomingQty()).isEqualTo(5L);
-        assertThat(result.getFirst().getProjectedAvailable()).isEqualTo(45L);
-        verify(forecastQuantityService).forecast(productId.toString(), LOC_1, horizon, 40L);
+        assertThat(result.getFirst().getIncomingQty()).isEqualByComparingTo("5");
+        assertThat(result.getFirst().getProjectedAvailable()).isEqualByComparingTo("45");
+        verify(forecastQuantityService).forecast(productId.toString(), LOC_1, horizon, new BigDecimal("40"));
     }
 
     @Test
@@ -300,17 +305,18 @@ class InventoryAvailabilityServiceImplTest {
         when(inventoryLedgerEntryRepository.findUnitsOfMeasureByStockItemAtLocation(
                         eq(productSku), eq(LOC_1), any(Pageable.class)))
                 .thenReturn(List.of());
-        when(forecastQuantityService.forecast(productSku, LOC_1, null, 10L))
-                .thenReturn(new ForecastQuantityService.ForecastQuantities(7L, 3L, 14L));
+        when(forecastQuantityService.forecast(productSku, LOC_1, null, new BigDecimal("10")))
+                .thenReturn(new ForecastQuantityService.ForecastQuantities(
+                        new BigDecimal("7"), new BigDecimal("3"), new BigDecimal("14")));
 
         AvailabilityView result = service.queryAvailability(productSku, LOC_1, null, null);
 
-        assertThat(result.getIncomingQty()).isEqualTo(7L);
-        assertThat(result.getOutgoingQty()).isEqualTo(3L);
-        assertThat(result.getProjectedAvailable()).isEqualTo(14L);
+        assertThat(result.getIncomingQty()).isEqualByComparingTo("7");
+        assertThat(result.getOutgoingQty()).isEqualByComparingTo("3");
+        assertThat(result.getProjectedAvailable()).isEqualByComparingTo("14");
         // Existing field semantics unchanged.
-        assertThat(result.getOnHandQuantity()).isEqualTo(10);
-        assertThat(result.getAvailableToPromiseQuantity()).isEqualTo(8);
+        assertThat(result.getOnHandQuantity()).isEqualByComparingTo("10");
+        assertThat(result.getAvailableToPromiseQuantity()).isEqualByComparingTo("8");
     }
 
     private InventoryStockSummary summary(
@@ -318,10 +324,10 @@ class InventoryAvailabilityServiceImplTest {
         return InventoryStockSummary.builder()
                 .stockItemId(stockItemId)
                 .locationId(locationId)
-                .onHand(onHand)
-                .allocated(allocated)
-                .reserved(reserved)
-                .atp(onHand - allocated)
+                .onHand(BigDecimal.valueOf(onHand))
+                .allocated(BigDecimal.valueOf(allocated))
+                .reserved(BigDecimal.valueOf(reserved))
+                .atp(BigDecimal.valueOf(onHand - allocated))
                 .build();
     }
 
@@ -343,7 +349,6 @@ class InventoryAvailabilityServiceImplTest {
 
         service.queryAvailability(sku, null, binId, null);
 
-        verify(forecastQuantityService)
-                .forecast(Mockito.eq(sku), Mockito.eq(siteId), Mockito.isNull(), Mockito.anyLong());
+        verify(forecastQuantityService).forecast(Mockito.eq(sku), Mockito.eq(siteId), Mockito.isNull(), Mockito.any());
     }
 }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryFactPublisherTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryFactPublisherTest.java
@@ -17,6 +17,7 @@ import com.positivity.inventory.internal.dto.AvailabilityView;
 import com.positivity.inventory.internal.dto.LocationInventoryInquiryResponse;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.service.InventoryFactPublisher;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -95,19 +96,19 @@ class InventoryFactPublisherTest {
                 .thenReturn(AvailabilityView.builder()
                         .productSku("SKU-1")
                         .locationId(locationId)
-                        .onHandQuantity(7)
-                        .allocatedQuantity(2)
-                        .availableToPromiseQuantity(5)
+                        .onHandQuantity(new BigDecimal("7"))
+                        .allocatedQuantity(new BigDecimal("2"))
+                        .availableToPromiseQuantity(new BigDecimal("5"))
                         .unitOfMeasure("EACH")
-                        .incomingQty(4L)
-                        .outgoingQty(1L)
-                        .projectedAvailable(10L)
+                        .incomingQty(new BigDecimal("4"))
+                        .outgoingQty(new BigDecimal("1"))
+                        .projectedAvailable(new BigDecimal("10"))
                         .build());
         when(inquiryService.getLocationInventory(locationId, null))
                 .thenReturn(LocationInventoryInquiryResponse.builder()
                         .locationId(locationId)
-                        .onHandQuantity(7)
-                        .availableToPromiseQuantity(5L)
+                        .onHandQuantity(new BigDecimal("7"))
+                        .availableToPromiseQuantity(new BigDecimal("5"))
                         .build());
 
         publisher.markEntry(entry);
@@ -122,15 +123,15 @@ class InventoryFactPublisherTest {
         assertThat(envelopes.get(0).schemaVersion()).isEqualTo(InventoryAvailabilityUpdatedV1.SCHEMA_VERSION);
         InventoryAvailabilityUpdatedV1 availability =
                 (InventoryAvailabilityUpdatedV1) envelopes.get(0).payload();
-        assertThat(availability.onHandQuantity()).isEqualTo(7);
-        assertThat(availability.availableToPromiseQuantity()).isEqualTo(5);
+        assertThat(availability.onHandQuantity()).isEqualByComparingTo("7");
+        assertThat(availability.availableToPromiseQuantity()).isEqualByComparingTo("5");
         // Schema v2 forecast fields (odoo-parity A2, #1028) carry the unbounded view values.
-        assertThat(availability.incomingQuantity()).isEqualTo(4L);
-        assertThat(availability.outgoingQuantity()).isEqualTo(1L);
-        assertThat(availability.projectedAvailableQuantity()).isEqualTo(10L);
+        assertThat(availability.incomingQuantity()).isEqualByComparingTo("4");
+        assertThat(availability.outgoingQuantity()).isEqualByComparingTo("1");
+        assertThat(availability.projectedAvailableQuantity()).isEqualByComparingTo("10");
         assertThat(envelopes.get(1).eventType()).isEqualTo(StorageLocationOnHandUpdatedV1.EVENT_TYPE);
         assertThat(((StorageLocationOnHandUpdatedV1) envelopes.get(1).payload()).onHandQuantity())
-                .isEqualTo(7);
+                .isEqualByComparingTo("7");
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryLocationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/InventoryLocationServiceImplTest.java
@@ -12,6 +12,7 @@ import com.positivity.inventory.internal.service.StorageLocationValidationServic
 import com.positivity.security.common.GatewaySecurityConstants;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Proxy;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -78,7 +79,8 @@ class InventoryLocationServiceImplTest {
             validations.put(destinationLocationId.toString(), validation(destinationLocationId, siteId, true, true));
             InventoryLocationServiceImpl service = new InventoryLocationServiceImpl(
                     stubLedgerRepository(
-                            List.of(onHand("SKU-001", 5L)), Map.of(stockKey("SKU-001", destinationLocationId), 3)),
+                            List.of(onHand("SKU-001", 5L)),
+                            Map.of(stockKey("SKU-001", destinationLocationId), new BigDecimal("3"))),
                     stubLedgerPostingService(persistedEntries),
                     new StubStorageLocationValidationService(validations),
                     eventPublisher(new ArrayList<>()),
@@ -93,7 +95,7 @@ class InventoryLocationServiceImplTest {
             assertThat(response.getTransfer().getMovedItems().get(0).getItemId())
                     .isEqualTo("SKU-001");
             assertThat(response.getTransfer().getMovedItems().get(0).getQuantity())
-                    .isEqualTo(5);
+                    .isEqualByComparingTo("5");
             assertThat(persistedEntries).hasSize(2);
             assertThat(persistedEntries.get(0).getEventType()).isEqualTo(InventoryLedgerEventType.TRANSFER_OUT);
             assertThat(persistedEntries.get(1).getEventType()).isEqualTo(InventoryLedgerEventType.TRANSFER_IN);
@@ -103,14 +105,14 @@ class InventoryLocationServiceImplTest {
     }
 
     private InventoryLedgerEntryRepository stubLedgerRepository(
-            List<InventoryLedgerEntryRepository.LocationOnHand> sourceRows, Map<String, Integer> destinationOnHand) {
+            List<InventoryLedgerEntryRepository.LocationOnHand> sourceRows, Map<String, BigDecimal> destinationOnHand) {
         return (InventoryLedgerEntryRepository) Proxy.newProxyInstance(
                 InventoryLedgerEntryRepository.class.getClassLoader(),
                 new Class[] {InventoryLedgerEntryRepository.class},
                 (proxy, method, args) -> switch (method.getName()) {
                     case "findPositiveOnHandByLocation" -> sourceRows;
                     case "calculateOnHandQuantityAtLocation" ->
-                        destinationOnHand.getOrDefault(stockKey((String) args[0], (UUID) args[1]), 0);
+                        destinationOnHand.getOrDefault(stockKey((String) args[0], (UUID) args[1]), BigDecimal.ZERO);
                     case "toString" -> "InventoryLedgerEntryRepositoryStub";
                     default -> defaultValue(method.getReturnType());
                 });
@@ -155,8 +157,8 @@ class InventoryLocationServiceImplTest {
             }
 
             @Override
-            public Long getOnHandQuantity() {
-                return onHandQuantity;
+            public BigDecimal getOnHandQuantity() {
+                return BigDecimal.valueOf(onHandQuantity);
             }
         };
     }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/LocationInventoryInquiryServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/LocationInventoryInquiryServiceImplTest.java
@@ -10,6 +10,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.InventoryStockSummaryRepository;
 import com.positivity.inventory.internal.service.AsOfQueryGuard;
 import com.positivity.inventory.internal.service.LocationInventoryInquiryServiceImpl;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -45,16 +46,16 @@ class LocationInventoryInquiryServiceImplTest {
         return InventoryStockSummary.builder()
                 .stockItemId(sku)
                 .locationId(LOCATION_ID)
-                .onHand(onHand)
-                .allocated(allocated)
-                .atp(onHand - allocated)
+                .onHand(BigDecimal.valueOf(onHand))
+                .allocated(BigDecimal.valueOf(allocated))
+                .atp(BigDecimal.valueOf(onHand - allocated))
                 .build();
     }
 
     @Test
     void listLocationInventoryItems_mapsPositiveOnHandRowsToItems() {
         var service = newService();
-        when(stockSummaryRepository.findByLocationIdAndOnHandGreaterThan(LOCATION_ID, 0L))
+        when(stockSummaryRepository.findByLocationIdAndOnHandGreaterThan(LOCATION_ID, new BigDecimal("0")))
                 .thenReturn(List.of(summary("MICH-XC2-0001", 24L, 0L), summary("MICH-DEF-0002", 8L, 0L)));
 
         LocationInventoryItemsResponse response = service.listLocationInventoryItems(LOCATION_ID);
@@ -65,13 +66,13 @@ class LocationInventoryInquiryServiceImplTest {
                 .containsExactly("MICH-XC2-0001", "MICH-DEF-0002");
         assertThat(response.getItems())
                 .extracting(LocationInventoryItemsResponse.Item::getOnHandQuantity)
-                .containsExactly(24L, 8L);
+                .containsExactly(new BigDecimal("24"), new BigDecimal("8"));
     }
 
     @Test
     void listLocationInventoryItems_returnsEmptyListForLocationWithoutStock() {
         var service = newService();
-        when(stockSummaryRepository.findByLocationIdAndOnHandGreaterThan(LOCATION_ID, 0L))
+        when(stockSummaryRepository.findByLocationIdAndOnHandGreaterThan(LOCATION_ID, new BigDecimal("0")))
                 .thenReturn(List.of());
 
         LocationInventoryItemsResponse response = service.listLocationInventoryItems(LOCATION_ID);
@@ -83,14 +84,14 @@ class LocationInventoryInquiryServiceImplTest {
     @Test
     void getLocationInventory_withoutSku_sumsAcrossStockItems() {
         var service = newService();
-        when(stockSummaryRepository.sumOnHandAtLocation(LOCATION_ID)).thenReturn(32L);
-        when(stockSummaryRepository.sumAllocatedAtLocation(LOCATION_ID)).thenReturn(5L);
+        when(stockSummaryRepository.sumOnHandAtLocation(LOCATION_ID)).thenReturn(new BigDecimal("32"));
+        when(stockSummaryRepository.sumAllocatedAtLocation(LOCATION_ID)).thenReturn(new BigDecimal("5"));
 
         LocationInventoryInquiryResponse response = service.getLocationInventory(LOCATION_ID, null);
 
         assertThat(response.getLocationId()).isEqualTo(LOCATION_ID);
-        assertThat(response.getOnHandQuantity()).isEqualTo(32);
-        assertThat(response.getAvailableToPromiseQuantity()).isEqualTo(27);
+        assertThat(response.getOnHandQuantity()).isEqualByComparingTo("32");
+        assertThat(response.getAvailableToPromiseQuantity()).isEqualByComparingTo("27");
     }
 
     @Test
@@ -101,8 +102,8 @@ class LocationInventoryInquiryServiceImplTest {
 
         LocationInventoryInquiryResponse response = service.getLocationInventory(LOCATION_ID, "MICH-XC2-0001");
 
-        assertThat(response.getOnHandQuantity()).isEqualTo(24);
-        assertThat(response.getAvailableToPromiseQuantity()).isEqualTo(20);
+        assertThat(response.getOnHandQuantity()).isEqualByComparingTo("24");
+        assertThat(response.getAvailableToPromiseQuantity()).isEqualByComparingTo("20");
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/LocationInventoryRollupServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/LocationInventoryRollupServiceImplTest.java
@@ -17,6 +17,7 @@ import com.positivity.inventory.internal.exception.RollupExpansionTooLargeExcept
 import com.positivity.inventory.internal.service.LocationInventoryRollupServiceImpl;
 import com.positivity.inventory.internal.service.StorageLocationTopologyService;
 import com.positivity.inventory.internal.service.StorageLocationTopologyService.LocationDescendant;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
@@ -61,10 +62,11 @@ class LocationInventoryRollupServiceImplTest {
                 "Floor",
                 "FLOOR",
                 "ACTIVE",
-                RollupQuantities.of(onHand, allocated),
-                RollupQuantities.of(onHand, allocated),
+                RollupQuantities.of(BigDecimal.valueOf(onHand), BigDecimal.valueOf(allocated)),
+                RollupQuantities.of(BigDecimal.valueOf(onHand), BigDecimal.valueOf(allocated)),
                 List.of());
-        return new SiteInventoryRollupResponse(siteId, RollupQuantities.of(onHand, allocated), List.of(node));
+        return new SiteInventoryRollupResponse(
+                siteId, RollupQuantities.of(BigDecimal.valueOf(onHand), BigDecimal.valueOf(allocated)), List.of(node));
     }
 
     @Test
@@ -83,9 +85,9 @@ class LocationInventoryRollupServiceImplTest {
 
         assertThat(response.locationId()).isEqualTo(BUILDING_ID);
         assertThat(response.parentType()).isEqualTo("PHYSICAL");
-        assertThat(response.totals().onHand()).isEqualTo(150);
-        assertThat(response.totals().allocated()).isEqualTo(15);
-        assertThat(response.totals().available()).isEqualTo(135);
+        assertThat(response.totals().onHand()).isEqualByComparingTo("150");
+        assertThat(response.totals().allocated()).isEqualByComparingTo("15");
+        assertThat(response.totals().available()).isEqualByComparingTo("135");
         assertThat(response.sites()).hasSize(2);
         assertThat(response.sites().getFirst().siteName()).isEqualTo("Site A");
         assertThat(response.sites().getFirst().nodes()).isNull();
@@ -138,7 +140,7 @@ class LocationInventoryRollupServiceImplTest {
                 service.getLocationInventoryRollup(BUILDING_ID, null, null, false, null, false);
 
         assertThat(response.sites()).hasSize(26);
-        assertThat(response.totals().onHand()).isEqualTo(26);
+        assertThat(response.totals().onHand()).isEqualByComparingTo("26");
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayExecuteServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayExecuteServiceImplTest.java
@@ -24,6 +24,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.PutawayTaskRepository;
 import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.inventory.internal.service.PutawayExecuteServiceImpl;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -90,9 +91,9 @@ class PutawayExecuteServiceImplTest {
         when(putawayTaskRepository.findByIdForUpdate(taskId)).thenReturn(Optional.of(task));
         when(putawayValidationService.validatePutawayExecution(request)).thenReturn(ValidationResult.success());
         when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation("sku-abc", sourceLocationId))
-                .thenReturn(50);
+                .thenReturn(new BigDecimal("50"));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation("sku-abc", destinationLocationId))
-                .thenReturn(5);
+                .thenReturn(new BigDecimal("5"));
         when(ledgerPostingService.post(any(InventoryLedgerEntry.class))).thenAnswer(invocation -> {
             InventoryLedgerEntry entry = invocation.getArgument(0);
             entry.setLedgerEntryId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
@@ -106,22 +107,22 @@ class PutawayExecuteServiceImplTest {
         List<InventoryLedgerEntry> allCaptured = ledgerCaptor.getAllValues();
 
         InventoryLedgerEntry sourceEntry = allCaptured.stream()
-                .filter(e -> e.getChangeInQuantity() == -10)
+                .filter(e -> e.getChangeInQuantity().compareTo(new BigDecimal("-10")) == 0)
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("No source decrement entry found"));
         assertThat(sourceEntry.getStockItemId()).isEqualTo("sku-abc");
         assertThat(sourceEntry.getLocationId()).isEqualTo(sourceLocationId);
         assertThat(sourceEntry.getTransactionUserId()).isEqualTo(DEFAULT_ACTOR);
-        assertThat(sourceEntry.getQuantityAfter()).isEqualTo(40);
+        assertThat(sourceEntry.getQuantityAfter()).isEqualByComparingTo("40");
 
         InventoryLedgerEntry destinationEntry = allCaptured.stream()
-                .filter(e -> e.getChangeInQuantity() == 10)
+                .filter(e -> e.getChangeInQuantity().compareTo(new BigDecimal("10")) == 0)
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("No destination credit entry found"));
         assertThat(destinationEntry.getStockItemId()).isEqualTo("sku-abc");
         assertThat(destinationEntry.getLocationId()).isEqualTo(destinationLocationId);
         assertThat(destinationEntry.getTransactionUserId()).isEqualTo(DEFAULT_ACTOR);
-        assertThat(destinationEntry.getQuantityAfter()).isEqualTo(15);
+        assertThat(destinationEntry.getQuantityAfter()).isEqualByComparingTo("15");
 
         ArgumentCaptor<PutawayTask> taskCaptor = ArgumentCaptor.forClass(PutawayTask.class);
         verify(putawayTaskRepository).save(taskCaptor.capture());
@@ -161,7 +162,7 @@ class PutawayExecuteServiceImplTest {
     @Test
     void executePutaway_throwsLocationAtCapacityException() {
         when(putawayTaskRepository.findByIdForUpdate(taskId)).thenReturn(Optional.of(task));
-        doThrow(new LocationAtCapacityException(destinationLocationId, 100, 100))
+        doThrow(new LocationAtCapacityException(destinationLocationId, new BigDecimal("100"), new BigDecimal("100")))
                 .when(putawayValidationService)
                 .validatePutawayExecution(request);
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayValidationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/PutawayValidationServiceImplTest.java
@@ -25,6 +25,7 @@ import com.positivity.inventory.internal.security.PutawayPermissions;
 import com.positivity.inventory.internal.service.PutawayValidationServiceImpl;
 import com.positivity.inventory.internal.service.StorageLocationValidationService;
 import com.positivity.security.common.GatewaySecurityConstants;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
@@ -136,7 +137,7 @@ class PutawayValidationServiceImplTest {
         PutawayValidationServiceImpl service = Mockito.spy(new PutawayValidationServiceImpl());
         PutawayExecutionRequest request = baseRequest();
 
-        Mockito.doThrow(new LocationAtCapacityException(DEST_1, 100, 100))
+        Mockito.doThrow(new LocationAtCapacityException(DEST_1, new BigDecimal("100"), new BigDecimal("100")))
                 .when(service)
                 .validateLocationCapacity(any(), anyInt());
 
@@ -206,7 +207,7 @@ class PutawayValidationServiceImplTest {
 
         when(locationValidationClient.getStorageLocationValidation(DEST_1.toString()))
                 .thenReturn(validation);
-        when(ledger.calculateOnHandQuantityAtLocation(eq(DEST_1), anyList())).thenReturn(7);
+        when(ledger.calculateOnHandQuantityAtLocation(eq(DEST_1), anyList())).thenReturn(new BigDecimal("7"));
         when(replenishmentPolicyRepository.sumMaximumQuantityByLocationId(DEST_1))
                 .thenReturn(10);
 
@@ -231,7 +232,7 @@ class PutawayValidationServiceImplTest {
 
         when(locationValidationClient.getStorageLocationValidation(DEST_1.toString()))
                 .thenReturn(validation);
-        when(ledger.calculateOnHandQuantityAtLocation(eq(DEST_1), anyList())).thenReturn(10);
+        when(ledger.calculateOnHandQuantityAtLocation(eq(DEST_1), anyList())).thenReturn(new BigDecimal("10"));
         when(replenishmentPolicyRepository.sumMaximumQuantityByLocationId(DEST_1))
                 .thenReturn(12);
 
@@ -261,7 +262,7 @@ class PutawayValidationServiceImplTest {
 
         when(locationValidationClient.getStorageLocationValidation(DEST_1.toString()))
                 .thenReturn(validation);
-        when(ledger.calculateOnHandQuantityAtLocation(eq(DEST_1), anyList())).thenReturn(8);
+        when(ledger.calculateOnHandQuantityAtLocation(eq(DEST_1), anyList())).thenReturn(new BigDecimal("8"));
         when(replenishmentPolicyRepository.sumMaximumQuantityByLocationId(DEST_1))
                 .thenReturn(1000);
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReceivingServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReceivingServiceImplTest.java
@@ -3,6 +3,7 @@ package com.positivity.inventory.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -16,22 +17,30 @@ import com.positivity.inventory.internal.dto.receiving.ReceiveItemsRequest;
 import com.positivity.inventory.internal.dto.receiving.ReceiveItemsResponse;
 import com.positivity.inventory.internal.dto.receiving.ReceiveLineRequest;
 import com.positivity.inventory.internal.dto.receiving.ReceivingSessionResponse;
+import com.positivity.inventory.internal.entity.ExtProductReplica;
+import com.positivity.inventory.internal.entity.ExtProductUomReplica;
 import com.positivity.inventory.internal.entity.InventoryLedgerEntry;
 import com.positivity.inventory.internal.entity.ReceivingLine;
 import com.positivity.inventory.internal.entity.ReceivingSession;
+import com.positivity.inventory.internal.enums.InventoryLedgerEventType;
 import com.positivity.inventory.internal.enums.ReceivingLineStatus;
 import com.positivity.inventory.internal.enums.ReceivingSessionStatus;
+import com.positivity.inventory.internal.exception.FractionalQuantityNotAllowedException;
 import com.positivity.inventory.internal.exception.PartMatchPermissionException;
 import com.positivity.inventory.internal.exception.ReceivingSessionNotFoundException;
 import com.positivity.inventory.internal.exception.SourceDocumentAlreadyReceivedException;
 import com.positivity.inventory.internal.exception.SourceDocumentNotFoundException;
 import com.positivity.inventory.internal.exception.WorkorderClosedException;
+import com.positivity.inventory.internal.repository.ExtProductReplicaRepository;
+import com.positivity.inventory.internal.repository.ExtProductUomReplicaRepository;
 import com.positivity.inventory.internal.repository.InventoryLedgerEntryRepository;
 import com.positivity.inventory.internal.repository.InventoryVarianceRepository;
 import com.positivity.inventory.internal.repository.ReceivingSessionRepository;
 import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.inventory.internal.service.ReceivingServiceImpl;
 import com.positivity.inventory.internal.service.SiteDefaultsService;
+import com.positivity.inventory.internal.service.UomConversionService;
+import com.positivity.inventory.internal.service.UomConversionServiceImpl;
 import com.positivity.inventory.internal.service.WorkorderValidationService;
 import com.positivity.security.common.GatewaySecurityConstants;
 import java.math.BigDecimal;
@@ -100,6 +109,19 @@ class ReceivingServiceImplTest {
     // resolveReceiptLot returns null by default.
     @Mock
     private com.positivity.inventory.internal.service.InventoryLotCaptureService lotCaptureService;
+
+    /**
+     * The real divisibility guard over a stubbable conversion service (ADR-0055, #1414). A mocked
+     * guard would answer null and NPE; a real one over a mocked conversion service answers "scale
+     * 0" for every product by default, which is the whole-units behaviour every SKU has today —
+     * so the existing vectors are unchanged and a divisible product can be stubbed in explicitly.
+     */
+    private final com.positivity.inventory.internal.service.UomConversionService uomConversionService =
+            org.mockito.Mockito.mock(com.positivity.inventory.internal.service.UomConversionService.class);
+
+    @Spy
+    private com.positivity.inventory.internal.service.QuantityScaleGuard quantityScaleGuard =
+            new com.positivity.inventory.internal.service.QuantityScaleGuard(uomConversionService);
 
     @InjectMocks
     private ReceivingServiceImpl receivingService;
@@ -587,7 +609,7 @@ class ReceivingServiceImplTest {
         when(receivingSessionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         when(ledgerPostingService.post(any())).thenAnswer(inv -> inv.getArgument(0));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation("PROD-001", STAGING_LOCATION_ID))
-                .thenReturn(7);
+                .thenReturn(new BigDecimal("7"));
 
         ReceiveItemsRequest request = new ReceiveItemsRequest(
                 List.of(new ReceiveLineRequest(lineId, new BigDecimal("10"), null, null, null)));
@@ -600,8 +622,8 @@ class ReceivingServiceImplTest {
 
         assertThat(savedLedgerEntry.getLocationId()).isEqualTo(STAGING_LOCATION_ID);
         assertThat(savedLedgerEntry.getToLocationId()).isEqualTo(STAGING_LOCATION_ID);
-        assertThat(savedLedgerEntry.getQuantityAfter()).isEqualTo(17);
-        assertThat(savedLedgerEntry.getChangeInQuantity()).isEqualTo(10);
+        assertThat(savedLedgerEntry.getQuantityAfter()).isEqualByComparingTo("17");
+        assertThat(savedLedgerEntry.getChangeInQuantity()).isEqualByComparingTo("10");
     }
 
     @Test
@@ -633,7 +655,7 @@ class ReceivingServiceImplTest {
                 .thenReturn(Optional.of(siteDefaultStagingLocationId));
         when(ledgerPostingService.post(any())).thenAnswer(inv -> inv.getArgument(0));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation("PROD-001", siteDefaultStagingLocationId))
-                .thenReturn(7);
+                .thenReturn(new BigDecimal("7"));
 
         ReceiveItemsRequest request = new ReceiveItemsRequest(
                 List.of(new ReceiveLineRequest(lineId, new BigDecimal("10"), null, null, null)));
@@ -646,7 +668,7 @@ class ReceivingServiceImplTest {
 
         assertThat(savedLedgerEntry.getLocationId()).isEqualTo(siteDefaultStagingLocationId);
         assertThat(savedLedgerEntry.getToLocationId()).isEqualTo(siteDefaultStagingLocationId);
-        assertThat(savedLedgerEntry.getQuantityAfter()).isEqualTo(17);
+        assertThat(savedLedgerEntry.getQuantityAfter()).isEqualByComparingTo("17");
     }
 
     @Test
@@ -990,7 +1012,7 @@ class ReceivingServiceImplTest {
     }
 
     @Test
-    void crossDockLineToWorkorder_fractionalQuantity_throwsIllegalArgumentException() {
+    void crossDockLineToWorkorder_fractionalQuantityForAWholeUnitsProduct_isRefused() {
         UUID sessionId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID lineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID workorderLineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
@@ -1017,11 +1039,16 @@ class ReceivingServiceImplTest {
         CrossDockRequest request =
                 new CrossDockRequest("WO-001", workorderLineId.toString(), new BigDecimal("1.5"), null);
 
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
+        // ADR-0055 (#1414): the refusal survives the widening, but it is now read from the
+        // product's catalog declaration rather than hardcoded — this product declares nothing,
+        // so it is stocked in whole units and 1.5 is refused with the same code the demand side
+        // raises (#1413).
+        FractionalQuantityNotAllowedException exception = assertThrows(
+                FractionalQuantityNotAllowedException.class,
                 () -> receivingService.crossDockLineToWorkorder(sessionId, lineId, request, "actor-user"));
 
-        assertThat(exception.getMessage()).contains("whole number");
+        assertThat(exception.getMessage()).contains(FractionalQuantityNotAllowedException.ERROR_CODE);
+        assertThat(exception.getMessage()).contains("whole units");
     }
 
     @Test
@@ -1129,7 +1156,7 @@ class ReceivingServiceImplTest {
         when(workorderValidationService.getWorkorderLineValidation("WO-001", workorderLineId.toString()))
                 .thenReturn(new WorkorderValidationService.WorkorderLineValidation("WORK_IN_PROGRESS", "PROD-001"));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantityAtLocation("PROD-001", CROSS_DOCK_LOCATION_ID))
-                .thenReturn(4, 14);
+                .thenReturn(new BigDecimal("4"), new BigDecimal("14"));
 
         CrossDockRequest request =
                 new CrossDockRequest("WO-001", workorderLineId.toString(), new BigDecimal("10"), null);
@@ -1143,14 +1170,14 @@ class ReceivingServiceImplTest {
         InventoryLedgerEntry receiptEntry = savedEntries.get(0);
         assertThat(receiptEntry.getLocationId()).isEqualTo(CROSS_DOCK_LOCATION_ID);
         assertThat(receiptEntry.getToLocationId()).isEqualTo(CROSS_DOCK_LOCATION_ID);
-        assertThat(receiptEntry.getQuantityAfter()).isEqualTo(14);
-        assertThat(receiptEntry.getChangeInQuantity()).isEqualTo(10);
+        assertThat(receiptEntry.getQuantityAfter()).isEqualByComparingTo("14");
+        assertThat(receiptEntry.getChangeInQuantity()).isEqualByComparingTo("10");
 
         InventoryLedgerEntry issueEntry = savedEntries.get(1);
         assertThat(issueEntry.getLocationId()).isEqualTo(CROSS_DOCK_LOCATION_ID);
         assertThat(issueEntry.getFromLocationId()).isEqualTo(CROSS_DOCK_LOCATION_ID);
-        assertThat(issueEntry.getQuantityAfter()).isEqualTo(4);
-        assertThat(issueEntry.getChangeInQuantity()).isEqualTo(-10);
+        assertThat(issueEntry.getQuantityAfter()).isEqualByComparingTo("4");
+        assertThat(issueEntry.getChangeInQuantity()).isEqualByComparingTo("-10");
     }
 
     @Test
@@ -1188,7 +1215,7 @@ class ReceivingServiceImplTest {
     }
 
     @Test
-    void receiveItemsIntoStaging_fractionalQuantity_throwsIllegalArgumentException() {
+    void receiveItemsIntoStaging_fractionalQuantityForAWholeUnitsProduct_isRefused() {
         UUID sessionId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID lineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
@@ -1210,11 +1237,87 @@ class ReceivingServiceImplTest {
         ReceiveItemsRequest request = new ReceiveItemsRequest(
                 List.of(new ReceiveLineRequest(lineId, new BigDecimal("2.75"), null, null, null)));
 
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
+        FractionalQuantityNotAllowedException exception = assertThrows(
+                FractionalQuantityNotAllowedException.class,
                 () -> receivingService.receiveItemsIntoStaging(sessionId, request, "test-user"));
 
-        assertThat(exception.getMessage()).contains("whole number");
+        assertThat(exception.getMessage()).contains(FractionalQuantityNotAllowedException.ERROR_CODE);
+        assertThat(exception.getMessage()).contains("whole units");
+    }
+
+    /**
+     * The ADR-0055 sentinel (#1414 AC). {@code UomConversionServiceImplTest} carries a product
+     * whose base UoM is {@code LB} at {@code precision_scale = 2}, and asserts that {@code 1 BAG}
+     * converts to {@code 1.01 LB}. Feed that same quantity through receiving before this stage and
+     * {@code toWholeLedgerQuantity}'s {@code intValueExact()} threw: the conversion subsystem and
+     * the ledger could not both be right about the same product. This is the single clearest proof
+     * that the contradiction is resolved — the posting round-trips into the ledger at its real
+     * quantity, and the guard is still there, just reading the declaration.
+     */
+    @Test
+    void receiveItemsIntoStaging_scaleTwoProduct_postsItsFractionalQuantityToTheLedger() {
+        UUID sessionId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID lineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID productId = UUID.fromString("018f0000-0000-7000-8000-000000000d02");
+
+        // Not a stubbed scale: the real conversion service reading the real fixture. This is the
+        // same product UomConversionServiceImplTest seeds — base LB at precision_scale 2, BAG at
+        // factor 1.005 — the one whose 1 BAG -> 1.01 LB vector receiving used to reject. Deriving
+        // the declaration here rather than stubbing it is what makes the two sides provably agree
+        // instead of coincidentally agreeing.
+        ExtProductReplicaRepository products = mock(ExtProductReplicaRepository.class);
+        ExtProductUomReplicaRepository productUoms = mock(ExtProductUomReplicaRepository.class);
+        when(products.findById(productId))
+                .thenReturn(Optional.of(ExtProductReplica.builder()
+                        .productId(productId)
+                        .baseUom("LB")
+                        .trackingLevel("NONE")
+                        .aggregateVersion(1L)
+                        .updatedAt(Instant.parse("2026-07-20T00:00:00Z"))
+                        .build()));
+        when(products.existsById(productId)).thenReturn(true);
+        when(productUoms.findByProductIdAndUomCode(productId, "LB"))
+                .thenReturn(Optional.of(ExtProductUomReplica.builder()
+                        .productId(productId)
+                        .uomCode("LB")
+                        .uomType("BASE")
+                        .factorToBase(BigDecimal.ONE)
+                        .precisionScale(2)
+                        .build()));
+        UomConversionService realConversion = new UomConversionServiceImpl(products, productUoms);
+        int declaredScale = realConversion.declaredBaseScale(productId);
+        assertThat(declaredScale).isEqualTo(2);
+        // Resolved before stubbing, not inside the when(...) argument: a real call that itself
+        // touches mocks would leave Mockito mid-stubbing.
+        when(uomConversionService.declaredBaseScale(productId)).thenReturn(declaredScale);
+
+        ReceivingLine line = ReceivingLine.builder()
+                .lineId(lineId)
+                .productId(productId.toString())
+                .expectedQuantity(new BigDecimal("1.01"))
+                .receivedQuantity(BigDecimal.ZERO)
+                .status(ReceivingLineStatus.EXPECTED)
+                .build();
+        ReceivingSession session = ReceivingSession.builder()
+                .sessionId(sessionId)
+                .sourceDocumentId("PO-BULK")
+                .lines(new java.util.ArrayList<>(List.of(line)))
+                .status(ReceivingSessionStatus.OPEN)
+                .build();
+        line.setSession(session);
+        when(receivingSessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(receivingSessionRepository.save(any(ReceivingSession.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(ledgerPostingService.post(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ReceiveItemsRequest request = new ReceiveItemsRequest(
+                List.of(new ReceiveLineRequest(lineId, new BigDecimal("1.01"), null, null, null)));
+
+        receivingService.receiveItemsIntoStaging(sessionId, request, "test-user");
+
+        ArgumentCaptor<InventoryLedgerEntry> posted = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
+        verify(ledgerPostingService).post(posted.capture());
+        assertThat(posted.getValue().getChangeInQuantity()).isEqualByComparingTo("1.01");
+        assertThat(posted.getValue().getEventType()).isEqualTo(InventoryLedgerEventType.GOODS_RECEIPT);
     }
 
     private void stubSourceDocumentLines() {

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReplenishmentServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReplenishmentServiceImplTest.java
@@ -23,6 +23,7 @@ import com.positivity.inventory.internal.service.ForecastQuantityService;
 import com.positivity.inventory.internal.service.ForecastSiteResolver;
 import com.positivity.inventory.internal.service.LeadTimeResolver;
 import com.positivity.inventory.internal.service.ReplenishmentServiceImpl;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -116,9 +117,9 @@ class ReplenishmentServiceImplTest {
                 .when(forecastSiteResolver.resolveForecastSite(any()))
                 .thenAnswer(invocation -> invocation.getArgument(0));
         Mockito.lenient()
-                .when(forecastQuantityService.forecast(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong()))
-                .thenAnswer(invocation ->
-                        new ForecastQuantityService.ForecastQuantities(0L, 0L, invocation.getArgument(3, Long.class)));
+                .when(forecastQuantityService.forecast(any(), any(), any(), any()))
+                .thenAnswer(invocation -> new ForecastQuantityService.ForecastQuantities(
+                        BigDecimal.ZERO, BigDecimal.ZERO, invocation.getArgument(3, BigDecimal.class)));
         Mockito.lenient()
                 .when(replenishmentTaskRepository.findByItemSKUAndDestinationLocationIdAndStatusIn(any(), any(), any()))
                 .thenReturn(Collections.emptyList());
@@ -328,8 +329,9 @@ class ReplenishmentServiceImplTest {
                 .thenReturn(false);
         givenOnHand("PROD123", PICKFACE_01, 3);
         // Inbound supply within the horizon lifts the projection to the minimum.
-        when(forecastQuantityService.forecast(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong()))
-                .thenReturn(new ForecastQuantityService.ForecastQuantities(2L, 0L, 5L));
+        when(forecastQuantityService.forecast(any(), any(), any(), any()))
+                .thenReturn(new ForecastQuantityService.ForecastQuantities(
+                        new BigDecimal("2"), new BigDecimal("0"), new BigDecimal("5")));
 
         ReplenishmentTaskResponse response =
                 replenishmentService.evaluatePickFaceForReplenishment("PROD123", PICKFACE_01);
@@ -385,7 +387,7 @@ class ReplenishmentServiceImplTest {
                 .thenReturn(java.util.Optional.of(InventoryStockSummary.builder()
                         .stockItemId(sku)
                         .locationId(locationId)
-                        .onHand(onHand)
+                        .onHand(BigDecimal.valueOf(onHand))
                         .build()));
     }
 
@@ -529,8 +531,9 @@ class ReplenishmentServiceImplTest {
         when(replenishmentPolicyRepository.findAll()).thenReturn(List.of(policy));
         givenOnHand("SKU-INBOUND", LOC_01, 3);
         // Inbound 7 due within the horizon: projected 10 >= min 5.
-        when(forecastQuantityService.forecast(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong()))
-                .thenReturn(new ForecastQuantityService.ForecastQuantities(7L, 0L, 10L));
+        when(forecastQuantityService.forecast(any(), any(), any(), any()))
+                .thenReturn(new ForecastQuantityService.ForecastQuantities(
+                        new BigDecimal("7"), new BigDecimal("0"), new BigDecimal("10")));
 
         ReplenishmentScanResultResponse result = replenishmentService.runBatchReplenishmentScan();
 
@@ -553,8 +556,9 @@ class ReplenishmentServiceImplTest {
         givenOnHand("SKU-LATE-PO", LOC_01, 1);
         // Horizon-bounded forecast: late PO excluded, but 3 units of due supply count →
         // projected 4 < min 5.
-        when(forecastQuantityService.forecast(any(), any(), any(), org.mockito.ArgumentMatchers.anyLong()))
-                .thenReturn(new ForecastQuantityService.ForecastQuantities(3L, 0L, 4L));
+        when(forecastQuantityService.forecast(any(), any(), any(), any()))
+                .thenReturn(new ForecastQuantityService.ForecastQuantities(
+                        new BigDecimal("3"), new BigDecimal("0"), new BigDecimal("4")));
         when(replenishmentTaskRepository.findFirstByItemSKUAndDestinationLocationIdAndStatusInOrderByCreatedAtAsc(
                         any(), any(), any()))
                 .thenReturn(java.util.Optional.empty());
@@ -594,7 +598,7 @@ class ReplenishmentServiceImplTest {
                         org.mockito.ArgumentMatchers.eq("SKU-HORIZON"),
                         org.mockito.ArgumentMatchers.eq(LOC_01),
                         horizonCaptor.capture(),
-                        org.mockito.ArgumentMatchers.eq(9L));
+                        org.mockito.ArgumentMatchers.eq(new BigDecimal("9")));
         assertEquals(Instant.now(TEST_CLOCK).plus(Duration.ofDays(5)), horizonCaptor.getValue());
         assertEquals(Instant.parse("2024-01-06T00:00:00Z"), horizonCaptor.getValue());
     }

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReservationServiceImplTest.java
@@ -28,6 +28,7 @@ import com.positivity.inventory.internal.repository.ReservationRepository;
 import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.inventory.internal.service.ReservationServiceImpl;
 import com.positivity.inventory.internal.service.StorageLocationValidationService;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -122,21 +123,21 @@ class ReservationServiceImplTest {
                     .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                     .workorderLineId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                     .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                    .requiredQuantity(5)
-                    .allocatedQuantity(5)
+                    .requiredQuantity(new BigDecimal("5"))
+                    .allocatedQuantity(new BigDecimal("5"))
                     .status(ReservationStatus.PENDING)
                     .build();
             return Optional.of(AllocationEntity.builder()
                     .allocationId(id)
                     .reservation(res)
-                    .allocatedQuantity(5)
+                    .allocatedQuantity(new BigDecimal("5"))
                     .allocationState(AllocationState.SOFT)
                     .status(AllocationStatus.ALLOCATED)
                     .build());
         });
         lenient()
                 .when(inventoryLedgerEntryRepository.calculateOnHandQuantity(any(UUID.class)))
-                .thenReturn(100);
+                .thenReturn(new BigDecimal("100"));
         lenient()
                 .when(storageLocationValidationService.getStorageLocationValidation(any(String.class)))
                 .thenReturn(validation(true, true));
@@ -164,7 +165,8 @@ class ReservationServiceImplTest {
         // Arrange
         UUID workorderLineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID stockItemId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        CreateReservationRequest request = new CreateReservationRequest(workorderLineId, stockItemId, 5);
+        CreateReservationRequest request =
+                new CreateReservationRequest(workorderLineId, stockItemId, new BigDecimal("5"));
 
         // Act — RED: impl throws UnsupportedOperationException; assertions are never
         // reached
@@ -172,7 +174,7 @@ class ReservationServiceImplTest {
 
         // Assert
         assertThat(result.getStatus()).isEqualTo(ReservationStatus.PENDING.name());
-        assertThat(result.getAllocatedQuantity()).isEqualTo(5);
+        assertThat(result.getAllocatedQuantity()).isEqualByComparingTo("5");
         assertThat(result.getWorkorderLineId()).isEqualTo(workorderLineId);
         assertThat(result.getStockItemId()).isEqualTo(stockItemId);
     }
@@ -194,9 +196,9 @@ class ReservationServiceImplTest {
         // Arrange
         UUID workorderLineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         CreateReservationRequest first = new CreateReservationRequest(
-                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000001"), 5);
+                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000001"), new BigDecimal("5"));
         CreateReservationRequest second = new CreateReservationRequest(
-                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000001"), 10);
+                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000001"), new BigDecimal("10"));
 
         // Act — RED: first call already throws UnsupportedOperationException
         service.createOrUpdateReservation(first);
@@ -204,7 +206,7 @@ class ReservationServiceImplTest {
 
         // Assert — only one reservation; quantity reflects second call
         assertThat(result.getWorkorderLineId()).isEqualTo(workorderLineId);
-        assertThat(result.getRequiredQuantity()).isEqualTo(10);
+        assertThat(result.getRequiredQuantity()).isEqualByComparingTo("10");
     }
 
     // ─── SC3: Promote SOFT → HARD ───────────────────────────────────────────────
@@ -259,7 +261,7 @@ class ReservationServiceImplTest {
         PromoteAllocationRequest request = new PromoteAllocationRequest(STORAGE_LOCATION_ID, "urgent");
         // Force insufficient ATP so the exception is thrown
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(any(UUID.class)))
-                .thenReturn(1);
+                .thenReturn(new BigDecimal("1"));
 
         // Act + Assert
         assertThatThrownBy(() -> service.promoteToHard(allocationId, request))
@@ -286,8 +288,8 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(workorderLineId)
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(3)
-                .allocatedQuantity(3)
+                .requiredQuantity(new BigDecimal("3"))
+                .allocatedQuantity(new BigDecimal("3"))
                 .status(ReservationStatus.PENDING)
                 .build();
         when(reservationRepository.findByWorkorderLineId(workorderLineId)).thenReturn(Optional.of(reservation));
@@ -321,14 +323,14 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(workorderLineId)
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(5)
-                .allocatedQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("5"))
                 .status(ReservationStatus.PENDING)
                 .build();
         AllocationEntity hardAlloc = AllocationEntity.builder()
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .reservation(reservation)
-                .allocatedQuantity(5)
+                .allocatedQuantity(new BigDecimal("5"))
                 .allocationState(AllocationState.HARD)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
@@ -362,16 +364,16 @@ class ReservationServiceImplTest {
         // Arrange
         UUID workorderLineId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         CreateReservationRequest original = new CreateReservationRequest(
-                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000001"), 3);
+                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000001"), new BigDecimal("3"));
         CreateReservationRequest update = new CreateReservationRequest(
-                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000001"), 7);
+                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000001"), new BigDecimal("7"));
 
         // Act — RED: first call throws UnsupportedOperationException
         service.createOrUpdateReservation(original);
         ReservationResponse result = service.createOrUpdateReservation(update);
 
         // Assert
-        assertThat(result.getRequiredQuantity()).isEqualTo(7);
+        assertThat(result.getRequiredQuantity()).isEqualByComparingTo("7");
         assertThat(result.getStatus()).isEqualTo(ReservationStatus.PENDING.name());
     }
 
@@ -392,8 +394,8 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(workorderLineId)
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(2)
-                .allocatedQuantity(2)
+                .requiredQuantity(new BigDecimal("2"))
+                .allocatedQuantity(new BigDecimal("2"))
                 .status(ReservationStatus.PENDING)
                 .build();
 
@@ -401,10 +403,10 @@ class ReservationServiceImplTest {
         when(reservationRepository.save(existing)).thenReturn(existing);
 
         ReservationResponse response = repositoryService.createOrUpdateReservation(new CreateReservationRequest(
-                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000001"), 9));
+                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000001"), new BigDecimal("9")));
 
-        assertThat(existing.getRequiredQuantity()).isEqualTo(9);
-        assertThat(response.getRequiredQuantity()).isEqualTo(9);
+        assertThat(existing.getRequiredQuantity()).isEqualByComparingTo("9");
+        assertThat(response.getRequiredQuantity()).isEqualByComparingTo("9");
         verify(allocationRepository, never()).save(any(AllocationEntity.class));
     }
 
@@ -438,11 +440,11 @@ class ReservationServiceImplTest {
         });
 
         ReservationResponse response = repositoryService.createOrUpdateReservation(new CreateReservationRequest(
-                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000001"), 4));
+                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000001"), new BigDecimal("4")));
 
         assertThat(response.getWorkorderLineId()).isEqualTo(workorderLineId);
         assertThat(response.getStatus()).isEqualTo(ReservationStatus.PENDING.name());
-        assertThat(response.getAllocatedQuantity()).isEqualTo(4);
+        assertThat(response.getAllocatedQuantity()).isEqualByComparingTo("4");
         verify(reservationRepository, times(2)).save(any(ReservationEntity.class));
         verify(allocationRepository).save(any(AllocationEntity.class));
     }
@@ -484,22 +486,22 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(5)
-                .allocatedQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("5"))
                 .status(ReservationStatus.PENDING)
                 .build();
         AllocationEntity allocation = AllocationEntity.builder()
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .reservation(reservation)
                 .locationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .allocatedQuantity(5)
+                .allocatedQuantity(new BigDecimal("5"))
                 .allocationState(AllocationState.SOFT)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
 
         when(allocationRepository.findById(allocation.getAllocationId())).thenReturn(Optional.of(allocation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(any(UUID.class)))
-                .thenReturn(2);
+                .thenReturn(new BigDecimal("2"));
         when(allocationRepository.findByReservationAndAllocationState(reservation, AllocationState.HARD))
                 .thenReturn(List.of());
         when(reservationRepository.save(any(ReservationEntity.class)))
@@ -532,22 +534,22 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(5)
-                .allocatedQuantity(0)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("0"))
                 .status(ReservationStatus.PENDING)
                 .build();
         AllocationEntity allocation = AllocationEntity.builder()
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .reservation(reservation)
                 .locationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .allocatedQuantity(5)
+                .allocatedQuantity(new BigDecimal("5"))
                 .allocationState(AllocationState.SOFT)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
 
         when(allocationRepository.findById(allocation.getAllocationId())).thenReturn(Optional.of(allocation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(any(UUID.class)))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(allocationRepository.findByReservationAndAllocationState(reservation, AllocationState.HARD))
                 .thenReturn(List.of());
         when(allocationRepository.save(any(AllocationEntity.class)))
@@ -563,7 +565,7 @@ class ReservationServiceImplTest {
         assertThat(allocation.getHardenedAt()).isNotNull();
         assertThat(allocation.getHardenedBy()).isNotBlank();
         assertThat(response.getStatus()).isEqualTo(ReservationStatus.FULFILLED.name());
-        assertThat(response.getAllocatedQuantity()).isEqualTo(5);
+        assertThat(response.getAllocatedQuantity()).isEqualByComparingTo("5");
         verify(allocationRepository).save(allocation);
     }
 
@@ -583,15 +585,15 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(5)
-                .allocatedQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("5"))
                 .status(ReservationStatus.PENDING)
                 .build();
         AllocationEntity current = AllocationEntity.builder()
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .reservation(reservation)
                 .locationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .allocatedQuantity(5)
+                .allocatedQuantity(new BigDecimal("5"))
                 .allocationState(AllocationState.HARD)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
@@ -599,14 +601,14 @@ class ReservationServiceImplTest {
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .reservation(reservation)
                 .locationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .allocatedQuantity(3)
+                .allocatedQuantity(new BigDecimal("3"))
                 .allocationState(AllocationState.HARD)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
 
         when(allocationRepository.findById(current.getAllocationId())).thenReturn(Optional.of(current));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(any(UUID.class)))
-                .thenReturn(6);
+                .thenReturn(new BigDecimal("6"));
         when(allocationRepository.findByReservationAndAllocationState(reservation, AllocationState.HARD))
                 .thenReturn(List.of(current, otherHard));
         when(reservationRepository.save(any(ReservationEntity.class)))
@@ -658,8 +660,8 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(workorderLineId)
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(5)
-                .allocatedQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("5"))
                 .status(ReservationStatus.PENDING)
                 .build();
 
@@ -693,15 +695,15 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(workorderLineId)
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(9)
-                .allocatedQuantity(9)
+                .requiredQuantity(new BigDecimal("9"))
+                .allocatedQuantity(new BigDecimal("9"))
                 .status(ReservationStatus.PARTIALLY_FULFILLED)
                 .build();
         AllocationEntity softAllocation = AllocationEntity.builder()
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .reservation(reservation)
                 .locationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .allocatedQuantity(4)
+                .allocatedQuantity(new BigDecimal("4"))
                 .allocationState(AllocationState.SOFT)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
@@ -709,7 +711,7 @@ class ReservationServiceImplTest {
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .reservation(reservation)
                 .locationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .allocatedQuantity(5)
+                .allocatedQuantity(new BigDecimal("5"))
                 .allocationState(AllocationState.HARD)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
@@ -739,22 +741,22 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(5)
-                .allocatedQuantity(0)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("0"))
                 .status(ReservationStatus.PENDING)
                 .build();
         AllocationEntity allocation = AllocationEntity.builder()
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
                 .reservation(reservation)
                 .locationId(null)
-                .allocatedQuantity(5)
+                .allocatedQuantity(new BigDecimal("5"))
                 .allocationState(AllocationState.SOFT)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
 
         when(allocationRepository.findById(allocation.getAllocationId())).thenReturn(Optional.of(allocation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(any(UUID.class)))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(allocationRepository.findByReservationAndAllocationState(reservation, AllocationState.HARD))
                 .thenReturn(List.of());
         when(allocationRepository.save(any(AllocationEntity.class))).thenAnswer(i -> i.getArgument(0));
@@ -771,7 +773,7 @@ class ReservationServiceImplTest {
         InventoryLedgerEntry entry = ledgerCaptor.getValue();
         assertThat(entry.getEventType()).isEqualTo(InventoryLedgerEventType.ALLOCATION_CREATED);
         assertThat(entry.getLocationId()).isEqualTo(STORAGE_LOCATION_ID);
-        assertThat(entry.getChangeInQuantity()).isEqualTo(5);
+        assertThat(entry.getChangeInQuantity()).isEqualByComparingTo("5");
         assertThat(entry.getStockItemId())
                 .isEqualTo(reservation.getStockItemId().toString());
         assertThat(entry.getSourceTransactionId())
@@ -786,22 +788,22 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(5)
-                .allocatedQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("5"))
                 .status(ReservationStatus.FULFILLED)
                 .build();
         AllocationEntity allocation = AllocationEntity.builder()
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
                 .reservation(reservation)
                 .locationId(STORAGE_LOCATION_ID)
-                .allocatedQuantity(5)
+                .allocatedQuantity(new BigDecimal("5"))
                 .allocationState(AllocationState.HARD)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
 
         when(allocationRepository.findById(allocation.getAllocationId())).thenReturn(Optional.of(allocation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(any(UUID.class)))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(allocationRepository.findByReservationAndAllocationState(reservation, AllocationState.HARD))
                 .thenReturn(List.of(allocation));
         when(allocationRepository.save(any(AllocationEntity.class))).thenAnswer(i -> i.getArgument(0));
@@ -825,22 +827,22 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(5)
-                .allocatedQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("5"))
                 .status(ReservationStatus.FULFILLED)
                 .build();
         AllocationEntity allocation = AllocationEntity.builder()
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
                 .reservation(reservation)
                 .locationId(originalLocation)
-                .allocatedQuantity(5)
+                .allocatedQuantity(new BigDecimal("5"))
                 .allocationState(AllocationState.HARD)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
 
         when(allocationRepository.findById(allocation.getAllocationId())).thenReturn(Optional.of(allocation));
         when(inventoryLedgerEntryRepository.calculateOnHandQuantity(any(UUID.class)))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
         when(allocationRepository.findByReservationAndAllocationState(reservation, AllocationState.HARD))
                 .thenReturn(List.of(allocation));
 
@@ -865,15 +867,15 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(workorderLineId)
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(5)
-                .allocatedQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("5"))
                 .status(ReservationStatus.FULFILLED)
                 .build();
         AllocationEntity locatedHard = AllocationEntity.builder()
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
                 .reservation(existing)
                 .locationId(STORAGE_LOCATION_ID)
-                .allocatedQuantity(5)
+                .allocatedQuantity(new BigDecimal("5"))
                 .allocationState(AllocationState.HARD)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
@@ -882,7 +884,7 @@ class ReservationServiceImplTest {
         when(allocationRepository.findByReservation(existing)).thenReturn(List.of(locatedHard));
 
         CreateReservationRequest skuChange = new CreateReservationRequest(
-                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000099"), 5);
+                workorderLineId, UUID.fromString("00000000-0000-0000-0000-000000000099"), new BigDecimal("5"));
 
         assertThatThrownBy(() -> service.createOrUpdateReservation(skuChange))
                 .isInstanceOf(IllegalStateException.class)
@@ -932,15 +934,15 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(workorderLineId)
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(5)
-                .allocatedQuantity(5)
+                .requiredQuantity(new BigDecimal("5"))
+                .allocatedQuantity(new BigDecimal("5"))
                 .status(ReservationStatus.FULFILLED)
                 .build();
         AllocationEntity locatedHard = AllocationEntity.builder()
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
                 .reservation(reservation)
                 .locationId(STORAGE_LOCATION_ID)
-                .allocatedQuantity(5)
+                .allocatedQuantity(new BigDecimal("5"))
                 .allocationState(AllocationState.HARD)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
@@ -951,13 +953,13 @@ class ReservationServiceImplTest {
         when(reservationRepository.save(any(ReservationEntity.class))).thenAnswer(i -> i.getArgument(0));
         when(inventoryLedgerEntryRepository.sumChangeBySourceTransactionIdAndEventType(
                         locatedHard.getAllocationId().toString(), InventoryLedgerEventType.ALLOCATION_RELEASED))
-                .thenReturn(3);
+                .thenReturn(new BigDecimal("3"));
 
         service.cancelReservation(workorderLineId);
 
         ArgumentCaptor<InventoryLedgerEntry> ledgerCaptor = ArgumentCaptor.forClass(InventoryLedgerEntry.class);
         verify(ledgerPostingService).post(ledgerCaptor.capture());
-        assertThat(ledgerCaptor.getValue().getChangeInQuantity()).isEqualTo(2);
+        assertThat(ledgerCaptor.getValue().getChangeInQuantity()).isEqualByComparingTo("2");
     }
 
     @Test
@@ -970,15 +972,15 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderLineId(workorderLineId)
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(12)
-                .allocatedQuantity(12)
+                .requiredQuantity(new BigDecimal("12"))
+                .allocatedQuantity(new BigDecimal("12"))
                 .status(ReservationStatus.PARTIALLY_FULFILLED)
                 .build();
         AllocationEntity softAllocation = AllocationEntity.builder()
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
                 .reservation(reservation)
                 .locationId(null)
-                .allocatedQuantity(4)
+                .allocatedQuantity(new BigDecimal("4"))
                 .allocationState(AllocationState.SOFT)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
@@ -986,7 +988,7 @@ class ReservationServiceImplTest {
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000003"))
                 .reservation(reservation)
                 .locationId(null)
-                .allocatedQuantity(3)
+                .allocatedQuantity(new BigDecimal("3"))
                 .allocationState(AllocationState.HARD)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
@@ -994,7 +996,7 @@ class ReservationServiceImplTest {
                 .allocationId(UUID.fromString("00000000-0000-0000-0000-000000000004"))
                 .reservation(reservation)
                 .locationId(STORAGE_LOCATION_ID)
-                .allocatedQuantity(5)
+                .allocatedQuantity(new BigDecimal("5"))
                 .allocationState(AllocationState.HARD)
                 .status(AllocationStatus.ALLOCATED)
                 .build();
@@ -1012,7 +1014,7 @@ class ReservationServiceImplTest {
         InventoryLedgerEntry entry = ledgerCaptor.getValue();
         assertThat(entry.getEventType()).isEqualTo(InventoryLedgerEventType.ALLOCATION_RELEASED);
         assertThat(entry.getLocationId()).isEqualTo(STORAGE_LOCATION_ID);
-        assertThat(entry.getChangeInQuantity()).isEqualTo(5);
+        assertThat(entry.getChangeInQuantity()).isEqualByComparingTo("5");
         assertThat(entry.getSourceTransactionId())
                 .isEqualTo(locatedHard.getAllocationId().toString());
     }
@@ -1027,8 +1029,8 @@ class ReservationServiceImplTest {
                 .reservationId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .salesOrderLineId(salesOrderLineId)
                 .stockItemId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-                .requiredQuantity(3)
-                .allocatedQuantity(3)
+                .requiredQuantity(new BigDecimal("3"))
+                .allocatedQuantity(new BigDecimal("3"))
                 .status(ReservationStatus.PENDING)
                 .build();
         when(reservationRepository.findBySalesOrderLineId(salesOrderLineId)).thenReturn(Optional.of(reservation));

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ReturnServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ReturnServiceImplTest.java
@@ -21,6 +21,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.InventoryReturnRepository;
 import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.inventory.internal.service.ReturnServiceImpl;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -92,7 +93,9 @@ class ReturnServiceImplTest {
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 new com.positivity.inventory.internal.service.DocumentQuantityConverter(
                         org.mockito.Mockito.mock(com.positivity.inventory.internal.service.UomConversionService.class)),
-                clock);
+                clock,
+                new com.positivity.inventory.internal.service.QuantityScaleGuard(org.mockito.Mockito.mock(
+                        com.positivity.inventory.internal.service.UomConversionService.class)));
     }
 
     private ReturnServiceImpl serviceWithLedgerRepository() {
@@ -103,7 +106,9 @@ class ReturnServiceImplTest {
                 org.mockito.Mockito.mock(com.positivity.inventory.internal.service.InventoryFactPublisher.class),
                 new com.positivity.inventory.internal.service.DocumentQuantityConverter(
                         org.mockito.Mockito.mock(com.positivity.inventory.internal.service.UomConversionService.class)),
-                clock);
+                clock,
+                new com.positivity.inventory.internal.service.QuantityScaleGuard(org.mockito.Mockito.mock(
+                        com.positivity.inventory.internal.service.UomConversionService.class)));
     }
 
     // ─── RS1: returnItemsToStock — valid request → ReturnResponse fields ─────────
@@ -127,14 +132,17 @@ class ReturnServiceImplTest {
         UUID workorderId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID skuId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         ReturnItemsRequest request = new ReturnItemsRequest(
-                workorderId, "Leftover brake pads", List.of(new ReturnItemLine(skuId, 2, null, null)));
+                workorderId,
+                "Leftover brake pads",
+                List.of(new ReturnItemLine(skuId, new BigDecimal("2"), null, null)));
 
         when(inventoryLedgerEntryRepository.findByStockItemIdAndEventTypeAndNotesContainingIgnoreCase(
                         eq(skuId.toString()),
                         eq(InventoryLedgerEventType.WORKORDER_CONSUMPTION),
                         eq(workorderId.toString())))
-                .thenReturn(List.of(
-                        InventoryLedgerEntry.builder().changeInQuantity(-100).build()));
+                .thenReturn(List.of(InventoryLedgerEntry.builder()
+                        .changeInQuantity(new BigDecimal("-100"))
+                        .build()));
         when(ledgerPostingService.postAll(anyList()))
                 .thenReturn(List.of(InventoryLedgerEntry.builder()
                         .ledgerEntryId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
@@ -144,7 +152,7 @@ class ReturnServiceImplTest {
 
         assertThat(result.getReturnId()).isNotNull();
         assertThat(result.getWorkorderId()).isEqualTo(workorderId);
-        assertThat(result.getTotalItemsReturned()).isEqualTo(2); // sum of quantityReturned
+        assertThat(result.getTotalItemsReturned()).isEqualByComparingTo("2"); // sum of quantityReturned
         assertThat(result.getCreatedAt()).isNotNull();
     }
 
@@ -173,12 +181,15 @@ class ReturnServiceImplTest {
         ReturnItemsRequest request = new ReturnItemsRequest(
                 workorderId,
                 "End of job surplus",
-                List.of(new ReturnItemLine(skuId1, 3, null, null), new ReturnItemLine(skuId2, 1, null, null)));
+                List.of(
+                        new ReturnItemLine(skuId1, new BigDecimal("3"), null, null),
+                        new ReturnItemLine(skuId2, new BigDecimal("1"), null, null)));
 
         when(inventoryLedgerEntryRepository.findByStockItemIdAndEventTypeAndNotesContainingIgnoreCase(
                         anyString(), any(), anyString()))
-                .thenReturn(List.of(
-                        InventoryLedgerEntry.builder().changeInQuantity(-100).build()));
+                .thenReturn(List.of(InventoryLedgerEntry.builder()
+                        .changeInQuantity(new BigDecimal("-100"))
+                        .build()));
 
         service().returnItemsToStock(request);
 
@@ -214,13 +225,22 @@ class ReturnServiceImplTest {
                 workorderId,
                 "Surplus parts",
                 List.of(
-                        new ReturnItemLine(UUID.fromString("00000000-0000-0000-0000-000000000001"), 1, null, null),
-                        new ReturnItemLine(UUID.fromString("00000000-0000-0000-0000-000000000001"), 2, null, null)));
+                        new ReturnItemLine(
+                                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                                new BigDecimal("1"),
+                                null,
+                                null),
+                        new ReturnItemLine(
+                                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                                new BigDecimal("2"),
+                                null,
+                                null)));
 
         when(inventoryLedgerEntryRepository.findByStockItemIdAndEventTypeAndNotesContainingIgnoreCase(
                         anyString(), any(), anyString()))
-                .thenReturn(List.of(
-                        InventoryLedgerEntry.builder().changeInQuantity(-100).build()));
+                .thenReturn(List.of(InventoryLedgerEntry.builder()
+                        .changeInQuantity(new BigDecimal("-100"))
+                        .build()));
         when(ledgerPostingService.postAll(anyList()))
                 .thenReturn(List.of(
                         InventoryLedgerEntry.builder()
@@ -256,7 +276,8 @@ class ReturnServiceImplTest {
         ReturnItemsRequest request = new ReturnItemsRequest(
                 UUID.fromString("00000000-0000-0000-0000-000000000001"),
                 null,
-                List.of(new ReturnItemLine(UUID.fromString("00000000-0000-0000-0000-000000000001"), 1, null, null)));
+                List.of(new ReturnItemLine(
+                        UUID.fromString("00000000-0000-0000-0000-000000000001"), new BigDecimal("1"), null, null)));
 
         // RED: UnsupportedOperationException is thrown — not in isInstanceOfAny set
         assertThatThrownBy(() -> service().returnItemsToStock(request))
@@ -285,7 +306,7 @@ class ReturnServiceImplTest {
         ReturnItemsRequest request = new ReturnItemsRequest(
                 UUID.fromString("00000000-0000-0000-0000-000000000001"),
                 "Over-return attempt",
-                List.of(new ReturnItemLine(skuId, 999, null, null)));
+                List.of(new ReturnItemLine(skuId, new BigDecimal("999"), null, null)));
 
         // RED: UnsupportedOperationException is thrown, not
         // ReturnQuantityExceededException
@@ -303,21 +324,25 @@ class ReturnServiceImplTest {
         ReturnItemsRequest request = new ReturnItemsRequest(
                 workorderId,
                 "  Completed workorder return  ",
-                List.of(new ReturnItemLine(skuId1, 3, null, null), new ReturnItemLine(skuId2, 1, null, null)));
+                List.of(
+                        new ReturnItemLine(skuId1, new BigDecimal("3"), null, null),
+                        new ReturnItemLine(skuId2, new BigDecimal("1"), null, null)));
 
         InventoryReturnEntity saved = InventoryReturnEntity.builder()
                 .returnId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .workorderId(workorderId)
                 .returnReason("Completed workorder return")
-                .totalItemsReturned(4)
+                .totalItemsReturned(new BigDecimal("4"))
                 .createdAt(Instant.parse("2026-02-25T03:00:00Z"))
                 .build();
         when(inventoryReturnRepository.save(entityCaptor.capture())).thenReturn(saved);
 
-        InventoryLedgerEntry consumedOne =
-                InventoryLedgerEntry.builder().changeInQuantity(-5).build();
-        InventoryLedgerEntry consumedTwo =
-                InventoryLedgerEntry.builder().changeInQuantity(2).build();
+        InventoryLedgerEntry consumedOne = InventoryLedgerEntry.builder()
+                .changeInQuantity(new BigDecimal("-5"))
+                .build();
+        InventoryLedgerEntry consumedTwo = InventoryLedgerEntry.builder()
+                .changeInQuantity(new BigDecimal("2"))
+                .build();
         when(inventoryLedgerEntryRepository.findByStockItemIdAndEventTypeAndNotesContainingIgnoreCase(
                         anyString(), eq(InventoryLedgerEventType.WORKORDER_CONSUMPTION), eq(workorderId.toString())))
                 .thenReturn(List.of(consumedOne, consumedTwo));
@@ -331,12 +356,12 @@ class ReturnServiceImplTest {
 
         ReturnResponse result = serviceWithLedgerRepository().returnItemsToStock(request);
 
-        assertThat(result.getTotalItemsReturned()).isEqualTo(4);
+        assertThat(result.getTotalItemsReturned()).isEqualByComparingTo("4");
         assertThat(result.getReturnReason()).isEqualTo("Completed workorder return");
         assertThat(result.getLedgerEntryIds()).containsExactly(firstLedgerId);
 
         InventoryReturnEntity captured = entityCaptor.getValue();
-        assertThat(captured.getTotalItemsReturned()).isEqualTo(4);
+        assertThat(captured.getTotalItemsReturned()).isEqualByComparingTo("4");
         assertThat(captured.getReturnReason()).isEqualTo("Completed workorder return");
     }
 
@@ -346,14 +371,15 @@ class ReturnServiceImplTest {
         UUID workorderId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID skuId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         ReturnItemsRequest request = new ReturnItemsRequest(
-                workorderId, "Return attempt", List.of(new ReturnItemLine(skuId, 3, null, null)));
+                workorderId, "Return attempt", List.of(new ReturnItemLine(skuId, new BigDecimal("3"), null, null)));
 
         when(inventoryLedgerEntryRepository.findByStockItemIdAndEventTypeAndNotesContainingIgnoreCase(
                         eq(skuId.toString()),
                         eq(InventoryLedgerEventType.WORKORDER_CONSUMPTION),
                         eq(workorderId.toString())))
-                .thenReturn(List.of(
-                        InventoryLedgerEntry.builder().changeInQuantity(1).build()));
+                .thenReturn(List.of(InventoryLedgerEntry.builder()
+                        .changeInQuantity(new BigDecimal("1"))
+                        .build()));
 
         assertThatThrownBy(() -> serviceWithLedgerRepository().returnItemsToStock(request))
                 .isInstanceOf(ReturnQuantityExceededException.class)
@@ -367,12 +393,14 @@ class ReturnServiceImplTest {
         ReturnItemsRequest request = new ReturnItemsRequest(
                 workorderId,
                 "Fallback return",
-                List.of(new ReturnItemLine(UUID.fromString("00000000-0000-0000-0000-000000000001"), 1, null, null)));
+                List.of(new ReturnItemLine(
+                        UUID.fromString("00000000-0000-0000-0000-000000000001"), new BigDecimal("1"), null, null)));
 
         when(inventoryLedgerEntryRepository.findByStockItemIdAndEventTypeAndNotesContainingIgnoreCase(
                         anyString(), any(), anyString()))
-                .thenReturn(List.of(
-                        InventoryLedgerEntry.builder().changeInQuantity(-100).build()));
+                .thenReturn(List.of(InventoryLedgerEntry.builder()
+                        .changeInQuantity(new BigDecimal("-100"))
+                        .build()));
         when(inventoryReturnRepository.save(any(InventoryReturnEntity.class))).thenReturn(null);
 
         assertThatThrownBy(() -> service().returnItemsToStock(request))
@@ -386,7 +414,8 @@ class ReturnServiceImplTest {
         ReturnItemsRequest request = new ReturnItemsRequest(
                 UUID.fromString("00000000-0000-0000-0000-000000000001"),
                 "Invalid return",
-                List.of(new ReturnItemLine(UUID.fromString("00000000-0000-0000-0000-000000000001"), 0, null, null)));
+                List.of(new ReturnItemLine(
+                        UUID.fromString("00000000-0000-0000-0000-000000000001"), new BigDecimal("0"), null, null)));
 
         assertThatThrownBy(() -> service().returnItemsToStock(request))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/ShortageResolutionServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/ShortageResolutionServiceImplTest.java
@@ -119,7 +119,8 @@ class ShortageResolutionServiceImplTest {
     @Test
     @DisplayName("options always include BACKORDER, EMERGENCY_PURCHASE and CANCEL_LINE with expected dates")
     void options_alwaysIncludeCoreOptions() {
-        List<ShortageOptionDto> options = service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, 3, SITE);
+        List<ShortageOptionDto> options =
+                service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, new BigDecimal("3"), SITE);
 
         assertThat(options)
                 .extracting(ShortageOptionDto::getOptionType)
@@ -142,7 +143,8 @@ class ShortageResolutionServiceImplTest {
                 .thenReturn(Optional.of(
                         ReplenishmentPolicy.builder().leadTimeDaysOverride(2).build()));
 
-        List<ShortageOptionDto> options = service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, 3, SITE);
+        List<ShortageOptionDto> options =
+                service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, new BigDecimal("3"), SITE);
 
         assertThat(optionOf(options, ShortageResolutionOption.BACKORDER).getExpectedResolutionDate())
                 .isEqualTo(TODAY.plusDays(2));
@@ -166,7 +168,8 @@ class ShortageResolutionServiceImplTest {
         when(skuCostStateRepository.findByStockItemId(SKU)).thenReturn(Optional.of(costState("20.00")));
         when(skuCostStateRepository.findByStockItemId(SUBSTITUTE)).thenReturn(Optional.of(costState("24.00")));
 
-        List<ShortageOptionDto> options = service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, 3, SITE);
+        List<ShortageOptionDto> options =
+                service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, new BigDecimal("3"), SITE);
 
         List<ShortageOptionDto> substitutes = options.stream()
                 .filter(o -> o.getOptionType() == ShortageResolutionOption.SUBSTITUTE)
@@ -174,7 +177,7 @@ class ShortageResolutionServiceImplTest {
         assertThat(substitutes).hasSize(1);
         ShortageOptionDto sub = substitutes.getFirst();
         assertThat(sub.getSubstituteSku()).isEqualTo(SUBSTITUTE);
-        assertThat(sub.getAvailableQuantity()).isEqualTo(10L);
+        assertThat(sub.getAvailableQuantity()).isEqualByComparingTo("10");
         assertThat(sub.getExpectedResolutionDate()).isEqualTo(TODAY);
         assertThat(sub.getCostDelta()).isEqualByComparingTo("4.00");
     }
@@ -190,7 +193,8 @@ class ShortageResolutionServiceImplTest {
         when(stockSummaryRepository.findByStockItemIdAndLocationId(SUBSTITUTE, SITE))
                 .thenReturn(Optional.of(summary(SUBSTITUTE, SITE, 0, 0)));
 
-        List<ShortageOptionDto> options = service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, 3, SITE);
+        List<ShortageOptionDto> options =
+                service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, new BigDecimal("3"), SITE);
 
         assertThat(options)
                 .extracting(ShortageOptionDto::getOptionType)
@@ -205,11 +209,12 @@ class ShortageResolutionServiceImplTest {
         when(stockSummaryRepository.findByStockItemId(SKU))
                 .thenReturn(List.of(summary(SKU, SIBLING_LOCATION, 8, 3))); // surplus 5 >= 3
 
-        List<ShortageOptionDto> options = service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, 3, SITE);
+        List<ShortageOptionDto> options =
+                service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, new BigDecimal("3"), SITE);
 
         ShortageOptionDto transfer = optionOf(options, ShortageResolutionOption.TRANSFER_IN);
         assertThat(transfer.getSourceLocationId()).isEqualTo(SIBLING_SITE);
-        assertThat(transfer.getAvailableQuantity()).isEqualTo(5L);
+        assertThat(transfer.getAvailableQuantity()).isEqualByComparingTo("5");
         assertThat(transfer.getExpectedResolutionDate()).isEqualTo(TODAY.plusDays(3));
     }
 
@@ -221,7 +226,8 @@ class ShortageResolutionServiceImplTest {
         when(stockSummaryRepository.findByStockItemId(SKU))
                 .thenReturn(List.of(summary(SKU, SIBLING_LOCATION, 4, 3))); // surplus 1 < 3
 
-        List<ShortageOptionDto> options = service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, 3, SITE);
+        List<ShortageOptionDto> options =
+                service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, new BigDecimal("3"), SITE);
 
         assertThat(options)
                 .extracting(ShortageOptionDto::getOptionType)
@@ -244,7 +250,8 @@ class ShortageResolutionServiceImplTest {
         when(vendorSelectionService.selectVendor(eq(SKU_ID), org.mockito.ArgumentMatchers.anyLong()))
                 .thenReturn(new VendorSelectionService.VendorSelection(vendor, "chosen"));
 
-        List<ShortageOptionDto> options = service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, 3, SITE);
+        List<ShortageOptionDto> options =
+                service.computeShortageOptions(ALLOCATION, WORKORDER_LINE, SKU, new BigDecimal("3"), SITE);
 
         ShortageOptionDto emergency = optionOf(options, ShortageResolutionOption.EMERGENCY_PURCHASE);
         assertThat(emergency.getExpectedResolutionDate()).isEqualTo(TODAY.plusDays(5));
@@ -255,7 +262,7 @@ class ShortageResolutionServiceImplTest {
     @DisplayName("resolve BACKORDER creates a backorder and records the artifact reference")
     void resolveBackorder_createsBackorderAndRecords() {
         UUID backorderId = UUID.fromString("00000000-0000-0000-0000-0000000000e1");
-        when(backorderService.createBackorder(WORKORDER_LINE, SKU, 3, SITE))
+        when(backorderService.createBackorder(WORKORDER_LINE, SKU, new BigDecimal("3"), SITE))
                 .thenReturn(BackorderResponse.builder().backorderId(backorderId).build());
 
         ShortageResolutionResultDto result = service.resolveShortage(
@@ -266,7 +273,7 @@ class ShortageResolutionServiceImplTest {
         assertThat(result.getArtifactId()).isEqualTo(backorderId);
         assertThat(result.getStatus()).isEqualTo("RESOLVED");
         assertThat(result.getResolvedAt()).isEqualTo(Instant.parse("2026-07-24T00:00:00Z"));
-        verify(backorderService).createBackorder(WORKORDER_LINE, SKU, 3, SITE);
+        verify(backorderService).createBackorder(WORKORDER_LINE, SKU, new BigDecimal("3"), SITE);
     }
 
     @Test
@@ -288,7 +295,7 @@ class ShortageResolutionServiceImplTest {
 
         assertThat(result.getArtifactId()).isEqualTo(stored.getArtifactId());
         assertThat(result.getResolvedAt()).isEqualTo(Instant.parse("2026-07-01T00:00:00Z"));
-        verify(backorderService, never()).createBackorder(any(), any(), org.mockito.ArgumentMatchers.anyInt(), any());
+        verify(backorderService, never()).createBackorder(any(), any(), any(), any());
         verify(resolutionRecordRepository, never()).save(any());
     }
 
@@ -386,7 +393,7 @@ class ShortageResolutionServiceImplTest {
                 .allocationId(ALLOCATION)
                 .optionType(option)
                 .sku(SKU)
-                .shortQuantity(3)
+                .shortQuantity(new BigDecimal("3"))
                 .locationId(SITE)
                 .workorderLineId(WORKORDER_LINE);
     }
@@ -395,9 +402,9 @@ class ShortageResolutionServiceImplTest {
         InventoryStockSummary s = new InventoryStockSummary();
         s.setStockItemId(sku);
         s.setLocationId(locationId);
-        s.setOnHand(onHand);
-        s.setAllocated(allocated);
-        s.setAtp(onHand - allocated);
+        s.setOnHand(BigDecimal.valueOf(onHand));
+        s.setAllocated(BigDecimal.valueOf(allocated));
+        s.setAtp(BigDecimal.valueOf(onHand - allocated));
         return s;
     }
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/SiteInventoryRollupServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/SiteInventoryRollupServiceImplTest.java
@@ -17,6 +17,7 @@ import com.positivity.inventory.internal.service.SiteInventoryQuantityLoader;
 import com.positivity.inventory.internal.service.SiteInventoryRollupServiceImpl;
 import com.positivity.inventory.internal.service.StorageLocationTopologyService;
 import com.positivity.inventory.internal.service.StorageLocationTopologyService.StorageLocationNode;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -72,28 +73,29 @@ class SiteInventoryRollupServiceImplTest {
         when(topologyService.fetchSiteTopology(SITE_ID)).thenReturn(threeLevelTopology());
         when(stockSummaryRepository.sumByLocationChunked(any(), isNull()))
                 .thenReturn(new LocationQuantityMaps(
-                        Map.of(SHELF_ID, 120L, BIN_ID, 360L), Map.of(SHELF_ID, 10L, BIN_ID, 20L)));
+                        Map.of(SHELF_ID, new BigDecimal("120"), BIN_ID, new BigDecimal("360")),
+                        Map.of(SHELF_ID, new BigDecimal("10"), BIN_ID, new BigDecimal("20"))));
 
         SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, null, true);
 
         assertThat(response.siteId()).isEqualTo(SITE_ID);
-        assertThat(response.totals().onHand()).isEqualTo(480);
-        assertThat(response.totals().allocated()).isEqualTo(30);
-        assertThat(response.totals().available()).isEqualTo(450);
+        assertThat(response.totals().onHand()).isEqualByComparingTo("480");
+        assertThat(response.totals().allocated()).isEqualByComparingTo("30");
+        assertThat(response.totals().available()).isEqualByComparingTo("450");
 
         StorageLocationRollupNode floor = response.nodes().getFirst();
         assertThat(floor.storageLocationId()).isEqualTo(FLOOR_ID);
         assertThat(floor.own().onHand()).isZero();
-        assertThat(floor.rolledUp().onHand()).isEqualTo(480);
-        assertThat(floor.rolledUp().available()).isEqualTo(450);
+        assertThat(floor.rolledUp().onHand()).isEqualByComparingTo("480");
+        assertThat(floor.rolledUp().available()).isEqualByComparingTo("450");
 
         StorageLocationRollupNode shelf = floor.children().getFirst();
-        assertThat(shelf.own().onHand()).isEqualTo(120);
-        assertThat(shelf.rolledUp().onHand()).isEqualTo(480);
+        assertThat(shelf.own().onHand()).isEqualByComparingTo("120");
+        assertThat(shelf.rolledUp().onHand()).isEqualByComparingTo("480");
 
         StorageLocationRollupNode bin = shelf.children().getFirst();
-        assertThat(bin.own().onHand()).isEqualTo(360);
-        assertThat(bin.rolledUp().onHand()).isEqualTo(360);
+        assertThat(bin.own().onHand()).isEqualByComparingTo("360");
+        assertThat(bin.rolledUp().onHand()).isEqualByComparingTo("360");
         assertThat(bin.children()).isEmpty();
     }
 
@@ -103,13 +105,14 @@ class SiteInventoryRollupServiceImplTest {
         // Issue #658: when sku given, all quantities are for that SKU only
         when(topologyService.fetchSiteTopology(SITE_ID)).thenReturn(threeLevelTopology());
         when(stockSummaryRepository.sumByLocationChunked(any(), eq("SKU-1")))
-                .thenReturn(new LocationQuantityMaps(Map.of(BIN_ID, 50L), Map.of(BIN_ID, 5L)));
+                .thenReturn(new LocationQuantityMaps(
+                        Map.of(BIN_ID, new BigDecimal("50")), Map.of(BIN_ID, new BigDecimal("5"))));
 
         SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, "SKU-1", null, true);
 
-        assertThat(response.totals().onHand()).isEqualTo(50);
-        assertThat(response.totals().allocated()).isEqualTo(5);
-        assertThat(response.totals().available()).isEqualTo(45);
+        assertThat(response.totals().onHand()).isEqualByComparingTo("50");
+        assertThat(response.totals().allocated()).isEqualByComparingTo("5");
+        assertThat(response.totals().available()).isEqualByComparingTo("45");
     }
 
     @Test
@@ -122,12 +125,12 @@ class SiteInventoryRollupServiceImplTest {
                         new StorageLocationNode(FLOOR_ID, "Floor A", "FLOOR", "ACTIVE", null),
                         new StorageLocationNode(SHELF_ID, "Orphan Shelf", "SHELF", "ACTIVE", ghostParent)));
         when(stockSummaryRepository.sumByLocationChunked(any(), isNull()))
-                .thenReturn(new LocationQuantityMaps(Map.of(SHELF_ID, 5L), Map.of()));
+                .thenReturn(new LocationQuantityMaps(Map.of(SHELF_ID, new BigDecimal("5")), Map.of()));
 
         SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, null, true);
 
         assertThat(response.nodes()).hasSize(2);
-        assertThat(response.totals().onHand()).isEqualTo(5);
+        assertThat(response.totals().onHand()).isEqualByComparingTo("5");
     }
 
     @Test
@@ -137,11 +140,12 @@ class SiteInventoryRollupServiceImplTest {
         when(topologyService.fetchSiteTopology(SITE_ID))
                 .thenReturn(List.of(new StorageLocationNode(BIN_ID, "Bin", "BIN", "ACTIVE", null)));
         when(stockSummaryRepository.sumByLocationChunked(any(), isNull()))
-                .thenReturn(new LocationQuantityMaps(Map.of(BIN_ID, 3L), Map.of(BIN_ID, 8L)));
+                .thenReturn(new LocationQuantityMaps(
+                        Map.of(BIN_ID, new BigDecimal("3")), Map.of(BIN_ID, new BigDecimal("8"))));
 
         SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, null, true);
 
-        assertThat(response.totals().available()).isEqualTo(-5);
+        assertThat(response.totals().available()).isEqualByComparingTo("-5");
     }
 
     @Test
@@ -155,7 +159,7 @@ class SiteInventoryRollupServiceImplTest {
                         new StorageLocationNode(SHELF_ID, "Shelf A-1", "SHELF", "ACTIVE", FLOOR_ID),
                         new StorageLocationNode(emptyBin, "Empty Bin", "BIN", "ACTIVE", FLOOR_ID)));
         when(stockSummaryRepository.sumByLocationChunked(any(), isNull()))
-                .thenReturn(new LocationQuantityMaps(Map.of(SHELF_ID, 9L), Map.of()));
+                .thenReturn(new LocationQuantityMaps(Map.of(SHELF_ID, new BigDecimal("9")), Map.of()));
 
         SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, null, false);
 
@@ -171,14 +175,14 @@ class SiteInventoryRollupServiceImplTest {
         // Issue #658: depth truncates the returned tree, not the math
         when(topologyService.fetchSiteTopology(SITE_ID)).thenReturn(threeLevelTopology());
         when(stockSummaryRepository.sumByLocationChunked(any(), isNull()))
-                .thenReturn(new LocationQuantityMaps(Map.of(BIN_ID, 360L), Map.of()));
+                .thenReturn(new LocationQuantityMaps(Map.of(BIN_ID, new BigDecimal("360")), Map.of()));
 
         SiteInventoryRollupResponse response = service.getSiteInventoryRollup(SITE_ID, null, 1, true);
 
         StorageLocationRollupNode floor = response.nodes().getFirst();
         assertThat(floor.children()).isEmpty();
-        assertThat(floor.rolledUp().onHand()).isEqualTo(360);
-        assertThat(response.totals().onHand()).isEqualTo(360);
+        assertThat(floor.rolledUp().onHand()).isEqualByComparingTo("360");
+        assertThat(response.totals().onHand()).isEqualByComparingTo("360");
     }
 
     @Test

--- a/pos-inventory/src/test/java/com/positivity/inventory/service/StockMovementServiceImplTest.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/service/StockMovementServiceImplTest.java
@@ -24,6 +24,7 @@ import com.positivity.inventory.internal.repository.InventoryLedgerEntryReposito
 import com.positivity.inventory.internal.repository.LocationRefRepository;
 import com.positivity.inventory.internal.service.LedgerPostingService;
 import com.positivity.inventory.internal.service.StockMovementServiceImpl;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
@@ -71,6 +72,8 @@ class StockMovementServiceImplTest {
                 ledgerPostingService,
                 locationRefRepository,
                 storageLocationRepository,
+                new com.positivity.inventory.internal.service.QuantityScaleGuard(
+                        org.mockito.Mockito.mock(com.positivity.inventory.internal.service.UomConversionService.class)),
                 clock);
     }
 
@@ -84,12 +87,12 @@ class StockMovementServiceImplTest {
         stubLedgerSaveReturnsEntry();
         RecordMovementRequest request = baseMovementRequest(MovementType.RECEIVE, 5);
         when(ledgerRepository.calculateOnHandQuantityAtLocation(request.getProductSku(), request.getFromLocationId()))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
 
         InventoryLedgerEntryResponse result = service.recordMovement(request, "actor-1");
 
         assertThat(result.getEventType()).isEqualTo(InventoryLedgerEventType.GOODS_RECEIPT);
-        assertThat(result.getChangeInQuantity()).isEqualTo(5);
+        assertThat(result.getChangeInQuantity()).isEqualByComparingTo("5");
         verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
@@ -99,12 +102,12 @@ class StockMovementServiceImplTest {
         stubLedgerSaveReturnsEntry();
         RecordMovementRequest request = baseMovementRequest(MovementType.PICK, 4);
         when(ledgerRepository.calculateOnHandQuantityAtLocation(request.getProductSku(), request.getFromLocationId()))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
 
         InventoryLedgerEntryResponse result = service.recordMovement(request, "actor-1");
 
         assertThat(result.getEventType()).isEqualTo(InventoryLedgerEventType.GOODS_ISSUE);
-        assertThat(result.getChangeInQuantity()).isEqualTo(-4);
+        assertThat(result.getChangeInQuantity()).isEqualByComparingTo("-4");
         verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
@@ -112,7 +115,7 @@ class StockMovementServiceImplTest {
     void recordMovement_pick_withInsufficientStock_throwsInsufficientStockException() {
         RecordMovementRequest request = baseMovementRequest(MovementType.PICK, 5);
         when(ledgerRepository.calculateOnHandQuantityAtLocation(request.getProductSku(), request.getFromLocationId()))
-                .thenReturn(3);
+                .thenReturn(new BigDecimal("3"));
 
         Throwable exception = catchThrowable(() -> service.recordMovement(request, "actor-1"));
 
@@ -124,7 +127,7 @@ class StockMovementServiceImplTest {
     void recordMovement_issue_withInsufficientStock_throwsInsufficientStockException() {
         RecordMovementRequest request = baseMovementRequest(MovementType.ISSUE, 7);
         when(ledgerRepository.calculateOnHandQuantityAtLocation(request.getProductSku(), request.getFromLocationId()))
-                .thenReturn(2);
+                .thenReturn(new BigDecimal("2"));
 
         Throwable exception = catchThrowable(() -> service.recordMovement(request, "actor-1"));
 
@@ -151,12 +154,12 @@ class StockMovementServiceImplTest {
         RecordMovementRequest request = baseMovementRequest(MovementType.PICK, 5);
         request.setFromLocationId(LOC_2);
         when(ledgerRepository.calculateOnHandQuantityAtLocation(request.getProductSku(), LOC_2))
-                .thenReturn(8);
+                .thenReturn(new BigDecimal("8"));
 
         InventoryLedgerEntryResponse result = service.recordMovement(request, "actor-1");
 
         assertThat(result.getEventType()).isEqualTo(InventoryLedgerEventType.GOODS_ISSUE);
-        assertThat(result.getChangeInQuantity()).isEqualTo(-5);
+        assertThat(result.getChangeInQuantity()).isEqualByComparingTo("-5");
         verify(ledgerRepository, times(2)).calculateOnHandQuantityAtLocation(request.getProductSku(), LOC_2);
         verify(ledgerRepository, never()).calculateOnHandQuantityAtLocation(request.getProductSku(), LOC_1);
         verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
@@ -169,9 +172,9 @@ class StockMovementServiceImplTest {
         RecordMovementRequest request = baseMovementRequest(MovementType.TRANSFER, 6);
         request.setToLocationId(LOC_2);
         when(ledgerRepository.calculateOnHandQuantityAtLocation(request.getProductSku(), LOC_2))
-                .thenReturn(20);
+                .thenReturn(new BigDecimal("20"));
         when(ledgerRepository.calculateOnHandQuantityAtLocation(request.getProductSku(), LOC_1))
-                .thenReturn(20);
+                .thenReturn(new BigDecimal("20"));
 
         service.recordMovement(request, "actor-1");
 
@@ -184,14 +187,14 @@ class StockMovementServiceImplTest {
         assertThat(transferIn.getLocationId()).isEqualTo(LOC_2);
         assertThat(transferIn.getFromLocationId()).isEqualTo(LOC_1);
         assertThat(transferIn.getToLocationId()).isEqualTo(LOC_2);
-        assertThat(transferIn.getChangeInQuantity()).isEqualTo(6);
+        assertThat(transferIn.getChangeInQuantity()).isEqualByComparingTo("6");
 
         InventoryLedgerEntry transferOut = savedEntries.get(1);
         assertThat(transferOut.getEventType()).isEqualTo(InventoryLedgerEventType.TRANSFER_OUT);
         assertThat(transferOut.getLocationId()).isEqualTo(LOC_1);
         assertThat(transferOut.getFromLocationId()).isEqualTo(LOC_1);
         assertThat(transferOut.getToLocationId()).isEqualTo(LOC_2);
-        assertThat(transferOut.getChangeInQuantity()).isEqualTo(-6);
+        assertThat(transferOut.getChangeInQuantity()).isEqualByComparingTo("-6");
         verify(ledgerRepository).calculateOnHandQuantityAtLocation("SKU-123", LOC_2);
         verify(ledgerRepository).calculateOnHandQuantityAtLocation("SKU-123", LOC_1);
     }
@@ -215,12 +218,12 @@ class StockMovementServiceImplTest {
         stubLedgerSaveReturnsEntry();
         RecordMovementRequest request = baseMovementRequest(MovementType.PUT_AWAY, 3);
         when(ledgerRepository.calculateOnHandQuantityAtLocation(request.getProductSku(), request.getFromLocationId()))
-                .thenReturn(8);
+                .thenReturn(new BigDecimal("8"));
 
         InventoryLedgerEntryResponse result = service.recordMovement(request, "actor-1");
 
         assertThat(result.getEventType()).isEqualTo(InventoryLedgerEventType.PUTAWAY);
-        assertThat(result.getChangeInQuantity()).isEqualTo(3);
+        assertThat(result.getChangeInQuantity()).isEqualByComparingTo("3");
         verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
@@ -230,12 +233,12 @@ class StockMovementServiceImplTest {
         stubLedgerSaveReturnsEntry();
         RecordMovementRequest request = baseMovementRequest(MovementType.RETURN, 2);
         when(ledgerRepository.calculateOnHandQuantityAtLocation(request.getProductSku(), request.getFromLocationId()))
-                .thenReturn(5);
+                .thenReturn(new BigDecimal("5"));
 
         InventoryLedgerEntryResponse result = service.recordMovement(request, "actor-1");
 
         assertThat(result.getEventType()).isEqualTo(InventoryLedgerEventType.RETURN_TO_STOCK);
-        assertThat(result.getChangeInQuantity()).isEqualTo(2);
+        assertThat(result.getChangeInQuantity()).isEqualByComparingTo("2");
         verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
@@ -245,7 +248,7 @@ class StockMovementServiceImplTest {
         stubLedgerSaveReturnsEntry();
         RecordMovementRequest request = baseMovementRequest(MovementType.RECEIVE, 1);
         when(ledgerRepository.calculateOnHandQuantityAtLocation(request.getProductSku(), request.getFromLocationId()))
-                .thenReturn(0);
+                .thenReturn(new BigDecimal("0"));
 
         service.recordMovement(request, "actor-xyz");
 
@@ -280,7 +283,7 @@ class StockMovementServiceImplTest {
 
         assertThat(result.getProductSku()).isEqualTo("SKU-123");
         assertThat(result.getLocationId()).isEqualTo(LOC_1);
-        assertThat(result.getQuantity()).isEqualTo(11);
+        assertThat(result.getQuantity()).isEqualByComparingTo("11");
         assertThat(result.getReasonCode()).isEqualTo("CYCLE_COUNT");
     }
 
@@ -292,12 +295,12 @@ class StockMovementServiceImplTest {
         InventoryAdjustmentRequest request = pendingAdjustmentRequest(4);
         when(adjustmentRepository.findById(request.getAdjustmentRequestId())).thenReturn(Optional.of(request));
         when(ledgerRepository.calculateOnHandQuantityAtLocation(request.getProductSku(), request.getLocationId()))
-                .thenReturn(15);
+                .thenReturn(new BigDecimal("15"));
 
         InventoryLedgerEntry result = service.approveAdjustmentRequest(request.getAdjustmentRequestId(), "approver-1");
 
         assertThat(result.getEventType()).isEqualTo(InventoryLedgerEventType.ADJUSTMENT_IN);
-        assertThat(result.getChangeInQuantity()).isEqualTo(4);
+        assertThat(result.getChangeInQuantity()).isEqualByComparingTo("4");
         verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
@@ -309,12 +312,12 @@ class StockMovementServiceImplTest {
         InventoryAdjustmentRequest request = pendingAdjustmentRequest(-3);
         when(adjustmentRepository.findById(request.getAdjustmentRequestId())).thenReturn(Optional.of(request));
         when(ledgerRepository.calculateOnHandQuantityAtLocation(request.getProductSku(), request.getLocationId()))
-                .thenReturn(10);
+                .thenReturn(new BigDecimal("10"));
 
         InventoryLedgerEntry result = service.approveAdjustmentRequest(request.getAdjustmentRequestId(), "approver-1");
 
         assertThat(result.getEventType()).isEqualTo(InventoryLedgerEventType.ADJUSTMENT_OUT);
-        assertThat(result.getChangeInQuantity()).isEqualTo(-3);
+        assertThat(result.getChangeInQuantity()).isEqualByComparingTo("-3");
         verify(ledgerPostingService).post(any(InventoryLedgerEntry.class));
     }
 
@@ -350,7 +353,7 @@ class StockMovementServiceImplTest {
         InventoryAdjustmentRequest request = pendingAdjustmentRequest(5);
         when(adjustmentRepository.findById(request.getAdjustmentRequestId())).thenReturn(Optional.of(request));
         when(ledgerRepository.calculateOnHandQuantityAtLocation(request.getProductSku(), request.getLocationId()))
-                .thenReturn(20);
+                .thenReturn(new BigDecimal("20"));
 
         service.approveAdjustmentRequest(request.getAdjustmentRequestId(), "approver-xyz");
 
@@ -369,7 +372,7 @@ class StockMovementServiceImplTest {
                 .fromLocationId(LOC_1)
                 .toLocationId(LOC_9)
                 .movementType(movementType)
-                .quantity(quantity)
+                .quantity(BigDecimal.valueOf(quantity))
                 .unitOfMeasure("EACH")
                 .sourceTransactionId("TX-1")
                 .build();
@@ -379,7 +382,7 @@ class StockMovementServiceImplTest {
         return CreateAdjustmentRequestDto.builder()
                 .productSku("SKU-123")
                 .locationId(LOC_1)
-                .quantity(quantity)
+                .quantity(BigDecimal.valueOf(quantity))
                 .reasonCode("CYCLE_COUNT")
                 .unitOfMeasure("EACH")
                 .build();
@@ -390,7 +393,7 @@ class StockMovementServiceImplTest {
                 .adjustmentRequestId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .productSku("SKU-123")
                 .locationId(LOC_1)
-                .quantity(quantity)
+                .quantity(BigDecimal.valueOf(quantity))
                 .reasonCode("CYCLE_COUNT")
                 .unitOfMeasure("EACH")
                 .status(AdjustmentRequestStatus.PENDING)

--- a/pos-location/src/main/java/com/positivity/location/internal/entity/ExtStorageLocationOnHandReplica.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/entity/ExtStorageLocationOnHandReplica.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -35,8 +36,9 @@ public class ExtStorageLocationOnHandReplica {
     @Column(name = "storage_location_id", nullable = false)
     private UUID storageLocationId;
 
-    @Column(name = "on_hand_quantity", nullable = false)
-    private int onHandQuantity;
+    /** Decimal since ADR-0055 (#1414); compare with {@code compareTo}, never {@code equals}. */
+    @Column(name = "on_hand_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal onHandQuantity;
 
     @Column(name = "aggregate_version", nullable = false)
     private long aggregateVersion;

--- a/pos-location/src/main/java/com/positivity/location/internal/service/StorageLocationServiceImpl.java
+++ b/pos-location/src/main/java/com/positivity/location/internal/service/StorageLocationServiceImpl.java
@@ -17,6 +17,7 @@ import com.positivity.location.internal.repository.LocationRepository;
 import com.positivity.location.internal.repository.StorageLocationRepository;
 import com.positivity.location.service.StorageLocationInventoryTransferService;
 import com.positivity.location.service.StorageLocationService;
+import java.math.BigDecimal;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -263,7 +264,7 @@ public class StorageLocationServiceImpl implements StorageLocationService {
                 .findByIdAndSiteId(storageLocationId, siteId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, STORAGE_LOCATION_NOT_FOUND));
 
-        if (replicaOnHandQuantity(storageLocationId) > 0) {
+        if (replicaOnHandQuantity(storageLocationId).signum() > 0) {
             transferInventory(siteId, existing, destinationStorageLocationId);
         }
 
@@ -278,11 +279,11 @@ public class StorageLocationServiceImpl implements StorageLocationService {
      * #899; replaces the retired LocationInventoryInquiryClient). A location the feed has never
      * reported carries no known stock, matching the owner ledger's empty state.
      */
-    private int replicaOnHandQuantity(UUID storageLocationId) {
+    private BigDecimal replicaOnHandQuantity(UUID storageLocationId) {
         return extStorageLocationOnHandReplicaRepository
                 .findById(storageLocationId)
                 .map(ExtStorageLocationOnHandReplica::getOnHandQuantity)
-                .orElse(0);
+                .orElse(BigDecimal.ZERO);
     }
 
     private String normalizeRequired(String value, String fieldName) {
@@ -398,7 +399,8 @@ public class StorageLocationServiceImpl implements StorageLocationService {
         if (requested == null) {
             return;
         }
-        if (requested == StorageLocationStatus.INACTIVE && replicaOnHandQuantity(storageLocationId) > 0) {
+        if (requested == StorageLocationStatus.INACTIVE
+                && replicaOnHandQuantity(storageLocationId).signum() > 0) {
             UUID destinationStorageLocationId = patch.getDestinationStorageLocationId();
             if (destinationStorageLocationId != null && destinationStorageLocationId.equals(storageLocationId)) {
                 throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_CONTENT, INVALID_DESTINATION);

--- a/pos-location/src/main/resources/db/migration/V5__decimal_storage_location_on_hand.sql
+++ b/pos-location/src/main/resources/db/migration/V5__decimal_storage_location_on_hand.sql
@@ -1,0 +1,11 @@
+-- ADR-0055 stage 2 (#1414): the on-hand facts this replica mirrors are now decimal.
+--
+-- StorageLocationOnHandUpdatedV1 carries a BigDecimal quantity because it sums the inventory
+-- ledger, which widened to numeric(19,4) so that a product whose catalog declaration permits
+-- decimals can be stocked at its real quantity. This table backs the "no decommission while
+-- stocked" guard, and that guard has to see a partial drum as stock rather than as zero.
+--
+-- Pre-production widening: numeric(19,4) holds every value the integer column could, so the
+-- implicit cast preserves existing rows exactly.
+ALTER TABLE ext_storage_location_on_hand
+    ALTER COLUMN on_hand_quantity TYPE numeric(19,4);

--- a/pos-location/src/test/java/com/positivity/location/service/StorageLocationServiceTest.java
+++ b/pos-location/src/test/java/com/positivity/location/service/StorageLocationServiceTest.java
@@ -17,6 +17,7 @@ import com.positivity.location.internal.repository.ExtStorageLocationOnHandRepli
 import com.positivity.location.internal.repository.LocationRepository;
 import com.positivity.location.internal.repository.StorageLocationRepository;
 import com.positivity.location.internal.service.StorageLocationServiceImpl;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -441,7 +442,7 @@ class StorageLocationServiceTest {
                 .thenReturn(java.util.Optional.of(
                         com.positivity.location.internal.entity.ExtStorageLocationOnHandReplica.builder()
                                 .storageLocationId(id)
-                                .onHandQuantity(5)
+                                .onHandQuantity(BigDecimal.valueOf(5))
                                 .build()));
 
         assertThatThrownBy(() -> storageLocationService.deactivateStorageLocation(siteId, id, null))
@@ -480,7 +481,7 @@ class StorageLocationServiceTest {
                 .thenReturn(java.util.Optional.of(
                         com.positivity.location.internal.entity.ExtStorageLocationOnHandReplica.builder()
                                 .storageLocationId(sourceId)
-                                .onHandQuantity(5)
+                                .onHandQuantity(BigDecimal.valueOf(5))
                                 .build()));
         when(storageLocationRepository.saveAndFlush(any(StorageLocationEntity.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
@@ -511,7 +512,7 @@ class StorageLocationServiceTest {
                 .thenReturn(java.util.Optional.of(
                         com.positivity.location.internal.entity.ExtStorageLocationOnHandReplica.builder()
                                 .storageLocationId(sourceId)
-                                .onHandQuantity(2)
+                                .onHandQuantity(BigDecimal.valueOf(2))
                                 .build()));
         when(storageLocationRepository.findByIdAndSiteId(destinationId, siteId)).thenReturn(Optional.empty());
 
@@ -550,7 +551,7 @@ class StorageLocationServiceTest {
                 .thenReturn(java.util.Optional.of(
                         com.positivity.location.internal.entity.ExtStorageLocationOnHandReplica.builder()
                                 .storageLocationId(sourceId)
-                                .onHandQuantity(2)
+                                .onHandQuantity(BigDecimal.valueOf(2))
                                 .build()));
         when(storageLocationRepository.findByIdAndSiteId(destinationId, siteId)).thenReturn(Optional.of(destination));
 
@@ -998,7 +999,7 @@ class StorageLocationServiceTest {
                 .thenReturn(java.util.Optional.of(
                         com.positivity.location.internal.entity.ExtStorageLocationOnHandReplica.builder()
                                 .storageLocationId(storageLocationId)
-                                .onHandQuantity(2)
+                                .onHandQuantity(BigDecimal.valueOf(2))
                                 .build()));
 
         assertThatThrownBy(() -> storageLocationService.patchStorageLocation(siteId, storageLocationId, patch))

--- a/pos-order/src/main/java/com/positivity/order/internal/client/InventoryPort.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/client/InventoryPort.java
@@ -1,5 +1,6 @@
 package com.positivity.order.internal.client;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -22,5 +23,5 @@ public interface InventoryPort {
      *     known stock, which reports insufficient rather than guessing
      */
     @NonNull
-    InventoryResult checkAvailability(@NonNull String itemSku, int quantity, @Nullable UUID locationId);
+    InventoryResult checkAvailability(@NonNull String itemSku, @NonNull BigDecimal quantity, @Nullable UUID locationId);
 }

--- a/pos-order/src/main/java/com/positivity/order/internal/client/InventoryResult.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/client/InventoryResult.java
@@ -1,3 +1,5 @@
 package com.positivity.order.internal.client;
 
-public record InventoryResult(boolean sufficient, int availableQuantity) {}
+import java.math.BigDecimal;
+
+public record InventoryResult(boolean sufficient, BigDecimal availableQuantity) {}

--- a/pos-order/src/main/java/com/positivity/order/internal/config/InventoryCommandPublisher.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/config/InventoryCommandPublisher.java
@@ -1,6 +1,7 @@
 package com.positivity.order.internal.config;
 
 import com.positivity.shared.id.UUIDv7Generator;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -46,13 +47,18 @@ public class InventoryCommandPublisher {
      *
      * @param salesOrderLineId demand line the reservation is for
      * @param stockItemId stock item requested
-     * @param requiredQuantity quantity requested
+     * @param requiredQuantity quantity requested; decimal-capable per the product's catalog
+     *     divisibility declaration (ADR-0055, #1414)
      * @param locationId selling location the demand must be covered at
      */
     public void requestReservation(
-            @NonNull UUID salesOrderLineId, @NonNull UUID stockItemId, int requiredQuantity, @NonNull UUID locationId) {
+            @NonNull UUID salesOrderLineId,
+            @NonNull UUID stockItemId,
+            @NonNull BigDecimal requiredQuantity,
+            @NonNull UUID locationId) {
         UUID commandId = deterministicCommandId(
-                RESERVATION_REQUEST_COMMAND_TYPE, salesOrderLineId + ":" + stockItemId + ":" + requiredQuantity);
+                RESERVATION_REQUEST_COMMAND_TYPE,
+                salesOrderLineId + ":" + stockItemId + ":" + normalizedQuantityKey(requiredQuantity));
         ReservationRequestPayload payload =
                 new ReservationRequestPayload(salesOrderLineId, stockItemId, requiredQuantity, locationId);
         send(RESERVATION_REQUEST_COMMAND_TYPE, commandId, salesOrderLineId.toString(), payload);
@@ -69,6 +75,18 @@ public class InventoryCommandPublisher {
         } catch (Exception e) {
             throw new IllegalStateException("Unable to publish " + commandType + " command " + commandId, e);
         }
+    }
+
+    /**
+     * The quantity as it appears in the idempotency key.
+     *
+     * <p>{@code stripTrailingZeros} first: since ADR-0055 (#1414) the quantity is a
+     * {@link BigDecimal}, and {@code 2} and {@code 2.00} are the same demand spelled two ways. A
+     * client retry that serialises the number differently must still collapse to the same command
+     * under pos-inventory's dedupe, which keying on the raw {@code toString} would not do.
+     */
+    private static String normalizedQuantityKey(@NonNull BigDecimal quantity) {
+        return quantity.stripTrailingZeros().toPlainString();
     }
 
     private static UUID deterministicCommandId(@NonNull String commandType, @NonNull String idempotencyKey) {
@@ -88,6 +106,6 @@ public class InventoryCommandPublisher {
     record ReservationRequestPayload(
             @NonNull UUID salesOrderLineId,
             @NonNull UUID stockItemId,
-            int requiredQuantity,
+            @NonNull BigDecimal requiredQuantity,
             @NonNull UUID locationId) {}
 }

--- a/pos-order/src/main/java/com/positivity/order/internal/entity/ExtInventoryAvailability.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/entity/ExtInventoryAvailability.java
@@ -8,6 +8,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -54,14 +55,14 @@ public class ExtInventoryAvailability {
     @Column(name = "location_id")
     private UUID locationId;
 
-    @Column(name = "on_hand_quantity", nullable = false)
-    private int onHandQuantity;
+    @Column(name = "on_hand_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal onHandQuantity;
 
-    @Column(name = "allocated_quantity", nullable = false)
-    private int allocatedQuantity;
+    @Column(name = "allocated_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal allocatedQuantity;
 
-    @Column(name = "available_to_promise_quantity", nullable = false)
-    private int availableToPromiseQuantity;
+    @Column(name = "available_to_promise_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal availableToPromiseQuantity;
 
     @Column(name = "unit_of_measure")
     private String unitOfMeasure;

--- a/pos-order/src/main/java/com/positivity/order/internal/service/ReplicaInventoryPortAdapter.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/ReplicaInventoryPortAdapter.java
@@ -6,6 +6,7 @@ import com.positivity.order.internal.entity.ExtInventoryAvailability;
 import com.positivity.order.internal.entity.ExtProduct;
 import com.positivity.order.internal.repository.ExtInventoryAvailabilityRepository;
 import com.positivity.order.internal.repository.ExtProductRepository;
+import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -51,10 +52,10 @@ public class ReplicaInventoryPortAdapter implements InventoryPort {
 
     @Override
     public @NonNull InventoryResult checkAvailability(
-            @NonNull String itemSku, int quantity, @Nullable UUID locationId) {
+            @NonNull String itemSku, @NonNull BigDecimal quantity, @Nullable UUID locationId) {
         if (locationId == null) {
             log.debug("No selling location for sku {}; reporting insufficient", itemSku);
-            return new InventoryResult(false, 0);
+            return new InventoryResult(false, BigDecimal.ZERO);
         }
         Optional<ExtInventoryAvailability> replica = productIdFor(itemSku)
                 .flatMap(productId -> extInventoryAvailabilityRepository.findByStockItemIdAndLocationId(
@@ -66,10 +67,12 @@ public class ReplicaInventoryPortAdapter implements InventoryPort {
                     "No availability replica row for sku {} at location {}; reporting insufficient",
                     itemSku,
                     locationId);
-            return new InventoryResult(false, 0);
+            return new InventoryResult(false, BigDecimal.ZERO);
         }
-        int atp = replica.get().getAvailableToPromiseQuantity();
-        return new InventoryResult(atp >= quantity, Math.max(atp, 0));
+        BigDecimal atp = replica.get().getAvailableToPromiseQuantity();
+        // compareTo, not equals or a primitive comparison: the replica column is numeric(19,4),
+        // so an ATP of 2.0000 must read as covering a demand of 2 (ADR-0055, #1414).
+        return new InventoryResult(atp.compareTo(quantity) >= 0, atp.max(BigDecimal.ZERO));
     }
 
     private Optional<UUID> productIdFor(String itemSku) {

--- a/pos-order/src/main/java/com/positivity/order/internal/service/SalesOrderServiceImpl.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/service/SalesOrderServiceImpl.java
@@ -211,8 +211,8 @@ public class SalesOrderServiceImpl implements SalesOrderService {
 
         // Advisory at line-add (an estimate may legitimately be built from out-of-stock items);
         // checkout re-evaluates and is what actually registers the demand.
-        InventoryResult inventoryResult =
-                inventoryPort.checkAvailability(command.itemSku(), command.quantity(), order.getLocationId());
+        InventoryResult inventoryResult = inventoryPort.checkAvailability(
+                command.itemSku(), BigDecimal.valueOf(command.quantity()), order.getLocationId());
         FulfillmentStatus fulfillmentStatus =
                 inventoryResult.sufficient() ? FulfillmentStatus.AVAILABLE : FulfillmentStatus.BACKORDER;
 
@@ -528,8 +528,8 @@ public class SalesOrderServiceImpl implements SalesOrderService {
             if (line == null) {
                 continue;
             }
-            InventoryResult availability =
-                    inventoryPort.checkAvailability(line.getItemSku(), line.getQuantity(), locationId);
+            InventoryResult availability = inventoryPort.checkAvailability(
+                    line.getItemSku(), BigDecimal.valueOf(line.getQuantity()), locationId);
             line.setFulfillmentStatus(
                     availability.sufficient() ? FulfillmentStatus.AVAILABLE : FulfillmentStatus.BACKORDER);
 
@@ -547,7 +547,10 @@ public class SalesOrderServiceImpl implements SalesOrderService {
                         order.getOrderId());
                 continue;
             }
-            publisher.requestReservation(line.getOrderLineId(), stockItemId, line.getQuantity(), locationId);
+            // Sales-order demand stays integral by decision (ADR-0055 leaves SalesOrderLine.quantity
+            // an int); the command is decimal, so this widens rather than narrowing.
+            publisher.requestReservation(
+                    line.getOrderLineId(), stockItemId, BigDecimal.valueOf(line.getQuantity()), locationId);
         }
     }
 

--- a/pos-order/src/main/resources/db/migration/V21__decimal_inventory_availability_replica.sql
+++ b/pos-order/src/main/resources/db/migration/V21__decimal_inventory_availability_replica.sql
@@ -1,0 +1,13 @@
+-- ADR-0055 stage 2 (#1414): the availability facts this replica mirrors are now decimal.
+--
+-- InventoryAvailabilityUpdatedV1 carries BigDecimal quantities so that a product whose catalog
+-- declaration (product_uom.precision_scale) permits decimals can be reported at its real
+-- quantity. Every product declares scale 0 today, so no value stored here changes; what changes
+-- is that a divisible one is no longer truncated on arrival.
+--
+-- Pre-production widening: numeric(19,4) holds every value the integer columns could, so the
+-- implicit cast preserves existing rows exactly.
+ALTER TABLE ext_inventory_availability
+    ALTER COLUMN on_hand_quantity TYPE numeric(19,4),
+    ALTER COLUMN allocated_quantity TYPE numeric(19,4),
+    ALTER COLUMN available_to_promise_quantity TYPE numeric(19,4);

--- a/pos-order/src/test/java/com/positivity/order/internal/service/InventoryAvailabilityGateTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/InventoryAvailabilityGateTest.java
@@ -19,6 +19,7 @@ import com.positivity.order.internal.repository.ExtProductRepository;
 import com.positivity.order.internal.repository.ProcessedEventRepository;
 import com.positivity.order.internal.repository.PurchaseOrderRepository;
 import com.positivity.order.internal.repository.SalesOrderLineRepository;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -100,17 +101,25 @@ class InventoryAvailabilityGateTest {
                 .aggregateId(AGGREGATE_ID)
                 .stockItemId(stockItemId)
                 .locationId(LOCATION_ID)
-                .onHandQuantity(atp)
-                .allocatedQuantity(0)
-                .availableToPromiseQuantity(atp)
+                .onHandQuantity(BigDecimal.valueOf(atp))
+                .allocatedQuantity(BigDecimal.ZERO)
+                .availableToPromiseQuantity(BigDecimal.valueOf(atp))
                 .aggregateVersion(1L)
                 .updatedAt(NOW)
                 .build();
     }
 
     private String availabilityEnvelope(String eventId, long aggregateVersion, int atp) {
-        InventoryAvailabilityUpdatedV1 payload =
-                new InventoryAvailabilityUpdatedV1(PRODUCT_ID.toString(), LOCATION_ID, atp, 0, atp, "EA", 0L, 0L, atp);
+        InventoryAvailabilityUpdatedV1 payload = new InventoryAvailabilityUpdatedV1(
+                PRODUCT_ID.toString(),
+                LOCATION_ID,
+                BigDecimal.valueOf(atp),
+                BigDecimal.ZERO,
+                BigDecimal.valueOf(atp),
+                "EA",
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.valueOf(atp));
         return objectMapper.writeValueAsString(java.util.Map.of(
                 "eventId", eventId,
                 "eventType", InventoryAvailabilityUpdatedV1.EVENT_TYPE,
@@ -125,7 +134,7 @@ class InventoryAvailabilityGateTest {
                 null,
                 salesOrderLineId,
                 PRODUCT_ID.toString(),
-                2,
+                BigDecimal.valueOf(2),
                 covered,
                 covered ? null : BACKORDER_ID,
                 NOW);
@@ -158,10 +167,10 @@ class InventoryAvailabilityGateTest {
             when(extInventoryAvailabilityRepository.findByStockItemIdAndLocationId(PRODUCT_ID.toString(), LOCATION_ID))
                     .thenReturn(Optional.of(replicaRow(PRODUCT_ID.toString(), 5)));
 
-            InventoryResult result = adapter().checkAvailability(SKU, 2, LOCATION_ID);
+            InventoryResult result = adapter().checkAvailability(SKU, BigDecimal.valueOf(2), LOCATION_ID);
 
             assertThat(result.sufficient()).isTrue();
-            assertThat(result.availableQuantity()).isEqualTo(5);
+            assertThat(result.availableQuantity()).isEqualByComparingTo("5");
         }
 
         @Test
@@ -176,7 +185,9 @@ class InventoryAvailabilityGateTest {
             when(extInventoryAvailabilityRepository.findByStockItemIdAndLocationId(PRODUCT_ID.toString(), LOCATION_ID))
                     .thenReturn(Optional.of(replicaRow(PRODUCT_ID.toString(), 1)));
 
-            assertThat(adapter().checkAvailability(SKU, 2, LOCATION_ID).sufficient())
+            assertThat(adapter()
+                            .checkAvailability(SKU, BigDecimal.valueOf(2), LOCATION_ID)
+                            .sufficient())
                     .isFalse();
         }
 
@@ -190,10 +201,10 @@ class InventoryAvailabilityGateTest {
 
             // Absence is not evidence of stock. Answering "sufficient" here would rebuild the
             // always-passing advisory stub this replaced, and would do it invisibly.
-            InventoryResult result = adapter().checkAvailability(SKU, 1, LOCATION_ID);
+            InventoryResult result = adapter().checkAvailability(SKU, BigDecimal.valueOf(1), LOCATION_ID);
 
             assertThat(result.sufficient()).isFalse();
-            assertThat(result.availableQuantity()).isZero();
+            assertThat(result.availableQuantity()).isEqualByComparingTo(BigDecimal.ZERO);
         }
 
         @Test
@@ -212,14 +223,19 @@ class InventoryAvailabilityGateTest {
 
             // The owner's ledger disagrees with itself about what goes in stockItemId, so a gate
             // that checked only one key would be silently wrong for every item stocked the other way.
-            assertThat(adapter().checkAvailability(SKU, 3, LOCATION_ID).sufficient())
+            assertThat(adapter()
+                            .checkAvailability(SKU, BigDecimal.valueOf(3), LOCATION_ID)
+                            .sufficient())
                     .isTrue();
         }
 
         @Test
         @DisplayName("reports short when the order has no selling location")
         void noLocationIsShort() {
-            assertThat(adapter().checkAvailability(SKU, 1, null).sufficient()).isFalse();
+            assertThat(adapter()
+                            .checkAvailability(SKU, BigDecimal.valueOf(1), null)
+                            .sufficient())
+                    .isFalse();
         }
     }
 
@@ -237,7 +253,7 @@ class InventoryAvailabilityGateTest {
 
             ArgumentCaptor<ExtInventoryAvailability> saved = ArgumentCaptor.forClass(ExtInventoryAvailability.class);
             verify(extInventoryAvailabilityRepository).save(saved.capture());
-            assertThat(saved.getValue().getAvailableToPromiseQuantity()).isEqualTo(7);
+            assertThat(saved.getValue().getAvailableToPromiseQuantity()).isEqualByComparingTo("7");
             assertThat(saved.getValue().getAggregateVersion()).isEqualTo(5L);
             verify(processedEventRepository).save(any());
         }

--- a/pos-order/src/test/java/com/positivity/order/internal/service/SalesOrderCartLifecycleTest.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/SalesOrderCartLifecycleTest.java
@@ -225,7 +225,8 @@ class SalesOrderCartLifecycleTest {
             }
             return line;
         });
-        when(inventoryPort.checkAvailability(anyString(), anyInt(), any())).thenReturn(new InventoryResult(true, 99));
+        when(inventoryPort.checkAvailability(anyString(), any(), any()))
+                .thenReturn(new InventoryResult(true, BigDecimal.valueOf(99)));
         when(pricingPort.quoteForSku(anyString(), anyInt(), any(), any())).thenReturn(priced("12.50", "Oil filter"));
         when(paymentRecordRepository.findByOrderId(any())).thenReturn(List.of());
         when(salesOrderRepository.findByCheckoutIdempotencyKey(anyString())).thenReturn(Optional.empty());
@@ -622,8 +623,8 @@ class SalesOrderCartLifecycleTest {
         @DisplayName("marks the line BACKORDER when inventory is short")
         void marksBackorder() {
             givenOrder(order(SalesOrderStatus.DRAFT));
-            when(inventoryPort.checkAvailability(anyString(), anyInt(), any()))
-                    .thenReturn(new InventoryResult(false, 0));
+            when(inventoryPort.checkAvailability(anyString(), any(), any()))
+                    .thenReturn(new InventoryResult(false, BigDecimal.valueOf(0)));
 
             assertThat(service.addItem(ORDER_ID, new AddItemCommand("SKU-1", 5, null, null, null, null, null, null))
                             .fulfillmentStatus())
@@ -1341,8 +1342,8 @@ class SalesOrderCartLifecycleTest {
             // than a lost sale — pos-inventory's backorder machinery exists for exactly this.
             SalesOrder order = checkoutReadyOrder();
             givenOrder(order);
-            when(inventoryPort.checkAvailability(anyString(), anyInt(), any()))
-                    .thenReturn(new InventoryResult(false, 0));
+            when(inventoryPort.checkAvailability(anyString(), any(), any()))
+                    .thenReturn(new InventoryResult(false, BigDecimal.valueOf(0)));
 
             CheckoutResult result = service.checkout(ORDER_ID, "co-1", null);
 
@@ -1357,8 +1358,8 @@ class SalesOrderCartLifecycleTest {
             SalesOrder order = checkoutReadyOrder();
             order.getLines().get(0).setFulfillmentStatus(FulfillmentStatus.BACKORDER);
             givenOrder(order);
-            when(inventoryPort.checkAvailability(anyString(), anyInt(), any()))
-                    .thenReturn(new InventoryResult(true, 10));
+            when(inventoryPort.checkAvailability(anyString(), any(), any()))
+                    .thenReturn(new InventoryResult(true, BigDecimal.valueOf(10)));
 
             service.checkout(ORDER_ID, "co-1", null);
 

--- a/pos-order/src/test/java/com/positivity/order/service/SalesOrderCheckoutTest.java
+++ b/pos-order/src/test/java/com/positivity/order/service/SalesOrderCheckoutTest.java
@@ -148,7 +148,8 @@ class SalesOrderCheckoutTest {
                 .thenReturn(java.util.Optional.empty());
         when(orderPaymentRecordRepository.findByOrderId(any())).thenReturn(java.util.List.of());
         when(salesOrderRepository.findByCheckoutIdempotencyKey(anyString())).thenReturn(Optional.empty());
-        when(inventoryPort.checkAvailability(anyString(), anyInt(), any())).thenReturn(new InventoryResult(true, 999));
+        when(inventoryPort.checkAvailability(anyString(), any(), any()))
+                .thenReturn(new InventoryResult(true, BigDecimal.valueOf(999)));
         when(pricingPort.quoteForSku(anyString(), anyInt(), any(), any()))
                 .thenReturn(new PricingQuote(
                         PricingQuote.Status.PRICED, money("50.00"), UUID.randomUUID(), "Widget", null, null));
@@ -271,7 +272,8 @@ class SalesOrderCheckoutTest {
     void checkout_insufficientAvailability_admittedAsBackorder() {
         SalesOrder order = draftOrderWithLine();
         when(salesOrderRepository.findById(ORDER_ID)).thenReturn(Optional.of(order));
-        when(inventoryPort.checkAvailability(anyString(), anyInt(), any())).thenReturn(new InventoryResult(false, 0));
+        when(inventoryPort.checkAvailability(anyString(), any(), any()))
+                .thenReturn(new InventoryResult(false, BigDecimal.valueOf(0)));
 
         salesOrderService.checkout(ORDER_ID, "chk-key-1");
 

--- a/pos-order/src/test/java/com/positivity/order/service/SalesOrderServiceImplTest.java
+++ b/pos-order/src/test/java/com/positivity/order/service/SalesOrderServiceImplTest.java
@@ -298,7 +298,8 @@ class SalesOrderServiceImplTest {
         when(salesOrderLineRepository.save(any(SalesOrderLine.class))).thenReturn(expectedLine);
         when(pricingPort.quoteForSku(eq("ABC-123"), anyInt(), any(), any()))
                 .thenReturn(priced(new BigDecimal("10.5000")));
-        when(inventoryPort.checkAvailability(eq("ABC-123"), eq(2), any())).thenReturn(new InventoryResult(true, 100));
+        when(inventoryPort.checkAvailability(eq("ABC-123"), eq(BigDecimal.valueOf(2)), any()))
+                .thenReturn(new InventoryResult(true, BigDecimal.valueOf(100)));
 
         // when
         SalesOrderLineSummary result = salesOrderService.addItem(orderId, "ABC-123", 2, null, null);
@@ -345,7 +346,8 @@ class SalesOrderServiceImplTest {
         when(salesOrderRepository.save(any(SalesOrder.class))).thenReturn(updatedOrder);
         when(pricingPort.quoteForSku(eq("ABC-123"), anyInt(), any(), any()))
                 .thenReturn(priced(new BigDecimal("10.5000")));
-        when(inventoryPort.checkAvailability(eq("ABC-123"), eq(2), any())).thenReturn(new InventoryResult(true, 100));
+        when(inventoryPort.checkAvailability(eq("ABC-123"), eq(BigDecimal.valueOf(2)), any()))
+                .thenReturn(new InventoryResult(true, BigDecimal.valueOf(100)));
 
         // when
         salesOrderService.addItem(orderId, "ABC-123", 2, null, null);
@@ -523,8 +525,8 @@ class SalesOrderServiceImplTest {
         when(salesOrderLineRepository.save(any(SalesOrderLine.class))).thenReturn(backorderLine);
         when(pricingPort.quoteForSku(eq("LOW-STOCK-SKU"), anyInt(), any(), any()))
                 .thenReturn(priced(new BigDecimal("10.5000")));
-        when(inventoryPort.checkAvailability(eq("LOW-STOCK-SKU"), eq(50), any()))
-                .thenReturn(new InventoryResult(false, 0));
+        when(inventoryPort.checkAvailability(eq("LOW-STOCK-SKU"), eq(BigDecimal.valueOf(50)), any()))
+                .thenReturn(new InventoryResult(false, BigDecimal.valueOf(0)));
 
         // when
         SalesOrderLineSummary result = salesOrderService.addItem(orderId, "LOW-STOCK-SKU", 50, null, null);
@@ -570,8 +572,8 @@ class SalesOrderServiceImplTest {
         when(salesOrderRepository.save(any(SalesOrder.class))).thenReturn(updatedOrder);
         when(pricingPort.quoteForSku(eq("LOW-STOCK-SKU"), anyInt(), any(), any()))
                 .thenReturn(priced(new BigDecimal("10.5000")));
-        when(inventoryPort.checkAvailability(eq("LOW-STOCK-SKU"), eq(50), any()))
-                .thenReturn(new InventoryResult(false, 0));
+        when(inventoryPort.checkAvailability(eq("LOW-STOCK-SKU"), eq(BigDecimal.valueOf(50)), any()))
+                .thenReturn(new InventoryResult(false, BigDecimal.valueOf(0)));
 
         // when
         salesOrderService.addItem(orderId, "LOW-STOCK-SKU", 50, null, null);
@@ -780,7 +782,8 @@ class SalesOrderServiceImplTest {
         when(salesOrderLineRepository.save(any(SalesOrderLine.class))).thenReturn(cachedPriceLine);
         when(pricingPort.quoteForSku(eq("ABC-123"), anyInt(), any(), any()))
                 .thenReturn(priced(new BigDecimal("10.5000")));
-        when(inventoryPort.checkAvailability(eq("ABC-123"), eq(1), any())).thenReturn(new InventoryResult(true, 100));
+        when(inventoryPort.checkAvailability(eq("ABC-123"), eq(BigDecimal.valueOf(1)), any()))
+                .thenReturn(new InventoryResult(true, BigDecimal.valueOf(100)));
 
         // when
         SalesOrderLineSummary result = salesOrderService.addItem(orderId, "ABC-123", 1, null, null);
@@ -825,7 +828,8 @@ class SalesOrderServiceImplTest {
                 .reasonCode("Manual entry")
                 .build();
         when(salesOrderRepository.findById(orderId)).thenReturn(Optional.of(order));
-        when(inventoryPort.checkAvailability(eq("ABC-123"), eq(1), any())).thenReturn(new InventoryResult(true, 100));
+        when(inventoryPort.checkAvailability(eq("ABC-123"), eq(BigDecimal.valueOf(1)), any()))
+                .thenReturn(new InventoryResult(true, BigDecimal.valueOf(100)));
         when(salesOrderLineRepository.save(any(SalesOrderLine.class))).thenReturn(savedLine);
         when(salesOrderRepository.save(any(SalesOrder.class))).thenReturn(order);
 

--- a/pos-order/src/test/java/com/positivity/order/service/SalesOrderWave4Test.java
+++ b/pos-order/src/test/java/com/positivity/order/service/SalesOrderWave4Test.java
@@ -164,7 +164,8 @@ class SalesOrderWave4Test {
         when(salesOrderRepository.findByCheckoutIdempotencyKey(anyString())).thenReturn(Optional.empty());
         when(orderPaymentRecordRepository.findByOrderId(any())).thenReturn(List.of());
         when(orderPaymentRecordRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
-        when(inventoryPort.checkAvailability(anyString(), anyInt(), any())).thenReturn(new InventoryResult(true, 999));
+        when(inventoryPort.checkAvailability(anyString(), any(), any()))
+                .thenReturn(new InventoryResult(true, BigDecimal.valueOf(999)));
         when(extProductRepository.findFirstBySkuIgnoreCaseAndActiveTrue(anyString()))
                 .thenReturn(Optional.empty());
         when(pricingPort.quoteForSku(anyString(), anyInt(), any(), any()))

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/config/InventoryCommandPublisher.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/config/InventoryCommandPublisher.java
@@ -1,6 +1,7 @@
 package com.positivity.workorder.internal.config;
 
 import com.positivity.shared.id.UUIDv7Generator;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
@@ -97,9 +98,13 @@ public class InventoryCommandPublisher {
      * command against the same reservation.
      */
     public void requestReservation(
-            @NonNull UUID workorderLineId, @NonNull UUID stockItemId, int requiredQuantity, @NonNull UUID locationId) {
+            @NonNull UUID workorderLineId,
+            @NonNull UUID stockItemId,
+            @NonNull BigDecimal requiredQuantity,
+            @NonNull UUID locationId) {
         UUID commandId = deterministicCommandId(
-                RESERVATION_REQUEST_COMMAND_TYPE, workorderLineId + ":" + stockItemId + ":" + requiredQuantity);
+                RESERVATION_REQUEST_COMMAND_TYPE,
+                workorderLineId + ":" + stockItemId + ":" + normalizedQuantityKey(requiredQuantity));
         ReservationRequestPayload payload =
                 new ReservationRequestPayload(workorderLineId, stockItemId, requiredQuantity, locationId);
         send(RESERVATION_REQUEST_COMMAND_TYPE, commandId, workorderLineId.toString(), payload);
@@ -116,6 +121,18 @@ public class InventoryCommandPublisher {
         } catch (Exception e) {
             throw new IllegalStateException("Unable to publish " + commandType + " command " + commandId, e);
         }
+    }
+
+    /**
+     * The quantity as it appears in the idempotency key.
+     *
+     * <p>{@code stripTrailingZeros} first: since ADR-0055 (#1414) the quantity is a
+     * {@link BigDecimal}, and {@code 2} and {@code 2.00} are the same demand spelled two ways. A
+     * client retry that serialises the number differently must still collapse to the same command
+     * under pos-inventory's dedupe, which keying on the raw {@code toString} would not do.
+     */
+    private static String normalizedQuantityKey(@NonNull BigDecimal quantity) {
+        return quantity.stripTrailingZeros().toPlainString();
     }
 
     private static UUID deterministicCommandId(@NonNull String commandType, @NonNull String idempotencyKey) {
@@ -146,7 +163,7 @@ public class InventoryCommandPublisher {
     record ReservationRequestPayload(
             @NonNull UUID workorderLineId,
             @NonNull UUID stockItemId,
-            int requiredQuantity,
+            @NonNull BigDecimal requiredQuantity,
             @NonNull UUID locationId) {}
 
     record ConsumePayload(

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/ExtInventoryAvailabilityReplica.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/entity/ExtInventoryAvailabilityReplica.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -46,14 +47,14 @@ public class ExtInventoryAvailabilityReplica {
     @Column(name = "location_id")
     private UUID locationId;
 
-    @Column(name = "on_hand_quantity", nullable = false)
-    private int onHandQuantity;
+    @Column(name = "on_hand_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal onHandQuantity;
 
-    @Column(name = "allocated_quantity", nullable = false)
-    private int allocatedQuantity;
+    @Column(name = "allocated_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal allocatedQuantity;
 
-    @Column(name = "available_to_promise_quantity", nullable = false)
-    private int availableToPromiseQuantity;
+    @Column(name = "available_to_promise_quantity", nullable = false, precision = 19, scale = 4)
+    private BigDecimal availableToPromiseQuantity;
 
     @Column(name = "unit_of_measure", length = 32)
     private String unitOfMeasure;

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/exception/InsufficientPartAvailabilityException.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/exception/InsufficientPartAvailabilityException.java
@@ -24,9 +24,10 @@ public class InsufficientPartAvailabilityException extends RuntimeException {
     private final transient UUID partLineId;
 
     public InsufficientPartAvailabilityException(
-            UUID partLineId, String itemLabel, BigDecimal requested, int available) {
-        super("Part " + itemLabel + " on line " + partLineId + " cannot be issued: requested " + requested
-                + " but only " + available + " available at the servicing site");
+            UUID partLineId, String itemLabel, BigDecimal requested, BigDecimal available) {
+        super("Part " + itemLabel + " on line " + partLineId + " cannot be issued: requested "
+                + requested.toPlainString()
+                + " but only " + available.toPlainString() + " available at the servicing site");
         this.partLineId = partLineId;
     }
 

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InventoryEventsListener.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/InventoryEventsListener.java
@@ -225,7 +225,7 @@ public class InventoryEventsListener {
         }
 
         BigDecimal issued = part.getQuantityIssued() == null ? BigDecimal.ZERO : part.getQuantityIssued();
-        BigDecimal reversed = issued.subtract(BigDecimal.valueOf(outcome.requiredQuantity()));
+        BigDecimal reversed = issued.subtract(outcome.requiredQuantity());
         part.setQuantityIssued(reversed.signum() < 0 ? BigDecimal.ZERO : reversed);
         part.setBackorderId(outcome.backorderId());
         workorderPartRepository.save(part);

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/PartAvailabilityService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/PartAvailabilityService.java
@@ -49,19 +49,19 @@ public class PartAvailabilityService {
      * @param workorder the job the part belongs to; supplies the servicing site
      * @param part the part line being asked about
      */
-    public int availableFor(@NonNull Workorder workorder, @NonNull WorkorderPart part) {
+    public BigDecimal availableFor(@NonNull Workorder workorder, @NonNull WorkorderPart part) {
         UUID locationId = workorder.getShopId();
         UUID stockItemId = part.getProductEntityId();
         if (locationId == null || stockItemId == null) {
             // A non-inventory part has no productEntityId and no owned stock to measure; a
             // workorder with no site has nowhere to measure it at. Both report short rather than
             // guessing, and the caller decides whether the gate applies at all.
-            return 0;
+            return BigDecimal.ZERO;
         }
         return lookup(stockItemId, locationId)
                 .map(ExtInventoryAvailabilityReplica::getAvailableToPromiseQuantity)
-                .map(atp -> Math.max(atp, 0))
-                .orElse(0);
+                .map(atp -> atp.max(BigDecimal.ZERO))
+                .orElse(BigDecimal.ZERO);
     }
 
     /**
@@ -76,7 +76,7 @@ public class PartAvailabilityService {
         if (part.getProductEntityId() == null) {
             return true;
         }
-        return BigDecimal.valueOf(availableFor(workorder, part)).compareTo(quantity) >= 0;
+        return availableFor(workorder, part).compareTo(quantity) >= 0;
     }
 
     /**

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/PartAvailabilityService.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/PartAvailabilityService.java
@@ -49,6 +49,7 @@ public class PartAvailabilityService {
      * @param workorder the job the part belongs to; supplies the servicing site
      * @param part the part line being asked about
      */
+    @NonNull
     public BigDecimal availableFor(@NonNull Workorder workorder, @NonNull WorkorderPart part) {
         UUID locationId = workorder.getShopId();
         UUID stockItemId = part.getProductEntityId();

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/WorkorderPartUsageServiceImpl.java
@@ -251,43 +251,19 @@ public class WorkorderPartUsageServiceImpl implements WorkorderPartUsageService 
      * Asks pos-inventory to reserve what was just issued. The gate above decided what to tell the
      * technician from the replica; this asks the owner to decide from its own ledger, and the
      * outcome fact corrects the part if the two disagree.
+     *
+     * <p>The quantity passes through unchanged since ADR-0055 stage 2 (#1414): the reservation
+     * command and its outcome fact carry a {@code BigDecimal}, so there is no longer a seam to
+     * convert across. What guarantees the quantity is legitimate is the divisibility gate at
+     * estimate-item entry and part issue (#1413), not a conversion here — the product's declared
+     * {@code precision_scale} has already decided whether these decimals are allowed at all.
      */
     private void registerDemand(Workorder workorder, WorkorderPart part, BigDecimal quantity) {
         InventoryCommandPublisher publisher = inventoryCommandPublisher.getIfAvailable();
         if (publisher == null || workorder.getShopId() == null || part.getProductEntityId() == null) {
             return;
         }
-        publisher.requestReservation(
-                part.getId(), part.getProductEntityId(), reservableQuantity(quantity), workorder.getShopId());
-    }
-
-    /**
-     * The reservation command and its outcome fact are integer-only (ADR-0044, CAP #1315 Phase 1),
-     * and the quantity reaching here is already integral: the divisibility gate above rejects a
-     * fractional quantity for a product declaring scale 0, and no product declares anything else —
-     * {@code product_uom} is unpopulated platform-wide, so nothing can be divisible yet.
-     *
-     * <p>So this converts exactly and throws if it cannot. It replaces a {@code RoundingMode.CEILING}
-     * that turned an issue of {@code 0.5} into a reservation of {@code 1}, holding half a unit
-     * against demand nobody asked for. That rounding was the safe <em>direction</em> at a seam that
-     * should not have been crossed silently at all; with the quantity constrained at entry the seam
-     * is gone, and a fraction arriving here now means the gate was bypassed rather than that a
-     * rounding decision is needed.
-     *
-     * <p>Genuinely divisible stock gets a decimal reservation contract in #1414. Until then this
-     * throw is unreachable, and that is what makes it the right shape: it fails loudly if the
-     * premise stops holding instead of quietly reserving the wrong amount.
-     */
-    private static int reservableQuantity(BigDecimal quantity) {
-        try {
-            return quantity.intValueExact();
-        } catch (ArithmeticException e) {
-            throw new IllegalStateException(
-                    "Cannot reserve a fractional quantity " + quantity.toPlainString()
-                            + ": the reservation contract is integer-only and the divisibility gate should have"
-                            + " rejected this quantity at entry",
-                    e);
-        }
+        publisher.requestReservation(part.getId(), part.getProductEntityId(), quantity, workorder.getShopId());
     }
 
     /**

--- a/pos-workorder/src/main/resources/db/migration/V18__decimal_inventory_availability_replica.sql
+++ b/pos-workorder/src/main/resources/db/migration/V18__decimal_inventory_availability_replica.sql
@@ -1,0 +1,13 @@
+-- ADR-0055 stage 2 (#1414): the availability facts this replica mirrors are now decimal.
+--
+-- InventoryAvailabilityUpdatedV1 carries BigDecimal quantities so that a product whose catalog
+-- declaration (product_uom.precision_scale) permits decimals can be reported at its real
+-- quantity. Every product declares scale 0 today, so no value stored here changes; what changes
+-- is that a divisible one is no longer truncated on arrival.
+--
+-- Pre-production widening: numeric(19,4) holds every value the integer columns could, so the
+-- implicit cast preserves existing rows exactly.
+ALTER TABLE ext_inventory_availability
+    ALTER COLUMN on_hand_quantity TYPE numeric(19,4),
+    ALTER COLUMN allocated_quantity TYPE numeric(19,4),
+    ALTER COLUMN available_to_promise_quantity TYPE numeric(19,4);

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/PartIssueAvailabilityGateTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/PartIssueAvailabilityGateTest.java
@@ -3,6 +3,7 @@ package com.positivity.workorder.internal.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -152,9 +153,9 @@ class PartIssueAvailabilityGateTest {
                         .aggregateId(UUID.randomUUID())
                         .stockItemId(productId.toString())
                         .locationId(SHOP_ID)
-                        .onHandQuantity(atp)
-                        .allocatedQuantity(0)
-                        .availableToPromiseQuantity(atp)
+                        .onHandQuantity(BigDecimal.valueOf(atp))
+                        .allocatedQuantity(BigDecimal.ZERO)
+                        .availableToPromiseQuantity(BigDecimal.valueOf(atp))
                         .aggregateVersion(1L)
                         .updatedAt(NOW)
                         .build()));
@@ -182,7 +183,12 @@ class PartIssueAvailabilityGateTest {
             service.issuePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("2"), null);
 
             assertThat(part.getQuantityIssued()).isEqualByComparingTo("2");
-            verify(inventoryCommandPublisher).requestReservation(PART_ID, PRODUCT_ID, 2, SHOP_ID);
+            verify(inventoryCommandPublisher)
+                    .requestReservation(
+                            eq(PART_ID),
+                            eq(PRODUCT_ID),
+                            argThat(q -> q.compareTo(new BigDecimal("2")) == 0),
+                            eq(SHOP_ID));
         }
 
         @Test
@@ -202,8 +208,7 @@ class PartIssueAvailabilityGateTest {
 
             assertThat(part.getQuantityIssued()).isEqualByComparingTo("0");
             verify(usageEventRepository, never()).save(any());
-            verify(inventoryCommandPublisher, never())
-                    .requestReservation(any(), any(), org.mockito.ArgumentMatchers.anyInt(), any());
+            verify(inventoryCommandPublisher, never()).requestReservation(any(), any(), any(), any());
         }
 
         @Test
@@ -220,8 +225,7 @@ class PartIssueAvailabilityGateTest {
             // Nothing is recorded and no demand registered: the part did not leave the shelf.
             assertThat(part.getQuantityIssued()).isEqualByComparingTo("0");
             verify(usageEventRepository, never()).save(any());
-            verify(inventoryCommandPublisher, never())
-                    .requestReservation(any(), any(), org.mockito.ArgumentMatchers.anyInt(), any());
+            verify(inventoryCommandPublisher, never()).requestReservation(any(), any(), any(), any());
         }
 
         @Test
@@ -250,23 +254,29 @@ class PartIssueAvailabilityGateTest {
             service.issuePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("0.25"), null);
 
             assertThat(part.getQuantityIssued()).isEqualByComparingTo("0.25");
-            verify(inventoryCommandPublisher, never())
-                    .requestReservation(any(), any(), org.mockito.ArgumentMatchers.anyInt(), any());
+            verify(inventoryCommandPublisher, never()).requestReservation(any(), any(), any(), any());
         }
 
         @Test
-        @DisplayName("passes a divisible product's quantity but cannot reserve it until #1414")
-        void divisibleProductPassesTheGateButCannotReserveYet() {
+        @DisplayName("issues and reserves a divisible product at its real fractional quantity")
+        void divisibleProductIssuesAndReservesItsFractionalQuantity() {
             WorkorderPart part = part(PART_ID, PRODUCT_ID, "4", "0");
             givenWorkorderAndPart(workorder(WorkorderStatus.WORK_IN_PROGRESS), part);
             givenAtp(PRODUCT_ID, 10);
             when(productUomRepository.findBasePrecisionScales(PRODUCT_ID)).thenReturn(List.of(2));
 
-            // The divisibility gate passes, but the reservation contract is still integer-only
-            // until #1414 — so the issue fails loudly here rather than reserving a rounded amount.
-            assertThatThrownBy(() -> service.issuePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("1.01"), null))
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("Cannot reserve a fractional quantity");
+            // ADR-0055 stage 2 (#1414): the reservation contract is decimal, so a product the
+            // catalog declares divisible to two places reserves exactly what left the shelf.
+            // Stage 1 could only fail loudly here; the seam it was guarding is gone.
+            service.issuePartQuantity(WORKORDER_ID, PART_ID, new BigDecimal("1.01"), null);
+
+            assertThat(part.getQuantityIssued()).isEqualByComparingTo("1.01");
+            verify(inventoryCommandPublisher)
+                    .requestReservation(
+                            eq(PART_ID),
+                            eq(PRODUCT_ID),
+                            argThat(q -> q.compareTo(new BigDecimal("1.01")) == 0),
+                            eq(SHOP_ID));
         }
     }
 

--- a/pos-workorder/src/test/java/com/positivity/workorder/internal/service/PartQuantityStrandingRegressionTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/internal/service/PartQuantityStrandingRegressionTest.java
@@ -270,9 +270,9 @@ class PartQuantityStrandingRegressionTest {
                             .aggregateId(UUID.randomUUID())
                             .stockItemId(PRODUCT_ID.toString())
                             .locationId(SHOP_ID)
-                            .onHandQuantity(10)
-                            .allocatedQuantity(0)
-                            .availableToPromiseQuantity(10)
+                            .onHandQuantity(BigDecimal.valueOf(10))
+                            .allocatedQuantity(BigDecimal.ZERO)
+                            .availableToPromiseQuantity(BigDecimal.valueOf(10))
                             .aggregateVersion(1L)
                             .updatedAt(NOW)
                             .build()));

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/InventoryEventsListenerTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/InventoryEventsListenerTest.java
@@ -224,7 +224,7 @@ class InventoryEventsListenerTest {
         ArgumentCaptor<com.positivity.workorder.internal.entity.ExtInventoryAvailabilityReplica> saved =
                 ArgumentCaptor.forClass(com.positivity.workorder.internal.entity.ExtInventoryAvailabilityReplica.class);
         verify(availability).save(saved.capture());
-        assertThat(saved.getValue().getAvailableToPromiseQuantity()).isEqualTo(7);
+        assertThat(saved.getValue().getAvailableToPromiseQuantity()).isEqualByComparingTo("7");
         assertThat(saved.getValue().getAggregateVersion()).isEqualTo(3L);
     }
 


### PR DESCRIPTION
> **Stacked PR 2 of 4** (ADR-0055, louisburroughs/durion#400). Base is stage 1 (#1418); do not merge before it. Diff shown here is stage 2 only.

## Capability & Traceability
- Capability: n/a — decision-driven task chain from durion-positivity-backend#1365
- Parent STORY (durion): n/a (ADR PR: louisburroughs/durion#400)
- Child issue: louisburroughs/durion-positivity-backend#1414
- Domain: `domain:inventory`, `domain:workexec`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` — availability-query and stock-movement/adjustment entries updated for the decimal shapes (durion commit `3e1553d` on branch `claude/fractional-quantities-usecases-u2xkqv`, part of louisburroughs/durion#400). No guide entry existed for `ReservationOutcomeV1` / `InventoryAvailabilityUpdatedV1`.
- Durion contract PR (if applicable): louisburroughs/durion#400

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller
- [x] `openapi.yaml` regenerated — semantic hand-sync (143 lines pos-inventory, 6 pos-catalog) verified zero semantic difference vs generator output; generator's wholesale key-reordering avoided
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — **not reachable from this session; required follow-up**

## Scope
- What changed (233 files, 6 modules: pos-domain-events, pos-inventory, pos-order, pos-workorder, pos-catalog, pos-location):
  - **Ledger**: `inventory_ledger_entry.change_in_quantity`/`quantity_after` → `numeric(19,4)` (`V39__decimal_inventory_quantities.sql`), `InventoryLedgerEntry` → `BigDecimal`.
  - **Reservation chain**: `ReservationEntity`, `BackorderRecord.quantityShort` (positivity CHECK re-stated so `0.0000` stays rejected), `ReservationRequestHandler` (the `(int) Math.min(...)` cast gone), `ReservationRequestPayload` in pos-order and pos-workorder.
  - **Contracts**: `ReservationOutcomeV1.requiredQuantity` and all six quantity fields on `InventoryAvailabilityUpdatedV1` → `BigDecimal` — including the v2 forecast fields (`projectedAvailable = onHand + incoming − outgoing`; leaving them integral would only relocate the truncation into the projection). Positivity checks preserved; zero still rejected. Also widened for coherence (no external consumers): `BackorderCreatedV1`, `BackorderResolvedV1`, `ProductValueChangedV1`, `StorageLocationOnHandUpdatedV1`.
  - **Availability path**: `inventory_stock_summary` → numeric, `InventoryAvailabilityServiceImpl`/`InventoryFactPublisher` `long` math and every `Math.toIntExact` replaced; fail-loud preserved via `QuantityScaleGuard` (new), which validates scale against the product's declared `precision_scale` instead of silently accepting arbitrary precision. Guard passes through when the stock reference names no catalog product (an absent declaration is not evidence a stored value is wrong).
  - **Replicas**: `ext_inventory_availability` widened in pos-order (V21), pos-workorder (V18), pos-catalog (V13); pos-location `storage_location` on-hand (V5) — it consumes `StorageLocationOnHandUpdatedV1` and its "no decommission while stocked" guard must see a partial drum as stock.
  - **Supply-side guards re-driven, not deleted**: `ReceivingServiceImpl`/`AsnServiceImpl`/`ReturnServiceImpl` now validate against declared `precision_scale` (0 when undeclared) instead of `intValueExact()` — scale-0 products still reject fractions; scale>0 products post fractional quantities. Serial-unit postings keep `intValueExact` (a serialised unit is discrete by definition); pick/putaway/transfer/sales-order lines stay integral per ADR-0055; replenishment need rounds **up** to whole orderable units.
  - Stage 1's unreachable `IllegalStateException` in `reservableQuantity` removed; scale-validated `BigDecimal` passes through.
- Why: resolves the contradiction latent in `main` — `product_uom.precision_scale` (tested at scale 2) declares divisibility the integer ledger could not store. ADR-0055 stage 2.

**Schema-version/rollout stance (AC):** pre-production, no live data, all consumers ship from this reactor in lockstep. The payload type change is breaking on the wire and the fleet deploys together; no dual-read shim, deliberately, per the pre-production policy. Documented in the pos-inventory README.

## Tests
- [x] Unit tests added/updated — `QuantityScaleGuardTest`; idempotency-key normalisation (`2` vs `2.00` still dedupe); `%d`-format and `@Builder.Default` regressions caught in adversarial pass and covered
- [x] Integration tests added/updated — AC sentinel: the scale-2 LB/BAG fixture round-trips 1.01 through receiving into the ledger; `InventoryCommandListenerTest` pins the JSON seam
- [x] Provider behavioral contract tests added/updated — pos-catalog now has a contract test serialising the real `InventoryAvailabilityUpdatedV1` with fractional quantities (it had none tying it to this contract)
- How to run: `./mvnw -pl pos-domain-events,pos-inventory,pos-order,pos-workorder,pos-catalog,pos-location -am test`

## Risk & Rollback
- Risk level: Medium — breaking payload change across three replicas + ledger type change; mitigated by lockstep pre-production deploy, no data to migrate, and per-module suites green
- Rollback plan: revert the stage-2 commit and the durion contract-guide commit; migrations are additive ALTERs on empty tables

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — stacked session branch
- [ ] PR title starts with `[CAP:<cap-id>]` — issue-numbered
- [x] Links to parent + child issues are present
- [x] Contract guide updated (see Contract References)
- [ ] Required CI checks passing — pending

**Verification run:** pos-domain-events 411 · pos-catalog 394 · pos-inventory 894 · pos-location 237 · pos-workorder 889 · pos-order 510 — all BUILD SUCCESS; `check-flyway-hygiene.sh` 25 modules pass. Cross-module `pos-archunit` not run (no package-layout change; each module's own ArchitectureTest green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJPZ9szyzL6C5KQdNyeF48

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJPZ9szyzL6C5KQdNyeF48)_