### PR TITLE
fix(alpha): enable Kafka for pos-people

### DIFF
--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -155,6 +155,15 @@ services:
     image: ${ECR_REGISTRY}/durion/pos-people:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
+    # ADR-0044 #875: counterpart to pos-people-contact below. Without this the
+    # base compose default (false) leaves every pos.people.kafka component off,
+    # including OutboxPublisher (person upsert commands toward
+    # people-contact.commands.v1) and PeopleContactEventsListener (which fills
+    # the ext_people_contact_person replica). StaffingAssignmentServiceImpl
+    # validates against that replica, so creating a staffing assignment fails
+    # with "Person not found" for a personId the service itself just reported.
+    environment:
+      POS_PEOPLE_KAFKA_ENABLED: "true"
 
   pos-people-contact:
     image: ${ECR_REGISTRY}/durion/pos-people-contact:${BACKEND_TAG}


### PR DESCRIPTION
## Capability & Traceability
- Capability: **not assigned** — operational config fix found while running the SDK integration suite against alpha. Please attach a `cap:` id if this repo requires one.
- Parent STORY (durion): _none — please link if one applies_
- Child issue: _none_
- Domain: `domain:people`

## Contract References
No contract change. No controller, DTO, event, or `openapi.yaml` was touched — this is a single environment variable in the alpha compose override, so the `BACKEND_CONTRACT_GUIDE.md` contract-sync path does not apply here.

## Contract Chain (when a Controller changed)
Not applicable — no controller changed.

## Scope

**What changed:** `POS_PEOPLE_KAFKA_ENABLED: "true"` for `pos-people` in `deployment/alpha/docker-compose.prod.yml`.

**Why:** `pos-people-contact` had its flag flipped on in #838, but its counterpart `pos-people` was never enabled, so the base compose default of `false` still applied on alpha.

That flag gates ten components behind `@ConditionalOnProperty(prefix = "pos.people.kafka", name = "enabled", havingValue = "true")` — declared **without** `matchIfMissing`, so absent means off. Two matter here:

- `OutboxPublisher` / `OutboxEventWriter` — person upsert commands toward `people-contact.commands.v1`
- `PeopleContactEventsListener` — the only writer of the `ext_people_contact_person` replica

`StaffingAssignmentServiceImpl.validatePersonAndLocation` resolves the person through that replica, so with the flag off it fails both ways: employee creation never asks people-contact to create the Person, and nothing would record it locally if it had. people-contact sits listening for commands `pos-people` never sends.

Reproduced against alpha through an SSM tunnel:

```
POST /v1/people/staffing/assignments
-> 404 {"detail":"Person not found: 01a025ef-889c-799a-aea5-904b2830ef41"}
```

That id is what `GET /v1/people/employees/by-number/EMP-T001` reports for the employee. Asking the owning service directly (`GET /people-contact/v1/people/{personId}`) returns an empty-bodied 404 — the handler ran and found nothing, confirming the Person was never created upstream. It is not a propagation lag: the same id still failed minutes later.

This blocks the `sdk-integration-tests` bootstrap (`PeopleBootstrap`) on alpha.

## Tests
- [ ] Unit tests added/updated — n/a, config only
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a

**How to run / verify the merge is safe:**

```bash
docker compose -f docker-compose.yml -f deployment/alpha/docker-compose.prod.yml --env-file <env> config
```

I ran this: `pos-people` keeps all 23 environment keys including `SPRING_DATASOURCE_URL`, and gains `POS_PEOPLE_KAFKA_ENABLED=true`. The override **merges** rather than replaces, which was the main risk.

After deploy: create an employee and confirm a staffing assignment succeeds, or check `SELECT count(*) FROM ext_people_contact_person` in `pos_people_db`.

## Risk & Rollback
- **Risk level: Medium.** Low blast radius in code terms (one env var), but it starts Kafka producers and consumers on a service that has had them dormant. Expect first-run consumer group creation and outbox drain.
- **Deploy caveat:** `SPRING_KAFKA_LISTENER_AUTO_STARTUP` also defaults to `false` in the base compose. If `/opt/durion/alpha/.env` does not set it true, the listeners register but never start and this flag alone changes nothing. Worth checking before concluding the fix failed.
- **Known follow-up:** `EMP-T001` already exists with a dangling `person_id` and will stay broken after the flip — its Person was never created upstream. Delete that employee row (and its `employee_location_assignment` children; the FK has no `ON DELETE CASCADE`) so the seeder recreates it.
- **Rollback:** revert this commit and redeploy. The flag is additive; nothing else reads it.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — **does not**; no capability id was available
- [ ] PR title starts with `[CAP:<cap-id>]` — **does not**, same reason
- [ ] Links to parent + child issues are present — **no**, none identified
- [x] Contract guide updated (when contract semantics changed) — n/a, no contract change
- [ ] Required CI checks passing — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URS1z16PpVtVkCo3WV7Lf9
