### PR TITLE
fix(customer): draw commercial customer numbers from a sequence

### DIFF
--- a/pos-customer/src/main/java/com/positivity/customer/internal/repository/CommercialPartyRepository.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/repository/CommercialPartyRepository.java
@@ -24,4 +24,16 @@ public interface CommercialPartyRepository extends JpaRepository<CommercialParty
      */
     @Query("SELECT p FROM CommercialParty p WHERE :vin MEMBER OF p.vehicleVins")
     List<CommercialParty> findByVehicleVin(@Param("vin") String vin);
+
+    /**
+     * Next value of the commercial customer-number sequence.
+     *
+     * <p>Customer numbers come from a sequence rather than from an id, because the id they used to
+     * be derived from repeats: the first 8 hex characters of a UUIDv7 are the top 32 bits of its
+     * millisecond timestamp, identical for every id minted within roughly 65 seconds.
+     *
+     * @return next sequence value for commercial customer number generation
+     */
+    @Query(value = "SELECT nextval('commercial_party_customer_number_seq')", nativeQuery = true)
+    long getNextCustomerNumberSequence();
 }

--- a/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
+++ b/pos-customer/src/main/java/com/positivity/customer/internal/service/PartyServiceImpl.java
@@ -79,6 +79,9 @@ public class PartyServiceImpl implements PartyService {
 
     private final Clock clock;
 
+    /** Largest sequence value that still renders as 8 base-36 characters. */
+    private static final long MAX_CUSTOMER_NUMBER_SEQUENCE = 2_821_109_907_455L;
+
     private final CommercialPartyRepository partyRepository;
     private final PersonPartyRepository personPartyRepository;
     private final PartyRelationshipRepository partyRelationshipRepository;
@@ -197,8 +200,28 @@ public class PartyServiceImpl implements PartyService {
         return party;
     }
 
+    /**
+     * A unique commercial customer number of the documented form CUST-XXXXXXXX.
+     *
+     * <p>This used to be the first 8 hex characters of a fresh UUIDv7. Those characters are the top
+     * 32 bits of the id's millisecond timestamp, so every id minted within the same ~65 second
+     * window produced the same customer number - and customer_number is UNIQUE. Exactly one
+     * commercial account could be created per window; every other attempt died on the constraint
+     * and surfaced as a 500.
+     *
+     * <p>The value now comes from a sequence, rendered base-36 into the same 8 characters, which is
+     * how pos-order numbers purchase orders. The sequence is monotonic, so no two calls can agree
+     * however close together they arrive.
+     */
     private String generateCustomerNumber() {
-        return "CUST-" + UUIDv7Generator.generate().toString().substring(0, 8).toUpperCase(Locale.US);
+        long sequence = partyRepository.getNextCustomerNumberSequence();
+        if (sequence < 1L || sequence > MAX_CUSTOMER_NUMBER_SEQUENCE) {
+            throw new IllegalStateException("Customer number sequence is out of range for 8-character codes");
+        }
+        return "CUST-"
+                + String.format(Locale.ROOT, "%8s", Long.toString(sequence, 36))
+                        .replace(' ', '0')
+                        .toUpperCase(Locale.ROOT);
     }
 
     @Override

--- a/pos-customer/src/main/resources/db/migration/V29__commercial_customer_number_sequence.sql
+++ b/pos-customer/src/main/resources/db/migration/V29__commercial_customer_number_sequence.sql
@@ -4,11 +4,23 @@
 -- the first account created in each window could be saved and every other one
 -- failed on the constraint.
 --
--- A sequence gives the same 8-character shape with none of that. It starts
--- above the values already issued so a fresh number can never collide with a
--- historical one; existing rows are left exactly as they are.
+-- A sequence gives the same 8-character shape with none of that. Numbers are
+-- rendered base-36 and zero-padded to 8 characters, so the sequence is bounded
+-- by 36^8 - 1 = 2821109907455; MAXVALUE states that in the database rather than
+-- leaving it to the application alone.
+--
+-- START WITH is chosen so a generated number can never equal a historical one.
+-- Every existing value renders 8 hex characters, and the largest string of hex
+-- characters read as base-36 is 'FFFFFFFF' = 1209047103195. Starting one above
+-- that puts the whole sequence range beyond anything the old scheme could have
+-- produced, without needing to read the table. The first number issued is
+-- CUST-FFFFFFFG and the last is CUST-ZZZZZZZZ, leaving 1.6e12 of them.
+--
+-- Existing rows are left exactly as they are.
 CREATE SEQUENCE IF NOT EXISTS commercial_party_customer_number_seq
     AS bigint
-    START WITH 1
+    START WITH 1209047103196
     INCREMENT BY 1
+    MINVALUE 1209047103196
+    MAXVALUE 2821109907455
     NO CYCLE;

--- a/pos-customer/src/main/resources/db/migration/V29__commercial_customer_number_sequence.sql
+++ b/pos-customer/src/main/resources/db/migration/V29__commercial_customer_number_sequence.sql
@@ -1,0 +1,14 @@
+-- Commercial customer numbers were the first 8 hex characters of a UUIDv7,
+-- which are the top 32 bits of its millisecond timestamp: the same value for
+-- every id minted inside a ~65 second window. With customer_number UNIQUE, only
+-- the first account created in each window could be saved and every other one
+-- failed on the constraint.
+--
+-- A sequence gives the same 8-character shape with none of that. It starts
+-- above the values already issued so a fresh number can never collide with a
+-- historical one; existing rows are left exactly as they are.
+CREATE SEQUENCE IF NOT EXISTS commercial_party_customer_number_seq
+    AS bigint
+    START WITH 1
+    INCREMENT BY 1
+    NO CYCLE;

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/CommercialCustomerNumberIT.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/CommercialCustomerNumberIT.java
@@ -50,7 +50,8 @@ class CommercialCustomerNumberIT {
             CreateCommercialAccountRequest request = new CreateCommercialAccountRequest();
             request.setLegalName("Back to back " + i);
             request.setDisplayName("Back to back " + i);
-            request.setPartyType("PERSON");
+            // COMMERCIAL is the path under test, and the service's own default.
+            request.setPartyType("COMMERCIAL");
 
             // Before the fix this threw on the second iteration: same customer number, unique
             // constraint. The loop is what the old code could not survive.
@@ -61,5 +62,14 @@ class CommercialCustomerNumberIT {
                 .as("every account must carry its own customer number")
                 .doesNotHaveDuplicates()
                 .allSatisfy(number -> assertThat(number).matches("CUST-[0-9A-Z]{8}"));
+
+        // The sequence starts beyond anything the old scheme could render, so a generated
+        // number can never equal a historical one. 'FFFFFFFF' read as base-36 is the largest
+        // value 8 hex characters can reach.
+        long largestHistoricalValue = Long.parseLong("FFFFFFFF", 36);
+        assertThat(customerNumbers)
+                .as("generated numbers must sit above every value the UUID-derived scheme could produce")
+                .allSatisfy(number -> assertThat(Long.parseLong(number.substring("CUST-".length()), 36))
+                        .isGreaterThan(largestHistoricalValue));
     }
 }

--- a/pos-customer/src/test/java/com/positivity/customer/internal/service/CommercialCustomerNumberIT.java
+++ b/pos-customer/src/test/java/com/positivity/customer/internal/service/CommercialCustomerNumberIT.java
@@ -1,0 +1,65 @@
+package com.positivity.customer.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.positivity.customer.internal.dto.CreateCommercialAccountRequest;
+import com.positivity.customer.service.PartyService;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Pins that commercial accounts created in quick succession each get their own customer number.
+ *
+ * <p>They did not. The number was the first 8 hex characters of a fresh UUIDv7, which are the top
+ * 32 bits of its millisecond timestamp - the same value for every id minted within roughly 65
+ * seconds. Since {@code customer_number} is UNIQUE, exactly one commercial account could be created
+ * per window and every other attempt failed on the constraint, surfacing as a 500. On alpha that
+ * measured as one success in ten.
+ *
+ * <p>Runs against a real Postgres so the sequence and the unique constraint are the ones that
+ * ship: the default H2 profile disables Flyway, so neither exists there.
+ */
+@SpringBootTest
+@ActiveProfiles("pg")
+@Testcontainers
+@DisplayName("Commercial customer numbers are unique within a single timestamp window")
+class CommercialCustomerNumberIT {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    private PartyService partyService;
+
+    @Test
+    @DisplayName("ten accounts created back to back all persist, with ten distinct numbers")
+    void backToBackAccountsGetDistinctCustomerNumbers() {
+        List<String> customerNumbers = new ArrayList<>();
+
+        for (int i = 0; i < 10; i++) {
+            CreateCommercialAccountRequest request = new CreateCommercialAccountRequest();
+            request.setLegalName("Back to back " + i);
+            request.setDisplayName("Back to back " + i);
+            request.setPartyType("PERSON");
+
+            // Before the fix this threw on the second iteration: same customer number, unique
+            // constraint. The loop is what the old code could not survive.
+            customerNumbers.add(partyService.createCommercialAccount(request).getCustomerNumber());
+        }
+
+        assertThat(customerNumbers)
+                .as("every account must carry its own customer number")
+                .doesNotHaveDuplicates()
+                .allSatisfy(number -> assertThat(number).matches("CUST-[0-9A-Z]{8}"));
+    }
+}

--- a/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
+++ b/pos-customer/src/test/java/com/positivity/customer/service/PartyServiceImplTest.java
@@ -385,6 +385,8 @@ class PartyServiceImplTest {
         saved.setLegalName("Acme Legal");
         saved.setCreatedAt(Instant.now(TEST_CLOCK));
         when(partyRepository.save(any(CommercialParty.class))).thenReturn(saved);
+        // Customer numbers come from a sequence rather than from a truncated id.
+        when(partyRepository.getNextCustomerNumberSequence()).thenReturn(42L);
 
         var response = service.createCommercialAccount(request);
 
@@ -395,7 +397,7 @@ class PartyServiceImplTest {
         ArgumentCaptor<CommercialParty> partyCaptor = ArgumentCaptor.forClass(CommercialParty.class);
         verify(partyRepository).save(partyCaptor.capture());
         assertThat(partyCaptor.getValue().getPartyType()).isEqualTo(PartyType.COMMERCIAL);
-        assertThat(partyCaptor.getValue().getCustomerNumber()).startsWith("CUST-");
+        assertThat(partyCaptor.getValue().getCustomerNumber()).isEqualTo("CUST-00000016");
         assertThat(partyCaptor.getValue().getExternalIdentifiers()).containsEntry("erp", "A-100");
     }
 


### PR DESCRIPTION
## Symptom

Creating a commercial account fails roughly **nine times out of ten** on alpha, with an unhandled 500 (Spring's default error body, so it never reached the `@ControllerAdvice`):

```
POST /v1/crm/accounts/parties -> 500
{"timestamp":"2026-08-23T11:01:01.055Z","status":500,"error":"Internal Server Error","path":"/v1/crm/accounts/parties"}
```

Reads and `/actuator/health` stay perfectly green throughout, which is what made it look like flaky infrastructure.

## Cause

```java
private String generateCustomerNumber() {
    return "CUST-" + UUIDv7Generator.generate().toString().substring(0, 8).toUpperCase(Locale.US);
}
```

The first 8 hex characters of a UUIDv7 are the **top 32 bits of its 48-bit millisecond timestamp**. They change once every 2¹⁶ ms — about **65 seconds**. Every account created inside one window drew the *same* customer number, and `commercial_party.customer_number` is `UNIQUE`.

So at most one commercial account could be created per ~65 seconds. Not a race, not load — a hard ceiling, permanent since V1.

Measured on alpha before the fix:

```
11:02:40 → 201  CUST-01A02E49
11:02:40 → 500     (same window)
11:02:40 → 500     (same window)
11:03:15 → 500     (still the same window, 35s later)
11:03:50 → 201  CUST-01A02E4A   ← next window
```

Ten creations in a burst: **one 201, nine 500s**. A control burst against `POST /catalog/v1/products` in the same window: 10/10 success — so this was never the broker or the box.

## Fix

Numbers come from a Postgres sequence rendered base-36 into the same 8 characters, which is how pos-order already numbers purchase orders. Monotonic, so no two calls can agree however close together they arrive. The documented `CUST-XXXXXXXX` shape is unchanged, existing rows are untouched, and the sequence is additive (`V29`).

`PersonServiceImpl` was already safe — it uses the full UUID.

## Verification

- New `CommercialCustomerNumberIT` creates ten accounts back to back against a **real Postgres** (Testcontainers, the existing `pg` profile), because both the sequence and the unique constraint come from Flyway and the default H2 profile disables it. On `main` it dies on the second iteration with `duplicate key value violates unique constraint "commercial_party_customer_number_key"`; with this change it passes.
- Full pos-customer suite: **656 tests, 0 failures, 0 errors** (`PartyServiceImplTest` updated — its mocked repository now stubs the sequence).

## Worth noting separately

A `DataIntegrityViolationException` escaping as a 500 with no code or correlation id is what made this cost an afternoon: the failure looked like a broken environment rather than a broken invariant. Mapping constraint violations to a 409 in this service's advice would turn the next one into a one-line diagnosis. Not in this PR.

Found while writing the SDK integration suites (durion-positivity-sdk#15), whose fixtures create a customer per test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FN8LzZGnCZurj4Hk47LbEr
