### PR TITLE
Suppress CVE-2026-18022 false positive on pgvector Java client

### DIFF
--- a/build-tools/owasp-suppressions.xml
+++ b/build-tools/owasp-suppressions.xml
@@ -45,6 +45,35 @@
     </suppress>
 
     <!--
+        pgvector-0.1.6 (Java JDBC client) — CVE-2026-18022
+        The CVE is an integer wraparound in the IVFFlat index-build code of the pgvector
+        PostgreSQL C extension (32-bit platforms only; fixed in extension 0.8.6).  The
+        com.pgvector:pgvector Java client shares the pgvector_project:pgvector CPE, so
+        Dependency-Check flags the client jar, but the client contains none of the affected
+        index-build code — it only converts vector values for JDBC.  0.1.6 is the latest
+        client release on Maven Central, so no upgrade exists that would clear the CPE match.
+        Actual remediation is server-side: run the pgvector database extension at >= 0.8.6
+        (tracked as an infrastructure task, not a build dependency).
+    -->
+    <suppress>
+        <notes>CPE false positive: CVE targets the pgvector PostgreSQL C extension (fixed 0.8.6), not the Java JDBC client; no newer client release exists.</notes>
+        <gav regex="true">^com\.pgvector:pgvector:.*$</gav>
+        <cve>CVE-2026-18022</cve>
+    </suppress>
+
+    <!--
+        Same CVE, second match path: in pos-coverage-aggregate the Archive Analyzer scans the
+        repackaged Spring Boot jars and finds pgvector nested under BOOT-INF/lib without GAV
+        evidence (CPE match only), so the same finding resurfaces there.  Match those
+        occurrences by file name.  Remove together with the rule above.
+    -->
+    <suppress>
+        <notes>Nested-jar duplicate of the pgvector CVE-2026-18022 suppression above (no GAV evidence inside boot jars).</notes>
+        <filePath regex="true">.*[\\/]pgvector[^\\/]*\.jar$</filePath>
+        <cve>CVE-2026-18022</cve>
+    </suppress>
+
+    <!--
         tomcat-embed-core-11.0.24 — CVE-2026-66299
         DoS via uncontrolled resource consumption in the WebSocket chat example of Tomcat's
         examples web application.  Embedded Tomcat as used by Spring Boot never ships the

--- a/build-tools/owasp-suppressions.xml
+++ b/build-tools/owasp-suppressions.xml
@@ -54,10 +54,14 @@
         client release on Maven Central, so no upgrade exists that would clear the CPE match.
         Actual remediation is server-side: run the pgvector database extension at >= 0.8.6
         (tracked as an infrastructure task, not a build dependency).
+
+        Pinned to version 0.1.6 (same convention as the Tomcat suppression below) so that a
+        future client upgrade forces this suppression to be re-evaluated rather than silently
+        carrying over.
     -->
     <suppress>
         <notes>CPE false positive: CVE targets the pgvector PostgreSQL C extension (fixed 0.8.6), not the Java JDBC client; no newer client release exists.</notes>
-        <gav regex="true">^com\.pgvector:pgvector:.*$</gav>
+        <gav regex="true">^com\.pgvector:pgvector:0\.1\.6$</gav>
         <cve>CVE-2026-18022</cve>
     </suppress>
 
@@ -65,11 +69,12 @@
         Same CVE, second match path: in pos-coverage-aggregate the Archive Analyzer scans the
         repackaged Spring Boot jars and finds pgvector nested under BOOT-INF/lib without GAV
         evidence (CPE match only), so the same finding resurfaces there.  Match those
-        occurrences by file name.  Remove together with the rule above.
+        occurrences by file name, pinned to 0.1.6 like the rule above.  Remove together with
+        the rule above.
     -->
     <suppress>
         <notes>Nested-jar duplicate of the pgvector CVE-2026-18022 suppression above (no GAV evidence inside boot jars).</notes>
-        <filePath regex="true">.*[\\/]pgvector[^\\/]*\.jar$</filePath>
+        <filePath regex="true">.*[\\/]pgvector-0\.1\.6\.jar$</filePath>
         <cve>CVE-2026-18022</cve>
     </suppress>
 


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (nightly security-scan fix, no capability work)
- Parent STORY (durion): n/a
- Child issue: n/a — fixes the nightly OWASP scan failure in [run 32556119348](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/32556119348)
- Domain: build/security tooling (`build-tools/owasp-suppressions.xml`)

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Not applicable — no controllers, DTOs, events, or `openapi.yaml` changed; the only change is an OWASP dependency-check suppression file.

## Contract Chain (when a Controller changed)
- Not applicable — no controller changed.

## Scope
- What changed: Added a suppression for CVE-2026-18022 on `com.pgvector:pgvector` to `build-tools/owasp-suppressions.xml` — a GAV-based rule plus the nested-jar `filePath` twin for the pos-coverage-aggregate Archive Analyzer path (mirroring the existing kotlin CVE-2026-53914 pair).
- Why: The nightly dependency-check scan fails `pos-mcp-server` on CVE-2026-18022 (CVSS 8.8) flagged against `pgvector-0.1.6.jar`. The CVE is an integer wraparound in the IVFFlat index-build code of the **pgvector PostgreSQL C extension** (32-bit platforms only; fixed in extension 0.8.6). The Java JDBC client (pulled transitively by `spring-ai-starter-vector-store-pgvector`) shares the `pgvector_project:pgvector` CPE, so Dependency-Check matches the client jar, but the client contains none of the affected index-build code — it only converts vector values over JDBC. 0.1.6 is the latest client release on Maven Central, so no dependency upgrade can clear the CPE match. Actual remediation is server-side: run the pgvector database extension at >= 0.8.6 (infrastructure task; alpha currently runs extension 0.7.2 on 64-bit hosts, which the CVE does not affect).

## Tests
- [ ] Unit tests added/updated — n/a (suppression-file-only change)
- [ ] Integration tests added/updated — n/a
- [ ] Provider behavioral contract tests added/updated — n/a
- How to run: the CI `Security Scan` job was dispatched on this branch and passed with the suppression applied — [run 32557888666](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/32557888666) (`Run OWASP Dependency Check` step green on commit bc1ac57).

## Risk & Rollback
- Risk level: Low — scoped to a single CVE id on a single GAV/file-name pattern; no runtime code affected.
- Rollback plan: revert the commit; the nightly scan returns to failing on the flagged jar.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, non-capability scan fix on `claude/pgvector-cve-2026-18022-ozc9e5`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a
- [x] Links to parent + child issues are present (nightly failure run linked above)
- [ ] Contract guide updated — n/a, no contract semantics changed
- [x] Required CI checks passing (Security Scan verified green on this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvKXQ1LZaeHHN6xvH5TXAq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvKXQ1LZaeHHN6xvH5TXAq)_