### PR TITLE
fix(order): supply an AuditorAware so created_by is populated

### DIFF
--- a/pos-order/src/main/java/com/positivity/order/internal/config/JpaAuditingConfig.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/config/JpaAuditingConfig.java
@@ -21,10 +21,13 @@ public class JpaAuditingConfig {
 
     /**
      * Supplies {@code @CreatedBy} / {@code @LastModifiedBy}. Auditing was enabled here without one,
-     * so those fields stayed null and every insert into a table with a NOT NULL {@code created_by}
-     * - purchase_order, sales_order, return_order - failed on the constraint. The "system" fallback
-     * matches pos-inventory and pos-customer: an event-driven or scheduled write has no
-     * authenticated principal but still has to name an author.
+     * so those fields stayed null and every insert of an audited entity failed on its NOT NULL
+     * {@code created_by}: {@link com.positivity.order.internal.entity.PurchaseOrderEntity} and
+     * {@link com.positivity.order.internal.entity.PriceOverride} are the two that depend on
+     * auditing. SalesOrder and ReturnOrder carry the same NOT NULL column but populate it in their
+     * services, which is why they kept working. The "system" fallback matches pos-inventory and
+     * pos-customer: an event-driven or scheduled write has no authenticated principal but still
+     * has to name an author.
      */
     @Bean
     AuditorAware<String> auditorAware() {

--- a/pos-order/src/main/java/com/positivity/order/internal/config/JpaAuditingConfig.java
+++ b/pos-order/src/main/java/com/positivity/order/internal/config/JpaAuditingConfig.java
@@ -1,19 +1,33 @@
 package com.positivity.order.internal.config;
 
+import com.positivity.security.common.SecurityContextHelper;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Optional;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
-@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider", auditorAwareRef = "auditorAware")
 public class JpaAuditingConfig {
 
     @Bean
     DateTimeProvider auditingDateTimeProvider(Clock clock) {
         return () -> Optional.of(Instant.now(clock));
+    }
+
+    /**
+     * Supplies {@code @CreatedBy} / {@code @LastModifiedBy}. Auditing was enabled here without one,
+     * so those fields stayed null and every insert into a table with a NOT NULL {@code created_by}
+     * - purchase_order, sales_order, return_order - failed on the constraint. The "system" fallback
+     * matches pos-inventory and pos-customer: an event-driven or scheduled write has no
+     * authenticated principal but still has to name an author.
+     */
+    @Bean
+    AuditorAware<String> auditorAware() {
+        return () -> Optional.of(SecurityContextHelper.getCurrentUsernameOrDefault("system"));
     }
 }

--- a/pos-order/src/test/java/com/positivity/order/internal/service/PurchaseOrderAuditingIT.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/PurchaseOrderAuditingIT.java
@@ -1,0 +1,82 @@
+package com.positivity.order.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.order.internal.dto.purchaseorder.CreatePurchaseOrderRequest;
+import com.positivity.order.internal.dto.purchaseorder.PurchaseOrderLineRequest;
+import com.positivity.order.internal.repository.PurchaseOrderRepository;
+import com.positivity.order.service.PurchaseOrderService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+/**
+ * Pins that creating a purchase order through the service - the path the REST endpoint takes -
+ * fills the audited {@code createdBy} column.
+ *
+ * <p>Nothing else covered it. {@code createdBy} is {@code @CreatedBy} with
+ * {@code @Column(nullable = false)}, and the only other test that persists an order
+ * ({@code RequestedPurchaseOrderIdentityIT}) sets the value on the builder by hand, so the
+ * auditing path it depends on was never exercised. With {@code @EnableJpaAuditing} declared but no
+ * {@code AuditorAware} bean, Spring Data leaves the field null and the insert dies on the
+ * constraint - which is what every POST /v1/orders/purchase-orders returned on alpha the day this
+ * service was first deployed.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+// The test schema comes from ddl-auto, which creates sequences only for @GeneratedValue
+// mappings. PO numbers are drawn from a standalone sequence that V14 creates and Hibernate
+// therefore does not - so it is declared here rather than the create path being untestable.
+@Sql(
+        statements = "CREATE SEQUENCE IF NOT EXISTS purchase_order_number_seq START WITH 1 INCREMENT BY 1",
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@DisplayName("A purchase order created through the service records who created it")
+class PurchaseOrderAuditingIT {
+
+    private static final UUID VENDOR_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d01");
+    private static final UUID SKU_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d02");
+    private static final UUID SHIP_TO_LOCATION_ID = UUID.fromString("018f0a1b-2c3d-7e4f-8a9b-0c1d2e3f4d03");
+
+    @Autowired
+    private PurchaseOrderService purchaseOrderService;
+
+    @Autowired
+    private PurchaseOrderRepository purchaseOrderRepository;
+
+    @Test
+    @DisplayName("createPurchaseOrder persists, and createdBy is populated by auditing")
+    void createPopulatesCreatedBy() {
+        PurchaseOrderLineRequest line = new PurchaseOrderLineRequest();
+        line.setLineNumber(1);
+        line.setSkuId(SKU_ID);
+        line.setDescription("audited line");
+        line.setQuantity(new BigDecimal("10"));
+        line.setUnitCostMinor(100L);
+
+        CreatePurchaseOrderRequest request = new CreatePurchaseOrderRequest();
+        request.setVendorId(VENDOR_ID);
+        request.setCurrency("USD");
+        request.setPoDate(LocalDate.of(2026, 1, 5));
+        request.setExpectedDeliveryDate(LocalDate.of(2026, 1, 12));
+        request.setShipToLocationId(SHIP_TO_LOCATION_ID);
+        request.setRequestedBy("itest");
+        request.setLines(List.of(line));
+
+        UUID created =
+                purchaseOrderService.createPurchaseOrder(request, "actor-1").getPurchaseOrderId();
+
+        assertThat(purchaseOrderRepository.findById(created))
+                .as("the order must persist rather than fail the created_by NOT NULL constraint")
+                .get()
+                .extracting(po -> po.getCreatedBy())
+                .as("auditing must supply createdBy; nothing in the create path sets it by hand")
+                .isNotNull();
+    }
+}

--- a/pos-order/src/test/java/com/positivity/order/internal/service/PurchaseOrderAuditingIT.java
+++ b/pos-order/src/test/java/com/positivity/order/internal/service/PurchaseOrderAuditingIT.java
@@ -72,11 +72,15 @@ class PurchaseOrderAuditingIT {
         UUID created =
                 purchaseOrderService.createPurchaseOrder(request, "actor-1").getPurchaseOrderId();
 
+        // The exact value, not merely non-null: this test has no authenticated principal, so
+        // auditing is the only thing that can produce "system". A non-null assertion would still
+        // pass if someone set createdBy on the builder or gave the column a default, which is
+        // precisely the shape of the bug it exists to catch.
         assertThat(purchaseOrderRepository.findById(created))
                 .as("the order must persist rather than fail the created_by NOT NULL constraint")
                 .get()
                 .extracting(po -> po.getCreatedBy())
-                .as("auditing must supply createdBy; nothing in the create path sets it by hand")
-                .isNotNull();
+                .as("AuditorAware must supply createdBy, falling back to \"system\" with no principal")
+                .isEqualTo("system");
     }
 }


### PR DESCRIPTION
## Symptom

pos-order came up healthy after #1462 (`/order/actuator/health` → 200), but **every** `POST /v1/orders/purchase-orders` returned 500 — with Spring's default error body rather than the app's `{code, message, correlationId}`, meaning the exception escaped the `@ControllerAdvice`:

```json
{"timestamp":"2026-08-22T20:23:09.102Z","status":500,"error":"Internal Server Error","path":"/v1/orders/purchase-orders"}
```

## Cause

`JpaAuditingConfig` enabled auditing but registered no `AuditorAware`:

```java
@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")   // no auditorAwareRef
```

So `@CreatedBy` / `@LastModifiedBy` resolved to null, and `purchase_order.created_by` is NOT NULL in both the entity mapping (`@Column(nullable = false)`) and `V14__purchase_order.sql` → `DataIntegrityViolationException` on insert.

Not only purchase orders: **`PriceOverride`** is the other entity in this service that depends on auditing (`@CreatedBy @Column(nullable = false)`, `price_override.created_by` NOT NULL in `V1`), so price override creation was failing the same way. `SalesOrder` and `ReturnOrder` carry the same NOT NULL column but populate it in their services, so they were unaffected — an earlier revision of this PR overstated that; corrected in de55a28.

It surfaced now because #1462 was the first time pos-order ran anywhere.

Reproduced locally rather than inferred:

```
DataIntegrityViolationException: NULL not allowed for column "created_by"
  insert into purchase_order (...) values (...)  [23502-240]
```

## Fix

Register the bean, mirroring pos-inventory and pos-customer — current username when there's an authenticated principal, `"system"` otherwise, since an event-driven or scheduled write still has to name an author.

## Why nothing caught it

Two independent gaps, both closed by the new test:

1. **The auditing path was never exercised.** The only other test that persists a purchase order (`RequestedPurchaseOrderIdentityIT`) sets `.createdBy("pos-inventory")` on the builder by hand.
2. **The service create path could not be tested at all.** PO numbers come from `purchase_order_number_seq`, which `V14` creates and `ddl-auto` does not — Hibernate generates sequences only for `@GeneratedValue` mappings, and Flyway is disabled under the `test` profile. A test that called the service died on a missing sequence *before* it could reach the constraint. `PurchaseOrderAuditingIT` declares the sequence, then drives the real `PurchaseOrderService.createPurchaseOrder`, so the create path is covered end to end.

The test asserts `createdBy` equals `"system"` rather than merely being non-null: with no authenticated principal that exact value can only come from `AuditorAware`, so the assertion cannot be satisfied by a builder assignment or a column default.

## Verification

- New test **fails on main** with `NULL not allowed for column "created_by"`, **passes** with this change
- Full pos-order suite: **507 tests, 0 failures, 0 errors**

## Follow-up worth considering

The sequence gap means any future test of a create path hits the same wall. Either enabling Flyway under the `test` profile or moving the sequence into an entity-owned generator would make the test schema match production instead of each test working around it. Not in this PR — it changes how every pos-order test gets its schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FN8LzZGnCZurj4Hk47LbEr
