### PR TITLE
observability: enable Loki ruler and materialize NLTI LogQL alert rules (#1424)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,9 @@ services:
       - "127.0.0.1:3100:3100"
     volumes:
       - ./observability/loki-config.yml:/etc/loki/loki-config.yml:ro
+      # NLTI LogQL alert rules for the ruler (#1424); "fake" is the tenant id
+      # Loki uses while auth_enabled is false.
+      - ./observability/loki/rules:/loki/rules/fake:ro
       - loki-data:/loki
     command: [ "-config.file=/etc/loki/loki-config.yml" ]
     healthcheck:

--- a/observability/README.md
+++ b/observability/README.md
@@ -145,6 +145,11 @@ alpha single-host EC2 box; not multi-tenant/clustered.
 - HTTP API: Port 3100 (`/ready`, `/loki/api/v1/push`, `/loki/api/v1/query_range`)
 - Retention: 168h (7 days), enforced by the compactor — matches Kafka event retention
 - Storage: `tsdb` index + filesystem chunks under the `loki-data` volume
+- Ruler (#1424): evaluates the NLTI Gate 7 LogQL alert rules from `loki/rules/nlti-alerts.yml`
+  (mounted at `/loki/rules/fake`; source doc `pos-mcp-server/docs/alerts/nlti-alerts.md`).
+  Verify with `curl loki:3100/loki/api/v1/rules` (loaded rule files) and
+  `curl loki:3100/prometheus/api/v1/rules` (evaluation state). No Alertmanager is deployed;
+  alert state shows in Grafana's Alerting UI via the Loki datasource.
 
 ### `promtail-config.yml`
 

--- a/observability/README.md
+++ b/observability/README.md
@@ -147,8 +147,9 @@ alpha single-host EC2 box; not multi-tenant/clustered.
 - Storage: `tsdb` index + filesystem chunks under the `loki-data` volume
 - Ruler (#1424): evaluates the NLTI Gate 7 LogQL alert rules from `loki/rules/nlti-alerts.yml`
   (mounted at `/loki/rules/fake`; source doc `pos-mcp-server/docs/alerts/nlti-alerts.md`).
-  Verify with `curl loki:3100/loki/api/v1/rules` (loaded rule files) and
-  `curl loki:3100/prometheus/api/v1/rules` (evaluation state). No Alertmanager is deployed;
+  Verify from the host with `curl localhost:3100/loki/api/v1/rules` (loaded rule files) and
+  `curl localhost:3100/prometheus/api/v1/rules` (evaluation state; use `loki:3100` from inside
+  the compose network). No Alertmanager is deployed;
   alert state shows in Grafana's Alerting UI via the Loki datasource.
 
 ### `promtail-config.yml`

--- a/observability/loki-config.yml
+++ b/observability/loki-config.yml
@@ -55,7 +55,7 @@ compactor:
 # observability/loki/rules/ and are bind-mounted by docker-compose at
 # /loki/rules/fake — "fake" is the tenant id Loki uses while auth_enabled is
 # false, and the local rule store expects one <tenant> directory per tenant
-# under its root. enable_api serves GET /ruler/api/v1/rules (the verification
+# under its root. enable_api serves GET /loki/api/v1/rules (the verification
 # endpoint) and lets Grafana's Alerting UI list the rules and their firing
 # state via the Loki datasource.
 #

--- a/observability/loki-config.yml
+++ b/observability/loki-config.yml
@@ -51,5 +51,27 @@ compactor:
   retention_enabled: true
   delete_request_store: filesystem
 
+# Ruler (#1424): evaluates the NLTI Gate 7 LogQL alert rules. Rule files live in
+# observability/loki/rules/ and are bind-mounted by docker-compose at
+# /loki/rules/fake — "fake" is the tenant id Loki uses while auth_enabled is
+# false, and the local rule store expects one <tenant> directory per tenant
+# under its root. enable_api serves GET /ruler/api/v1/rules (the verification
+# endpoint) and lets Grafana's Alerting UI list the rules and their firing
+# state via the Loki datasource.
+#
+# No Alertmanager runs in this stack, and Grafana's embedded Alertmanager only
+# accepts Grafana-managed alerts — so, like the Grafana-provisioned
+# domain-events alerts, delivery is dashboard/UI-only for now. When an
+# Alertmanager is added, point alertmanager_url at it here.
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /loki/rules
+  rule_path: /loki/ruler          # scratch dir for evaluated copies; must be writable
+  evaluation_interval: 1m
+  poll_interval: 1m
+  enable_api: true
+
 analytics:
   reporting_enabled: false

--- a/observability/loki/rules/nlti-alerts.yml
+++ b/observability/loki/rules/nlti-alerts.yml
@@ -215,7 +215,8 @@ groups:
     interval: 1m
     rules:
       # Doc rule 8. rag.promptLayers is a JSON array, hence the parameterized | json;
-      # the regex matches both a missing field ("") and an empty array ("[]").
+      # the regex matches only a missing field ("") or an empty array ("[]") — LogQL
+      # label-filter regexes are fully anchored, but the ^$ anchors make that explicit.
       - alert: NltiPromptLayerMissing
         expr: |
           sum(count_over_time(
@@ -224,7 +225,7 @@ groups:
               | line_format "{{.telemetry}}"
               | json prompt_layers="rag.promptLayers"
               | __error__=""
-              | prompt_layers =~ `(\[\])?` [15m]
+              | prompt_layers =~ `^(\[\])?$` [15m]
           )) > 0
         labels:
           severity: P2

--- a/observability/loki/rules/nlti-alerts.yml
+++ b/observability/loki/rules/nlti-alerts.yml
@@ -1,0 +1,341 @@
+# Loki ruler rules for the NLTI Gate 7 LogQL alerts (#1424).
+#
+# Source of truth for intent and thresholds: pos-mcp-server/docs/alerts/nlti-alerts.md.
+# This file materializes the Loki-evaluable half of that document (doc rules 2, 5-8, 10
+# and the Loki supplements of 9 and 11); the Prometheus half stays where the document
+# says it lives. docker-compose mounts this directory at /loki/rules/fake ("fake" is
+# the tenant id Loki uses while auth_enabled is false), where the ruler configured in
+# observability/loki-config.yml picks it up.
+#
+# Validate after editing (parses every expression with the LogQL parser — but note it
+# rewrites the file in place, so run it on a copy):
+#   lokitool rules lint <copy-of-this-file>
+#
+# Conventions, per the document's Implementation Notes:
+# - Every stream selector filters service="pos-mcp-server" (Promtail label from the
+#   compose service name; identical locally and on alpha).
+# - The telemetry prefix (abbreviated TELEMETRY in the document) is spelled out in
+#   every expression — rule files have no macros. Parameterized `| json` extracts only
+#   the field a rule needs, both to keep series cardinality down and because
+#   `rag.promptLayers` is a JSON array a bare `| json` would silently skip.
+# - LogQL has no clamp_min(); ratio rules guard division and flapping with an
+#   `and on () <total> > N` minimum-volume clause instead.
+# - A doc rule that lists several trigger signals appears here as several rules
+#   sharing one alertname, one expression each, so a single group keeps loading if a
+#   signal needs tuning.
+#
+# When an emitter gap closes (fallbackUsed, rag.retrieved scores — see the gap table
+# in pos-mcp-server/docs/dashboards/nlti-overview.md), switch the affected rule to the
+# telemetry form named in the document and delete the substitute here.
+
+groups:
+  - name: nlti-request-health
+    interval: 1m
+    rules:
+      # Doc rule 2. p99 over latency.totalMs (milliseconds); max() collapses the
+      # per-stream quantiles into one series.
+      - alert: HighNLTIRequestLatency
+        expr: |
+          max(
+            quantile_over_time(0.99,
+              {job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry"
+                | regexp `(?P<telemetry>[{]"schemaVersion".+[}])`
+                | line_format "{{.telemetry}}"
+                | json latency_totalMs="latency.totalMs"
+                | __error__=""
+                | unwrap latency_totalMs [5m]
+            )
+          ) > 2000
+        for: 5m
+        labels:
+          severity: P2
+        annotations:
+          summary: NLTI p99 request latency above 2s over 5m (latency.totalMs telemetry field).
+          runbook: pos-mcp-server/docs/runbooks/downstream-timeout.md
+
+  - name: nlti-gate7-routing
+    interval: 1m
+    rules:
+      # Doc rule 5. Share of one intent type rose >30pp vs the same hour yesterday.
+      # An intent type absent yesterday produces no pair and cannot fire; the
+      # unclassified-dominance rule below is the backstop for that case.
+      - alert: NltiRoutingMixShift
+        expr: |
+          (
+              (
+                sum by (routing_intentType) (
+                  count_over_time(
+                    {job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry"
+                      | regexp `(?P<telemetry>[{]"schemaVersion".+[}])`
+                      | line_format "{{.telemetry}}"
+                      | json routing_intentType="routing.intentType"
+                      | __error__="" [1h]
+                  )
+                )
+              / on () group_left ()
+                sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [1h]))
+              )
+            -
+              (
+                sum by (routing_intentType) (
+                  count_over_time(
+                    {job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry"
+                      | regexp `(?P<telemetry>[{]"schemaVersion".+[}])`
+                      | line_format "{{.telemetry}}"
+                      | json routing_intentType="routing.intentType"
+                      | __error__="" [1h] offset 24h
+                  )
+                )
+              / on () group_left ()
+                sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [1h] offset 24h))
+              )
+          ) > 0.3
+          and on ()
+          sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [1h])) > 100
+        labels:
+          severity: P3
+        annotations:
+          summary: Share of intent type {{ $labels.routing_intentType }} rose more than 30pp vs the same window yesterday.
+          runbook: pos-mcp-server/docs/runbooks/planning-failure.md
+      # Doc rule 5, falling side of the same comparison.
+      - alert: NltiRoutingMixShift
+        expr: |
+          (
+              (
+                sum by (routing_intentType) (
+                  count_over_time(
+                    {job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry"
+                      | regexp `(?P<telemetry>[{]"schemaVersion".+[}])`
+                      | line_format "{{.telemetry}}"
+                      | json routing_intentType="routing.intentType"
+                      | __error__="" [1h]
+                  )
+                )
+              / on () group_left ()
+                sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [1h]))
+              )
+            -
+              (
+                sum by (routing_intentType) (
+                  count_over_time(
+                    {job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry"
+                      | regexp `(?P<telemetry>[{]"schemaVersion".+[}])`
+                      | line_format "{{.telemetry}}"
+                      | json routing_intentType="routing.intentType"
+                      | __error__="" [1h] offset 24h
+                  )
+                )
+              / on () group_left ()
+                sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [1h] offset 24h))
+              )
+          ) < -0.3
+          and on ()
+          sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [1h])) > 100
+        labels:
+          severity: P3
+        annotations:
+          summary: Share of intent type {{ $labels.routing_intentType }} fell more than 30pp vs the same window yesterday.
+          runbook: pos-mcp-server/docs/runbooks/planning-failure.md
+      # Doc rule 5, unclassified dominance — the Gate 4 router attached no
+      # classification at all (empty/missing routing.intentType majority).
+      - alert: NltiRoutingMixShift
+        expr: |
+          (
+            sum(count_over_time(
+              {job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry"
+                | regexp `(?P<telemetry>[{]"schemaVersion".+[}])`
+                | line_format "{{.telemetry}}"
+                | json routing_intentType="routing.intentType"
+                | __error__=""
+                | routing_intentType = "" [1h]
+            ))
+            /
+            sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [1h]))
+          ) > 0.5
+          and on ()
+          sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [1h])) > 100
+        labels:
+          severity: P3
+        annotations:
+          summary: Majority of NLTI requests carry no routing.intentType — the Gate 4 router is not classifying.
+          runbook: pos-mcp-server/docs/runbooks/planning-failure.md
+      # Doc rule 6. Only meaningful with MCP_MODEL_TIERING_ENABLED=true — the flag is
+      # not visible to LogQL, so silence this alert when tiering is deliberately off.
+      - alert: NltiModelTierStarved
+        expr: |
+          sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [1h])) > 100
+          unless
+          sum(count_over_time(
+            {job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry"
+              | regexp `(?P<telemetry>[{]"schemaVersion".+[}])`
+              | line_format "{{.telemetry}}"
+              | json routing_tier="routing.tier"
+              | __error__=""
+              | routing_tier = "T2_COMPLEX" [1h]
+          )) > 0
+        labels:
+          severity: P2
+        annotations:
+          summary: No T2_COMPLEX traffic in 1h despite >100 NLTI requests — the tiered router is not routing.
+          runbook: pos-mcp-server/docs/runbooks/planning-failure.md
+      # Doc rule 6, second signal — no-tier share above 20%.
+      - alert: NltiModelTierStarved
+        expr: |
+          (
+            sum(count_over_time(
+              {job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry"
+                | regexp `(?P<telemetry>[{]"schemaVersion".+[}])`
+                | line_format "{{.telemetry}}"
+                | json routing_tier="routing.tier"
+                | __error__=""
+                | routing_tier = "" [1h]
+            ))
+            /
+            sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [1h]))
+          ) > 0.2
+          and on ()
+          sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [1h])) > 100
+        labels:
+          severity: P2
+        annotations:
+          summary: More than 20% of NLTI requests carry no routing.tier — tier-quality comparisons in this window are void.
+          runbook: pos-mcp-server/docs/runbooks/planning-failure.md
+      # Doc rule 7, substitute signal. The telemetry form (model.fallbackUsed) cannot
+      # fire yet — the factory hardcodes fallbackUsed=false; switch when instrumented.
+      - alert: NltiModelFallbackRateHigh
+        expr: |
+          sum(count_over_time({job="docker", service="pos-mcp-server", level="WARN"} |= "MCP tiered model resolver" [10m])) > 0
+        labels:
+          severity: P2
+        annotations:
+          summary: Tier resolver warned in the last 10m — a tier silently served the default model.
+          runbook: pos-mcp-server/docs/runbooks/downstream-timeout.md
+
+  - name: nlti-gate7-prompt-rag
+    interval: 1m
+    rules:
+      # Doc rule 8. rag.promptLayers is a JSON array, hence the parameterized | json;
+      # the regex matches both a missing field ("") and an empty array ("[]").
+      - alert: NltiPromptLayerMissing
+        expr: |
+          sum(count_over_time(
+            {job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry"
+              | regexp `(?P<telemetry>[{]"schemaVersion".+[}])`
+              | line_format "{{.telemetry}}"
+              | json prompt_layers="rag.promptLayers"
+              | __error__=""
+              | prompt_layers =~ `(\[\])?` [15m]
+          )) > 0
+        labels:
+          severity: P2
+        annotations:
+          summary: NLTI requests composed with no prompt layers in the last 15m — answers degrade to the built-in BASE layer.
+          runbook: pos-mcp-server/docs/runbooks/planning-failure.md
+      # Doc rule 8, seeding WARN stream.
+      - alert: NltiPromptLayerMissing
+        expr: |
+          sum(count_over_time({job="docker", service="pos-mcp-server", level="WARN"} |~ "MCP no master prompt seeded|MCP no role persona seeded" [15m])) > 0
+        labels:
+          severity: P2
+        annotations:
+          summary: Prompt seeding warned in the last 15m — master prompt or role persona missing.
+          runbook: pos-mcp-server/docs/runbooks/planning-failure.md
+      # Doc rule 8, ROLE-layer share below 90% of composed prompts.
+      - alert: NltiPromptLayerMissing
+        expr: |
+          (
+            sum(count_over_time(
+              {job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry"
+                | regexp `(?P<telemetry>[{]"schemaVersion".+[}])`
+                | line_format "{{.telemetry}}"
+                | json prompt_layers="rag.promptLayers"
+                | __error__=""
+                | prompt_layers =~ `.*"ROLE".*` [15m]
+            ))
+            /
+            sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [15m]))
+          ) < 0.9
+          and on ()
+          sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [15m])) > 100
+        labels:
+          severity: P2
+        annotations:
+          summary: ROLE prompt-layer share below 90% — responses are losing the permission-appropriate persona.
+          runbook: pos-mcp-server/docs/runbooks/planning-failure.md
+      # Doc rule 10, substitute signal: DOMAIN prompt-layer share as the grounding
+      # proxy. Switch to the rag.retrieved[0].score form once retrieval scores are
+      # emitted (the factory currently always passes null for Rag.retrieved).
+      - alert: NltiRagRecallDegraded
+        expr: |
+          (
+            sum(count_over_time(
+              {job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry"
+                | regexp `(?P<telemetry>[{]"schemaVersion".+[}])`
+                | line_format "{{.telemetry}}"
+                | json prompt_layers="rag.promptLayers"
+                | __error__=""
+                | prompt_layers =~ `.*"DOMAIN".*` [1h]
+            ))
+            /
+            sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [1h]))
+          ) < 0.5
+          and on ()
+          sum(count_over_time({job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry" [1h])) > 100
+        labels:
+          severity: P2
+        annotations:
+          summary: DOMAIN prompt-layer share below 50% — RAG grounding is degraded.
+          runbook: pos-mcp-server/docs/runbooks/planning-failure.md
+      # Doc rule 10, static-corpus preload failure.
+      - alert: NltiRagRecallDegraded
+        expr: |
+          sum(count_over_time({job="docker", service="pos-mcp-server", level="WARN"} |= "Preload failed for document_id=" [1h])) > 0
+        labels:
+          severity: P2
+        annotations:
+          summary: Static-corpus preload failed in the last hour — part of the RAG corpus is missing.
+          runbook: pos-mcp-server/docs/runbooks/planning-failure.md
+
+  - name: nlti-gate7-authz-write
+    interval: 1m
+    rules:
+      # Doc rule 9, Loki supplement (the 403-ratio half is Prometheus). p05 of
+      # actor.permissionCodeCount at zero means >=5% of requests decoded an empty
+      # permission bitset — catches a broken gateway decode before it surfaces as 403s.
+      - alert: NltiPermissionRejectSpike
+        expr: |
+          min(
+            quantile_over_time(0.05,
+              {job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry"
+                | regexp `(?P<telemetry>[{]"schemaVersion".+[}])`
+                | line_format "{{.telemetry}}"
+                | json actor_permissionCodeCount="actor.permissionCodeCount"
+                | __error__=""
+                | unwrap actor_permissionCodeCount [10m]
+            )
+          ) == 0
+        for: 10m
+        labels:
+          severity: P1
+        annotations:
+          summary: At least 5% of NLTI requests resolved zero permission codes — likely a broken gateway bitset decode, will present as mass user error.
+          runbook: pos-mcp-server/docs/runbooks/authz-outage.md
+      # Doc rule 11, Loki complement (the confirmation-outcome half is Prometheus):
+      # write intents detected but no write plan created in the same window.
+      - alert: NltiWriteIntentWithoutPlan
+        expr: |
+          sum(count_over_time(
+            {job="docker", service="pos-mcp-server"} |= "nlti.request.telemetry"
+              | regexp `(?P<telemetry>[{]"schemaVersion".+[}])`
+              | line_format "{{.telemetry}}"
+              | json write_isWrite="write.isWrite"
+              | __error__=""
+              | write_isWrite = "true" [15m]
+          )) > 0
+          unless
+          sum(count_over_time({job="docker", service="pos-mcp-server"} |= "NLTI write plan created" [15m])) > 0
+        labels:
+          severity: P2
+        annotations:
+          summary: Write intents detected in the last 15m but no write plan was created — the confirmation gate is not engaging.
+          runbook: pos-mcp-server/docs/runbooks/confirmation-gate-mismatch.md

--- a/pos-mcp-server/docs/alerts/nlti-alerts.md
+++ b/pos-mcp-server/docs/alerts/nlti-alerts.md
@@ -175,8 +175,9 @@ populated yet, the rule states the substitute signal it fires on today.
   `observability/loki/rules/nlti-alerts.yml` (compose-mounted at `/loki/rules/fake`) carries rules
   2, 5–8, 10 and the Loki supplements of 9 and 11. That file is the deployed form; this document
   stays the source of truth for intent and thresholds — change both together. Verify with
-  `curl loki:3100/loki/api/v1/rules` (loaded rule files) and `curl loki:3100/prometheus/api/v1/rules`
-  (evaluation state). No Alertmanager is deployed and Grafana's embedded Alertmanager only accepts
+  `curl localhost:3100/loki/api/v1/rules` (loaded rule files) and
+  `curl localhost:3100/prometheus/api/v1/rules` (evaluation state) — Loki is bound to
+  `127.0.0.1:3100` on the host; use `loki:3100` from inside the compose network. No Alertmanager is deployed and Grafana's embedded Alertmanager only accepts
   Grafana-managed alerts, so ruler alert state is dashboard/UI-only (Grafana → Alerting → Alert
   rules, via the Loki datasource) until an Alertmanager is added and `ruler.alertmanager_url` set.
 - Every Loki rule filters `service="pos-mcp-server"`, the label Promtail derives from the Docker

--- a/pos-mcp-server/docs/alerts/nlti-alerts.md
+++ b/pos-mcp-server/docs/alerts/nlti-alerts.md
@@ -170,11 +170,15 @@ populated yet, the rule states the substitute signal it fires on today.
 
 ## Implementation Notes
 
-- Rules 1–4 and 9, 11 are Prometheus-evaluable; 5–8, 10 are Loki (LogQL) rules. Loki rule evaluation
-  requires the ruler to be enabled — `observability/loki-config.yml` provisions a
-  `rules_directory` (`/loki/rules`) but no ruler config block, so LogQL alerting must be added there
-  or the rules mirrored as Grafana unified-alerting rules under
-  `observability/grafana/provisioning/alerting/` (see `domain-events-alerts.yml` for the format).
+- Rules 1–4 and 9, 11 are Prometheus-evaluable; 5–8, 10 are Loki (LogQL) rules. The Loki half is
+  materialized (#1424): `observability/loki-config.yml` configures the ruler, and the rule file
+  `observability/loki/rules/nlti-alerts.yml` (compose-mounted at `/loki/rules/fake`) carries rules
+  2, 5–8, 10 and the Loki supplements of 9 and 11. That file is the deployed form; this document
+  stays the source of truth for intent and thresholds — change both together. Verify with
+  `curl loki:3100/loki/api/v1/rules` (loaded rule files) and `curl loki:3100/prometheus/api/v1/rules`
+  (evaluation state). No Alertmanager is deployed and Grafana's embedded Alertmanager only accepts
+  Grafana-managed alerts, so ruler alert state is dashboard/UI-only (Grafana → Alerting → Alert
+  rules, via the Loki datasource) until an Alertmanager is added and `ruler.alertmanager_url` set.
 - Every Loki rule filters `service="pos-mcp-server"`, the label Promtail derives from the Docker
   Compose service name; it is identical on the local stack and on alpha.
 - Volume guards matter: the NLTI traffic floor on alpha is low enough that ratio alerts will flap


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A (observability infrastructure fix, no capability id)
- Parent STORY (durion): N/A — Gate 7 signed exception carried by louisburroughs/durion-positivity-backend#1219
- Child issue: louisburroughs/durion-positivity-backend#1424 (fixes)
- Domain: `domain:observability` (pos-mcp-server NLTI alerting)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): N/A — no controllers, DTOs, events, or `openapi.yaml` change; the PR touches only observability config (`loki-config.yml`, `docker-compose.yml` loki mount) and docs
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — N/A, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — N/A
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — N/A

## Scope
- What changed:
  - Added a `ruler:` block to `observability/loki-config.yml` (local rule storage at `/loki/rules`, `rule_path: /loki/ruler`, 1m evaluation/poll interval, `enable_api: true`).
  - New `observability/loki/rules/nlti-alerts.yml` materializing the Loki-evaluable half of `pos-mcp-server/docs/alerts/nlti-alerts.md` (doc rules 2, 5–8, 10 plus the Loki supplements of 9 and 11): 14 rules in 4 groups, split so one group failing to load doesn't take down the rest. LogQL has no `clamp_min()`, so ratio rules carry `and on () <total> > N` minimum-volume guards (also the flap guard the doc requires).
  - `docker-compose.yml` mounts the rules directory at `/loki/rules/fake` (`fake` = the tenant id Loki uses while `auth_enabled: false`).
  - Updated the `nlti-alerts.md` implementation note and `observability/README.md` with the deployed rule location and verification endpoints. Note: the ruler API is **not** under `/ruler` on Loki — use `/loki/api/v1/rules` (loaded rule files) and `/prometheus/api/v1/rules` (evaluation state).
  - No `alertmanager_url` set: the stack runs no Alertmanager and Grafana's embedded Alertmanager only accepts Grafana-managed alerts, so delivery is dashboard/UI-only (Grafana → Alerting, via the Loki datasource), matching the provisioned domain-events alerts. The wiring point is documented in the ruler block.
- Why: `nlti-alerts.md` defined the Gate 7 LogQL alert rules but `loki-config.yml` had no `ruler:` section, so Loki never loaded or evaluated any LogQL rule — the alert definitions were documentation only (Gate 7 signed exception in #1219).

## Tests
- [ ] Unit tests added/updated — N/A, config/docs only
- [ ] Integration tests added/updated — N/A
- [ ] Provider behavioral contract tests added/updated — N/A
- How to run: verified against a real `grafana/loki` 3.1.1 binary with this config: `loki -verify-config` passes; all 4 groups / 14 rules load and appear in `/prometheus/api/v1/rules`; every expression parses under `lokitool rules lint`. On a running stack: `docker compose up -d loki`, then `curl loki:3100/loki/api/v1/rules` and `curl loki:3100/prometheus/api/v1/rules`. The alpha force-fire test from the issue (temporarily lower a threshold against harness traffic) remains to be done on alpha.

## Risk & Rollback
- Risk level: Low — additive config on the Loki container only; no service code touched. Worst case a rule group fails to load and the ruler logs it; ingestion/query paths are unaffected.
- Rollback plan: revert the commit (removes the ruler block, the rules mount, and the rule file); Loki returns to its previous no-ruler behavior on next `docker compose up -d loki`.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, no capability; branch is `claude/issue-1424-lg7wwd` per the issue workflow
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, no capability
- [x] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed) — N/A, no contract change
- [ ] Required CI checks passing — pending on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zN7kMFTgb6C3nQtX9ftKk

---
_Generated by [Claude Code](https://claude.ai/code/session_011zN7kMFTgb6C3nQtX9ftKk)_