### PR TITLE
fix(catalog): read products inside a transaction so LOB columns load

### DIFF
--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/CatalogServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/CatalogServiceImpl.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class CatalogServiceImpl implements CatalogService {
@@ -51,26 +52,31 @@ public class CatalogServiceImpl implements CatalogService {
         this.catalogRepository = catalogRepository;
     }
 
+    @Transactional(readOnly = true)
     public Optional<ProductDto> getProductById(UUID productId) {
         return productRepository.findById(productId).map(this::toProductDto);
     }
 
+    @Transactional(readOnly = true)
     public List<ProductDto> getProductsByName(String name) {
         return productRepository.findByName(name).stream()
                 .map(this::toProductDto)
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public Optional<ServiceDto> getServiceById(UUID serviceId) {
         return serviceRepository.findById(serviceId).map(this::toServiceDto);
     }
 
+    @Transactional(readOnly = true)
     public List<ServiceDto> getServicesByName(String name) {
         return serviceRepository.findByName(name).stream()
                 .map(this::toServiceDto)
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public List<ServiceDto> searchServices(String q, int limit) {
         if (q == null || q.isBlank()) {
             return Collections.emptyList();
@@ -82,20 +88,24 @@ public class CatalogServiceImpl implements CatalogService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public Optional<NonInventoryProductDto> getNonInventoryProductById(UUID productId) {
         return nonInventoryProductRepository.findById(productId).map(this::toNonInventoryProductDto);
     }
 
+    @Transactional(readOnly = true)
     public List<NonInventoryProductDto> getNonInventoryProductsByName(String name) {
         return nonInventoryProductRepository.findByName(name).stream()
                 .map(this::toNonInventoryProductDto)
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public Optional<CatalogDto> getCatalogById(UUID catalogId) {
         return catalogRepository.findById(catalogId).map(this::toCatalogDto);
     }
 
+    @Transactional(readOnly = true)
     public List<CatalogDto> getCatalogsByName(String name) {
         return catalogRepository.findByNameContainingIgnoreCase(name).stream()
                 .map(this::toCatalogDto)

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/service/CatalogServiceImpl.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/service/CatalogServiceImpl.java
@@ -52,11 +52,13 @@ public class CatalogServiceImpl implements CatalogService {
         this.catalogRepository = catalogRepository;
     }
 
+    @Override
     @Transactional(readOnly = true)
     public Optional<ProductDto> getProductById(UUID productId) {
         return productRepository.findById(productId).map(this::toProductDto);
     }
 
+    @Override
     @Transactional(readOnly = true)
     public List<ProductDto> getProductsByName(String name) {
         return productRepository.findByName(name).stream()
@@ -64,11 +66,13 @@ public class CatalogServiceImpl implements CatalogService {
                 .toList();
     }
 
+    @Override
     @Transactional(readOnly = true)
     public Optional<ServiceDto> getServiceById(UUID serviceId) {
         return serviceRepository.findById(serviceId).map(this::toServiceDto);
     }
 
+    @Override
     @Transactional(readOnly = true)
     public List<ServiceDto> getServicesByName(String name) {
         return serviceRepository.findByName(name).stream()
@@ -76,6 +80,7 @@ public class CatalogServiceImpl implements CatalogService {
                 .toList();
     }
 
+    @Override
     @Transactional(readOnly = true)
     public List<ServiceDto> searchServices(String q, int limit) {
         if (q == null || q.isBlank()) {
@@ -88,11 +93,13 @@ public class CatalogServiceImpl implements CatalogService {
                 .toList();
     }
 
+    @Override
     @Transactional(readOnly = true)
     public Optional<NonInventoryProductDto> getNonInventoryProductById(UUID productId) {
         return nonInventoryProductRepository.findById(productId).map(this::toNonInventoryProductDto);
     }
 
+    @Override
     @Transactional(readOnly = true)
     public List<NonInventoryProductDto> getNonInventoryProductsByName(String name) {
         return nonInventoryProductRepository.findByName(name).stream()
@@ -100,11 +107,13 @@ public class CatalogServiceImpl implements CatalogService {
                 .toList();
     }
 
+    @Override
     @Transactional(readOnly = true)
     public Optional<CatalogDto> getCatalogById(UUID catalogId) {
         return catalogRepository.findById(catalogId).map(this::toCatalogDto);
     }
 
+    @Override
     @Transactional(readOnly = true)
     public List<CatalogDto> getCatalogsByName(String name) {
         return catalogRepository.findByNameContainingIgnoreCase(name).stream()
@@ -112,6 +121,7 @@ public class CatalogServiceImpl implements CatalogService {
                 .toList();
     }
 
+    @Override
     public CatalogItemResponseDto addCatalogItem(String type, CatalogItemRequestDto request) {
         return switch (normalizeType(type)) {
             case PRODUCT -> toCatalogItemResponse(PRODUCT, productRepository.save(toProductEntity(request)));
@@ -122,6 +132,7 @@ public class CatalogServiceImpl implements CatalogService {
         };
     }
 
+    @Override
     public Optional<CatalogItemResponseDto> updateCatalogItem(
             String type, UUID catalogId, CatalogItemRequestDto request) {
         return switch (normalizeType(type)) {
@@ -147,6 +158,7 @@ public class CatalogServiceImpl implements CatalogService {
         };
     }
 
+    @Override
     public boolean deleteCatalogItem(String type, UUID catalogId) {
         return switch (normalizeType(type)) {
             case PRODUCT -> deleteProduct(catalogId);
@@ -156,10 +168,12 @@ public class CatalogServiceImpl implements CatalogService {
         };
     }
 
+    @Override
     public CatalogDto addCatalog(CatalogDto request) {
         return toCatalogDto(catalogRepository.save(toCatalogEntity(request)));
     }
 
+    @Override
     public Optional<CatalogDto> updateCatalog(UUID catalogId, CatalogDto request) {
         return catalogRepository.findById(catalogId).map(existing -> {
             CatalogEntity updated = toCatalogEntity(request);
@@ -168,6 +182,7 @@ public class CatalogServiceImpl implements CatalogService {
         });
     }
 
+    @Override
     public boolean deleteCatalog(UUID catalogId) {
         if (!catalogRepository.existsById(catalogId)) {
             return false;


### PR DESCRIPTION
## Symptom

`GET /v1/products/name/{name}` returns **500 on every call** for a name that exists on alpha (`Oil Filter 1`), with Spring's default error body rather than the app's:

```
JpaSystemException: Unable to access lob stream
caused by: org.postgresql.util.PSQLException: Large Objects may not be used in auto-commit mode
    at org.hibernate.type.descriptor.jdbc.ClobJdbcType$1.doExtract
    at org.hibernate.sql.results.graph.entity.internal.EntityInitializerImpl.extractConcreteTypeStateValues
    at CatalogServiceImpl.getProductsByName(CatalogServiceImpl.java:59)
```

## Cause

`ProductEntity` maps two fields as `@Lob` Strings:

```java
@Lob private String attributes;       // product.attributes  -> oid
@Lob private String specifications;   // product.specifications -> oid
```

`V1__baseline_catalog_schema.sql` declares both columns as **`oid`** — Postgres large objects, not `text`. Reading a large object requires an open transaction, and (per the stack) the read happens during **entity hydration**, not when the getter is called. So *any* load of a `ProductEntity` outside a transaction fails, regardless of which DTO fields the caller wants.

That explains why the fault looked selective:

| Path | Transactional? | Result |
| --- | --- | --- |
| `findById` | yes — `SimpleJpaRepository` is `@Transactional(readOnly = true)` | works |
| `findByName` (derived query) | **no** — Spring Data does not wrap derived queries | 500 |
| `ProductSearchServiceImpl`, `ProductMasterDataServiceImpl`, `ProductCodeLookupServiceImpl`, `ProductFactReplayServiceImpl` | already annotated | work |
| `CatalogServiceImpl` | **no annotations at all** | 500 on by-name reads |

Confirmed against alpha — `getProductById` and `getProductDetailView` return 200 with `attributes` populated, `listProductsByName` returns 500, on the same product id.

## Fix

`@Transactional(readOnly = true)` on `CatalogServiceImpl`'s nine read methods, matching every sibling service in the module. Writes are untouched — they go through repository `save` methods, which bring their own transaction.

## Verification

- `pos-catalog` suite: **396 tests, 0 failures**
- Diagnosis reproduced end to end against alpha through the SSM tunnel before and after (post-deploy recheck still owed once this lands)

**No regression test.** The failure is Postgres large-object semantics; `pos-catalog` tests run on H2, which reads CLOBs happily in auto-commit, so a test here would pass with or without the fix. I'd rather say that than ship a green test that proves nothing.

## Follow-up worth its own issue

`@Lob` on a `String` is the wrong mapping for Postgres. Beyond needing a transaction on every read, large objects are **not deleted with the row** — every product delete or attribute rewrite leaks an orphaned LO until someone runs `vacuumlo`. The durable fix is a migration of `attributes`/`specifications` from `oid` to `text` (`convert_from(lo_get(attributes), 'UTF8')`), dropping `@Lob`, unlinking the orphans, and an ArchUnit rule banning `@Lob` on `String` fields so it cannot come back. That needs a data migration against alpha, so it is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FN8LzZGnCZurj4Hk47LbEr
