### PR TITLE
Add spring.kafka configuration to pos-supplier (#1450)

### DIFF
--- a/pos-supplier/src/main/resources/application.yml
+++ b/pos-supplier/src/main/resources/application.yml
@@ -1,6 +1,20 @@
 spring:
   application:
     name: supplier
+  kafka:
+    bootstrap-servers:
+      - ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    # Explicit String (de)serializers (#1450): spring-kafka 4.1 defaults to ByteArraySerializer,
+    # and SupplierOutboxPublisher sends String key/payload through KafkaTemplate — the same
+    # SerializationException #1449 fixed on six other services. No global consumer group-id:
+    # each @KafkaListener sets its own from pos.supplier.kafka.*-consumer-group.
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
   datasource:
     # Deployment wiring points at the per-service pos_supplier_db (docker-compose / env).
     url: ${SPRING_DATASOURCE_URL:}
@@ -241,6 +255,11 @@ pos:
       # events, and they drain once this is enabled. It also gates the catalog product-code
       # consumer, so a deployment with Kafka off cannot match PRICAT lines at all — by design: an
       # empty replica is reported as unavailable rather than as a catalog full of misses.
+      #
+      # Deployment status (#1450): pos-supplier is deliberately NOT in
+      # deployment/alpha/docker-compose.prod.yml. When it is added there, set
+      # SUPPLIER_KAFKA_ENABLED=true and KAFKA_BOOTSTRAP_SERVERS together and verify the outbox
+      # drains (supplier_outbox_event.published_at set, attempts not climbing).
       enabled: ${SUPPLIER_KAFKA_ENABLED:false}
       catalog-events-topic: ${SUPPLIER_CATALOG_EVENTS_TOPIC:catalog.events.v1}
       catalog-events-consumer-group: ${SUPPLIER_CATALOG_EVENTS_CONSUMER_GROUP:pos-supplier-catalog-events}

--- a/pos-supplier/src/main/resources/application.yml
+++ b/pos-supplier/src/main/resources/application.yml
@@ -259,7 +259,7 @@ pos:
       # Deployment status (#1450): pos-supplier is deliberately NOT in
       # deployment/alpha/docker-compose.prod.yml. When it is added there, set
       # SUPPLIER_KAFKA_ENABLED=true and KAFKA_BOOTSTRAP_SERVERS together and verify the outbox
-      # drains (supplier_outbox_event.published_at set, attempts not climbing).
+      # drains (supplier_event_outbox.published_at set, attempts not climbing).
       enabled: ${SUPPLIER_KAFKA_ENABLED:false}
       catalog-events-topic: ${SUPPLIER_CATALOG_EVENTS_TOPIC:catalog.events.v1}
       catalog-events-consumer-group: ${SUPPLIER_CATALOG_EVENTS_CONSUMER_GROUP:pos-supplier-catalog-events}


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (config bug fix)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1450
- Domain: `domain:supplier`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Not applicable — no controllers, DTOs, events, or `openapi.yaml` changed; this PR only adds a `spring.kafka` block to `application.yml`.

## Contract Chain (when a Controller changed)
- No controller changed — chain not applicable.

## Scope
- What changed: Added the standard `spring.kafka` block to `pos-supplier/src/main/resources/application.yml` — `bootstrap-servers` from `${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}`, explicit `StringSerializer`/`StringDeserializer` for producer and consumer, and `auto-offset-reset: earliest` — matching `pos-people` after #1449. No global consumer `group-id`: each `@KafkaListener` in the module already sets its own from `pos.supplier.kafka.*-consumer-group`. Also documented at the `pos.supplier.kafka.enabled` flag that `pos-supplier` is deliberately absent from `deployment/alpha/docker-compose.prod.yml`, with the checklist to follow when it is added (set `SUPPLIER_KAFKA_ENABLED` and `KAFKA_BOOTSTRAP_SERVERS` together, verify the outbox drains).
- Why: `pos-supplier` has a Kafka outbox publisher (`SupplierOutboxPublisher`) and three `@KafkaListener`s but had no `spring.kafka` configuration at all. The moment `SUPPLIER_KAFKA_ENABLED=true` is set, it would target the Spring default `localhost:9092` instead of the deployment broker and inherit the spring-kafka 4.1 default `ByteArraySerializer` while sending String key/payload — the exact `SerializationException` #1449 fixed on six other services, which poisons the first outbox row and stalls every later event on the topic.

## Tests
- [ ] Unit tests added/updated — none needed; config-only change, existing suite covers the module
- [ ] Integration tests added/updated — n/a; the remaining acceptance criteria in #1450 (outbox drains, listeners consume) require a live broker and are verified at enable time with the SQL check in the issue
- [ ] Provider behavioral contract tests added/updated — n/a
- How to run: `./mvnw -pl pos-supplier -am test` (588 tests, 0 failures locally)

## Risk & Rollback
- Risk level: Low — inert until `SUPPLIER_KAFKA_ENABLED=true`; the `spring.kafka` properties only take effect when Kafka beans are created, and the service is not deployed on alpha.
- Rollback plan: Revert the commit; the service returns to its previous (dormant, unconfigured) state.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, issue-execution branch `claude/execute-1450-mf6fuh`
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability; references issue #1450
- [x] Links to parent + child issues are present (#1450; related #1449, #1447, #1444)
- [ ] Contract guide updated — n/a, no contract semantics changed
- [ ] Required CI checks passing

Closes #1450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1UfCvRitmDpUtiMrJo6sA

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1UfCvRitmDpUtiMrJo6sA)_