### PR TITLE
Enforce fine-grained authorization on workorder, estimate, and product endpoints (#1432–#1435)

### DIFF
--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,4 +1,4 @@
-generatedAt: "2026-08-20T10:04:14.589172+00:00"
+generatedAt: "2026-08-21T15:14:14.681665+00:00"
 root: "."
 summary:
   manifestCount: 23

--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,4 +1,4 @@
-generatedAt: "2026-08-21T15:20:45.307714+00:00"
+generatedAt: "2026-08-21T15:38:54.057834+00:00"
 root: "."
 summary:
   manifestCount: 23

--- a/docs/permissions-report.yaml
+++ b/docs/permissions-report.yaml
@@ -1,4 +1,4 @@
-generatedAt: "2026-08-21T15:14:14.681665+00:00"
+generatedAt: "2026-08-21T15:20:45.307714+00:00"
 root: "."
 summary:
   manifestCount: 23

--- a/pos-catalog/openapi.yaml
+++ b/pos-catalog/openapi.yaml
@@ -921,7 +921,7 @@ paths:
       security:
       - bearerAuth:
         - ROLE_ADMIN
-        - ROLE_CATALOG_VIEW
+        - ROLE_CATALOG_EDIT
       summary: Create Product Master Record
       tags:
       - Products API

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/controller/ProductController.java
@@ -389,10 +389,10 @@ public class ProductController {
         return ResponseEntity.ok(productSearchService.searchProducts(q, brand, category, sku, cursor, limit, detailed));
     }
 
-    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_VIEW')")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('CATALOG_EDIT')")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(
             name = "bearerAuth",
-            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_VIEW"})
+            scopes = {"ROLE_ADMIN", "ROLE_CATALOG_EDIT"})
     @PostMapping
     @Operation(operationId = "createProduct", summary = "Create Product Master Record", description = """
             Creates a product master record with an immutable SKU, status ACTIVE, and uniqueness enforced on \

--- a/pos-catalog/src/test/java/com/positivity/catalog/contract/ProductMasterContractBehaviorIT.java
+++ b/pos-catalog/src/test/java/com/positivity/catalog/contract/ProductMasterContractBehaviorIT.java
@@ -43,6 +43,18 @@ class ProductMasterContractBehaviorIT extends BaseContractIntegrationTest {
     }
 
     @Test
+    @DisplayName("VE-165-003: Create product with only ROLE_CATALOG_VIEW returns 403")
+    void createProduct_withViewRoleOnly_returnsForbidden() throws Exception {
+        mockMvc.perform(withAuth(
+                        post("/v1/products")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(
+                                        validCreatePayload("SKU-165-403", "MPN-165-403"))),
+                        "ROLE_CATALOG_VIEW"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     @DisplayName("VE-165-002: Attempt to change SKU returns 400")
     void updateSku_returnsBadRequest() throws Exception {
         UUID productId = createProductAndGetId("SKU-165-IMM", "MPN-165-IMM");

--- a/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
+++ b/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
@@ -40,6 +40,16 @@
 --   LOCATION_MANAGER, MANAGER and SHOP_MANAGER — per the product decision on
 --   that issue. Do not widen it: the permission exists specifically to cap
 --   what a service advisor can finalize by naming an absent manager.
+-- * workorder:workorder:delete (#1432) is a hard delete that destroys history,
+--   so it is held by ADMIN and the manager roles only — GENERAL_MANAGER,
+--   LOCATION_MANAGER, MANAGER and SHOP_MANAGER — mirroring the
+--   invoice:finalize:override precedent. Advisors create workorders
+--   (workorder:workorder:create) but cannot destroy them.
+-- * SERVICE_ADVISOR holds the CRM onboarding surface (#1435):
+--   crm:party:view/search/create and crm:person:read/create, so a walk-in
+--   customer can be looked up, duplicate-checked and onboarded at the counter.
+--   Deliberately NOT crm:party:edit/deactivate/merge — corrections and
+--   destructive party operations stay manager-and-above.
 -- * The inventory adjustment roles (#1373) carry the model RoleInitializer's
 --   javadoc documents: INVENTORY_LEAD creates and views adjustment requests;
 --   INVENTORY_MANAGER and INVENTORY_CONTROLLER additionally approve them. The two
@@ -907,6 +917,7 @@ FROM (VALUES
     ('GENERAL_MANAGER', 'security:role:view'),
     ('GENERAL_MANAGER', 'workorder:timeEntry:approve'),
     ('GENERAL_MANAGER', 'workorder:timeEntry:reject'),
+    ('GENERAL_MANAGER', 'workorder:workorder:delete'),
     ('INVENTORY_CONTROLLER', 'catalog:category:view'),
     ('INVENTORY_CONTROLLER', 'catalog:product:view'),
     ('INVENTORY_CONTROLLER', 'inventory:adjustment:approve'),
@@ -1032,6 +1043,7 @@ FROM (VALUES
     ('LOCATION_MANAGER', 'workorder:workorder:assign-technician'),
     ('LOCATION_MANAGER', 'workorder:workorder:complete'),
     ('LOCATION_MANAGER', 'workorder:workorder:create'),
+    ('LOCATION_MANAGER', 'workorder:workorder:delete'),
     ('LOCATION_MANAGER', 'workorder:workorder:edit'),
     ('LOCATION_MANAGER', 'workorder:workorder:generate_invoice'),
     ('LOCATION_MANAGER', 'workorder:workorder:reopen_completed'),
@@ -1052,6 +1064,7 @@ FROM (VALUES
     ('MANAGER', 'security:role:view'),
     ('MANAGER', 'workorder:timeEntry:approve'),
     ('MANAGER', 'workorder:timeEntry:reject'),
+    ('MANAGER', 'workorder:workorder:delete'),
     ('SELF_SERVICE_CUSTOMER', 'mcp:chat:execute'),
     ('SELF_SERVICE_CUSTOMER', 'mcp:chat:stream'),
     ('SELF_SERVICE_CUSTOMER', 'nlti:request:read'),
@@ -1060,6 +1073,11 @@ FROM (VALUES
     ('SERVICE_ADVISOR', 'appointments:create'),
     ('SERVICE_ADVISOR', 'appointments:reschedule'),
     ('SERVICE_ADVISOR', 'appointments:view'),
+    ('SERVICE_ADVISOR', 'crm:party:create'),
+    ('SERVICE_ADVISOR', 'crm:party:search'),
+    ('SERVICE_ADVISOR', 'crm:party:view'),
+    ('SERVICE_ADVISOR', 'crm:person:create'),
+    ('SERVICE_ADVISOR', 'crm:person:read'),
     ('SERVICE_ADVISOR', 'crm:vehicle:search'),
     ('SERVICE_ADVISOR', 'crm:vehicle:view'),
     ('SERVICE_ADVISOR', 'inventory:availability:read'),
@@ -1117,6 +1135,7 @@ FROM (VALUES
     ('SHOP_MANAGER', 'shop:schedule:edit'),
     ('SHOP_MANAGER', 'shop:schedule:view'),
     ('SHOP_MANAGER', 'shop:technician:view'),
+    ('SHOP_MANAGER', 'workorder:workorder:delete'),
     ('SYSTEM_ADMINISTRATOR', 'mcp:chat:execute'),
     ('SYSTEM_ADMINISTRATOR', 'mcp:chat:stream'),
     ('SYSTEM_ADMINISTRATOR', 'mcp:document:ingest'),

--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -897,7 +897,7 @@ paths:
 
         Use this tool when opening a workorder directly; do not use promoteEstimate, which is the estimate-side path that promotes an APPROVED estimate into a workorder.
 
-        Preconditions: the referenced estimate must exist; the location falls back to the caller''s primary location when the estimate carries none.
+        Preconditions: the referenced estimate must exist, and the caller must hold workorder:workorder:create; the location falls back to the caller''s primary location when the estimate carries none.
 
         Required inputs: estimateId and customerId (UUIDs); an Idempotency-Key header is recommended — a repeated key returns the originally created workorder instead of a duplicate.
 
@@ -936,12 +936,13 @@ paths:
                 $ref: '#/components/schemas/WorkorderResponse'
           description: Work order created successfully, or existing work order returned if idempotency key was previously processed.
       security:
-      - bearerAuth: []
+      - bearerAuth:
+        - workorder:workorder:create
       summary: Create a New Workorder
       tags:
       - Work Order API
       x-required-permissions:
-      - AUTHENTICATED
+      - workorder:workorder:create
   /v1/workorders/changeRequests/{changeId}:
     get:
       description: 'Returns one change request with its status, description, emergency flags, approval details, and item associations.
@@ -1445,7 +1446,7 @@ paths:
 
         Use this tool when an appointment arrives and needs an estimate started; do not use createEstimate, which builds an estimate from scratch without an appointment link or idempotency guarantee.
 
-        Preconditions: none beyond authentication — the appointment id is not verified against the scheduling service, and an estimate already linked to the appointmentId short-circuits creation.
+        Preconditions: the caller must hold workorder:estimate:create; the appointment id is not verified against the scheduling service, and an estimate already linked to the appointmentId short-circuits creation.
 
         Required inputs: idempotencyKey, appointmentId, customerId, vehicleId, and locationId (all UUIDs); requestedServices is an optional list of free-text service descriptions.
 
@@ -1511,7 +1512,7 @@ paths:
       tags:
       - Estimates from Appointments
       x-required-permissions:
-      - AUTHENTICATED
+      - workorder:estimate:create
   /v1/workorders/estimates/location/{locationId}:
     get:
       description: 'Returns all estimates recorded against one location, unpaginated and in every status.
@@ -3104,7 +3105,7 @@ paths:
 
         Use this tool only to remove mistakenly created workorders; do not use completeWorkorder or reopenWorkorder, which drive the normal lifecycle without destroying history.
 
-        Preconditions: none are enforced — deletion is idempotent and deleting an unknown id is a silent no-op.
+        Preconditions: the caller must hold workorder:workorder:delete; deletion is idempotent and deleting an unknown id is a silent no-op.
 
         Required inputs: workorderId (UUID) as a path parameter; there is no request body.
 
@@ -3129,12 +3130,13 @@ paths:
         '404':
           description: Work order not found.
       security:
-      - bearerAuth: []
+      - bearerAuth:
+        - workorder:workorder:delete
       summary: Delete a Workorder
       tags:
       - Work Order API
       x-required-permissions:
-      - AUTHENTICATED
+      - workorder:workorder:delete
     get:
       description: 'Returns the raw workorder record — status, customer, vehicle, estimate linkage, approval and completion fields — for one workorder id.
 
@@ -5438,12 +5440,13 @@ paths:
                 type: array
           description: Snapshot history returned successfully.
       security:
-      - bearerAuth: []
+      - bearerAuth:
+        - workorder:workorder:view
       summary: Get Workorder Snapshot History
       tags:
       - Work Order API
       x-required-permissions:
-      - AUTHENTICATED
+      - workorder:workorder:view
   /v1/workorders/{workorderId}/start:
     post:
       description: 'Transitions the workorder to WORK_IN_PROGRESS, stamps workStartedAt, assigns a new operational context version, and locks the context against further overrides.
@@ -5799,12 +5802,13 @@ paths:
                 type: array
           description: Transition history returned successfully.
       security:
-      - bearerAuth: []
+      - bearerAuth:
+        - workorder:workorder:view
       summary: Get Workorder Transition History
       tags:
       - Work Order API
       x-required-permissions:
-      - AUTHENTICATED
+      - workorder:workorder:view
 components:
   schemas:
     AddBreakSegmentRequest:

--- a/pos-workorder/openapi.yaml
+++ b/pos-workorder/openapi.yaml
@@ -3126,9 +3126,7 @@ paths:
           type: string
       responses:
         '204':
-          description: Work order deleted successfully.
-        '404':
-          description: Work order not found.
+          description: Work order deleted whether or not it previously existed.
       security:
       - bearerAuth:
         - workorder:workorder:delete

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/EstimateFromAppointmentController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/EstimateFromAppointmentController.java
@@ -3,6 +3,7 @@ package com.positivity.workorder.internal.controller;
 import com.positivity.events.EmitEvent;
 import com.positivity.workorder.internal.dto.CreateEstimateFromAppointmentRequest;
 import com.positivity.workorder.internal.dto.CreateEstimateFromAppointmentResponse;
+import com.positivity.workorder.internal.security.WorkorderPermissions;
 import com.positivity.workorder.service.EstimateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -29,7 +30,10 @@ public class EstimateFromAppointmentController {
 
     @PostMapping("/from-appointment")
     @EmitEvent(id = "WORKORDER_ESTIMATE_CREATE_FROM_APPOINTMENT", apiVersion = "1")
-    @PreAuthorize("isAuthenticated()")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"workorder:estimate:create"})
+    @PreAuthorize("hasAuthority('" + WorkorderPermissions.ESTIMATE_CREATE + "')")
     @Operation(
             operationId = "createEstimateFromAppointment",
             summary = "Create Draft Estimate From Appointment",
@@ -39,9 +43,9 @@ public class EstimateFromAppointmentController {
                     Use this tool when an appointment arrives and needs an estimate started; do not use \
                     createEstimate, which builds an estimate from scratch without an appointment link or \
                     idempotency guarantee.
-                    Preconditions: none beyond authentication — the appointment id is not verified against the \
-                    scheduling service, and an estimate already linked to the appointmentId short-circuits \
-                    creation.
+                    Preconditions: the caller must hold workorder:estimate:create; the appointment id is not \
+                    verified against the scheduling service, and an estimate already linked to the appointmentId \
+                    short-circuits creation.
                     Required inputs: idempotencyKey, appointmentId, customerId, vehicleId, and locationId (all \
                     UUIDs); requestedServices is an optional list of free-text service descriptions.
                     Emits a WORKORDER_ESTIMATE_CREATE_FROM_APPOINTMENT event; the call is idempotent on \

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderController.java
@@ -154,8 +154,9 @@ public class WorkorderController {
                     CRM references and generating a workorder number.
                     Use this tool when opening a workorder directly; do not use promoteEstimate, which is the \
                     estimate-side path that promotes an APPROVED estimate into a workorder.
-                    Preconditions: the referenced estimate must exist; the location falls back to the caller's \
-                    primary location when the estimate carries none.
+                    Preconditions: the referenced estimate must exist, and the caller must hold \
+                    workorder:workorder:create; the location falls back to the caller's primary location when \
+                    the estimate carries none.
                     Required inputs: estimateId and customerId (UUIDs); an Idempotency-Key header is recommended \
                     — a repeated key returns the originally created workorder instead of a duplicate.
                     Emits a WORKORDER_CREATE event and marks the workorder fact changed for downstream \
@@ -179,8 +180,10 @@ public class WorkorderController {
                                                     """)))
     @PostMapping
     @EmitEvent(id = "WORKORDER_CREATE", apiVersion = "1")
-    @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
-    @PreAuthorize("isAuthenticated()")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"workorder:workorder:create"})
+    @PreAuthorize("hasAuthority('" + WorkorderPermissions.WORKORDER_CREATE + "')")
     public ResponseEntity<WorkorderResponse> createWorkorder(
             @Parameter(description = "Work order creation request") @Valid @RequestBody CreateWorkorderRequest request,
             @Parameter(
@@ -199,8 +202,8 @@ public class WorkorderController {
                     Deletes a workorder row by id, a hard delete with no status guard or soft-delete fallback.
                     Use this tool only to remove mistakenly created workorders; do not use completeWorkorder or \
                     reopenWorkorder, which drive the normal lifecycle without destroying history.
-                    Preconditions: none are enforced — deletion is idempotent and deleting an unknown id is a \
-                    silent no-op.
+                    Preconditions: the caller must hold workorder:workorder:delete; deletion is idempotent and \
+                    deleting an unknown id is a silent no-op.
                     Required inputs: workorderId (UUID) as a path parameter; there is no request body.
                     Emits a WORKORDER_DELETE event.
                     Returns 204 regardless of whether the workorder previously existed.
@@ -209,8 +212,10 @@ public class WorkorderController {
     @ApiResponse(responseCode = "404", description = "Work order not found.")
     @DeleteMapping("/{workorderId}")
     @EmitEvent(id = "WORKORDER_DELETE", apiVersion = "1")
-    @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
-    @PreAuthorize("isAuthenticated()")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"workorder:workorder:delete"})
+    @PreAuthorize("hasAuthority('" + WorkorderPermissions.WORKORDER_DELETE + "')")
     public ResponseEntity<Void> deleteWorkorder(
             @Parameter(description = "ID of the work order to delete", example = "550e8400-e29b-41d4-a716-446655440000")
                     @PathVariable
@@ -231,8 +236,10 @@ public class WorkorderController {
                     """)
     @ApiResponse(responseCode = "200", description = "Transition history returned successfully.")
     @GetMapping("/{workorderId}/transitions")
-    @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
-    @PreAuthorize("isAuthenticated()")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"workorder:workorder:view"})
+    @PreAuthorize("hasAuthority('" + WorkorderPermissions.WORKORDER_VIEW + "')")
     public ResponseEntity<List<WorkorderStateTransitionResponse>> getTransitionHistory(
             @Parameter(description = "ID of the work order", example = "550e8400-e29b-41d4-a716-446655440000")
                     @PathVariable
@@ -255,8 +262,10 @@ public class WorkorderController {
                     """)
     @ApiResponse(responseCode = "200", description = "Snapshot history returned successfully.")
     @GetMapping("/{workorderId}/snapshots")
-    @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "bearerAuth")
-    @PreAuthorize("isAuthenticated()")
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(
+            name = "bearerAuth",
+            scopes = {"workorder:workorder:view"})
+    @PreAuthorize("hasAuthority('" + WorkorderPermissions.WORKORDER_VIEW + "')")
     public ResponseEntity<List<WorkorderSnapshotResponse>> getSnapshotHistory(
             @Parameter(description = "ID of the work order", example = "550e8400-e29b-41d4-a716-446655440000")
                     @PathVariable

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderController.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/controller/WorkorderController.java
@@ -208,8 +208,7 @@ public class WorkorderController {
                     Emits a WORKORDER_DELETE event.
                     Returns 204 regardless of whether the workorder previously existed.
                     """)
-    @ApiResponse(responseCode = "204", description = "Work order deleted successfully.")
-    @ApiResponse(responseCode = "404", description = "Work order not found.")
+    @ApiResponse(responseCode = "204", description = "Work order deleted whether or not it previously existed.")
     @DeleteMapping("/{workorderId}")
     @EmitEvent(id = "WORKORDER_DELETE", apiVersion = "1")
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/security/WorkorderPermissions.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/security/WorkorderPermissions.java
@@ -134,6 +134,12 @@ public final class WorkorderPermissions {
     /** Complete workorders. */
     public static final String WORKORDER_COMPLETE = "workorder:workorder:complete";
 
+    /** Create workorders. */
+    public static final String WORKORDER_CREATE = "workorder:workorder:create";
+
+    /** Delete workorders (hard delete of mistakenly created records). */
+    public static final String WORKORDER_DELETE = "workorder:workorder:delete";
+
     /** Generate invoice workorder. */
     public static final String WORKORDER_GENERATE_INVOICE = "workorder:workorder:generate_invoice";
 

--- a/pos-workorder/src/test/java/com/positivity/workorder/contract/AuthorizationEnforcementContractBehaviorIT.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/contract/AuthorizationEnforcementContractBehaviorIT.java
@@ -1,0 +1,85 @@
+package com.positivity.workorder.contract;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.positivity.workorder.support.BaseContractIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Negative-path authorization tests for the endpoints tightened in #1432 and #1433.
+ *
+ * <p>Every request here authenticates successfully but carries an authority set that lacks the one
+ * permission the endpoint requires, pinning the enforcement to the specific authority rather than
+ * to authentication. The happy paths are covered by the other contract ITs, which run with the full
+ * {@code TEST_AUTHORITIES} set.
+ */
+@DisplayName("Authorization Enforcement Contract Behavior Tests (#1432, #1433)")
+@Import(ContractTestConfiguration.class)
+class AuthorizationEnforcementContractBehaviorIT extends BaseContractIntegrationTest {
+
+    private static final UUID ANY_ID = UUID.fromString("00000000-0000-0000-0000-000000000042");
+
+    /** Authenticated with real workorder authorities, just not the one under test. */
+    private MockHttpServletRequestBuilder withAuthorities(MockHttpServletRequestBuilder req, String authorities) {
+        return req.header("Authorization", "Bearer " + TEST_BEARER_TOKEN)
+                .header("X-User-Id", SYSTEM_USER_ID)
+                .header("X-User", SYSTEM_USER_ID)
+                .header("X-Authorities", authorities);
+    }
+
+    @Test
+    @DisplayName("AE-001: createWorkorder without workorder:workorder:create returns 403")
+    void createWorkorder_withoutCreateAuthority_returnsForbidden() throws Exception {
+        String body = "{\"estimateId\":\"" + ANY_ID + "\",\"customerId\":\"" + ANY_ID + "\"}";
+
+        mockMvc.perform(withAuthorities(post("/v1/workorders"), "workorder:workorder:view")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("AE-002: deleteWorkorder without workorder:workorder:delete returns 403")
+    void deleteWorkorder_withoutDeleteAuthority_returnsForbidden() throws Exception {
+        mockMvc.perform(withAuthorities(
+                        delete("/v1/workorders/{workorderId}", ANY_ID),
+                        "workorder:workorder:view,workorder:workorder:create"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("AE-003: getWorkorderTransitions without workorder:workorder:view returns 403")
+    void getTransitionHistory_withoutViewAuthority_returnsForbidden() throws Exception {
+        mockMvc.perform(withAuthorities(
+                        get("/v1/workorders/{workorderId}/transitions", ANY_ID), "workorder:workorder:create"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("AE-004: getWorkorderSnapshots without workorder:workorder:view returns 403")
+    void getSnapshotHistory_withoutViewAuthority_returnsForbidden() throws Exception {
+        mockMvc.perform(withAuthorities(
+                        get("/v1/workorders/{workorderId}/snapshots", ANY_ID), "workorder:workorder:create"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("AE-005: createEstimateFromAppointment without workorder:estimate:create returns 403")
+    void createEstimateFromAppointment_withoutEstimateCreateAuthority_returnsForbidden() throws Exception {
+        String body = "{\"idempotencyKey\":\"" + ANY_ID + "\",\"appointmentId\":\"" + ANY_ID + "\",\"customerId\":\""
+                + ANY_ID + "\",\"vehicleId\":\"" + ANY_ID + "\",\"locationId\":\"" + ANY_ID + "\"}";
+
+        mockMvc.perform(withAuthorities(post("/v1/workorders/estimates/from-appointment"), "workorder:estimate:view")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A — authorization-gap remediation, no parent capability
- Parent STORY (durion): N/A
- Child issues: closes louisburroughs/durion-positivity-backend#1432, closes #1433, closes #1434, closes #1435
- Domain: `domain:workorder`, `domain:catalog`, `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/workorder/.business-rules/BACKEND_CONTRACT_GUIDE.md` — no contract-shape change: request/response schemas, paths, and status codes are unchanged; only the required authorities on six existing operations changed (documented in the regenerated `openapi.yaml` security scopes)
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- [x] OpenAPI annotations updated on the controller
- [x] `openapi.yaml` regenerated (`scripts/generate-openapi.sh pos-workorder pos-catalog`); `pos-api-gateway/docs/openapi-aggregate.yaml` unchanged — it indexes paths only and no paths were added or removed
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — no schema/path changes, so no SDK surface change expected

## Scope
- What changed:
  - **#1432**: `createWorkorder`/`deleteWorkorder` now require `workorder:workorder:create`/`workorder:workorder:delete` instead of `isAuthenticated()`; both permissions already existed in the catalog (bits 177/179) but were never enforced. `getTransitionHistory`/`getSnapshotHistory` now require `workorder:workorder:view` like the other workorder reads. `workorder:workorder:delete` is seeded to ADMIN + GENERAL_MANAGER, LOCATION_MANAGER, MANAGER, SHOP_MANAGER (hard delete stays manager-and-above, mirroring the `invoice:finalize:override` precedent from #1374).
  - **#1433**: `createEstimateFromAppointment` now requires `workorder:estimate:create`, matching every other estimate-creation path. No seed change — SERVICE_ADVISOR already holds it.
  - **#1434**: `createProduct` moves from `ROLE_CATALOG_VIEW` (a view role gating a write) to `ROLE_CATALOG_EDIT`, matching the controller's other writes. Role seeding stays deferred to #42/#237.
  - **#1435**: SERVICE_ADVISOR seeded with `crm:party:view`, `crm:party:search`, `crm:party:create`, `crm:person:read`, `crm:person:create` so advisors can look up, duplicate-check, and onboard walk-in customers. Deliberately excludes party edit/deactivate/merge — documented in the seed file's policy header.
- Why: four authorization enforcement gaps where mutating or sensitive endpoints were reachable by any authenticated user, plus a seed gap blocking the service-advisor onboarding workflow. Full evidence in the linked issues.

## Tests
- [ ] Unit tests added/updated — existing suites already cover these endpoints; test security configs (`TestSecurityConfig`, `BaseIntegrationTest`) already grant the now-required authorities, so behavior under authorization is exercised without changes
- [x] Integration tests passing (`pos-workorder`, `pos-catalog` full module suites)
- [ ] Provider behavioral contract tests added/updated — no contract shape change
- How to run: `./mvnw -pl pos-workorder test && ./mvnw -pl pos-catalog test`; `scripts/check-flyway-hygiene.sh`; `scripts/generate-permissions.sh --sync --check`

## Risk & Rollback
- Risk level: Medium — tightens authorization: callers that relied on the missing checks (any authenticated principal without the named authorities) will now receive 403 on the six affected operations. Role seeds are additive and idempotent (`ON CONFLICT DO NOTHING` in a repeatable migration).
- Rollback plan: revert the two commits. Seed grants are additive, so a revert restores prior enforcement without needing a compensating migration; removing the granted rows (if ever desired) needs a versioned migration per the seed file's policy.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A (no capability; issue-remediation branch `claude/fix-authz-enforcement-1432-1435`)
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A (no capability)
- [x] Links to parent + child issues are present (child issues #1432–#1435; no parent STORY)
- [x] Contract guide updated (when contract semantics changed) — no semantic contract change; authorization scopes documented in regenerated specs
- [ ] Required CI checks passing — pending first run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKBY1mzs8VgS1E385cmVXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKBY1mzs8VgS1E385cmVXj)_