### PR TITLE
fix(pos-inventory): compare BigDecimal balances by value in contract ITs

### DIFF
--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/CrossSiteTransferGuardIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/CrossSiteTransferGuardIT.java
@@ -111,8 +111,8 @@ class CrossSiteTransferGuardIT extends BaseContractIntegrationTest {
                         .content(transferBody(sku, BIN_A1, BIN_A2, 4)))
                 .andExpect(status().isCreated());
 
-        assertThat(onHand(sku, BIN_A1)).isEqualTo(6);
-        assertThat(onHand(sku, BIN_A2)).isEqualTo(4);
+        assertThat(onHand(sku, BIN_A1)).isEqualByComparingTo("6");
+        assertThat(onHand(sku, BIN_A2)).isEqualByComparingTo("4");
         // The paired OUT/IN posts in one transaction: in-transit cancels to zero everywhere.
         assertThat(summaryRepository.findByStockItemId(sku))
                 .allMatch(row -> row.getInTransitQty().signum() == 0);
@@ -131,8 +131,8 @@ class CrossSiteTransferGuardIT extends BaseContractIntegrationTest {
                         .content(transferBody(sku, freeFrom, freeTo, 3)))
                 .andExpect(status().isCreated());
 
-        assertThat(onHand(sku, freeFrom)).isEqualTo(7);
-        assertThat(onHand(sku, freeTo)).isEqualTo(3);
+        assertThat(onHand(sku, freeFrom)).isEqualByComparingTo("7");
+        assertThat(onHand(sku, freeTo)).isEqualByComparingTo("3");
     }
 
     // ─── Helpers ──────────────────────────────────────────────────────────────

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/LotInboundCaptureIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/LotInboundCaptureIT.java
@@ -194,12 +194,12 @@ class LotInboundCaptureIT extends BaseContractIntegrationTest {
                         .findByKey(productId.toString(), locationId, lot.getLotId())
                         .orElseThrow()
                         .getOnHand())
-                .isEqualTo(12);
+                .isEqualByComparingTo("12");
         assertThat(summaryRepository
                         .findByStockItemIdAndLocationId(productId.toString(), locationId)
                         .orElseThrow()
                         .getOnHand())
-                .isEqualTo(12);
+                .isEqualByComparingTo("12");
     }
 
     // ─── receive-into-staging path ──────────────────────────────────────────────
@@ -233,7 +233,7 @@ class LotInboundCaptureIT extends BaseContractIntegrationTest {
                         .findByKey(productId.toString(), stagingLocation, lot.getLotId())
                         .orElseThrow()
                         .getOnHand())
-                .isEqualTo(4);
+                .isEqualByComparingTo("4");
 
         // The keyed lot number is persisted on the receiving line for audit.
         String persistedLotNumber = jdbcTemplate.queryForObject(
@@ -273,7 +273,7 @@ class LotInboundCaptureIT extends BaseContractIntegrationTest {
                             .findByStockItemIdAndLocationId(sku, locationId)
                             .orElseThrow()
                             .getOnHand())
-                    .isEqualTo(9);
+                    .isEqualByComparingTo("9");
         }
     }
 

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/LotOutboundFlowsIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/LotOutboundFlowsIT.java
@@ -237,13 +237,13 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
                 workorderId, null, List.of(new ConsumeItemLine(task.getPickTaskId(), productId, 3))));
 
         // Exact per-lot decrement: lot A 5 -> 2, lot B untouched, agnostic row 10 -> 7.
-        assertThat(perLotOnHand(productId, null, lotA.getLotId())).isEqualTo(2);
-        assertThat(perLotOnHand(productId, null, lotB.getLotId())).isEqualTo(5);
+        assertThat(perLotOnHand(productId, null, lotA.getLotId())).isEqualByComparingTo("2");
+        assertThat(perLotOnHand(productId, null, lotB.getLotId())).isEqualByComparingTo("5");
         assertThat(summaryRepository
                         .findByStockItemIdAndLocationIdIsNull(productId.toString())
                         .orElseThrow()
                         .getOnHand())
-                .isEqualTo(7);
+                .isEqualByComparingTo("7");
         List<InventoryLedgerEntry> consumptionEntries =
                 entriesOf(productId, InventoryLedgerEventType.WORKORDER_CONSUMPTION);
         assertThat(consumptionEntries).hasSize(1);
@@ -256,7 +256,7 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
         assertThatThrownBy(() -> consumptionService.consumePickedItems(overRequest))
                 .isInstanceOf(LotInsufficientStockException.class)
                 .hasMessageContaining("LOT_INSUFFICIENT_STOCK");
-        assertThat(perLotOnHand(productId, null, lotA.getLotId())).isEqualTo(2);
+        assertThat(perLotOnHand(productId, null, lotA.getLotId())).isEqualByComparingTo("2");
         assertThat(lotRepository.findById(lotA.getLotId()).orElseThrow().getStatus())
                 .isEqualTo(InventoryLotStatus.ACTIVE);
 
@@ -293,8 +293,8 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
                 workorderId,
                 null,
                 List.of(new ConsumeItemLine(legacyTask.getPickTaskId(), productId, 2, "LOT-SRC-B"))));
-        assertThat(perLotOnHand(productId, null, lotB.getLotId())).isEqualTo(2);
-        assertThat(perLotOnHand(productId, null, lotA.getLotId())).isEqualTo(4);
+        assertThat(perLotOnHand(productId, null, lotB.getLotId())).isEqualByComparingTo("2");
+        assertThat(perLotOnHand(productId, null, lotA.getLotId())).isEqualByComparingTo("4");
     }
 
     // ─── Returns: re-increment + CONSUMED → ACTIVE ──────────────────────────────
@@ -332,7 +332,7 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
                 workorderId,
                 "DAMAGED",
                 List.of(new ReturnItemLine(productId, new BigDecimal("2"), null, null, "LOT-RET-A"))));
-        assertThat(perLotOnHand(productId, null, lot.getLotId())).isEqualTo(2);
+        assertThat(perLotOnHand(productId, null, lot.getLotId())).isEqualByComparingTo("2");
         assertThat(lotRepository.findById(lot.getLotId()).orElseThrow().getStatus())
                 .isEqualTo(InventoryLotStatus.ACTIVE);
         List<InventoryLedgerEntry> returnEntries = entriesOf(productId, InventoryLedgerEventType.RETURN_TO_STOCK);
@@ -367,7 +367,7 @@ class LotOutboundFlowsIT extends BaseContractIntegrationTest {
         List<InventoryLedgerEntry> scrapEntries = entriesOf(productId, InventoryLedgerEventType.SCRAP_OUT);
         assertThat(scrapEntries).hasSize(1);
         assertThat(scrapEntries.getFirst().getLotId()).isEqualTo(lot.getLotId());
-        assertThat(perLotOnHand(productId, locationId, lot.getLotId())).isEqualTo(4);
+        assertThat(perLotOnHand(productId, locationId, lot.getLotId())).isEqualByComparingTo("4");
     }
 
     // ─── Cross-dock ─────────────────────────────────────────────────────────────

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/ScrapContractBehaviorIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/ScrapContractBehaviorIT.java
@@ -125,7 +125,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
         assertThat(scrapEntries.getFirst().getReasonCode()).isEqualTo("DAMAGED");
         assertThat(scrapEntries.getFirst().getSourceTransactionId()).isEqualTo(scrapId);
 
-        assertThat(onHand(sku)).isEqualTo(7);
+        assertThat(onHand(sku)).isEqualByComparingTo("7");
 
         List<OutboxEvent> factRows = outboxEventRepository.findAll().stream()
                 .filter(row -> row.getPayload().contains(ScrapPostedV1.EVENT_TYPE))
@@ -156,7 +156,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
                 .asString();
 
         // Nothing posted while pending.
-        assertThat(onHand(sku)).isEqualTo(10);
+        assertThat(onHand(sku)).isEqualByComparingTo("10");
 
         mockMvc.perform(withGatewayAuth(post("/v1/inventory/scraps/{id}/approve", scrapId))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -165,7 +165,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
                 .andExpect(jsonPath("$.status").value("POSTED"))
                 .andExpect(jsonPath("$.approvedBy").value("contract-test-user"));
 
-        assertThat(onHand(sku)).isEqualTo(7);
+        assertThat(onHand(sku)).isEqualByComparingTo("7");
         assertThat(outboxEventRepository.findAll())
                 .anyMatch(row -> row.getPayload().contains(ScrapPostedV1.EVENT_TYPE));
     }
@@ -196,7 +196,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
                 .andExpect(jsonPath("$.status").value("REJECTED"))
                 .andExpect(jsonPath("$.rejectedBy").value("contract-test-user"));
 
-        assertThat(onHand(sku)).isEqualTo(10);
+        assertThat(onHand(sku)).isEqualByComparingTo("10");
         assertThat(ledgerEntryRepository.findByStockItemIdOrderByTimestampDesc(sku))
                 .noneMatch(entry -> entry.getEventType() == InventoryLedgerEventType.SCRAP_OUT);
         assertThat(outboxEventRepository.findAll())
@@ -220,7 +220,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
 
         // The whole create transaction rolled back: no scrap document, stock untouched.
         assertThat(scrapRepository.findAll()).isEmpty();
-        assertThat(onHand(sku)).isEqualTo(2);
+        assertThat(onHand(sku)).isEqualByComparingTo("2");
     }
 
     // ─── Override path: authorized override drives on-hand negative ───────────
@@ -239,7 +239,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
 
         // SCRAP_OUT is BLOCKED_OVERRIDABLE: the explicit authorized override
         // permits the negative balance (NegativeStockPolicy matrix, K1).
-        assertThat(onHand(sku)).isEqualTo(-3);
+        assertThat(onHand(sku)).isEqualByComparingTo("-3");
     }
 
     @Test
@@ -253,7 +253,7 @@ class ScrapContractBehaviorIT extends BaseContractIntegrationTest {
                         .content(createBody(sku, 5, "DAMAGED", null, true)))
                 .andExpect(status().isForbidden());
 
-        assertThat(onHand(sku)).isEqualTo(2);
+        assertThat(onHand(sku)).isEqualByComparingTo("2");
     }
 
     // ─── Validation and permission gating ─────────────────────────────────────

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/TransferOrderDispatchReceiveIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/TransferOrderDispatchReceiveIT.java
@@ -465,15 +465,15 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
         assertThat(perLotRow(sku, SOURCE_SITE, lotId)
                         .map(row -> row.getOnHand())
                         .orElse(BigDecimal.ZERO))
-                .isEqualTo(sourceOnHand);
+                .isEqualByComparingTo(BigDecimal.valueOf(sourceOnHand));
         assertThat(perLotRow(sku, DESTINATION_SITE, lotId)
                         .map(row -> row.getInTransitQty())
                         .orElse(BigDecimal.ZERO))
-                .isEqualTo(destinationInTransit);
+                .isEqualByComparingTo(BigDecimal.valueOf(destinationInTransit));
         assertThat(perLotRow(sku, DESTINATION_SITE, lotId)
                         .map(row -> row.getOnHand())
                         .orElse(BigDecimal.ZERO))
-                .isEqualTo(destinationOnHand);
+                .isEqualByComparingTo(BigDecimal.valueOf(destinationOnHand));
     }
 
     private java.util.Optional<com.positivity.inventory.internal.entity.InventoryStockSummary> perLotRow(
@@ -488,12 +488,12 @@ class TransferOrderDispatchReceiveIT extends BaseContractIntegrationTest {
      * conservation invariant holds globally, not just over the asserted keys.
      */
     private void assertBalances(String sku, long sourceOnHand, long destinationInTransit, long destinationOnHand) {
-        assertThat(onHand(sku, SOURCE_SITE)).isEqualTo(sourceOnHand);
-        assertThat(inTransit(sku, DESTINATION_SITE)).isEqualTo(destinationInTransit);
-        assertThat(onHand(sku, DESTINATION_SITE)).isEqualTo(destinationOnHand);
+        assertThat(onHand(sku, SOURCE_SITE)).isEqualByComparingTo(BigDecimal.valueOf(sourceOnHand));
+        assertThat(inTransit(sku, DESTINATION_SITE)).isEqualByComparingTo(BigDecimal.valueOf(destinationInTransit));
+        assertThat(onHand(sku, DESTINATION_SITE)).isEqualByComparingTo(BigDecimal.valueOf(destinationOnHand));
         assertThat(totalAcrossAllKeys(sku))
                 .as("conservation: no stock outside source on-hand + destination in-transit + destination on-hand")
-                .isEqualTo(sourceOnHand + destinationInTransit + destinationOnHand);
+                .isEqualByComparingTo(BigDecimal.valueOf(sourceOnHand + destinationInTransit + destinationOnHand));
     }
 
     private BigDecimal totalAcrossAllKeys(String sku) {

--- a/pos-inventory/src/test/java/com/positivity/inventory/contract/TransferOrderShortCloseIT.java
+++ b/pos-inventory/src/test/java/com/positivity/inventory/contract/TransferOrderShortCloseIT.java
@@ -444,15 +444,15 @@ class TransferOrderShortCloseIT extends BaseContractIntegrationTest {
      * short-close under either disposition leaks nothing to any other key.
      */
     private void assertBalances(String sku, long sourceOnHand, long destinationInTransit, long destinationOnHand) {
-        assertThat(onHand(sku, SOURCE_SITE)).isEqualTo(sourceOnHand);
-        assertThat(inTransit(sku, DESTINATION_SITE)).isEqualTo(destinationInTransit);
-        assertThat(onHand(sku, DESTINATION_SITE)).isEqualTo(destinationOnHand);
+        assertThat(onHand(sku, SOURCE_SITE)).isEqualByComparingTo(BigDecimal.valueOf(sourceOnHand));
+        assertThat(inTransit(sku, DESTINATION_SITE)).isEqualByComparingTo(BigDecimal.valueOf(destinationInTransit));
+        assertThat(onHand(sku, DESTINATION_SITE)).isEqualByComparingTo(BigDecimal.valueOf(destinationOnHand));
         assertThat(inTransit(sku, SOURCE_SITE))
                 .as("source key must carry no residual in-transit after any short-close shape")
                 .isZero();
         assertThat(totalAcrossAllKeys(sku))
                 .as("conservation: no stock outside source on-hand + destination in-transit + destination on-hand")
-                .isEqualTo(sourceOnHand + destinationInTransit + destinationOnHand);
+                .isEqualByComparingTo(BigDecimal.valueOf(sourceOnHand + destinationInTransit + destinationOnHand));
     }
 
     private BigDecimal totalAcrossAllKeys(String sku) {


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — CI fix (test-only)
- Parent STORY (durion): n/a
- Child issue: n/a — follow-up to ADR-0055 stage 2 (#1414 / PR #1419)
- Domain: `domain:inventory`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- n/a — no API/event behavior changed; test assertions only (no controllers, DTOs, events, or openapi.yaml touched)

## Contract Chain (when a Controller changed)
- n/a — no controller changed

## Scope
- What changed: 34 assertions across the six pos-inventory contract ITs (`CrossSiteTransferGuardIT`, `LotInboundCaptureIT`, `LotOutboundFlowsIT`, `ScrapContractBehaviorIT`, `TransferOrderDispatchReceiveIT`, `TransferOrderShortCloseIT`) switched from AssertJ `isEqualTo(int/long)` to `isEqualByComparingTo` when the actual value is a `BigDecimal` balance.
- Why: the decimal inventory ledger (ADR-0055 stage 2, merged in #1419) stores summary quantities as `BigDecimal` with scale 4. AssertJ's `isEqualTo` uses `BigDecimal.equals`, which is scale-sensitive, so `expected: 6 but was: 6.0000` has failed every main build since (runs 2591–2597). `isEqualByComparingTo` compares numeric value only. No production code changed.

## Tests
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated
- How to run: `./mvnw -pl pos-inventory -am verify -Dit.test='CrossSiteTransferGuardIT,LotInboundCaptureIT,LotOutboundFlowsIT,ScrapContractBehaviorIT,TransferOrderDispatchReceiveIT,TransferOrderShortCloseIT'` — 47 tests, 0 failures locally.

## Risk & Rollback
- Risk level: Low — test-only change, relaxes scale sensitivity, not numeric value.
- Rollback plan: revert the single commit.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` (n/a — CI-fix branch)
- [ ] PR title starts with `[CAP:<cap-id>]` (n/a — no capability)
- [x] Links to parent + child issues are present (n/a noted above)
- [x] Contract guide updated (when contract semantics changed) — n/a, semantics unchanged
- [x] Required CI checks passing (pending this run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvpRCxZaz1KXGVK4fEmedR

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvpRCxZaz1KXGVK4fEmedR)_