### PR TITLE
feat(security): seed crm:vehicle:create to SERVICE_ADVISOR

### DIFF
--- a/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
+++ b/pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql
@@ -45,11 +45,13 @@
 --   LOCATION_MANAGER, MANAGER and SHOP_MANAGER — mirroring the
 --   invoice:finalize:override precedent. Advisors create workorders
 --   (workorder:workorder:create) but cannot destroy them.
--- * SERVICE_ADVISOR holds the CRM onboarding surface (#1435):
---   crm:party:view/search/create and crm:person:read/create, so a walk-in
---   customer can be looked up, duplicate-checked and onboarded at the counter.
---   Deliberately NOT crm:party:edit/deactivate/merge — corrections and
---   destructive party operations stay manager-and-above.
+-- * SERVICE_ADVISOR holds the CRM onboarding surface (#1435, #1437):
+--   crm:party:view/search/create, crm:person:read/create and
+--   crm:vehicle:create (alongside its existing crm:vehicle:search/view), so a
+--   walk-in customer can be looked up, duplicate-checked, onboarded and have
+--   their vehicle registered at the counter. Deliberately NOT
+--   crm:party:edit/deactivate/merge — corrections and destructive party
+--   operations stay manager-and-above.
 -- * INVENTORY_LEAD is the parts-receiving persona (#1439): it holds the
 --   receiving surface (ASN, receiving sessions, goods receipts, cross-dock
 --   issue, putaway, shortages, on-hand visibility) plus purchase-order
@@ -1118,6 +1120,7 @@ FROM (VALUES
     ('SERVICE_ADVISOR', 'crm:party:view'),
     ('SERVICE_ADVISOR', 'crm:person:create'),
     ('SERVICE_ADVISOR', 'crm:person:read'),
+    ('SERVICE_ADVISOR', 'crm:vehicle:create'),
     ('SERVICE_ADVISOR', 'crm:vehicle:search'),
     ('SERVICE_ADVISOR', 'crm:vehicle:view'),
     ('SERVICE_ADVISOR', 'inventory:availability:read'),


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A (RBAC seed correction)
- Parent STORY (durion): N/A
- Child issue: louisburroughs/durion-positivity-backend#1437
- Domain: `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- N/A — no controllers, DTOs, events, or `openapi.yaml` touched; this PR changes only the `R__seed_role_permissions.sql` role-grant baseline.

## Contract Chain (when a Controller changed)
- N/A — no controller changed.

## Scope
- What changed: Added the grant row `('SERVICE_ADVISOR', 'crm:vehicle:create')` to `pos-security-service/src/main/resources/db/migration/R__seed_role_permissions.sql`, alongside SERVICE_ADVISOR's existing `crm:vehicle:search`/`crm:vehicle:view`, and updated the seed's policy header (the #1435 bullet now also covers #1437). No section-4 assertion-list change was needed: the permission and role are already listed there via the existing ADMIN grant.
- Why: `createVehicleForParty` enforces `crm:vehicle:create`, which the seed granted to ADMIN only. After #1435 a service advisor can onboard a walk-in customer but still needed an admin to register that customer's vehicle, leaving vehicle registration as an admin fixture step in every otherwise advisor-driven intake flow (appointment → estimate → workorder). This completes the walk-in intake surface started in #1435; corrective/destructive vehicle operations, if added later, stay manager-and-above per the same precedent.

Closes #1437

## Tests
- [ ] Unit tests added/updated — existing `RolePermissionBaselineTest` (21 tests) passes and guards the new grant (no duplicates, permission defined, bit index catalogued, section-4 list in sync).
- [ ] Integration tests added/updated — existing `RolePermissionSeedIT` covers seed application/idempotency; requires Docker, so it runs in CI `verify`, not in the dev sandbox.
- [ ] Provider behavioral contract tests added/updated — N/A, no API behavior change.
- How to run: `./mvnw -pl pos-security-service -Dtest=RolePermissionBaselineTest test`

## Risk & Rollback
- Risk level: Low — additive seed-data-only change to one role's grants; the repeatable migration re-applies idempotently on next startup.
- Rollback plan: Revert the commit; the next run of `R__seed_role_permissions.sql` deletes and re-seeds `role_permissions` to the reverted baseline.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A, issue-fix branch `claude/issue-1437-closure-kf8e84`
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A, no capability id
- [x] Links to parent + child issues are present (child #1437; no parent STORY)
- [x] Contract guide updated (when contract semantics changed) — N/A, no contract change
- [ ] Required CI checks passing — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Zn7aLbaCJ1rtmhmLHh16Q

---
_Generated by [Claude Code](https://claude.ai/code/session_013Zn7aLbaCJ1rtmhmLHh16Q)_