### PR TITLE
Disambiguate unit_of_measure on multi-unit package SKUs in catalog and inventory seeds (#1417)

### DIFF
--- a/pos-catalog/src/main/resources/db/migration/R__seed_reference_catalog_2_products.sql
+++ b/pos-catalog/src/main/resources/db/migration/R__seed_reference_catalog_2_products.sql
@@ -1,6 +1,19 @@
 -- =============================================================
 -- R__seed_reference_catalog_2_products.sql
 -- 500 real mechanical auto parts products
+--
+-- unit_of_measure convention (issue #1417 / ADR-0055):
+--   * A packaged SKU (bottle, jug, box, kit, set) carries the unit the shop
+--     counts on the shelf. A sealed multi-unit package is ONE stocked thing:
+--     a 5-quart jug is 'EA', never 'QT' — otherwise on-hand is ambiguous
+--     between containers and contents (they differ by the package factor).
+--   * A single-unit container may carry its content unit ('QT' for a 1-quart
+--     bottle, 'GA' for a 1-gallon jug) because container-count and
+--     content-count coincide at factor 1.
+--   * Only genuinely divisible, bulk-dispensed stock carries a content unit
+--     with a non-unit factor (e.g. PARK-387TC-4-FT hydraulic hose in 'FT').
+--     Such products must also declare their base precision via product_uom
+--     (BASE row, precision_scale > 0) once product_uom is seeded.
 -- =============================================================
 SET TIME ZONE 'UTC';
 
@@ -128,11 +141,11 @@ VALUES
     (gen_random_uuid(), 'DORM-300-002', 'Dorman Power Steering Pump 300-002', 'ACTIVE', '01960034-0000-7000-8000-000000000023', 'Dorman', 'Dorman', '300-002', 'US', 'PART', 'EA', '01960030-0000-7000-8000-000000000006', '01960031-0000-7000-8000-000000000018', NOW(), NOW()),
     (gen_random_uuid(), 'ACDL-36-365556', 'ACDelco Power Steering Hose 36-365556', 'ACTIVE', '01960034-0000-7000-8000-00000000000e', 'ACDelco', 'ACDelco', '36-365556', 'US', 'PART', 'EA', '01960030-0000-7000-8000-000000000006', '01960031-0000-7000-8000-000000000018', NOW(), NOW()),
     (gen_random_uuid(), 'MOBI-104561', 'Mobil 1 Full Synthetic 5W-30 Motor Oil 1qt', 'ACTIVE', '01960034-0000-7000-8000-00000000001e', 'Mobil', 'Mobil', '104561', 'US', 'PART', 'QT', '01960030-0000-7000-8000-000000000007', '01960031-0000-7000-8000-000000000019', NOW(), NOW()),
-    (gen_random_uuid(), 'MOBI-120764', 'Mobil 1 Full Synthetic 5W-30 Motor Oil 5qt', 'ACTIVE', '01960034-0000-7000-8000-00000000001e', 'Mobil', 'Mobil', '120764', 'US', 'PART', 'QT', '01960030-0000-7000-8000-000000000007', '01960031-0000-7000-8000-000000000019', NOW(), NOW()),
-    (gen_random_uuid(), 'MOBI-14977', 'Mobil 1 Extended Performance 5W-30 5qt', 'ACTIVE', '01960034-0000-7000-8000-00000000001e', 'Mobil', 'Mobil', '14977', 'US', 'PART', 'QT', '01960030-0000-7000-8000-000000000007', '01960031-0000-7000-8000-000000000019', NOW(), NOW()),
-    (gen_random_uuid(), 'MOBI-72206', 'Mobil 1 High Mileage 10W-40 5qt', 'ACTIVE', '01960034-0000-7000-8000-00000000001e', 'Mobil', 'Mobil', '72206', 'US', 'PART', 'QT', '01960030-0000-7000-8000-000000000007', '01960031-0000-7000-8000-000000000019', NOW(), NOW()),
-    (gen_random_uuid(), 'VALV-787987', 'Valvoline Advanced Full Synthetic 5W-20 5qt', 'ACTIVE', '01960034-0000-7000-8000-00000000001c', 'Valvoline', 'Valvoline', '787987', 'US', 'PART', 'QT', '01960030-0000-7000-8000-000000000007', '01960031-0000-7000-8000-000000000019', NOW(), NOW()),
-    (gen_random_uuid(), 'VALV-782253', 'Valvoline High Mileage MaxLife 5W-30 5qt', 'ACTIVE', '01960034-0000-7000-8000-00000000001c', 'Valvoline', 'Valvoline', '782253', 'US', 'PART', 'QT', '01960030-0000-7000-8000-000000000007', '01960031-0000-7000-8000-000000000019', NOW(), NOW()),
+    (gen_random_uuid(), 'MOBI-120764', 'Mobil 1 Full Synthetic 5W-30 Motor Oil 5qt', 'ACTIVE', '01960034-0000-7000-8000-00000000001e', 'Mobil', 'Mobil', '120764', 'US', 'PART', 'EA', '01960030-0000-7000-8000-000000000007', '01960031-0000-7000-8000-000000000019', NOW(), NOW()),
+    (gen_random_uuid(), 'MOBI-14977', 'Mobil 1 Extended Performance 5W-30 5qt', 'ACTIVE', '01960034-0000-7000-8000-00000000001e', 'Mobil', 'Mobil', '14977', 'US', 'PART', 'EA', '01960030-0000-7000-8000-000000000007', '01960031-0000-7000-8000-000000000019', NOW(), NOW()),
+    (gen_random_uuid(), 'MOBI-72206', 'Mobil 1 High Mileage 10W-40 5qt', 'ACTIVE', '01960034-0000-7000-8000-00000000001e', 'Mobil', 'Mobil', '72206', 'US', 'PART', 'EA', '01960030-0000-7000-8000-000000000007', '01960031-0000-7000-8000-000000000019', NOW(), NOW()),
+    (gen_random_uuid(), 'VALV-787987', 'Valvoline Advanced Full Synthetic 5W-20 5qt', 'ACTIVE', '01960034-0000-7000-8000-00000000001c', 'Valvoline', 'Valvoline', '787987', 'US', 'PART', 'EA', '01960030-0000-7000-8000-000000000007', '01960031-0000-7000-8000-000000000019', NOW(), NOW()),
+    (gen_random_uuid(), 'VALV-782253', 'Valvoline High Mileage MaxLife 5W-30 5qt', 'ACTIVE', '01960034-0000-7000-8000-00000000001c', 'Valvoline', 'Valvoline', '782253', 'US', 'PART', 'EA', '01960030-0000-7000-8000-000000000007', '01960031-0000-7000-8000-000000000019', NOW(), NOW()),
     (gen_random_uuid(), 'VALV-882', 'Valvoline Daily Protection 10W-40 1qt', 'ACTIVE', '01960034-0000-7000-8000-00000000001c', 'Valvoline', 'Valvoline', '882', 'US', 'PART', 'QT', '01960030-0000-7000-8000-000000000007', '01960031-0000-7000-8000-000000000019', NOW(), NOW()),
     (gen_random_uuid(), 'PRES-AF2100', 'Prestone Extended Life 50/50 Antifreeze 1gal', 'ACTIVE', '01960034-0000-7000-8000-00000000001d', 'Prestone', 'Prestone', 'AF2100', 'US', 'PART', 'GA', '01960030-0000-7000-8000-000000000007', '01960031-0000-7000-8000-00000000001a', NOW(), NOW())
 ON CONFLICT (sku) DO UPDATE SET

--- a/pos-inventory/src/main/resources/db/migration/R__seed_reference_inventory.sql
+++ b/pos-inventory/src/main/resources/db/migration/R__seed_reference_inventory.sql
@@ -44,11 +44,11 @@ ON CONFLICT (config_id) DO NOTHING;
 -- Shelf A — Motor Oils & Fluids (Bins A-01..A-10)
 INSERT INTO inventory_ledger_entry (ledger_entry_id, stock_item_id, location_id, event_type, change_in_quantity, quantity_after, unit_cost, unit_of_measure, "timestamp", created_at, updated_at, transaction_user_id, notes)
 VALUES
-  (md5('inv_seed:MOBI-120764')::uuid,  'MOBI-120764', '01960004-0001-7000-8000-000000000009'::uuid, 'GOODS_RECEIPT', 24, 24, 9.99,  'QT',  NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Mobil 1 5W-30 Full Synthetic Quart'),
-  (md5('inv_seed:MOBI-14977')::uuid,   'MOBI-14977',  '01960004-0001-7000-8000-00000000000a'::uuid, 'GOODS_RECEIPT', 12, 12, 26.99, 'GAL', NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Mobil 1 5W-30 Full Synthetic 5-Qt Jug'),
-  (md5('inv_seed:VALV-787987')::uuid,  'VALV-787987', '01960004-0001-7000-8000-00000000000b'::uuid, 'GOODS_RECEIPT', 24, 24, 8.49,  'QT',  NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Valvoline Advanced Full Synthetic 5W-30'),
-  (md5('inv_seed:VALV-782253')::uuid,  'VALV-782253', '01960004-0001-7000-8000-00000000000c'::uuid, 'GOODS_RECEIPT', 12, 12, 24.99, 'GAL', NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Valvoline Advanced Full Synthetic 5W-30 5-Qt'),
-  (md5('inv_seed:MOBI-72206')::uuid,   'MOBI-72206',  '01960004-0001-7000-8000-00000000000d'::uuid, 'GOODS_RECEIPT', 24, 24, 8.99,  'QT',  NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Mobil Super 5000 10W-30'),
+  (md5('inv_seed:MOBI-120764')::uuid,  'MOBI-120764', '01960004-0001-7000-8000-000000000009'::uuid, 'GOODS_RECEIPT', 24, 24, 17.75, 'EA',  NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Mobil 1 Full Synthetic 5W-30 Motor Oil 5qt'),
+  (md5('inv_seed:MOBI-14977')::uuid,   'MOBI-14977',  '01960004-0001-7000-8000-00000000000a'::uuid, 'GOODS_RECEIPT', 12, 12, 17.94, 'EA',  NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Mobil 1 Extended Performance 5W-30 5qt'),
+  (md5('inv_seed:VALV-787987')::uuid,  'VALV-787987', '01960004-0001-7000-8000-00000000000b'::uuid, 'GOODS_RECEIPT', 24, 24, 10.69, 'EA',  NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Valvoline Advanced Full Synthetic 5W-20 5qt'),
+  (md5('inv_seed:VALV-782253')::uuid,  'VALV-782253', '01960004-0001-7000-8000-00000000000c'::uuid, 'GOODS_RECEIPT', 12, 12, 10.47, 'EA',  NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Valvoline High Mileage MaxLife 5W-30 5qt'),
+  (md5('inv_seed:MOBI-72206')::uuid,   'MOBI-72206',  '01960004-0001-7000-8000-00000000000d'::uuid, 'GOODS_RECEIPT', 24, 24, 15.94, 'EA',  NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Mobil 1 High Mileage 10W-40 5qt'),
   (md5('inv_seed:PRES-AF2100')::uuid,  'PRES-AF2100', '01960004-0001-7000-8000-00000000000e'::uuid, 'GOODS_RECEIPT', 12, 12, 11.49, 'GAL', NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Prestone 50/50 Antifreeze/Coolant 1-Gal'),
   (md5('inv_seed:PRES-AF6100')::uuid,  'PRES-AF6100', '01960004-0001-7000-8000-00000000000f'::uuid, 'GOODS_RECEIPT', 6,  6,  18.99, 'GAL', NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Prestone Extended Life Antifreeze 1-Gal'),
   (md5('inv_seed:VALV-ATF-ML-QT')::uuid, 'VALV-ATF-ML-QT', '01960004-0001-7000-8000-000000000010'::uuid, 'GOODS_RECEIPT', 12, 12, 7.99, 'QT', NOW(), NOW(), NOW(), 'system-seed', 'Initial stock: Valvoline MaxLife ATF Quart'),


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — data-quality fix found during the #1365 / ADR-0055 investigation
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1417
- Domain: `domain:product`, `domain:inventory`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/*/.business-rules/BACKEND_CONTRACT_GUIDE.md` — no API or event behavior changes; seed data only. Reference retained for the contract-sync check.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- No controller changed; no OpenAPI or SDK impact.

## Scope
- What changed:
  - **pos-catalog** `R__seed_reference_catalog_2_products.sql`: the five 5-quart oil SKUs (`MOBI-120764`, `MOBI-14977`, `MOBI-72206`, `VALV-787987`, `VALV-782253`) change `unit_of_measure` `QT` → `EA`. A sealed multi-unit package is one stocked thing; `QT` made on-hand ambiguous by the package factor of 5. A convention block in the file header records the rule for future seeding: package SKUs carry the shelf-count unit; single-unit containers may keep their content unit (factor 1); only genuinely divisible bulk stock (`PARK-387TC-4-FT` hose, `FT`) carries a content unit, and must declare `precision_scale > 0` via `product_uom` once seeding exists.
  - **pos-inventory** `R__seed_reference_inventory.sql`: the issue predicted a risk; the inventory seed showed it already live — the same five SKUs were seeded in `QT` at one location, `GAL` at another, and `EA` at a third, with per-quart unit costs and descriptions drifted from the catalog (`"Mobil Super 5000 10W-30"` for the catalog's `"Mobil 1 High Mileage 10W-40 5qt"`). All five rows now post in `EA`, with `unit_cost` set to the pricing seed's per-jug `last_cost` and descriptions matched to catalog names. Idempotency keys (`md5('inv_seed:SKU')`) unchanged, so the repeatable migration replaces cleanly.
- Why: closes #1417. The urgency is #1413 (merged): `unit_of_measure` stops being descriptive once `product_uom` seeding begins, because `ProductUomType.BASE` requires the base row's code to match it — seeding against the ambiguous values would bake the factor-of-5 error into conversion factors.

### Per the issue's acceptance criteria
- [x] Five 5qt SKUs no longer ambiguous
- [x] Single-unit container rows (1qt `QT` / 1gal `GA`) reviewed and **left as-is with the reason recorded** in the convention block (factor 1 — container-count and content-count coincide)
- [x] `PARK-387TC-4-FT` confirmed intentional bulk, untouched
- [x] Convention written where the next seeder will see it
- [x] Pricing rows verified: `product_msrp` and `item_cost` were **already per-jug** (`MOBI-120764` $45.78 vs 1qt `MOBI-104561` $11.86, ≈3.9×) — no pricing change needed, no price silently changes meaning
- [x] `product_uom` seeding (none exists yet) will be authored against the corrected values

## Tests
- [ ] Unit tests added/updated — n/a, seed data only
- [x] Integration tests added/updated — existing Flyway-backed suites execute these seed files; both modules green
- [ ] Provider behavioral contract tests — n/a
- How to run: `./mvnw -pl pos-catalog,pos-inventory -am test`

## Risk & Rollback
- Risk level: Low — repeatable seed migrations on a pre-production system with no real data; `R__` files re-apply on next Flyway run and replace by unchanged idempotency keys
- Rollback plan: revert the commit; seeds re-apply to prior values

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — session-mandated branch
- [ ] PR title starts with `[CAP:<cap-id>]` — issue-numbered title
- [x] Links to parent + child issues are present
- [x] Contract guide reference present (no contract semantics changed)
- [ ] Required CI checks passing — pending

**Verification run:** `./mvnw -pl pos-catalog,pos-inventory -am test` → BUILD SUCCESS (includes both modules' ArchitectureTests); `scripts/check-flyway-hygiene.sh` → 25 modules pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJPZ9szyzL6C5KQdNyeF48

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJPZ9szyzL6C5KQdNyeF48)_