### PR TITLE
fix(pos-inventory): resolve SonarQube reliability findings

### DIFF
--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/CycleCountConflictException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/CycleCountConflictException.java
@@ -15,8 +15,13 @@ public class CycleCountConflictException extends RuntimeException {
 
     public CycleCountConflictException(UUID taskId, BigDecimal movementDelta) {
         super("Cycle count task " + taskId + " has interfering stock movements (net on-hand delta "
-                + movementDelta.toPlainString()
+                + plain(movementDelta)
                 + ") since the count snapshot; task flagged CONFLICT. Request a recount, or approve again to accept"
                 + " the variance recomputed against current on-hand.");
+    }
+
+    // Building the error message must never itself throw and mask the conflict being reported.
+    private static String plain(BigDecimal value) {
+        return value == null ? "unknown" : value.toPlainString();
     }
 }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/InsufficientAtpException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/InsufficientAtpException.java
@@ -29,10 +29,15 @@ public class InsufficientAtpException extends RuntimeException {
     public InsufficientAtpException(UUID allocationId, BigDecimal requiredQuantity, BigDecimal availableAtp) {
         super(String.format(
                 "INSUFFICIENT_ATP: allocationId=%s requiredQuantity=%s availableAtp=%s",
-                allocationId, requiredQuantity.toPlainString(), availableAtp.toPlainString()));
+                allocationId, plain(requiredQuantity), plain(availableAtp)));
         this.allocationId = allocationId;
         this.requiredQuantity = requiredQuantity;
         this.availableAtp = availableAtp;
+    }
+
+    // Building the error message must never itself throw and mask the shortage being reported.
+    private static String plain(BigDecimal value) {
+        return value == null ? "unknown" : value.toPlainString();
     }
 
     public String getErrorCode() {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LocationAtCapacityException.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/exception/LocationAtCapacityException.java
@@ -23,10 +23,15 @@ public class LocationAtCapacityException extends PutawayValidationException {
                 ERROR_CODE,
                 String.format(
                         "Location %s is at full capacity (%s/%s units)",
-                        locationId, currentCapacity.toPlainString(), maxCapacity.toPlainString()));
+                        locationId, plain(currentCapacity), plain(maxCapacity)));
         this.locationId = locationId;
         this.currentCapacity = currentCapacity;
         this.maxCapacity = maxCapacity;
+    }
+
+    // Building the error message must never itself throw and mask the capacity breach being reported.
+    private static String plain(BigDecimal value) {
+        return value == null ? "unknown" : value.toPlainString();
     }
 
     public UUID getLocationId() {

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountConflictDetector.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountConflictDetector.java
@@ -45,7 +45,7 @@ public class CycleCountConflictDetector {
      * was taken. Non-zero ⇒ the count window was interfered with.
      */
     @Transactional(readOnly = true)
-    public BigDecimal movementDeltaSinceSnapshot(@NonNull CycleCountTask task) {
+    public @NonNull BigDecimal movementDeltaSinceSnapshot(@NonNull CycleCountTask task) {
         Optional<UUID> locationId = locationIdOf(task);
         BigDecimal delta = locationId
                 .map(location -> ledgerRepository.sumChangeForStockItemAtLocationSince(

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountToleranceResolver.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/CycleCountToleranceResolver.java
@@ -97,11 +97,11 @@ public class CycleCountToleranceResolver {
         if (!resolution.isConfigured()) {
             return absVariance.signum() == 0;
         }
-        boolean withinAbsolute =
-                resolution.absoluteTolerance() != null && absVariance.compareTo(resolution.absoluteTolerance()) <= 0;
-        boolean withinPercentage = resolution.percentageTolerance() != null
-                && absVariance.compareTo(allowedQuantityForPercentage(resolution.percentageTolerance(), bookQuantity))
-                        <= 0;
+        BigDecimal absoluteTolerance = resolution.absoluteTolerance();
+        BigDecimal percentageTolerance = resolution.percentageTolerance();
+        boolean withinAbsolute = absoluteTolerance != null && absVariance.compareTo(absoluteTolerance) <= 0;
+        boolean withinPercentage = percentageTolerance != null
+                && absVariance.compareTo(allowedQuantityForPercentage(percentageTolerance, bookQuantity)) <= 0;
         return withinAbsolute || withinPercentage;
     }
 

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/Quantities.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/Quantities.java
@@ -1,6 +1,7 @@
 package com.positivity.inventory.internal.service;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -21,7 +22,7 @@ final class Quantities {
 
     /** The value, or {@code ZERO} when absent. An absent quantity has always meant none. */
     static @NonNull BigDecimal nz(@Nullable BigDecimal value) {
-        return value == null ? BigDecimal.ZERO : value;
+        return Objects.requireNonNullElse(value, BigDecimal.ZERO);
     }
 
     /** {@code a > b} by value, ignoring scale. */

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/QuantityScaleGuard.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/QuantityScaleGuard.java
@@ -47,6 +47,7 @@ public class QuantityScaleGuard {
      *     omitted the field — is rejected here rather than at the first arithmetic on it
      * @throws FractionalQuantityNotAllowedException when the quantity carries more decimal places
      *     than the product declares
+     * @throws IllegalArgumentException when {@code quantity} is {@code null}
      */
     public @NonNull BigDecimal requirePostable(
             @Nullable UUID productId,

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/QuantityScaleGuard.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/QuantityScaleGuard.java
@@ -43,7 +43,8 @@ public class QuantityScaleGuard {
      *     reference resolves to no catalog product, which declares nothing and so is integral
      * @param stockReference the SKU or stock-item id, used to name the product in the error
      * @param fieldName the request field the quantity came from
-     * @param quantity the base-UoM quantity about to be posted
+     * @param quantity the base-UoM quantity about to be posted; {@code null} — a request that
+     *     omitted the field — is rejected here rather than at the first arithmetic on it
      * @throws FractionalQuantityNotAllowedException when the quantity carries more decimal places
      *     than the product declares
      */
@@ -51,7 +52,7 @@ public class QuantityScaleGuard {
             @Nullable UUID productId,
             @NonNull String stockReference,
             @NonNull String fieldName,
-            @NonNull BigDecimal quantity) {
+            @Nullable BigDecimal quantity) {
         if (quantity == null) {
             throw new IllegalArgumentException(fieldName + " is required");
         }


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A — code-quality remediation (SonarCloud reliability findings), no capability change
- Parent STORY (durion): N/A
- Child issue: N/A
- Domain: `domain:inventory`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` — no contract semantics changed. The exception classes touched here alter only internal null-safe message formatting; error codes, `ApiError` mapping, and API/event behavior are unchanged, so no guide update is needed.
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- N/A — no controller changed

## Scope
- What changed: Resolves all 12 open reliability issues SonarCloud reports against `pos-inventory`:
  - `Quantities.nz` now uses `Objects.requireNonNullElse(value, ZERO)`, making the non-null return explicit to dataflow analysis. Sonar's engine summarized the old ternary as "may return its (possibly null) argument" and propagated a phantom null through `gt`/`gte`/`lt`/`isPositive`/`isZero` into nine downstream `S2259` findings (`Quantities` itself, `ReservationRequestHandler`, `InventoryAvailabilityServiceImpl`, `PutawayValidationServiceImpl`, and three exception constructors).
  - `QuantityScaleGuard.requirePostable`'s `quantity` parameter is now `@Nullable` (`S2583` "condition always evaluates to false"): the null check is intentional — it rejects requests that omitted the field with a domain error — so the annotation, not the check, was wrong.
  - `CycleCountToleranceResolver.isWithinTolerance` hoists the record accessors into locals so the null checks dominate the subsequent uses (`S2637` on repeated `percentageTolerance()` calls).
  - `CycleCountConflictException`, `InsufficientAtpException`, and `LocationAtCapacityException` format quantities null-safely (`S2259`): building an error message must never itself NPE and mask the condition being reported.
  - `CycleCountConflictDetector.movementDeltaSinceSnapshot` declares its already-guaranteed `@NonNull` return.
- Why: SonarCloud reports 12 open reliability (bug-type) issues, all in `pos-inventory`. Nine are false positives rooted in the analyzer's summary of `Quantities.nz`; the fixes make the null-safety contracts explicit so both the analyzer and readers can prove them. The remaining three (`S2583`, `S2637`, and defensive exception-message formatting) are genuine annotation/robustness corrections.

## Tests
- [ ] Unit tests added/updated — none added; behavior is unchanged, and existing coverage (932 tests, incl. `QuantityScaleGuardTest`, `ReservationRequestHandlerTest`, ArchUnit) exercises every touched path
- [ ] Integration tests added/updated — N/A, no behavior change
- [ ] Provider behavioral contract tests added/updated — N/A, no contract change
- How to run: `./mvnw -pl pos-inventory -am test`

## Risk & Rollback
- Risk level: Low — semantically equivalent refactors plus null-safe message formatting; no API, schema, or event changes
- Rollback plan: revert the single commit (`git revert 6bd2116`); no migrations or config involved

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, not capability work (branch `claude/pos-inventory-sonarqube-reliability-b2g4e4`)
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, not capability work
- [ ] Links to parent + child issues are present — N/A
- [ ] Contract guide updated (when contract semantics changed) — N/A, no contract semantics changed
- [x] Required CI checks passing — full `pos-inventory` build green locally (Spotless, Checkstyle, ArchUnit, 932 tests)

Note: findings clear on SonarCloud only after its next analysis of this branch; any survivor from the false-positive family can be marked FP in the SonarCloud UI — the code side is provably null-safe either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoB4QEMnqsyzi1qCTPQVNH