### PR TITLE
fix(alpha): enable Kafka for pos-location and pos-catalog

### DIFF
--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -105,6 +105,12 @@ services:
     image: ${ECR_REGISTRY}/durion/pos-catalog:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
+    # pos-inventory validates products and UoMs against ext_product /
+    # ext_product_uom, which only this service's events populate. With the flag
+    # off nothing is written to its outbox at all, so those replicas stay empty
+    # and inventory rejects every product it is asked about.
+    environment:
+      POS_CATALOG_KAFKA_ENABLED: "true"
 
   pos-customer:
     image: ${ECR_REGISTRY}/durion/pos-customer:${BACKEND_TAG}
@@ -145,6 +151,13 @@ services:
     image: ${ECR_REGISTRY}/durion/pos-location:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
+    # pos-people validates staffing-assignment locations against ext_location,
+    # and pos-inventory against ext_storage_location / ext_location_parent.
+    # Same gating as pos-catalog above: flag off means no outbox rows, so those
+    # replicas are empty and every location lookup reports 'not found or
+    # inactive'.
+    environment:
+      POS_LOCATION_KAFKA_ENABLED: "true"
 
   pos-mcp-server:
     image: ${ECR_REGISTRY}/durion/pos-mcp-server:${BACKEND_TAG}


### PR DESCRIPTION
## Capability & Traceability
- Capability: **not assigned** — alpha environment config, found by the SDK integration bootstrap. Please attach a `cap:` id if required.
- Parent STORY (durion): _none_
- Child issue: _none_
- Domain: `domain:platform` (affects people, inventory, location, catalog)

## Contract References
No contract change — two environment variables in the alpha compose override. No controller, DTO, event schema, or `openapi.yaml` touched, so the `BACKEND_CONTRACT_GUIDE.md` contract-sync path does not apply.

## Contract Chain (when a Controller changed)
Not applicable.

## Scope

**What changed:** `POS_LOCATION_KAFKA_ENABLED` and `POS_CATALOG_KAFKA_ENABLED` set to `"true"` on alpha.

**Why:** both services own replicas that already-enabled consumers validate against, and both still default to `false`, so those replicas are empty:

| consumer (already enabled) | replica | owner |
|---|---|---|
| pos-people | `ext_location` | pos-location |
| pos-inventory | `ext_storage_location`, `ext_location_parent` | pos-location |
| pos-inventory | `ext_product`, `ext_product_uom` | pos-catalog |

## How it surfaced

With #1444, #1447 and #1449 deployed, the person replica now resolves — `GET /people-contact/v1/people/{personId}` returns the Person that had been stuck in the outbox. The staffing assignment moved on to its **next** validation and failed there:

```
POST /v1/people/staffing/assignments
-> 404 {"detail":"Location not found or inactive: 01a025ef-821a-7985-ae7d-b0009ae21def"}
```

That location exists and is active in `pos-location` (`GET /location/v1/locations` returns it). The 404 comes from `LocationReferenceService.isLocationActive`, which reads `ext_location` **only** — the synchronous `LocationReferenceClient` was retired in ADR-0044 §6 (#892), and its javadoc is explicit that a location missing from the replica "behaves exactly like the owner's 404 did". An empty replica is indistinguishable from a deleted location by design.

`CatalogBootstrap` and `InventoryBootstrap` sit behind the same wall via `ext_product` / `ext_product_uom`, so both owners are enabled here rather than discovering `pos-catalog` on the next run.

## ⚠️ This does not backfill existing data

Both services gate `OutboxEventWriter` on the same flag, so **nothing was ever written** for entities created while it was off. `MAIN-01`, its three bays, and the seeded catalog products have no outbox rows to publish. Manifest reconciliation does not help either: `LocationManifestListener` recomputes a checksum over the owner's window and requests a replay from that same empty outbox, so it detects no drift.

Enabling the flag only starts the flow for **new** writes. Existing entities need one of:

1. **Touch each entity** — any update writes an outbox row and publishes. Smallest blast radius; a no-op `PUT` on `MAIN-01` is enough to populate `ext_location` for it.
2. **Delete the seeded reference data** so the integration bootstrap recreates it, emitting events on the way. Cleanest end state, but it is destructive and the seeder is idempotent — it *skips* entities that already exist, which is exactly why they will not re-emit on their own.

Option 1 is enough to unblock the current failure. Option 2 is the honest fix if alpha's replicas should reflect all seeded reference data.

## Tests
- [ ] Unit tests added/updated — n/a, config only
- [ ] Integration tests added/updated — n/a (this is what `sdk-integration-tests` exercises)
- [ ] Provider behavioral contract tests added/updated — n/a

**How to run:**
```bash
docker compose -f docker-compose.yml -f deployment/alpha/docker-compose.prod.yml --env-file <env> config
```
Verified: `pos-catalog` keeps 22 environment keys and `pos-location` 21, both including `SPRING_DATASOURCE_URL`, and each gains its flag. The override merges rather than replaces.

**Post-deploy verification:**
```sql
-- pos_people_db
SELECT count(*) FROM ext_location;          -- 0 until an event is emitted
-- pos_location_db
SELECT topic, count(*) FILTER (WHERE published_at IS NULL) FROM event_outbox GROUP BY topic;
```
Then touch `MAIN-01` and re-check `ext_location`.

## Risk & Rollback
- **Risk level: Medium.** Two more services begin publishing and consuming for the first time on alpha. Their outboxes are empty (nothing was ever written), so there is no accumulated backlog to drain — unlike the services in #1449.
- Both are already covered by #1449's serializer fix, so they will not hit the `ByteArraySerializer` failure.
- **Rollback:** revert and redeploy; both return to not publishing, which is the current state.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — **does not**; no capability id available
- [ ] PR title starts with `[CAP:<cap-id>]` — **does not**, same reason
- [ ] Links to parent + child issues are present — **no**
- [x] Contract guide updated (when contract semantics changed) — n/a
- [ ] Required CI checks passing — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URS1z16PpVtVkCo3WV7Lf9
