### PR TITLE
fix(pos-accounting): stop the scheduled OutboxProcessor from racing GL posting ITs

### DIFF
--- a/pos-accounting/src/test/java/com/positivity/accounting/service/CustomerCreditIssuanceGLPostingIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/CustomerCreditIssuanceGLPostingIT.java
@@ -24,6 +24,7 @@ import com.positivity.accounting.internal.repository.IdempotencyKeyRepository;
 import com.positivity.accounting.internal.repository.JournalEntryRepository;
 import com.positivity.accounting.internal.repository.PaymentApplicationRepository;
 import com.positivity.accounting.internal.repository.ReceivablePaymentRepository;
+import com.positivity.accounting.internal.service.OutboxProcessor;
 import com.positivity.accounting.internal.service.PaymentApplicationServiceImpl;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -41,6 +42,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.junit.jupiter.Container;
@@ -126,6 +128,15 @@ class CustomerCreditIssuanceGLPostingIT {
 
     @Autowired
     private PlatformTransactionManager transactionManager;
+
+    /**
+     * The real bean's 5-second poll would dispatch PENDING outbox rows concurrently with the
+     * deterministic {@link #drainOutbox()} calls and the {@code @AfterEach} cleanup, leaking
+     * another test's GL postings into this one's account sums. Mocking it keeps every dispatch
+     * on the test thread.
+     */
+    @MockitoBean
+    private OutboxProcessor outboxProcessor;
 
     @AfterEach
     void cleanUp() {

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/CustomerCreditLifecycleGLPostingIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/CustomerCreditLifecycleGLPostingIT.java
@@ -34,6 +34,7 @@ import com.positivity.accounting.internal.repository.IdempotencyKeyRepository;
 import com.positivity.accounting.internal.repository.JournalEntryRepository;
 import com.positivity.accounting.internal.repository.PaymentApplicationRepository;
 import com.positivity.accounting.internal.repository.ReceivablePaymentRepository;
+import com.positivity.accounting.internal.service.OutboxProcessor;
 import com.positivity.accounting.internal.service.PaymentApplicationServiceImpl;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -51,6 +52,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.junit.jupiter.Container;
@@ -156,6 +158,15 @@ class CustomerCreditLifecycleGLPostingIT {
 
     @Autowired
     private PlatformTransactionManager transactionManager;
+
+    /**
+     * The real bean's 5-second poll would dispatch PENDING outbox rows concurrently with the
+     * deterministic {@link #drainOutbox()} calls and the {@code @AfterEach} cleanup, leaking
+     * another test's GL postings into this one's account sums. Mocking it keeps every dispatch
+     * on the test thread.
+     */
+    @MockitoBean
+    private OutboxProcessor outboxProcessor;
 
     @AfterEach
     void cleanUp() {

--- a/pos-accounting/src/test/java/com/positivity/accounting/service/PaymentApplicationReversalGLPostingLifecycleIT.java
+++ b/pos-accounting/src/test/java/com/positivity/accounting/service/PaymentApplicationReversalGLPostingLifecycleIT.java
@@ -17,6 +17,7 @@ import com.positivity.accounting.internal.repository.EventOutboxRepository;
 import com.positivity.accounting.internal.repository.GLAccountRepository;
 import com.positivity.accounting.internal.repository.IdempotencyKeyRepository;
 import com.positivity.accounting.internal.repository.JournalEntryRepository;
+import com.positivity.accounting.internal.service.OutboxProcessor;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
@@ -33,6 +34,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -94,6 +96,14 @@ class PaymentApplicationReversalGLPostingLifecycleIT {
 
     @Autowired
     private PlatformTransactionManager transactionManager;
+
+    /**
+     * The real bean's 5-second poll would dispatch PENDING outbox rows concurrently with the
+     * test-thread handler calls and the {@code @AfterEach} cleanup, leaking another test's GL
+     * postings into this one's account sums. Mocking it keeps every dispatch on the test thread.
+     */
+    @MockitoBean
+    private OutboxProcessor outboxProcessor;
 
     private UUID undepositedFundsAccountId;
     private UUID arAccountId;


### PR DESCRIPTION
## Capability & Traceability
- Capability: N/A (test-isolation fix for a flaky CI failure on main)
- Parent STORY (durion): N/A
- Child issue: N/A
- Domain: `domain:accounting`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- N/A — test-only change; no controllers, DTOs, events, or API/event behavior touched, so no `BACKEND_CONTRACT_GUIDE.md` entry applies.
- Durion contract PR (if applicable): N/A

## Contract Chain (when a Controller changed)
- N/A — no controllers changed.

## Scope
- What changed: Replaced `OutboxProcessor` with a `@MockitoBean` in the three `pos-accounting` ITs that assert on outbox-driven GL state (`CustomerCreditIssuanceGLPostingIT`, `CustomerCreditLifecycleGLPostingIT`, `PaymentApplicationReversalGLPostingLifecycleIT`). Test sources only; no production code changes.
- Why: `CustomerCreditLifecycleGLPostingIT.fullApplication_netsLiabilityToZero` failed on main ([run 32639545871](https://github.com/louisburroughs/durion-positivity-backend/actions/runs/32639545871)) with Dr 2300 = 950.00 instead of 600.00 — exactly its own 600.00 plus the 250.00 + 100.00 relief postings from `partialDrawDowns_leaveMatchingResidual`. These ITs boot the full application context, and `PosAccountingApplication` has `@EnableScheduling`, so `OutboxProcessor.processPendingEvents()` polls every 5 seconds on a background thread during the test run. It can claim PENDING outbox rows just before an `@AfterEach` `deleteAll()` and publish them just after, leaking one test's journal entries into the next test's account sums. The tests already dispatch outbox work deterministically on the test thread (`drainOutbox()` / direct handler calls), so the background poller adds only nondeterminism. The identical source passed on the previous main run (2669), confirming a timing race rather than a regression.

## Tests
- [ ] Unit tests added/updated — N/A (existing tests fixed for isolation, none added)
- [x] Integration tests added/updated — the three affected ITs now suppress the scheduled poller
- [ ] Provider behavioral contract tests added/updated — N/A
- How to run: `./mvnw -pl pos-accounting -am verify` (requires Docker for the Testcontainers ITs; they skip cleanly without it)

## Risk & Rollback
- Risk level: Low — test-only; production `OutboxProcessor` behavior is unchanged.
- Rollback plan: Revert this commit.

## Checklist
- [ ] Branch name matches `cap/<cap-id>` — N/A (maintenance branch)
- [ ] PR title starts with `[CAP:<cap-id>]` — N/A (maintenance PR)
- [x] Links to parent + child issues are present (N/A)
- [x] Contract guide updated (no contract semantics changed)
- [ ] Required CI checks passing (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSsjUJpzE7zsjfPjSgRvMq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSsjUJpzE7zsjfPjSgRvMq)_