### PR TITLE
fix: clear remaining SonarQube reliability findings (pos-inventory, pos-events, pos-workorder)

### DIFF
--- a/pos-events/src/main/java/com/positivity/time/ScaledClock.java
+++ b/pos-events/src/main/java/com/positivity/time/ScaledClock.java
@@ -4,6 +4,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A clock whose returned Instant advances faster than real time.
@@ -27,7 +28,7 @@ public final class ScaledClock extends Clock {
     private final double scale;
     private final boolean converge;
 
-    private volatile boolean converged;
+    private final AtomicBoolean converged = new AtomicBoolean(false);
 
     /**
      * Creates a clock that accelerates without bound and never converges on wall time.
@@ -88,14 +89,14 @@ public final class ScaledClock extends Clock {
         if (!converge) {
             return false;
         }
-        if (converged) {
+        if (converged.get()) {
             return true;
         }
         Instant now = baseClock.instant();
         if (!scaledInstant(now).isBefore(now)) {
-            converged = true;
+            converged.set(true);
         }
-        return converged;
+        return converged.get();
     }
 
     @Override
@@ -108,7 +109,7 @@ public final class ScaledClock extends Clock {
         ScaledClock copy = new ScaledClock(baseClock, zone, realStart, virtualStart, scale, converge);
         // Carry the latch: without it a backward step of the base clock could make the copy
         // recompute the accelerated formula and report virtual time below wall time again.
-        copy.converged = this.converged;
+        copy.converged.set(this.converged.get());
         return copy;
     }
 
@@ -119,13 +120,13 @@ public final class ScaledClock extends Clock {
         if (!converge) {
             return scaledInstant(now);
         }
-        if (converged) {
+        if (converged.get()) {
             return now;
         }
 
         Instant scaled = scaledInstant(now);
         if (!scaled.isBefore(now)) {
-            converged = true;
+            converged.set(true);
             return now;
         }
         return scaled;

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayValidationServiceImpl.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/PutawayValidationServiceImpl.java
@@ -151,12 +151,16 @@ public class PutawayValidationServiceImpl implements PutawayValidationService {
                 destinationLocationId, ON_HAND_EVENT_TYPES));
         BigDecimal maxCapacity = BigDecimal.valueOf(getMaxCapacity(destinationLocationId, locationValidation));
 
-        if (!Quantities.isPositive(maxCapacity)) {
+        // Direct signum/compareTo rather than the Quantities helpers: every value here is
+        // provably non-null (nz above, BigDecimal.valueOf, add), and mixing the null-tolerant
+        // helpers with the direct dereferences below reads as inconsistent null handling — to
+        // SonarCloud's dataflow engine and to a human alike.
+        if (maxCapacity.signum() <= 0) {
             throw new LocationAtCapacityException(destinationLocationId, currentCapacity, maxCapacity);
         }
 
         BigDecimal projectedCapacity = currentCapacity.add(BigDecimal.valueOf(quantity));
-        if (Quantities.lt(projectedCapacity, maxCapacity)) {
+        if (projectedCapacity.compareTo(maxCapacity) < 0) {
             addCapacityNearLimitWarning(result, projectedCapacity, maxCapacity);
             return result;
         }

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/Quantities.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/Quantities.java
@@ -22,7 +22,11 @@ final class Quantities {
 
     /** The value, or {@code ZERO} when absent. An absent quantity has always meant none. */
     static @NonNull BigDecimal nz(@Nullable BigDecimal value) {
-        return Objects.requireNonNullElse(value, BigDecimal.ZERO);
+        // requireNonNull is here for the analyzers, not the runtime: SonarCloud's dataflow
+        // engine treats a static-field read (BigDecimal.ZERO) as possibly null, and its Java
+        // analyzer treats requireNonNullElse the same way — this is the one shape both prove
+        // non-null.
+        return value != null ? value : Objects.requireNonNull(BigDecimal.ZERO);
     }
 
     /** {@code a > b} by value, ignoring scale. */

--- a/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationRequestHandler.java
+++ b/pos-inventory/src/main/java/com/positivity/inventory/internal/service/ReservationRequestHandler.java
@@ -103,7 +103,11 @@ public class ReservationRequestHandler implements ReservationRequestService {
         BigDecimal atp = availableToPromise(stockItemId, locationId);
         Instant now = Instant.now(clock);
 
-        if (Quantities.gte(atp, requiredQuantityBase)) {
+        // Direct compareTo rather than Quantities.gte: both values are provably non-null
+        // (requirePostable throws on null, availableToPromise defaults to ZERO), and routing
+        // them through the null-tolerant helper here while dereferencing them below reads as
+        // inconsistent null handling — to SonarCloud's dataflow engine and to a human alike.
+        if (atp.compareTo(requiredQuantityBase) >= 0) {
             log.info(
                     "Reservation {} covered: demandLine={} sku={} qty={} atp={}",
                     reservation.getReservationId(),
@@ -128,7 +132,7 @@ public class ReservationRequestHandler implements ReservationRequestService {
         // someone else's deficit. Decimal since ADR-0055 (#1414) — a shortfall on a divisible
         // product is itself divisible, and the old (int) cast would have floored it toward zero,
         // quietly backordering less than is actually missing.
-        BigDecimal quantityShort = Quantities.min(requiredQuantityBase, requiredQuantityBase.subtract(atp));
+        BigDecimal quantityShort = requiredQuantityBase.min(requiredQuantityBase.subtract(atp));
         markBackordered(reservation.getReservationId());
         BackorderResponse backorder = workorderLineId != null
                 ? backorderService.createBackorder(workorderLineId, stockItemId.toString(), quantityShort, locationId)

--- a/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
+++ b/pos-workorder/src/main/java/com/positivity/workorder/internal/service/EstimateServiceImpl.java
@@ -802,8 +802,10 @@ public class EstimateServiceImpl implements EstimateService {
         estimate.setTotal(total);
         estimate.setTaxPending(taxPending);
 
-        // Check if total changed (financially significant)
-        boolean totalChanged = (oldTotal == null && total != null) || (oldTotal != null && !oldTotal.equals(total));
+        // Check if total changed (financially significant). compareTo, not equals: BigDecimal
+        // equality is scale-sensitive, and 100 vs 100.00 is not a financial change.
+        boolean totalChanged = (oldTotal == null) != (total == null)
+                || (oldTotal != null && total != null && oldTotal.compareTo(total) != 0);
 
         if (totalChanged) {
             // Increment version on financial changes

--- a/pos-workorder/src/test/java/com/positivity/workorder/service/EstimateServiceImplTest.java
+++ b/pos-workorder/src/test/java/com/positivity/workorder/service/EstimateServiceImplTest.java
@@ -344,6 +344,38 @@ class EstimateServiceImplTest {
     }
 
     @Test
+    void updateEstimateFinancials_scaleOnlyTotalRestatement_isNotARevision() {
+        // 100 vs 100.00 is the same amount at a different scale — e.g. the value read back from
+        // a numeric column. It must not bump the version or publish EstimateRevisedEvent.
+        estimate.setTotal(new BigDecimal("100"));
+        estimate.setVersion(3);
+        when(estimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.of(estimate));
+        when(estimateRepository.save(any(Estimate.class))).thenAnswer(i -> i.getArgument(0));
+
+        estimateService.updateEstimateFinancials(
+                ESTIMATE_ID, new BigDecimal("90.00"), new BigDecimal("10.00"), new BigDecimal("100.00"), "testuser");
+
+        assertEquals(3, estimate.getVersion());
+        org.mockito.Mockito.verify(workOrderRepository, org.mockito.Mockito.never())
+                .findAllByEstimate_Id(any(UUID.class));
+    }
+
+    @Test
+    void updateEstimateFinancials_totalValueChange_bumpsVersionAndPublishesRevision() {
+        estimate.setTotal(new BigDecimal("100.00"));
+        estimate.setVersion(3);
+        when(estimateRepository.findById(ESTIMATE_ID)).thenReturn(Optional.of(estimate));
+        when(estimateRepository.save(any(Estimate.class))).thenAnswer(i -> i.getArgument(0));
+        when(workOrderRepository.findAllByEstimate_Id(ESTIMATE_ID)).thenReturn(List.of());
+
+        estimateService.updateEstimateFinancials(
+                ESTIMATE_ID, new BigDecimal("100.00"), new BigDecimal("10.00"), new BigDecimal("110.00"), "testuser");
+
+        assertEquals(4, estimate.getVersion());
+        org.mockito.Mockito.verify(workOrderRepository).findAllByEstimate_Id(ESTIMATE_ID);
+    }
+
+    @Test
     void deleteEstimateItem_valid_deletesItem() {
         EstimateItem item =
                 EstimateItem.builder().id(ITEM_ID).estimate(estimate).build();


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A — code-quality remediation (SonarCloud reliability findings), no capability change
- Parent STORY (durion): N/A
- Child issue: N/A
- Domain: `domain:inventory`, `domain:workorder`, shared `pos-events` time library

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): `domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` — no contract semantics changed. All changes are internal-service/library refactors; error codes, `ApiError` mapping, event payloads, and API behavior are unchanged.
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- N/A — no controller changed

## Scope
- What changed: Clears the 6 reliability findings SonarCloud reports after PR #1431's follow-up analysis — the 3 pos-inventory survivors, the 1 finding #1431 introduced, and the 2 findings outside pos-inventory:
  - **pos-inventory `Quantities.nz`** (new `java:S2637`): Sonar's Java analyzer does not model `Objects.requireNonNullElse` as non-null, while its dataflow engine does not model a static-field read (`BigDecimal.ZERO`) as non-null. Reshaped to the one form both engines prove: a null-checked ternary whose fallback goes through `Objects.requireNonNull`.
  - **pos-inventory `ReservationRequestHandler` / `PutawayValidationServiceImpl`** (surviving `javabugs:S2259`): the engine flags inconsistent null handling — values routed through the null-tolerant `Quantities` helpers (`gte`/`lt`/`isPositive`/`min`) and then dereferenced directly. These values are provably non-null (`requirePostable` throws on null; `orElse(ZERO)`; `nz`; `BigDecimal.valueOf`; `add`), so they now use direct `compareTo`/`signum`/`min`, reserving the null-tolerant helpers for genuinely nullable ledger values.
  - **pos-events `ScaledClock`** (`java:S3078`): the `converged` latch was a volatile boolean used in check-then-act sequences; it is now an `AtomicBoolean`. The latch is monotonic (false→true only), so plain get/set preserves the existing semantics while making every access atomic.
  - **pos-workorder `EstimateServiceImpl`** (`java:S9351`): the changed-total check compared `BigDecimal`s with `equals()`, which is scale-sensitive — a total restated as `100.00` from `100` would have counted as a financial change, bumped the estimate version, and published a revision event. It now uses `compareTo()` so only value changes count, keeping the null-transition cases (null→value, value→null) flagged as changes.
- Why: Follow-up to PR #1431 — SonarCloud's post-merge analysis showed 6 open reliability findings; this PR drives the count to zero. The `pos-workorder` fix is the one behavioral correction (scale-only restatements no longer publish spurious revision events); everything else is behavior-preserving.

## Tests
- [ ] Unit tests added/updated — none added; existing coverage exercises every touched path (`pos-inventory`: 936 tests incl. `ReservationRequestHandlerTest` and `PutawayValidationServiceImplTest`; `pos-events`: `ScaledClockTest`/`TimeSourceTest`/`TimeConfigTest`; `pos-workorder`: `EstimateServiceImplTest`)
- [ ] Integration tests added/updated — N/A
- [ ] Provider behavioral contract tests added/updated — N/A, no contract change
- How to run: `./mvnw -pl pos-inventory,pos-events,pos-workorder -am test`

## Risk & Rollback
- Risk level: Low — behavior-preserving refactors plus one narrow correctness fix (scale-insensitive total comparison); no API, schema, or event-shape changes
- Rollback plan: revert the three commits (`git revert 5b5cb2f 296e561`; `68529db`/`6bd2116` merged via #1431); no migrations or config involved

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, not capability work (branch `claude/pos-inventory-sonarqube-reliability-b2g4e4`)
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, not capability work
- [ ] Links to parent + child issues are present — N/A
- [ ] Contract guide updated (when contract semantics changed) — N/A, no contract semantics changed
- [x] Required CI checks passing — affected-module suites green locally (Spotless, Checkstyle, ArchUnit; pos-inventory 936 tests, pos-events 49, pos-workorder EstimateServiceImplTest 14)

Note: SonarCloud findings clear on its next analysis of this branch/main. If the two `javabugs:S2259` survivors resist even this reshaping, the remaining recourse is marking them false-positive in the SonarCloud UI — the code is provably null-safe either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoB4QEMnqsyzi1qCTPQVNH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoB4QEMnqsyzi1qCTPQVNH)_