### PR TITLE
fix(alpha): start Kafka listeners for pos-people and pos-people-contact

### DIFF
--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -162,16 +162,27 @@ services:
     # the ext_people_contact_person replica). StaffingAssignmentServiceImpl
     # validates against that replica, so creating a staffing assignment fails
     # with "Person not found" for a personId the service itself just reported.
+    # The consumer half: the base compose defaults
+    # SPRING_KAFKA_LISTENER_AUTO_STARTUP to false, which registers every
+    # @KafkaListener but starts none of them. pos-people needs its
+    # PeopleContactEventsListener running to populate the
+    # ext_people_contact_person replica that staffing assignments validate
+    # against.
     environment:
       POS_PEOPLE_KAFKA_ENABLED: "true"
+      SPRING_KAFKA_LISTENER_AUTO_STARTUP: "true"
 
   pos-people-contact:
     image: ${ECR_REGISTRY}/durion/pos-people-contact:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
     # #838 second deploy: broker verified healthy, flag flipped on.
+    # Listener auto-startup for the same reason as pos-people above: without it
+    # the people-contact.commands.v1 consumer never starts, so the person upsert
+    # commands pos-people publishes are never acted on.
     environment:
       POS_PEOPLE_CONTACT_KAFKA_ENABLED: "true"
+      SPRING_KAFKA_LISTENER_AUTO_STARTUP: "true"
 
   pos-price:
     image: ${ECR_REGISTRY}/durion/pos-price:${BACKEND_TAG}


### PR DESCRIPTION
## Capability & Traceability
- Capability: **not assigned** — operational config, found while tracing the alpha staffing-assignment failure. Please attach a `cap:` id if required.
- Parent STORY (durion): _none_
- Child issue: _none_
- Domain: `domain:people`

## Contract References
No contract change — one environment variable per service in the alpha compose override. No controller, DTO, event schema, or `openapi.yaml` touched, so the `BACKEND_CONTRACT_GUIDE.md` contract-sync path does not apply.

## Contract Chain (when a Controller changed)
Not applicable.

## Scope

**What changed:** `SPRING_KAFKA_LISTENER_AUTO_STARTUP: "true"` for `pos-people` and `pos-people-contact` in `deployment/alpha/docker-compose.prod.yml`.

**Why:** the base compose defaults it to `false`, which registers every `@KafkaListener` container but starts none. Both services have their Kafka flags on and consume nothing:

| service | listener that never starts |
|---|---|
| pos-people | `PeopleContactEventsListener` — the only writer of the `ext_people_contact_person` replica that `StaffingAssignmentServiceImpl` validates against |
| pos-people-contact | the `people-contact.commands.v1` consumer that acts on the person-upsert commands pos-people publishes |

Confirmed on the running containers via `docker inspect` — both carry `SPRING_KAFKA_LISTENER_AUTO_STARTUP=false` alongside their enabled Kafka flags.

## The full picture

This is the last of **three independent faults** behind `Person not found` on alpha:

1. `POS_PEOPLE_KAFKA_ENABLED` was false — #1444, merged and deployed
2. `pos-people` never enabled `@Scheduled`, so `OutboxPublisher` never drained the outbox — #1447
3. listeners registered but never started — **this PR**

Each masked the next. With (1) fixed, the outbox showed 2 rows written and 0 attempted, which exposed (2). Fixing (2) will publish them — and (3) is why nothing would consume them.

## Why scoped to two services

Deliberately **not** set globally in `/opt/durion/alpha/.env`. A global flip starts consumers on every service at once, several of which have never consumed anything on alpha — that is a much larger behavioural change and deserves its own PR with its own verification. This PR restores exactly the two consumers the people flow needs.

## Tests
- [ ] Unit tests added/updated — n/a, config only
- [ ] Integration tests added/updated — n/a (exercised end-to-end by `sdk-integration-tests`, see below)
- [ ] Provider behavioral contract tests added/updated — n/a

**How to run:**
```bash
docker compose -f docker-compose.yml -f deployment/alpha/docker-compose.prod.yml --env-file <env> config
```
I ran this: both services keep all 23 environment keys including `SPRING_DATASOURCE_URL`, and gain `SPRING_KAFKA_LISTENER_AUTO_STARTUP=true`. The override merges rather than replaces.

**Deploy order matters** — #1447 first, then this:

1. Deploy #1447 → `pos_people_db.event_outbox` should drain to `unpublished = 0` within seconds of startup
2. Deploy this → people-contact consumes the command and creates the Person; pos-people's replica listener records it
3. Verify: `SELECT count(*) FROM ext_people_contact_person;` in `pos_people_db` is non-zero
4. `npm run test:integration` in durion-positivity-sdk gets past `PeopleBootstrap`

Note `EMP-T001` currently exists with a dangling `person_id` from a failed run and should be deleted again before the final verification, so the seeder recreates it cleanly.

## Risk & Rollback
- **Risk level: Medium.** Two consumers start for the first time on alpha. Expect consumer-group creation and, on people-contact, a backlog drain of whatever `people-contact.commands.v1` has retained once #1447 starts publishing.
- Contained to two services by design; nothing else changes behaviour.
- **Rollback:** revert this commit and redeploy. Listeners return to registered-but-stopped, i.e. current state.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — **does not**; no capability id available
- [ ] PR title starts with `[CAP:<cap-id>]` — **does not**, same reason
- [ ] Links to parent + child issues are present — **no**
- [x] Contract guide updated (when contract semantics changed) — n/a
- [ ] Required CI checks passing — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URS1z16PpVtVkCo3WV7Lf9
