### PR TITLE
Seed product_uom: PARK-387TC-4-FT as the first bulk row (BASE FT scale 2, PURCHASE ROLL ×50)

### DIFF
--- a/pos-catalog/src/main/resources/db/migration/R__seed_reference_catalog_5_uom.sql
+++ b/pos-catalog/src/main/resources/db/migration/R__seed_reference_catalog_5_uom.sql
@@ -23,7 +23,7 @@
 SET TIME ZONE 'UTC';
 
 INSERT INTO product_uom (id, product_id, uom_code, uom_type, factor_to_base, precision_scale, created_at, updated_at)
-SELECT '01960040-0000-7000-8000-000000000001'::uuid, p.id, 'FT', 'BASE', 1::numeric, 2, NOW(), NOW()
+SELECT md5('uom_seed:PARK-387TC-4-FT:FT')::uuid, p.id, 'FT', 'BASE', 1::numeric, 2, NOW(), NOW()
 FROM product p WHERE p.sku = 'PARK-387TC-4-FT'
 ON CONFLICT (product_id, uom_code) DO UPDATE SET
     uom_type = EXCLUDED.uom_type,
@@ -32,7 +32,7 @@ ON CONFLICT (product_id, uom_code) DO UPDATE SET
     updated_at = NOW();
 
 INSERT INTO product_uom (id, product_id, uom_code, uom_type, factor_to_base, precision_scale, created_at, updated_at)
-SELECT '01960040-0000-7000-8000-000000000002'::uuid, p.id, 'ROLL', 'PURCHASE', 50::numeric, 0, NOW(), NOW()
+SELECT md5('uom_seed:PARK-387TC-4-FT:ROLL')::uuid, p.id, 'ROLL', 'PURCHASE', 50::numeric, 0, NOW(), NOW()
 FROM product p WHERE p.sku = 'PARK-387TC-4-FT'
 ON CONFLICT (product_id, uom_code) DO UPDATE SET
     uom_type = EXCLUDED.uom_type,

--- a/pos-catalog/src/main/resources/db/migration/R__seed_reference_catalog_5_uom.sql
+++ b/pos-catalog/src/main/resources/db/migration/R__seed_reference_catalog_5_uom.sql
@@ -1,0 +1,41 @@
+-- =============================================================
+-- R__seed_reference_catalog_5_uom.sql
+-- product_uom seed — per-product divisibility and purchase units
+--
+-- First rows in this table platform-wide (ADR-0055 / #1417 / #1365).
+-- Rules (see also the convention block in R__seed_reference_catalog_2_products.sql):
+--   * Only products whose stock is genuinely divisible get a BASE row with
+--     precision_scale > 0. Every product with no rows here defaults to
+--     scale 0 (integral) — that default is load-bearing; do not seed
+--     BASE/scale-0 rows for ordinary packaged SKUs just to be explicit.
+--   * The BASE row's uom_code MUST match product.unit_of_measure, and its
+--     factor_to_base MUST be 1 (ProductUomType.BASE contract).
+--   * product_id is resolved by SKU because product ids are generated
+--     (gen_random_uuid()); never hardcode product uuids here.
+--
+-- PARK-387TC-4-FT — Parker Hydraulic Hose 387TC-4, cut to length:
+--   * BASE FT at precision_scale 2: dispensed lengths are recorded to
+--     hundredths of a foot (3.5 ft, 12.25 ft). This is the first product
+--     for which the ADR-0055 chain accepts fractional quantities.
+--   * PURCHASE ROLL, factor 50: purchased as sealed 50-ft reels, whole
+--     reels only (precision_scale 0 on the purchase document unit).
+-- =============================================================
+SET TIME ZONE 'UTC';
+
+INSERT INTO product_uom (id, product_id, uom_code, uom_type, factor_to_base, precision_scale, created_at, updated_at)
+SELECT '01960040-0000-7000-8000-000000000001'::uuid, p.id, 'FT', 'BASE', 1::numeric, 2, NOW(), NOW()
+FROM product p WHERE p.sku = 'PARK-387TC-4-FT'
+ON CONFLICT (product_id, uom_code) DO UPDATE SET
+    uom_type = EXCLUDED.uom_type,
+    factor_to_base = EXCLUDED.factor_to_base,
+    precision_scale = EXCLUDED.precision_scale,
+    updated_at = NOW();
+
+INSERT INTO product_uom (id, product_id, uom_code, uom_type, factor_to_base, precision_scale, created_at, updated_at)
+SELECT '01960040-0000-7000-8000-000000000002'::uuid, p.id, 'ROLL', 'PURCHASE', 50::numeric, 0, NOW(), NOW()
+FROM product p WHERE p.sku = 'PARK-387TC-4-FT'
+ON CONFLICT (product_id, uom_code) DO UPDATE SET
+    uom_type = EXCLUDED.uom_type,
+    factor_to_base = EXCLUDED.factor_to_base,
+    precision_scale = EXCLUDED.precision_scale,
+    updated_at = NOW();


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a — activates the ADR-0055 divisibility chain for the first real product
- Parent STORY (durion): n/a (ADR-0055: louisburroughs/durion#400)
- Child issue: follows louisburroughs/durion-positivity-backend#1417 (merged in #1426) and the #1365 decision; no dedicated issue
- Domain: `domain:product`, `domain:inventory`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/*/.business-rules/BACKEND_CONTRACT_GUIDE.md` — no API or event behavior changes; seed data only. Reference retained for the contract-sync check.
- Durion contract PR (if applicable): n/a

## Contract Chain (when a Controller changed)
- No controller changed; no OpenAPI or SDK impact.

## Scope
- What changed: new `pos-catalog/src/main/resources/db/migration/R__seed_reference_catalog_5_uom.sql` — the **first rows in `product_uom` platform-wide**:
  - `PARK-387TC-4-FT` (Parker Hydraulic Hose, cut to length — the one genuinely bulk SKU in the catalog, confirmed in #1417):
    - **BASE `FT`, factor 1, `precision_scale 2`** — dispensed lengths recorded to hundredths of a foot. First product for which the ADR-0055 chain (#1413–#1416) accepts fractional quantities end to end.
    - **PURCHASE `ROLL`, factor 50, `precision_scale 0`** — purchased as sealed 50-ft reels, whole reels only.
  - `product_id` resolved by SKU join (product ids are `gen_random_uuid()`); idempotent via `ON CONFLICT (product_id, uom_code) DO UPDATE`, matching existing seed style. `R__` alphabetical ordering guarantees products exist before this file runs.
  - The file header records the seeding rules — notably that **absence of rows is load-bearing** (absent = scale 0 = integral), so packaged SKUs must not be given explicit scale-0 rows out of tidiness.
- Why: `product_uom` shipped with the odoo-parity work (V7) and has been built-but-unpopulated ever since. ADR-0055 made its BASE `precision_scale` the per-product divisibility switch; this makes it live for a real product. The BASE code matches the product's `unit_of_measure` (`FT`) as `ProductUomType.BASE` requires — possible only because #1426 corrected the ambiguous seed values first.

### Behavior notes
- **Replicas populate via events, not seeds.** The `ext_product_uom` replicas in pos-inventory/pos-order/pos-workorder are event-fed per ADR-0044 and have no seed files anywhere. Until catalog publishes product events at runtime, the workorder/inventory gates keep the fail-closed scale-0 default for this product — a fresh environment rejects a 3.5 ft issue until replication has occurred, and accepts it after. Designed behavior, not a gap.
- Hose pricing (`product_msrp` $26.94, `item_cost` ~$10.89) is per-FT, consistent with the `FT` base — no pricing change needed.

## Tests
- [ ] Unit tests added/updated — n/a, seed data only
- [x] Integration tests added/updated — existing Flyway-backed suites execute the new seed; the "Product Contract Attributes (UoM / tracking level / substitution groups)" behavioral suite runs against it (12/12)
- [ ] Provider behavioral contract tests — n/a
- How to run: `./mvnw -pl pos-catalog -am test`

## Risk & Rollback
- Risk level: Low — additive repeatable seed on a pre-production system; two rows, one product; every other product unchanged (absent rows → scale 0)
- Rollback plan: revert the commit; existing rows deletable by id (`01960040-0000-7000-8000-000000000001/2`)

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — session-mandated branch
- [ ] PR title starts with `[CAP:<cap-id>]` — no capability id
- [x] Links to parent + child issues are present
- [x] Contract guide reference present (no contract semantics changed)
- [ ] Required CI checks passing — pending

**Verification run:** `./mvnw -pl pos-catalog -am test` → BUILD SUCCESS; `scripts/check-flyway-hygiene.sh` → 25 modules pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJPZ9szyzL6C5KQdNyeF48

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJPZ9szyzL6C5KQdNyeF48)_