### PR TITLE
Seed an INVENTORY_LEAD operational user

### DIFF
--- a/pos-security-service/src/main/resources/db/migration/R__seed_security_operational_data.sql
+++ b/pos-security-service/src/main/resources/db/migration/R__seed_security_operational_data.sql
@@ -1,5 +1,5 @@
 -- Repeatable seed migration for pos-security-service operational users.
--- 16 employees across 7 roles for Durion Positivity (medium truck mechanical repair corporation).
+-- 17 employees across 8 roles for Durion Positivity (medium truck mechanical repair corporation).
 
 SET TIME ZONE 'UTC';
 
@@ -21,7 +21,8 @@ VALUES
     ('01960010-0000-7000-8000-00000000000d', 'tyrone.williams', '$2y$10$r2Vph.8y7daYEIMfBfDp/eGd0sAIwewYL9sBAAN2eonKnAYBJSfc.', true),
     ('01960010-0000-7000-8000-00000000000e', 'olivia.chen',     '$2y$10$r2Vph.8y7daYEIMfBfDp/eGd0sAIwewYL9sBAAN2eonKnAYBJSfc.', true),
     ('01960010-0000-7000-8000-00000000000f', 'harold.sanders',  '$2y$10$r2Vph.8y7daYEIMfBfDp/eGd0sAIwewYL9sBAAN2eonKnAYBJSfc.', true),
-    ('01960010-0000-7000-8000-000000000010', 'irene.torres',    '$2y$10$r2Vph.8y7daYEIMfBfDp/eGd0sAIwewYL9sBAAN2eonKnAYBJSfc.', true)
+    ('01960010-0000-7000-8000-000000000010', 'irene.torres',    '$2y$10$r2Vph.8y7daYEIMfBfDp/eGd0sAIwewYL9sBAAN2eonKnAYBJSfc.', true),
+    ('01960010-0000-7000-8000-000000000011', 'gloria.mendez',   '$2y$10$r2Vph.8y7daYEIMfBfDp/eGd0sAIwewYL9sBAAN2eonKnAYBJSfc.', true)
 ON CONFLICT (username) DO UPDATE SET password = EXCLUDED.password, enabled = EXCLUDED.enabled;
 
 -- Role assignments (resolved by role name to tolerate variable UUIDs from versioned migrations)
@@ -43,7 +44,8 @@ FROM (VALUES
     ('01960010-0000-7000-8000-00000000000d'::uuid, 'SERVICE_ADVISOR'),
     ('01960010-0000-7000-8000-00000000000e'::uuid, 'ACCOUNTING_ASSOCIATE'),
     ('01960010-0000-7000-8000-00000000000f'::uuid, 'ACCOUNTING_ASSOCIATE'),
-    ('01960010-0000-7000-8000-000000000010'::uuid, 'ACCOUNT_MANAGER')
+    ('01960010-0000-7000-8000-000000000010'::uuid, 'ACCOUNT_MANAGER'),
+    ('01960010-0000-7000-8000-000000000011'::uuid, 'INVENTORY_LEAD')
 ) AS a(user_id, role_name)
 JOIN roles r ON r.name = a.role_name
 ON CONFLICT (user_id, role_id) DO NOTHING;

--- a/pos-security-service/src/test/java/com/positivity/securityservice/migration/RolePermissionSeedIT.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/migration/RolePermissionSeedIT.java
@@ -166,6 +166,11 @@ class RolePermissionSeedIT {
         assertThat(effectivePermissionsOf("olivia.chen"))
                 .as("olivia.chen is an ACCOUNTING_ASSOCIATE")
                 .contains("accounting:ap:view", "accounting:ap:pay");
+
+        assertThat(effectivePermissionsOf("gloria.mendez"))
+                .as("gloria.mendez is an INVENTORY_LEAD: receiving and PO entry (#1439), no PO approval")
+                .contains("inventory:receiving:create", "inventory:goods_receipt:create", "order:purchase_order:create")
+                .doesNotContain("order:purchase_order:approve", "inventory:goods_receipt:override");
     }
 
     @Test


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A — operational seed data follow-up to the #1438–#1440 series (PR #1441)
- Parent STORY (durion): N/A
- Child issue: N/A — completes the persona chain from louisburroughs/durion-positivity-backend#1439
- Domain: `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): N/A — no controller, DTO, event, or `openapi.yaml` change; seed data and one integration-test assertion only. (`BACKEND_CONTRACT_GUIDE.md` referenced for the contract-sync check; no entry applies.)
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- [ ] N/A — no controller changed

## Scope
- What changed:
  - `R__seed_security_operational_data.sql`: adds operational user **gloria.mendez** (`01960010-0000-7000-8000-000000000011`, next id in the file's sequence, same shared bcrypt hash as the other operational users) with a `user_roles` binding to **INVENTORY_LEAD**, resolved by role name and idempotent on re-run like the rest of the file. Header updated to 17 employees across 8 roles.
  - `RolePermissionSeedIT`: new end-to-end assertion that gloria.mendez's effective permissions resolve through `user_roles → roles → role_permissions → permissions` to the #1439 receiving set (`inventory:receiving:create`, `inventory:goods_receipt:create`, `order:purchase_order:create`) and exclude the elevated permissions (`order:purchase_order:approve`, `inventory:goods_receipt:override`).
- Why: after #1439/#1441 the INVENTORY_LEAD role carries the parts-receiving grants, but no seeded operational user held any inventory role — the receiving and PO-entry flows had authority defined and nobody to exercise it. This seeds the missing principal and pins the resolution path in the Postgres IT.

## Tests
- [x] Unit tests passing — full `pos-security-service` suite (488 tests)
- [ ] Integration tests — the new `RolePermissionSeedIT` assertion requires Docker (Testcontainers Postgres), unavailable in this environment; it runs in CI's reactor build
- [ ] Provider behavioral contract tests — N/A, no API change
- How to run: `./mvnw -pl pos-security-service test`; `scripts/check-flyway-hygiene.sh`

## Risk & Rollback
- Risk level: Low — additive seed data (one user, one role binding), idempotent `ON CONFLICT` semantics matching the existing rows. Note the file's existing convention applies: the shared operational password hash is upserted on re-run, same as the other 16 users.
- Rollback plan: revert the commit; removing the already-inserted row from populated databases (if desired) needs a `DELETE` via the admin API or a versioned migration, per the seed policy.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A (seed follow-up branch `claude/seed-inventory-lead-user`)
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A (no capability)
- [x] Links to parent + child issues are present (follow-up to #1439 / PR #1441; no parent STORY)
- [x] Contract guide updated (when contract semantics changed) — no contract semantics changed
- [ ] Required CI checks passing — pending first run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKBY1mzs8VgS1E385cmVXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKBY1mzs8VgS1E385cmVXj)_