### PR TITLE
Upgrade GitHub Actions to Node 24 runtimes to clear deprecation warnings

### DIFF
--- a/.github/workflows/build-push-ecr.yml
+++ b/.github/workflows/build-push-ecr.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Download tested JARs from CI run
         if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: service-jars
@@ -243,7 +243,7 @@ jobs:
           ref: ${{ env.BUILD_SHA }}
 
       - name: Download JAR artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: service-jars
           path: downloaded-jars
@@ -268,14 +268,14 @@ jobs:
           cp "${JAR_PATH}" "${{ matrix.service }}/target/"
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Log in to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
+        uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2.1.7
 
       - name: Set image metadata
         id: meta
@@ -300,10 +300,10 @@ jobs:
           echo "Image: ${FULL_IMAGE}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build and push ${{ matrix.service }}
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./${{ matrix.service }}
           file: ./${{ matrix.service }}/Dockerfile
@@ -389,7 +389,7 @@ jobs:
           ref: ${{ env.BUILD_SHA }}
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,7 +546,7 @@ jobs:
         id: tested-jar
         # Prefer the JAR that passed build-test (spec §4.6). Fall back to a scoped
         # Maven build only if this service wasn't part of the tested artifact.
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: service-jars
@@ -567,10 +567,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./${{ matrix.service }}
           file: ./${{ matrix.service }}/Dockerfile
@@ -581,14 +581,14 @@ jobs:
 
       - name: Log in to Docker Hub
         if: vars.ENABLE_DOCKERHUB_PUSH == 'true'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push Docker image
         if: vars.ENABLE_DOCKERHUB_PUSH == 'true'
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./${{ matrix.service }}
           file: ./${{ matrix.service }}/Dockerfile
@@ -690,7 +690,7 @@ jobs:
 
       - name: Download JaCoCo coverage reports
         if: github.event_name == 'pull_request' && env.SONAR_TOKEN != ''
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           pattern: jacoco-coverage-*

--- a/.github/workflows/contract-sync.yml
+++ b/.github/workflows/contract-sync.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Detect contract-relevant file changes
         id: changes
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
           # If any of these match, we require contract links in the PR body.
           filters: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -96,7 +96,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -125,7 +125,7 @@ jobs:
     
     steps:
       - name: Create PR comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const modules = '${{ needs.detect-changes.outputs.modules }}';

--- a/.github/workflows/sync-alpha-config.yml
+++ b/.github/workflows/sync-alpha-config.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A (CI/workflow maintenance only)
- Parent STORY (durion): N/A
- Child issue: N/A
- Domain: N/A

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- N/A — no contract-relevant files change; only `.github/workflows/*.yml` are touched.
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- N/A — no controllers changed.

## Scope
- What changed: Bumped every GitHub Action still declaring the deprecated `node20` runtime to its current `node24` release. Node20 actions appeared in five of the repo's seven workflows (`ci.yml`, `build-push-ecr.yml`, `pr-checks.yml`, `contract-sync.yml`, `sync-alpha-config.yml`); the other two (`dependency-check.yml`, `nightly-full-stack-compose.yml`) only use `actions/checkout@v5`, `actions/setup-java@v5`, and `actions/upload-artifact@v6`, which are already node24, so they need no changes. Third-party actions remain SHA-pinned with version comments:
  - `aws-actions/configure-aws-credentials` v4.3.1 → v6.2.3 (v5 line is still node20)
  - `aws-actions/amazon-ecr-login` v2.1.6 → v2.1.7
  - `docker/setup-buildx-action` v3.12.0 → v4.3.0
  - `docker/build-push-action` v5 (ci.yml) / v6.19.2 (build-push-ecr) → v7.3.0
  - `docker/login-action` v3.7.0 → v4.6.0
  - `dorny/paths-filter` v3.0.3 → v4.0.3
  - `actions/download-artifact` v5 → v7 (v6 is still node20)
  - `actions/setup-python` v5 → v6
  - `actions/github-script` v7 → v8
- Why: GitHub's runner emits a Node 20 deprecation warning for every job step using an action that declares `runs.using: node20`, so all builds were noisy with warnings. Each new pin was verified to declare `using: node24` in its `action.yml`, and the inputs these workflows use are unchanged across the major bumps.

## Tests
- [ ] Unit tests added/updated — N/A, no code changes
- [ ] Integration tests added/updated — N/A
- [ ] Provider behavioral contract tests added/updated — N/A
- How to run: CI on this PR exercises the updated actions directly; the warnings should no longer appear in job logs.

## Risk & Rollback
- Risk level: Low — version bumps only; all inputs used by the workflows exist unchanged in the new majors.
- Rollback plan: Revert this commit to restore the previous action pins.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A (maintenance branch)
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A (maintenance PR)
- [x] Links to parent + child issues are present (N/A)
- [x] Contract guide updated (no contract semantics changed)
- [ ] Required CI checks passing (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSsjUJpzE7zsjfPjSgRvMq