### PR TITLE
fix(catalog): store product attributes/specifications as text, not large objects

### DIFF
--- a/pos-archunit/src/test/java/com/positivity/archunit/EntityStandardsArchitectureTest.java
+++ b/pos-archunit/src/test/java/com/positivity/archunit/EntityStandardsArchitectureTest.java
@@ -3,6 +3,7 @@ package com.positivity.archunit;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaCall;
@@ -51,6 +52,7 @@ class EntityStandardsArchitectureTest {
     private static final String UUIDV7_ID_ANNOTATION = "com.positivity.shared.id.UUIDv7Id";
     private static final String UUIDV7_GENERATOR = "com.positivity.shared.id.UUIDv7Generator";
     private static final String ASSIGNED_IDENTIFIER_ANNOTATION = "com.positivity.shared.id.AssignedIdentifier";
+    private static final String LOB_ANNOTATION = "jakarta.persistence.Lob";
 
     private static final DescribedPredicate<JavaCall<?>> UUID_RANDOM_UUID_CALL =
             new DescribedPredicate<>("call UUID.randomUUID()") {
@@ -144,6 +146,27 @@ class EntityStandardsArchitectureTest {
             .beAnnotatedWith(LAST_MODIFIED_DATE_ANNOTATION)
             .allowEmptyShould(true)
             .because("ADR-0024 requires updatedAt to be populated via @LastModifiedDate");
+
+    /**
+     * On Postgres, {@code @Lob} on a {@code String} does not mean "unbounded text" — it stores a
+     * large-object OID whose bytes live in {@code pg_largeobject}. Hibernate then reads the value
+     * during entity hydration through the LOB API, which requires an ambient transaction, so any
+     * load of the entity in auto-commit mode fails — and rewriting or deleting the row leaks the
+     * object, since large objects are never unlinked automatically (#1461). Long text belongs in a
+     * plain {@code text} column: {@code @Column(columnDefinition = "TEXT")}. This rule is
+     * fleet-wide, not limited to ENFORCED_ENTITY_PACKAGES, because the failure mode is identical
+     * everywhere.
+     */
+    @ArchTest
+    static final ArchRule string_fields_should_not_be_lob = noFields()
+            .that()
+            .haveRawType(String.class)
+            .should()
+            .beAnnotatedWith(LOB_ANNOTATION)
+            .allowEmptyShould(true)
+            .because("@Lob on String maps to a Postgres large object (oid): reads fail outside a transaction"
+                    + " and updates/deletes leak pg_largeobject storage (#1461);"
+                    + " use @Column(columnDefinition = \"TEXT\") instead");
 
     @ArchTest
     static final ArchRule entities_with_audit_fields_should_declare_entity_listeners = classes()

--- a/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductEntity.java
+++ b/pos-catalog/src/main/java/com/positivity/catalog/internal/entity/ProductEntity.java
@@ -137,7 +137,7 @@ public class ProductEntity implements CatalogItem {
     @Schema(description = "UPC code for product", example = "0123456789012")
     private String upc;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     @Schema(description = "Arbitrary key-value product attributes stored as JSON")
     private String attributes;
 
@@ -172,7 +172,7 @@ public class ProductEntity implements CatalogItem {
     @Schema(description = "Warranty information for the product", example = "2 years parts and labor")
     private String warranty;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     @Schema(
             description = "Detailed specifications of the product",
             example = "{\"weight\": \"5kg\", \"length\": \"30cm\"}")

--- a/pos-catalog/src/main/resources/db/migration/V14__product_lob_columns_to_text.sql
+++ b/pos-catalog/src/main/resources/db/migration/V14__product_lob_columns_to_text.sql
@@ -1,0 +1,41 @@
+-- #1461: product.attributes and product.specifications were mapped with @Lob, which on
+-- Postgres stores a large-object OID rather than the text itself. Large objects cannot be
+-- read in auto-commit mode (so any ProductEntity load outside a transaction fails) and are
+-- not deleted with the referencing row (so updates and deletes leak pg_largeobject
+-- storage). Both fields hold small JSON strings; convert the columns to plain text.
+
+ALTER TABLE product ADD COLUMN attributes_text text;
+ALTER TABLE product ADD COLUMN specifications_text text;
+
+-- Copy the large-object contents into the text columns. The pg_largeobject_metadata guard
+-- turns a dangling OID (object already unlinked) into NULL instead of failing the
+-- migration.
+UPDATE product p
+SET attributes_text = convert_from(lo_get(p.attributes), 'UTF8')
+WHERE p.attributes IS NOT NULL
+  AND EXISTS (SELECT 1 FROM pg_largeobject_metadata m WHERE m.oid = p.attributes);
+
+UPDATE product p
+SET specifications_text = convert_from(lo_get(p.specifications), 'UTF8')
+WHERE p.specifications IS NOT NULL
+  AND EXISTS (SELECT 1 FROM pg_largeobject_metadata m WHERE m.oid = p.specifications);
+
+-- Unlink every large object the old columns still reference, so this conversion leaves no
+-- orphans of its own. UNION deduplicates OIDs shared across rows/columns so no OID is
+-- unlinked twice.
+SELECT lo_unlink(o.lo_oid)
+FROM (
+    SELECT attributes AS lo_oid FROM product WHERE attributes IS NOT NULL
+    UNION
+    SELECT specifications FROM product WHERE specifications IS NOT NULL
+) o
+WHERE EXISTS (SELECT 1 FROM pg_largeobject_metadata m WHERE m.oid = o.lo_oid);
+
+ALTER TABLE product DROP COLUMN attributes;
+ALTER TABLE product DROP COLUMN specifications;
+ALTER TABLE product RENAME COLUMN attributes_text TO attributes;
+ALTER TABLE product RENAME COLUMN specifications_text TO specifications;
+
+-- Orphans leaked before this migration (rewrites and row deletes while the columns were
+-- OIDs) are not reachable from any table and are swept separately with vacuumlo during the
+-- maintenance window; see #1461.


### PR DESCRIPTION
## Capability & Traceability
- Capability: n/a (bug fix, no capability)
- Parent STORY (durion): n/a
- Child issue: louisburroughs/durion-positivity-backend#1461
- Domain: `domain:product`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entry (durion): n/a — no API or event behavior change (BACKEND_CONTRACT_GUIDE.md unaffected: entity storage mapping, Flyway migration, and an ArchUnit rule only; no controllers, DTOs, or events touched)
- Durion contract PR (if applicable): louisburroughs/durion#402 (companion ADR-0007 doc fix)

## Contract Chain (when a Controller changed)
- [ ] OpenAPI annotations updated on the controller — n/a, no controller changed
- [ ] `openapi.yaml` (+ `pos-api-gateway/docs/openapi-aggregate.yaml`) regenerated — n/a
- [ ] Angular SDK regenerated (`durion-positivity-sdk-angular`) — n/a

## Scope
- What changed:
  - `ProductEntity.attributes` and `ProductEntity.specifications` are now mapped as `@Column(columnDefinition = "TEXT")` instead of `@Lob`.
  - New `V14__product_lob_columns_to_text.sql` converts `product.attributes` and `product.specifications` from `oid` to `text` in place: copies each large object's contents via `convert_from(lo_get(...), 'UTF8')` (guarded against dangling OIDs), `lo_unlink`s every referenced object so the conversion leaves no orphans of its own, then drops and renames the columns. Orphans leaked *before* the migration are swept separately with `vacuumlo` during the maintenance window (see #1461).
  - New fleet-wide ArchUnit rule `string_fields_should_not_be_lob` in `EntityStandardsArchitectureTest` fails the build if `@Lob` is ever applied to a `String` field again. Deliberately not limited to `ENFORCED_ENTITY_PACKAGES`, since the failure mode is identical everywhere.
  - The read-transaction annotations from #1460 remain — correct on their own merits, but no longer load-bearing for the endpoint.
- Why: on Postgres, `@Lob` on a `String` stores a large-object OID, not text. Large objects cannot be read in auto-commit mode — Hibernate extracts them during entity hydration, so any `ProductEntity` load outside a transaction 500s (`Unable to access lob stream`, shipped on alpha) — and they are not deleted with the referencing row, so every rewrite and delete leaks `pg_largeobject` storage. Both fields hold small JSON strings; large-object storage was never warranted. Fixes #1461.

## Tests
- [x] Unit tests added/updated — existing pos-catalog suite (396 tests) passes against the new mapping; the ArchUnit rule is the new automated guard
- [ ] Integration tests added/updated — n/a; the migration is Postgres-only (Flyway is disabled on the H2 profiles) and was reviewed statement-by-statement
- [ ] Provider behavioral contract tests added/updated — n/a, no contract change
- How to run:
  - `./mvnw -pl pos-catalog -am test`
  - `./mvnw -pl pos-archunit -am -Dtest=ArchitectureTests,EntityStandardsArchitectureTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - Negative check performed: temporarily re-adding `@Lob` fails the build with `Field <com.positivity.catalog.internal.entity.ProductEntity.attributes> is annotated with @Lob`.

## Risk & Rollback
- Risk level: Medium — the migration rewrites two columns of live data on alpha and unlinks the referenced large objects. Per #1461 it should ship in a maintenance window with a verified backup; the `vacuumlo` orphan sweep is a separate ops step in the same window.
- Rollback plan: restore from the pre-migration backup (the unlinked large objects are not recoverable otherwise); the code change alone rolls back by reverting the commit, since `text` columns readable by the old `@Lob` mapping do not exist — code and migration must roll back together.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — n/a, bug fix branch
- [ ] PR title starts with `[CAP:<cap-id>]` — n/a, no capability
- [x] Links to parent + child issues are present (#1461; no parent STORY)
- [x] Contract guide updated (when contract semantics changed) — n/a, no contract semantics changed
- [ ] Required CI checks passing — pending first run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bih62ZDxS4H5DTdkyC6DTN