### PR TITLE
fix(alpha): consume customer events in pos-shop-manager

### DIFF
--- a/deployment/alpha/docker-compose.prod.yml
+++ b/deployment/alpha/docker-compose.prod.yml
@@ -210,6 +210,12 @@ services:
     image: ${ECR_REGISTRY}/durion/pos-shop-manager:${BACKEND_TAG}
     restart: unless-stopped
     logging: *logging
+    # Appointments validate crmCustomerId against ext_customer_party, which only
+    # customer.events.v1 fills. With the flag off that replica stays empty, so
+    # every appointment for a customer created after deployment is rejected with
+    # CUSTOMER_NOT_FOUND however long the caller waits.
+    environment:
+      POS_SHOP_MANAGER_KAFKA_ENABLED: "true"
 
   pos-tax:
     image: ${ECR_REGISTRY}/durion/pos-tax:${BACKEND_TAG}


### PR DESCRIPTION
## Symptom

Every attempt to book an appointment for a newly created customer is rejected on alpha:

```
404 {"code":"CUSTOMER_NOT_FOUND","message":"CRM customer not found: 01a02ca8-5734-706d-a90c-9c0859866e8e"}
```

Retrying does not help. I let it poll for a full 60 seconds — the customer never becomes visible, because nothing is in flight to arrive.

## Cause

`AppointmentService` validates `crmCustomerId` against `ext_customer_party`, a read-only replica fed by `CustomerEventsListener` from `customer.events.v1`. That listener is gated on:

```yaml
# pos-shop-manager/src/main/resources/application.yml
kafka:
  enabled: ${POS_SHOP_MANAGER_KAFKA_ENABLED:false}
```

The default is `false` and `deployment/alpha/docker-compose.prod.yml` never overrode it, so the replica has been empty since the service was first deployed. Any customer created after that point cannot be given an appointment.

## Fix

Set the flag for alpha, matching the ten services already flipped there — accounting, catalog, customer, inventory, invoice, location, order, people, people-contact, warranty. pos-customer is already publishing `customer.events.v1` (`POS_CUSTOMER_KAFKA_ENABLED: "true"`), so the facts exist; only the consumer was switched off.

## Verification

- `docker compose config -q` clean for the base file and the alpha merge
- Found by durion-positivity-sdk Suite A (appointments), whose A1 step books an appointment for a customer it creates moments earlier. I will re-run that suite against alpha once this deploys and confirm the booking succeeds.

## Note on scope

This is config only — no application change. Worth asking separately whether the default should stay `false`: a replica-backed validation that silently rejects everything is hard to diagnose from the outside, and the failure looks like bad input rather than a disabled consumer. A startup warning when a replica-backed validator has its feed disabled would have turned an afternoon into a minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FN8LzZGnCZurj4Hk47LbEr
