### PR TITLE
feat(deploy): stand up pos-order

### DIFF
--- a/.github/workflows/build-push-ecr.yml
+++ b/.github/workflows/build-push-ecr.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          ALL_SERVICES_JSON='["pos-accounting","pos-api-gateway","pos-bulk-loader","pos-catalog","pos-customer","pos-documents","pos-event-receiver","pos-image","pos-inventory","pos-invoice","pos-location","pos-marketing","pos-mcp-server","pos-people","pos-people-contact","pos-price","pos-security-service","pos-service-discovery","pos-shop-manager","pos-tax","pos-vehicle-inventory","pos-warranty","pos-workorder"]'
+          ALL_SERVICES_JSON='["pos-accounting","pos-api-gateway","pos-bulk-loader","pos-catalog","pos-customer","pos-documents","pos-event-receiver","pos-image","pos-inventory","pos-invoice","pos-location","pos-marketing","pos-mcp-server","pos-order","pos-people","pos-people-contact","pos-price","pos-security-service","pos-service-discovery","pos-shop-manager","pos-tax","pos-vehicle-inventory","pos-warranty","pos-workorder"]'
           echo "all-services=${ALL_SERVICES_JSON}" >> "$GITHUB_OUTPUT"
           FORCE_FULL_REBUILD=false
 

--- a/deployment/alpha/deploy-backend.sh
+++ b/deployment/alpha/deploy-backend.sh
@@ -152,6 +152,7 @@ DOMAIN_SERVICES=(
   pos-invoice
   pos-location
   pos-mcp-server
+  pos-order
   pos-people
   pos-people-contact
   pos-price

--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -164,6 +164,16 @@ services:
     restart: unless-stopped
     logging: *logging
 
+  pos-order:
+    image: ${ECR_REGISTRY}/durion/pos-order:${BACKEND_TAG}
+    restart: unless-stopped
+    logging: *logging
+    # First deployment of this service (#1461 follow-up / SDK Suite D). Kafka on from
+    # the start: pos-inventory builds its ext_purchase_order replicas from
+    # order.events.v1, so receiving against a PO is impossible with the flag off.
+    environment:
+      POS_ORDER_KAFKA_ENABLED: "true"
+
   pos-people:
     image: ${ECR_REGISTRY}/durion/pos-people:${BACKEND_TAG}
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -921,6 +921,44 @@ services:
   #     timeout: 3s
   #     retries: 20
 
+  pos-order:
+    build:
+      context: ./pos-order
+      dockerfile: Dockerfile
+    environment:
+      EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka/
+      GATEWAY_URL: http://pos-api-gateway:8080
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/pos_order_db
+      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+      SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
+      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:29092}
+      MANAGEMENT_HEALTH_KAFKA_ENABLED: ${MANAGEMENT_HEALTH_KAFKA_ENABLED:-false}
+      # ADR-0049 #1334: pos-order owns the purchase-order aggregate and publishes
+      # purchaseorder.updated on order.events.v1. pos-inventory reads that topic into
+      # its ext_purchase_order replicas, so ASNs and goods receipts cannot reference a
+      # PO with this off. Also feeds this service's own CRM/catalog/location replicas.
+      POS_ORDER_KAFKA_ENABLED: ${POS_ORDER_KAFKA_ENABLED:-true}
+      <<: [ *pos-security-client-env, *pos-events-client-env ]
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+      OTEL_METRICS_EXPORTER: none # app metrics are pull-only via /actuator/prometheus (#867)
+      SERVER_PORT: 8080
+      MANAGEMENT_SERVER_PORT: 8080
+    depends_on:
+      eureka-server:
+        condition: service_healthy
+      pos-security-service:
+        condition: service_healthy
+    logging: *logging
+    networks:
+      - pos-network
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health || exit 1" ]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 300s
+
   pos-people:
     build:
       context: ./pos-people


### PR DESCRIPTION
## Why

`pos-order` was never deployed — not down. It has a module, a `Dockerfile`, Flyway migrations, and `pos_order_db` already declared in `postgres/init-databases.sql`, and it has been in the reactor since the initial commit. But it appears in **none** of the four places a service has to appear to actually run:

| | before |
| --- | --- |
| `docker-compose.yml` service | absent |
| `ALL_SERVICES_JSON` (ECR build matrix) | absent |
| `deployment/alpha/docker-compose.prod.yml` | absent |
| `deploy-backend.sh` `DOMAIN_SERVICES` | absent |
| gateway route | **present** — `- id: order → lb://ORDER, Path=/order/**` |

So the gateway has been routing `/order/**` to a Eureka name nothing ever registers, returning 503 for an unresolvable service. That reads as "the service crashed" when nothing was ever built. @louisburroughs created the ECR repository; this PR is the rest.

## What

Adds the four missing entries. The compose service is modelled on `pos-inventory`: Eureka, gateway URL, `pos_order_db`, the shared `pos-security-client-env` / `pos-events-client-env` anchors, same healthcheck and 300s start period.

**Kafka is on from the first deploy**, unlike the staged rollout #838 used for earlier services. pos-order owns the purchase-order aggregate and publishes `purchaseorder.updated` on `order.events.v1` (ADR-0049 §3, #1334); pos-inventory builds its `ext_purchase_order` replicas from exactly that topic, so an ASN or goods receipt cannot reference a purchase order while the flag is off — the receiving chain would come up broken. The alpha broker is already carrying catalog, inventory, people and workorder traffic.

Assumption worth confirming: the ECR repository is named `durion/pos-order`, which is what the workflow's default naming produces (only `pos-service-discovery` is special-cased).

## Verification

- `docker compose config -q` clean for the base file **and** for the base + alpha-override merge; inspected the merged `pos-order` definition (image, env, depends_on, healthcheck all resolve as intended)
- `mvn package` produces `target/pos-order.jar`, the exact path the Dockerfile copies (parent pom sets `finalName` to the artifactId)
- `docker build ./pos-order` succeeds

## What this unblocks

The SDK integration suite's inventory bootstrap: every `POST /v1/orders/purchase-orders` currently fails, so no stock is seeded, and Suite D (purchase order → ASN → goods receipt) cannot be written against alpha. See durion-positivity-sdk#12.

## Same gap, other services — not in this PR

The audit that found this turned up three more instances of the same drift:

- **`pos-inquiry` and `pos-vehicle-fitment`** — routed by the gateway, module + Dockerfile in the reactor, absent from compose and ECR. Both 503 on alpha.
- **`pos-supplier`** — in `docker-compose.yml` but missing from `ALL_SERVICES_JSON`; 503 on alpha.
- **`pos-tax`** — has a compose service and runs, but no gateway route, so `/tax/**` 404s. The inverse gap.

Happy to file these as an issue (or fix them) once this one is proven out — standing up four services in one PR seemed like the wrong trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FN8LzZGnCZurj4Hk47LbEr
