### PR TITLE
Fix SelfRegistrationControllerIT: seed SELF_SERVICE_CUSTOMER in the Flyway-less H2 test context

### DIFF
--- a/pos-security-service/src/test/java/com/positivity/securityservice/internal/controller/SelfRegistrationControllerIT.java
+++ b/pos-security-service/src/test/java/com/positivity/securityservice/internal/controller/SelfRegistrationControllerIT.java
@@ -11,6 +11,7 @@ import com.positivity.domainevents.peoplecontact.UserPersonLinkCreateRequestedV1
 import com.positivity.securityservice.BaseIntegrationTest;
 import com.positivity.securityservice.internal.entity.ExtCustomerPersonIdentity;
 import com.positivity.securityservice.internal.entity.ExtPersonReplica;
+import com.positivity.securityservice.internal.entity.Role;
 import com.positivity.securityservice.internal.entity.User;
 import com.positivity.securityservice.internal.repository.ExtCustomerPersonIdentityRepository;
 import com.positivity.securityservice.internal.repository.ExtPersonReplicaRepository;
@@ -69,6 +70,17 @@ class SelfRegistrationControllerIT extends BaseIntegrationTest {
         userRepository.deleteAll();
         extPersonReplicaRepository.deleteAll();
         extCustomerPersonIdentityRepository.deleteAll();
+        // The test profile runs H2 with Flyway disabled, so the migration-seeded
+        // SELF_SERVICE_CUSTOMER role (V8 / R__seed_reference_security.sql) never lands here, and
+        // since #1440 no runtime code creates roles. Provision the one role this flow assigns.
+        if (roleRepository.findByName("SELF_SERVICE_CUSTOMER").isEmpty()) {
+            Role customerRole = new Role();
+            customerRole.setName("SELF_SERVICE_CUSTOMER");
+            customerRole.setDescription("Low-privilege self-registration role for external customer access");
+            customerRole.setCreatedBy("test");
+            customerRole.setCreatedAt(Instant.now());
+            roleRepository.save(customerRole);
+        }
         assertThat(roleRepository.findByName("SELF_SERVICE_CUSTOMER")).isPresent();
     }
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A — CI fix for the red main build ([failing run](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/32515401732))
- Parent STORY (durion): N/A
- Child issue: N/A — regression from #1440 (PR #1441)
- Domain: `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): N/A — one test file changed, no API/event behavior touched. (`BACKEND_CONTRACT_GUIDE.md` referenced for the contract-sync check; no entry applies.)
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- [ ] N/A — no controller changed

## Scope
- What changed: `SelfRegistrationControllerIT.clearUsers` now provisions the `SELF_SERVICE_CUSTOMER` role when absent, with a comment explaining why; the existing `isPresent()` assertion stays as the guard.
- Why: the `test` profile runs H2 with **Flyway disabled** (`application-test.yml`), so the migration-seeded role (V8 / `R__seed_reference_security.sql`) never lands in that context — it only existed there because the `RoleInitializer` bean created it at startup. #1440 (PR #1441) deleted the bean by design, emptying the H2 context's roles table and failing all six cases at the setup assertion. PR CI didn't catch it because the PR reactor runs surefire only; the post-merge main build runs failsafe ITs. Note: this was **not** caused by the gloria.mendez seed in PR #1442 — that commit touched no roles; it was simply the merge whose main build surfaced the latent #1441 regression.

## Tests
- [x] Reproduced the exact 6/6 `clearUsers:72` failure locally on main before fixing
- [x] `SelfRegistrationControllerIT` now 6/6 green; full `pos-security-service` verify passes 570/570 (excluding the Docker-only `RolePermissionSeedIT`, which is unaffected — it runs the `pg` profile with real Flyway)
- How to run: `./mvnw -pl pos-security-service verify -Dit.test='!RolePermissionSeedIT'`

## Risk & Rollback
- Risk level: Low — test-only change, scoped to one IT's setup.
- Rollback plan: revert the commit (restores the red main build).

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A (CI-fix branch)
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A
- [x] Links to parent + child issues are present (regression source #1440 / PR #1441; failing run linked)
- [x] Contract guide updated (when contract semantics changed) — no contract change
- [ ] Required CI checks passing — pending first run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKBY1mzs8VgS1E385cmVXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKBY1mzs8VgS1E385cmVXj)_