### PR TITLE
fix: add @EnableScheduling to three services with dead @Scheduled jobs

### DIFF
--- a/pos-accounting/src/main/java/com/positivity/accounting/PosAccountingApplication.java
+++ b/pos-accounting/src/main/java/com/positivity/accounting/PosAccountingApplication.java
@@ -6,11 +6,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * Main Spring Boot application for POS Accounting module.
  */
 @SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
+@EnableScheduling
 @EnableRetry
 @ComponentScan(basePackages = {"com.positivity.accounting", "com.positivity.events", "com.positivity.security.common"})
 public class PosAccountingApplication {

--- a/pos-people/src/main/java/com/positivity/people/PosPeopleApplication.java
+++ b/pos-people/src/main/java/com/positivity/people/PosPeopleApplication.java
@@ -4,8 +4,10 @@ import com.positivity.shared.annotation.CoverageGenerated;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
+@EnableScheduling
 public class PosPeopleApplication {
 
     @CoverageGenerated

--- a/pos-security-service/src/main/java/com/positivity/securityservice/PosSecurityServiceApplication.java
+++ b/pos-security-service/src/main/java/com/positivity/securityservice/PosSecurityServiceApplication.java
@@ -4,8 +4,10 @@ import com.positivity.shared.annotation.CoverageGenerated;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
+@EnableScheduling
 public class PosSecurityServiceApplication {
     @CoverageGenerated
     public static void main(String[] args) {


### PR DESCRIPTION
## Capability & Traceability
- Capability: **not assigned** — defect found while running the SDK integration suite against alpha. Please attach a `cap:` id if required.
- Parent STORY (durion): _none_
- Child issue: _none_
- Domain: `domain:platform` (affects `people`, `accounting`, `security`)

## Contract References
No contract change — no controller, DTO, event schema, or `openapi.yaml` touched. Three annotations. The `BACKEND_CONTRACT_GUIDE.md` contract-sync path does not apply.

## Contract Chain (when a Controller changed)
Not applicable.

## Scope

**What changed:** `@EnableScheduling` added to `PosPeopleApplication`, `PosAccountingApplication`, `PosSecurityServiceApplication`.

**Why:** Spring silently ignores `@Scheduled` unless the context is scheduling-enabled. These three services declare `@Scheduled` methods and none enabled it, so those jobs have **never run in any environment**:

| service | dead jobs |
|---|---|
| pos-people | `OutboxPublisher.publishPending` (1s), `ManifestPublisher.publishDueManifest` (5m) |
| pos-accounting | `OutboxProcessor.processPendingEvents` (5s), `cleanupOldEvents` (daily 02:00) |
| pos-security-service | `OutboxPublisher.publishPending` (1s) |

Fourteen other services with `@Scheduled` methods already have it, so this is drift rather than a deliberate pattern.

## How it was found

Staffing assignments 404 on alpha with `Person not found` for a personId the people service itself reports. After `POS_PEOPLE_KAFKA_ENABLED` was enabled (#1444), `pos-people`'s outbox showed:

```
 topic                      | total | unpublished | max_attempts | last_error
----------------------------+-------+-------------+--------------+-----------
 people.events.v1           |     1 |           1 |            0 |
 people-contact.commands.v1 |     1 |           1 |            0 |
```

Written but never *attempted*. `attempts` stays 0 and `last_error` stays null only if the publisher never runs — a broker problem increments `attempts` and records an error. So the person-upsert command never leaves the outbox, people-contact never creates the Person, and `StaffingAssignmentServiceImpl.validatePersonAndLocation` 404s against the `ext_people_contact_person` replica.

## Impact beyond the immediate bug

`pos-accounting` and `pos-inventory` also have their Kafka flags enabled on alpha. Accounting's outbox has been accumulating unpublished rows the same way, and `cleanupOldEvents` has never pruned. Worth checking after deploy:

```sql
-- pos_accounting_db
SELECT count(*) FILTER (WHERE published_at IS NULL) FROM event_outbox;
```

`pos-inventory` was **already correct** — it uses the fully-qualified `@org.springframework.scheduling.annotation.EnableScheduling`, which a naive search for `@EnableScheduling` misses. I initially "fixed" it, caught the duplicate, and reverted; it is untouched here.

## Tests
- [ ] Unit tests added/updated — n/a, annotation only
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a

**How to run:**
```bash
mvn -pl pos-people,pos-accounting,pos-security-service -am compile
```
Passes, spotless check included. (Import ordering is spotless-formatted, not hand-sorted.)

**Post-deploy verification:** the two stuck rows in `pos_people_db.event_outbox` should drain within ~1s of startup, i.e. `unpublished` drops to 0.

## Risk & Rollback
- **Risk level: Medium.** The change is three annotations, but the effect is starting jobs that have never run in production. On first startup each service will drain whatever its outbox has accumulated — expect a burst of previously-unsent events. Accounting's `cleanupOldEvents` will also perform its first-ever prune at 02:00.
- Worth eyeballing outbox depth in `pos_accounting_db` before deploying, so the size of that burst is known rather than discovered.
- **Rollback:** revert the commit and redeploy; the jobs return to dormant.

## Follow-up required (not in this PR)
`SPRING_KAFKA_LISTENER_AUTO_STARTUP=false` on alpha for both `pos-people` and `pos-people-contact` — confirmed by `docker inspect`. Consumers register but never start, so even once the outbox drains, people-contact will not consume the command. That is a deployment-config change and needs its own decision.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — **does not**; no capability id available
- [ ] PR title starts with `[CAP:<cap-id>]` — **does not**, same reason
- [ ] Links to parent + child issues are present — **no**
- [x] Contract guide updated (when contract semantics changed) — n/a
- [ ] Required CI checks passing — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URS1z16PpVtVkCo3WV7Lf9
