### PR TITLE
fix: set explicit String Kafka serializers on six services

### DIFF
--- a/pos-customer/src/main/resources/application.yml
+++ b/pos-customer/src/main/resources/application.yml
@@ -16,6 +16,9 @@ spring:
   kafka:
     bootstrap-servers:
       - ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
     consumer:
       group-id: pos-customer-workorder-events
       auto-offset-reset: earliest

--- a/pos-location/src/main/resources/application.yml
+++ b/pos-location/src/main/resources/application.yml
@@ -15,6 +15,9 @@ spring:
   kafka:
     bootstrap-servers:
       - ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
     consumer:
       group-id: pos-location-commands
       auto-offset-reset: earliest

--- a/pos-people-contact/src/main/resources/application.yml
+++ b/pos-people-contact/src/main/resources/application.yml
@@ -4,6 +4,13 @@ spring:
   kafka:
     bootstrap-servers:
       - ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
   datasource:
     url: ${SPRING_DATASOURCE_URL:}
     username: ${SPRING_DATASOURCE_USERNAME:}

--- a/pos-people/src/main/resources/application.yml
+++ b/pos-people/src/main/resources/application.yml
@@ -4,6 +4,13 @@ spring:
   kafka:
     bootstrap-servers:
       - ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
   datasource:
     url: ${SPRING_DATASOURCE_URL:}
     username: ${SPRING_DATASOURCE_USERNAME:}

--- a/pos-security-service/src/main/resources/application.yml
+++ b/pos-security-service/src/main/resources/application.yml
@@ -7,6 +7,13 @@ spring:
   kafka:
     bootstrap-servers:
       - ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
   datasource:
     url: ${SPRING_DATASOURCE_URL:}
     username: ${SPRING_DATASOURCE_USERNAME:}

--- a/pos-vehicle-inventory/src/main/resources/application.yml
+++ b/pos-vehicle-inventory/src/main/resources/application.yml
@@ -4,6 +4,13 @@ spring:
   kafka:
     bootstrap-servers:
       - ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
   datasource:
     url: ${SPRING_DATASOURCE_URL:}
     username: ${SPRING_DATASOURCE_USERNAME:}


### PR DESCRIPTION
## Capability & Traceability
- Capability: **not assigned** — Spring Boot 4 upgrade regression found while tracing the alpha `Person not found` failure. Please attach a `cap:` id if required.
- Parent STORY (durion): _none_
- Child issue: _none_
- Domain: `domain:platform` (affects people, people-contact, customer, location, security, vehicle-inventory)

## Contract References
No API contract change — Kafka client serializer configuration only. No controller, DTO, event **schema**, or `openapi.yaml` touched. The wire format is unchanged: these services were already intended to publish String keys/values, and this restores that. `BACKEND_CONTRACT_GUIDE.md` needs no update.

## Contract Chain (when a Controller changed)
Not applicable.

## Scope

**What changed:** explicit `StringSerializer` / `StringDeserializer` in `spring.kafka` for six services.

**Why:** Spring Boot 4 / spring-kafka 4.1 default the producer key and value serializers to `ByteArraySerializer`. Every outbox publisher here uses `KafkaTemplate<String, String>`, so any service relying on the old default now fails on **every** send:

```
org.apache.kafka.common.errors.SerializationException: Can't convert key of class
java.lang.String to class org.apache.kafka.common.serialization.ByteArraySerializer
specified in key.serializer
```

Nine services already pin `StringSerializer` explicitly and sailed through the upgrade. These six did not:

| service | added |
|---|---|
| pos-customer | producer only (consumer block already present) |
| pos-location | producer only (consumer block already present) |
| pos-people | producer + consumer |
| pos-people-contact | producer + consumer |
| pos-security-service | producer + consumer |
| pos-vehicle-inventory | producer + consumer |

## Evidence from alpha

`pos-people`'s outbox, after #1444 and #1447 made the publisher actually run:

```
 topic                      | unpublished | max_attempts | last_error
----------------------------+-------------+--------------+---------------------------
 people-contact.commands.v1 |           1 |        17038 | Can't convert key of ...
 people.events.v1           |           1 |            0 |
```

Retrying once a second since startup. `people.events.v1` shows **0** attempts because `OutboxPublisher` stops the batch at the first failure to preserve publish order — so a single poisoned row blocks everything behind it. That ordering guarantee is correct; it just means one bad row halts the topic.

Container logs confirm the path, including `ScheduledMethodRunnable` (i.e. #1447 working) and `spring-kafka-4.1.0` / `kafka-clients-4.3.1`.

## Why the consumer side too

A listener taking a `String` payload cannot be fed by the `ByteArrayDeserializer` default either, so the four services without a consumer block get one. `auto-offset-reset: earliest` matches the existing `pos-customer` and `pos-order` blocks and is what a replica consumer needs in order to build itself from history. No global `group-id` is set — every `@KafkaListener` here specifies its own.

## Not included

`pos-supplier` has a `SupplierOutboxPublisher` but **no `spring.kafka` configuration at all**, not even `bootstrap-servers` — it would publish to `localhost:9092`. That is a distinct pre-existing gap and wants its own change rather than a serializer line bolted on. It is not deployed on alpha.

## Tests
- [ ] Unit tests added/updated — n/a, configuration only
- [ ] Integration tests added/updated — n/a (covered end-to-end by `sdk-integration-tests`)
- [ ] Provider behavioral contract tests added/updated — n/a

**How to run:**
```bash
mvn -pl pos-people,pos-people-contact -am compile
```
Passes. Every edited `application.yml` still parses (two are multi-document).

**Post-deploy verification** — the stuck rows should drain within a second:
```sql
-- pos_people_db
SELECT topic, count(*) FILTER (WHERE published_at IS NULL) FROM event_outbox GROUP BY topic;
```
Then `GET /people-contact/v1/people/{personId}` returns 200 for a seeded employee's personId, and `npm run test:integration` in durion-positivity-sdk gets past `PeopleBootstrap`.

## Risk & Rollback
- **Risk level: Medium.** Six services start successfully publishing for the first time since the Boot 4 upgrade. Expect each to drain its accumulated outbox on deploy — check depth first if that matters:
  ```sql
  SELECT count(*) FILTER (WHERE published_at IS NULL) FROM event_outbox;  -- per service db
  ```
- Consumers on the four newly-configured services will also start reading with `auto-offset-reset: earliest`, so a first-time consumer group replays retained history. That is intended for replica builders but is the main thing to watch.
- **Rollback:** revert and redeploy; publishing returns to failing, which is the current state.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — **does not**; no capability id available
- [ ] PR title starts with `[CAP:<cap-id>]` — **does not**, same reason
- [ ] Links to parent + child issues are present — **no**
- [x] Contract guide updated (when contract semantics changed) — n/a
- [ ] Required CI checks passing — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URS1z16PpVtVkCo3WV7Lf9
