### PR TITLE
fix(pos-mcp-server): log per-tool invocations with a real tool_id so priority tuning has data

### DIFF
--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SessionAgentManager.java
@@ -22,6 +22,7 @@ import com.positivity.mcp.internal.service.NltiWorkflowStateService;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
 import com.positivity.mcp.internal.service.RequestScopedUserContext;
 import com.positivity.mcp.internal.service.SystemPromptDefaults;
+import com.positivity.mcp.internal.service.ToolInvocationRecorder;
 import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry;
 import com.positivity.mcp.internal.telemetry.NltiRequestTelemetryFactory;
 import com.positivity.mcp.internal.telemetry.NltiRequestTelemetryFactory.TierRouting;
@@ -95,6 +96,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
     private final @Nullable AnswerResolutionLadder answerResolutionLadder;
     private final @Nullable RequestScopedUserContext requestScopedUserContext;
     private final @Nullable RoleDefaultPermissionsClient roleDefaultPermissionsClient;
+    private final @Nullable ToolInvocationRecorder toolInvocationRecorder;
     private final NltiWorkflowStateService workflowStateService;
     private final @Nullable NltiRouter nltiRouter;
     private final @Nullable TieredChatModelResolver tieredChatModelResolver;
@@ -124,6 +126,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
             @Nullable AnswerResolutionLadder answerResolutionLadder,
             @Nullable RequestScopedUserContext requestScopedUserContext,
             @Nullable RoleDefaultPermissionsClient roleDefaultPermissionsClient,
+            @Nullable ToolInvocationRecorder toolInvocationRecorder,
             @NonNull NltiWorkflowStateService workflowStateService,
             @Nullable NltiRouter nltiRouter,
             @Nullable TieredChatModelResolver tieredChatModelResolver,
@@ -151,6 +154,7 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
         this.answerResolutionLadder = answerResolutionLadder;
         this.requestScopedUserContext = requestScopedUserContext;
         this.roleDefaultPermissionsClient = roleDefaultPermissionsClient;
+        this.toolInvocationRecorder = toolInvocationRecorder;
         this.workflowStateService = workflowStateService;
         this.nltiRouter = nltiRouter;
         this.tieredChatModelResolver = tieredChatModelResolver;
@@ -397,7 +401,8 @@ public class SessionAgentManager implements AgentOrchestrationService, SessionAg
                 resilientContentRetriever,
                 this::chatMemoryFor,
                 openApiToolProvider,
-                answerResolutionLadder);
+                answerResolutionLadder,
+                toolInvocationRecorder);
         LOGGER.debug(
                 "Built MCP role agent role={} promptName={} ragScope={} tier={} toolNames={}",
                 role,

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistant.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistant.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration;
 import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
 import com.positivity.mcp.internal.service.AnswerResolutionLadder;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
+import com.positivity.mcp.internal.service.ToolInvocationRecorder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -44,10 +45,11 @@ final class SpringAiPosAssistant implements PosAssistant {
             @NonNull QueryDocumentRetriever ragRetriever,
             @NonNull Function<String, ChatMemory> chatMemoryProvider,
             @Nullable OpenApiToolProvider openApiToolProvider,
-            @Nullable AnswerResolutionLadder answerResolutionLadder) {
+            @Nullable AnswerResolutionLadder answerResolutionLadder,
+            @Nullable ToolInvocationRecorder invocationRecorder) {
         this.chatModel = chatModel;
         this.systemPromptSupplier = systemPromptSupplier;
-        this.staticToolCallbacks = SpringAiToolCallbackResolver.fromObjects(staticTools);
+        this.staticToolCallbacks = SpringAiToolCallbackResolver.fromObjects(staticTools, invocationRecorder);
         this.ragRetriever = ragRetriever;
         this.chatMemoryProvider = chatMemoryProvider;
         this.openApiToolProvider = openApiToolProvider;

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistant.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistant.java
@@ -2,6 +2,7 @@ package com.positivity.mcp.internal.orchestration;
 
 import com.positivity.mcp.internal.orchestration.rag.QueryDocumentRetriever;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
+import com.positivity.mcp.internal.service.ToolInvocationRecorder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -42,10 +43,11 @@ final class SpringAiStreamingPosAssistant implements StreamingPosAssistant {
             @NonNull List<Object> staticTools,
             @NonNull QueryDocumentRetriever ragRetriever,
             @NonNull Function<String, ChatMemory> chatMemoryProvider,
-            @Nullable OpenApiToolProvider openApiToolProvider) {
+            @Nullable OpenApiToolProvider openApiToolProvider,
+            @Nullable ToolInvocationRecorder invocationRecorder) {
         this.streamingChatModel = streamingChatModel;
         this.systemPromptSupplier = systemPromptSupplier;
-        this.staticToolCallbacks = SpringAiToolCallbackResolver.fromObjects(staticTools);
+        this.staticToolCallbacks = SpringAiToolCallbackResolver.fromObjects(staticTools, invocationRecorder);
         this.ragRetriever = ragRetriever;
         this.chatMemoryProvider = chatMemoryProvider;
         this.openApiToolProvider = openApiToolProvider;

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiToolCallbackResolver.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/SpringAiToolCallbackResolver.java
@@ -3,6 +3,7 @@ package com.positivity.mcp.internal.orchestration;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.positivity.mcp.internal.service.ToolInvocationRecorder;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
@@ -20,6 +21,7 @@ import org.springframework.ai.tool.definition.DefaultToolDefinition;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.metadata.DefaultToolMetadata;
 import org.springframework.ai.tool.metadata.ToolMetadata;
+import org.springframework.util.ClassUtils;
 
 final class SpringAiToolCallbackResolver {
 
@@ -29,15 +31,28 @@ final class SpringAiToolCallbackResolver {
     private SpringAiToolCallbackResolver() {}
 
     static @NonNull List<ToolCallback> fromObjects(@NonNull List<Object> toolObjects) {
+        return fromObjects(toolObjects, null);
+    }
+
+    /**
+     * #1422: when a recorder is supplied, every facade callback is wrapped so each execution logs
+     * an {@code mcp_tool_invocation_log} row. The lookup key is the owning facade's user-class
+     * simple name (e.g. {@code OrderFacadeTool}) — that is how facade rows are keyed in
+     * {@code mcp_tool.name}; the callback's own name is the {@code @Tool} method name.
+     */
+    static @NonNull List<ToolCallback> fromObjects(
+            @NonNull List<Object> toolObjects, @Nullable ToolInvocationRecorder invocationRecorder) {
         List<ToolCallback> callbacks = new ArrayList<>();
         for (Object toolObject : toolObjects) {
-            callbacks.addAll(fromObject(toolObject));
+            callbacks.addAll(fromObject(toolObject, invocationRecorder));
         }
         return List.copyOf(callbacks);
     }
 
-    private static @NonNull List<ToolCallback> fromObject(@NonNull Object toolObject) {
+    private static @NonNull List<ToolCallback> fromObject(
+            @NonNull Object toolObject, @Nullable ToolInvocationRecorder invocationRecorder) {
         List<ToolCallback> callbacks = new ArrayList<>();
+        String facadeName = ClassUtils.getUserClass(toolObject).getSimpleName();
         for (Method method : toolObject.getClass().getMethods()) {
             Tool toolAnnotation = method.getAnnotation(Tool.class);
             if (toolAnnotation == null) {
@@ -47,7 +62,8 @@ final class SpringAiToolCallbackResolver {
             if (description.isBlank()) {
                 description = method.getName();
             }
-            callbacks.add(new ReflectiveToolCallback(toolObject, method, description));
+            ToolCallback callback = new ReflectiveToolCallback(toolObject, method, description);
+            callbacks.add(invocationRecorder != null ? invocationRecorder.wrap(callback, facadeName) : callback);
         }
         return callbacks;
     }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManager.java
@@ -19,6 +19,7 @@ import com.positivity.mcp.internal.service.NltiWorkflowStateService;
 import com.positivity.mcp.internal.service.OpenApiToolProvider;
 import com.positivity.mcp.internal.service.RequestScopedUserContext;
 import com.positivity.mcp.internal.service.SystemPromptDefaults;
+import com.positivity.mcp.internal.service.ToolInvocationRecorder;
 import com.positivity.mcp.internal.telemetry.NltiRequestTelemetry;
 import com.positivity.mcp.internal.telemetry.NltiRequestTelemetryFactory;
 import com.positivity.mcp.internal.telemetry.NltiRequestTelemetryFactory.TierRouting;
@@ -97,6 +98,9 @@ public class StreamingSessionAgentManager
     @Nullable
     private final RoleDefaultPermissionsClient roleDefaultPermissionsClient;
 
+    @Nullable
+    private final ToolInvocationRecorder toolInvocationRecorder;
+
     private final NltiWorkflowStateService workflowStateService;
 
     private final @Nullable NltiRouter nltiRouter;
@@ -127,6 +131,7 @@ public class StreamingSessionAgentManager
             @Nullable OpenApiToolProvider openApiToolProvider,
             @Nullable RequestScopedUserContext requestScopedUserContext,
             @Nullable RoleDefaultPermissionsClient roleDefaultPermissionsClient,
+            @Nullable ToolInvocationRecorder toolInvocationRecorder,
             @NonNull NltiWorkflowStateService workflowStateService,
             @Nullable NltiRouter nltiRouter,
             @Nullable TieredChatModelResolver tieredChatModelResolver,
@@ -150,6 +155,7 @@ public class StreamingSessionAgentManager
         this.openApiToolProvider = openApiToolProvider;
         this.requestScopedUserContext = requestScopedUserContext;
         this.roleDefaultPermissionsClient = roleDefaultPermissionsClient;
+        this.toolInvocationRecorder = toolInvocationRecorder;
         this.workflowStateService = workflowStateService;
         this.nltiRouter = nltiRouter;
         this.tieredChatModelResolver = tieredChatModelResolver;
@@ -505,7 +511,8 @@ public class StreamingSessionAgentManager
                 tools,
                 resilientContentRetriever,
                 this::chatMemoryFor,
-                openApiToolProvider);
+                openApiToolProvider,
+                toolInvocationRecorder);
         LOGGER.debug(
                 "Built MCP streaming role agent role={} promptName={} ragScope={} tier={} toolNames={}",
                 role,

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepository.java
@@ -63,6 +63,14 @@ public interface ToolMetadataRepository {
     @NonNull
     Optional<UUID> findDiscoveredToolIdByName(@NonNull String name);
 
+    /**
+     * #1422: resolves any tool id by its unique name regardless of source — facade rows (PascalCase
+     * class names) and discovered openapi rows alike — so per-execution invocation logging can
+     * attribute a {@code tool_id}. Empty when no tool has the given name.
+     */
+    @NonNull
+    Optional<UUID> findToolIdByName(@NonNull String name);
+
     /** Gate 3 (#785): the permission codes currently granted to a tool, ascending. */
     @NonNull
     List<String> listToolPermissions(@NonNull UUID toolId);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/repository/ToolMetadataRepositoryImpl.java
@@ -262,6 +262,13 @@ public class ToolMetadataRepositoryImpl implements ToolMetadataRepository {
     }
 
     @Override
+    public @NonNull Optional<UUID> findToolIdByName(@NonNull String name) {
+        List<UUID> ids = jdbcTemplate.query(
+                "SELECT id FROM mcp_tool WHERE name = ?", (rs, rowNum) -> rs.getObject("id", UUID.class), name);
+        return ids.isEmpty() ? Optional.empty() : Optional.of(ids.get(0));
+    }
+
+    @Override
     public @NonNull Optional<UUID> findDiscoveredToolIdByName(@NonNull String name) {
         List<UUID> ids = jdbcTemplate.query(
                 "SELECT id FROM mcp_tool WHERE name = ? AND source = 'openapi'",

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiToolProvider.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiToolProvider.java
@@ -175,6 +175,7 @@ public class OpenApiToolProvider {
     private final ObjectMapper objectMapper;
     private final int candidateLimit;
     private final Duration executionTimeout;
+    private final @Nullable ToolInvocationRecorder invocationRecorder;
 
     public OpenApiToolProvider(
             @NonNull ToolMetadataRepository repository,
@@ -183,7 +184,8 @@ public class OpenApiToolProvider {
             @NonNull OperationProxyFactory proxyFactory,
             @NonNull ObjectMapper objectMapper,
             @Value("${mcp.agent.candidate-tool-limit:8}") int candidateLimit,
-            @Value("${mcp.openapi.tool.timeout:30s}") @NonNull Duration executionTimeout) {
+            @Value("${mcp.openapi.tool.timeout:30s}") @NonNull Duration executionTimeout,
+            @Nullable ToolInvocationRecorder invocationRecorder) {
         this.repository = repository;
         this.embeddingModel = embeddingModel;
         this.userContext = userContext;
@@ -191,6 +193,7 @@ public class OpenApiToolProvider {
         this.objectMapper = objectMapper;
         this.candidateLimit = Math.max(1, candidateLimit);
         this.executionTimeout = executionTimeout;
+        this.invocationRecorder = invocationRecorder;
     }
 
     public @NonNull List<ToolCallback> resolveToolCallbacks(@Nullable String userMessage) {
@@ -221,13 +224,15 @@ public class OpenApiToolProvider {
             writeCapableToolsPresent = writeCapableToolsPresent || isWriteCapable(op);
             OpenApiOperationExecutor executor =
                     new OpenApiOperationExecutor(proxyFactory, op, objectMapper, executionTimeout, authHeader);
-            tools.add(new OpenApiSpringAiToolCallback(
+            ToolCallback callback = new OpenApiSpringAiToolCallback(
                     DefaultToolDefinition.builder()
                             .name(op.name())
                             .description(describeOperation(op))
                             .inputSchema(buildParameterSchema(op))
                             .build(),
-                    executor));
+                    executor);
+            // #1422: per-execution invocation logging; discovered names match mcp_tool.name exactly.
+            tools.add(invocationRecorder != null ? invocationRecorder.wrap(callback, op.name()) : callback);
         }
         userContext.recordDiscoveredOpenapiTools(tools.stream()
                 .map(callback -> callback.getToolDefinition().name())

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiWritePlanExecutor.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiWritePlanExecutor.java
@@ -27,16 +27,19 @@ public class OpenApiWritePlanExecutor implements WritePlanExecutor {
     private final OperationProxyFactory proxyFactory;
     private final ObjectMapper objectMapper;
     private final Duration executionTimeout;
+    private final @Nullable ToolInvocationRecorder invocationRecorder;
 
     public OpenApiWritePlanExecutor(
             @NonNull ToolMetadataRepository repository,
             @NonNull OperationProxyFactory proxyFactory,
             @NonNull ObjectMapper objectMapper,
-            @Value("${mcp.openapi.tool.timeout:30s}") @NonNull Duration executionTimeout) {
+            @Value("${mcp.openapi.tool.timeout:30s}") @NonNull Duration executionTimeout,
+            @Nullable ToolInvocationRecorder invocationRecorder) {
         this.repository = repository;
         this.proxyFactory = proxyFactory;
         this.objectMapper = objectMapper;
         this.executionTimeout = executionTimeout;
+        this.invocationRecorder = invocationRecorder;
     }
 
     @Override
@@ -49,9 +52,17 @@ public class OpenApiWritePlanExecutor implements WritePlanExecutor {
             throw new WritePlanExecutionException(
                     "Discovered operation is missing execution coordinates: " + targetTool);
         }
+        long startMs = System.currentTimeMillis();
         String result = new OpenApiOperationExecutor(
                         proxyFactory, operation, objectMapper, executionTimeout, authHeader)
                 .execute(argsJson);
+        int elapsedMs = (int) (System.currentTimeMillis() - startMs);
+        // #1422: the Gate 3 executor renders failures as an Error: prefix instead of throwing, so
+        // success for the invocation log is "non-null and not an error rendering".
+        boolean success = result != null && !result.startsWith(ERROR_PREFIX);
+        if (invocationRecorder != null) {
+            invocationRecorder.record(targetTool, success, elapsedMs, success ? null : "WritePlanExecutionException");
+        }
         if (result == null) {
             throw new WritePlanExecutionException("Write-plan tool execution returned no result for " + targetTool);
         }

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiWritePlanExecutor.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/OpenApiWritePlanExecutor.java
@@ -7,6 +7,7 @@ import com.positivity.mcp.internal.domain.DiscoveredOperation;
 import com.positivity.mcp.internal.exception.WritePlanExecutionException;
 import com.positivity.mcp.internal.repository.ToolMetadataRepository;
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Value;
@@ -52,11 +53,11 @@ public class OpenApiWritePlanExecutor implements WritePlanExecutor {
             throw new WritePlanExecutionException(
                     "Discovered operation is missing execution coordinates: " + targetTool);
         }
-        long startMs = System.currentTimeMillis();
+        long startNanos = System.nanoTime();
         String result = new OpenApiOperationExecutor(
                         proxyFactory, operation, objectMapper, executionTimeout, authHeader)
                 .execute(argsJson);
-        int elapsedMs = (int) (System.currentTimeMillis() - startMs);
+        int elapsedMs = (int) TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
         // #1422: the Gate 3 executor renders failures as an Error: prefix instead of throwing, so
         // success for the invocation log is "non-null and not an error rendering".
         boolean success = result != null && !result.startsWith(ERROR_PREFIX);

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolInvocationRecorder.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolInvocationRecorder.java
@@ -1,0 +1,141 @@
+package com.positivity.mcp.internal.service;
+
+import com.positivity.mcp.internal.repository.ToolMetadataRepository;
+import com.positivity.mcp.service.CurrentUserContext;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.tool.metadata.ToolMetadata;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * #1422: records one {@code mcp_tool_invocation_log} row per individual tool execution, carrying a
+ * real {@code tool_id}. Before this, only the chat managers logged — one request-level row per chat
+ * with a hardcoded {@code null} toolId — so {@code ToolPriorityTuningService}'s stats query
+ * ({@code WHERE tool_id IS NOT NULL}) matched nothing and the nightly tuner computed zero proposals
+ * forever.
+ *
+ * <p>Two tool families resolve to different {@code mcp_tool.name} keys: a facade tool callback is
+ * named after its {@code @Tool} <em>method</em> while the {@code mcp_tool} row is keyed by the
+ * facade <em>class</em> simple name (e.g. {@code OrderFacadeTool}), so facade wrapping passes the
+ * owning class name as the lookup key; discovered (source=openapi) callbacks are keyed by their
+ * discovered tool name directly. An unresolvable name still logs (with a null id, WARN once) —
+ * a visible gap beats a silent one.
+ *
+ * <p>Failure to record never fails the tool call: resolution and logging are both guarded, and
+ * the underlying {@code ToolAuditService} already swallows write failures with a WARN.
+ */
+@Component
+@Profile("!test")
+public class ToolInvocationRecorder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ToolInvocationRecorder.class);
+
+    private final ToolAuditService auditService;
+    private final ToolMetadataRepository toolMetadataRepository;
+    private final RequestScopedUserContext userContext;
+    private final Map<String, Optional<UUID>> toolIdCache = new ConcurrentHashMap<>();
+
+    public ToolInvocationRecorder(
+            @NonNull ToolAuditService auditService,
+            @NonNull ToolMetadataRepository toolMetadataRepository,
+            @NonNull RequestScopedUserContext userContext) {
+        this.auditService = auditService;
+        this.toolMetadataRepository = toolMetadataRepository;
+        this.userContext = userContext;
+    }
+
+    /**
+     * Wraps a tool callback so each {@code call} logs one invocation row. {@code toolLookupName} is
+     * the {@code mcp_tool.name} key — the facade class simple name for facade tools, the discovered
+     * tool name for openapi tools.
+     */
+    public @NonNull ToolCallback wrap(@NonNull ToolCallback delegate, @NonNull String toolLookupName) {
+        return new RecordingToolCallback(delegate, toolLookupName);
+    }
+
+    /**
+     * Records a tool execution that does not go through a {@link ToolCallback} — the NLTI confirmed
+     * write-plan path executes discovered operations directly.
+     */
+    public void record(
+            @NonNull String toolLookupName, boolean success, int executionTimeMs, @Nullable String errorType) {
+        try {
+            auditService.logToolExecution(
+                    resolveToolId(toolLookupName), currentUsername(), success, false, executionTimeMs, errorType);
+        } catch (RuntimeException exception) {
+            LOGGER.warn("Failed to record tool invocation for '{}'", toolLookupName, exception);
+        }
+    }
+
+    private @Nullable UUID resolveToolId(String toolLookupName) {
+        Optional<UUID> resolved = toolIdCache.computeIfAbsent(toolLookupName, name -> {
+            Optional<UUID> id;
+            try {
+                id = toolMetadataRepository.findToolIdByName(name);
+            } catch (RuntimeException exception) {
+                LOGGER.warn("mcp_tool id lookup failed for '{}'", name, exception);
+                // Do not negative-cache a transient lookup failure.
+                throw exception;
+            }
+            if (id.isEmpty()) {
+                LOGGER.warn(
+                        "No mcp_tool row named '{}'; its invocations will log with a null tool_id "
+                                + "and stay invisible to priority tuning (#1422)",
+                        name);
+            }
+            return id;
+        });
+        return resolved.orElse(null);
+    }
+
+    private @NonNull String currentUsername() {
+        return userContext.current().map(CurrentUserContext::username).orElse("unknown");
+    }
+
+    private final class RecordingToolCallback implements ToolCallback {
+
+        private final ToolCallback delegate;
+        private final String toolLookupName;
+
+        private RecordingToolCallback(ToolCallback delegate, String toolLookupName) {
+            this.delegate = delegate;
+            this.toolLookupName = toolLookupName;
+        }
+
+        @Override
+        public ToolDefinition getToolDefinition() {
+            return delegate.getToolDefinition();
+        }
+
+        @Override
+        public ToolMetadata getToolMetadata() {
+            return delegate.getToolMetadata();
+        }
+
+        @Override
+        public String call(String toolInput) {
+            long startMs = System.currentTimeMillis();
+            try {
+                String result = delegate.call(toolInput);
+                record(toolLookupName, true, (int) (System.currentTimeMillis() - startMs), null);
+                return result;
+            } catch (RuntimeException exception) {
+                record(
+                        toolLookupName,
+                        false,
+                        (int) (System.currentTimeMillis() - startMs),
+                        exception.getClass().getSimpleName());
+                throw exception;
+            }
+        }
+    }
+}

--- a/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolInvocationRecorder.java
+++ b/pos-mcp-server/src/main/java/com/positivity/mcp/internal/service/ToolInvocationRecorder.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -123,19 +124,23 @@ public class ToolInvocationRecorder {
 
         @Override
         public String call(String toolInput) {
-            long startMs = System.currentTimeMillis();
+            long startNanos = System.nanoTime();
             try {
                 String result = delegate.call(toolInput);
-                record(toolLookupName, true, (int) (System.currentTimeMillis() - startMs), null);
+                record(toolLookupName, true, elapsedMs(startNanos), null);
                 return result;
             } catch (RuntimeException exception) {
                 record(
                         toolLookupName,
                         false,
-                        (int) (System.currentTimeMillis() - startMs),
+                        elapsedMs(startNanos),
                         exception.getClass().getSimpleName());
                 throw exception;
             }
+        }
+
+        private int elapsedMs(long startNanos) {
+            return (int) TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
         }
     }
 }

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/config/SessionAgentManagerTestConfiguration.java
@@ -110,6 +110,11 @@ public class SessionAgentManagerTestConfiguration {
             }
 
             @Override
+            public java.util.Optional<java.util.UUID> findToolIdByName(String name) {
+                return java.util.Optional.empty();
+            }
+
+            @Override
             public java.util.Optional<com.positivity.mcp.internal.domain.DiscoveredOperation>
                     findDiscoveredOperationByName(String name) {
                 return java.util.Optional.empty();

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/CachedAgentOpenApiPermissionLeakageTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/CachedAgentOpenApiPermissionLeakageTest.java
@@ -165,7 +165,8 @@ class CachedAgentOpenApiPermissionLeakageTest {
                 proxyFactory,
                 new ObjectMapper(),
                 8,
-                Duration.ofSeconds(30));
+                Duration.ofSeconds(30),
+                null);
 
         // Seeded discovered op (source='openapi'), gated on exactly one permission. The candidate
         // query is fail-closed: it returns the op only when the caller's codes contain that
@@ -302,6 +303,7 @@ class CachedAgentOpenApiPermissionLeakageTest {
                 null, // answerResolutionLadder
                 contextOrNull,
                 null, // roleDefaultPermissionsClient
+                null, // toolInvocationRecorder
                 workflowStateService,
                 null, // nltiRouter
                 null, // tieredChatModelResolver

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTest.java
@@ -194,6 +194,7 @@ class SessionAgentManagerTest {
                 null, // answerResolutionLadder
                 null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
+                null, // toolInvocationRecorder
                 workflowStateService,
                 null, // nltiRouter
                 null, // tieredChatModelResolver
@@ -404,6 +405,7 @@ class SessionAgentManagerTest {
                 null, // answerResolutionLadder
                 null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
+                null, // toolInvocationRecorder
                 workflowStateService,
                 null, // nltiRouter
                 null, // tieredChatModelResolver
@@ -475,6 +477,7 @@ class SessionAgentManagerTest {
                 null, // answerResolutionLadder
                 null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
+                null, // toolInvocationRecorder
                 workflowStateService,
                 null, // nltiRouter
                 null, // tieredChatModelResolver

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTieringTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SessionAgentManagerTieringTest.java
@@ -287,6 +287,7 @@ class SessionAgentManagerTieringTest {
                 null, // answerResolutionLadder
                 contextOrNull,
                 null, // roleDefaultPermissionsClient
+                null, // toolInvocationRecorder
                 workflowStateService,
                 router,
                 resolver,

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiPosAssistantTest.java
@@ -55,6 +55,7 @@ class SpringAiPosAssistantTest {
                 ragRetriever,
                 ignored -> chatMemory,
                 openApiToolProvider,
+                null,
                 null);
 
         String response = assistant.chat("user-1::ROLE_TECH", "where is stock", "ctx:role=TECH");
@@ -123,6 +124,7 @@ class SpringAiPosAssistantTest {
                 ragRetriever,
                 ignored -> chatMemory,
                 openApiToolProvider,
+                null,
                 null);
 
         assistant.chat("user-1::ROLE_TECH", "PO number format", "ctx:role=TECH");
@@ -178,7 +180,7 @@ class SpringAiPosAssistantTest {
                         new LadderResult("View them here — Work Orders: /workorders", Rung.DEEP_LINK, "/workorders"));
 
         SpringAiPosAssistant assistant = new SpringAiPosAssistant(
-                chatModel, () -> "base prompt", List.of(), ragRetriever, ignored -> chatMemory, null, ladder);
+                chatModel, () -> "base prompt", List.of(), ragRetriever, ignored -> chatMemory, null, ladder, null);
 
         String response = assistant.chat("user-1::ROLE_ADMIN", "how many workorders are open", "ctx");
 
@@ -203,7 +205,7 @@ class SpringAiPosAssistantTest {
         when(chatModel.call(any(Prompt.class))).thenReturn(chatResponse("There are 12 open work orders."));
 
         SpringAiPosAssistant assistant = new SpringAiPosAssistant(
-                chatModel, () -> "base prompt", List.of(), ragRetriever, ignored -> chatMemory, null, ladder);
+                chatModel, () -> "base prompt", List.of(), ragRetriever, ignored -> chatMemory, null, ladder, null);
 
         String response = assistant.chat("user-1::ROLE_ADMIN", "how many workorders are open", "ctx");
 

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistantTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiStreamingPosAssistantTest.java
@@ -53,7 +53,8 @@ class SpringAiStreamingPosAssistantTest {
                 List.of(new PingTool()),
                 ragRetriever,
                 ignored -> chatMemory,
-                openApiToolProvider);
+                openApiToolProvider,
+                null);
 
         List<String> tokens = assistant
                 .chat("user-2::ROLE_TECH", "where is stock", "ctx:role=TECH")
@@ -116,7 +117,8 @@ class SpringAiStreamingPosAssistantTest {
                 List.of(new PingTool()),
                 ragRetriever,
                 ignored -> chatMemory,
-                openApiToolProvider);
+                openApiToolProvider,
+                null);
 
         assistant
                 .chat("user-3::ROLE_TECH", "where is stock", "ctx:role=TECH")

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiToolCallbackResolverTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/SpringAiToolCallbackResolverTest.java
@@ -18,6 +18,33 @@ class SpringAiToolCallbackResolverTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
+    void fromObjects_decoratorReceivesOwningFacadeClassSimpleName() {
+        // #1422: mcp_tool facade rows are keyed by the facade CLASS name, not the @Tool method
+        // name, so the recorder wrap must be handed the owning class simple name as lookup key.
+        java.util.List<String> lookupNames = new java.util.ArrayList<>();
+        com.positivity.mcp.internal.service.ToolAuditService auditService =
+                org.mockito.Mockito.mock(com.positivity.mcp.internal.service.ToolAuditService.class);
+        com.positivity.mcp.internal.repository.ToolMetadataRepository repository =
+                org.mockito.Mockito.mock(com.positivity.mcp.internal.repository.ToolMetadataRepository.class);
+        org.mockito.Mockito.when(repository.findToolIdByName(org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(java.util.Optional.empty());
+        com.positivity.mcp.internal.service.ToolInvocationRecorder recorder =
+                new com.positivity.mcp.internal.service.ToolInvocationRecorder(
+                        auditService, repository, new com.positivity.mcp.internal.service.RequestScopedUserContext()) {
+                    @Override
+                    public ToolCallback wrap(ToolCallback delegate, String toolLookupName) {
+                        lookupNames.add(toolLookupName);
+                        return delegate;
+                    }
+                };
+
+        List<ToolCallback> callbacks = SpringAiToolCallbackResolver.fromObjects(List.of(new SampleTool()), recorder);
+
+        assertThat(callbacks).isNotEmpty();
+        assertThat(lookupNames).containsOnly("SampleTool");
+    }
+
+    @Test
     void call_bindsArgumentsUsingArgIndexFallbackNames() {
         ToolCallback callback = SpringAiToolCallbackResolver.fromObjects(List.of(new SampleTool()))
                 .getFirst();

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTest.java
@@ -190,6 +190,7 @@ class StreamingSessionAgentManagerTest {
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
+                null, // toolInvocationRecorder
                 workflowStateService,
                 null, // nltiRouter
                 null, // tieredChatModelResolver
@@ -391,6 +392,7 @@ class StreamingSessionAgentManagerTest {
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
+                null, // toolInvocationRecorder
                 workflowStateService,
                 null, // nltiRouter
                 null, // tieredChatModelResolver
@@ -432,6 +434,7 @@ class StreamingSessionAgentManagerTest {
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
+                null, // toolInvocationRecorder
                 workflowStateService,
                 null, // nltiRouter
                 null, // tieredChatModelResolver
@@ -498,6 +501,7 @@ class StreamingSessionAgentManagerTest {
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
+                null, // toolInvocationRecorder
                 workflowStateService,
                 null, // nltiRouter
                 null, // tieredChatModelResolver
@@ -550,6 +554,7 @@ class StreamingSessionAgentManagerTest {
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
+                null, // toolInvocationRecorder
                 workflowStateService,
                 null, // nltiRouter
                 null, // tieredChatModelResolver
@@ -618,6 +623,7 @@ class StreamingSessionAgentManagerTest {
                 openApiToolProvider,
                 requestContext,
                 null, // roleDefaultPermissionsClient
+                null, // toolInvocationRecorder
                 workflowStateService,
                 null, // nltiRouter
                 null, // tieredChatModelResolver

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTieringTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/orchestration/StreamingSessionAgentManagerTieringTest.java
@@ -189,6 +189,7 @@ class StreamingSessionAgentManagerTieringTest {
                 null, // openApiToolProvider
                 null, // requestScopedUserContext
                 null, // roleDefaultPermissionsClient
+                null, // toolInvocationRecorder
                 workflowStateService,
                 router,
                 null, // tieredChatModelResolver

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolProviderTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/OpenApiToolProviderTest.java
@@ -30,7 +30,7 @@ class OpenApiToolProviderTest {
     private final OperationProxyFactory proxyFactory = mock(OperationProxyFactory.class);
     private final RequestScopedUserContext userContext = new RequestScopedUserContext();
     private final OpenApiToolProvider provider = new OpenApiToolProvider(
-            repository, embeddingModel, userContext, proxyFactory, new ObjectMapper(), 8, Duration.ofSeconds(30));
+            repository, embeddingModel, userContext, proxyFactory, new ObjectMapper(), 8, Duration.ofSeconds(30), null);
 
     @AfterEach
     void cleanup() {

--- a/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolInvocationRecorderTest.java
+++ b/pos-mcp-server/src/test/java/com/positivity/mcp/internal/service/ToolInvocationRecorderTest.java
@@ -1,0 +1,171 @@
+package com.positivity.mcp.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.positivity.mcp.internal.repository.ToolMetadataRepository;
+import com.positivity.mcp.service.CurrentUserContext;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.DefaultToolDefinition;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+/**
+ * #1422: per-execution invocation logging must attribute a real {@code tool_id}, never fail the
+ * wrapped tool call, and hit the repository once per distinct lookup name.
+ */
+class ToolInvocationRecorderTest {
+
+    private static final UUID TOOL_ID = UUID.fromString("01a01e00-0000-7000-8000-000000000042");
+
+    private final ToolAuditService auditService = mock(ToolAuditService.class);
+    private final ToolMetadataRepository repository = mock(ToolMetadataRepository.class);
+    private final RequestScopedUserContext userContext = new RequestScopedUserContext();
+    private final ToolInvocationRecorder recorder = new ToolInvocationRecorder(auditService, repository, userContext);
+
+    @BeforeEach
+    void setUp() {
+        userContext.set(new CurrentUserContext(
+                "diana.rowe",
+                UUID.fromString("01960010-0000-7000-8000-000000000002"),
+                "LOCATION_MANAGER",
+                Set.of("LOCATION_MANAGER"),
+                Set.of(),
+                Set.of("pricing:promotion:manage")));
+    }
+
+    @AfterEach
+    void cleanup() {
+        userContext.clear();
+    }
+
+    @Test
+    @DisplayName("successful call logs tool_id, username and success=true")
+    void wrap_success_logsResolvedToolId() {
+        when(repository.findToolIdByName("OrderFacadeTool")).thenReturn(Optional.of(TOOL_ID));
+        ToolCallback wrapped = recorder.wrap(fixedCallback("ok"), "OrderFacadeTool");
+
+        assertThat(wrapped.call("{}")).isEqualTo("ok");
+
+        verify(auditService).logToolExecution(eq(TOOL_ID), eq("diana.rowe"), eq(true), eq(false), anyInt(), isNull());
+    }
+
+    @Test
+    @DisplayName("failing call logs success=false with the exception type and rethrows")
+    void wrap_failure_logsErrorTypeAndRethrows() {
+        when(repository.findToolIdByName("OrderFacadeTool")).thenReturn(Optional.of(TOOL_ID));
+        ToolCallback wrapped = recorder.wrap(throwingCallback(new IllegalStateException("boom")), "OrderFacadeTool");
+
+        assertThatThrownBy(() -> wrapped.call("{}")).isInstanceOf(IllegalStateException.class);
+
+        verify(auditService)
+                .logToolExecution(
+                        eq(TOOL_ID), eq("diana.rowe"), eq(false), eq(false), anyInt(), eq("IllegalStateException"));
+    }
+
+    @Test
+    @DisplayName("unresolvable tool name still logs, with a null tool_id")
+    void wrap_unknownName_logsWithNullToolId() {
+        when(repository.findToolIdByName("GhostTool")).thenReturn(Optional.empty());
+        ToolCallback wrapped = recorder.wrap(fixedCallback("ok"), "GhostTool");
+
+        wrapped.call("{}");
+
+        verify(auditService).logToolExecution(isNull(), eq("diana.rowe"), eq(true), eq(false), anyInt(), isNull());
+    }
+
+    @Test
+    @DisplayName("tool id resolution is cached — one repository lookup per name")
+    void resolution_isCachedPerName() {
+        when(repository.findToolIdByName("OrderFacadeTool")).thenReturn(Optional.of(TOOL_ID));
+        ToolCallback wrapped = recorder.wrap(fixedCallback("ok"), "OrderFacadeTool");
+
+        wrapped.call("{}");
+        wrapped.call("{}");
+        wrapped.call("{}");
+
+        verify(repository, times(1)).findToolIdByName("OrderFacadeTool");
+        verify(auditService, times(3))
+                .logToolExecution(eq(TOOL_ID), eq("diana.rowe"), eq(true), eq(false), anyInt(), isNull());
+    }
+
+    @Test
+    @DisplayName("a failing audit write never fails the tool call")
+    void auditFailure_neverFailsTheToolCall() {
+        when(repository.findToolIdByName("OrderFacadeTool")).thenReturn(Optional.of(TOOL_ID));
+        doThrow(new IllegalStateException("db down"))
+                .when(auditService)
+                .logToolExecution(any(), any(), anyBoolean(), anyBoolean(), anyInt(), any());
+        ToolCallback wrapped = recorder.wrap(fixedCallback("ok"), "OrderFacadeTool");
+
+        assertThat(wrapped.call("{}")).isEqualTo("ok");
+    }
+
+    @Test
+    @DisplayName("no request-scoped user falls back to 'unknown', not a failure")
+    void missingUserContext_logsUnknownUser() {
+        userContext.clear();
+        when(repository.findToolIdByName("OrderFacadeTool")).thenReturn(Optional.of(TOOL_ID));
+        ToolCallback wrapped = recorder.wrap(fixedCallback("ok"), "OrderFacadeTool");
+
+        wrapped.call("{}");
+
+        verify(auditService).logToolExecution(eq(TOOL_ID), eq("unknown"), eq(true), eq(false), anyInt(), isNull());
+    }
+
+    @Test
+    @DisplayName("record() logs a direct (non-callback) execution — the NLTI confirm path")
+    void record_logsDirectExecution() {
+        when(repository.findToolIdByName("price_deletepromotioneligibilityrule"))
+                .thenReturn(Optional.of(TOOL_ID));
+
+        recorder.record("price_deletepromotioneligibilityrule", true, 123, null);
+
+        verify(auditService).logToolExecution(eq(TOOL_ID), eq("diana.rowe"), eq(true), eq(false), eq(123), isNull());
+    }
+
+    private static ToolCallback fixedCallback(String result) {
+        return callback(input -> result);
+    }
+
+    private static ToolCallback throwingCallback(RuntimeException exception) {
+        return callback(input -> {
+            throw exception;
+        });
+    }
+
+    private static ToolCallback callback(java.util.function.Function<String, String> body) {
+        ToolDefinition definition = DefaultToolDefinition.builder()
+                .name("sample")
+                .description("sample")
+                .inputSchema("{\"type\":\"object\",\"properties\":{}}")
+                .build();
+        return new ToolCallback() {
+            @Override
+            public ToolDefinition getToolDefinition() {
+                return definition;
+            }
+
+            @Override
+            public String call(String toolInput) {
+                return body.apply(toolInput);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #1422

## Capability & Traceability
- Capability: `cap:n/a` (bug fix; no capability story)
- Parent STORY (durion): n/a
- Child issue: #1422
- Domain: `domain:mcp`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
<!--
  The "Contract Sync Enforcement" check FAILS unless the text BACKEND_CONTRACT_GUIDE.md
  appears somewhere in this PR body whenever contract-relevant files change
  (controllers, DTOs, *Request/*Response, events, openapi.yaml, validation/error models).
  Keep the reference below and link it to the relevant domain anchor.
-->
- Contract guide entry (durion): n/a — no API/event contract changes (internal audit-logging path only); BACKEND_CONTRACT_GUIDE.md unaffected
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — n/a, no controller changes
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope
- What changed: 21 files in `pos-mcp-server` (+443/−19). `mcp_tool_invocation_log` only ever received request-level rows with a hardcoded `null` toolId, so `ToolPriorityTuningService`'s stats query (`tool_id IS NOT NULL`, `HAVING >= 10`) matched nothing and the nightly tuner proposed zero changes forever. This PR wires per-tool invocation logging at the tool-execution layer:
  - New `ToolInvocationRecorder` (`internal.service`, `@Profile("!test")`, backed by the public `ToolAuditService`). Placed in the service package to satisfy the ArchUnit repository-access rule and avoid an orchestration↔service package cycle — both of which failed a first cut that lived in orchestration.
  - Decorates every Spring AI `ToolCallback`: facade callbacks are wrapped in `SpringAiToolCallbackResolver` using the owning facade class simple name as lookup key (`mcp_tool` facade rows are keyed by class name, e.g. `OrderFacadeTool`, not the `@Tool` method name; `ClassUtils.getUserClass` guards CGLIB proxies). Discovered openapi callbacks are wrapped in `OpenApiToolProvider` under their discovered name (exact `mcp_tool.name` match).
  - NLTI confirmed write-plan path records directly from `OpenApiWritePlanExecutor` (success = non-null result without the `Error:` prefix).
  - `ToolMetadataRepository` gains `findToolIdByName` (source-agnostic).
  - Guarantees: id resolution is cached per name (one query per distinct name); an unresolvable name still logs with null id plus a single WARN; a failing audit write never fails the tool call; a missing request-scoped user logs `"unknown"`.
  - Request-level rows from the chat managers are retained (only per-request latency record; the tuner ignores null-toolId rows).
- Why: #1422 — the tuner was built against a table contract nothing fulfilled; every nightly run (shadow or live) computed 0 proposals regardless of traffic, making the #1219 Gate 7 shadow soak structurally inert.

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests added/updated — n/a, covered by unit tests + existing suite
- [ ] Provider behavioral contract tests added/updated — n/a
- How to run: `./mvnw -pl pos-mcp-server -am test` (full pos-mcp-server suite: 729 tests, 0 failures; Spotless/Checkstyle/SpotBugs enforced) and `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests test` (cross-module ArchUnit: 12/12).
  New tests: `ToolInvocationRecorderTest` (7 cases: success/failure/rethrow, null-id logging, per-name cache, audit-failure isolation, unknown-user fallback, direct `record()` for the confirm path) and a resolver test pinning that the decorator receives the facade class simple name.

## Risk & Rollback
- Risk level: Low — additive audit-logging path; audit-write failures are isolated from tool execution; no API, schema, or contract changes.
- Rollback plan: revert this single commit; the table simply returns to receiving only request-level null-toolId rows (prior behavior).

## Post-merge verification (Gate 7 signed-exception retirement)
Deploy to alpha, run one shadow night (02:00 UTC cron) plus a write-gate/`--allow-writes` run to generate tool traffic, confirm `mcp.tuning.shadow` proposal lines and the `mcp_tuning_proposals` counter, then rerun `--suite admin` (admin-tuning-shadow should flip PASS) — that retires the Gate 7 signed exception recorded in the checklist. The issue closes on merge; live re-verification is tracked by this signed-exception retirement note.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, issue-fix branch `claude/issue-1422-tool-invocation-audit`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability
- [x] Links to parent + child issues are present (child #1422; no parent STORY)
- [ ] Contract guide updated (when contract semantics changed) — n/a, no contract semantics changed
- [ ] Required CI checks passing — pending CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUr5ocMQmymrSa2x2TuNX3